### PR TITLE
feat: glow-underline merge + theme-aware settings

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -12,7 +12,7 @@ complexity:
     threshold: 200
   TooManyFunctions:
     thresholdInClasses: 25
-    thresholdInObjects: 15
+    thresholdInObjects: 20
   CyclomaticComplexMethod:
     threshold: 15
   NestedBlockDepth:

--- a/src/main/kotlin/dev/ayuislands/AppearanceSyncService.kt
+++ b/src/main/kotlin/dev/ayuislands/AppearanceSyncService.kt
@@ -34,8 +34,8 @@ class AppearanceSyncService {
         val settings = AyuIslandsSettings.getInstance()
         val targetThemeName =
             when (appearance) {
-                Appearance.DARK -> settings.state.lastDarkThemeName
-                Appearance.LIGHT -> settings.state.lastLightThemeName
+                Appearance.DARK -> settings.state.lastDarkAppearanceTheme
+                Appearance.LIGHT -> settings.state.lastLightAppearanceTheme
             } ?: return
 
         lastSyncedAppearance = appearance
@@ -47,8 +47,8 @@ class AppearanceSyncService {
         val variant = AyuVariant.fromThemeName(themeName) ?: return
         val settings = AyuIslandsSettings.getInstance()
         when (variant) {
-            AyuVariant.MIRAGE, AyuVariant.DARK -> settings.state.lastDarkThemeName = themeName
-            AyuVariant.LIGHT -> settings.state.lastLightThemeName = themeName
+            AyuVariant.MIRAGE, AyuVariant.DARK -> settings.state.lastDarkAppearanceTheme = themeName
+            AyuVariant.LIGHT -> settings.state.lastLightAppearanceTheme = themeName
         }
         LOG.info("Recorded manual appearance choice: $themeName")
     }

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.extensions.PluginId
 import com.intellij.ui.ColorUtil
 import dev.ayuislands.accent.conflict.ConflictRegistry
+import dev.ayuislands.glow.GlowStyle
 import dev.ayuislands.glow.GlowTabMode
 import dev.ayuislands.indent.IndentRainbowSync
 import dev.ayuislands.settings.AyuIslandsSettings
@@ -33,6 +34,7 @@ object AccentApplicator {
     private val DARK_FOREGROUND = Color(DARK_FOREGROUND_HEX)
     private const val TAB_ACCENT_BG_ALPHA = 50
     private const val KEY_TAB_BACKGROUND = "EditorTabs.underlinedTabBackground"
+    private const val DEFAULT_UNDERLINE_ARC = 8
     private const val CGP_RESOLUTION_FAILED = "method resolution failed"
     private const val CGP_SYNC_FAILED = "sync failed"
     private val EMPTY_TEXT_ATTRIBUTES = TextAttributes()
@@ -75,6 +77,7 @@ object AccentApplicator {
         listOf(
             ColorKey.find("BUTTON_BACKGROUND"),
             ColorKey.find("WARNING_FOREGROUND"),
+            ColorKey.find("TAB_UNDERLINE"),
         )
 
     private data class AttrOverride(
@@ -115,6 +118,8 @@ object AccentApplicator {
                     IndentRainbowSync.apply(variant)
                 }
                 applyAlwaysOnEditorKeys(accent)
+                overrideTabUnderlineForOffMode(state, variant)
+                applyTabUnderlineStyle(state)
                 repaintAllWindows(Window.getWindows())
             }
 
@@ -139,6 +144,8 @@ object AccentApplicator {
                 UIManager.put("Button.default.startBorderColor", null)
                 UIManager.put("Button.default.endBorderColor", null)
                 UIManager.put(KEY_TAB_BACKGROUND, null)
+                UIManager.put("EditorTabs.underlineHeight", null)
+                UIManager.put("EditorTabs.underlineArc", null)
 
                 for (element in EP_NAME.extensionList) {
                     try {
@@ -250,6 +257,17 @@ object AccentApplicator {
         }
     }
 
+    fun resolveUnderlineHeight(state: AyuIslandsState): Int {
+        val tabMode = GlowTabMode.fromName(state.glowTabMode ?: "MINIMAL")
+        if (tabMode == GlowTabMode.OFF) return state.tabUnderlineHeight
+
+        if (state.tabUnderlineGlowSync && state.glowEnabled) {
+            val style = GlowStyle.fromName(state.glowStyle ?: GlowStyle.SOFT.name)
+            return state.getWidthForStyle(style)
+        }
+        return state.tabUnderlineHeight
+    }
+
     private fun applyAlwaysOnEditorKeys(accent: Color) {
         val scheme = EditorColorsManager.getInstance().globalScheme
 
@@ -279,6 +297,26 @@ object AccentApplicator {
                 .syncPublisher(EditorColorsManager.TOPIC)
                 .globalSchemeChange(null)
         }
+    }
+
+    private fun applyTabUnderlineStyle(state: AyuIslandsState) {
+        val height = resolveUnderlineHeight(state)
+        UIManager.put("EditorTabs.underlineHeight", Integer.valueOf(height))
+
+        val arc = UIManager.getInt("Island.arc").let { if (it > 0) it else DEFAULT_UNDERLINE_ARC }
+        UIManager.put("EditorTabs.underlineArc", Integer.valueOf(arc))
+
+        log.info("Tab underline: height=${height}px, arc=${arc}px")
+    }
+
+    private fun overrideTabUnderlineForOffMode(
+        state: AyuIslandsState,
+        variant: AyuVariant?,
+    ) {
+        val tabMode = GlowTabMode.fromName(state.glowTabMode ?: "MINIMAL")
+        if (tabMode != GlowTabMode.OFF || variant == null) return
+        val scheme = EditorColorsManager.getInstance().globalScheme
+        scheme.setColor(ColorKey.find("TAB_UNDERLINE"), Color.decode(variant.neutralGray))
     }
 
     private fun revertAlwaysOnEditorKeys() {
@@ -376,8 +414,7 @@ object AccentApplicator {
             // CGP panels repaint via globalSchemeChange notification (no manual walk needed)
             log.info("CodeGlance Pro viewport color synced to $hexWithoutHash")
         } catch (exception: java.lang.reflect.InvocationTargetException) {
-            val cause = exception.cause
-            logCgpWarning(CGP_SYNC_FAILED, cause ?: exception)
+            logCgpWarning(CGP_SYNC_FAILED, exception.cause ?: exception)
         } catch (exception: ReflectiveOperationException) {
             logCgpWarning(CGP_SYNC_FAILED, exception)
         } catch (exception: RuntimeException) {

--- a/src/main/kotlin/dev/ayuislands/accent/AyuVariant.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AyuVariant.kt
@@ -8,12 +8,14 @@ enum class AyuVariant(
     val parentSchemeName: String,
     val themeNames: Set<String>,
 ) {
-    MIRAGE("#FFCC66", "#445066", "Darcula", setOf("Ayu Islands Mirage", "Ayu Islands Mirage (Islands UI)")),
-    DARK("#E6B450", "#2C3342", "Darcula", setOf("Ayu Islands Dark", "Ayu Islands Dark (Islands UI)")),
-    LIGHT("#F29718", "#CCC8B8", "Default", setOf("Ayu Islands Light", "Ayu Islands Light (Islands UI)")),
+    MIRAGE("#FFCC66", "#445066", "Darcula", setOf("Ayu Mirage", "Ayu Mirage (Islands UI)")),
+    DARK("#E6B450", "#2C3342", "Darcula", setOf("Ayu Dark", "Ayu Dark (Islands UI)")),
+    LIGHT("#F29718", "#CCC8B8", "Default", setOf("Ayu Light", "Ayu Light (Islands UI)")),
     ;
 
     companion object {
+        private const val ISLANDS_UI_SUFFIX = "(Islands UI)"
+
         fun fromThemeName(name: String): AyuVariant? = entries.firstOrNull { name in it.themeNames }
 
         @Suppress("UnstableApiUsage")
@@ -21,5 +23,12 @@ enum class AyuVariant(
             val themeName = LafManager.getInstance().currentUIThemeLookAndFeel.name
             return fromThemeName(themeName)
         }
+
+        @Suppress("UnstableApiUsage")
+        fun isIslandsUi(): Boolean =
+            LafManager
+                .getInstance()
+                .currentUIThemeLookAndFeel.name
+                .contains(ISLANDS_UI_SUFFIX)
     }
 }

--- a/src/main/kotlin/dev/ayuislands/glow/GlowGlassPane.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/GlowGlassPane.kt
@@ -22,6 +22,7 @@ class GlowGlassPane(
     var glowStyle: GlowStyle,
     var glowIntensity: Int,
     var glowWidth: Int,
+    var isEditorOverlay: Boolean = false,
 ) : JPanel(null) {
     private val renderer = GlowRenderer()
     private var fadeAlpha: Float = 0.0f

--- a/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ToolWindowType
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener
+import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
@@ -306,6 +307,23 @@ class GlowOverlayManager(
         return null
     }
 
+    private fun findTabBarHeight(host: JComponent): Int {
+        // EditorsSplitters has one child: EditorTabs (full JBTabsImpl tabbed pane).
+        // EditorTabs.height = entire editor area — NOT the tab strip.
+        // Walk into EditorTabs and find a TabLabel — its (y + height) is the strip height.
+        val editorTabs =
+            host.components.firstOrNull {
+                it.javaClass.name.contains("EditorTabs")
+            } as? Container ?: return 0
+
+        for (child in editorTabs.components) {
+            if (child.javaClass.name.contains("TabLabel")) {
+                return child.y + child.height
+            }
+        }
+        return 0
+    }
+
     private fun updateOverlayBounds(
         glassPane: GlowGlassPane,
         host: JComponent,
@@ -314,7 +332,12 @@ class GlowOverlayManager(
         if (!host.isShowing) return
         try {
             val point = SwingUtilities.convertPoint(host, 0, 0, layeredPane)
-            glassPane.setBounds(point.x, point.y, host.width, host.height)
+            if (glassPane.isEditorOverlay) {
+                val tabHeight = findTabBarHeight(host)
+                glassPane.setBounds(point.x, point.y + tabHeight, host.width, host.height - tabHeight)
+            } else {
+                glassPane.setBounds(point.x, point.y, host.width, host.height)
+            }
         } catch (exception: RuntimeException) {
             log.debug("Component hierarchy changed during overlay bounds update", exception)
         }
@@ -323,6 +346,7 @@ class GlowOverlayManager(
     private fun attachOverlay(
         id: String,
         host: JComponent,
+        isEditorOverlay: Boolean = false,
     ) {
         if (overlays.containsKey(id)) return
         if (host.width == 0 || host.height == 0) return
@@ -342,6 +366,7 @@ class GlowOverlayManager(
                 glowStyle = style,
                 glowIntensity = state.getIntensityForStyle(style),
                 glowWidth = state.getWidthForStyle(style),
+                isEditorOverlay = isEditorOverlay,
             )
 
         layeredPane.add(glassPane, JLayeredPane.PALETTE_LAYER)
@@ -393,7 +418,7 @@ class GlowOverlayManager(
         if (!state.isIslandEnabled(EDITOR_ID)) return
 
         val host = findEditorHost() ?: return
-        attachOverlay(EDITOR_ID, host)
+        attachOverlay(EDITOR_ID, host, isEditorOverlay = true)
     }
 
     private fun activateGlow(id: String) {
@@ -508,6 +533,10 @@ class GlowOverlayManager(
                 UIManager.put(KEY_TAB_BACKGROUND, Color(0, 0, 0, 0))
             }
         }
+
+        // Sync underline height (ensures glow width changes propagate when sync is on)
+        UIManager.put("EditorTabs.underlineHeight", AccentApplicator.resolveUnderlineHeight(state))
+
         repaintEditorTabs()
     }
 

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsElementsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsElementsPanel.kt
@@ -4,6 +4,7 @@ package dev.ayuislands.settings
 
 import com.intellij.ui.dsl.builder.AlignY
 import com.intellij.ui.dsl.builder.Panel
+import com.intellij.ui.dsl.builder.Row
 import com.intellij.ui.dsl.builder.SegmentedButton
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentElementId
@@ -11,6 +12,7 @@ import dev.ayuislands.accent.AccentGroup
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.conflict.ConflictRegistry
 import dev.ayuislands.accent.conflict.ConflictType
+import dev.ayuislands.glow.GlowStyle
 import dev.ayuislands.glow.GlowTabMode
 import dev.ayuislands.licensing.LicenseChecker
 import java.awt.event.MouseAdapter
@@ -25,8 +27,18 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
     private var storedForceOverrides: Set<String> = emptySet()
     private var pendingTabMode: String = "MINIMAL"
     private var storedTabMode: String = "MINIMAL"
+    private var pendingTabUnderlineHeight: Int = AyuIslandsState.DEFAULT_TAB_UNDERLINE_HEIGHT
+    private var storedTabUnderlineHeight: Int = AyuIslandsState.DEFAULT_TAB_UNDERLINE_HEIGHT
+    private var pendingTabUnderlineGlowSync: Boolean = false
+    private var storedTabUnderlineGlowSync: Boolean = false
     private val checkboxes: MutableMap<AccentElementId, JCheckBox> = mutableMapOf()
     private var tabModeSegmented: SegmentedButton<GlowTabMode>? = null
+    private var tabModeCommentRow: Row? = null
+    private var tabModeRow: Row? = null
+    private var thicknessSegmented: SegmentedButton<Int>? = null
+    private var thicknessRow: Row? = null
+    private var syncRow: Row? = null
+    private var syncCheckbox: JCheckBox? = null
     private var variant: AyuVariant? = null
     private var elementPreview: AyuIslandsPreviewPanel? = null
 
@@ -57,6 +69,11 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
 
         storedTabMode = state.glowTabMode ?: "MINIMAL"
         pendingTabMode = storedTabMode
+
+        storedTabUnderlineHeight = state.tabUnderlineHeight
+        pendingTabUnderlineHeight = storedTabUnderlineHeight
+        storedTabUnderlineGlowSync = state.tabUnderlineGlowSync
+        pendingTabUnderlineGlowSync = storedTabUnderlineGlowSync
 
         // Detect conflicts on panel open and clean stale overrides for blocked elements
         ConflictRegistry.detectConflicts()
@@ -97,7 +114,10 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
                         {
                             panel {
                                 row { label("Interactive").bold() }
-                                for (id in AccentElementId.entries.filter { it.group == AccentGroup.INTERACTIVE }) {
+                                for (
+                                id in
+                                AccentElementId.entries.filter { it.group == AccentGroup.INTERACTIVE }
+                                ) {
                                     buildToggleRow(this, id, licensed)
                                 }
                             }
@@ -133,25 +153,84 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
         panel: Panel,
         licensed: Boolean,
     ) {
+        val state = AyuIslandsSettings.getInstance().state
+        val glowEnabled = state.glowEnabled
+
+        val islandsUi = AyuVariant.isIslandsUi()
+
         panel.group("Active Tab") {
-            row {
-                comment("Minimal = underline only, Full = underline + tinted background, Off = neutral")
-            }
-            row {
-                label("Tab accent style")
-                val segmented =
-                    segmentedButton(GlowTabMode.entries) { mode ->
-                        text = mode.displayName
+            // Tab accent style (Islands UI only)
+            tabModeCommentRow =
+                row {
+                    comment(
+                        "Minimal = underline only, Full = underline + tinted background, Off = neutral",
+                    )
+                }.visible(islandsUi)
+            tabModeRow =
+                row {
+                    label("Tab accent style")
+                    val segmented =
+                        segmentedButton(GlowTabMode.entries) { mode -> text = mode.displayName }
+                    segmented.selectedItem = GlowTabMode.fromName(pendingTabMode)
+                    segmented.enabled(licensed)
+                    @Suppress("UnstableApiUsage")
+                    segmented.whenItemSelected { mode ->
+                        pendingTabMode = mode.name
+                        updateThicknessRowVisibility()
                     }
-                segmented.selectedItem = GlowTabMode.fromName(pendingTabMode)
-                segmented.enabled(licensed)
-                @Suppress("UnstableApiUsage")
-                segmented.whenItemSelected { mode ->
-                    pendingTabMode = mode.name
-                }
-                tabModeSegmented = segmented
-            }
+                    tabModeSegmented = segmented
+                }.visible(islandsUi)
+
+            // Underline thickness presets (non-Islands only)
+            val tabModeIsOff = GlowTabMode.fromName(pendingTabMode) == GlowTabMode.OFF
+            thicknessRow =
+                row {
+                    label("Underline thickness")
+                    val thickSegmented =
+                        segmentedButton(UNDERLINE_THICKNESS_PRESETS) { value -> text = "${value}px" }
+                    thickSegmented.selectedItem = pendingTabUnderlineHeight
+                    thickSegmented.enabled(licensed && !pendingTabUnderlineGlowSync)
+                    @Suppress("UnstableApiUsage")
+                    thickSegmented.whenItemSelected { value -> pendingTabUnderlineHeight = value }
+                    thicknessSegmented = thickSegmented
+                }.visible(!tabModeIsOff && !islandsUi)
+
+            // Sync with the glow width checkbox (hidden on Islands UI)
+            syncRow =
+                row {
+                    val cb = checkBox("Sync with glow width")
+                    cb.component.isSelected = pendingTabUnderlineGlowSync
+                    cb.component.isEnabled = licensed && glowEnabled
+                    if (!glowEnabled) {
+                        cb.component.toolTipText = "Enable glow to sync"
+                    }
+                    cb.component.addActionListener {
+                        pendingTabUnderlineGlowSync = cb.component.isSelected
+                        updateThicknessEnabledState()
+                        if (pendingTabUnderlineGlowSync && glowEnabled) {
+                            val style = GlowStyle.fromName(state.glowStyle ?: GlowStyle.SOFT.name)
+                            val syncedWidth = state.getWidthForStyle(style)
+                            thicknessSegmented?.selectedItem = syncedWidth
+                        }
+                    }
+                    syncCheckbox = cb.component
+                }.visible(!tabModeIsOff && !islandsUi)
         }
+    }
+
+    private fun updateThicknessRowVisibility() {
+        val isOff = GlowTabMode.fromName(pendingTabMode) == GlowTabMode.OFF
+        val hidden = isOff || AyuVariant.isIslandsUi()
+        thicknessRow?.visible(!hidden)
+        syncRow?.visible(!hidden)
+        if (!hidden) {
+            updateThicknessEnabledState()
+        }
+    }
+
+    private fun updateThicknessEnabledState() {
+        thicknessSegmented?.enabled(!pendingTabUnderlineGlowSync)
+        syncCheckbox?.isEnabled = AyuIslandsSettings.getInstance().state.glowEnabled
     }
 
     private fun buildToggleRow(
@@ -190,9 +269,7 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
         }
 
         if (isBlocking) {
-            panel.row {
-                comment("Managed by ${conflict.pluginDisplayName}")
-            }
+            panel.row { comment("Managed by ${conflict.pluginDisplayName}") }
         }
     }
 
@@ -211,6 +288,8 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
         if (pendingToggles != storedToggles) return true
         if (pendingForceOverrides != storedForceOverrides) return true
         if (pendingTabMode != storedTabMode) return true
+        if (pendingTabUnderlineHeight != storedTabUnderlineHeight) return true
+        if (pendingTabUnderlineGlowSync != storedTabUnderlineGlowSync) return true
         return false
     }
 
@@ -223,10 +302,14 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
         }
         state.forceOverrides = pendingForceOverrides.toMutableSet()
         state.glowTabMode = pendingTabMode
+        state.tabUnderlineHeight = pendingTabUnderlineHeight
+        state.tabUnderlineGlowSync = pendingTabUnderlineGlowSync
 
         storedToggles = pendingToggles.toMap()
         storedForceOverrides = pendingForceOverrides.toSet()
         storedTabMode = pendingTabMode
+        storedTabUnderlineHeight = pendingTabUnderlineHeight
+        storedTabUnderlineGlowSync = pendingTabUnderlineGlowSync
 
         // Re-apply accent with new toggle states
         val currentVariant = variant ?: return
@@ -239,8 +322,17 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
         pendingToggles.putAll(storedToggles)
         pendingForceOverrides = storedForceOverrides.toMutableSet()
         pendingTabMode = storedTabMode
+        pendingTabUnderlineHeight = storedTabUnderlineHeight
+        pendingTabUnderlineGlowSync = storedTabUnderlineGlowSync
         refreshCheckboxes()
         syncPreviewToggles()
         tabModeSegmented?.selectedItem = GlowTabMode.fromName(pendingTabMode)
+        thicknessSegmented?.selectedItem = pendingTabUnderlineHeight
+        syncCheckbox?.isSelected = pendingTabUnderlineGlowSync
+        updateThicknessRowVisibility()
+    }
+
+    companion object {
+        private val UNDERLINE_THICKNESS_PRESETS = listOf(2, 4, 6, 8)
     }
 }

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsElementsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsElementsPanel.kt
@@ -39,6 +39,7 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
     private var thicknessRow: Row? = null
     private var syncRow: Row? = null
     private var syncCheckbox: JCheckBox? = null
+    private var licensed: Boolean = false
     private var variant: AyuVariant? = null
     private var elementPreview: AyuIslandsPreviewPanel? = null
 
@@ -55,7 +56,7 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
     ) {
         this.variant = variant
         val state = AyuIslandsSettings.getInstance().state
-        val licensed = LicenseChecker.isLicensedOrGrace()
+        licensed = LicenseChecker.isLicensedOrGrace()
 
         // Initialize toggle state from persisted settings
         for (id in AccentElementId.entries) {
@@ -146,13 +147,10 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
             }
         }
 
-        buildActiveTabRow(panel, licensed)
+        buildActiveTabRow(panel)
     }
 
-    private fun buildActiveTabRow(
-        panel: Panel,
-        licensed: Boolean,
-    ) {
+    private fun buildActiveTabRow(panel: Panel) {
         val state = AyuIslandsSettings.getInstance().state
         val glowEnabled = state.glowEnabled
 
@@ -229,8 +227,8 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
     }
 
     private fun updateThicknessEnabledState() {
-        thicknessSegmented?.enabled(!pendingTabUnderlineGlowSync)
-        syncCheckbox?.isEnabled = AyuIslandsSettings.getInstance().state.glowEnabled
+        thicknessSegmented?.enabled(licensed && !pendingTabUnderlineGlowSync)
+        syncCheckbox?.isEnabled = licensed && AyuIslandsSettings.getInstance().state.glowEnabled
     }
 
     private fun buildToggleRow(

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -14,8 +14,8 @@ class AyuIslandsState : BaseState() {
     var lightAccent by string("#F29718")
     var followSystemAccent by property(false)
     var followSystemAppearance by property(false)
-    var lastDarkThemeName by string("Ayu Islands Mirage (Islands UI)")
-    var lastLightThemeName by string("Ayu Islands Light (Islands UI)")
+    var lastDarkAppearanceTheme by string("Ayu Mirage (Islands UI)")
+    var lastLightAppearanceTheme by string("Ayu Light (Islands UI)")
     var trialExpiredNotified by property(false)
     var proDefaultsApplied by property(false)
 
@@ -62,6 +62,12 @@ class AyuIslandsState : BaseState() {
 
     // Tab glow mode: MINIMAL (underline only), FULL (underline + tinted bg), OFF
     var glowTabMode by string("MINIMAL")
+
+    // Tab underline height (pixels): 2, 4, 6, or 8
+    var tabUnderlineHeight by property(DEFAULT_TAB_UNDERLINE_HEIGHT)
+
+    // Sync underline height with glow width (1:1)
+    var tabUnderlineGlowSync by property(false)
 
     // Focused input focus-ring glow (subtle, less intense than an island glow)
     var glowFocusRing by property(true)
@@ -188,6 +194,7 @@ class AyuIslandsState : BaseState() {
     }
 
     companion object {
+        const val DEFAULT_TAB_UNDERLINE_HEIGHT = 4
         private const val DEFAULT_SOFT_INTENSITY = 20
         private const val DEFAULT_SHARP_NEON_INTENSITY = 50
         private const val DEFAULT_GRADIENT_INTENSITY = 30

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,65 +1,74 @@
 <idea-plugin>
-  <id>com.ayuislands.theme</id>
-  <name>Ayu Islands</name>
-  <!-- version patched by Gradle from gradle.properties -->
-  <vendor email="roman.borodavkin@gmail.com"
-          url="https://github.com/barad1tos/ayu-jetbrains">ayu-islands</vendor>
+    <id>com.ayuislands.theme</id>
+    <name>Ayu Islands</name>
+    <!-- version patched by Gradle from gradle.properties -->
+    <vendor email="roman.borodavkin@gmail.com"
+            url="https://github.com/barad1tos/ayu-jetbrains">ayu-islands
+    </vendor>
 
-  <description><![CDATA[
-    <p>Warm, refined color themes for JetBrains IDEs — three Ayu palettes with modern Islands UI. Free themes with optional premium accent and glow customization.</p>
+    <description><![CDATA[
+    <p>Ayu colors, reimagined for modern JetBrains IDEs. Warm, refined palettes purpose-built for Islands UI with deep IDE integration that goes beyond simple color mapping.</p>
 
-    <h3>Free Features</h3>
+    <h3>What makes this different</h3>
     <ul>
-      <li><strong>6 themes</strong> — Ayu Mirage, Ayu Dark, and Ayu Light, each in classic and Islands UI variants</li>
-      <li><strong>20+ language highlights</strong> — Java, C#/.NET, Rust, Go, Python, JS/TS, HCL/Terraform, Kotlin, Scala, Dart, Ruby, PHP, HTML/CSS, SQL, Bash, YAML, JSON, XML, Markdown</li>
-      <li><strong>Islands UI</strong> — rounded panels, island gaps, and compact mode support</li>
-      <li><strong>Canonical ayu-colors</strong> — syntax palettes from <a href="https://github.com/ayu-theme/ayu-colors">ayu-theme/ayu-colors</a></li>
-      <li><strong>Full VCS integration</strong> — tuned diff gutters, file status colors, and 16-color terminal palette</li>
-      <li><strong>Accent color customization</strong> — 10 hand-picked Ayu palette presets with per-variant storage and live visual preview</li>
+      <li><strong>6 variants</strong> covering all lighting preferences — Mirage, Dark, and Light, each in Classic UI and Islands UI</li>
+      <li><strong>500+ UI properties</strong> hand-tuned per variant (not auto-generated from a base)</li>
+      <li><strong>Native Islands UI support</strong> with rounded panels, island gaps, and compact mode</li>
+      <li><strong>30+ language syntaxes</strong> individually crafted — Java, Kotlin, Scala, C#/.NET, Rust, Go, Python, JS/TS, Ruby, PHP, Dart, Swift, HCL/Terraform, HTML/CSS, SQL, Bash, YAML, JSON, XML, Markdown, and more</li>
+      <li>Built on the official <a href="https://github.com/ayu-theme/ayu-colors">ayu-colors</a> palette — faithful to the original</li>
     </ul>
 
-    <h3>Premium Features</h3>
+    <h3>Free — a complete theme, not a teaser</h3>
     <ul>
-      <li><strong>Per-element accent toggles</strong> — fine-grained control over tabs, scrollbars, links, caret row, and more</li>
-      <li><strong>Neon glow effects</strong> — island borders, active tabs, and focused inputs with 3 glow styles (Soft, Sharp Neon, Pulse animation)</li>
-      <li><strong>Conflict detection</strong> — automatic detection and override for third-party plugin conflicts (Atom Material Icons, CodeGlance Pro)</li>
+      <li>All six themes with full syntax highlighting</li>
+      <li>VCS/diff integration with a 16-color terminal palette</li>
+      <li>Ten accent color presets with per-variant storage and live preview</li>
+      <li>Islands UI plus Classic UI support</li>
     </ul>
 
-    <p>Settings panel under Appearance &gt; Ayu Islands with tabbed Accent/Effects layout.</p>
-    <p><strong>Verified on 12 IDEs</strong> — IntelliJ IDEA, PyCharm, WebStorm, GoLand, RustRover, Rider, PhpStorm, CLion, DataGrip, RubyMine</p>
+    <h3>Premium — optional extras for deeper customization</h3>
+    <ul>
+      <li><strong>Per-element accent controls</strong> — tabs, scrollbars, links, caret row, inlay hints, and more</li>
+      <li><strong>Neon glow effects</strong> — island borders, active tabs, and focused inputs with three glow styles (Soft, Sharp Neon, Pulse)</li>
+      <li><strong>Indent Rainbow integration</strong> — accent-colored indent guides with intensity presets</li>
+      <li><strong>Conflict detection</strong> — automatic override for third-party plugin conflicts (Atom Material Icons, CodeGlance Pro)</li>
+    </ul>
+
+    <p>Settings: Appearance &gt; Ayu Islands. Verified on IntelliJ IDEA, PyCharm, WebStorm, GoLand, RustRover, Rider, PhpStorm, CLion, DataGrip, RubyMine.</p>
+    <p><em>Color palette: <a href="https://github.com/ayu-theme/ayu-colors">ayu-theme</a> (MIT) by dempfi. Ayu Islands adds deep JetBrains integration, Islands UI support, and premium customization tools.</em></p>
   ]]></description>
 
-  <change-notes><![CDATA[
+    <change-notes><![CDATA[
     <h3>2.1.1</h3>
     <ul>
-      <li>[Paid] Add "Highlight indent errors" toggle for Indent Rainbow — disable to blend continuation lines into gradient</li>
+      <li>[Paid] Add the "Highlight indent errors" toggle for Indent Rainbow — disable to blend continuation lines into gradient</li>
       <li>[Paid] Fix write-unsafe EDT context error on startup with Indent Rainbow</li>
     </ul>
     <h3>2.1.0</h3>
     <ul>
-      <li>[Paid] Indent Rainbow integration: accent-colored indent guides with 4 intensity presets</li>
+      <li>[Paid] Indent Rainbow integration: accent-colored indent guides with four intensity presets</li>
       <li>[Paid] Bracket scope gutter highlight for matched braces</li>
       <li>[Free] Accent-colored matched bracket styling</li>
       <li>[Free] New Integrations settings panel for third-party plugin sync</li>
     </ul>
     <h3>2.0.1</h3>
     <ul>
-      <li>Fix crash on theme switch (null attributes in editor scheme revert)</li>
-      <li>Fix crash on theme switch (premature repaint before new theme loaded)</li>
+      <li>Fix crash on theme switch (null attributes in an editor scheme revert)</li>
+      <li>Fix crash on the theme switch (premature repaint before the new theme loaded)</li>
       <li>Replace deprecated platform API calls for Marketplace compatibility</li>
     </ul>
     <h3>2.0.0</h3>
     <ul>
       <li>Accent color customization: 10 Ayu palette presets with per-element toggles and visual preview (premium)</li>
-      <li>Neon glow effects: island borders, active tabs, and focused inputs with 3 glow styles (premium)</li>
+      <li>Neon glow effects: island borders, active tabs, and focused inputs with three glow styles (premium)</li>
       <li>Per-variant accent storage (independent colors for Mirage, Dark, Light)</li>
       <li>Third-party conflict detection (Atom Material Icons, CodeGlance Pro)</li>
       <li>Settings panel under Appearance with tabbed Accent/Effects layout</li>
-      <li>Freemium licensing: all 6 base themes remain free</li>
+      <li>Freemium licensing: all six base themes remain free</li>
     </ul>
     <h3>1.2.1</h3>
     <ul>
-      <li>Add missing Marketplace changelog for v1.2.0 changes</li>
+      <li>Add a missing Marketplace changelog for v1.2.0 changes</li>
     </ul>
     <h3>1.2.0</h3>
     <ul>
@@ -86,83 +95,83 @@
     </ul>
   ]]></change-notes>
 
-  <!-- idea-version patched by Gradle from gradle.properties -->
-  <depends>com.intellij.modules.platform</depends>
+    <!-- idea-version patched by Gradle from gradle.properties -->
+    <depends>com.intellij.modules.platform</depends>
 
-  <product-descriptor
-      code="PAYUISLANDS"
-      release-date="20260307"
-      release-version="21"
-      optional="true"/>
+    <product-descriptor
+            code="PAYUISLANDS"
+            release-date="20260307"
+            release-version="21"
+            optional="true"/>
 
-  <extensionPoints>
-    <extensionPoint
-        name="accentElement"
-        interface="dev.ayuislands.accent.AccentElement"/>
-  </extensionPoints>
+    <extensionPoints>
+        <extensionPoint
+                name="accentElement"
+                interface="dev.ayuislands.accent.AccentElement"/>
+    </extensionPoints>
 
-  <extensions defaultExtensionNs="com.ayuislands.theme">
-    <accentElement implementation="dev.ayuislands.accent.elements.InlayHintsElement"/>
-    <accentElement implementation="dev.ayuislands.accent.elements.CaretRowElement"/>
-    <accentElement implementation="dev.ayuislands.accent.elements.ProgressBarElement"/>
-    <accentElement implementation="dev.ayuislands.accent.elements.ScrollbarElement"/>
-    <accentElement implementation="dev.ayuislands.accent.elements.LinksElement"/>
-    <accentElement implementation="dev.ayuislands.accent.elements.BracketMatchElement"/>
-    <accentElement implementation="dev.ayuislands.accent.elements.SearchResultsElement"/>
-    <accentElement implementation="dev.ayuislands.accent.elements.CheckboxElement"/>
-  </extensions>
+    <extensions defaultExtensionNs="com.ayuislands.theme">
+        <accentElement implementation="dev.ayuislands.accent.elements.InlayHintsElement"/>
+        <accentElement implementation="dev.ayuislands.accent.elements.CaretRowElement"/>
+        <accentElement implementation="dev.ayuislands.accent.elements.ProgressBarElement"/>
+        <accentElement implementation="dev.ayuislands.accent.elements.ScrollbarElement"/>
+        <accentElement implementation="dev.ayuislands.accent.elements.LinksElement"/>
+        <accentElement implementation="dev.ayuislands.accent.elements.BracketMatchElement"/>
+        <accentElement implementation="dev.ayuislands.accent.elements.SearchResultsElement"/>
+        <accentElement implementation="dev.ayuislands.accent.elements.CheckboxElement"/>
+    </extensions>
 
-  <extensions defaultExtensionNs="com.intellij">
-    <!-- Settings panel under Appearance > Ayu Islands -->
-    <applicationConfigurable
-        parentId="appearance"
-        instance="dev.ayuislands.settings.AyuIslandsConfigurable"
-        id="dev.ayuislands.settings.AyuIslandsConfigurable"
-        displayName="Ayu Islands"/>
+    <extensions defaultExtensionNs="com.intellij">
+        <!-- Settings panel under Appearance > Ayu Islands -->
+        <applicationConfigurable
+                parentId="appearance"
+                instance="dev.ayuislands.settings.AyuIslandsConfigurable"
+                id="dev.ayuislands.settings.AyuIslandsConfigurable"
+                displayName="Ayu Islands"/>
 
-    <!-- Persistent accent color state -->
-    <applicationService
-        serviceImplementation="dev.ayuislands.settings.AyuIslandsSettings"/>
+        <!-- Persistent accent color state -->
+        <applicationService
+                serviceImplementation="dev.ayuislands.settings.AyuIslandsSettings"/>
 
-    <!-- Appearance sync (follow system Light/Dark mode) -->
-    <applicationService
-        serviceImplementation="dev.ayuislands.AppearanceSyncService"/>
+        <!-- Appearance sync (follow system Light/Dark mode) -->
+        <applicationService
+                serviceImplementation="dev.ayuislands.AppearanceSyncService"/>
 
-    <!-- Glow overlay manager (per-project lifecycle) -->
-    <projectService
-        serviceImplementation="dev.ayuislands.glow.GlowOverlayManager"/>
+        <!-- Glow overlay manager (per-project lifecycle) -->
+        <projectService
+                serviceImplementation="dev.ayuislands.glow.GlowOverlayManager"/>
 
-    <!-- Plugin lifecycle -->
-    <postStartupActivity
-        implementation="dev.ayuislands.AyuIslandsStartupActivity"/>
+        <!-- Plugin lifecycle -->
+        <postStartupActivity
+                implementation="dev.ayuislands.AyuIslandsStartupActivity"/>
 
-    <!-- Trial expiry notifications -->
-    <notificationGroup id="Ayu Islands"
-                       displayType="BALLOON"/>
+        <!-- Trial expiry notifications -->
+        <notificationGroup id="Ayu Islands"
+                           displayType="BALLOON"/>
 
-    <!-- Mirage variants -->
-    <themeProvider id="com.ayuislands.theme.mirage"
-                   path="/themes/ayu-islands-mirage.theme.json"/>
-    <themeProvider id="com.ayuislands.theme.mirage.islands"
-                   path="/themes/ayu-islands-mirage-islands.theme.json"/>
-    <!-- Dark variants -->
-    <themeProvider id="com.ayuislands.theme.dark"
-                   path="/themes/ayu-islands-dark.theme.json"/>
-    <themeProvider id="com.ayuislands.theme.dark.islands"
-                   path="/themes/ayu-islands-dark-islands.theme.json"/>
-    <!-- Light variants -->
-    <themeProvider id="com.ayuislands.theme.light"
-                   path="/themes/ayu-islands-light.theme.json"/>
-    <themeProvider id="com.ayuislands.theme.light.islands"
-                   path="/themes/ayu-islands-light-islands.theme.json"/>
-  </extensions>
+        <!-- Mirage variants -->
+        <themeProvider id="com.ayuislands.theme.mirage"
+                       path="/themes/ayu-islands-mirage.theme.json"/>
+        <themeProvider id="com.ayuislands.theme.mirage.islands"
+                       path="/themes/ayu-islands-mirage-islands.theme.json"/>
+        <!-- Dark variants -->
+        <themeProvider id="com.ayuislands.theme.dark"
+                       path="/themes/ayu-islands-dark.theme.json"/>
+        <themeProvider id="com.ayuislands.theme.dark.islands"
+                       path="/themes/ayu-islands-dark-islands.theme.json"/>
+        <!-- Light variants -->
+        <themeProvider id="com.ayuislands.theme.light"
+                       path="/themes/ayu-islands-light.theme.json"/>
+        <themeProvider id="com.ayuislands.theme.light.islands"
+                       path="/themes/ayu-islands-light-islands.theme.json"/>
+    </extensions>
 
-  <applicationListeners>
-    <listener
-        class="dev.ayuislands.AyuIslandsLafListener"
-        topic="com.intellij.ide.ui.LafManagerListener"/>
-    <listener
-        class="dev.ayuislands.AppearanceSyncListener"
-        topic="com.intellij.openapi.application.ApplicationActivationListener"/>
-  </applicationListeners>
+    <applicationListeners>
+        <listener
+                class="dev.ayuislands.AyuIslandsLafListener"
+                topic="com.intellij.ide.ui.LafManagerListener"/>
+        <listener
+                class="dev.ayuislands.AppearanceSyncListener"
+                topic="com.intellij.openapi.application.ApplicationActivationListener"/>
+    </applicationListeners>
 </idea-plugin>

--- a/src/main/resources/themes/ayu-islands-dark-islands.theme.json
+++ b/src/main/resources/themes/ayu-islands-dark-islands.theme.json
@@ -1,5 +1,5 @@
 {
-  "name": "Ayu Islands Dark (Islands UI)",
+  "name": "Ayu Dark (Islands UI)",
   "dark": true,
   "author": "cloud",
   "parentTheme": "Islands Dark",

--- a/src/main/resources/themes/ayu-islands-dark.theme.json
+++ b/src/main/resources/themes/ayu-islands-dark.theme.json
@@ -1,5 +1,5 @@
 {
-  "name": "Ayu Islands Dark",
+  "name": "Ayu Dark",
   "dark": true,
   "author": "cloud",
   "parentTheme": "ExperimentalDark",
@@ -101,22 +101,7 @@
       "inactiveBackground": "BackgroundMid"
     },
 
-    "Islands": 1,
-    "Island": {
-      "arc": 20,
-      "arc.compact": 16,
-      "borderArcLength": 14,
-      "borderArcLength.compact": 10,
-      "borderWidth": 6,
-      "borderWidth.compact": 4,
-      "borderColor": "Gray2.5",
-      "inactiveAlpha": 0.44,
-      "inactiveAlphaInStatusBar": {
-        "os.mac": 0.2,
-        "os.windows": 0.2,
-        "os.linux": 0.15
-      }
-    },
+    "Islands": 0,
 
     "MainWindow.background": "BackgroundLight",
 
@@ -145,7 +130,7 @@
       "background": "BackgroundLight",
       "borderColor": "BorderTransparent",
       "Dropdown.transparentHoverBackground": "#FFFFFF12",
-      "Button.arc.compact": 8
+      "Button.arc.compact": 0
     },
 
     "StatusBar": {
@@ -327,6 +312,10 @@
     },
 
     "TextField.background": "InputBackground",
+
+    "Component.arc": 0,
+    "Button.arc": 0,
+    "TabbedPane.tabSelectionArc": 0,
 
     "Component.borderColor": "ComponentBorder",
     "Component.focusedBorderColor": "#E6B450",
@@ -804,8 +793,7 @@
 
       "Borders.color": "#171C27",
       "Borders.ContrastBorderColor": "#171C27",
-      "ToolWindow.Header.borderColor": "#171C27",
-      "Island.borderColor": "#0D1017"
+      "ToolWindow.Header.borderColor": "#171C27"
     },
 
     "AlertDialog.background": "PopupBackground",

--- a/src/main/resources/themes/ayu-islands-light-islands.theme.json
+++ b/src/main/resources/themes/ayu-islands-light-islands.theme.json
@@ -1,5 +1,5 @@
 {
-  "name": "Ayu Islands Light (Islands UI)",
+  "name": "Ayu Light (Islands UI)",
   "dark": false,
   "author": "cloud",
   "parentTheme": "ExperimentalLight",

--- a/src/main/resources/themes/ayu-islands-light.theme.json
+++ b/src/main/resources/themes/ayu-islands-light.theme.json
@@ -1,5 +1,5 @@
 {
-  "name": "Ayu Islands Light",
+  "name": "Ayu Light",
   "dark": false,
   "author": "cloud",
   "parentTheme": "IntelliJ",
@@ -101,22 +101,7 @@
       "inactiveBackground": "BackgroundMid"
     },
 
-    "Islands": 1,
-    "Island": {
-      "arc": 20,
-      "arc.compact": 16,
-      "borderArcLength": 14,
-      "borderArcLength.compact": 10,
-      "borderWidth": 6,
-      "borderWidth.compact": 4,
-      "borderColor": "Gray2.5",
-      "inactiveAlpha": 0.44,
-      "inactiveAlphaInStatusBar": {
-        "os.mac": 0.2,
-        "os.windows": 0.2,
-        "os.linux": 0.15
-      }
-    },
+    "Islands": 0,
 
     "MainWindow.background": "BackgroundLight",
 
@@ -145,7 +130,7 @@
       "background": "BackgroundLight",
       "borderColor": "BorderTransparent",
       "Dropdown.transparentHoverBackground": "#00000012",
-      "Button.arc.compact": 8
+      "Button.arc.compact": 0
     },
 
     "StatusBar": {
@@ -331,6 +316,10 @@
     },
 
     "TextField.background": "InputBackground",
+
+    "Component.arc": 0,
+    "Button.arc": 0,
+    "TabbedPane.tabSelectionArc": 0,
 
     "Component.borderColor": "ComponentBorder",
     "Component.focusedBorderColor": "#F29718",
@@ -808,8 +797,7 @@
 
       "Borders.color": "#E7E5DC",
       "Borders.ContrastBorderColor": "#E7E5DC",
-      "ToolWindow.Header.borderColor": "#E7E5DC",
-      "Island.borderColor": "#F8F9FA"
+      "ToolWindow.Header.borderColor": "#E7E5DC"
     },
 
     "AlertDialog.background": "PopupBackground",

--- a/src/main/resources/themes/ayu-islands-mirage-islands.theme.json
+++ b/src/main/resources/themes/ayu-islands-mirage-islands.theme.json
@@ -1,5 +1,5 @@
 {
-  "name": "Ayu Islands Mirage (Islands UI)",
+  "name": "Ayu Mirage (Islands UI)",
   "dark": true,
   "author": "cloud",
   "parentTheme": "Islands Dark",

--- a/src/main/resources/themes/ayu-islands-mirage.theme.json
+++ b/src/main/resources/themes/ayu-islands-mirage.theme.json
@@ -1,5 +1,5 @@
 {
-  "name": "Ayu Islands Mirage",
+  "name": "Ayu Mirage",
   "dark": true,
   "author": "cloud",
   "parentTheme": "ExperimentalDark",
@@ -100,22 +100,7 @@
       "inactiveBackground": "BackgroundMid"
     },
 
-    "Islands": 1,
-    "Island": {
-      "arc": 20,
-      "arc.compact": 16,
-      "borderArcLength": 14,
-      "borderArcLength.compact": 10,
-      "borderWidth": 6,
-      "borderWidth.compact": 4,
-      "borderColor": "Gray2.5",
-      "inactiveAlpha": 0.44,
-      "inactiveAlphaInStatusBar": {
-        "os.mac": 0.2,
-        "os.windows": 0.2,
-        "os.linux": 0.15
-      }
-    },
+    "Islands": 0,
 
     "MainWindow.background": "BackgroundLight",
 
@@ -144,7 +129,7 @@
       "background": "BackgroundLight",
       "borderColor": "BorderTransparent",
       "Dropdown.transparentHoverBackground": "#FFFFFF12",
-      "Button.arc.compact": 8
+      "Button.arc.compact": 0
     },
 
     "StatusBar": {
@@ -326,6 +311,10 @@
     },
 
     "TextField.background": "InputBackground",
+
+    "Component.arc": 0,
+    "Button.arc": 0,
+    "TabbedPane.tabSelectionArc": 0,
 
     "Component.borderColor": "ComponentBorder",
     "Component.focusedBorderColor": "#FFCC66",
@@ -795,8 +784,7 @@
 
       "Borders.color": "#2B3245",
       "Borders.ContrastBorderColor": "#2B3245",
-      "ToolWindow.Header.borderColor": "#2B3245",
-      "Island.borderColor": "#1F2430"
+      "ToolWindow.Header.borderColor": "#2B3245"
     },
 
     "AlertDialog.background": "PopupBackground",

--- a/src/test/kotlin/dev/ayuislands/AppearanceSyncServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AppearanceSyncServiceTest.kt
@@ -83,7 +83,7 @@ class AppearanceSyncServiceTest {
     fun `syncIfNeeded does nothing when target theme name is null`() {
         every { SystemAppearanceProvider.resolve() } returns Appearance.DARK
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
-        state.lastDarkThemeName = null
+        state.lastDarkAppearanceTheme = null
 
         service.syncIfNeeded()
 
@@ -93,16 +93,16 @@ class AppearanceSyncServiceTest {
     @Test
     fun `syncIfNeeded does nothing when appearance unchanged from last sync`() {
         val currentThemeLaf = mockk<UIThemeLookAndFeelInfo>(relaxed = true)
-        every { currentThemeLaf.name } returns "Ayu Islands Mirage"
+        every { currentThemeLaf.name } returns "Ayu Mirage"
         every { lafManager.currentUIThemeLookAndFeel } returns currentThemeLaf
 
         val targetThemeLaf = mockk<UIThemeLookAndFeelInfo>(relaxed = true)
-        every { targetThemeLaf.name } returns "Ayu Islands Dark"
+        every { targetThemeLaf.name } returns "Ayu Dark"
         every { lafManager.installedThemes } returns sequenceOf(targetThemeLaf)
 
         every { SystemAppearanceProvider.resolve() } returns Appearance.DARK
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
-        state.lastDarkThemeName = "Ayu Islands Dark"
+        state.lastDarkAppearanceTheme = "Ayu Dark"
 
         // The first call syncs successfully
         service.syncIfNeeded()
@@ -119,12 +119,12 @@ class AppearanceSyncServiceTest {
     // -- syncIfNeeded: light appearance branch --
 
     @Test
-    fun `syncIfNeeded uses lastLightThemeName for LIGHT appearance`() {
-        val lightThemeName = "Ayu Islands Light (Islands UI)"
-        state.lastLightThemeName = lightThemeName
+    fun `syncIfNeeded uses lastLightAppearanceTheme for LIGHT appearance`() {
+        val lightThemeName = "Ayu Light (Islands UI)"
+        state.lastLightAppearanceTheme = lightThemeName
 
         val currentThemeLaf = mockk<UIThemeLookAndFeelInfo>(relaxed = true)
-        every { currentThemeLaf.name } returns "Ayu Islands Mirage"
+        every { currentThemeLaf.name } returns "Ayu Mirage"
         every { lafManager.currentUIThemeLookAndFeel } returns currentThemeLaf
 
         val targetThemeLaf = mockk<UIThemeLookAndFeelInfo>(relaxed = true)
@@ -141,8 +141,8 @@ class AppearanceSyncServiceTest {
     }
 
     @Test
-    fun `syncIfNeeded returns when lastLightThemeName is null`() {
-        state.lastLightThemeName = null
+    fun `syncIfNeeded returns when lastLightAppearanceTheme is null`() {
+        state.lastLightAppearanceTheme = null
 
         every { SystemAppearanceProvider.resolve() } returns Appearance.LIGHT
         every { AyuVariant.detect() } returns AyuVariant.LIGHT
@@ -156,11 +156,11 @@ class AppearanceSyncServiceTest {
 
     @Test
     fun `syncIfNeeded switches theme when all conditions met`() {
-        val targetName = "Ayu Islands Dark (Islands UI)"
-        state.lastDarkThemeName = targetName
+        val targetName = "Ayu Dark (Islands UI)"
+        state.lastDarkAppearanceTheme = targetName
 
         val currentThemeLaf = mockk<UIThemeLookAndFeelInfo>(relaxed = true)
-        every { currentThemeLaf.name } returns "Ayu Islands Mirage"
+        every { currentThemeLaf.name } returns "Ayu Mirage"
         every { lafManager.currentUIThemeLookAndFeel } returns currentThemeLaf
 
         val targetThemeLaf = mockk<UIThemeLookAndFeelInfo>(relaxed = true)
@@ -181,8 +181,8 @@ class AppearanceSyncServiceTest {
 
     @Test
     fun `switchToTheme does nothing when current theme matches target`() {
-        val themeName = "Ayu Islands Mirage"
-        state.lastDarkThemeName = themeName
+        val themeName = "Ayu Mirage"
+        state.lastDarkAppearanceTheme = themeName
 
         val currentThemeLaf = mockk<UIThemeLookAndFeelInfo>(relaxed = true)
         every { currentThemeLaf.name } returns themeName
@@ -202,11 +202,11 @@ class AppearanceSyncServiceTest {
 
     @Test
     fun `switchToTheme logs warning when target theme not installed`() {
-        val targetName = "Ayu Islands Mirage (Islands UI)"
-        state.lastDarkThemeName = targetName
+        val targetName = "Ayu Mirage (Islands UI)"
+        state.lastDarkAppearanceTheme = targetName
 
         val currentThemeLaf = mockk<UIThemeLookAndFeelInfo>(relaxed = true)
-        every { currentThemeLaf.name } returns "Ayu Islands Dark"
+        every { currentThemeLaf.name } returns "Ayu Dark"
         every { lafManager.currentUIThemeLookAndFeel } returns currentThemeLaf
 
         // No matching theme in the installed list
@@ -226,10 +226,10 @@ class AppearanceSyncServiceTest {
 
     @Test
     fun `switchToTheme logs warning when installed themes list is empty`() {
-        state.lastDarkThemeName = "Ayu Islands Mirage"
+        state.lastDarkAppearanceTheme = "Ayu Mirage"
 
         val currentThemeLaf = mockk<UIThemeLookAndFeelInfo>(relaxed = true)
-        every { currentThemeLaf.name } returns "Ayu Islands Dark"
+        every { currentThemeLaf.name } returns "Ayu Dark"
         every { lafManager.currentUIThemeLookAndFeel } returns currentThemeLaf
         every { lafManager.installedThemes } returns emptySequence()
 
@@ -246,76 +246,76 @@ class AppearanceSyncServiceTest {
 
     @Test
     fun `recordManualChoice stores dark theme name for Mirage`() {
-        val themeName = "Ayu Islands Mirage"
+        val themeName = "Ayu Mirage"
 
         service.recordManualChoice(themeName)
 
-        assertEquals(themeName, state.lastDarkThemeName)
+        assertEquals(themeName, state.lastDarkAppearanceTheme)
     }
 
     @Test
     fun `recordManualChoice stores dark theme name for Dark variant`() {
-        val themeName = "Ayu Islands Dark"
+        val themeName = "Ayu Dark"
 
         service.recordManualChoice(themeName)
 
-        assertEquals(themeName, state.lastDarkThemeName)
+        assertEquals(themeName, state.lastDarkAppearanceTheme)
     }
 
     @Test
     fun `recordManualChoice stores dark theme name for Dark Islands UI variant`() {
-        val themeName = "Ayu Islands Dark (Islands UI)"
+        val themeName = "Ayu Dark (Islands UI)"
 
         service.recordManualChoice(themeName)
 
-        assertEquals(themeName, state.lastDarkThemeName)
+        assertEquals(themeName, state.lastDarkAppearanceTheme)
     }
 
     @Test
     fun `recordManualChoice stores light theme name`() {
-        val themeName = "Ayu Islands Light"
+        val themeName = "Ayu Light"
 
         service.recordManualChoice(themeName)
 
-        assertEquals(themeName, state.lastLightThemeName)
+        assertEquals(themeName, state.lastLightAppearanceTheme)
     }
 
     @Test
     fun `recordManualChoice stores light Islands UI theme name`() {
-        val themeName = "Ayu Islands Light (Islands UI)"
+        val themeName = "Ayu Light (Islands UI)"
 
         service.recordManualChoice(themeName)
 
-        assertEquals(themeName, state.lastLightThemeName)
+        assertEquals(themeName, state.lastLightAppearanceTheme)
     }
 
     @Test
     fun `recordManualChoice ignores non-Ayu themes`() {
-        val originalDark = state.lastDarkThemeName
-        val originalLight = state.lastLightThemeName
+        val originalDark = state.lastDarkAppearanceTheme
+        val originalLight = state.lastLightAppearanceTheme
 
         service.recordManualChoice("Darcula")
 
-        assertEquals(originalDark, state.lastDarkThemeName)
-        assertEquals(originalLight, state.lastLightThemeName)
+        assertEquals(originalDark, state.lastDarkAppearanceTheme)
+        assertEquals(originalLight, state.lastLightAppearanceTheme)
     }
 
     @Test
     fun `recordManualChoice does not modify light slot when storing dark theme`() {
-        val originalLight = state.lastLightThemeName
+        val originalLight = state.lastLightAppearanceTheme
 
-        service.recordManualChoice("Ayu Islands Mirage (Islands UI)")
+        service.recordManualChoice("Ayu Mirage (Islands UI)")
 
-        assertEquals(originalLight, state.lastLightThemeName)
+        assertEquals(originalLight, state.lastLightAppearanceTheme)
     }
 
     @Test
     fun `recordManualChoice does not modify dark slot when storing light theme`() {
-        val originalDark = state.lastDarkThemeName
+        val originalDark = state.lastDarkAppearanceTheme
 
-        service.recordManualChoice("Ayu Islands Light")
+        service.recordManualChoice("Ayu Light")
 
-        assertEquals(originalDark, state.lastDarkThemeName)
+        assertEquals(originalDark, state.lastDarkAppearanceTheme)
     }
 
     // -- clearProgrammaticSwitch --
@@ -329,11 +329,11 @@ class AppearanceSyncServiceTest {
 
     @Test
     fun `clearProgrammaticSwitch resets flag after it was set by theme switch`() {
-        val targetName = "Ayu Islands Dark"
-        state.lastDarkThemeName = targetName
+        val targetName = "Ayu Dark"
+        state.lastDarkAppearanceTheme = targetName
 
         val currentThemeLaf = mockk<UIThemeLookAndFeelInfo>(relaxed = true)
-        every { currentThemeLaf.name } returns "Ayu Islands Mirage"
+        every { currentThemeLaf.name } returns "Ayu Mirage"
         every { lafManager.currentUIThemeLookAndFeel } returns currentThemeLaf
 
         val targetThemeLaf = mockk<UIThemeLookAndFeelInfo>(relaxed = true)
@@ -374,11 +374,11 @@ class AppearanceSyncServiceTest {
 
     @Test
     fun `syncIfNeeded updates lastSyncedAppearance on successful sync`() {
-        val targetName = "Ayu Islands Dark"
-        state.lastDarkThemeName = targetName
+        val targetName = "Ayu Dark"
+        state.lastDarkAppearanceTheme = targetName
 
         val currentThemeLaf = mockk<UIThemeLookAndFeelInfo>(relaxed = true)
-        every { currentThemeLaf.name } returns "Ayu Islands Mirage"
+        every { currentThemeLaf.name } returns "Ayu Mirage"
         every { lafManager.currentUIThemeLookAndFeel } returns currentThemeLaf
 
         val targetThemeLaf = mockk<UIThemeLookAndFeelInfo>(relaxed = true)

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
@@ -594,7 +594,7 @@ class AccentApplicatorTest {
     @Test
     fun `ALWAYS_ON_EDITOR_COLOR_KEYS contains expected keys`() {
         val keys = getPrivateField<List<ColorKey>>("ALWAYS_ON_EDITOR_COLOR_KEYS")
-        assertEquals(2, keys.size, "Expected 2 always-on editor color keys")
+        assertEquals(3, keys.size, "Expected 3 always-on editor color keys")
     }
 
     @Test
@@ -1325,6 +1325,107 @@ class AccentApplicatorTest {
                 .first { it.name == "neutralizeOrRevert" }
         method.isAccessible = true
         method.invoke(AccentApplicator, *args)
+    }
+
+    // resolveUnderlineHeight tests
+
+    @Test
+    fun `resolveUnderlineHeight returns tabUnderlineHeight when tab mode is OFF`() {
+        state.glowTabMode = "OFF"
+        state.tabUnderlineHeight = 6
+
+        assertEquals(6, AccentApplicator.resolveUnderlineHeight(state))
+    }
+
+    @Test
+    fun `resolveUnderlineHeight returns tabUnderlineHeight when glow sync disabled`() {
+        state.glowTabMode = "MINIMAL"
+        state.tabUnderlineGlowSync = false
+        state.tabUnderlineHeight = 4
+
+        assertEquals(4, AccentApplicator.resolveUnderlineHeight(state))
+    }
+
+    @Test
+    fun `resolveUnderlineHeight returns glow width when sync enabled and glow active`() {
+        state.glowTabMode = "MINIMAL"
+        state.tabUnderlineGlowSync = true
+        state.glowEnabled = true
+        state.glowStyle = "SOFT"
+
+        val expected = state.getWidthForStyle(dev.ayuislands.glow.GlowStyle.SOFT)
+        assertEquals(expected, AccentApplicator.resolveUnderlineHeight(state))
+    }
+
+    @Test
+    fun `resolveUnderlineHeight returns tabUnderlineHeight when sync enabled but glow disabled`() {
+        state.glowTabMode = "MINIMAL"
+        state.tabUnderlineGlowSync = true
+        state.glowEnabled = false
+        state.tabUnderlineHeight = 8
+
+        assertEquals(8, AccentApplicator.resolveUnderlineHeight(state))
+    }
+
+    // applyTabUnderlineStyle tests
+
+    @Test
+    fun `applyTabUnderlineStyle sets underline height and arc via UIManager`() {
+        state.glowTabMode = "MINIMAL"
+        state.tabUnderlineHeight = 4
+        state.tabUnderlineGlowSync = false
+
+        val method =
+            AccentApplicator::class.java.getDeclaredMethod(
+                "applyTabUnderlineStyle",
+                AyuIslandsState::class.java,
+            )
+        method.isAccessible = true
+        method.invoke(AccentApplicator, state)
+
+        verify { UIManager.put("EditorTabs.underlineHeight", Integer.valueOf(4)) }
+        verify { UIManager.put("EditorTabs.underlineArc", any<Int>()) }
+    }
+
+    // overrideTabUnderlineForOffMode tests
+
+    @Test
+    fun `overrideTabUnderlineForOffMode sets neutral gray when OFF and variant present`() {
+        state.glowTabMode = "OFF"
+
+        val method =
+            AccentApplicator::class.java.declaredMethods
+                .first { it.name == "overrideTabUnderlineForOffMode" }
+        method.isAccessible = true
+        method.invoke(AccentApplicator, state, AyuVariant.MIRAGE)
+
+        verify { mockScheme.setColor(any(), Color.decode(AyuVariant.MIRAGE.neutralGray)) }
+    }
+
+    @Test
+    fun `overrideTabUnderlineForOffMode does nothing when not OFF`() {
+        state.glowTabMode = "MINIMAL"
+
+        val method =
+            AccentApplicator::class.java.declaredMethods
+                .first { it.name == "overrideTabUnderlineForOffMode" }
+        method.isAccessible = true
+        method.invoke(AccentApplicator, state, AyuVariant.MIRAGE)
+
+        verify(exactly = 0) { mockScheme.setColor(ColorKey.find("TAB_UNDERLINE"), any()) }
+    }
+
+    @Test
+    fun `overrideTabUnderlineForOffMode does nothing when variant is null`() {
+        state.glowTabMode = "OFF"
+
+        val method =
+            AccentApplicator::class.java.declaredMethods
+                .first { it.name == "overrideTabUnderlineForOffMode" }
+        method.isAccessible = true
+        method.invoke(AccentApplicator, state, null)
+
+        verify(exactly = 0) { mockScheme.setColor(ColorKey.find("TAB_UNDERLINE"), any()) }
     }
 
     private fun resetCgpState() {

--- a/src/test/kotlin/dev/ayuislands/accent/AyuVariantTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AyuVariantTest.kt
@@ -1,27 +1,52 @@
+@file:Suppress("UnstableApiUsage")
+
 package dev.ayuislands.accent
 
+import com.intellij.ide.ui.LafManager
+import com.intellij.ide.ui.laf.UIThemeLookAndFeelInfo
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class AyuVariantTest {
+    private lateinit var lafManager: LafManager
+
+    @BeforeTest
+    fun setUp() {
+        lafManager = mockk(relaxed = true)
+        mockkStatic(LafManager::class)
+        every { LafManager.getInstance() } returns lafManager
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
     @Test
     fun `fromThemeName returns MIRAGE for Mirage theme names`() {
-        assertEquals(AyuVariant.MIRAGE, AyuVariant.fromThemeName("Ayu Islands Mirage"))
-        assertEquals(AyuVariant.MIRAGE, AyuVariant.fromThemeName("Ayu Islands Mirage (Islands UI)"))
+        assertEquals(AyuVariant.MIRAGE, AyuVariant.fromThemeName("Ayu Mirage"))
+        assertEquals(AyuVariant.MIRAGE, AyuVariant.fromThemeName("Ayu Mirage (Islands UI)"))
     }
 
     @Test
     fun `fromThemeName returns DARK for Dark theme names`() {
-        assertEquals(AyuVariant.DARK, AyuVariant.fromThemeName("Ayu Islands Dark"))
-        assertEquals(AyuVariant.DARK, AyuVariant.fromThemeName("Ayu Islands Dark (Islands UI)"))
+        assertEquals(AyuVariant.DARK, AyuVariant.fromThemeName("Ayu Dark"))
+        assertEquals(AyuVariant.DARK, AyuVariant.fromThemeName("Ayu Dark (Islands UI)"))
     }
 
     @Test
     fun `fromThemeName returns LIGHT for Light theme names`() {
-        assertEquals(AyuVariant.LIGHT, AyuVariant.fromThemeName("Ayu Islands Light"))
-        assertEquals(AyuVariant.LIGHT, AyuVariant.fromThemeName("Ayu Islands Light (Islands UI)"))
+        assertEquals(AyuVariant.LIGHT, AyuVariant.fromThemeName("Ayu Light"))
+        assertEquals(AyuVariant.LIGHT, AyuVariant.fromThemeName("Ayu Light (Islands UI)"))
     }
 
     @Test
@@ -101,5 +126,50 @@ class AyuVariantTest {
                 )
             }
         }
+    }
+
+    @Test
+    fun `detect returns variant for matching theme`() {
+        val themeLaf = mockk<UIThemeLookAndFeelInfo>(relaxed = true)
+        every { themeLaf.name } returns "Ayu Mirage"
+        every { lafManager.currentUIThemeLookAndFeel } returns themeLaf
+
+        assertEquals(AyuVariant.MIRAGE, AyuVariant.detect())
+    }
+
+    @Test
+    fun `detect returns null for non-Ayu theme`() {
+        val themeLaf = mockk<UIThemeLookAndFeelInfo>(relaxed = true)
+        every { themeLaf.name } returns "Darcula"
+        every { lafManager.currentUIThemeLookAndFeel } returns themeLaf
+
+        assertNull(AyuVariant.detect())
+    }
+
+    @Test
+    fun `isIslandsUi returns true for Islands UI theme`() {
+        val themeLaf = mockk<UIThemeLookAndFeelInfo>(relaxed = true)
+        every { themeLaf.name } returns "Ayu Mirage (Islands UI)"
+        every { lafManager.currentUIThemeLookAndFeel } returns themeLaf
+
+        assertTrue(AyuVariant.isIslandsUi())
+    }
+
+    @Test
+    fun `isIslandsUi returns false for non-Islands theme`() {
+        val themeLaf = mockk<UIThemeLookAndFeelInfo>(relaxed = true)
+        every { themeLaf.name } returns "Ayu Mirage"
+        every { lafManager.currentUIThemeLookAndFeel } returns themeLaf
+
+        assertFalse(AyuVariant.isIslandsUi())
+    }
+
+    @Test
+    fun `isIslandsUi returns false for non-Ayu theme`() {
+        val themeLaf = mockk<UIThemeLookAndFeelInfo>(relaxed = true)
+        every { themeLaf.name } returns "Darcula"
+        every { lafManager.currentUIThemeLookAndFeel } returns themeLaf
+
+        assertFalse(AyuVariant.isIslandsUi())
     }
 }


### PR DESCRIPTION
## Summary
- Offset editor glow overlay below tab strip so its top edge sits at the tab-editor boundary (visual harmony, no underline conflict)
- Show tab accent style controls only on Islands UI; show underline thickness/sync controls only on non-Islands
- Add `AyuVariant.isIslandsUi()` detection, `GlowGlassPane.isEditorOverlay` flag
- Add tab underline settings (height, glow sync) to persisted state
- Rewrite plugin description for clearer free/premium split
- Tests for AyuVariant and AccentApplicator (85%+ coverage)

## Test plan
- [ ] `./gradlew buildPlugin` succeeds
- [ ] `./gradlew test` passes
- [ ] Islands UI: glow starts below tabs, tab accent style visible in settings
- [ ] Non-Islands: underline thickness + sync visible, tab accent style hidden
- [ ] Toggle glow on/off: underline restored correctly

## Summary by Sourcery

Introduce theme-aware tab underline customization and align glow overlays with the Islands UI while updating theme naming and appearance sync.

New Features:
- Add configurable tab underline thickness and optional glow-width sync for non-Islands UI.
- Persist tab underline customization and appearance sync preferences in settings state.

Enhancements:
- Offset the editor glow overlay below the tab strip for better alignment with editor tabs.
- Expose separate tab accent style controls for Islands UI and underline controls for non-Islands UI.
- Refine Ayu variant detection and add Islands UI detection to drive UI-conditional behavior.
- Include the tab underline color in always-on editor color handling and neutralize it when glow is disabled.
- Relax Detekt function-count threshold for objects to accommodate new logic.
- Rename stored dark and light appearance theme fields to clarify their role and update appearance sync behavior accordingly.

Documentation:
- Rewrite the Marketplace plugin description to clarify free vs premium features and update wording in change notes.

Tests:
- Extend AccentApplicator tests to cover tab underline resolution, styling, and OFF-mode overrides.
- Expand AyuVariant tests to cover detection via LafManager and Islands UI identification.
- Update appearance sync tests for the renamed appearance theme fields and new theme names.
- Adjust existing tests to account for the added always-on editor color key.