### PR TITLE
docs: add Marketplace install badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
 </p>
 
 <p align="center">
+  <a href="https://plugins.jetbrains.com/plugin/30373-ayu-islands">
+    <img src="https://img.shields.io/badge/Install-JetBrains%20Marketplace-FFCC66?style=for-the-badge&logo=jetbrains&logoColor=white&colorA=1F2430" alt="Install from Marketplace">
+  </a>
+</p>
+
+<p align="center">
   <a href="https://github.com/barad1tos/ayu-jetbrains/actions/workflows/build.yml">
     <img src="https://github.com/barad1tos/ayu-jetbrains/actions/workflows/build.yml/badge.svg" alt="Build">
   </a>


### PR DESCRIPTION
Add a prominent for-the-badge style CTA linking to the JetBrains Marketplace page, placed between the subtitle and metric badges.

## Summary by Sourcery

Documentation:
- Add a centered call-to-action badge in the README linking to the JetBrains Marketplace plugin page.