### PR TITLE
chore: bump version to 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.1.1] - 2026-03-07
+
+### Added
+- [Paid] "Highlight indent errors" toggle for Indent Rainbow — disable to blend continuation lines into gradient
+
+### Fixed
+- [Paid] Fix write-unsafe EDT context error on startup with Indent Rainbow integration
+
 ## [2.1.0] - 2026-03-07
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.1.0
+pluginVersion=2.1.1
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -118,11 +118,10 @@ object AccentApplicator {
                 repaintAllWindows(Window.getWindows())
             }
 
-        val app = ApplicationManager.getApplication()
         if (SwingUtilities.isEventDispatchThread()) {
             work.run()
         } else {
-            app.invokeLater(work)
+            invokeLaterSafe(work)
         }
     }
 
@@ -161,11 +160,10 @@ object AccentApplicator {
                 // The platform repaints everything after the theme switch.
             }
 
-        val app = ApplicationManager.getApplication()
         if (SwingUtilities.isEventDispatchThread()) {
             work.run()
         } else {
-            app.invokeLater(work)
+            invokeLaterSafe(work)
         }
     }
 
@@ -304,6 +302,15 @@ object AccentApplicator {
                 .messageBus
                 .syncPublisher(EditorColorsManager.TOPIC)
                 .globalSchemeChange(null)
+        }
+    }
+
+    private fun invokeLaterSafe(work: Runnable) {
+        val app = ApplicationManager.getApplication()
+        if (app != null) {
+            app.invokeLater(work)
+        } else {
+            SwingUtilities.invokeLater(work)
         }
     }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -30,6 +30,11 @@
   ]]></description>
 
   <change-notes><![CDATA[
+    <h3>2.1.1</h3>
+    <ul>
+      <li>[Paid] Add "Highlight indent errors" toggle for Indent Rainbow — disable to blend continuation lines into gradient</li>
+      <li>[Paid] Fix write-unsafe EDT context error on startup with Indent Rainbow</li>
+    </ul>
     <h3>2.1.0</h3>
     <ul>
       <li>[Paid] Indent Rainbow integration: accent-colored indent guides with 4 intensity presets</li>


### PR DESCRIPTION
## Summary

- Bump plugin version to 2.1.1
- Guard `Application.invokeLater` with null check (Sourcery review feedback from #23)
- Update CHANGELOG.md and plugin.xml change-notes

## Test plan

- [x] `./gradlew clean buildPlugin` passes

## Summary by Sourcery

Bump plugin to version 2.1.1 and improve EDT scheduling safety for accent application and Indent Rainbow integration.

New Features:
- Add a paid "Highlight indent errors" toggle for Indent Rainbow to allow blending continuation lines into the gradient.

Bug Fixes:
- Guard Application.invokeLater calls with a null-safe helper to avoid write-unsafe EDT context errors on startup with Indent Rainbow integration.

Build:
- Update plugin version in gradle.properties to 2.1.1.

Documentation:
- Update CHANGELOG and plugin.xml change notes for the 2.1.1 release.