### PR TITLE
fix: revert release-date for 2.1.x

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -108,7 +108,7 @@
 
     <product-descriptor
             code="PAYUISLANDS"
-            release-date="20260308"
+            release-date="20260307"
             release-version="21"
             optional="true"/>
 


### PR DESCRIPTION
Marketplace rejects different release-date for same release-version (21). Revert to 20260307.

## Summary by Sourcery

Bug Fixes:
- Restore the plugin release date for version 21 from 2026-03-08 back to 2026-03-07 to comply with marketplace constraints on release metadata.