### PR TITLE
fix(ci): remove duplicate main push trigger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main, dev]
-    paths-ignore:
-      - '**/*.md'
-      - 'LICENSE'
-      - '.gitignore'
-      - '.sourcery.yaml'
   pull_request:
     branches: [main]
     paths-ignore:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [dev]
-    paths-ignore:
-      - '**/*.md'
-      - 'LICENSE'
-      - '.gitignore'
-      - '.sourcery.yaml'
   pull_request:
     branches: [main]
     paths-ignore:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,13 @@
 name: CI
 
 on:
+  push:
+    branches: [dev]
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.sourcery.yaml'
   pull_request:
     branches: [main]
     paths-ignore:


### PR DESCRIPTION
## Summary

- Remove `push` trigger block entirely from build.yml
- CI already runs on every PR to main — push trigger is redundant
- `dev` branch not used in project workflow

## Before

Every PR merge triggered 2 CI runs: PR event + push-to-main event.
Direct pushes to `dev` also triggered CI (unused).

## After

CI runs once per PR targeting main.
`workflow_dispatch` remains for manual runs.
Release workflow (`v*` tags) is unaffected.

## Test plan

- [ ] This PR triggers CI via `pull_request`
- [ ] After merge, no CI run on main push