### PR TITLE
test: add negative SwingUtilities.invokeLater assertions

### DIFF
--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
@@ -908,6 +908,7 @@ class AccentApplicatorTest {
         AccentApplicator.apply("#FFCC66")
 
         verify { mockApplication.invokeLater(any()) }
+        verify(exactly = 0) { SwingUtilities.invokeLater(any()) }
         verify(atLeast = 1) { UIManager.put(any<String>(), any()) }
     }
 
@@ -983,6 +984,7 @@ class AccentApplicatorTest {
         AccentApplicator.revertAll()
 
         verify { mockApplication.invokeLater(any()) }
+        verify(exactly = 0) { SwingUtilities.invokeLater(any()) }
         verify(atLeast = 13) { UIManager.put(any<String>(), null) }
     }
 


### PR DESCRIPTION
Per Sourcery review on #25 — add verify(exactly=0) guards.

## Summary by Sourcery

Tests:
- Add negative verifications ensuring SwingUtilities.invokeLater is never invoked in apply and revertAll test cases.