### PR TITLE
test: update invokeLater assertions for Application.invokeLater

### DIFF
--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
@@ -901,14 +901,13 @@ class AccentApplicatorTest {
         every { IndentRainbowSync.apply(any()) } returns Unit
         state.cgpIntegrationEnabled = false
         every { SwingUtilities.isEventDispatchThread() } returns false
-        every { SwingUtilities.invokeLater(any()) } answers {
-            // Execute the Runnable to verify its contents
+        every { mockApplication.invokeLater(any()) } answers {
             firstArg<Runnable>().run()
         }
 
         AccentApplicator.apply("#FFCC66")
 
-        verify { SwingUtilities.invokeLater(any()) }
+        verify { mockApplication.invokeLater(any()) }
         verify(atLeast = 1) { UIManager.put(any<String>(), any()) }
     }
 
@@ -977,13 +976,13 @@ class AccentApplicatorTest {
     fun `revertAll posts to invokeLater when not on EDT`() {
         mockEpExtensionList(emptyList())
         every { SwingUtilities.isEventDispatchThread() } returns false
-        every { SwingUtilities.invokeLater(any()) } answers {
+        every { mockApplication.invokeLater(any()) } answers {
             firstArg<Runnable>().run()
         }
 
         AccentApplicator.revertAll()
 
-        verify { SwingUtilities.invokeLater(any()) }
+        verify { mockApplication.invokeLater(any()) }
         verify(atLeast = 13) { UIManager.put(any<String>(), null) }
     }
 


### PR DESCRIPTION
## Summary

- Fix 2 failing tests that verified `SwingUtilities.invokeLater` — now verify `Application.invokeLater` per the `invokeLaterSafe` change in #24

## Test plan

- [x] `./gradlew test` — 393 tests pass

## Summary by Sourcery

Tests:
- Adjust AccentApplicator tests to stub and verify Application.invokeLater usage instead of SwingUtilities.invokeLater when executed off the EDT.