### PR TITLE
fix: release-version mismatch for v2.1.0

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -87,7 +87,7 @@
   <product-descriptor
       code="PAYUISLANDS"
       release-date="20260302"
-      release-version="20"
+      release-version="21"
       optional="true"/>
 
   <extensionPoints>


### PR DESCRIPTION
## Summary

- Update `product-descriptor release-version` from `20` to `21`
- Marketplace requires release-version to match pluginVersion prefix
- `20` matched `2.0.x` but not `2.1.x`

## Root cause

`release-version="20"` → Marketplace checks `210`.startsWith(`20`) → false → upload rejected.
Fix: `release-version="21"` → `210`.startsWith(`21`) → true.

## Test plan

- [ ] CI passes
- [ ] After merge: re-tag v2.1.0, release.yml publishes successfully

## Summary by Sourcery

Enhancements:
- Update the product-descriptor release-version in plugin.xml to match the v2.1.0 plugin version expected by the marketplace.