### PR TITLE
fix(ci): exclude RustRover from verify

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,7 +96,7 @@ intellijPlatform {
             }
             if (group != "A") {
                 // Group B: Language-specific IDEs
-                create(IntelliJPlatformType.RustRover, "2025.1.3")
+                // RustRover 2025.1.3 excluded: corrupted CDN artifact (InvalidIdeException: missing Core plugin)
                 create(IntelliJPlatformType.GoLand, "2025.1.3")
                 create(IntelliJPlatformType.PyCharm, "2025.1.3")
                 create(IntelliJPlatformType.DataGrip, "2025.1.3")


### PR DESCRIPTION
## Summary

- Exclude RustRover 2025.1.3 from verifyPlugin — CDN artifact corrupted (missing Core plugin JAR)
- Blocks both local and CI verification with `InvalidIdeException`

## Test plan

- [x] `./gradlew verifyPlugin -DverifyGroup=A` passes
- [ ] CI Verify (B) should pass without RustRover

## Summary by Sourcery

Build:
- Update Gradle IntelliJ platform configuration to skip RustRover 2025.1.3 from verifyPlugin while retaining other language-specific IDE targets.