### PR TITLE
fix: glow on floating tool windows

### DIFF
--- a/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
@@ -9,7 +9,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowManager
-import com.intellij.openapi.wm.ToolWindowType
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AyuVariant
@@ -160,6 +159,7 @@ class GlowOverlayManager(
                         val activeId = toolWindowManager.activeToolWindowId ?: return@invokeLater
                         val tw = toolWindowManager.getToolWindow(activeId) ?: return@invokeLater
                         if (tw.isVisible) {
+                            reattachToolWindowOverlayIfNeeded(tw)
                             attachToolWindowOverlay(tw)
                         }
                     }
@@ -396,13 +396,40 @@ class GlowOverlayManager(
         log.info("Glow overlay attached: $id (host: ${host.javaClass.simpleName})")
     }
 
+    private fun removeOverlay(id: String) {
+        val entry = overlays.remove(id) ?: return
+        entry.glassPane.stopAnimation()
+        entry.componentListener?.let { entry.host.removeComponentListener(it) }
+        entry.hierarchyBoundsListener?.let { entry.host.removeHierarchyBoundsListener(it) }
+        entry.layeredPane.remove(entry.glassPane)
+        entry.layeredPane.repaint(
+            entry.glassPane.x,
+            entry.glassPane.y,
+            entry.glassPane.width,
+            entry.glassPane.height,
+        )
+        if (activeGlowId == id) activeGlowId = null
+        log.info("Glow overlay removed: $id")
+    }
+
+    private fun reattachToolWindowOverlayIfNeeded(toolWindow: ToolWindow) {
+        val id = toolWindow.id
+        val existing = overlays[id] ?: return
+
+        val rootPane = SwingUtilities.getRootPane(existing.host)
+        if (rootPane == null || rootPane.layeredPane !== existing.layeredPane) {
+            // Host moved to a different window (dock↔float transition)
+            removeOverlay(id)
+            attachToolWindowOverlay(toolWindow)
+        }
+    }
+
     private fun attachToolWindowOverlay(toolWindow: ToolWindow) {
         val id = toolWindow.id
         if (overlays.containsKey(id)) return
 
         val state = AyuIslandsSettings.getInstance().state
         if (!state.isIslandEnabled(id)) return
-        if (!state.glowFloatingPanels && toolWindow.type == ToolWindowType.FLOATING) return
 
         val component = toolWindow.component
         if (!component.isDisplayable) return

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -72,9 +72,6 @@ class AyuIslandsState : BaseState() {
     // Focused input focus-ring glow (subtle, less intense than an island glow)
     var glowFocusRing by property(true)
 
-    // Floating panels — controls whether floating (undocked) tool windows get the glow
-    var glowFloatingPanels by property(false)
-
     // CodeGlancePro integration (opt-in, default OFF)
     var cgpIntegrationEnabled by property(false)
 

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateTest.kt
@@ -192,12 +192,6 @@ class AyuIslandsStateTest {
     }
 
     @Test
-    fun `glow floating panels is off by default`() {
-        val state = freshState()
-        assertFalse(state.glowFloatingPanels)
-    }
-
-    @Test
     fun `cgp integration is off by default`() {
         val state = freshState()
         assertFalse(state.cgpIntegrationEnabled)


### PR DESCRIPTION
## Summary
- Remove dead `glowFloatingPanels` gate (always `false`, UI control removed in 9868f83)
- Add dock↔float re-attachment: detect when tool window moves to a new JDialog and re-attach overlay to the new JLayeredPane
- Clean up unused `ToolWindowType` import and dead test

## Test plan
- [ ] Enable glow on Ayu theme, dock a tool window → glow appears
- [ ] Float the tool window → glow follows to floating panel
- [ ] Re-dock → glow returns to docked panel

## Summary by Sourcery

Ensure glow overlays correctly follow tool windows when docking and undocking.

New Features:
- Automatically reattach glow overlays when tool windows move between docked and floating dialogs.

Bug Fixes:
- Fix glow overlays not appearing or following tool windows after dock↔float transitions.

Enhancements:
- Add explicit overlay removal helper to clean up listeners and animations when detaching overlays.
- Simplify settings by removing the unused glowFloatingPanels option and its associated test and import.