### PR TITLE
docs: update README install paths and counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,29 +111,15 @@ Then activate: **Settings** → **Appearance & Behavior** → **Appearance** →
 
 ## Supported Languages
 
-Ayu Islands provides hand-tuned syntax highlighting for 21 languages and formats:
+Ayu Islands provides hand-tuned syntax highlighting for 40+ languages and formats:
 
-- Java
-- Kotlin
-- Scala
-- C# / .NET (Rider / ReSharper)
-- Rust
-- Go
-- Python
-- JavaScript / TypeScript
-- Ruby
-- PHP
-- Dart
-- HCL / Terraform
-- HTML
-- CSS
-- XML
-- JSON
-- YAML
-- Bash / Shell
-- Markdown
-- Django Templates
-- Regular Expressions
+- Java, Kotlin, Scala, C# / .NET (Rider / ReSharper), Swift
+- Rust, Go, Erlang, Lua
+- Python, Ruby, PHP, Dart
+- JavaScript / TypeScript, CoffeeScript
+- HTML, CSS, HAML, SLIM, JSP, Qute, Django Templates
+- GraphQL, JSON, XML, YAML, Properties, Puppet
+- Bash / Shell, Markdown, Regular Expressions
 
 Languages without explicit overrides (SQL, TOML, and others) inherit from `DEFAULT_*` attributes, which are also themed — so every language benefits from the Ayu palette.
 

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ Each variant uses canonical colors from [ayu-colors](https://github.com/ayu-them
 
 - **6 themes** — Mirage, Dark, and Light, each in classic and Islands UI variants
 - **Islands UI** — rounded panels, island gaps, and compact mode support
-- **20+ language-specific highlights** — carefully tuned per-language tokens, not just defaults
+- **40+ language-specific highlights** — carefully tuned per-language tokens, not just defaults
 - **Canonical ayu-colors** — syntax palettes from [ayu-theme/ayu-colors](https://github.com/ayu-theme/ayu-colors)
-- **Accent color customization** — 10 hand-picked Ayu palette presets with live visual preview
+- **Accent color customization** — 12 Ayu palette presets + custom color picker with live preview
 - **Full VCS integration** — diff gutters, file status colors, merge indicators, blame annotations
 - **16-color terminal palette** — per-variant terminal colors that feel native
 - **Project color gradients** — 9 color groups in Ayu hues
@@ -102,9 +102,12 @@ Then activate: **Settings** → **Appearance & Behavior** → **Appearance** →
 
 ### Manual
 
-1. Download the `.zip` from [Releases](https://github.com/barad1tos/ayu-jetbrains/releases)
+1. Download the `.zip` from [Releases](https://github.com/barad1tos/ayu-jetbrains/releases/latest)
 2. **Settings** → **Plugins** → **⚙** → **Install Plugin from Disk...**
 3. Select the downloaded `.zip` and restart the IDE
+
+> The release archive is the same artifact published to the Marketplace —
+> just a different install path.
 
 ## Supported Languages
 


### PR DESCRIPTION
── Summary ─────────────────────────────────

Add explicit note that manual install from GitHub Releases
delivers the same artifact as the Marketplace. Link directly
to /releases/latest. Sync feature counts (40+ languages,
12 presets) to match plugin.xml.

── Changes ─────────────────────────────────

| Type | File | Description |
|------|------|-------------|
| Docs | `README.md:105` | Link `/releases` → `/releases/latest` |
| Docs | `README.md:108-109` | Add note: same artifact as Marketplace |
| Docs | `README.md:77` | 20+ → 40+ languages |
| Docs | `README.md:79` | 10 presets → 12 presets + custom picker |

── Validation ──────────────────────────────

Visual: verify links and formatting render correctly on GitHub.

## Summary by Sourcery

Clarify README documentation for manual installation and feature descriptions.

Documentation:
- Update README feature list to reflect 40+ language highlights and 12 presets with a custom color picker.
- Adjust manual installation instructions to download from the latest GitHub release and note parity with Marketplace artifacts.