### PR TITLE
Add ayutheme.com credit to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines and [CHANGELOG.md](CHANGEL
 
 ## Credits
 
-- Color palettes from [ayu-theme/ayu-colors](https://github.com/ayu-theme/ayu-colors) by Ike Ku
+- Inspired by [Ayu](https://ayutheme.com) by Ike Ku ([@dempfi](https://github.com/dempfi))
+- Color palettes from [ayu-theme/ayu-colors](https://github.com/ayu-theme/ayu-colors)
 - Built on the [IntelliJ Platform](https://plugins.jetbrains.com/docs/intellij/welcome.html) by JetBrains
 
 ## License


### PR DESCRIPTION
## Summary
- Add link to [ayutheme.com](https://ayutheme.com) and credit [@dempfi](https://github.com/dempfi) as the original Ayu author
- Restructure Credits: original theme first, then color palettes, then platform

Prompted by dempfi's [comment](https://github.com/dempfi/ayu-site/pull/3) — also opened [dempfi/ayu-site#3](https://github.com/dempfi/ayu-site/pull/3) to list Ayu Islands on ayutheme.com.

## Summary by Sourcery

Documentation:
- Add a credit to ayutheme.com and its author as the inspiration for this theme in the README credits section.