### PR TITLE
fix: update release-date for v2.1.0

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -86,7 +86,7 @@
 
   <product-descriptor
       code="PAYUISLANDS"
-      release-date="20260302"
+      release-date="20260307"
       release-version="21"
       optional="true"/>
 


### PR DESCRIPTION
## Summary
- Bump `release-date` from `20260302` to `20260307` in `plugin.xml`
- Marketplace rejects uploads when `release-version` changes but `release-date` stays the same

## Test plan
- [ ] CI build passes
- [ ] Re-tag v2.1.0 after merge and verify release workflow succeeds

## Summary by Sourcery

Bug Fixes:
- Adjust the plugin release-date to prevent marketplace upload rejections when the release version changes without a corresponding date update.