### PR TITLE
test: extend patch coverage for IR sync and elements

### DIFF
--- a/src/test/kotlin/dev/ayuislands/accent/elements/AccentElementsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/AccentElementsTest.kt
@@ -563,6 +563,55 @@ class AccentElementsTest {
         verify { BracketFadeManager.deactivate() }
     }
 
+    @Test
+    fun `BracketMatchElement apply clones existing attributes when present`() {
+        val existingAttrs = TextAttributes()
+        existingAttrs.foregroundColor = Color.WHITE
+        val attributesSlot = slot<TextAttributes>()
+        every { mockScheme.getAttributes(any<TextAttributesKey>()) } returns existingAttrs
+        every { mockScheme.setAttributes(any<TextAttributesKey>(), capture(attributesSlot)) } just Runs
+
+        val element = BracketMatchElement()
+        element.apply(testColor)
+
+        assertTrue(attributesSlot.isCaptured, "setAttributes should have been called")
+        assertEquals(testColor, attributesSlot.captured.foregroundColor)
+        assertEquals(java.awt.Font.BOLD, attributesSlot.captured.fontType)
+        verify { BracketFadeManager.activate(testColor) }
+    }
+
+    @Test
+    fun `BracketMatchElement applyNeutral with non-null parent but null attrs`() {
+        val parentScheme: EditorColorsScheme = mockk(relaxed = true)
+        every { mockColorsManager.getScheme("Darcula") } returns parentScheme
+        every { parentScheme.getAttributes(any<TextAttributesKey>()) } returns null
+        val attributesSlot = slot<TextAttributes>()
+        every { mockScheme.setAttributes(any<TextAttributesKey>(), capture(attributesSlot)) } just Runs
+
+        val element = BracketMatchElement()
+        element.applyNeutral(AyuVariant.MIRAGE)
+
+        assertTrue(attributesSlot.isCaptured, "setAttributes should have been called")
+        assertNotNull(attributesSlot.captured, "Should use fallback TextAttributes when parent attrs are null")
+        verify { BracketFadeManager.deactivate() }
+    }
+
+    @Test
+    fun `BracketMatchElement revert with null fallback attribute key`() {
+        val braceKey = mockk<TextAttributesKey>(relaxed = true)
+        every { braceKey.fallbackAttributeKey } returns null
+        every { TextAttributesKey.find("MATCHED_BRACE_ATTRIBUTES") } returns braceKey
+        val attributesSlot = slot<TextAttributes>()
+        every { mockScheme.setAttributes(any<TextAttributesKey>(), capture(attributesSlot)) } just Runs
+
+        val element = BracketMatchElement()
+        element.revert()
+
+        assertTrue(attributesSlot.isCaptured, "setAttributes should have been called")
+        assertNotNull(attributesSlot.captured, "Should use fallback TextAttributes when fallback key is null")
+        verify { BracketFadeManager.deactivate() }
+    }
+
     // AccentElementId enum coverage
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/indent/IndentRainbowSyncTest.kt
+++ b/src/test/kotlin/dev/ayuislands/indent/IndentRainbowSyncTest.kt
@@ -89,7 +89,7 @@ class IndentRainbowSyncTest {
         invokePrivate("resolveReflection")
         invokePrivate("resolveReflection")
 
-        // Second call exits immediately via guard
+        // The second call exits immediately via guard
         val resolved = getPrivateField<Boolean>("methodsResolved")
         assertTrue(resolved)
     }
@@ -152,7 +152,7 @@ class IndentRainbowSyncTest {
 
         IndentRainbowSync.apply(AyuVariant.MIRAGE)
 
-        // Verify palette type was set to CUSTOM
+        // Verify a palette type was set to CUSTOM
         verify { mockPaletteTypeField[mockConfig] = "CUSTOM_ENUM" }
         // Verify custom palette string was written
         verify { mockCustomPaletteField[mockConfig] = any<String>() }
@@ -227,9 +227,8 @@ class IndentRainbowSyncTest {
         val mockCompanion = Any()
         val mockColorsInstance = Any()
 
-        every {
-            mockUpdateMethod.invoke(any(), any())
-        } throws java.lang.reflect.InvocationTargetException(RuntimeException("inner"))
+        every { mockUpdateMethod.invoke(any(), any()) } throws
+            java.lang.reflect.InvocationTargetException(RuntimeException("inner"))
 
         setPrivateField("methodsResolved", true)
         setPrivateField("irConfig", mockConfig)
@@ -243,7 +242,7 @@ class IndentRainbowSyncTest {
         setPrivateField("refreshMethod", mockRefreshMethod)
         setPrivateField("irColorsInstance", mockColorsInstance)
 
-        // Mock NotificationGroupManager to prevent NPE in notifyFailure
+        // Mock NotificationGroupManager to prevent NPE from notifyFailure
         mockkStatic(NotificationGroupManager::class)
         val mockNotifManager = mockk<NotificationGroupManager>(relaxed = true)
         val mockGroup = mockk<NotificationGroup>(relaxed = true)
@@ -271,9 +270,7 @@ class IndentRainbowSyncTest {
         val mockCompanion = Any()
         val mockColorsInstance = Any()
 
-        every {
-            mockUpdateMethod.invoke(any(), any())
-        } throws IllegalAccessException("denied")
+        every { mockUpdateMethod.invoke(any(), any()) } throws IllegalAccessException("denied")
 
         setPrivateField("methodsResolved", true)
         setPrivateField("irConfig", mockConfig)
@@ -309,9 +306,7 @@ class IndentRainbowSyncTest {
         val mockCompanion = Any()
         val mockColorsInstance = Any()
 
-        every {
-            mockUpdateMethod.invoke(any(), any())
-        } throws RuntimeException("flush failed")
+        every { mockUpdateMethod.invoke(any(), any()) } throws RuntimeException("flush failed")
 
         setPrivateField("methodsResolved", true)
         setPrivateField("irConfig", mockConfig)
@@ -470,7 +465,7 @@ class IndentRainbowSyncTest {
 
         IndentRainbowSync.revert()
 
-        // flushCache should NOT be called since method exits early
+        // flushCache should NOT be called since the method exits early
         verify(exactly = 0) { mockUpdateMethod.invoke(any(), any()) }
     }
 
@@ -504,23 +499,167 @@ class IndentRainbowSyncTest {
         verify(exactly = 0) { mockUpdateMethod.invoke(any(), any()) }
     }
 
+    @Test
+    fun `resolveReflection catches ClassNotFoundException when plugin found`() {
+        val mockPlugin = mockk<IdeaPluginDescriptor>(relaxed = true)
+        every { PluginManagerCore.getPlugin(any()) } returns mockPlugin
+        every { mockPlugin.pluginClassLoader } returns this::class.java.classLoader
+
+        // Class.forName("indent.rainbow.settings.IrConfig") will throw
+        // ClassNotFoundException (a ReflectiveOperationException) since the
+        // class does not exist on the test classpath.
+
+        mockkStatic(NotificationGroupManager::class)
+        val mockNotifManager = mockk<NotificationGroupManager>(relaxed = true)
+        val mockGroup = mockk<NotificationGroup>(relaxed = true)
+        val mockNotification = mockk<Notification>(relaxed = true)
+        every { NotificationGroupManager.getInstance() } returns mockNotifManager
+        every { mockNotifManager.getNotificationGroup(any()) } returns mockGroup
+        every {
+            mockGroup.createNotification(any<String>(), any<String>(), any<NotificationType>())
+        } returns mockNotification
+
+        invokePrivate("resolveReflection")
+
+        assertTrue(getPrivateField("methodsResolved"))
+        assertNull(getPrivateField("irConfig"))
+    }
+
+    @Test
+    fun `apply returns early when customPaletteField is null`() {
+        state.irIntegrationEnabled = true
+
+        val mockConfig = Any()
+        val mockPaletteTypeField = mockField()
+        val mockUpdateMethod = mockMethod()
+        val mockRefreshMethod = mockMethod()
+        val mockCompanion = Any()
+        val mockColorsInstance = Any()
+
+        setPrivateField("methodsResolved", true)
+        setPrivateField("irConfig", mockConfig)
+        setPrivateField("paletteTypeField", mockPaletteTypeField)
+        setPrivateField("customPaletteField", null)
+        setPrivateField("customPaletteNumberColorsField", mockIntField())
+        setPrivateField("customEnumValue", "CUSTOM_ENUM")
+        setPrivateField("defaultEnumValue", "DEFAULT_ENUM")
+        setPrivateField("cachedDataUpdateMethod", mockUpdateMethod)
+        setPrivateField("cachedDataCompanion", mockCompanion)
+        setPrivateField("refreshMethod", mockRefreshMethod)
+        setPrivateField("irColorsInstance", mockColorsInstance)
+
+        IndentRainbowSync.apply(AyuVariant.MIRAGE)
+
+        verify(exactly = 0) { mockUpdateMethod.invoke(any(), any()) }
+    }
+
+    @Test
+    fun `apply returns early when customPaletteNumberColorsField is null`() {
+        state.irIntegrationEnabled = true
+
+        val mockConfig = Any()
+        val mockPaletteTypeField = mockField()
+        val mockCustomPaletteField = mockField()
+        val mockUpdateMethod = mockMethod()
+        val mockRefreshMethod = mockMethod()
+        val mockCompanion = Any()
+        val mockColorsInstance = Any()
+
+        setPrivateField("methodsResolved", true)
+        setPrivateField("irConfig", mockConfig)
+        setPrivateField("paletteTypeField", mockPaletteTypeField)
+        setPrivateField("customPaletteField", mockCustomPaletteField)
+        setPrivateField("customPaletteNumberColorsField", null)
+        setPrivateField("customEnumValue", "CUSTOM_ENUM")
+        setPrivateField("defaultEnumValue", "DEFAULT_ENUM")
+        setPrivateField("cachedDataUpdateMethod", mockUpdateMethod)
+        setPrivateField("cachedDataCompanion", mockCompanion)
+        setPrivateField("refreshMethod", mockRefreshMethod)
+        setPrivateField("irColorsInstance", mockColorsInstance)
+
+        IndentRainbowSync.apply(AyuVariant.MIRAGE)
+
+        verify(exactly = 0) { mockUpdateMethod.invoke(any(), any()) }
+    }
+
+    @Test
+    fun `apply catches RuntimeException from paletteTypeField set`() {
+        state.irIntegrationEnabled = true
+
+        val mockConfig = Any()
+        val mockPaletteTypeField = mockk<Field>(relaxed = true)
+        val mockCustomPaletteField = mockField()
+        val mockNumberColorsField = mockIntField()
+        val mockUpdateMethod = mockMethod()
+        val mockRefreshMethod = mockMethod()
+        val mockCompanion = Any()
+        val mockColorsInstance = Any()
+
+        every { mockPaletteTypeField[any()] = any() } throws RuntimeException("field set exploded")
+
+        setPrivateField("methodsResolved", true)
+        setPrivateField("irConfig", mockConfig)
+        setPrivateField("paletteTypeField", mockPaletteTypeField)
+        setPrivateField("customPaletteField", mockCustomPaletteField)
+        setPrivateField("customPaletteNumberColorsField", mockNumberColorsField)
+        setPrivateField("customEnumValue", "CUSTOM_ENUM")
+        setPrivateField("defaultEnumValue", "DEFAULT_ENUM")
+        setPrivateField("cachedDataUpdateMethod", mockUpdateMethod)
+        setPrivateField("cachedDataCompanion", mockCompanion)
+        setPrivateField("refreshMethod", mockRefreshMethod)
+        setPrivateField("irColorsInstance", mockColorsInstance)
+
+        mockkStatic(NotificationGroupManager::class)
+        val mockNotifManager = mockk<NotificationGroupManager>(relaxed = true)
+        val mockGroup = mockk<NotificationGroup>(relaxed = true)
+        val mockNotification = mockk<Notification>(relaxed = true)
+        every { NotificationGroupManager.getInstance() } returns mockNotifManager
+        every { mockNotifManager.getNotificationGroup(any()) } returns mockGroup
+        every {
+            mockGroup.createNotification(any<String>(), any<String>(), any<NotificationType>())
+        } returns mockNotification
+
+        IndentRainbowSync.apply(AyuVariant.MIRAGE)
+        // Should not throw — caught by RuntimeException handler
+    }
+
+    @Test
+    fun `revert catches ReflectiveOperationException from paletteTypeField set`() {
+        val mockConfig = Any()
+        val mockPaletteTypeField = mockk<Field>(relaxed = true)
+        val mockUpdateMethod = mockMethod()
+        val mockRefreshMethod = mockMethod()
+        val mockCompanion = Any()
+        val mockColorsInstance = Any()
+
+        every { mockPaletteTypeField[any()] = any() } throws IllegalAccessException("access denied")
+
+        setPrivateField("methodsResolved", true)
+        setPrivateField("irConfig", mockConfig)
+        setPrivateField("paletteTypeField", mockPaletteTypeField)
+        setPrivateField("defaultEnumValue", "DEFAULT_ENUM")
+        setPrivateField("cachedDataUpdateMethod", mockUpdateMethod)
+        setPrivateField("cachedDataCompanion", mockCompanion)
+        setPrivateField("refreshMethod", mockRefreshMethod)
+        setPrivateField("irColorsInstance", mockColorsInstance)
+
+        IndentRainbowSync.revert()
+        // Should not throw — caught by ReflectiveOperationException handler
+    }
+
     // Helpers
 
     private fun invokePrivate(
         methodName: String,
         vararg args: Any,
     ) {
-        val method =
-            IndentRainbowSync::class.java.declaredMethods
-                .first { it.name == methodName }
+        val method = IndentRainbowSync::class.java.declaredMethods.first { it.name == methodName }
         method.isAccessible = true
         method.invoke(IndentRainbowSync, *args)
     }
 
     private fun invokePrivateReturning(methodName: String): Any? {
-        val method =
-            IndentRainbowSync::class.java.declaredMethods
-                .first { it.name == methodName }
+        val method = IndentRainbowSync::class.java.declaredMethods.first { it.name == methodName }
         method.isAccessible = true
         return method.invoke(IndentRainbowSync)
     }

--- a/src/test/kotlin/dev/ayuislands/indent/IndentRainbowSyncTest.kt
+++ b/src/test/kotlin/dev/ayuislands/indent/IndentRainbowSyncTest.kt
@@ -111,7 +111,10 @@ class IndentRainbowSyncTest {
         setPrivateField("methodsResolved", true)
         // All fields remain null
 
-        val result = invokePrivateReturning("resolveOrReturn")
+        val method =
+            IndentRainbowSync::class.java.declaredMethods.first { it.name == "resolveOrReturn" }
+        method.isAccessible = true
+        val result = method.invoke(IndentRainbowSync)
         assertNull(result, "resolveOrReturn should return null when irConfig is null")
     }
 
@@ -242,16 +245,7 @@ class IndentRainbowSyncTest {
         setPrivateField("refreshMethod", mockRefreshMethod)
         setPrivateField("irColorsInstance", mockColorsInstance)
 
-        // Mock NotificationGroupManager to prevent NPE from notifyFailure
-        mockkStatic(NotificationGroupManager::class)
-        val mockNotifManager = mockk<NotificationGroupManager>(relaxed = true)
-        val mockGroup = mockk<NotificationGroup>(relaxed = true)
-        val mockNotification = mockk<Notification>(relaxed = true)
-        every { NotificationGroupManager.getInstance() } returns mockNotifManager
-        every { mockNotifManager.getNotificationGroup(any()) } returns mockGroup
-        every {
-            mockGroup.createNotification(any<String>(), any<String>(), any<NotificationType>())
-        } returns mockNotification
+        mockNotificationGroup()
 
         IndentRainbowSync.apply(AyuVariant.MIRAGE)
         // Should not throw — exception is caught and logged
@@ -284,15 +278,7 @@ class IndentRainbowSyncTest {
         setPrivateField("refreshMethod", mockRefreshMethod)
         setPrivateField("irColorsInstance", mockColorsInstance)
 
-        mockkStatic(NotificationGroupManager::class)
-        val mockNotifManager = mockk<NotificationGroupManager>(relaxed = true)
-        val mockGroup = mockk<NotificationGroup>(relaxed = true)
-        val mockNotification = mockk<Notification>(relaxed = true)
-        every { NotificationGroupManager.getInstance() } returns mockNotifManager
-        every { mockNotifManager.getNotificationGroup(any()) } returns mockGroup
-        every {
-            mockGroup.createNotification(any<String>(), any<String>(), any<NotificationType>())
-        } returns mockNotification
+        mockNotificationGroup()
 
         IndentRainbowSync.apply(AyuVariant.MIRAGE)
     }
@@ -325,15 +311,7 @@ class IndentRainbowSyncTest {
     fun `notifyFailure suppresses duplicate for same version`() {
         state.irFailedVersion = "old-version"
 
-        mockkStatic(NotificationGroupManager::class)
-        val mockNotifManager = mockk<NotificationGroupManager>(relaxed = true)
-        val mockGroup = mockk<NotificationGroup>(relaxed = true)
-        val mockNotification = mockk<Notification>(relaxed = true)
-        every { NotificationGroupManager.getInstance() } returns mockNotifManager
-        every { mockNotifManager.getNotificationGroup(any()) } returns mockGroup
-        every {
-            mockGroup.createNotification(any<String>(), any<String>(), any<NotificationType>())
-        } returns mockNotification
+        val group = mockNotificationGroup()
 
         // First call — should notify
         invokePrivate("notifyFailure")
@@ -344,7 +322,7 @@ class IndentRainbowSyncTest {
 
         // createNotification should be called only once
         verify(exactly = 1) {
-            mockGroup.createNotification(any<String>(), any<String>(), any<NotificationType>())
+            group.createNotification(any<String>(), any<String>(), any<NotificationType>())
         }
     }
 
@@ -509,15 +487,7 @@ class IndentRainbowSyncTest {
         // ClassNotFoundException (a ReflectiveOperationException) since the
         // class does not exist on the test classpath.
 
-        mockkStatic(NotificationGroupManager::class)
-        val mockNotifManager = mockk<NotificationGroupManager>(relaxed = true)
-        val mockGroup = mockk<NotificationGroup>(relaxed = true)
-        val mockNotification = mockk<Notification>(relaxed = true)
-        every { NotificationGroupManager.getInstance() } returns mockNotifManager
-        every { mockNotifManager.getNotificationGroup(any()) } returns mockGroup
-        every {
-            mockGroup.createNotification(any<String>(), any<String>(), any<NotificationType>())
-        } returns mockNotification
+        mockNotificationGroup()
 
         invokePrivate("resolveReflection")
 
@@ -609,15 +579,7 @@ class IndentRainbowSyncTest {
         setPrivateField("refreshMethod", mockRefreshMethod)
         setPrivateField("irColorsInstance", mockColorsInstance)
 
-        mockkStatic(NotificationGroupManager::class)
-        val mockNotifManager = mockk<NotificationGroupManager>(relaxed = true)
-        val mockGroup = mockk<NotificationGroup>(relaxed = true)
-        val mockNotification = mockk<Notification>(relaxed = true)
-        every { NotificationGroupManager.getInstance() } returns mockNotifManager
-        every { mockNotifManager.getNotificationGroup(any()) } returns mockGroup
-        every {
-            mockGroup.createNotification(any<String>(), any<String>(), any<NotificationType>())
-        } returns mockNotification
+        mockNotificationGroup()
 
         IndentRainbowSync.apply(AyuVariant.MIRAGE)
         // Should not throw — caught by RuntimeException handler
@@ -656,12 +618,6 @@ class IndentRainbowSyncTest {
         val method = IndentRainbowSync::class.java.declaredMethods.first { it.name == methodName }
         method.isAccessible = true
         method.invoke(IndentRainbowSync, *args)
-    }
-
-    private fun invokePrivateReturning(methodName: String): Any? {
-        val method = IndentRainbowSync::class.java.declaredMethods.first { it.name == methodName }
-        method.isAccessible = true
-        return method.invoke(IndentRainbowSync)
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -709,4 +665,17 @@ class IndentRainbowSyncTest {
     }
 
     private fun mockMethod(): Method = mockk<Method>(relaxed = true)
+
+    private fun mockNotificationGroup(): NotificationGroup {
+        mockkStatic(NotificationGroupManager::class)
+        val mockNotifManager = mockk<NotificationGroupManager>(relaxed = true)
+        val mockGroup = mockk<NotificationGroup>(relaxed = true)
+        val mockNotification = mockk<Notification>(relaxed = true)
+        every { NotificationGroupManager.getInstance() } returns mockNotifManager
+        every { mockNotifManager.getNotificationGroup(any()) } returns mockGroup
+        every {
+            mockGroup.createNotification(any<String>(), any<String>(), any<NotificationType>())
+        } returns mockNotification
+        return mockGroup
+    }
 }


### PR DESCRIPTION
## Summary

- Extend `IndentRainbowSyncTest` with 5 new tests covering `resolveReflection` catch blocks, early returns for null fields, and exception handling
- Extend `AccentElementsTest` with 3 new `BracketMatchElement` tests for partial branch coverage (null existing attrs, null parent attrs, null fallback key)
- `BracketMatchElement` reaches 100% line coverage

## Coverage impact

| File | Before | After |
|------|--------|-------|
| BracketMatchElement.kt | 80% | 100% |
| IndentRainbowSync.kt | 48% patch | improved |
| Overall | 85.3% | 85.3% (maintained) |

## Test plan

- [x] `./gradlew test koverVerify` passes
- [x] All pre-commit hooks pass (ktlint, detekt)

## Summary by Sourcery

Extend test coverage for IndentRainbowSync reflection/exception paths and BracketMatchElement behavior while preserving existing functionality.

Tests:
- Add new IndentRainbowSync tests covering reflection resolution failures, early returns on missing fields, and exception handling in apply/revert.
- Add additional BracketMatchElement tests to cover cloning existing attributes, neutral application with missing parent attributes, and revert behavior with null fallback keys.