### PR TITLE
feat(ir): add error highlight toggle, fix write-unsafe EDT context

### DIFF
--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -118,10 +118,11 @@ object AccentApplicator {
                 repaintAllWindows(Window.getWindows())
             }
 
+        val app = ApplicationManager.getApplication()
         if (SwingUtilities.isEventDispatchThread()) {
             work.run()
         } else {
-            SwingUtilities.invokeLater(work)
+            app.invokeLater(work)
         }
     }
 
@@ -160,10 +161,11 @@ object AccentApplicator {
                 // The platform repaints everything after the theme switch.
             }
 
+        val app = ApplicationManager.getApplication()
         if (SwingUtilities.isEventDispatchThread()) {
             work.run()
         } else {
-            SwingUtilities.invokeLater(work)
+            app.invokeLater(work)
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/indent/IndentPalette.kt
+++ b/src/main/kotlin/dev/ayuislands/indent/IndentPalette.kt
@@ -13,12 +13,24 @@ data class IndentPalette(
     val errorColor: String,
     val accentColor: String,
 ) {
-    fun toColorStrings(alpha: Int): List<String> {
-        val errorAlphaHex = alpha.toString(HEX_RADIX).uppercase().padStart(HEX_PAD_LENGTH, PAD_CHAR)
-        val errorStr = errorAlphaHex + errorColor
+    fun toColorStrings(
+        alpha: Int,
+        highlightErrors: Boolean = true,
+    ): List<String> {
+        val pyramidSteps = (1..INDENT_COUNT) + (INDENT_COUNT - 1 downTo 2)
+        val firstStepAlpha = (alpha * 1 / INDENT_COUNT).coerceIn(MIN_ALPHA, MAX_ALPHA)
+
+        val errorStr =
+            if (highlightErrors) {
+                val errorAlphaHex = alpha.toString(HEX_RADIX).uppercase().padStart(HEX_PAD_LENGTH, PAD_CHAR)
+                errorAlphaHex + errorColor
+            } else {
+                val alphaHex = firstStepAlpha.toString(HEX_RADIX).uppercase().padStart(HEX_PAD_LENGTH, PAD_CHAR)
+                alphaHex + accentColor
+            }
 
         val indentColors =
-            (1..INDENT_COUNT).map { step ->
+            pyramidSteps.map { step ->
                 val stepAlpha = (alpha * step / INDENT_COUNT).coerceIn(MIN_ALPHA, MAX_ALPHA)
                 val stepAlphaHex = stepAlpha.toString(HEX_RADIX).uppercase().padStart(HEX_PAD_LENGTH, PAD_CHAR)
                 stepAlphaHex + accentColor

--- a/src/main/kotlin/dev/ayuislands/indent/IndentRainbowSync.kt
+++ b/src/main/kotlin/dev/ayuislands/indent/IndentRainbowSync.kt
@@ -53,7 +53,11 @@ object IndentRainbowSync {
                 )
             val rawAlpha = preset.alpha ?: state.indentCustomAlpha
             val alpha = rawAlpha.coerceIn(1, MAX_ALPHA_VALUE)
-            val colorStrings = palette.toColorStrings(alpha)
+            val colorStrings =
+                palette.toColorStrings(
+                    alpha,
+                    highlightErrors = state.irErrorHighlightEnabled,
+                )
             val customPaletteValue = colorStrings.joinToString(", ")
 
             resolved.paletteTypeField[resolved.config] = enumValue

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -84,6 +84,9 @@ class AyuIslandsState : BaseState() {
     // Bracket scope gutter highlight (default ON)
     var bracketScopeEnabled by property(true)
 
+    // IR error highlight toggle (true = red error color, false = accent gradient)
+    var irErrorHighlightEnabled by property(true)
+
     // IR version that failed reflection (suppresses repeated notifications)
     var irFailedVersion by string(null)
 

--- a/src/main/kotlin/dev/ayuislands/settings/IntegrationsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/IntegrationsPanel.kt
@@ -27,10 +27,13 @@ class IntegrationsPanel : AyuIslandsSettingsPanel {
     private var storedBracketScope: Boolean = true
     private var pendingCgpIntegration: Boolean = false
     private var storedCgpIntegration: Boolean = false
+    private var pendingErrorHighlight: Boolean = true
+    private var storedErrorHighlight: Boolean = true
 
     private var variant: AyuVariant? = null
     private var enabledCheckbox: JCheckBox? = null
     private var cgpCheckbox: JCheckBox? = null
+    private var errorHighlightCheckbox: JCheckBox? = null
     private var alphaSlider: JSlider? = null
     private var alphaValueLabel: JLabel? = null
     private var presetSegmented: SegmentedButton<IndentPreset>? = null
@@ -54,6 +57,9 @@ class IntegrationsPanel : AyuIslandsSettingsPanel {
 
         storedEnabled = state.irIntegrationEnabled
         pendingEnabled = storedEnabled
+
+        storedErrorHighlight = state.irErrorHighlightEnabled
+        pendingErrorHighlight = storedErrorHighlight
 
         storedPreset = state.indentPresetName ?: IndentPreset.AMBIENT.name
         pendingPreset = storedPreset
@@ -137,6 +143,19 @@ class IntegrationsPanel : AyuIslandsSettingsPanel {
                     presetSegmented = segmented
                 }.visibleIf(irEnabled)
 
+                // Error highlight toggle (visible when IR enabled)
+                row {
+                    val cb =
+                        checkBox("Highlight indent errors")
+                            .comment("When off, lines with irregular indentation blend into the color gradient")
+                    cb.component.isSelected = pendingErrorHighlight
+                    cb.component.isEnabled = licensed
+                    cb.component.addActionListener {
+                        pendingErrorHighlight = cb.component.isSelected
+                    }
+                    errorHighlightCheckbox = cb.component
+                }.visibleIf(irEnabled)
+
                 // Custom alpha slider (visible only in CUSTOM mode AND IR enabled)
                 row {
                     label("Alpha")
@@ -165,7 +184,8 @@ class IntegrationsPanel : AyuIslandsSettingsPanel {
             pendingPreset != storedPreset ||
             pendingCustomAlpha != storedCustomAlpha ||
             pendingBracketScope != storedBracketScope ||
-            pendingCgpIntegration != storedCgpIntegration
+            pendingCgpIntegration != storedCgpIntegration ||
+            pendingErrorHighlight != storedErrorHighlight
 
     override fun apply() {
         if (!isModified()) return
@@ -176,12 +196,14 @@ class IntegrationsPanel : AyuIslandsSettingsPanel {
         state.indentCustomAlpha = pendingCustomAlpha
         state.bracketScopeEnabled = pendingBracketScope
         state.cgpIntegrationEnabled = pendingCgpIntegration
+        state.irErrorHighlightEnabled = pendingErrorHighlight
 
         storedEnabled = pendingEnabled
         storedPreset = pendingPreset
         storedCustomAlpha = pendingCustomAlpha
         storedBracketScope = pendingBracketScope
         storedCgpIntegration = pendingCgpIntegration
+        storedErrorHighlight = pendingErrorHighlight
 
         // Trigger IR sync immediately
         val currentVariant = variant ?: return
@@ -195,10 +217,12 @@ class IntegrationsPanel : AyuIslandsSettingsPanel {
         pendingCustomAlpha = storedCustomAlpha
         pendingBracketScope = storedBracketScope
         pendingCgpIntegration = storedCgpIntegration
+        pendingErrorHighlight = storedErrorHighlight
 
         suppressListeners = true
         enabledCheckbox?.isSelected = storedEnabled
         cgpCheckbox?.isSelected = storedCgpIntegration
+        errorHighlightCheckbox?.isSelected = storedErrorHighlight
         presetSegmented?.selectedItem = IndentPreset.fromName(storedPreset)
         alphaSlider?.value = storedCustomAlpha
         alphaValueLabel?.text = "$storedCustomAlpha"

--- a/src/test/kotlin/dev/ayuislands/indent/IndentPaletteTest.kt
+++ b/src/test/kotlin/dev/ayuislands/indent/IndentPaletteTest.kt
@@ -35,14 +35,14 @@ class IndentPaletteTest {
     }
 
     @Test
-    fun `toColorStrings produces 7 AARRGGBB strings`() {
+    fun `toColorStrings produces 11 AARRGGBB strings`() {
         for (variant in AyuVariant.entries) {
             val palette = IndentPalette.forAccent(testAccent, variant)
             val colors = palette.toColorStrings(0x2E)
             assertEquals(
-                7,
+                11,
                 colors.size,
-                "${variant.name} should produce 7 color strings (1 error + 6 indent)",
+                "${variant.name} should produce 11 color strings (1 error + 10 indent)",
             )
         }
     }
@@ -71,17 +71,27 @@ class IndentPaletteTest {
     }
 
     @Test
-    fun `indent colors use gradient alpha increasing with depth`() {
+    fun `indent colors use pyramid alpha pattern`() {
         val palette = IndentPalette.forAccent(testAccent, AyuVariant.MIRAGE)
         val alpha = 0x3C
         val colors = palette.toColorStrings(alpha)
 
-        // Skip index 0 (error), check indices 1-6 have increasing alpha
         val indentAlphas = colors.drop(1).map { it.substring(0, 2).toInt(16) }
-        for (i in 0 until indentAlphas.size - 1) {
+        assertEquals(10, indentAlphas.size, "Should have 10 indent colors")
+
+        // First 6 ascending (steps 1..6)
+        for (i in 0 until 5) {
             assertTrue(
-                indentAlphas[i] <= indentAlphas[i + 1],
-                "Alpha should increase with depth: ${indentAlphas[i]} <= ${indentAlphas[i + 1]}",
+                indentAlphas[i] < indentAlphas[i + 1],
+                "Ascending phase: ${indentAlphas[i]} < ${indentAlphas[i + 1]}",
+            )
+        }
+
+        // Last 4 descending (steps 5,4,3,2)
+        for (i in 5 until 9) {
+            assertTrue(
+                indentAlphas[i] > indentAlphas[i + 1],
+                "Descending phase: ${indentAlphas[i]} > ${indentAlphas[i + 1]}",
             )
         }
     }
@@ -101,5 +111,36 @@ class IndentPaletteTest {
         val palette1 = IndentPalette.forAccent("#FFCC66", AyuVariant.MIRAGE)
         val palette2 = IndentPalette.forAccent("#E6B450", AyuVariant.MIRAGE)
         assertNotEquals(palette1.accentColor, palette2.accentColor)
+    }
+
+    @Test
+    fun `error color is red when highlightErrors is true`() {
+        val palette = IndentPalette.forAccent(testAccent, AyuVariant.MIRAGE)
+        val colors = palette.toColorStrings(0x2E, highlightErrors = true)
+        assertEquals(
+            palette.errorColor,
+            colors[0].substring(2),
+            "error color should use red variant when highlightErrors=true",
+        )
+    }
+
+    @Test
+    fun `error color matches first indent color when highlightErrors is false`() {
+        val palette = IndentPalette.forAccent(testAccent, AyuVariant.MIRAGE)
+        val colors = palette.toColorStrings(0x2E, highlightErrors = false)
+
+        // Error (index 0) should use accent color, not the red error color
+        assertEquals(
+            palette.accentColor,
+            colors[0].substring(2),
+            "error color should use accent when highlightErrors=false",
+        )
+
+        // Error alpha should match first indent step alpha
+        assertEquals(
+            colors[1].substring(0, 2),
+            colors[0].substring(0, 2),
+            "error alpha should match first indent step alpha",
+        )
     }
 }

--- a/src/test/kotlin/dev/ayuislands/indent/IndentRainbowSyncTest.kt
+++ b/src/test/kotlin/dev/ayuislands/indent/IndentRainbowSyncTest.kt
@@ -159,8 +159,8 @@ class IndentRainbowSyncTest {
         verify { mockPaletteTypeField[mockConfig] = "CUSTOM_ENUM" }
         // Verify custom palette string was written
         verify { mockCustomPaletteField[mockConfig] = any<String>() }
-        // Verify number of colors = 7 (1 error + 6 indent)
-        verify { mockNumberColorsField.setInt(mockConfig, 7) }
+        // Verify number of colors = 11 (IR ignores this field, pass full count)
+        verify { mockNumberColorsField.setInt(mockConfig, 11) }
         // Verify cache flush
         verify { mockUpdateMethod.invoke(mockCompanion, mockConfig) }
         verify { mockRefreshMethod.invoke(mockColorsInstance) }
@@ -379,8 +379,8 @@ class IndentRainbowSyncTest {
         verify {
             mockCustomPaletteField[mockConfig] =
                 match<String> { palette ->
-                    // NEON alpha = 0x4D, 7 colors joined with ", "
-                    palette.split(", ").size == 7
+                    // NEON alpha = 0x4D, 11 colors joined with ", "
+                    palette.split(", ").size == 11
                 }
         }
     }
@@ -583,6 +583,46 @@ class IndentRainbowSyncTest {
 
         IndentRainbowSync.apply(AyuVariant.MIRAGE)
         // Should not throw — caught by RuntimeException handler
+    }
+
+    @Test
+    fun `apply uses accent error color when irErrorHighlightEnabled is false`() {
+        state.irIntegrationEnabled = true
+        state.irErrorHighlightEnabled = false
+        state.indentPresetName = "AMBIENT"
+
+        val mockConfig = Any()
+        val mockPaletteTypeField = mockField()
+        val mockCustomPaletteField = mockField()
+        val mockNumberColorsField = mockIntField()
+        val mockUpdateMethod = mockMethod()
+        val mockRefreshMethod = mockMethod()
+        val mockCompanion = Any()
+        val mockColorsInstance = Any()
+
+        setPrivateField("methodsResolved", true)
+        setPrivateField("irConfig", mockConfig)
+        setPrivateField("paletteTypeField", mockPaletteTypeField)
+        setPrivateField("customPaletteField", mockCustomPaletteField)
+        setPrivateField("customPaletteNumberColorsField", mockNumberColorsField)
+        setPrivateField("customEnumValue", "CUSTOM_ENUM")
+        setPrivateField("defaultEnumValue", "DEFAULT_ENUM")
+        setPrivateField("cachedDataUpdateMethod", mockUpdateMethod)
+        setPrivateField("cachedDataCompanion", mockCompanion)
+        setPrivateField("refreshMethod", mockRefreshMethod)
+        setPrivateField("irColorsInstance", mockColorsInstance)
+
+        IndentRainbowSync.apply(AyuVariant.MIRAGE)
+
+        // Verify palette string: error color (index 0) should use accent, not red
+        verify {
+            mockCustomPaletteField[mockConfig] =
+                match<String> { palette ->
+                    val colors = palette.split(", ")
+                    // Error color (first) should use accent hex (FFCC66), not red (F27983)
+                    colors[0].endsWith("FFCC66") && !colors[0].endsWith("F27983")
+                }
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Add "Highlight indent errors" toggle to IR integration settings — when off, continuation lines (HTML/XML) blend into the accent gradient instead of showing jarring red
- Fix `Write-unsafe context` error on startup by replacing `SwingUtilities.invokeLater` with `Application.invokeLater` in AccentApplicator
- Revert `customPaletteNumberColors` from `size-1` to `size` (IR ignores this field)

## Test plan

- [x] `./gradlew test` — all indent tests pass (including 3 new tests)
- [x] `./gradlew buildPlugin` — builds successfully
- [ ] Deploy to IDE → Settings → Ayu Islands → Integrations:
  - [ ] Toggle ON: error lines show red
  - [ ] Toggle OFF: error lines blend into gradient
- [ ] Verify no `Write-unsafe context` errors in `idea.log` on startup

## Summary by Sourcery

Add a configurable indent error highlighting mode for IR integration, extend the indent color palette, and fix EDT write-unsafe context usage in accent application.

New Features:
- Introduce an "Highlight indent errors" toggle in IR integration settings to switch between red error lines and gradient-blended continuation lines.
- Allow the indent palette to generate a larger pyramid-pattern gradient of colors used by the IR integration.

Bug Fixes:
- Resolve write-unsafe context errors on startup by invoking accent application work via the IntelliJ Application API instead of Swing utilities.
- Ensure IR custom palette color count reflects the full generated palette size to align with IR expectations.

Tests:
- Expand indent palette tests to cover the new pyramid alpha pattern and error highlight behavior.
- Extend IR sync tests to assert correct palette size and behavior when error highlighting is disabled.