### PR TITLE
chore: release v2.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [2.1.3] - 2026-03-09
+
+### Fixed
+- [Free] Improve Light theme surface colors: separator, hover, and folded text backgrounds for better contrast
+- [Paid] Glow now renders on floating (detached) tool windows — overlay re-attaches on dock↔float transitions
+
+### Added
+- [Free] Six theme preview screenshots (Classic + Islands UI for Mirage, Dark, Light)
+
 ## [2.1.2] - 2026-03-08
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.1.2
+pluginVersion=2.1.3
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -39,6 +39,12 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>2.1.3</h3>
+    <ul>
+      <li>[Free] Improve Light theme surface colors for better contrast (separators, hover, folded text)</li>
+      <li>[Paid] Glow now renders on floating (detached) tool windows with dock↔float re-attachment</li>
+      <li>[Free] Six theme preview screenshots (Classic + Islands UI for all variants)</li>
+    </ul>
     <h3>2.1.2</h3>
     <ul>
       <li>[Free] Reintroduce non-Islands (Classic UI) theme variants for Mirage, Dark, and Light</li>


### PR DESCRIPTION
## Summary
- Bump version to 2.1.3
- Light theme surface color improvements
- Glow on floating tool windows fix
- Preview screenshots for all variants

## Changelog
- [Free] Improve Light theme surface colors for better contrast
- [Paid] Glow now renders on floating (detached) tool windows with dock↔float re-attachment
- [Free] Six theme preview screenshots

## Summary by Sourcery

Release version 2.1.3 of the Ayu Islands plugin with updated changelog and metadata.

New Features:
- Add six theme preview screenshots covering Classic and Islands UI variants.

Bug Fixes:
- Improve Light theme surface colors for better contrast in separators, hover states, and folded text backgrounds.
- Ensure Glow effect renders correctly on floating tool windows and persists across dock/float transitions.

Build:
- Bump plugin version to 2.1.3 in build configuration.

Documentation:
- Update changelog and plugin change notes for the 2.1.3 release.