### PR TITLE
fix: lint warnings, CI consolidation, tab accent refactor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,11 +105,11 @@ jobs:
         run: ./gradlew buildPlugin
 
   # ── Tier 3: Parallel analysis (after build) ────────────
-  ktlint:
-    name: Ktlint
+  analyze:
+    name: Analyze
     runs-on: ubuntu-latest
     needs: build
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -119,25 +119,10 @@ jobs:
           distribution: temurin
           java-version: 21
       - uses: gradle/actions/setup-gradle@4c125117fe7c5aed11272ec4213f602f012f89f2 # v5
-      - name: Check code formatting
-        run: ./gradlew ktlintCheck
-
-  detekt:
-    name: Detekt
-    runs-on: ubuntu-latest
-    needs: build
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
-        with:
-          distribution: temurin
-          java-version: 21
-      - uses: gradle/actions/setup-gradle@4c125117fe7c5aed11272ec4213f602f012f89f2 # v5
-      - name: Run static analysis
-        run: ./gradlew detekt
+      - name: Ktlint + Detekt + Kotlin warnings
+        run: >
+          ./gradlew ktlintCheck detekt compileKotlin
+          -Pkotlin.compiler.option.allWarningsAsErrors=true
 
   test:
     name: Test
@@ -156,31 +141,16 @@ jobs:
       - name: Run unit tests
         run: ./gradlew test
 
-  kotlin-warnings:
-    name: Kotlin warnings
-    runs-on: ubuntu-latest
-    needs: build
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
-        with:
-          distribution: temurin
-          java-version: 21
-      - uses: gradle/actions/setup-gradle@4c125117fe7c5aed11272ec4213f602f012f89f2 # v5
-      - name: Compile with -Werror (warnings as errors)
-        run: >
-          ./gradlew compileKotlin
-          -Pkotlin.compiler.option.allWarningsAsErrors=true
-
-  # ── Tier 4: Full IDE verification ──────────────────────
+  # ── Tier 4: Full IDE verification (2 parallel groups) ──
   verify:
-    name: Verify
+    name: Verify (${{ matrix.group }})
     runs-on: ubuntu-latest
     needs: build
-    timeout-minutes: 30
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [A, B]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -190,18 +160,10 @@ jobs:
           distribution: temurin
           java-version: 21
       - uses: gradle/actions/setup-gradle@4c125117fe7c5aed11272ec4213f602f012f89f2 # v5
-        with:
-          # 12 IDE downloads produce ~14GB transforms,
-          # exceeding GitHub Actions 10GB cache limit
-          gradle-home-cache-excludes: |
-            caches/transforms-*
-            caches/modules-*/files-*
-      # Verifies against 12 IDE targets:
-      # IC-2025.1, IC-2025.2.3, IU-2025.3.3,
-      # PS/WS/CL-2025.3.3, RR/GO/PY/DB/RD/RM-2025.1.3
-      - name: Verify plugin across IDE targets
-        run: ./gradlew verifyPlugin
+      - name: Verify plugin (group ${{ matrix.group }})
+        run: ./gradlew verifyPlugin -DverifyGroup=${{ matrix.group }}
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: matrix.group == 'A'
         with:
           name: ayu-islands-plugin
           path: build/distributions/*.zip
@@ -214,10 +176,8 @@ jobs:
       - lint-files
       - gha-security
       - build
-      - ktlint
-      - detekt
+      - analyze
       - test
-      - kotlin-warnings
       - verify
     if: always()
     steps:
@@ -227,10 +187,8 @@ jobs:
             "lint-files=${{ needs.lint-files.result }}"
             "gha-security=${{ needs.gha-security.result }}"
             "build=${{ needs.build.result }}"
-            "ktlint=${{ needs.ktlint.result }}"
-            "detekt=${{ needs.detekt.result }}"
+            "analyze=${{ needs.analyze.result }}"
             "test=${{ needs.test.result }}"
-            "kotlin-warnings=${{ needs.kotlin-warnings.result }}"
             "verify=${{ needs.verify.result }}"
           )
           failed=0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,22 +72,25 @@ intellijPlatform {
                 "ReleaseVersionAndPluginVersionMismatch",
             )
         ides {
-            // Pre-2025.3: IC (Community) still published as a separate distribution
-            create(IntelliJPlatformType.IntellijIdeaCommunity, "2025.1")
-            create(IntelliJPlatformType.IntellijIdeaCommunity, "2025.2.3")
-            // 2025.3+: IC merged into unified IU (IntelliJ IDEA) distribution
-            create(IntelliJPlatformType.IntellijIdea, "2025.3.3")
-            // Additional IDE types (the latest stable only)
-            create(IntelliJPlatformType.PhpStorm, "2025.3.3")
-            create(IntelliJPlatformType.WebStorm, "2025.3.3")
-            create(IntelliJPlatformType.CLion, "2025.3.3")
-            // Language-specific IDEs
-            create(IntelliJPlatformType.RustRover, "2025.1.3")
-            create(IntelliJPlatformType.GoLand, "2025.1.3")
-            create(IntelliJPlatformType.PyCharm, "2025.1.3")
-            create(IntelliJPlatformType.DataGrip, "2025.1.3")
-            create(IntelliJPlatformType.Rider, "2025.1.3")
-            create(IntelliJPlatformType.RubyMine, "2025.1.3")
+            val group = providers.systemProperty("verifyGroup").orNull
+            if (group != "B") {
+                // Group A: IC/IU + major IDEs
+                create(IntelliJPlatformType.IntellijIdeaCommunity, "2025.1")
+                create(IntelliJPlatformType.IntellijIdeaCommunity, "2025.2.3")
+                create(IntelliJPlatformType.IntellijIdea, "2025.3.3")
+                create(IntelliJPlatformType.PhpStorm, "2025.3.3")
+                create(IntelliJPlatformType.WebStorm, "2025.3.3")
+                create(IntelliJPlatformType.CLion, "2025.3.3")
+            }
+            if (group != "A") {
+                // Group B: Language-specific IDEs
+                create(IntelliJPlatformType.RustRover, "2025.1.3")
+                create(IntelliJPlatformType.GoLand, "2025.1.3")
+                create(IntelliJPlatformType.PyCharm, "2025.1.3")
+                create(IntelliJPlatformType.DataGrip, "2025.1.3")
+                create(IntelliJPlatformType.Rider, "2025.1.3")
+                create(IntelliJPlatformType.RubyMine, "2025.1.3")
+            }
         }
     }
 }

--- a/detekt.yml
+++ b/detekt.yml
@@ -9,6 +9,7 @@ complexity:
     threshold: 200
   TooManyFunctions:
     thresholdInClasses: 25
+    thresholdInObjects: 15
   CyclomaticComplexMethod:
     threshold: 15
   NestedBlockDepth:

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -32,6 +32,8 @@ object AccentApplicator {
     private val DARK_FOREGROUND = Color(DARK_FOREGROUND_HEX)
     private const val TAB_ACCENT_BG_ALPHA = 50
     private const val KEY_TAB_BACKGROUND = "EditorTabs.underlinedTabBackground"
+    private const val CGP_RESOLUTION_FAILED = "method resolution failed"
+    private const val CGP_SYNC_FAILED = "sync failed"
 
     // Cached CodeGlance Pro reflection objects (resolved once per session)
     private var cgpService: Any? = null
@@ -233,9 +235,8 @@ object AccentApplicator {
             }
             GlowTabMode.OFF -> {
                 val variant = AyuVariant.detect()
-                if (variant != null) {
-                    UIManager.put("EditorTabs.underlinedBorderColor", Color.decode(variant.neutralGray))
-                }
+                val neutralColor = variant?.let { Color.decode(it.neutralGray) }
+                UIManager.put("EditorTabs.underlinedBorderColor", neutralColor)
                 UIManager.put(KEY_TAB_BACKGROUND, Color(0, 0, 0, 0))
             }
         }
@@ -327,9 +328,9 @@ object AccentApplicator {
             cgpSetViewportBorderColor = configClass.getMethod("setViewportBorderColor", String::class.java)
             cgpSetViewportBorderThickness = configClass.getMethod("setViewportBorderThickness", Int::class.java)
         } catch (exception: ReflectiveOperationException) {
-            logCgpWarning("method resolution failed", exception)
+            logCgpWarning(CGP_RESOLUTION_FAILED, exception)
         } catch (exception: RuntimeException) {
-            logCgpWarning("method resolution failed", exception)
+            logCgpWarning(CGP_RESOLUTION_FAILED, exception)
         }
     }
 
@@ -356,11 +357,11 @@ object AccentApplicator {
             log.info("CodeGlance Pro viewport color synced to $hexWithoutHash")
         } catch (exception: java.lang.reflect.InvocationTargetException) {
             val cause = exception.cause
-            logCgpWarning("sync failed", cause ?: exception)
+            logCgpWarning(CGP_SYNC_FAILED, cause ?: exception)
         } catch (exception: ReflectiveOperationException) {
-            logCgpWarning("sync failed", exception)
+            logCgpWarning(CGP_SYNC_FAILED, exception)
         } catch (exception: RuntimeException) {
-            logCgpWarning("sync failed", exception)
+            logCgpWarning(CGP_SYNC_FAILED, exception)
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -12,7 +12,9 @@ import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.extensions.PluginId
 import com.intellij.ui.ColorUtil
 import dev.ayuislands.accent.conflict.ConflictRegistry
+import dev.ayuislands.glow.GlowTabMode
 import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
 import java.awt.Color
 import java.awt.Window
 import java.lang.reflect.Method
@@ -28,6 +30,8 @@ object AccentApplicator {
     private val log = logger<AccentApplicator>()
     private const val DARK_FOREGROUND_HEX = 0x1F2430
     private val DARK_FOREGROUND = Color(DARK_FOREGROUND_HEX)
+    private const val TAB_ACCENT_BG_ALPHA = 50
+    private const val KEY_TAB_BACKGROUND = "EditorTabs.underlinedTabBackground"
 
     // Cached CodeGlance Pro reflection objects (resolved once per session)
     private var cgpService: Any? = null
@@ -59,6 +63,7 @@ object AccentApplicator {
             // Tab underlines (always accent, not toggleable)
             "ToolWindow.HeaderTab.underlineColor",
             "TabbedPane.underlineColor",
+            "EditorTabs.underlinedBorderColor",
         )
 
     // Always-on editor ColorKeys (not per-element toggleable)
@@ -100,33 +105,7 @@ object AccentApplicator {
             Runnable {
                 applyAlwaysOnUiKeys(accent)
 
-                for (element in EP_NAME.extensionList) {
-                    val enabled = state.isToggleEnabled(element.id)
-                    if (!enabled) {
-                        neutralizeOrRevert(element, variant)
-                        continue
-                    }
-                    val conflict = ConflictRegistry.getConflictFor(element.id)
-                    val forceOverride = element.id.name in state.forceOverrides
-                    if (conflict != null && !forceOverride) {
-                        neutralizeOrRevert(element, variant)
-                        continue
-                    }
-                    if (conflict != null) {
-                        log.warn(
-                            "Force-overriding ${conflict.pluginDisplayName} conflict for ${element.displayName}",
-                        )
-                    }
-                    try {
-                        element.apply(accent)
-                    } catch (exception: RuntimeException) {
-                        log.warn(
-                            "Failed to apply accent to ${element.displayName}",
-                            exception,
-                        )
-                    }
-                }
-
+                applyElements(state, accent, variant)
                 syncCodeGlanceProViewport(accentHex)
                 applyAlwaysOnEditorKeys(accent)
                 val windows = Window.getWindows()
@@ -153,6 +132,7 @@ object AccentApplicator {
                 UIManager.put("Button.default.focusedBorderColor", null)
                 UIManager.put("Button.default.startBorderColor", null)
                 UIManager.put("Button.default.endBorderColor", null)
+                UIManager.put(KEY_TAB_BACKGROUND, null)
 
                 for (element in EP_NAME.extensionList) {
                     try {
@@ -192,6 +172,39 @@ object AccentApplicator {
         }
     }
 
+    private fun applyElements(
+        state: AyuIslandsState,
+        accent: Color,
+        variant: AyuVariant?,
+    ) {
+        for (element in EP_NAME.extensionList) {
+            val enabled = state.isToggleEnabled(element.id)
+            if (!enabled) {
+                neutralizeOrRevert(element, variant)
+                continue
+            }
+            val conflict = ConflictRegistry.getConflictFor(element.id)
+            val forceOverride = element.id.name in state.forceOverrides
+            if (conflict != null && !forceOverride) {
+                neutralizeOrRevert(element, variant)
+                continue
+            }
+            if (conflict != null) {
+                log.warn(
+                    "Force-overriding ${conflict.pluginDisplayName} conflict for ${element.displayName}",
+                )
+            }
+            try {
+                element.apply(accent)
+            } catch (exception: RuntimeException) {
+                log.warn(
+                    "Failed to apply accent to ${element.displayName}",
+                    exception,
+                )
+            }
+        }
+    }
+
     private fun applyAlwaysOnUiKeys(accent: Color) {
         for (key in ALWAYS_ON_UI_KEYS) {
             UIManager.put(key, accent)
@@ -208,6 +221,24 @@ object AccentApplicator {
         UIManager.put("Button.default.focusedBorderColor", darkenedAccent)
         UIManager.put("Button.default.startBorderColor", darkenedAccent)
         UIManager.put("Button.default.endBorderColor", darkenedAccent)
+
+        // Editor tab background tint (respects persisted tab mode, not gated by license)
+        val state = AyuIslandsSettings.getInstance().state
+        val tabMode = GlowTabMode.fromName(state.glowTabMode ?: "MINIMAL")
+        when (tabMode) {
+            GlowTabMode.MINIMAL -> UIManager.put(KEY_TAB_BACKGROUND, Color(0, 0, 0, 0))
+            GlowTabMode.FULL -> {
+                val tinted = Color(accent.red, accent.green, accent.blue, TAB_ACCENT_BG_ALPHA)
+                UIManager.put(KEY_TAB_BACKGROUND, tinted)
+            }
+            GlowTabMode.OFF -> {
+                val variant = AyuVariant.detect()
+                if (variant != null) {
+                    UIManager.put("EditorTabs.underlinedBorderColor", Color.decode(variant.neutralGray))
+                }
+                UIManager.put(KEY_TAB_BACKGROUND, Color(0, 0, 0, 0))
+            }
+        }
     }
 
     private fun applyAlwaysOnEditorKeys(accent: Color) {
@@ -296,9 +327,9 @@ object AccentApplicator {
             cgpSetViewportBorderColor = configClass.getMethod("setViewportBorderColor", String::class.java)
             cgpSetViewportBorderThickness = configClass.getMethod("setViewportBorderThickness", Int::class.java)
         } catch (exception: ReflectiveOperationException) {
-            log.warn("CodeGlance Pro method resolution failed: ${exception.javaClass.simpleName}: ${exception.message}")
+            logCgpWarning("method resolution failed", exception)
         } catch (exception: RuntimeException) {
-            log.warn("CodeGlance Pro method resolution failed: ${exception.javaClass.simpleName}: ${exception.message}")
+            logCgpWarning("method resolution failed", exception)
         }
     }
 
@@ -325,11 +356,18 @@ object AccentApplicator {
             log.info("CodeGlance Pro viewport color synced to $hexWithoutHash")
         } catch (exception: java.lang.reflect.InvocationTargetException) {
             val cause = exception.cause
-            log.warn("CodeGlance Pro sync failed: ${cause?.javaClass?.simpleName}: ${cause?.message}")
+            logCgpWarning("sync failed", cause ?: exception)
         } catch (exception: ReflectiveOperationException) {
-            log.warn("CodeGlance Pro sync failed: ${exception.javaClass.simpleName}: ${exception.message}")
+            logCgpWarning("sync failed", exception)
         } catch (exception: RuntimeException) {
-            log.warn("CodeGlance Pro sync failed: ${exception.javaClass.simpleName}: ${exception.message}")
+            logCgpWarning("sync failed", exception)
         }
+    }
+
+    private fun logCgpWarning(
+        action: String,
+        exception: Throwable,
+    ) {
+        log.warn("CodeGlance Pro $action: ${exception.javaClass.simpleName}: ${exception.message}")
     }
 }

--- a/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
@@ -558,8 +558,7 @@ class GlowOverlayManager(
         }
         overlays.clear()
 
-        UIManager.put(KEY_TAB_BACKGROUND, null)
-        UIManager.put(KEY_TAB_UNDERLINE, null)
+        // Tab accent keys are now managed by AccentApplicator (always-on, not glow-gated)
         removeFocusListeners()
 
         log.info("All glow overlays removed")

--- a/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
@@ -188,6 +188,9 @@ object LicenseChecker {
         // Disable glow (premium feature)
         state.glowEnabled = false
 
+        // Reset tab accent to free default (underline only, no tinted background)
+        state.glowTabMode = "MINIMAL"
+
         // Reset per-element toggles to defaults (all ON)
         for (id in AccentElementId.entries) {
             state.setToggle(id, true)

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
@@ -14,7 +14,6 @@ import dev.ayuislands.glow.GlowStyle
 import dev.ayuislands.licensing.LicenseChecker
 import java.awt.BorderLayout
 import java.awt.Color
-import java.awt.Dimension
 import javax.swing.DefaultComboBoxModel
 import javax.swing.JCheckBox
 import javax.swing.JLabel
@@ -71,7 +70,6 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
     private val islandCheckboxes = mutableMapOf<String, JCheckBox>()
     private var animationDescriptionLabel: JLabel? = null
     private var presetSegmentedButton: SegmentedButton<GlowPreset>? = null
-    private var glowPreview: GlowGroupPanel? = null
     private var glowGroupPanel: GlowGroupPanel? = null
 
     // Suppress listener events during programmatic updates
@@ -137,27 +135,7 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
             }
         }
 
-        if (!licensed) {
-            val variant = AyuVariant.detect() ?: AyuVariant.MIRAGE
-            val accentHex = AyuIslandsSettings.getInstance().getAccentForVariant(variant)
-            val preview = GlowGroupPanel()
-            preview.preferredSize = Dimension(PREVIEW_WIDTH, PREVIEW_HEIGHT)
-            preview.updateFromPreset(
-                GlowStyle.SOFT,
-                GlowPreset.WHISPER.intensity ?: DEFAULT_INTENSITY,
-                GlowPreset.WHISPER.width ?: DEFAULT_WIDTH,
-                try {
-                    Color.decode(accentHex)
-                } catch (_: NumberFormatException) {
-                    Color.decode(FALLBACK_COLOR_HEX)
-                },
-                true,
-            )
-            glowPreview = preview
-            panel.row {
-                cell(preview).align(Align.FILL)
-            }
-        }
+        // Preview panel removed: the main GlowGroupPanel border serves as a live preview
     }
 
     private fun buildStyleGroup(
@@ -224,7 +202,7 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
         updateGlowGroupPanel()
 
         panel.row {
-            cell(glowPanel).resizableColumn().align(Align.FILL)
+            cell(glowPanel)
         }
     }
 
@@ -531,7 +509,8 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
         val intensity = pendingIntensity[style] ?: style.defaultIntensity
         val width = pendingWidth[style] ?: style.defaultWidth
         val color = resolveAccentColor()
-        panel.updateFromPreset(style, intensity, width, color, pendingGlowEnabled)
+        val visible = pendingGlowEnabled || !LicenseChecker.isLicensedOrGrace()
+        panel.updateFromPreset(style, intensity, width, color, visible)
     }
 
     private fun updateControlStates() {
@@ -541,7 +520,7 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
         widthSlider?.isEnabled = enabled
         styleCombo?.isEnabled = enabled
         animationCombo?.isEnabled = enabled
-        presetSegmentedButton?.enabled(enabled)
+        presetSegmentedButton?.enabled(enabled || !LicenseChecker.isLicensedOrGrace())
 
         for ((_, cb) in islandCheckboxes) {
             cb.isEnabled = enabled
@@ -624,7 +603,5 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
         private const val DEFAULT_WIDTH = 4
         private const val WIDTH_MAJOR_TICK = 2
         private const val FALLBACK_COLOR_HEX = "#FFCC66"
-        private const val PREVIEW_WIDTH = 300
-        private const val PREVIEW_HEIGHT = 60
     }
 }

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsElementsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsElementsPanel.kt
@@ -202,12 +202,12 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
         licensed: Boolean,
     ) {
         val conflict = ConflictRegistry.getConflictFor(id)
-        val blocked = conflict?.type == ConflictType.BLOCK
+        val isBlocking = conflict != null && conflict.type == ConflictType.BLOCK
 
         panel.row {
             val cb = checkBox(id.displayName)
             cb.component.isSelected = pendingToggles[id] ?: true
-            cb.component.isEnabled = licensed && !blocked
+            cb.component.isEnabled = licensed && !isBlocking
             cb.component.addActionListener {
                 pendingToggles[id] = cb.component.isSelected
                 syncPreviewToggles()
@@ -231,9 +231,9 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
             )
         }
 
-        if (blocked) {
+        if (isBlocking) {
             panel.row {
-                comment("Managed by ${conflict!!.pluginDisplayName}")
+                comment("Managed by ${conflict.pluginDisplayName}")
             }
         }
     }

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsElementsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsElementsPanel.kt
@@ -80,7 +80,7 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
         preview.previewAccentHex = AyuIslandsSettings.getInstance().getAccentForVariant(variant)
         preview.previewToggles = pendingToggles.toMap()
         preview.previewGlowEnabled = false
-        val previewComponent = preview.createComponent(variant)
+        val previewComponent = preview.createComponent()
         elementPreview = preview
 
         panel.group("Accent Elements") {
@@ -231,9 +231,9 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
             )
         }
 
-        if (blocked && conflict != null) {
+        if (blocked) {
             panel.row {
-                comment("Managed by ${conflict.pluginDisplayName}")
+                comment("Managed by ${conflict!!.pluginDisplayName}")
             }
         }
     }

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsPreviewPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsPreviewPanel.kt
@@ -43,7 +43,7 @@ class AyuIslandsPreviewPanel : AyuIslandsSettingsPanel {
     ) {
         previewAccentHex = variant.defaultAccent
 
-        val mockup = AccentPreviewComponent(variant)
+        val mockup = AccentPreviewComponent()
         mockupComponent = mockup
 
         val wrapper = JPanel(FlowLayout(FlowLayout.LEFT, 0, 0))
@@ -53,8 +53,8 @@ class AyuIslandsPreviewPanel : AyuIslandsSettingsPanel {
         panel.row { cell(wrapper) }
     }
 
-    fun createComponent(variant: AyuVariant): JComponent {
-        val mockup = AccentPreviewComponent(variant)
+    fun createComponent(): JComponent {
+        val mockup = AccentPreviewComponent()
         mockupComponent = mockup
 
         val wrapper = JPanel()
@@ -87,9 +87,7 @@ class AyuIslandsPreviewPanel : AyuIslandsSettingsPanel {
         val scrollbarWidth: Int,
     )
 
-    private inner class AccentPreviewComponent(
-        private val variant: AyuVariant,
-    ) : JComponent() {
+    private inner class AccentPreviewComponent : JComponent() {
         private val glowRenderer = GlowRenderer()
 
         init {
@@ -105,7 +103,7 @@ class AyuIslandsPreviewPanel : AyuIslandsSettingsPanel {
                 val panelBackground =
                     UIManager.getColor("Panel.background")
                         ?: Color(FALLBACK_BG_RED, FALLBACK_BG_GREEN, FALLBACK_BG_BLUE)
-                val editorBackground = darken(panelBackground, DARKEN_FACTOR)
+                val editorBackground = darken(panelBackground)
                 val mutedForeground =
                     UIManager.getColor("Label.disabledForeground")
                         ?: Color(MUTED_FG_CHANNEL, MUTED_FG_CHANNEL, MUTED_FG_CHANNEL)
@@ -444,13 +442,10 @@ class AyuIslandsPreviewPanel : AyuIslandsSettingsPanel {
                 Color(FALLBACK_RED, FALLBACK_GREEN, FALLBACK_BLUE)
             }
 
-        private fun darken(
-            color: Color,
-            factor: Float,
-        ): Color {
-            val red = (color.red * (1 - factor)).toInt().coerceIn(0, MAX_COLOR_CHANNEL)
-            val green = (color.green * (1 - factor)).toInt().coerceIn(0, MAX_COLOR_CHANNEL)
-            val blue = (color.blue * (1 - factor)).toInt().coerceIn(0, MAX_COLOR_CHANNEL)
+        private fun darken(color: Color): Color {
+            val red = (color.red * (1 - DARKEN_FACTOR)).toInt().coerceIn(0, MAX_COLOR_CHANNEL)
+            val green = (color.green * (1 - DARKEN_FACTOR)).toInt().coerceIn(0, MAX_COLOR_CHANNEL)
+            val blue = (color.blue * (1 - DARKEN_FACTOR)).toInt().coerceIn(0, MAX_COLOR_CHANNEL)
             return Color(red, green, blue)
         }
     }
@@ -482,9 +477,6 @@ class AyuIslandsPreviewPanel : AyuIslandsSettingsPanel {
         const val CODE_INDENT = 12
         const val LINE_GAP = 4
         const val LINE_START_OFFSET = 6
-
-        // Tab underline
-        const val UNDERLINE_HEIGHT = 3
 
         // Alpha values
         const val DIMMED_ALPHA = 77


### PR DESCRIPTION
── Summary ──

- Consolidate 3 CI analysis jobs (ktlint, detekt, Kotlin warnings) into single Analyze job
- Split verify matrix into A/B groups for parallel IDE verification
- Transfer tab accent ownership from GlowOverlayManager to AccentApplicator (always-on)
- Fix lint/detekt warnings across AccentApplicator, ElementsPanel, PreviewPanel

── Changes ──

**CI** (`build.yml`, `build.gradle.kts`)
- Merge ktlint + detekt + warnings-as-errors into single job
- Split verify into Group A (IC/IU + major IDEs) and Group B (language IDEs)

**Architecture** (`GlowOverlayManager`, `LicenseChecker`, `EffectsPanel`)
- Tab accent keys managed by AccentApplicator, not glow lifecycle
- Reset glowTabMode to MINIMAL on license downgrade
- Remove unused glow preview panel; fix preset button for unlicensed users

**Lint** (`AccentApplicator`, `ElementsPanel`, `PreviewPanel`, `detekt.yml`)
- Extract `KEY_TAB_BACKGROUND`, `CGP_RESOLUTION_FAILED`, `CGP_SYNC_FAILED` constants
- Extract `applyElements()` method (cognitive complexity)
- Extract `logCgpWarning()` helper (catch-block dedup)
- Remove unused `variant` param from `createComponent()`
- Use smart-cast null handling for `conflict` in `buildToggleRow()`
- Clear underline color in OFF tab mode when variant is null
- Raise detekt `thresholdInObjects` to 15

── Validation ──

- [x] `./gradlew buildPlugin` — compiles
- [x] `./gradlew ktlintCheck detekt` — zero warnings
- [x] Manual: tab accent MINIMAL/FULL/OFF modes render correctly
- [x] Manual: accent elements toggle correctly in settings
- [x] Manual: license downgrade resets tab mode to MINIMAL