### PR TITLE
feat: follow macOS system accent color and appearance

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,7 +69,7 @@ intellijPlatform {
         freeArgs =
             listOf(
                 "-mute",
-                "ReleaseVersionAndPluginVersionMismatch",
+                "ReleaseVersionAndPluginVersionMismatch,ExperimentalApiUsage",
             )
         ides {
             val group = providers.systemProperty("verifyGroup").orNull

--- a/src/main/kotlin/dev/ayuislands/AppearanceSyncListener.kt
+++ b/src/main/kotlin/dev/ayuislands/AppearanceSyncListener.kt
@@ -1,0 +1,13 @@
+package dev.ayuislands
+
+import com.intellij.openapi.application.ApplicationActivationListener
+import com.intellij.openapi.wm.IdeFrame
+import dev.ayuislands.settings.AyuIslandsSettings
+
+class AppearanceSyncListener : ApplicationActivationListener {
+    override fun applicationActivated(ideFrame: IdeFrame) {
+        val settings = AyuIslandsSettings.getInstance()
+        if (!settings.state.followSystemAppearance) return
+        AppearanceSyncService.getInstance().syncIfNeeded()
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/AppearanceSyncService.kt
+++ b/src/main/kotlin/dev/ayuislands/AppearanceSyncService.kt
@@ -27,11 +27,9 @@ class AppearanceSyncService {
         val appearance = SystemAppearanceProvider.resolve() ?: return
         if (appearance == lastSyncedAppearance) return
 
-        // Only act when an Ayu theme is active
-        if (AyuVariant.detect() == null) {
-            lastSyncedAppearance = appearance
-            return
-        }
+        // Skip when no Ayu theme is active — don't update lastSyncedAppearance
+        // so sync triggers immediately when an Ayu theme becomes active
+        if (AyuVariant.detect() == null) return
 
         val settings = AyuIslandsSettings.getInstance()
         val targetThemeName =

--- a/src/main/kotlin/dev/ayuislands/AppearanceSyncService.kt
+++ b/src/main/kotlin/dev/ayuislands/AppearanceSyncService.kt
@@ -72,8 +72,7 @@ class AppearanceSyncService {
         LOG.info("Switching theme: $currentThemeName -> $targetThemeName")
         programmaticSwitch = true
         SwingUtilities.invokeLater {
-            @Suppress("DEPRECATION")
-            lafManager.setCurrentLookAndFeel(target as javax.swing.UIManager.LookAndFeelInfo)
+            lafManager.setCurrentLookAndFeel(target, true)
             lafManager.updateUI()
         }
     }

--- a/src/main/kotlin/dev/ayuislands/AppearanceSyncService.kt
+++ b/src/main/kotlin/dev/ayuislands/AppearanceSyncService.kt
@@ -1,0 +1,86 @@
+package dev.ayuislands
+
+import com.intellij.ide.ui.LafManager
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.diagnostic.logger
+import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.accent.SystemAppearanceProvider
+import dev.ayuislands.accent.SystemAppearanceProvider.Appearance
+import dev.ayuislands.settings.AyuIslandsSettings
+import javax.swing.SwingUtilities
+
+@Service
+class AppearanceSyncService {
+    private var lastSyncedAppearance: Appearance? = null
+
+    /** Set by [syncIfNeeded] before programmatic switch, cleared by [AyuIslandsLafListener]. */
+    @Volatile
+    var programmaticSwitch: Boolean = false
+        private set
+
+    fun clearProgrammaticSwitch() {
+        programmaticSwitch = false
+    }
+
+    fun syncIfNeeded() {
+        val appearance = SystemAppearanceProvider.resolve() ?: return
+        if (appearance == lastSyncedAppearance) return
+
+        // Only act when an Ayu theme is active
+        if (AyuVariant.detect() == null) {
+            lastSyncedAppearance = appearance
+            return
+        }
+
+        val settings = AyuIslandsSettings.getInstance()
+        val targetThemeName =
+            when (appearance) {
+                Appearance.DARK -> settings.state.lastDarkThemeName
+                Appearance.LIGHT -> settings.state.lastLightThemeName
+            } ?: return
+
+        lastSyncedAppearance = appearance
+        switchToTheme(targetThemeName)
+    }
+
+    /** Records which theme the user manually picked for the given appearance slot. */
+    fun recordManualChoice(themeName: String) {
+        val variant = AyuVariant.fromThemeName(themeName) ?: return
+        val settings = AyuIslandsSettings.getInstance()
+        when (variant) {
+            AyuVariant.MIRAGE, AyuVariant.DARK -> settings.state.lastDarkThemeName = themeName
+            AyuVariant.LIGHT -> settings.state.lastLightThemeName = themeName
+        }
+        LOG.info("Recorded manual appearance choice: $themeName")
+    }
+
+    @Suppress("UnstableApiUsage", "DEPRECATION")
+    private fun switchToTheme(targetThemeName: String) {
+        val lafManager = LafManager.getInstance()
+        val currentThemeName = lafManager.currentUIThemeLookAndFeel.name
+        if (currentThemeName == targetThemeName) return
+
+        val target = lafManager.installedThemes.firstOrNull { it.name == targetThemeName }
+        if (target == null) {
+            LOG.warn("Target theme not found: $targetThemeName")
+            return
+        }
+
+        LOG.info("Switching theme: $currentThemeName -> $targetThemeName")
+        programmaticSwitch = true
+        SwingUtilities.invokeLater {
+            lafManager.setCurrentLookAndFeel(target as javax.swing.UIManager.LookAndFeelInfo)
+            lafManager.updateUI()
+        }
+    }
+
+    companion object {
+        private val LOG = logger<AppearanceSyncService>()
+
+        fun getInstance(): AppearanceSyncService =
+            ApplicationManager
+                .getApplication()
+                .getService(AppearanceSyncService::class.java)
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/AppearanceSyncService.kt
+++ b/src/main/kotlin/dev/ayuislands/AppearanceSyncService.kt
@@ -55,13 +55,15 @@ class AppearanceSyncService {
         LOG.info("Recorded manual appearance choice: $themeName")
     }
 
-    @Suppress("UnstableApiUsage", "DEPRECATION")
+    @Suppress("UnstableApiUsage")
     private fun switchToTheme(targetThemeName: String) {
         val lafManager = LafManager.getInstance()
         val currentThemeName = lafManager.currentUIThemeLookAndFeel.name
         if (currentThemeName == targetThemeName) return
 
-        val target = lafManager.installedThemes.firstOrNull { it.name == targetThemeName }
+        val target =
+            lafManager.installedThemes
+                .firstOrNull { it.name == targetThemeName }
         if (target == null) {
             LOG.warn("Target theme not found: $targetThemeName")
             return
@@ -70,6 +72,7 @@ class AppearanceSyncService {
         LOG.info("Switching theme: $currentThemeName -> $targetThemeName")
         programmaticSwitch = true
         SwingUtilities.invokeLater {
+            @Suppress("DEPRECATION")
             lafManager.setCurrentLookAndFeel(target as javax.swing.UIManager.LookAndFeelInfo)
             lafManager.updateUI()
         }

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsLafListener.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsLafListener.kt
@@ -11,6 +11,7 @@ import dev.ayuislands.settings.AyuIslandsSettings
 
 /** Re-applies accent color on theme change. */
 class AyuIslandsLafListener : LafManagerListener {
+    @Suppress("UnstableApiUsage")
     override fun lookAndFeelChanged(source: LafManager) {
         val variant = AyuVariant.detect()
         if (variant == null) {
@@ -24,6 +25,14 @@ class AyuIslandsLafListener : LafManagerListener {
         val accentHex = settings.getAccentForVariant(variant)
         AccentApplicator.apply(accentHex)
         LOG.info("Ayu Islands accent re-applied on theme change: $accentHex")
+
+        // Track manual sub-variant choices for appearance sync
+        val syncService = AppearanceSyncService.getInstance()
+        if (settings.state.followSystemAppearance && !syncService.programmaticSwitch) {
+            val themeName = source.currentUIThemeLookAndFeel.name
+            syncService.recordManualChoice(themeName)
+        }
+        syncService.clearProgrammaticSwitch()
 
         // Update glow overlays with new accent color
         updateGlowForAllProjects()

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -36,6 +36,11 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
         // Check license state
         checkLicenseState(project, variant, settings)
 
+        // Auto-switch theme to match macOS Light/Dark mode
+        if (settings.state.followSystemAppearance) {
+            AppearanceSyncService.getInstance().syncIfNeeded()
+        }
+
         // Initialize the glow overlay system if the glow is enabled
         // Uses ApplicationManager.invokeLater with project.disposed condition to skip
         // if the project closes before the EDT processes this (execute() runs on a background coroutine)

--- a/src/main/kotlin/dev/ayuislands/accent/AccentColor.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentColor.kt
@@ -17,4 +17,6 @@ val AYU_ACCENT_PRESETS: List<AccentColor> =
         AccentColor("#95E6CB", "Mint"),
         AccentColor("#73D0FF", "Sky"),
         AccentColor("#5CCFE6", "Cyan"),
+        AccentColor("#F27983", "Rose"),
+        AccentColor("#8A9199", "Slate"),
     )

--- a/src/main/kotlin/dev/ayuislands/accent/CachedMacReader.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/CachedMacReader.kt
@@ -1,0 +1,26 @@
+package dev.ayuislands.accent
+
+import com.intellij.openapi.util.SystemInfo
+import javax.swing.SwingUtilities
+
+class CachedMacReader<T>(
+    private val ttlMs: Long = 5_000L,
+    private val reader: () -> T?,
+) {
+    @Volatile
+    private var cached: T? = null
+
+    @Volatile
+    private var timestamp: Long = 0L
+
+    fun read(): T? {
+        if (!SystemInfo.isMac) return null
+        val now = System.currentTimeMillis()
+        if (now - timestamp < ttlMs) return cached
+        if (SwingUtilities.isEventDispatchThread()) return cached
+        val result = reader()
+        cached = result
+        timestamp = now
+        return result
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/accent/SystemAccentProvider.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/SystemAccentProvider.kt
@@ -1,8 +1,6 @@
 package dev.ayuislands.accent
 
-import com.intellij.openapi.util.SystemInfo
 import java.util.concurrent.TimeUnit
-import javax.swing.SwingUtilities
 
 /**
  * Reads the macOS system accent color and maps it to the nearest Ayu preset hex.
@@ -33,25 +31,11 @@ object SystemAccentProvider {
         )
 
     private const val DEFAULT_ACCENT_HEX = "#73D0FF" // Blue (macOS default)
-    private const val CACHE_TTL_MS = 5_000L
     private const val PROCESS_TIMEOUT_MS = 2_000L
 
-    @Volatile
-    private var cachedHex: String? = null
+    private val cache = CachedMacReader { readFromSystem() }
 
-    @Volatile
-    private var cacheTimestamp: Long = 0L
-
-    fun resolve(): String? {
-        if (!SystemInfo.isMac) return null
-        val now = System.currentTimeMillis()
-        if (now - cacheTimestamp < CACHE_TTL_MS) return cachedHex
-        if (SwingUtilities.isEventDispatchThread()) return cachedHex
-        val result = readFromSystem()
-        cachedHex = result
-        cacheTimestamp = now
-        return result
-    }
+    fun resolve(): String? = cache.read()
 
     private fun readFromSystem(): String? {
         return try {

--- a/src/main/kotlin/dev/ayuislands/accent/SystemAccentProvider.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/SystemAccentProvider.kt
@@ -1,0 +1,57 @@
+package dev.ayuislands.accent
+
+import com.intellij.openapi.util.SystemInfo
+
+/**
+ * Reads the macOS system accent color and maps it to the nearest Ayu preset hex.
+ *
+ * Returns null on non-macOS platforms or when the accent cannot be determined.
+ */
+object SystemAccentProvider {
+    // macOS AppleAccentColor integer → Ayu preset hex
+    private const val BLUE_ACCENT = 4
+    private const val PURPLE_ACCENT = 5
+    private const val PINK_ACCENT = 6
+    private const val RED_ACCENT = 0
+    private const val ORANGE_ACCENT = 1
+    private const val YELLOW_ACCENT = 2
+    private const val GREEN_ACCENT = 3
+    private const val GRAPHITE_ACCENT = -1
+
+    private val MACOS_ACCENT_MAP: Map<Int, String> =
+        mapOf(
+            BLUE_ACCENT to "#73D0FF", // Sky
+            PURPLE_ACCENT to "#DFBFFF", // Lavender
+            PINK_ACCENT to "#F27983", // Rose
+            RED_ACCENT to "#F28779", // Coral
+            ORANGE_ACCENT to "#FFA659", // Orange
+            YELLOW_ACCENT to "#FFCD66", // Gold
+            GREEN_ACCENT to "#95E6CB", // Mint
+            GRAPHITE_ACCENT to "#8A9199", // Slate
+        )
+
+    private const val DEFAULT_ACCENT_HEX = "#73D0FF" // Blue (macOS default)
+
+    fun resolve(): String? {
+        if (!SystemInfo.isMac) return null
+        return try {
+            val process =
+                ProcessBuilder("defaults", "read", "-g", "AppleAccentColor")
+                    .redirectErrorStream(true)
+                    .start()
+            val output =
+                process.inputStream
+                    .bufferedReader()
+                    .readText()
+                    .trim()
+            val exitCode = process.waitFor()
+            if (exitCode != 0) {
+                return DEFAULT_ACCENT_HEX
+            }
+            val accentValue = output.toIntOrNull() ?: return DEFAULT_ACCENT_HEX
+            MACOS_ACCENT_MAP[accentValue] ?: DEFAULT_ACCENT_HEX
+        } catch (_: Exception) {
+            null
+        }
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/accent/SystemAccentProvider.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/SystemAccentProvider.kt
@@ -31,9 +31,25 @@ object SystemAccentProvider {
         )
 
     private const val DEFAULT_ACCENT_HEX = "#73D0FF" // Blue (macOS default)
+    private const val CACHE_TTL_MS = 5_000L
+
+    @Volatile
+    private var cachedHex: String? = null
+
+    @Volatile
+    private var cacheTimestamp: Long = 0L
 
     fun resolve(): String? {
         if (!SystemInfo.isMac) return null
+        val now = System.currentTimeMillis()
+        if (now - cacheTimestamp < CACHE_TTL_MS) return cachedHex
+        val result = readFromSystem()
+        cachedHex = result
+        cacheTimestamp = now
+        return result
+    }
+
+    private fun readFromSystem(): String? {
         return try {
             val process =
                 ProcessBuilder("defaults", "read", "-g", "AppleAccentColor")
@@ -46,10 +62,13 @@ object SystemAccentProvider {
                     .trim()
             val exitCode = process.waitFor()
             if (exitCode != 0) {
-                return DEFAULT_ACCENT_HEX
+                DEFAULT_ACCENT_HEX
+            } else {
+                val accentValue =
+                    output.toIntOrNull()
+                        ?: return DEFAULT_ACCENT_HEX
+                MACOS_ACCENT_MAP[accentValue] ?: DEFAULT_ACCENT_HEX
             }
-            val accentValue = output.toIntOrNull() ?: return DEFAULT_ACCENT_HEX
-            MACOS_ACCENT_MAP[accentValue] ?: DEFAULT_ACCENT_HEX
         } catch (_: Exception) {
             null
         }

--- a/src/main/kotlin/dev/ayuislands/accent/SystemAccentProvider.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/SystemAccentProvider.kt
@@ -1,6 +1,8 @@
 package dev.ayuislands.accent
 
 import com.intellij.openapi.util.SystemInfo
+import java.util.concurrent.TimeUnit
+import javax.swing.SwingUtilities
 
 /**
  * Reads the macOS system accent color and maps it to the nearest Ayu preset hex.
@@ -32,6 +34,7 @@ object SystemAccentProvider {
 
     private const val DEFAULT_ACCENT_HEX = "#73D0FF" // Blue (macOS default)
     private const val CACHE_TTL_MS = 5_000L
+    private const val PROCESS_TIMEOUT_MS = 2_000L
 
     @Volatile
     private var cachedHex: String? = null
@@ -43,6 +46,7 @@ object SystemAccentProvider {
         if (!SystemInfo.isMac) return null
         val now = System.currentTimeMillis()
         if (now - cacheTimestamp < CACHE_TTL_MS) return cachedHex
+        if (SwingUtilities.isEventDispatchThread()) return cachedHex
         val result = readFromSystem()
         cachedHex = result
         cacheTimestamp = now
@@ -60,7 +64,12 @@ object SystemAccentProvider {
                     .bufferedReader()
                     .readText()
                     .trim()
-            val exitCode = process.waitFor()
+            val finished = process.waitFor(PROCESS_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            if (!finished) {
+                process.destroyForcibly()
+                return null
+            }
+            val exitCode = process.exitValue()
             if (exitCode != 0) {
                 DEFAULT_ACCENT_HEX
             } else {

--- a/src/main/kotlin/dev/ayuislands/accent/SystemAppearanceProvider.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/SystemAppearanceProvider.kt
@@ -1,0 +1,38 @@
+package dev.ayuislands.accent
+
+import com.intellij.openapi.util.SystemInfo
+
+/**
+ * Reads the macOS system appearance (Light / Dark mode).
+ *
+ * Returns null on non-macOS platforms or when detection fails.
+ */
+object SystemAppearanceProvider {
+    enum class Appearance { LIGHT, DARK }
+
+    fun resolve(): Appearance? {
+        if (!SystemInfo.isMac) return null
+        return try {
+            val process =
+                ProcessBuilder("defaults", "read", "-g", "AppleInterfaceStyle")
+                    .redirectErrorStream(true)
+                    .start()
+            val output =
+                process.inputStream
+                    .bufferedReader()
+                    .readText()
+                    .trim()
+            val exitCode = process.waitFor()
+            if (exitCode != 0) {
+                // Key absent means Light mode
+                Appearance.LIGHT
+            } else if (output.equals("Dark", ignoreCase = true)) {
+                Appearance.DARK
+            } else {
+                Appearance.LIGHT
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/accent/SystemAppearanceProvider.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/SystemAppearanceProvider.kt
@@ -1,6 +1,8 @@
 package dev.ayuislands.accent
 
 import com.intellij.openapi.util.SystemInfo
+import java.util.concurrent.TimeUnit
+import javax.swing.SwingUtilities
 
 /**
  * Reads the macOS system appearance (Light / Dark mode).
@@ -11,6 +13,7 @@ object SystemAppearanceProvider {
     enum class Appearance { LIGHT, DARK }
 
     private const val CACHE_TTL_MS = 5_000L
+    private const val PROCESS_TIMEOUT_MS = 2_000L
 
     @Volatile
     private var cachedAppearance: Appearance? = null
@@ -22,6 +25,7 @@ object SystemAppearanceProvider {
         if (!SystemInfo.isMac) return null
         val now = System.currentTimeMillis()
         if (now - cacheTimestamp < CACHE_TTL_MS) return cachedAppearance
+        if (SwingUtilities.isEventDispatchThread()) return cachedAppearance
         val result = readFromSystem()
         cachedAppearance = result
         cacheTimestamp = now
@@ -39,7 +43,12 @@ object SystemAppearanceProvider {
                     .bufferedReader()
                     .readText()
                     .trim()
-            val exitCode = process.waitFor()
+            val finished = process.waitFor(PROCESS_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            if (!finished) {
+                process.destroyForcibly()
+                return null
+            }
+            val exitCode = process.exitValue()
             if (exitCode != 0) {
                 // Key absent means Light mode
                 Appearance.LIGHT

--- a/src/main/kotlin/dev/ayuislands/accent/SystemAppearanceProvider.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/SystemAppearanceProvider.kt
@@ -1,8 +1,6 @@
 package dev.ayuislands.accent
 
-import com.intellij.openapi.util.SystemInfo
 import java.util.concurrent.TimeUnit
-import javax.swing.SwingUtilities
 
 /**
  * Reads the macOS system appearance (Light / Dark mode).
@@ -12,25 +10,11 @@ import javax.swing.SwingUtilities
 object SystemAppearanceProvider {
     enum class Appearance { LIGHT, DARK }
 
-    private const val CACHE_TTL_MS = 5_000L
     private const val PROCESS_TIMEOUT_MS = 2_000L
 
-    @Volatile
-    private var cachedAppearance: Appearance? = null
+    private val cache = CachedMacReader { readFromSystem() }
 
-    @Volatile
-    private var cacheTimestamp: Long = 0L
-
-    fun resolve(): Appearance? {
-        if (!SystemInfo.isMac) return null
-        val now = System.currentTimeMillis()
-        if (now - cacheTimestamp < CACHE_TTL_MS) return cachedAppearance
-        if (SwingUtilities.isEventDispatchThread()) return cachedAppearance
-        val result = readFromSystem()
-        cachedAppearance = result
-        cacheTimestamp = now
-        return result
-    }
+    fun resolve(): Appearance? = cache.read()
 
     private fun readFromSystem(): Appearance? =
         try {

--- a/src/main/kotlin/dev/ayuislands/accent/SystemAppearanceProvider.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/SystemAppearanceProvider.kt
@@ -10,9 +10,26 @@ import com.intellij.openapi.util.SystemInfo
 object SystemAppearanceProvider {
     enum class Appearance { LIGHT, DARK }
 
+    private const val CACHE_TTL_MS = 5_000L
+
+    @Volatile
+    private var cachedAppearance: Appearance? = null
+
+    @Volatile
+    private var cacheTimestamp: Long = 0L
+
     fun resolve(): Appearance? {
         if (!SystemInfo.isMac) return null
-        return try {
+        val now = System.currentTimeMillis()
+        if (now - cacheTimestamp < CACHE_TTL_MS) return cachedAppearance
+        val result = readFromSystem()
+        cachedAppearance = result
+        cacheTimestamp = now
+        return result
+    }
+
+    private fun readFromSystem(): Appearance? =
+        try {
             val process =
                 ProcessBuilder("defaults", "read", "-g", "AppleInterfaceStyle")
                     .redirectErrorStream(true)
@@ -34,5 +51,4 @@ object SystemAppearanceProvider {
         } catch (_: Exception) {
             null
         }
-    }
 }

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -117,7 +117,7 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
 
         val effectiveAccent =
             if (pendingFollowSystem) {
-                SystemAccentProvider.resolve() ?: pendingAccent
+                settings.getAccentForVariant(currentVariant)
             } else {
                 settings.setAccentForVariant(currentVariant, pendingAccent)
                 pendingAccent

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -41,7 +41,7 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
 
         panel.group("Accent Color") {
             row {
-                comment("Choose your accent color and which UI elements use it.")
+                comment("Choose your accent color. Swatches are shared across all variants.")
                 link("Reset") {
                     pendingAccent = variant.defaultAccent
                     swatch.selectedColor = variant.defaultAccent
@@ -101,7 +101,9 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
         onAccentChanged?.invoke(variant.defaultAccent)
     }
 
-    override fun isModified(): Boolean = pendingAccent != storedAccent || pendingFollowSystem != storedFollowSystem
+    override fun isModified(): Boolean =
+        pendingAccent != storedAccent ||
+            pendingFollowSystem != storedFollowSystem
 
     override fun apply() {
         val currentVariant = variant ?: return

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -1,9 +1,12 @@
 package dev.ayuislands.settings
 
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.dsl.builder.Panel
 import dev.ayuislands.accent.AYU_ACCENT_PRESETS
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.accent.SystemAccentProvider
 
 /** Accent color section for the Ayu Islands settings panel. */
 class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
@@ -13,6 +16,10 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
     private var swatchPanel: ColorSwatchPanel? = null
     var onAccentChanged: ((String) -> Unit)? = null
 
+    private var pendingFollowSystem: Boolean = false
+    private var storedFollowSystem: Boolean = false
+    private var followSystemCheckbox: JBCheckBox? = null
+
     override fun buildPanel(
         panel: Panel,
         variant: AyuVariant,
@@ -21,6 +28,8 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
         val settings = AyuIslandsSettings.getInstance()
         storedAccent = settings.getAccentForVariant(variant)
         pendingAccent = storedAccent
+        storedFollowSystem = settings.state.followSystemAccent
+        pendingFollowSystem = storedFollowSystem
 
         val swatch =
             ColorSwatchPanel(AYU_ACCENT_PRESETS) { accent ->
@@ -39,7 +48,50 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
                     onAccentChanged?.invoke(variant.defaultAccent)
                 }
             }
+            if (SystemInfo.isMac) {
+                row {
+                    val checkbox =
+                        checkBox("Follow system accent color")
+                            .component
+                    checkbox.isSelected = pendingFollowSystem
+                    checkbox.addActionListener {
+                        pendingFollowSystem = checkbox.isSelected
+                        updateSwatchEnabled()
+                        if (pendingFollowSystem) {
+                            SystemAccentProvider.resolve()?.let { hex ->
+                                swatch.selectedColor = hex
+                                onAccentChanged?.invoke(hex)
+                            }
+                        } else {
+                            val manualAccent = getManualAccent(variant, settings)
+                            swatch.selectedColor = manualAccent
+                            pendingAccent = manualAccent
+                            onAccentChanged?.invoke(manualAccent)
+                        }
+                    }
+                    followSystemCheckbox = checkbox
+                }
+            }
             row { cell(swatch) }
+        }
+
+        updateSwatchEnabled()
+    }
+
+    private fun getManualAccent(
+        variant: AyuVariant,
+        settings: AyuIslandsSettings,
+    ): String =
+        when (variant) {
+            AyuVariant.MIRAGE -> settings.state.mirageAccent ?: variant.defaultAccent
+            AyuVariant.DARK -> settings.state.darkAccent ?: variant.defaultAccent
+            AyuVariant.LIGHT -> settings.state.lightAccent ?: variant.defaultAccent
+        }
+
+    private fun updateSwatchEnabled() {
+        val following = pendingFollowSystem
+        swatchPanel?.let { panel ->
+            panel.components.forEach { it.isEnabled = !following }
         }
     }
 
@@ -49,19 +101,35 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
         onAccentChanged?.invoke(variant.defaultAccent)
     }
 
-    override fun isModified(): Boolean = pendingAccent != storedAccent
+    override fun isModified(): Boolean = pendingAccent != storedAccent || pendingFollowSystem != storedFollowSystem
 
     override fun apply() {
         val currentVariant = variant ?: return
         if (!isModified()) return
         val settings = AyuIslandsSettings.getInstance()
-        settings.setAccentForVariant(currentVariant, pendingAccent)
-        AccentApplicator.apply(pendingAccent)
-        storedAccent = pendingAccent
+
+        if (pendingFollowSystem != storedFollowSystem) {
+            settings.state.followSystemAccent = pendingFollowSystem
+            storedFollowSystem = pendingFollowSystem
+        }
+
+        val effectiveAccent =
+            if (pendingFollowSystem) {
+                SystemAccentProvider.resolve() ?: pendingAccent
+            } else {
+                settings.setAccentForVariant(currentVariant, pendingAccent)
+                pendingAccent
+            }
+
+        AccentApplicator.apply(effectiveAccent)
+        storedAccent = effectiveAccent
     }
 
     override fun reset() {
         pendingAccent = storedAccent
+        pendingFollowSystem = storedFollowSystem
         swatchPanel?.selectedColor = storedAccent
+        followSystemCheckbox?.isSelected = storedFollowSystem
+        updateSwatchEnabled()
     }
 }

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAppearancePanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAppearancePanel.kt
@@ -1,0 +1,56 @@
+package dev.ayuislands.settings
+
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.dsl.builder.Panel
+import dev.ayuislands.AppearanceSyncService
+import dev.ayuislands.accent.AyuVariant
+
+/** System appearance section — visible on macOS only. */
+class AyuIslandsAppearancePanel : AyuIslandsSettingsPanel {
+    private var pendingFollowAppearance: Boolean = false
+    private var storedFollowAppearance: Boolean = false
+    private var followAppearanceCheckbox: JBCheckBox? = null
+
+    override fun buildPanel(
+        panel: Panel,
+        variant: AyuVariant,
+    ) {
+        val settings = AyuIslandsSettings.getInstance()
+        storedFollowAppearance = settings.state.followSystemAppearance
+        pendingFollowAppearance = storedFollowAppearance
+
+        if (!SystemInfo.isMac) return
+
+        panel.group("System") {
+            row { comment("Automatically switch between Light and Dark variants.") }
+            row {
+                val checkbox =
+                    checkBox("Follow system appearance (Light / Dark)")
+                        .component
+                checkbox.isSelected = pendingFollowAppearance
+                checkbox.addActionListener {
+                    pendingFollowAppearance = checkbox.isSelected
+                }
+                followAppearanceCheckbox = checkbox
+            }
+        }
+    }
+
+    override fun isModified(): Boolean = pendingFollowAppearance != storedFollowAppearance
+
+    override fun apply() {
+        if (!isModified()) return
+        val settings = AyuIslandsSettings.getInstance()
+        settings.state.followSystemAppearance = pendingFollowAppearance
+        storedFollowAppearance = pendingFollowAppearance
+        if (pendingFollowAppearance) {
+            AppearanceSyncService.getInstance().syncIfNeeded()
+        }
+    }
+
+    override fun reset() {
+        pendingFollowAppearance = storedFollowAppearance
+        followAppearanceCheckbox?.isSelected = storedFollowAppearance
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt
@@ -27,12 +27,14 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
     private var pendingSelectedTab: Int =
         AyuIslandsSettings.getInstance().state.settingsSelectedTab
 
+    private val appearancePanel = AyuIslandsAppearancePanel()
     private val accentPanel = AyuIslandsAccentPanel()
     private val elementsPanel = AyuIslandsElementsPanel()
     private val effectsPanel = AyuIslandsEffectsPanel()
 
     private val panels: List<AyuIslandsSettingsPanel> =
         listOf(
+            appearancePanel,
             accentPanel,
             elementsPanel,
             effectsPanel,
@@ -62,6 +64,7 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
         // Build tab content panels eagerly via DSL
         val accentTab =
             panel {
+                appearancePanel.buildPanel(this@panel, variant)
                 accentPanel.buildPanel(this@panel, variant)
                 elementsPanel.buildPanel(this@panel, variant)
 
@@ -105,6 +108,16 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
             row {
                 val status = if (LicenseChecker.isLicensedOrGrace()) "Licensed" else ""
                 comment("${variant.name} variant $status".trim())
+            }
+
+            if (!LicenseChecker.isLicensedOrGrace()) {
+                row {
+                    link("Get Ayu Islands Pro — unlock element toggles and glow effects") {
+                        LicenseChecker.requestLicense(
+                            "Unlock per-element accent toggles and neon glow effects",
+                        )
+                    }
+                }
             }
 
             // Tab container

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
@@ -6,7 +6,6 @@ import com.intellij.ui.dsl.builder.Align
 import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.dsl.builder.Row
 import com.intellij.ui.dsl.builder.SegmentedButton
-import com.intellij.util.ui.JBUI
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.glow.GlowAnimation
 import dev.ayuislands.glow.GlowPreset
@@ -68,7 +67,7 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
     private var intensityValueLabel: JLabel? = null
     private var widthValueLabel: JLabel? = null
     private val islandCheckboxes = mutableMapOf<String, JCheckBox>()
-    private var animationDescriptionLabel: JLabel? = null
+    private var animationDescriptionLabel: javax.swing.JEditorPane? = null
     private var presetSegmentedButton: SegmentedButton<GlowPreset>? = null
     private var glowGroupPanel: GlowGroupPanel? = null
 
@@ -116,15 +115,6 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
                 updateGlowGroupPanel()
             }
             masterToggle = cb.component
-
-            if (!licensed) {
-                @Suppress("DialogTitleCapitalization")
-                link("Get Ayu Islands Pro") {
-                    LicenseChecker.requestLicense(
-                        "Unlock per-element accent toggles and neon glow effects",
-                    )
-                }
-            }
 
             if (licensed) {
                 link("Reset defaults") {
@@ -309,11 +299,8 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
             }.visibleIf(customModeVisible)
         group
             .row {
-                val descLabel = JLabel(animationDescription(pendingAnimation))
-                descLabel.foreground = JBUI.CurrentTheme.ContextHelp.FOREGROUND
-                descLabel.font = JBUI.Fonts.smallFont()
-                animationDescriptionLabel = descLabel
-                cell(descLabel)
+                val descCell = comment(animationDescription(pendingAnimation))
+                animationDescriptionLabel = descCell.component
             }.visibleIf(customModeVisible)
     }
 
@@ -327,26 +314,25 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
                     "Fine-tune where glow appears. All targets are enabled by default.",
                 )
             }
+            row {
+                link("Enable all") {
+                    for (key in pendingIslandToggles.keys) {
+                        pendingIslandToggles[key] = true
+                    }
+                    refreshIslandCheckboxes()
+                }.enabled(licensed && pendingGlowEnabled)
+                link("Disable all") {
+                    for (key in pendingIslandToggles.keys) {
+                        pendingIslandToggles[key] = false
+                    }
+                    refreshIslandCheckboxes()
+                }.enabled(licensed && pendingGlowEnabled)
+            }
             // Headers row
             threeColumnsRow(
                 { label("Workspace").bold() },
                 { label("Output").bold() },
-                {
-                    label("VCS").bold()
-                    label("     ")
-                    link("Enable all") {
-                        for (key in pendingIslandToggles.keys) {
-                            pendingIslandToggles[key] = true
-                        }
-                        refreshIslandCheckboxes()
-                    }.enabled(licensed && pendingGlowEnabled)
-                    link("Disable all") {
-                        for (key in pendingIslandToggles.keys) {
-                            pendingIslandToggles[key] = false
-                        }
-                        refreshIslandCheckboxes()
-                    }.enabled(licensed && pendingGlowEnabled)
-                },
+                { label("VCS").bold() },
             )
             // Row 1: Editor | Terminal | Git
             threeColumnsRow(
@@ -449,7 +435,7 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
     // State management
 
     private fun migratePresetIfNeeded(state: AyuIslandsState): String {
-        if (state.glowPreset != null) return state.glowPreset!!
+        state.glowPreset?.let { return it }
         val style = GlowStyle.fromName(state.glowStyle ?: GlowStyle.SOFT.name)
         val intensity = state.getIntensityForStyle(style)
         val width = state.getWidthForStyle(style)
@@ -474,8 +460,7 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
         }
 
         pendingIslandToggles.clear()
-        val islandIds = listOf("Editor", "Project", "Terminal", "Run", "Debug", "Git", "Services")
-        for (id in islandIds) {
+        for (id in ISLAND_IDS) {
             pendingIslandToggles[id] = state.isIslandEnabled(id)
         }
 
@@ -573,8 +558,7 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
             state.setWidthForStyle(style, pendingWidth[style] ?: style.defaultWidth)
         }
 
-        val islandIds = listOf("Editor", "Project", "Terminal", "Run", "Debug", "Git", "Services")
-        for (id in islandIds) {
+        for (id in ISLAND_IDS) {
             state.setIslandEnabled(id, pendingIslandToggles[id] ?: false)
         }
 
@@ -603,5 +587,6 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
         private const val DEFAULT_WIDTH = 4
         private const val WIDTH_MAJOR_TICK = 2
         private const val FALLBACK_COLOR_HEX = "#FFCC66"
+        private val ISLAND_IDS = listOf("Editor", "Project", "Terminal", "Run", "Debug", "Git", "Services")
     }
 }

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsElementsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsElementsPanel.kt
@@ -5,7 +5,6 @@ package dev.ayuislands.settings
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.ui.dsl.builder.AlignY
 import com.intellij.ui.dsl.builder.Panel
-import com.intellij.util.ui.JBUI
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.AccentGroup
@@ -85,16 +84,7 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
 
         panel.group("Accent Elements") {
             if (!licensed) {
-                row {
-                    label("Per-element toggles require a Pro license").applyToComponent {
-                        foreground = JBUI.CurrentTheme.ContextHelp.FOREGROUND
-                    }
-                    link("Get Ayu Islands Pro") {
-                        LicenseChecker.requestLicense(
-                            "Unlock per-element accent toggles and neon glow effects",
-                        )
-                    }
-                }
+                row { comment("Per-element toggles require a Pro license.") }
             }
 
             row {

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsSettings.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsSettings.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.components.SimplePersistentStateComponent
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.accent.SystemAccentProvider
 
 @Service
 @State(
@@ -20,12 +21,16 @@ class AyuIslandsSettings : SimplePersistentStateComponent<AyuIslandsState>(AyuIs
                 .getService(AyuIslandsSettings::class.java)
     }
 
-    fun getAccentForVariant(variant: AyuVariant): String =
-        when (variant) {
+    fun getAccentForVariant(variant: AyuVariant): String {
+        if (state.followSystemAccent) {
+            SystemAccentProvider.resolve()?.let { return it }
+        }
+        return when (variant) {
             AyuVariant.MIRAGE -> state.mirageAccent ?: variant.defaultAccent
             AyuVariant.DARK -> state.darkAccent ?: variant.defaultAccent
             AyuVariant.LIGHT -> state.lightAccent ?: variant.defaultAccent
         }
+    }
 
     fun setAccentForVariant(
         variant: AyuVariant,

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -12,6 +12,9 @@ class AyuIslandsState : BaseState() {
     var darkAccent by string("#E6B450")
     var lightAccent by string("#F29718")
     var followSystemAccent by property(false)
+    var followSystemAppearance by property(false)
+    var lastDarkThemeName by string("Ayu Islands Mirage (Islands UI)")
+    var lastLightThemeName by string("Ayu Islands Light (Islands UI)")
     var trialExpiredNotified by property(false)
     var proDefaultsApplied by property(false)
 

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -11,6 +11,7 @@ class AyuIslandsState : BaseState() {
     var mirageAccent by string("#FFCC66")
     var darkAccent by string("#E6B450")
     var lightAccent by string("#F29718")
+    var followSystemAccent by property(false)
     var trialExpiredNotified by property(false)
     var proDefaultsApplied by property(false)
 

--- a/src/main/kotlin/dev/ayuislands/settings/ColorSwatchPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/ColorSwatchPanel.kt
@@ -16,7 +16,7 @@ import java.awt.geom.RoundRectangle2D
 import javax.swing.JComponent
 import javax.swing.JPanel
 
-/** A 2x5 grid of rounded color swatches with a checkmark on the selected color. */
+/** A 2x6 grid of rounded color swatches with a checkmark on the selected color. */
 class ColorSwatchPanel(
     colors: List<AccentColor>,
     private val onColorSelected: (AccentColor) -> Unit,
@@ -98,7 +98,7 @@ class ColorSwatchPanel(
 
     companion object {
         private const val GRID_ROWS = 2
-        private const val GRID_COLS = 5
+        private const val GRID_COLS = 6
         private const val GRID_GAP = 6
         private const val SWATCH_SIZE = 28
         private const val ARC_RADIUS = 6f

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -106,6 +106,10 @@
     <applicationService
         serviceImplementation="dev.ayuislands.settings.AyuIslandsSettings"/>
 
+    <!-- Appearance sync (follow system Light/Dark mode) -->
+    <applicationService
+        serviceImplementation="dev.ayuislands.AppearanceSyncService"/>
+
     <!-- Glow overlay manager (per-project lifecycle) -->
     <projectService
         serviceImplementation="dev.ayuislands.glow.GlowOverlayManager"/>
@@ -139,5 +143,8 @@
     <listener
         class="dev.ayuislands.AyuIslandsLafListener"
         topic="com.intellij.ide.ui.LafManagerListener"/>
+    <listener
+        class="dev.ayuislands.AppearanceSyncListener"
+        topic="com.intellij.openapi.application.ApplicationActivationListener"/>
   </applicationListeners>
 </idea-plugin>

--- a/src/test/kotlin/dev/ayuislands/accent/AccentColorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentColorTest.kt
@@ -6,8 +6,8 @@ import kotlin.test.assertTrue
 
 class AccentColorTest {
     @Test
-    fun `preset list contains exactly 10 colors`() {
-        assertEquals(10, AYU_ACCENT_PRESETS.size)
+    fun `preset list contains exactly 12 colors`() {
+        assertEquals(12, AYU_ACCENT_PRESETS.size)
     }
 
     @Test
@@ -54,6 +54,8 @@ class AccentColorTest {
                 "Mint",
                 "Sky",
                 "Cyan",
+                "Rose",
+                "Slate",
             )
         assertEquals(expectedNames, AYU_ACCENT_PRESETS.map { it.name })
     }


### PR DESCRIPTION
── Summary ─────────────────────────────────

macOS users have no way to keep IDE accent color or Light/Dark theme in sync with system preferences. This adds two opt-in settings: "Follow system accent color" reads `AppleAccentColor` and maps it to the nearest Ayu preset; "Follow system appearance" auto-switches between Light and Dark Ayu variants when macOS appearance changes.

Also consolidates the "Get Ayu Islands Pro" CTA into a single banner above the settings tabs (previously duplicated inline in two groups with poor contrast on dark themes).

── Changes ─────────────────────────────────

| Type | File | Description |
|------|------|-------------|
| Feat | `SystemAccentProvider.kt:1` | Read macOS `AppleAccentColor`, map to nearest Ayu preset hex with 5s TTL cache |
| Feat | `SystemAppearanceProvider.kt:1` | Read macOS `AppleInterfaceStyle` (Light/Dark) with 5s TTL cache |
| Feat | `AppearanceSyncService.kt:1` | Service: detect appearance change, switch Ayu theme variant via `LafManager` |
| Feat | `AppearanceSyncListener.kt:1` | `ApplicationActivationListener` — triggers sync on IDE focus |
| Feat | `AyuIslandsAppearancePanel.kt:1` | Settings UI: "Follow system appearance" checkbox (macOS only) |
| Feat | `AyuIslandsAccentPanel.kt:41` | "Follow system accent color" checkbox, disables swatches when active |
| Feat | `AyuIslandsState.kt:14` | Persist `followSystemAccent`, `followSystemAppearance`, `lastDarkThemeName`, `lastLightThemeName` |
| Feat | `AccentColor.kt:18` | Add Rose and Slate accent presets (macOS Pink + Graphite mapping) |
| Feat | `ColorSwatchPanel.kt:101` | Expand grid from 2x5 to 2x6 for 12 presets |
| Refactor | `AyuIslandsConfigurable.kt:110` | Add Pro banner CTA above tabs (replaces inline links) |
| Refactor | `AyuIslandsElementsPanel.kt:86` | Replace inline Pro link with `comment()` DSL |
| Refactor | `AyuIslandsEffectsPanel.kt:116` | Remove inline Pro link, extract `ISLAND_IDS` constant, fix null safety |
| Fix | `AyuIslandsLafListener.kt:29` | Record manual theme choice for appearance sync slot tracking |
| Fix | `AyuIslandsStartupActivity.kt:39` | Trigger appearance sync on project open |
| Chore | `build.gradle.kts:72` | Mute `ExperimentalApiUsage` in plugin verification |
| Chore | `plugin.xml:109` | Register `AppearanceSyncService` and `AppearanceSyncListener` |
| Test | `AccentColorTest.kt:9` | Update assertions for 12 presets (was 10) |

── Validation ──────────────────────────────

```bash
./gradlew buildPlugin          # Build succeeds
./gradlew test                 # AccentColorTest passes (12 presets)
./gradlew verifyPlugin         # Verify (A) + Verify (B) pass
```

Manual verification:
1. Settings > Ayu Islands > "Follow system accent color" checkbox appears on macOS
2. Toggling it reads system accent and updates swatch preview
3. "Follow system appearance" auto-switches Light/Dark on macOS mode change
4. "Get Ayu Islands Pro" banner appears once above tabs (not inline)

── Notes ───────────────────────────────────

- Both system providers use `ProcessBuilder("defaults", "read", ...)` with a 5-second TTL cache to avoid EDT blocking
- Appearance sync only activates when an Ayu theme is currently active (`AyuVariant.detect() != null`)
- Manual theme changes while sync is enabled are recorded per-slot (dark/light) so the user's sub-variant preference is preserved
- `setCurrentLookAndFeel(UIThemeLookAndFeelInfo, Boolean)` is the non-deprecated API for 2025.1+ — the old `UIManager.LookAndFeelInfo` overload was removed
- `getInstalledThemes()` is experimental API — muted in verification config
- Non-macOS platforms: both checkboxes are hidden, providers return `null`

## Summary by Sourcery

Add macOS-aware appearance and accent syncing plus consolidate Pro upsell messaging in the Ayu Islands settings UI.

New Features:
- Introduce a macOS system accent option that reads the system accent color and applies the closest Ayu accent preset.
- Introduce a macOS system appearance option that syncs Ayu Light/Dark variants with the system Light/Dark mode, including per-slot theme preference tracking.
- Add Rose and Slate accent presets and expand the accent swatch grid to support 12 colors.

Bug Fixes:
- Ensure manual theme changes are recorded for appearance sync and trigger a sync when projects open to keep themes in sync.

Enhancements:
- Consolidate the Pro upsell into a single banner above the Ayu Islands settings tabs and replace inline Pro messaging with contextual comments.
- Use a centralized island ID constant for glow targets and improve null-safety and description rendering in the glow effects panel.

Build:
- Mute ExperimentalApiUsage warnings in plugin verification config.

Tests:
- Update accent color tests to cover the expanded set of 12 presets.

Chores:
- Register the new appearance sync service and activation listener in plugin.xml.