### PR TITLE
chore: bump version to 2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [2.1.2] - 2026-03-08
+
+### Added
+- [Free] Reintroduce non-Islands (Classic UI) theme variants for Mirage, Dark, and Light
+- [Free] Glow overlay now renders below tab strip for visual harmony with underline
+- [Free] Settings controls adapt to active theme type (Islands UI vs Classic)
+- [Free] Tab underline thickness and glow-sync controls for Classic UI
+
+### Changed
+- [Free] Updated plugin description with clearer free/premium feature breakdown
+- Raised detekt object function threshold to 20
+
+### Fixed
+- [Free] License enforcement in dynamic settings state updates
+
 ## [2.1.1] - 2026-03-07
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.1.1
+pluginVersion=2.1.2
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -39,6 +39,14 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>2.1.2</h3>
+    <ul>
+      <li>[Free] Reintroduce non-Islands (Classic UI) theme variants for Mirage, Dark, and Light</li>
+      <li>[Free] Glow overlay now renders below tab strip for visual harmony with underline</li>
+      <li>[Free] Settings controls adapt to active theme type (Islands UI vs Classic)</li>
+      <li>[Free] Tab underline thickness and glow-sync controls for Classic UI</li>
+      <li>[Free] Updated plugin description with clearer feature breakdown</li>
+    </ul>
     <h3>2.1.1</h3>
     <ul>
       <li>[Paid] Add the "Highlight indent errors" toggle for Indent Rainbow — disable to blend continuation lines into gradient</li>
@@ -100,7 +108,7 @@
 
     <product-descriptor
             code="PAYUISLANDS"
-            release-date="20260307"
+            release-date="20260308"
             release-version="21"
             optional="true"/>
 


### PR DESCRIPTION
## Summary
- Version bump to 2.1.2
- Updated changelog and release notes

## Changes included in this release
- Reintroduce non-Islands (Classic UI) theme variants
- Glow overlay below tab strip for visual harmony
- Theme-aware settings controls (Islands UI vs Classic)
- Tab underline thickness and glow-sync controls
- License enforcement fix in dynamic state updates

## Summary by Sourcery

Release version 2.1.2 of the Ayu Islands plugin with updated UI features, documentation, and metadata.

New Features:
- Reintroduce non-Islands (Classic UI) theme variants for Mirage, Dark, and Light.
- Add glow overlay rendering below the tab strip for improved visual harmony with the underline.
- Make settings controls adapt to the active theme type (Islands UI vs Classic).
- Add tab underline thickness and glow-sync customization controls for the Classic UI.

Bug Fixes:
- Correct license enforcement handling in dynamic settings state updates.

Enhancements:
- Clarify the plugin description with a clearer breakdown of free and premium features.

Build:
- Bump plugin version to 2.1.2 and update product descriptor release date and version metadata.
- Increase the detekt object function threshold to 20.

Documentation:
- Update changelog and in-IDE change notes for version 2.1.2.