### PR TITLE
chore: bump version to 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [2.0.1] - 2026-03-06
 
 ### Fixed
 - Fix crash on theme switch: `setAttributes` received null in `revertAlwaysOnEditorKeys`

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.0.0
+pluginVersion=2.0.1
 pluginSinceBuild=251
 platformVersion=2025.1
 


### PR DESCRIPTION
## Summary
- Bump `pluginVersion` 2.0.0 → 2.0.1 in `gradle.properties`
- Finalize CHANGELOG.md `[Unreleased]` → `[2.0.1] - 2026-03-06`
- `plugin.xml` change-notes already updated in #16

## Context
PR #16 merged crash fixes and deprecated API replacements. This is the version bump commit for tagging v2.0.1.

## Post-merge
Tag `v2.0.1` on main → triggers `release.yml` → Marketplace publish.

## Summary by Sourcery

Bump the plugin version to 2.0.1 and finalize the changelog entry for this release.

Build:
- Update Gradle pluginVersion from 2.0.0 to 2.0.1.

Documentation:
- Finalize the changelog by converting the Unreleased section into the 2.0.1 entry with release date.