### PR TITLE
chore: release v2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [2.2.2] - 2026-03-14
+
+### Fixed
+
+- [Free] Fix diff/merge viewer using wrong default colors instead of theme palette
+- [Free] Fix black toolbar in merge conflict gutter on light themes
+- [Free] Improve diff modified-line background visibility across all variants
+
+## [2.2.1] - 2026-03-11
+
+### Fixed
+
+- [Free] VCS modified-line colors corrected to canonical ayu palette (Mirage, Dark)
+
+## [2.2.0] - 2026-03-11
+
+### Added
+
+- [Free] Font presets: 4 curated Nerd Fonts (Whisper, Ambient, Neon, Cyberpunk) with one-click apply, live preview, and per-preset customization
+- [Free] Custom accent color picker — choose any color beyond the 12 presets
+- [Free] 12 accent presets (added Rose and Slate)
+- [Free] Follow system accent color on macOS
+- [Free] Redesigned accent panel with shade name display
+- [Free] Follow system appearance (auto Light/Dark switching)
+
 ## [2.1.3] - 2026-03-09
 
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.2.1
+pluginVersion=2.2.2
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -44,6 +44,12 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>2.2.2</h3>
+    <ul>
+      <li>[Free] Fix diff/merge viewer using wrong default colors instead of theme palette</li>
+      <li>[Free] Fix black toolbar in merge conflict gutter on light themes</li>
+      <li>[Free] Improve diff modified-line background visibility across all variants</li>
+    </ul>
     <h3>2.2.1</h3>
     <ul>
       <li>[Free] VCS modified-line colors corrected to canonical ayu palette (Mirage, Dark)</li>

--- a/src/main/resources/themes/AyuIslandsDark.xml
+++ b/src/main/resources/themes/AyuIslandsDark.xml
@@ -869,25 +869,26 @@
         <!-- Diff -->
         <option name="DIFF_CONFLICT">
             <value>
-                <option name="FOREGROUND" value="121724" />
+                <option name="BACKGROUND" value="701015" />
+                <option name="ERROR_STRIPE_COLOR" value="D95757" />
             </value>
         </option>
         <option name="DIFF_DELETED">
             <value>
-                <option name="FOREGROUND" value="380F19" />
                 <option name="BACKGROUND" value="76070E" />
+                <option name="ERROR_STRIPE_COLOR" value="F26D78" />
             </value>
         </option>
         <option name="DIFF_INSERTED">
             <value>
-                <option name="FOREGROUND" value="0F330D" />
                 <option name="BACKGROUND" value="0F6201" />
+                <option name="ERROR_STRIPE_COLOR" value="70BF56" />
             </value>
         </option>
         <option name="DIFF_MODIFIED">
             <value>
-                <option name="FOREGROUND" value="2A4670" />
-                <option name="BACKGROUND" value="0F1E30" />
+                <option name="BACKGROUND" value="152A48" />
+                <option name="ERROR_STRIPE_COLOR" value="59C2FF" />
             </value>
         </option>
 

--- a/src/main/resources/themes/AyuIslandsLight.xml
+++ b/src/main/resources/themes/AyuIslandsLight.xml
@@ -840,25 +840,26 @@
         <!-- Diff -->
         <option name="DIFF_CONFLICT">
             <value>
-                <option name="FOREGROUND" value="FFF0E0" />
+                <option name="BACKGROUND" value="E6505020" />
+                <option name="ERROR_STRIPE_COLOR" value="E65050" />
             </value>
         </option>
         <option name="DIFF_DELETED">
             <value>
-                <option name="FOREGROUND" value="FFE8EC" />
                 <option name="BACKGROUND" value="FF738320" />
+                <option name="ERROR_STRIPE_COLOR" value="FF7383" />
             </value>
         </option>
         <option name="DIFF_INSERTED">
             <value>
-                <option name="FOREGROUND" value="E8F5E0" />
                 <option name="BACKGROUND" value="6CBF4320" />
+                <option name="ERROR_STRIPE_COLOR" value="6CBF43" />
             </value>
         </option>
         <option name="DIFF_MODIFIED">
             <value>
-                <option name="FOREGROUND" value="E0ECFF" />
-                <option name="BACKGROUND" value="478ACC20" />
+                <option name="BACKGROUND" value="478ACC30" />
+                <option name="ERROR_STRIPE_COLOR" value="478ACC" />
             </value>
         </option>
 

--- a/src/main/resources/themes/AyuIslandsMirage.xml
+++ b/src/main/resources/themes/AyuIslandsMirage.xml
@@ -780,25 +780,26 @@
         <!-- Diff -->
         <option name="DIFF_CONFLICT">
             <value>
-                <option name="FOREGROUND" value="222734" />
+                <option name="BACKGROUND" value="80202A" />
+                <option name="ERROR_STRIPE_COLOR" value="FF6666" />
             </value>
         </option>
         <option name="DIFF_DELETED">
             <value>
-                <option name="FOREGROUND" value="481F29" />
                 <option name="BACKGROUND" value="86171E" />
+                <option name="ERROR_STRIPE_COLOR" value="F27983" />
             </value>
         </option>
         <option name="DIFF_INSERTED">
             <value>
-                <option name="FOREGROUND" value="1F431D" />
                 <option name="BACKGROUND" value="1F7201" />
+                <option name="ERROR_STRIPE_COLOR" value="87D96C" />
             </value>
         </option>
         <option name="DIFF_MODIFIED">
             <value>
-                <option name="FOREGROUND" value="3A6080" />
-                <option name="BACKGROUND" value="1A2E40" />
+                <option name="BACKGROUND" value="253D58" />
+                <option name="ERROR_STRIPE_COLOR" value="73D0FF" />
             </value>
         </option>
 

--- a/src/main/resources/themes/ayu-islands-dark-islands.theme.json
+++ b/src/main/resources/themes/ayu-islands-dark-islands.theme.json
@@ -793,6 +793,7 @@
 
     "VersionControl": {
       "MarkerPopup.borderColor": "Gray4",
+      "MarkerPopup.Toolbar.background": "PanelBackground",
       "Log.Commit.currentBranchBackground": "#141821",
       "Log.Commit.Reference.foreground": "#606B7D",
       "Log.Commit.unmatchedForeground": "#606B7D",

--- a/src/main/resources/themes/ayu-islands-dark.theme.json
+++ b/src/main/resources/themes/ayu-islands-dark.theme.json
@@ -763,6 +763,7 @@
 
     "VersionControl": {
       "MarkerPopup.borderColor": "Gray4",
+      "MarkerPopup.Toolbar.background": "PanelBackground",
       "Log.Commit.currentBranchBackground": "#141821",
       "Log.Commit.Reference.foreground": "#606B7D",
       "Log.Commit.unmatchedForeground": "#606B7D",

--- a/src/main/resources/themes/ayu-islands-light-islands.theme.json
+++ b/src/main/resources/themes/ayu-islands-light-islands.theme.json
@@ -778,6 +778,7 @@
 
     "VersionControl": {
       "MarkerPopup.borderColor": "Gray4",
+      "MarkerPopup.Toolbar.background": "PanelBackground",
       "Log.Commit.currentBranchBackground": "#EBECED",
       "Log.Commit.Reference.foreground": "#828E9F",
       "Log.Commit.unmatchedForeground": "#828E9F",

--- a/src/main/resources/themes/ayu-islands-light.theme.json
+++ b/src/main/resources/themes/ayu-islands-light.theme.json
@@ -767,6 +767,7 @@
 
     "VersionControl": {
       "MarkerPopup.borderColor": "Gray4",
+      "MarkerPopup.Toolbar.background": "PanelBackground",
       "Log.Commit.currentBranchBackground": "#EBECED",
       "Log.Commit.Reference.foreground": "#828E9F",
       "Log.Commit.unmatchedForeground": "#828E9F",

--- a/src/main/resources/themes/ayu-islands-mirage-islands.theme.json
+++ b/src/main/resources/themes/ayu-islands-mirage-islands.theme.json
@@ -786,6 +786,7 @@
 
     "VersionControl": {
       "MarkerPopup.borderColor": "Gray4",
+      "MarkerPopup.Toolbar.background": "PanelBackground",
       "Log.Commit.Reference.foreground": "#8A9199",
       "Merge.Status.NoConflicts.foreground": "#87D96C"
     },

--- a/src/main/resources/themes/ayu-islands-mirage.theme.json
+++ b/src/main/resources/themes/ayu-islands-mirage.theme.json
@@ -756,6 +756,7 @@
 
     "VersionControl": {
       "MarkerPopup.borderColor": "Gray4",
+      "MarkerPopup.Toolbar.background": "PanelBackground",
       "Log.Commit.Reference.foreground": "#8A9199",
       "Merge.Status.NoConflicts.foreground": "#87D96C"
     },


### PR DESCRIPTION
## Summary

- Fix diff/merge viewer using wrong default colors (amber/gold instead of theme-appropriate)
- Fix black MarkerPopup toolbar in merge conflict gutter on light themes
- Improve DIFF_MODIFIED background visibility across all variants
- Sync CHANGELOG.md with plugin.xml (backfill 2.2.0, 2.2.1 entries)

## Changes

- 6x `.theme.json`: add `VersionControl.MarkerPopup.Toolbar.background`
- 3x `.xml`: add BACKGROUND + ERROR_STRIPE_COLOR to DIFF attributes, remove FOREGROUND, boost DIFF_MODIFIED saturation
- `gradle.properties`: 2.2.1 → 2.2.2
- `plugin.xml`: add 2.2.2 change-notes
- `CHANGELOG.md`: add 2.2.2, backfill 2.2.0 and 2.2.1

## Test plan

- [x] `./gradlew buildPlugin` passes
- [x] `./gradlew verifyPlugin -DverifyGroup=A` passes
- [x] Deployed to WebStorm — merge conflict viewer shows correct theme colors
- [x] MarkerPopup toolbar matches theme background
- [x] DIFF_MODIFIED blue visible alongside red/green

## Summary by Sourcery

Release version 2.2.2 with corrected diff/merge viewer colors and updated metadata.

Bug Fixes:
- Align diff and merge viewer colors with the theme palette, including improved modified-line visibility and non-black toolbars on light themes.

Build:
- Bump plugin version to 2.2.2 in build configuration.

Documentation:
- Update changelog with 2.2.2 entry and backfill notes for 2.2.0 and 2.2.1.

Chores:
- Add 2.2.2 change notes to plugin metadata.