### PR TITLE
fix: correct freemium tags in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Added
 - [Free] Reintroduce non-Islands (Classic UI) theme variants for Mirage, Dark, and Light
-- [Free] Glow overlay now renders below tab strip for visual harmony with underline
 - [Free] Settings controls adapt to active theme type (Islands UI vs Classic)
-- [Free] Tab underline thickness and glow-sync controls for Classic UI
+- [Paid] Glow overlay now renders below tab strip for visual harmony with underline
+- [Paid] Tab underline thickness and glow-sync controls for Classic UI
 
 ### Changed
 - [Free] Updated plugin description with clearer free/premium feature breakdown

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -42,10 +42,10 @@
     <h3>2.1.2</h3>
     <ul>
       <li>[Free] Reintroduce non-Islands (Classic UI) theme variants for Mirage, Dark, and Light</li>
-      <li>[Free] Glow overlay now renders below tab strip for visual harmony with underline</li>
       <li>[Free] Settings controls adapt to active theme type (Islands UI vs Classic)</li>
-      <li>[Free] Tab underline thickness and glow-sync controls for Classic UI</li>
       <li>[Free] Updated plugin description with clearer feature breakdown</li>
+      <li>[Paid] Glow overlay now renders below tab strip for visual harmony with underline</li>
+      <li>[Paid] Tab underline thickness and glow-sync controls for Classic UI</li>
     </ul>
     <h3>2.1.1</h3>
     <ul>


### PR DESCRIPTION
Glow offset and underline thickness controls are paid, not free.

## Summary by Sourcery

Correct feature tier labels for glow overlay and tab underline controls in changelog and plugin metadata.

Bug Fixes:
- Fix mislabelled free vs paid indicators for glow and underline controls in documentation and plugin metadata.

Enhancements:
- Align plugin.xml feature listing with the actual freemium breakdown for glow and underline controls.

Documentation:
- Update changelog to mark glow overlay and tab underline controls as paid features instead of free.