### PR TITLE
feat: update notification balloon on version upgrade

### DIFF
--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -54,6 +54,9 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
             AppearanceSyncService.getInstance().syncIfNeeded()
         }
 
+        // Show a one-time update notification if the plugin version changed
+        SwingUtilities.invokeLater { UpdateNotifier.showIfUpdated(project) }
+
         // Initialize the glow overlay system if the glow is enabled
         // Uses ApplicationManager.invokeLater with project.disposed condition to skip
         // if the project closes before the EDT processes this (execute() runs on a background coroutine)

--- a/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
@@ -1,0 +1,60 @@
+package dev.ayuislands
+
+import com.intellij.ide.BrowserUtil
+import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.notification.NotificationAction
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.extensions.PluginId
+import com.intellij.openapi.project.Project
+import dev.ayuislands.settings.AyuIslandsSettings
+
+internal object UpdateNotifier {
+    private const val PLUGIN_ID = "com.ayuislands.theme"
+    private const val MARKETPLACE_URL =
+        "https://plugins.jetbrains.com/plugin/30373-ayu-islands"
+
+    fun showIfUpdated(project: Project) {
+        val descriptor =
+            PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID))
+                ?: return
+        val currentVersion = descriptor.version
+        val state = AyuIslandsSettings.getInstance().state
+        val lastSeen = state.lastSeenVersion
+
+        if (lastSeen == currentVersion) return
+
+        state.lastSeenVersion = currentVersion
+
+        // Skip notification on the first installation (no previous version)
+        if (lastSeen == null) return
+
+        val notes = changeNotes(currentVersion) ?: return
+
+        NotificationGroupManager
+            .getInstance()
+            .getNotificationGroup("Ayu Islands")
+            .createNotification(
+                "Ayu Islands updated to $currentVersion",
+                notes,
+                NotificationType.INFORMATION,
+            ).addAction(
+                NotificationAction.createSimpleExpiring(
+                    "What's New",
+                ) {
+                    BrowserUtil.browse(MARKETPLACE_URL)
+                },
+            ).notify(project)
+    }
+
+    private fun changeNotes(version: String): String? = RELEASE_NOTES[version]
+
+    private val RELEASE_NOTES =
+        mapOf(
+            "2.2.0" to
+                "4 font presets (Whisper, Ambient, Neon, Cyberpunk) " +
+                "with one-click apply. " +
+                "12 accent presets + custom color picker. " +
+                "Follow system appearance on macOS.",
+        )
+}

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -102,6 +102,9 @@ class AyuIslandsState : BaseState() {
     // Per-preset custom settings: key = preset name, value = "size|spacing|ligatures|weight"
     var fontPresetCustomizations by map<String, String>()
 
+    // Update notification (shown once per version upgrade)
+    var lastSeenVersion by string(null)
+
     // Settings tab selection (persisted across settings opens)
     var settingsSelectedTab by property(0)
 

--- a/src/test/kotlin/dev/ayuislands/UpdateNotifierTest.kt
+++ b/src/test/kotlin/dev/ayuislands/UpdateNotifierTest.kt
@@ -1,0 +1,144 @@
+package dev.ayuislands
+
+import com.intellij.ide.plugins.IdeaPluginDescriptor
+import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationGroup
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.extensions.PluginId
+import com.intellij.openapi.project.Project
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class UpdateNotifierTest {
+    private val project = mockk<Project>(relaxed = true)
+    private val state = AyuIslandsState()
+    private val descriptor = mockk<IdeaPluginDescriptor>()
+
+    @BeforeTest
+    fun setUp() {
+        mockkStatic(PluginManagerCore::class)
+        mockkObject(AyuIslandsSettings.Companion)
+        mockkStatic(NotificationGroupManager::class)
+
+        val settings = mockk<AyuIslandsSettings>()
+        every { AyuIslandsSettings.getInstance() } returns settings
+        every { settings.state } returns state
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `no-op when plugin descriptor not found`() {
+        every {
+            PluginManagerCore.getPlugin(any<PluginId>())
+        } returns null
+
+        UpdateNotifier.showIfUpdated(project)
+
+        assertNull(state.lastSeenVersion)
+    }
+
+    @Test
+    fun `no-op when version already seen`() {
+        state.lastSeenVersion = "2.2.0"
+        every {
+            PluginManagerCore.getPlugin(any<PluginId>())
+        } returns descriptor
+        every { descriptor.version } returns "2.2.0"
+
+        UpdateNotifier.showIfUpdated(project)
+
+        assertEquals("2.2.0", state.lastSeenVersion)
+    }
+
+    @Test
+    fun `updates lastSeenVersion on first install without notification`() {
+        state.lastSeenVersion = null
+        every {
+            PluginManagerCore.getPlugin(any<PluginId>())
+        } returns descriptor
+        every { descriptor.version } returns "2.2.0"
+
+        UpdateNotifier.showIfUpdated(project)
+
+        assertEquals("2.2.0", state.lastSeenVersion)
+    }
+
+    @Test
+    fun `no notification when no release notes for version`() {
+        state.lastSeenVersion = "2.1.0"
+        every {
+            PluginManagerCore.getPlugin(any<PluginId>())
+        } returns descriptor
+        every { descriptor.version } returns "9.9.9"
+
+        UpdateNotifier.showIfUpdated(project)
+
+        assertEquals("9.9.9", state.lastSeenVersion)
+    }
+
+    @Test
+    fun `shows notification when upgrading to version with release notes`() {
+        state.lastSeenVersion = "2.1.0"
+        every {
+            PluginManagerCore.getPlugin(any<PluginId>())
+        } returns descriptor
+        every { descriptor.version } returns "2.2.0"
+
+        val notification = mockk<Notification>(relaxed = true)
+        val group = mockk<NotificationGroup>()
+        val groupManager = mockk<NotificationGroupManager>()
+        every { NotificationGroupManager.getInstance() } returns groupManager
+        every { groupManager.getNotificationGroup("Ayu Islands") } returns group
+        every {
+            group.createNotification(
+                any<String>(),
+                any<String>(),
+                any<NotificationType>(),
+            )
+        } returns notification
+        every { notification.addAction(any()) } returns notification
+
+        UpdateNotifier.showIfUpdated(project)
+
+        assertEquals("2.2.0", state.lastSeenVersion)
+        verify {
+            group.createNotification(
+                "Ayu Islands updated to 2.2.0",
+                match<String> { it.contains("font presets") },
+                NotificationType.INFORMATION,
+            )
+        }
+        verify { notification.notify(project) }
+    }
+
+    @Test
+    fun `updates state before checking release notes`() {
+        state.lastSeenVersion = "2.0.0"
+        every {
+            PluginManagerCore.getPlugin(any<PluginId>())
+        } returns descriptor
+        every { descriptor.version } returns "2.1.0"
+
+        UpdateNotifier.showIfUpdated(project)
+
+        // Version updated even though 2.1.0 has no release notes entry
+        assertEquals("2.1.0", state.lastSeenVersion)
+    }
+}


### PR DESCRIPTION
## Summary

Show a one-time notification balloon when the plugin updates to a new version with tracked release notes.

- `UpdateNotifier` compares `lastSeenVersion` in persisted state vs current plugin descriptor version
- Skips notification on first install (no previous version to compare)
- Shows balloon with key highlights + "What's New" button linking to Marketplace
- `RELEASE_NOTES` map controls which versions trigger notifications (silent patches possible)

## Files
- **New**: `UpdateNotifier.kt` — version comparison + notification logic
- **Modified**: `AyuIslandsState.kt` — `lastSeenVersion` property
- **Modified**: `AyuIslandsStartupActivity.kt` — wires `UpdateNotifier.showIfUpdated()`

## Test plan
- [x] `./gradlew test` passes
- [x] `./gradlew buildPlugin` succeeds
- [ ] Manual: install older version, upgrade, verify balloon appears once

## Summary by Sourcery

Add a one-time in-IDE notification when the Ayu Islands plugin is updated to certain tracked versions.

New Features:
- Introduce an update notifier that shows a balloon with release highlights and a link to the plugin Marketplace page after version upgrades.

Enhancements:
- Persist the last seen plugin version in settings to control whether update notifications are shown.