### PR TITLE
feat(workspace): add tool window auto-fit and Project View controls

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,7 +96,7 @@ intellijPlatform {
             }
             if (group != "A") {
                 // Group B: Language-specific IDEs
-                create(IntelliJPlatformType.RustRover, "2025.1.3")
+                // RustRover 2025.1.3 excluded: corrupted CDN artifact (InvalidIdeException: missing Core plugin)
                 create(IntelliJPlatformType.GoLand, "2025.1.3")
                 create(IntelliJPlatformType.PyCharm, "2025.1.3")
                 create(IntelliJPlatformType.DataGrip, "2025.1.3")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -150,6 +150,16 @@ kover {
                     "dev.ayuislands.AppearanceSyncListener*",
                     // LicenseChecker: public API tested, private crypto is JetBrains boilerplate
                     "dev.ayuislands.licensing.LicenseChecker*",
+                    // IDE glue: Swing UI DSL panel (pure rendering, no extractable logic)
+                    "dev.ayuislands.settings.WorkspacePanel*",
+                    "dev.ayuislands.settings.PluginsPanel*",
+                    // IDE glue: thin ToolWindowManagerListener wrappers delegating to ToolWindowAutoFitter
+                    "dev.ayuislands.commitpanel.CommitPanelAutoFitManager*",
+                    "dev.ayuislands.gitpanel.GitPanelAutoFitManager*",
+                    // IDE glue: Project service (ToolWindowManager, Registry, ProjectView singletons)
+                    "dev.ayuislands.projectview.ProjectViewScrollbarManager*",
+                    // IDE glue: JTree traversal, ToolWindowManager, Timer, expansion listeners
+                    "dev.ayuislands.toolwindow.ToolWindowAutoFitter*",
                 )
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,7 +96,7 @@ intellijPlatform {
             }
             if (group != "A") {
                 // Group B: Language-specific IDEs
-                // RustRover 2025.1.3 excluded: corrupted CDN artifact (InvalidIdeException: missing Core plugin)
+                create(IntelliJPlatformType.RustRover, "2025.1.3")
                 create(IntelliJPlatformType.GoLand, "2025.1.3")
                 create(IntelliJPlatformType.PyCharm, "2025.1.3")
                 create(IntelliJPlatformType.DataGrip, "2025.1.3")

--- a/proguard-rules.pro
+++ b/proguard-rules.pro
@@ -31,6 +31,15 @@
 -keep enum dev.ayuislands.font.FontWeight { *; }
 -keep enum dev.ayuislands.font.FontPreset { *; }
 
+# plugin.xml: projectService (Project View tweaks)
+-keep class dev.ayuislands.projectview.ProjectViewScrollbarManager { *; }
+-keep class dev.ayuislands.projectview.ProjectViewScrollbarManager$Companion { *; }
+
+# plugin.xml: applicationListeners
+-keep class dev.ayuislands.AyuIslandsAppListener { *; }
+-keep class dev.ayuislands.AppearanceSyncListener { *; }
+-keep class dev.ayuislands.AppearanceSyncService { *; }
+
 # Public API singletons (called from kept classes)
 -keep class dev.ayuislands.accent.AccentApplicator { *; }
 -keep class dev.ayuislands.accent.AccentColor { *; }

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsLafListener.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsLafListener.kt
@@ -8,6 +8,7 @@ import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.font.FontPresetApplicator
 import dev.ayuislands.glow.GlowOverlayManager
+import dev.ayuislands.projectview.ProjectViewScrollbarManager
 import dev.ayuislands.settings.AyuIslandsSettings
 
 /** Re-applies accent color on theme change. */
@@ -39,8 +40,22 @@ class AyuIslandsLafListener : LafManagerListener {
         }
         syncService.clearProgrammaticSwitch()
 
+        // Re-apply Project View scrollbar setting
+        reapplyProjectViewScrollbar()
+
         // Update glow overlays with new accent color
         updateGlowForAllProjects()
+    }
+
+    private fun reapplyProjectViewScrollbar() {
+        if (!AyuIslandsSettings.getInstance().state.hideProjectViewHScrollbar) return
+        for (openProject in ProjectManager.getInstance().openProjects) {
+            try {
+                ProjectViewScrollbarManager.getInstance(openProject).apply()
+            } catch (exception: RuntimeException) {
+                LOG.warn("Failed to re-apply scrollbar for project ${openProject.name}: ${exception.message}")
+            }
+        }
     }
 
     private fun updateGlowForAllProjects() {

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -8,12 +8,15 @@ import com.intellij.openapi.startup.ProjectActivity
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.conflict.ConflictRegistry
+import dev.ayuislands.commitpanel.CommitPanelAutoFitManager
 import dev.ayuislands.font.FontPreset
 import dev.ayuislands.font.FontPresetApplicator
+import dev.ayuislands.gitpanel.GitPanelAutoFitManager
 import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.projectview.ProjectViewScrollbarManager
 import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.PanelWidthMode
 import javax.swing.SwingUtilities
 
 internal class AyuIslandsStartupActivity : ProjectActivity {
@@ -64,14 +67,28 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
             settings.state.projectViewMigrated = true
         }
 
+        // Migrate old boolean auto-fit fields to new PanelWidthMode enum
+        settings.state.migrateWidthModes()
+
         // Eagerly initialize Project View customizer — its init block subscribes
         // to ToolWindowManagerListener, which will apply() when the tree is ready.
         val pvState = settings.state
-        if (pvState.hideProjectViewHScrollbar ||
-            pvState.hideProjectRootPath ||
-            pvState.hideRootVcsAnnotations
+        val hasProjectViewCustomizations =
+            pvState.hideProjectViewHScrollbar ||
+                pvState.hideProjectRootPath ||
+                pvState.hideRootVcsAnnotations
+        if (hasProjectViewCustomizations ||
+            PanelWidthMode.fromString(pvState.projectPanelWidthMode) != PanelWidthMode.DEFAULT
         ) {
             ProjectViewScrollbarManager.getInstance(project)
+        }
+
+        if (PanelWidthMode.fromString(pvState.commitPanelWidthMode) != PanelWidthMode.DEFAULT) {
+            CommitPanelAutoFitManager.getInstance(project)
+        }
+
+        if (PanelWidthMode.fromString(pvState.gitPanelWidthMode) != PanelWidthMode.DEFAULT) {
+            GitPanelAutoFitManager.getInstance(project)
         }
 
         // Initialize the glow overlay system if the glow is enabled

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -12,6 +12,7 @@ import dev.ayuislands.font.FontPreset
 import dev.ayuislands.font.FontPresetApplicator
 import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.projectview.ProjectViewScrollbarManager
 import dev.ayuislands.settings.AyuIslandsSettings
 import javax.swing.SwingUtilities
 
@@ -56,6 +57,22 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
 
         // Show a one-time update notification if the plugin version changed
         SwingUtilities.invokeLater { UpdateNotifier.showIfUpdated(project) }
+
+        // Migrate: users with old hideProjectRootPath=true expect VCS also hidden
+        if (settings.state.hideProjectRootPath && !settings.state.projectViewMigrated) {
+            settings.state.hideRootVcsAnnotations = true
+            settings.state.projectViewMigrated = true
+        }
+
+        // Eagerly initialize Project View customizer — its init block subscribes
+        // to ToolWindowManagerListener, which will apply() when the tree is ready.
+        val pvState = settings.state
+        if (pvState.hideProjectViewHScrollbar ||
+            pvState.hideProjectRootPath ||
+            pvState.hideRootVcsAnnotations
+        ) {
+            ProjectViewScrollbarManager.getInstance(project)
+        }
 
         // Initialize the glow overlay system if the glow is enabled
         // Uses ApplicationManager.invokeLater with project.disposed condition to skip

--- a/src/main/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManager.kt
+++ b/src/main/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManager.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.wm.ex.ToolWindowManagerListener
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.PanelWidthMode
+import dev.ayuislands.toolwindow.AutoFitCalculator
 import dev.ayuislands.toolwindow.ToolWindowAutoFitter
 
 /** Per-project service that auto-fits the Commit tool window width to its tree content. */
@@ -19,7 +20,7 @@ class CommitPanelAutoFitManager(
         ToolWindowAutoFitter(
             project = project,
             toolWindowId = "Commit",
-            minWidth = MIN_AUTOFIT_WIDTH,
+            minWidth = AutoFitCalculator.MIN_COMMIT_AUTOFIT_WIDTH,
         ).apply {
             maxWidthProvider = { AyuIslandsSettings.getInstance().state.autoFitCommitMaxWidth }
         }
@@ -46,17 +47,11 @@ class CommitPanelAutoFitManager(
     fun apply() {
         if (!LicenseChecker.isLicensedOrGrace()) return
         val state = AyuIslandsSettings.getInstance().state
-        when (PanelWidthMode.fromString(state.commitPanelWidthMode)) {
-            PanelWidthMode.DEFAULT -> autoFitter.removeExpansionListener()
-            PanelWidthMode.AUTO_FIT -> {
-                autoFitter.installExpansionListener()
-                autoFitter.applyAutoFitWidth(state.autoFitCommitMaxWidth)
-            }
-            PanelWidthMode.FIXED -> {
-                autoFitter.removeExpansionListener()
-                autoFitter.applyFixedWidth(state.commitPanelFixedWidth)
-            }
-        }
+        autoFitter.applyWidthMode(
+            PanelWidthMode.fromString(state.commitPanelWidthMode),
+            state.autoFitCommitMaxWidth,
+            state.commitPanelFixedWidth,
+        )
     }
 
     override fun dispose() {
@@ -64,8 +59,6 @@ class CommitPanelAutoFitManager(
     }
 
     companion object {
-        const val MIN_AUTOFIT_WIDTH = 269
-
         fun getInstance(project: Project): CommitPanelAutoFitManager =
             project.getService(
                 CommitPanelAutoFitManager::class.java,

--- a/src/main/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManager.kt
+++ b/src/main/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManager.kt
@@ -1,0 +1,74 @@
+package dev.ayuislands.commitpanel
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ToolWindowManager
+import com.intellij.openapi.wm.ex.ToolWindowManagerListener
+import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.PanelWidthMode
+import dev.ayuislands.toolwindow.ToolWindowAutoFitter
+
+/** Per-project service that auto-fits the Commit tool window width to its tree content. */
+@Service(Service.Level.PROJECT)
+class CommitPanelAutoFitManager(
+    private val project: Project,
+) : Disposable {
+    private val autoFitter =
+        ToolWindowAutoFitter(
+            project = project,
+            toolWindowId = "Commit",
+            minWidth = MIN_AUTOFIT_WIDTH,
+        ).apply {
+            maxWidthProvider = { AyuIslandsSettings.getInstance().state.autoFitCommitMaxWidth }
+        }
+
+    init {
+        project.messageBus.connect(this).subscribe(
+            ToolWindowManagerListener.TOPIC,
+            object : ToolWindowManagerListener {
+                override fun stateChanged(
+                    toolWindowManager: ToolWindowManager,
+                    changeType: ToolWindowManagerListener.ToolWindowManagerEventType,
+                ) {
+                    val mode =
+                        PanelWidthMode.fromString(
+                            AyuIslandsSettings.getInstance().state.commitPanelWidthMode,
+                        )
+                    if (mode == PanelWidthMode.DEFAULT) return
+                    apply()
+                }
+            },
+        )
+    }
+
+    fun apply() {
+        if (!LicenseChecker.isLicensedOrGrace()) return
+        val state = AyuIslandsSettings.getInstance().state
+        when (PanelWidthMode.fromString(state.commitPanelWidthMode)) {
+            PanelWidthMode.DEFAULT -> autoFitter.removeExpansionListener()
+            PanelWidthMode.AUTO_FIT -> {
+                autoFitter.installExpansionListener()
+                autoFitter.applyAutoFitWidth(state.autoFitCommitMaxWidth)
+            }
+            PanelWidthMode.FIXED -> {
+                autoFitter.removeExpansionListener()
+                autoFitter.applyFixedWidth(state.commitPanelFixedWidth)
+            }
+        }
+    }
+
+    override fun dispose() {
+        autoFitter.removeExpansionListener()
+    }
+
+    companion object {
+        const val MIN_AUTOFIT_WIDTH = 269
+
+        fun getInstance(project: Project): CommitPanelAutoFitManager =
+            project.getService(
+                CommitPanelAutoFitManager::class.java,
+            )
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/font/FontPresetApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontPresetApplicator.kt
@@ -1,6 +1,7 @@
 package dev.ayuislands.font
 
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.colors.ModifiableFontPreferences
@@ -56,11 +57,13 @@ object FontPresetApplicator {
                 scheme.consoleLineSpacing = settings.lineSpacing
             }
 
-            ApplicationManager
-                .getApplication()
-                .messageBus
-                .syncPublisher(EditorColorsManager.TOPIC)
-                .globalSchemeChange(null)
+            ReadAction.run<Nothing> {
+                ApplicationManager
+                    .getApplication()
+                    .messageBus
+                    .syncPublisher(EditorColorsManager.TOPIC)
+                    .globalSchemeChange(null)
+            }
             LOG.info(
                 "Font preset applied: ${settings.preset.displayName} " +
                     "($resolvedFamily, subFamily=$subFamily, " +
@@ -88,11 +91,13 @@ object FontPresetApplicator {
             scheme.setConsoleFontSize(DEFAULT_FONT_SIZE)
             scheme.consoleLineSpacing = DEFAULT_LINE_SPACING
 
-            ApplicationManager
-                .getApplication()
-                .messageBus
-                .syncPublisher(EditorColorsManager.TOPIC)
-                .globalSchemeChange(null)
+            ReadAction.run<Nothing> {
+                ApplicationManager
+                    .getApplication()
+                    .messageBus
+                    .syncPublisher(EditorColorsManager.TOPIC)
+                    .globalSchemeChange(null)
+            }
             LOG.info("Font preset reverted to defaults")
         }
     }

--- a/src/main/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManager.kt
+++ b/src/main/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManager.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.wm.ex.ToolWindowManagerListener
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.PanelWidthMode
+import dev.ayuislands.toolwindow.AutoFitCalculator
 import dev.ayuislands.toolwindow.ToolWindowAutoFitter
 
 /** Per-project service that manages Git tool window width (auto-fit or fixed). */
@@ -19,7 +20,7 @@ class GitPanelAutoFitManager(
         ToolWindowAutoFitter(
             project = project,
             toolWindowId = "Git",
-            minWidth = MIN_AUTOFIT_WIDTH,
+            minWidth = AutoFitCalculator.MIN_GIT_AUTOFIT_WIDTH,
         ).apply {
             maxWidthProvider = { AyuIslandsSettings.getInstance().state.gitPanelAutoFitMaxWidth }
         }
@@ -46,17 +47,11 @@ class GitPanelAutoFitManager(
     fun apply() {
         if (!LicenseChecker.isLicensedOrGrace()) return
         val state = AyuIslandsSettings.getInstance().state
-        when (PanelWidthMode.fromString(state.gitPanelWidthMode)) {
-            PanelWidthMode.DEFAULT -> autoFitter.removeExpansionListener()
-            PanelWidthMode.AUTO_FIT -> {
-                autoFitter.installExpansionListener()
-                autoFitter.applyAutoFitWidth(state.gitPanelAutoFitMaxWidth)
-            }
-            PanelWidthMode.FIXED -> {
-                autoFitter.removeExpansionListener()
-                autoFitter.applyFixedWidth(state.gitPanelFixedWidth)
-            }
-        }
+        autoFitter.applyWidthMode(
+            PanelWidthMode.fromString(state.gitPanelWidthMode),
+            state.gitPanelAutoFitMaxWidth,
+            state.gitPanelFixedWidth,
+        )
     }
 
     override fun dispose() {
@@ -64,8 +59,9 @@ class GitPanelAutoFitManager(
     }
 
     companion object {
-        const val MIN_AUTOFIT_WIDTH = 200
-
-        fun getInstance(project: Project) = project.getService(GitPanelAutoFitManager::class.java)
+        fun getInstance(project: Project): GitPanelAutoFitManager =
+            project.getService(
+                GitPanelAutoFitManager::class.java,
+            )
     }
 }

--- a/src/main/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManager.kt
+++ b/src/main/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManager.kt
@@ -1,0 +1,71 @@
+package dev.ayuislands.gitpanel
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ToolWindowManager
+import com.intellij.openapi.wm.ex.ToolWindowManagerListener
+import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.PanelWidthMode
+import dev.ayuislands.toolwindow.ToolWindowAutoFitter
+
+/** Per-project service that manages Git tool window width (auto-fit or fixed). */
+@Service(Service.Level.PROJECT)
+class GitPanelAutoFitManager(
+    private val project: Project,
+) : Disposable {
+    private val autoFitter =
+        ToolWindowAutoFitter(
+            project = project,
+            toolWindowId = "Git",
+            minWidth = MIN_AUTOFIT_WIDTH,
+        ).apply {
+            maxWidthProvider = { AyuIslandsSettings.getInstance().state.gitPanelAutoFitMaxWidth }
+        }
+
+    init {
+        project.messageBus.connect(this).subscribe(
+            ToolWindowManagerListener.TOPIC,
+            object : ToolWindowManagerListener {
+                override fun stateChanged(
+                    toolWindowManager: ToolWindowManager,
+                    changeType: ToolWindowManagerListener.ToolWindowManagerEventType,
+                ) {
+                    val mode =
+                        PanelWidthMode.fromString(
+                            AyuIslandsSettings.getInstance().state.gitPanelWidthMode,
+                        )
+                    if (mode == PanelWidthMode.DEFAULT) return
+                    apply()
+                }
+            },
+        )
+    }
+
+    fun apply() {
+        if (!LicenseChecker.isLicensedOrGrace()) return
+        val state = AyuIslandsSettings.getInstance().state
+        when (PanelWidthMode.fromString(state.gitPanelWidthMode)) {
+            PanelWidthMode.DEFAULT -> autoFitter.removeExpansionListener()
+            PanelWidthMode.AUTO_FIT -> {
+                autoFitter.installExpansionListener()
+                autoFitter.applyAutoFitWidth(state.gitPanelAutoFitMaxWidth)
+            }
+            PanelWidthMode.FIXED -> {
+                autoFitter.removeExpansionListener()
+                autoFitter.applyFixedWidth(state.gitPanelFixedWidth)
+            }
+        }
+    }
+
+    override fun dispose() {
+        autoFitter.removeExpansionListener()
+    }
+
+    companion object {
+        const val MIN_AUTOFIT_WIDTH = 200
+
+        fun getInstance(project: Project) = project.getService(GitPanelAutoFitManager::class.java)
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
+++ b/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
@@ -316,7 +316,7 @@ private class RootLocationHidingRenderer(
             iter.next()
             val text = iter.fragment
             val trimmed = text.trim()
-            if (isKeptFragment(trimmed, projectName, basePath, tildeBasePath)) {
+            if (RootFragmentFilter.isKeptFragment(trimmed, projectName, basePath, tildeBasePath)) {
                 kept.add(text to iter.textAttributes)
             }
         }
@@ -324,24 +324,5 @@ private class RootLocationHidingRenderer(
         for ((text, attrs) in kept) {
             component.append(text, attrs)
         }
-    }
-
-    private fun isKeptFragment(
-        trimmed: String,
-        projectName: String,
-        basePath: String?,
-        tildeBasePath: String?,
-    ): Boolean {
-        if (trimmed.isEmpty()) return false
-        if (trimmed == projectName) return true
-        if (basePath != null && trimmed.contains(basePath)) {
-            return true
-        }
-        if (tildeBasePath != null &&
-            trimmed.contains(tildeBasePath)
-        ) {
-            return true
-        }
-        return false
     }
 }

--- a/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
+++ b/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
@@ -9,7 +9,10 @@ import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener
 import com.intellij.ui.SimpleColoredComponent
 import com.intellij.ui.SimpleTextAttributes
+import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.PanelWidthMode
+import dev.ayuislands.toolwindow.ToolWindowAutoFitter
 import java.awt.Component
 import java.awt.Container
 import java.beans.PropertyChangeListener
@@ -27,6 +30,14 @@ class ProjectViewScrollbarManager(
     private var registryKeyModified = false
     private var trackedTree: JTree? = null
     private var rendererListener: PropertyChangeListener? = null
+    private val autoFitter =
+        ToolWindowAutoFitter(
+            project = project,
+            toolWindowId = "Project",
+            minWidth = MIN_AUTOFIT_WIDTH,
+        ).apply {
+            maxWidthProvider = { AyuIslandsSettings.getInstance().state.autoFitMaxWidth }
+        }
 
     init {
         project.messageBus.connect(this).subscribe(
@@ -38,10 +49,12 @@ class ProjectViewScrollbarManager(
                 ) {
                     val state =
                         AyuIslandsSettings.getInstance().state
-                    if (!state.hideProjectRootPath &&
-                        !state.hideRootVcsAnnotations &&
-                        !state.hideProjectViewHScrollbar
-                    ) {
+                    val widthMode = PanelWidthMode.fromString(state.projectPanelWidthMode)
+                    val allFeaturesDisabled =
+                        !state.hideProjectRootPath &&
+                            !state.hideRootVcsAnnotations &&
+                            !state.hideProjectViewHScrollbar
+                    if (allFeaturesDisabled && widthMode == PanelWidthMode.DEFAULT) {
                         return
                     }
                     apply()
@@ -51,8 +64,10 @@ class ProjectViewScrollbarManager(
     }
 
     fun apply() {
+        if (!LicenseChecker.isLicensedOrGrace()) return
         applyScrollbar()
         applyRootDisplay()
+        manageAutoFit()
     }
 
     private fun applyScrollbar() {
@@ -71,6 +86,21 @@ class ProjectViewScrollbarManager(
             scrollPane.horizontalScrollBarPolicy =
                 originalScrollbarPolicy!!
             originalScrollbarPolicy = null
+        }
+    }
+
+    private fun manageAutoFit() {
+        val state = AyuIslandsSettings.getInstance().state
+        when (PanelWidthMode.fromString(state.projectPanelWidthMode)) {
+            PanelWidthMode.DEFAULT -> autoFitter.removeExpansionListener()
+            PanelWidthMode.AUTO_FIT -> {
+                autoFitter.installExpansionListener()
+                autoFitter.applyAutoFitWidth(state.autoFitMaxWidth)
+            }
+            PanelWidthMode.FIXED -> {
+                autoFitter.removeExpansionListener()
+                autoFitter.applyFixedWidth(state.projectPanelFixedWidth)
+            }
         }
     }
 
@@ -208,6 +238,7 @@ class ProjectViewScrollbarManager(
 
     override fun dispose() {
         removeRendererGuard()
+        autoFitter.removeExpansionListener()
         val scrollPane = findProjectScrollPane()
         if (scrollPane != null && originalScrollbarPolicy != null) {
             scrollPane.horizontalScrollBarPolicy =
@@ -227,6 +258,7 @@ class ProjectViewScrollbarManager(
     companion object {
         private const val SHOW_URL_KEY =
             "project.tree.structure.show.url"
+        const val MIN_AUTOFIT_WIDTH = 253
 
         fun getInstance(project: Project): ProjectViewScrollbarManager =
             project.getService(

--- a/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
+++ b/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
@@ -1,0 +1,315 @@
+package dev.ayuislands.projectview
+
+import com.intellij.ide.projectView.ProjectView
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.registry.Registry
+import com.intellij.openapi.wm.ToolWindowManager
+import com.intellij.openapi.wm.ex.ToolWindowManagerListener
+import com.intellij.ui.SimpleColoredComponent
+import com.intellij.ui.SimpleTextAttributes
+import dev.ayuislands.settings.AyuIslandsSettings
+import java.awt.Component
+import java.awt.Container
+import java.beans.PropertyChangeListener
+import javax.swing.JScrollPane
+import javax.swing.JTree
+import javax.swing.ScrollPaneConstants
+import javax.swing.tree.TreeCellRenderer
+
+/** Per-project service that manages Project tool window tweaks (scrollbar, root path). */
+@Service(Service.Level.PROJECT)
+class ProjectViewScrollbarManager(
+    private val project: Project,
+) : Disposable {
+    private var originalScrollbarPolicy: Int? = null
+    private var registryKeyModified = false
+    private var trackedTree: JTree? = null
+    private var rendererListener: PropertyChangeListener? = null
+
+    init {
+        project.messageBus.connect(this).subscribe(
+            ToolWindowManagerListener.TOPIC,
+            object : ToolWindowManagerListener {
+                override fun stateChanged(
+                    toolWindowManager: ToolWindowManager,
+                    changeType: ToolWindowManagerListener.ToolWindowManagerEventType,
+                ) {
+                    val state =
+                        AyuIslandsSettings.getInstance().state
+                    if (!state.hideProjectRootPath &&
+                        !state.hideRootVcsAnnotations &&
+                        !state.hideProjectViewHScrollbar
+                    ) {
+                        return
+                    }
+                    apply()
+                }
+            },
+        )
+    }
+
+    fun apply() {
+        applyScrollbar()
+        applyRootDisplay()
+    }
+
+    private fun applyScrollbar() {
+        val scrollPane = findProjectScrollPane() ?: return
+        val shouldHide =
+            AyuIslandsSettings.getInstance().state.hideProjectViewHScrollbar
+
+        if (shouldHide) {
+            if (originalScrollbarPolicy == null) {
+                originalScrollbarPolicy =
+                    scrollPane.horizontalScrollBarPolicy
+            }
+            scrollPane.horizontalScrollBarPolicy =
+                ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER
+        } else if (originalScrollbarPolicy != null) {
+            scrollPane.horizontalScrollBarPolicy =
+                originalScrollbarPolicy!!
+            originalScrollbarPolicy = null
+        }
+    }
+
+    private fun applyRootDisplay() {
+        applyFilesystemPathVisibility()
+        applyVcsAnnotationVisibility()
+        ProjectView.getInstance(project).refresh()
+    }
+
+    private fun applyFilesystemPathVisibility() {
+        val shouldHide =
+            AyuIslandsSettings.getInstance().state.hideProjectRootPath
+        val registryKey = Registry.get(SHOW_URL_KEY)
+        if (shouldHide) {
+            registryKey.setValue(false)
+            registryKeyModified = true
+        } else if (registryKeyModified) {
+            registryKey.resetToDefault()
+            registryKeyModified = false
+        }
+    }
+
+    private fun applyVcsAnnotationVisibility() {
+        val shouldHideVcs =
+            AyuIslandsSettings.getInstance().state.hideRootVcsAnnotations
+        val tree = findProjectTree() ?: return
+        if (shouldHideVcs) {
+            installRendererWrapper(tree)
+            installRendererGuard(tree)
+        } else {
+            removeRendererGuard()
+            unwrapRenderer(tree)
+        }
+    }
+
+    private fun installRendererWrapper(tree: JTree) {
+        val current = tree.cellRenderer
+        if (current !is RootLocationHidingRenderer) {
+            tree.cellRenderer =
+                RootLocationHidingRenderer(current, project)
+        }
+    }
+
+    private fun unwrapRenderer(tree: JTree) {
+        val current = tree.cellRenderer
+        if (current is RootLocationHidingRenderer) {
+            tree.cellRenderer = current.delegate
+        }
+    }
+
+    private fun installRendererGuard(tree: JTree) {
+        if (trackedTree === tree && rendererListener != null) return
+
+        removeRendererGuard()
+        trackedTree = tree
+        rendererListener =
+            PropertyChangeListener { event ->
+                if (event.propertyName == "cellRenderer") {
+                    val newRenderer =
+                        event.newValue as? TreeCellRenderer
+                            ?: return@PropertyChangeListener
+                    if (newRenderer !is RootLocationHidingRenderer &&
+                        AyuIslandsSettings
+                            .getInstance()
+                            .state
+                            .hideRootVcsAnnotations
+                    ) {
+                        tree.cellRenderer =
+                            RootLocationHidingRenderer(
+                                newRenderer,
+                                project,
+                            )
+                    }
+                }
+            }
+        tree.addPropertyChangeListener(
+            "cellRenderer",
+            rendererListener,
+        )
+    }
+
+    private fun removeRendererGuard() {
+        val tree = trackedTree ?: return
+        val listener = rendererListener ?: return
+        tree.removePropertyChangeListener(
+            "cellRenderer",
+            listener,
+        )
+        trackedTree = null
+        rendererListener = null
+    }
+
+    private fun findProjectScrollPane(): JScrollPane? {
+        val content = findProjectContent() ?: return null
+        return findFirstOfType(
+            content,
+            JScrollPane::class.java,
+        ) as? JScrollPane
+    }
+
+    private fun findProjectTree(): JTree? {
+        val content = findProjectContent() ?: return null
+        return findFirstOfType(
+            content,
+            JTree::class.java,
+        ) as? JTree
+    }
+
+    private fun findProjectContent(): Component? {
+        val toolWindow =
+            ToolWindowManager
+                .getInstance(project)
+                .getToolWindow("Project")
+                ?: return null
+        return toolWindow
+            .contentManager
+            .contents
+            .firstOrNull()
+            ?.component
+    }
+
+    private fun findFirstOfType(
+        component: Component,
+        type: Class<*>,
+    ): Component? {
+        if (type.isInstance(component)) return component
+        if (component is Container) {
+            for (child in component.components) {
+                val found = findFirstOfType(child, type)
+                if (found != null) return found
+            }
+        }
+        return null
+    }
+
+    override fun dispose() {
+        removeRendererGuard()
+        val scrollPane = findProjectScrollPane()
+        if (scrollPane != null && originalScrollbarPolicy != null) {
+            scrollPane.horizontalScrollBarPolicy =
+                originalScrollbarPolicy!!
+            originalScrollbarPolicy = null
+        }
+        if (registryKeyModified) {
+            Registry.get(SHOW_URL_KEY).resetToDefault()
+            registryKeyModified = false
+        }
+        val tree = findProjectTree()
+        if (tree != null) {
+            unwrapRenderer(tree)
+        }
+    }
+
+    companion object {
+        private const val SHOW_URL_KEY =
+            "project.tree.structure.show.url"
+
+        fun getInstance(project: Project): ProjectViewScrollbarManager =
+            project.getService(
+                ProjectViewScrollbarManager::class.java,
+            )
+    }
+}
+
+/**
+ * Strips VCS annotations (branch name, changed file count)
+ * from the project root node. Rebuilds the component keeping
+ * only the project name and filesystem path fragments.
+ */
+private class RootLocationHidingRenderer(
+    val delegate: TreeCellRenderer,
+    private val project: Project,
+) : TreeCellRenderer {
+    override fun getTreeCellRendererComponent(
+        tree: JTree,
+        value: Any?,
+        selected: Boolean,
+        expanded: Boolean,
+        leaf: Boolean,
+        row: Int,
+        hasFocus: Boolean,
+    ): Component {
+        val component =
+            delegate.getTreeCellRendererComponent(
+                tree,
+                value,
+                selected,
+                expanded,
+                leaf,
+                row,
+                hasFocus,
+            )
+        if (row == 0 && component is SimpleColoredComponent) {
+            stripVcsFragments(component)
+        }
+        return component
+    }
+
+    private fun stripVcsFragments(component: SimpleColoredComponent) {
+        val projectName = project.name
+        val basePath = project.basePath
+        val tildeBasePath =
+            basePath?.replace(
+                System.getProperty("user.home"),
+                "~",
+            )
+        val kept =
+            mutableListOf<Pair<String, SimpleTextAttributes>>()
+        val iter = component.iterator()
+        while (iter.hasNext()) {
+            iter.next()
+            val text = iter.fragment
+            val trimmed = text.trim()
+            if (isKeptFragment(trimmed, projectName, basePath, tildeBasePath)) {
+                kept.add(text to iter.textAttributes)
+            }
+        }
+        component.clear()
+        for ((text, attrs) in kept) {
+            component.append(text, attrs)
+        }
+    }
+
+    private fun isKeptFragment(
+        trimmed: String,
+        projectName: String,
+        basePath: String?,
+        tildeBasePath: String?,
+    ): Boolean {
+        if (trimmed.isEmpty()) return false
+        if (trimmed == projectName) return true
+        if (basePath != null && trimmed.contains(basePath)) {
+            return true
+        }
+        if (tildeBasePath != null &&
+            trimmed.contains(tildeBasePath)
+        ) {
+            return true
+        }
+        return false
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
+++ b/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
@@ -12,9 +12,9 @@ import com.intellij.ui.SimpleTextAttributes
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.PanelWidthMode
+import dev.ayuislands.toolwindow.AutoFitCalculator
 import dev.ayuislands.toolwindow.ToolWindowAutoFitter
 import java.awt.Component
-import java.awt.Container
 import java.beans.PropertyChangeListener
 import javax.swing.JScrollPane
 import javax.swing.JTree
@@ -34,7 +34,7 @@ class ProjectViewScrollbarManager(
         ToolWindowAutoFitter(
             project = project,
             toolWindowId = "Project",
-            minWidth = MIN_AUTOFIT_WIDTH,
+            minWidth = AutoFitCalculator.MIN_PROJECT_AUTOFIT_WIDTH,
         ).apply {
             maxWidthProvider = { AyuIslandsSettings.getInstance().state.autoFitMaxWidth }
         }
@@ -195,7 +195,7 @@ class ProjectViewScrollbarManager(
 
     private fun findProjectScrollPane(): JScrollPane? {
         val content = findProjectContent() ?: return null
-        return findFirstOfType(
+        return AutoFitCalculator.findFirstOfType(
             content,
             JScrollPane::class.java,
         ) as? JScrollPane
@@ -203,7 +203,7 @@ class ProjectViewScrollbarManager(
 
     private fun findProjectTree(): JTree? {
         val content = findProjectContent() ?: return null
-        return findFirstOfType(
+        return AutoFitCalculator.findFirstOfType(
             content,
             JTree::class.java,
         ) as? JTree
@@ -220,20 +220,6 @@ class ProjectViewScrollbarManager(
             .contents
             .firstOrNull()
             ?.component
-    }
-
-    private fun findFirstOfType(
-        component: Component,
-        type: Class<*>,
-    ): Component? {
-        if (type.isInstance(component)) return component
-        if (component is Container) {
-            for (child in component.components) {
-                val found = findFirstOfType(child, type)
-                if (found != null) return found
-            }
-        }
-        return null
     }
 
     override fun dispose() {
@@ -258,7 +244,6 @@ class ProjectViewScrollbarManager(
     companion object {
         private const val SHOW_URL_KEY =
             "project.tree.structure.show.url"
-        const val MIN_AUTOFIT_WIDTH = 253
 
         fun getInstance(project: Project): ProjectViewScrollbarManager =
             project.getService(

--- a/src/main/kotlin/dev/ayuislands/projectview/RootFragmentFilter.kt
+++ b/src/main/kotlin/dev/ayuislands/projectview/RootFragmentFilter.kt
@@ -1,0 +1,17 @@
+package dev.ayuislands.projectview
+
+/** Pure logic for filtering VCS annotation fragments from project root node. */
+object RootFragmentFilter {
+    fun isKeptFragment(
+        trimmed: String,
+        projectName: String,
+        basePath: String?,
+        tildeBasePath: String?,
+    ): Boolean {
+        if (trimmed.isEmpty()) return false
+        if (trimmed == projectName) return true
+        if (basePath != null && trimmed.contains(basePath)) return true
+        if (tildeBasePath != null && trimmed.contains(tildeBasePath)) return true
+        return false
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt
@@ -68,7 +68,6 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
                 appearancePanel.buildPanel(this@panel, variant)
                 accentPanel.buildPanel(this@panel, variant)
                 elementsPanel.buildPanel(this@panel, variant)
-                integrationsPanel.buildPanel(this@panel, variant)
 
                 // "Reset all settings..." link at the bottom of the Accent tab
                 row {
@@ -94,6 +93,11 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
                 fontPresetPanel.buildFontTab(this@panel)
             }
 
+        val integrationsTab =
+            panel {
+                integrationsPanel.buildPanel(this@panel, variant)
+            }
+
         val glowTab =
             panel {
                 effectsPanel.buildGlowPanel(this@panel)
@@ -104,6 +108,7 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
         val tabs = JBTabbedPane()
         tabs.addTab("Accent", accentTab)
         tabs.addTab("Font", fontTab)
+        tabs.addTab("Integrations", integrationsTab)
         tabs.addTab("Glow", glowTab)
         tabs.selectedIndex = state.settingsSelectedTab.coerceIn(0, tabs.tabCount - 1)
         tabs.addChangeListener {
@@ -155,6 +160,7 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
     private fun resetAllSettings() {
         accentPanel.resetToDefault()
         elementsPanel.reset()
+        integrationsPanel.reset()
         fontPresetPanel.reset()
         effectsPanel.reset()
     }

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt
@@ -22,12 +22,14 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
 
     private companion object {
         const val LOGO_HEIGHT = 28
+        const val MIN_TABS_WIDTH = 600
     }
 
     private val appearancePanel = AyuIslandsAppearancePanel()
     private val accentPanel = AyuIslandsAccentPanel()
     private val elementsPanel = AyuIslandsElementsPanel()
-    private val integrationsPanel = IntegrationsPanel()
+    private val workspacePanel = WorkspacePanel()
+    private val pluginsPanel = PluginsPanel()
     private val fontPresetPanel = FontPresetPanel()
     private val effectsPanel = AyuIslandsEffectsPanel()
 
@@ -36,9 +38,10 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
             appearancePanel,
             accentPanel,
             elementsPanel,
-            integrationsPanel,
             fontPresetPanel,
             effectsPanel,
+            workspacePanel,
+            pluginsPanel,
         )
 
     override fun createPanel(): com.intellij.openapi.ui.DialogPanel {
@@ -93,23 +96,30 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
                 fontPresetPanel.buildFontTab(this@panel)
             }
 
-        val integrationsTab =
-            panel {
-                integrationsPanel.buildPanel(this@panel, variant)
-            }
-
         val glowTab =
             panel {
                 effectsPanel.buildGlowPanel(this@panel)
             }
 
+        val workspaceTab =
+            panel {
+                workspacePanel.buildPanel(this@panel, variant)
+            }
+
+        val pluginsTab =
+            panel {
+                pluginsPanel.buildPanel(this@panel, variant)
+            }
+
         // Single-level tab container
         val state = AyuIslandsSettings.getInstance().state
         val tabs = JBTabbedPane()
+        tabs.minimumSize = java.awt.Dimension(MIN_TABS_WIDTH, 0)
         tabs.addTab("Accent", accentTab)
         tabs.addTab("Font", fontTab)
-        tabs.addTab("Integrations", integrationsTab)
         tabs.addTab("Glow", glowTab)
+        tabs.addTab("Workspace", workspaceTab)
+        tabs.addTab("Plugins", pluginsTab)
         tabs.selectedIndex = state.settingsSelectedTab.coerceIn(0, tabs.tabCount - 1)
         tabs.addChangeListener {
             AyuIslandsSettings.getInstance().state.settingsSelectedTab = tabs.selectedIndex
@@ -160,9 +170,10 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
     private fun resetAllSettings() {
         accentPanel.resetToDefault()
         elementsPanel.reset()
-        integrationsPanel.reset()
         fontPresetPanel.reset()
         effectsPanel.reset()
+        workspacePanel.reset()
+        pluginsPanel.reset()
     }
 
     override fun isModified(): Boolean = super.isModified() || panels.any { it.isModified() }

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
@@ -189,7 +189,6 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
             }
 
         glowPanel.add(innerContent, BorderLayout.CENTER)
-        glowPanel.minimumSize = java.awt.Dimension(MIN_PANEL_WIDTH, 0)
         updateGlowGroupPanel()
 
         panel.row {
@@ -590,7 +589,6 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
         private const val DEFAULT_WIDTH = 4
         private const val WIDTH_MAJOR_TICK = 2
         private const val FALLBACK_COLOR_HEX = "#FFCC66"
-        private const val MIN_PANEL_WIDTH = 450
         private val ISLAND_IDS = listOf("Editor", "Project", "Terminal", "Run", "Debug", "Git", "Services")
     }
 }

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsElementsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsElementsPanel.kt
@@ -31,6 +31,8 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
     private var storedTabUnderlineHeight: Int = AyuIslandsState.DEFAULT_TAB_UNDERLINE_HEIGHT
     private var pendingTabUnderlineGlowSync: Boolean = false
     private var storedTabUnderlineGlowSync: Boolean = false
+    private var pendingBracketScope: Boolean = true
+    private var storedBracketScope: Boolean = true
     private val checkboxes: MutableMap<AccentElementId, JCheckBox> = mutableMapOf()
     private var tabModeSegmented: SegmentedButton<GlowTabMode>? = null
     private var tabModeCommentRow: Row? = null
@@ -39,6 +41,7 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
     private var thicknessRow: Row? = null
     private var syncRow: Row? = null
     private var syncCheckbox: JCheckBox? = null
+    private var bracketScopeCheckbox: JCheckBox? = null
     private var licensed: Boolean = false
     private var variant: AyuVariant? = null
     private var elementPreview: AyuIslandsPreviewPanel? = null
@@ -75,6 +78,8 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
         pendingTabUnderlineHeight = storedTabUnderlineHeight
         storedTabUnderlineGlowSync = state.tabUnderlineGlowSync
         pendingTabUnderlineGlowSync = storedTabUnderlineGlowSync
+        storedBracketScope = state.bracketScopeEnabled
+        pendingBracketScope = storedBracketScope
 
         // Detect conflicts on panel open and clean stale overrides for blocked elements
         ConflictRegistry.detectConflicts()
@@ -144,6 +149,20 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
 
                 // Right: hover preview mockup
                 cell(previewComponent).align(AlignY.CENTER)
+            }
+        }
+
+        panel.group("Bracket Scope") {
+            row {
+                val scopeCb =
+                    checkBox("Highlight bracket scope on gutter")
+                        .comment("Show accent-colored scope stripe when caret is on a bracket")
+                scopeCb.component.isSelected = pendingBracketScope
+                scopeCb.component.isEnabled = licensed
+                scopeCb.component.addActionListener {
+                    pendingBracketScope = scopeCb.component.isSelected
+                }
+                bracketScopeCheckbox = scopeCb.component
             }
         }
 
@@ -288,6 +307,7 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
         if (pendingTabMode != storedTabMode) return true
         if (pendingTabUnderlineHeight != storedTabUnderlineHeight) return true
         if (pendingTabUnderlineGlowSync != storedTabUnderlineGlowSync) return true
+        if (pendingBracketScope != storedBracketScope) return true
         return false
     }
 
@@ -302,12 +322,14 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
         state.glowTabMode = pendingTabMode
         state.tabUnderlineHeight = pendingTabUnderlineHeight
         state.tabUnderlineGlowSync = pendingTabUnderlineGlowSync
+        state.bracketScopeEnabled = pendingBracketScope
 
         storedToggles = pendingToggles.toMap()
         storedForceOverrides = pendingForceOverrides.toSet()
         storedTabMode = pendingTabMode
         storedTabUnderlineHeight = pendingTabUnderlineHeight
         storedTabUnderlineGlowSync = pendingTabUnderlineGlowSync
+        storedBracketScope = pendingBracketScope
 
         // Re-apply accent with new toggle states
         val currentVariant = variant ?: return
@@ -322,7 +344,9 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
         pendingTabMode = storedTabMode
         pendingTabUnderlineHeight = storedTabUnderlineHeight
         pendingTabUnderlineGlowSync = storedTabUnderlineGlowSync
+        pendingBracketScope = storedBracketScope
         refreshCheckboxes()
+        bracketScopeCheckbox?.isSelected = storedBracketScope
         syncPreviewToggles()
         tabModeSegmented?.selectedItem = GlowTabMode.fromName(pendingTabMode)
         thicknessSegmented?.selectedItem = pendingTabUnderlineHeight

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -93,6 +93,14 @@ class AyuIslandsState : BaseState() {
     // IR version that failed reflection (suppresses repeated notifications)
     var irFailedVersion by string(null)
 
+    // Project View tweaks
+    var hideProjectRootPath by property(false)
+    var hideRootVcsAnnotations by property(false)
+    var hideProjectViewHScrollbar by property(false)
+
+    // Migration: existing users with hideProjectRootPath=true expect VCS hidden too
+    var projectViewMigrated by property(false)
+
     // Font preset
     var fontPresetEnabled by property(false)
     var fontPresetName by string("AMBIENT")

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -7,6 +7,17 @@ import dev.ayuislands.glow.GlowPreset
 import dev.ayuislands.glow.GlowStyle
 import dev.ayuislands.indent.IndentPreset
 
+enum class PanelWidthMode {
+    DEFAULT,
+    AUTO_FIT,
+    FIXED,
+    ;
+
+    companion object {
+        fun fromString(value: String?): PanelWidthMode = entries.firstOrNull { it.name == value } ?: DEFAULT
+    }
+}
+
 class AyuIslandsState : BaseState() {
     // Per-variant accent colors
     var mirageAccent by string("#FFCC66")
@@ -97,6 +108,21 @@ class AyuIslandsState : BaseState() {
     var hideProjectRootPath by property(false)
     var hideRootVcsAnnotations by property(false)
     var hideProjectViewHScrollbar by property(false)
+    var autoFitProjectPanelWidth by property(false)
+    var autoFitMaxWidth by property(DEFAULT_AUTO_FIT_MAX_WIDTH)
+
+    // Commit panel auto-fit
+    var autoFitCommitPanelWidth by property(false)
+    var autoFitCommitMaxWidth by property(DEFAULT_AUTO_FIT_MAX_WIDTH)
+
+    // Panel width mode (3-state: DEFAULT / AUTO_FIT / FIXED)
+    var projectPanelWidthMode by string(PanelWidthMode.DEFAULT.name)
+    var projectPanelFixedWidth by property(DEFAULT_FIXED_WIDTH)
+    var commitPanelWidthMode by string(PanelWidthMode.DEFAULT.name)
+    var commitPanelFixedWidth by property(DEFAULT_FIXED_WIDTH)
+    var gitPanelWidthMode by string(PanelWidthMode.DEFAULT.name)
+    var gitPanelAutoFitMaxWidth by property(DEFAULT_AUTO_FIT_MAX_WIDTH)
+    var gitPanelFixedWidth by property(DEFAULT_FIXED_WIDTH)
 
     // Migration: existing users with hideProjectRootPath=true expect VCS hidden too
     var projectViewMigrated by property(false)
@@ -115,6 +141,11 @@ class AyuIslandsState : BaseState() {
 
     // Settings tab selection (persisted across settings opens)
     var settingsSelectedTab by property(0)
+
+    // Workspace tab: collapsible group expanded states
+    var workspaceProjectViewExpanded by property(true)
+    var workspaceCommitPanelExpanded by property(false)
+    var workspaceGitPanelExpanded by property(false)
 
     // Force overrides for conflicting elements (element ID names)
     var forceOverrides by stringSet()
@@ -210,8 +241,19 @@ class AyuIslandsState : BaseState() {
         }
     }
 
+    fun migrateWidthModes() {
+        if (autoFitProjectPanelWidth && projectPanelWidthMode == PanelWidthMode.DEFAULT.name) {
+            projectPanelWidthMode = PanelWidthMode.AUTO_FIT.name
+        }
+        if (autoFitCommitPanelWidth && commitPanelWidthMode == PanelWidthMode.DEFAULT.name) {
+            commitPanelWidthMode = PanelWidthMode.AUTO_FIT.name
+        }
+    }
+
     companion object {
         const val DEFAULT_TAB_UNDERLINE_HEIGHT = 4
+        const val DEFAULT_AUTO_FIT_MAX_WIDTH = 400
+        const val DEFAULT_FIXED_WIDTH = 300
         private const val DEFAULT_SOFT_INTENSITY = 20
         private const val DEFAULT_SHARP_NEON_INTENSITY = 50
         private const val DEFAULT_GRADIENT_INTENSITY = 30

--- a/src/main/kotlin/dev/ayuislands/settings/IntegrationsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/IntegrationsPanel.kt
@@ -2,7 +2,9 @@
 
 package dev.ayuislands.settings
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.observable.properties.AtomicBooleanProperty
+import com.intellij.openapi.project.ProjectManager
 import com.intellij.ui.dsl.builder.Align
 import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.dsl.builder.SegmentedButton
@@ -11,12 +13,22 @@ import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.conflict.ConflictRegistry
 import dev.ayuislands.indent.IndentPreset
 import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.projectview.ProjectViewScrollbarManager
 import javax.swing.JCheckBox
 import javax.swing.JLabel
 import javax.swing.JSlider
 
-/** Third-party integrations: bracket scope, CodeGlance Pro, and Indent Rainbow. */
+/** Integrations tab: Project View tweaks and third-party editor integrations. */
 class IntegrationsPanel : AyuIslandsSettingsPanel {
+    // Project View toggles
+    private var pendingHideRootPath: Boolean = false
+    private var storedHideRootPath: Boolean = false
+    private var pendingHideRootVcs: Boolean = false
+    private var storedHideRootVcs: Boolean = false
+    private var pendingHideHScrollbar: Boolean = false
+    private var storedHideHScrollbar: Boolean = false
+
+    // Editor integrations
     private var pendingEnabled: Boolean = false
     private var storedEnabled: Boolean = false
     private var pendingPreset: String = IndentPreset.AMBIENT.name
@@ -31,6 +43,9 @@ class IntegrationsPanel : AyuIslandsSettingsPanel {
     private var storedErrorHighlight: Boolean = true
 
     private var variant: AyuVariant? = null
+    private var hideRootPathCheckbox: JCheckBox? = null
+    private var hideRootVcsCheckbox: JCheckBox? = null
+    private var hideHScrollbarCheckbox: JCheckBox? = null
     private var enabledCheckbox: JCheckBox? = null
     private var cgpCheckbox: JCheckBox? = null
     private var errorHighlightCheckbox: JCheckBox? = null
@@ -49,21 +64,25 @@ class IntegrationsPanel : AyuIslandsSettingsPanel {
         val state = AyuIslandsSettings.getInstance().state
         val licensed = LicenseChecker.isLicensedOrGrace()
 
+        // Project View state
+        storedHideRootPath = state.hideProjectRootPath
+        pendingHideRootPath = storedHideRootPath
+        storedHideRootVcs = state.hideRootVcsAnnotations
+        pendingHideRootVcs = storedHideRootVcs
+        storedHideHScrollbar = state.hideProjectViewHScrollbar
+        pendingHideHScrollbar = storedHideHScrollbar
+
+        // Editor integrations state
         storedBracketScope = state.bracketScopeEnabled
         pendingBracketScope = storedBracketScope
-
         storedCgpIntegration = state.cgpIntegrationEnabled
         pendingCgpIntegration = storedCgpIntegration
-
         storedEnabled = state.irIntegrationEnabled
         pendingEnabled = storedEnabled
-
         storedErrorHighlight = state.irErrorHighlightEnabled
         pendingErrorHighlight = storedErrorHighlight
-
         storedPreset = state.indentPresetName ?: IndentPreset.AMBIENT.name
         pendingPreset = storedPreset
-
         storedCustomAlpha = state.indentCustomAlpha
         pendingCustomAlpha = storedCustomAlpha
 
@@ -73,7 +92,40 @@ class IntegrationsPanel : AyuIslandsSettingsPanel {
 
         val irEnabled = AtomicBooleanProperty(pendingEnabled)
 
-        panel.group("Integrations") {
+        panel.group("Project View") {
+            row {
+                val cb =
+                    checkBox("Hide filesystem path")
+                        .comment("Remove the directory path shown next to the project name")
+                cb.component.isSelected = pendingHideRootPath
+                cb.component.addActionListener {
+                    pendingHideRootPath = cb.component.isSelected
+                }
+                hideRootPathCheckbox = cb.component
+            }
+            row {
+                val cb =
+                    checkBox("Hide VCS annotations")
+                        .comment("Remove branch name and changed file count from the project root")
+                cb.component.isSelected = pendingHideRootVcs
+                cb.component.addActionListener {
+                    pendingHideRootVcs = cb.component.isSelected
+                }
+                hideRootVcsCheckbox = cb.component
+            }
+            row {
+                val cb =
+                    checkBox("Hide horizontal scrollbar")
+                        .comment("Remove the bottom scrollbar from the Project tool window")
+                cb.component.isSelected = pendingHideHScrollbar
+                cb.component.addActionListener {
+                    pendingHideHScrollbar = cb.component.isSelected
+                }
+                hideHScrollbarCheckbox = cb.component
+            }
+        }
+
+        panel.group("Editor") {
             // Bracket scope — always visible (independent of third-party plugins)
             row {
                 val scopeCb =
@@ -180,7 +232,10 @@ class IntegrationsPanel : AyuIslandsSettingsPanel {
     }
 
     override fun isModified(): Boolean =
-        pendingEnabled != storedEnabled ||
+        pendingHideRootPath != storedHideRootPath ||
+            pendingHideRootVcs != storedHideRootVcs ||
+            pendingHideHScrollbar != storedHideHScrollbar ||
+            pendingEnabled != storedEnabled ||
             pendingPreset != storedPreset ||
             pendingCustomAlpha != storedCustomAlpha ||
             pendingBracketScope != storedBracketScope ||
@@ -191,6 +246,19 @@ class IntegrationsPanel : AyuIslandsSettingsPanel {
         if (!isModified()) return
         val state = AyuIslandsSettings.getInstance().state
 
+        val rootPathChanged = pendingHideRootPath != storedHideRootPath
+        val vcsAnnotationsChanged = pendingHideRootVcs != storedHideRootVcs
+        val hScrollbarChanged = pendingHideHScrollbar != storedHideHScrollbar
+
+        // Project View settings
+        state.hideProjectRootPath = pendingHideRootPath
+        state.hideRootVcsAnnotations = pendingHideRootVcs
+        state.hideProjectViewHScrollbar = pendingHideHScrollbar
+        storedHideRootPath = pendingHideRootPath
+        storedHideRootVcs = pendingHideRootVcs
+        storedHideHScrollbar = pendingHideHScrollbar
+
+        // Editor integrations
         state.irIntegrationEnabled = pendingEnabled
         state.indentPresetName = pendingPreset
         state.indentCustomAlpha = pendingCustomAlpha
@@ -205,6 +273,16 @@ class IntegrationsPanel : AyuIslandsSettingsPanel {
         storedCgpIntegration = pendingCgpIntegration
         storedErrorHighlight = pendingErrorHighlight
 
+        // Apply Project View changes to all open projects
+        if (rootPathChanged || vcsAnnotationsChanged || hScrollbarChanged) {
+            for (openProject in ProjectManager.getInstance().openProjects) {
+                ApplicationManager.getApplication().invokeLater(
+                    { ProjectViewScrollbarManager.getInstance(openProject).apply() },
+                    openProject.disposed,
+                )
+            }
+        }
+
         // Trigger IR sync immediately
         val currentVariant = variant ?: return
         val accentHex = AyuIslandsSettings.getInstance().getAccentForVariant(currentVariant)
@@ -212,6 +290,9 @@ class IntegrationsPanel : AyuIslandsSettingsPanel {
     }
 
     override fun reset() {
+        pendingHideRootPath = storedHideRootPath
+        pendingHideRootVcs = storedHideRootVcs
+        pendingHideHScrollbar = storedHideHScrollbar
         pendingEnabled = storedEnabled
         pendingPreset = storedPreset
         pendingCustomAlpha = storedCustomAlpha
@@ -220,6 +301,9 @@ class IntegrationsPanel : AyuIslandsSettingsPanel {
         pendingErrorHighlight = storedErrorHighlight
 
         suppressListeners = true
+        hideRootPathCheckbox?.isSelected = storedHideRootPath
+        hideRootVcsCheckbox?.isSelected = storedHideRootVcs
+        hideHScrollbarCheckbox?.isSelected = storedHideHScrollbar
         enabledCheckbox?.isSelected = storedEnabled
         cgpCheckbox?.isSelected = storedCgpIntegration
         errorHighlightCheckbox?.isSelected = storedErrorHighlight

--- a/src/main/kotlin/dev/ayuislands/settings/PanelWidthState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/PanelWidthState.kt
@@ -1,0 +1,56 @@
+package dev.ayuislands.settings
+
+import dev.ayuislands.settings.AyuIslandsState.Companion.DEFAULT_AUTO_FIT_MAX_WIDTH
+import dev.ayuislands.settings.AyuIslandsState.Companion.DEFAULT_FIXED_WIDTH
+
+/**
+ * Pure state machine for tool window width mode tracking.
+ * Extracted from WorkspacePanel for testability — no Swing dependencies.
+ */
+class PanelWidthState {
+    var pendingMode = PanelWidthMode.DEFAULT
+    var storedMode = PanelWidthMode.DEFAULT
+    var pendingAutoFitMaxWidth = DEFAULT_AUTO_FIT_MAX_WIDTH
+    var storedAutoFitMaxWidth = DEFAULT_AUTO_FIT_MAX_WIDTH
+    var pendingFixedWidth = DEFAULT_FIXED_WIDTH
+    var storedFixedWidth = DEFAULT_FIXED_WIDTH
+
+    fun load(
+        mode: PanelWidthMode,
+        autoFitMaxWidth: Int,
+        fixedWidth: Int,
+    ) {
+        storedMode = mode
+        pendingMode = mode
+        storedAutoFitMaxWidth = autoFitMaxWidth
+        pendingAutoFitMaxWidth = autoFitMaxWidth
+        storedFixedWidth = fixedWidth
+        pendingFixedWidth = fixedWidth
+    }
+
+    fun isModified(): Boolean =
+        pendingMode != storedMode ||
+            pendingAutoFitMaxWidth != storedAutoFitMaxWidth ||
+            pendingFixedWidth != storedFixedWidth
+
+    fun commitStored() {
+        storedMode = pendingMode
+        storedAutoFitMaxWidth = pendingAutoFitMaxWidth
+        storedFixedWidth = pendingFixedWidth
+    }
+
+    fun reset() {
+        pendingMode = storedMode
+        pendingAutoFitMaxWidth = storedAutoFitMaxWidth
+        pendingFixedWidth = storedFixedWidth
+    }
+
+    companion object {
+        fun widthSummary(state: PanelWidthState): String =
+            when (state.pendingMode) {
+                PanelWidthMode.DEFAULT -> "Default"
+                PanelWidthMode.AUTO_FIT -> "Auto-fit \u00B7 max ${state.pendingAutoFitMaxWidth}px"
+                PanelWidthMode.FIXED -> "Fixed \u00B7 ${state.pendingFixedWidth}px"
+            }
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
@@ -78,6 +78,8 @@ class PluginsPanel : AyuIslandsSettingsPanel {
             return
         }
 
+        panel.row { comment("Sync Ayu accent colors with compatible plugins.") }
+
         if (cgpDetected) {
             panel.group("CodeGlance Pro") {
                 row {

--- a/src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
@@ -2,9 +2,7 @@
 
 package dev.ayuislands.settings
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.observable.properties.AtomicBooleanProperty
-import com.intellij.openapi.project.ProjectManager
 import com.intellij.ui.dsl.builder.Align
 import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.dsl.builder.SegmentedButton
@@ -13,46 +11,30 @@ import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.conflict.ConflictRegistry
 import dev.ayuislands.indent.IndentPreset
 import dev.ayuislands.licensing.LicenseChecker
-import dev.ayuislands.projectview.ProjectViewScrollbarManager
 import javax.swing.JCheckBox
 import javax.swing.JLabel
 import javax.swing.JSlider
 
-/** Integrations tab: Project View tweaks and third-party editor integrations. */
-class IntegrationsPanel : AyuIslandsSettingsPanel {
-    // Project View toggles
-    private var pendingHideRootPath: Boolean = false
-    private var storedHideRootPath: Boolean = false
-    private var pendingHideRootVcs: Boolean = false
-    private var storedHideRootVcs: Boolean = false
-    private var pendingHideHScrollbar: Boolean = false
-    private var storedHideHScrollbar: Boolean = false
-
-    // Editor integrations
+/** Plugins tab: third-party plugin integrations (CodeGlance Pro, Indent Rainbow). */
+class PluginsPanel : AyuIslandsSettingsPanel {
     private var pendingEnabled: Boolean = false
     private var storedEnabled: Boolean = false
     private var pendingPreset: String = IndentPreset.AMBIENT.name
     private var storedPreset: String = IndentPreset.AMBIENT.name
     private var pendingCustomAlpha: Int = IndentPreset.DEFAULT_ALPHA
     private var storedCustomAlpha: Int = IndentPreset.DEFAULT_ALPHA
-    private var pendingBracketScope: Boolean = true
-    private var storedBracketScope: Boolean = true
     private var pendingCgpIntegration: Boolean = false
     private var storedCgpIntegration: Boolean = false
     private var pendingErrorHighlight: Boolean = true
     private var storedErrorHighlight: Boolean = true
 
     private var variant: AyuVariant? = null
-    private var hideRootPathCheckbox: JCheckBox? = null
-    private var hideRootVcsCheckbox: JCheckBox? = null
-    private var hideHScrollbarCheckbox: JCheckBox? = null
     private var enabledCheckbox: JCheckBox? = null
     private var cgpCheckbox: JCheckBox? = null
     private var errorHighlightCheckbox: JCheckBox? = null
     private var alphaSlider: JSlider? = null
     private var alphaValueLabel: JLabel? = null
     private var presetSegmented: SegmentedButton<IndentPreset>? = null
-    private var bracketScopeCheckbox: JCheckBox? = null
     private val customModeVisible = AtomicBooleanProperty(false)
     private var suppressListeners = false
 
@@ -64,17 +46,6 @@ class IntegrationsPanel : AyuIslandsSettingsPanel {
         val state = AyuIslandsSettings.getInstance().state
         val licensed = LicenseChecker.isLicensedOrGrace()
 
-        // Project View state
-        storedHideRootPath = state.hideProjectRootPath
-        pendingHideRootPath = storedHideRootPath
-        storedHideRootVcs = state.hideRootVcsAnnotations
-        pendingHideRootVcs = storedHideRootVcs
-        storedHideHScrollbar = state.hideProjectViewHScrollbar
-        pendingHideHScrollbar = storedHideHScrollbar
-
-        // Editor integrations state
-        storedBracketScope = state.bracketScopeEnabled
-        pendingBracketScope = storedBracketScope
         storedCgpIntegration = state.cgpIntegrationEnabled
         pendingCgpIntegration = storedCgpIntegration
         storedEnabled = state.irIntegrationEnabled
@@ -92,55 +63,23 @@ class IntegrationsPanel : AyuIslandsSettingsPanel {
 
         val irEnabled = AtomicBooleanProperty(pendingEnabled)
 
-        panel.group("Project View") {
-            row {
-                val cb =
-                    checkBox("Hide filesystem path")
-                        .comment("Remove the directory path shown next to the project name")
-                cb.component.isSelected = pendingHideRootPath
-                cb.component.addActionListener {
-                    pendingHideRootPath = cb.component.isSelected
+        val cgpDetected = ConflictRegistry.isCodeGlanceProDetected()
+        val irDetected = ConflictRegistry.isIndentRainbowDetected()
+
+        if (!cgpDetected && !irDetected) {
+            panel.group("Plugins") {
+                row {
+                    comment(
+                        "No supported plugins detected." +
+                            " Install CodeGlance Pro or Indent Rainbow for accent color sync.",
+                    )
                 }
-                hideRootPathCheckbox = cb.component
             }
-            row {
-                val cb =
-                    checkBox("Hide VCS annotations")
-                        .comment("Remove branch name and changed file count from the project root")
-                cb.component.isSelected = pendingHideRootVcs
-                cb.component.addActionListener {
-                    pendingHideRootVcs = cb.component.isSelected
-                }
-                hideRootVcsCheckbox = cb.component
-            }
-            row {
-                val cb =
-                    checkBox("Hide horizontal scrollbar")
-                        .comment("Remove the bottom scrollbar from the Project tool window")
-                cb.component.isSelected = pendingHideHScrollbar
-                cb.component.addActionListener {
-                    pendingHideHScrollbar = cb.component.isSelected
-                }
-                hideHScrollbarCheckbox = cb.component
-            }
+            return
         }
 
-        panel.group("Editor") {
-            // Bracket scope — always visible (independent of third-party plugins)
-            row {
-                val scopeCb =
-                    checkBox("Highlight bracket scope on gutter")
-                        .comment("Show accent-colored scope stripe when caret is on a bracket")
-                scopeCb.component.isSelected = pendingBracketScope
-                scopeCb.component.isEnabled = licensed
-                scopeCb.component.addActionListener {
-                    pendingBracketScope = scopeCb.component.isSelected
-                }
-                bracketScopeCheckbox = scopeCb.component
-            }
-
-            // CGP section — only when CodeGlance Pro detected
-            if (ConflictRegistry.isCodeGlanceProDetected()) {
+        if (cgpDetected) {
+            panel.group("CodeGlance Pro") {
                 row {
                     val cb =
                         checkBox("Sync color with CodeGlance")
@@ -155,9 +94,10 @@ class IntegrationsPanel : AyuIslandsSettingsPanel {
                     browserLink("Plugin page", "https://plugins.jetbrains.com/plugin/18824-codeglance-pro")
                 }
             }
+        }
 
-            // IR section — only when IR plugin detected
-            if (ConflictRegistry.isIndentRainbowDetected()) {
+        if (irDetected) {
+            panel.group("Indent Rainbow") {
                 row {
                     val cb =
                         checkBox("Sync colors with Indent Rainbow")
@@ -176,7 +116,6 @@ class IntegrationsPanel : AyuIslandsSettingsPanel {
                     )
                 }
 
-                // Preset row (visible when IR integration is enabled)
                 row {
                     label("Preset")
                     val segmented =
@@ -195,7 +134,6 @@ class IntegrationsPanel : AyuIslandsSettingsPanel {
                     presetSegmented = segmented
                 }.visibleIf(irEnabled)
 
-                // Error highlight toggle (visible when IR enabled)
                 row {
                     val cb =
                         checkBox("Highlight indent errors")
@@ -208,7 +146,6 @@ class IntegrationsPanel : AyuIslandsSettingsPanel {
                     errorHighlightCheckbox = cb.component
                 }.visibleIf(irEnabled)
 
-                // Custom alpha slider (visible only in CUSTOM mode AND IR enabled)
                 row {
                     label("Alpha")
                     val slider = JSlider(MIN_ALPHA, MAX_ALPHA, pendingCustomAlpha)
@@ -232,13 +169,9 @@ class IntegrationsPanel : AyuIslandsSettingsPanel {
     }
 
     override fun isModified(): Boolean =
-        pendingHideRootPath != storedHideRootPath ||
-            pendingHideRootVcs != storedHideRootVcs ||
-            pendingHideHScrollbar != storedHideHScrollbar ||
-            pendingEnabled != storedEnabled ||
+        pendingEnabled != storedEnabled ||
             pendingPreset != storedPreset ||
             pendingCustomAlpha != storedCustomAlpha ||
-            pendingBracketScope != storedBracketScope ||
             pendingCgpIntegration != storedCgpIntegration ||
             pendingErrorHighlight != storedErrorHighlight
 
@@ -246,71 +179,37 @@ class IntegrationsPanel : AyuIslandsSettingsPanel {
         if (!isModified()) return
         val state = AyuIslandsSettings.getInstance().state
 
-        val rootPathChanged = pendingHideRootPath != storedHideRootPath
-        val vcsAnnotationsChanged = pendingHideRootVcs != storedHideRootVcs
-        val hScrollbarChanged = pendingHideHScrollbar != storedHideHScrollbar
-
-        // Project View settings
-        state.hideProjectRootPath = pendingHideRootPath
-        state.hideRootVcsAnnotations = pendingHideRootVcs
-        state.hideProjectViewHScrollbar = pendingHideHScrollbar
-        storedHideRootPath = pendingHideRootPath
-        storedHideRootVcs = pendingHideRootVcs
-        storedHideHScrollbar = pendingHideHScrollbar
-
-        // Editor integrations
         state.irIntegrationEnabled = pendingEnabled
         state.indentPresetName = pendingPreset
         state.indentCustomAlpha = pendingCustomAlpha
-        state.bracketScopeEnabled = pendingBracketScope
         state.cgpIntegrationEnabled = pendingCgpIntegration
         state.irErrorHighlightEnabled = pendingErrorHighlight
 
         storedEnabled = pendingEnabled
         storedPreset = pendingPreset
         storedCustomAlpha = pendingCustomAlpha
-        storedBracketScope = pendingBracketScope
         storedCgpIntegration = pendingCgpIntegration
         storedErrorHighlight = pendingErrorHighlight
 
-        // Apply Project View changes to all open projects
-        if (rootPathChanged || vcsAnnotationsChanged || hScrollbarChanged) {
-            for (openProject in ProjectManager.getInstance().openProjects) {
-                ApplicationManager.getApplication().invokeLater(
-                    { ProjectViewScrollbarManager.getInstance(openProject).apply() },
-                    openProject.disposed,
-                )
-            }
-        }
-
-        // Trigger IR sync immediately
         val currentVariant = variant ?: return
         val accentHex = AyuIslandsSettings.getInstance().getAccentForVariant(currentVariant)
         AccentApplicator.apply(accentHex)
     }
 
     override fun reset() {
-        pendingHideRootPath = storedHideRootPath
-        pendingHideRootVcs = storedHideRootVcs
-        pendingHideHScrollbar = storedHideHScrollbar
         pendingEnabled = storedEnabled
         pendingPreset = storedPreset
         pendingCustomAlpha = storedCustomAlpha
-        pendingBracketScope = storedBracketScope
         pendingCgpIntegration = storedCgpIntegration
         pendingErrorHighlight = storedErrorHighlight
 
         suppressListeners = true
-        hideRootPathCheckbox?.isSelected = storedHideRootPath
-        hideRootVcsCheckbox?.isSelected = storedHideRootVcs
-        hideHScrollbarCheckbox?.isSelected = storedHideHScrollbar
         enabledCheckbox?.isSelected = storedEnabled
         cgpCheckbox?.isSelected = storedCgpIntegration
         errorHighlightCheckbox?.isSelected = storedErrorHighlight
         presetSegmented?.selectedItem = IndentPreset.fromName(storedPreset)
         alphaSlider?.value = storedCustomAlpha
         alphaValueLabel?.text = "$storedCustomAlpha"
-        bracketScopeCheckbox?.isSelected = storedBracketScope
         customModeVisible.set(
             IndentPreset.fromName(pendingPreset) == IndentPreset.CUSTOM,
         )

--- a/src/main/kotlin/dev/ayuislands/settings/WorkspacePanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/WorkspacePanel.kt
@@ -80,6 +80,8 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
             state.gitPanelFixedWidth,
         )
 
+        panel.row { comment("Customize tool window width and Project View display options.") }
+
         projectViewGroup =
             panel.collapsibleGroup("Project View") {
                 row {

--- a/src/main/kotlin/dev/ayuislands/settings/WorkspacePanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/WorkspacePanel.kt
@@ -12,8 +12,6 @@ import dev.ayuislands.commitpanel.CommitPanelAutoFitManager
 import dev.ayuislands.gitpanel.GitPanelAutoFitManager
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.projectview.ProjectViewScrollbarManager
-import dev.ayuislands.settings.AyuIslandsState.Companion.DEFAULT_AUTO_FIT_MAX_WIDTH
-import dev.ayuislands.settings.AyuIslandsState.Companion.DEFAULT_FIXED_WIDTH
 import java.awt.Color
 import java.awt.Component
 import java.util.Locale
@@ -40,9 +38,9 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
     private var hideRootVcsCheckbox: JCheckBox? = null
     private var hideHScrollbarCheckbox: JCheckBox? = null
 
-    private val projectWidth = WidthModeState()
-    private val commitWidth = WidthModeState()
-    private val gitWidth = WidthModeState()
+    private val projectWidth = WidthModeUiState()
+    private val commitWidth = WidthModeUiState()
+    private val gitWidth = WidthModeUiState()
 
     private var projectViewGroup: CollapsibleRow? = null
     private var commitPanelGroup: CollapsibleRow? = null
@@ -64,17 +62,17 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
         storedHideHScrollbar = state.hideProjectViewHScrollbar
         pendingHideHScrollbar = storedHideHScrollbar
 
-        projectWidth.load(
+        projectWidth.state.load(
             PanelWidthMode.fromString(state.projectPanelWidthMode),
             state.autoFitMaxWidth,
             state.projectPanelFixedWidth,
         )
-        commitWidth.load(
+        commitWidth.state.load(
             PanelWidthMode.fromString(state.commitPanelWidthMode),
             state.autoFitCommitMaxWidth,
             state.commitPanelFixedWidth,
         )
-        gitWidth.load(
+        gitWidth.state.load(
             PanelWidthMode.fromString(state.gitPanelWidthMode),
             state.gitPanelAutoFitMaxWidth,
             state.gitPanelFixedWidth,
@@ -119,47 +117,40 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
                 }
                 separator()
                 buildWidthModeGroup(this, projectWidth, MIN_PROJECT_AUTOFIT_WIDTH, licensed) {
-                    updateGroupTitle(projectViewGroup, "Project View", projectWidth)
+                    updateGroupTitle(projectViewGroup, "Project View", projectWidth.state)
                 }
             }
         projectViewGroup?.expanded = state.workspaceProjectViewExpanded
         projectViewGroup?.addExpandedListener { state.workspaceProjectViewExpanded = it }
-        updateGroupTitle(projectViewGroup, "Project View", projectWidth)
+        updateGroupTitle(projectViewGroup, "Project View", projectWidth.state)
 
         commitPanelGroup =
             panel.collapsibleGroup("Commit Panel") {
                 buildWidthModeGroup(this, commitWidth, MIN_COMMIT_AUTOFIT_WIDTH, licensed) {
-                    updateGroupTitle(commitPanelGroup, "Commit Panel", commitWidth)
+                    updateGroupTitle(commitPanelGroup, "Commit Panel", commitWidth.state)
                 }
             }
         commitPanelGroup?.expanded = state.workspaceCommitPanelExpanded
         commitPanelGroup?.addExpandedListener { state.workspaceCommitPanelExpanded = it }
-        updateGroupTitle(commitPanelGroup, "Commit Panel", commitWidth)
+        updateGroupTitle(commitPanelGroup, "Commit Panel", commitWidth.state)
 
         gitPanelGroup =
             panel.collapsibleGroup("Git Panel") {
                 buildWidthModeGroup(this, gitWidth, MIN_GIT_AUTOFIT_WIDTH, licensed) {
-                    updateGroupTitle(gitPanelGroup, "Git Panel", gitWidth)
+                    updateGroupTitle(gitPanelGroup, "Git Panel", gitWidth.state)
                 }
             }
         gitPanelGroup?.expanded = state.workspaceGitPanelExpanded
         gitPanelGroup?.addExpandedListener { state.workspaceGitPanelExpanded = it }
-        updateGroupTitle(gitPanelGroup, "Git Panel", gitWidth)
+        updateGroupTitle(gitPanelGroup, "Git Panel", gitWidth.state)
     }
-
-    private fun widthSummary(widthState: WidthModeState): String =
-        when (widthState.pendingMode) {
-            PanelWidthMode.DEFAULT -> "Default"
-            PanelWidthMode.AUTO_FIT -> "Auto-fit \u00B7 max ${widthState.pendingAutoFitMaxWidth}px"
-            PanelWidthMode.FIXED -> "Fixed \u00B7 ${widthState.pendingFixedWidth}px"
-        }
 
     private fun updateGroupTitle(
         group: CollapsibleRow?,
         baseName: String,
-        widthState: WidthModeState,
+        widthState: PanelWidthState,
     ) {
-        val summary = widthSummary(widthState)
+        val summary = PanelWidthState.widthSummary(widthState)
         val mutedHex = mutedColorHex()
         group?.setTitle("<html>$baseName <font color='$mutedHex'>\u00B7 $summary</font></html>")
     }
@@ -179,20 +170,20 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
 
     private fun buildWidthModeGroup(
         panel: Panel,
-        widthState: WidthModeState,
+        uiState: WidthModeUiState,
         minAutoFitWidth: Int,
         licensed: Boolean,
         onModeChanged: () -> Unit = {},
     ) {
-        val autoFitVisible = widthState.autoFitVisible
-        val fixedVisible = widthState.fixedVisible
-        autoFitVisible.set(widthState.pendingMode == PanelWidthMode.AUTO_FIT)
-        fixedVisible.set(widthState.pendingMode == PanelWidthMode.FIXED)
+        val autoFitVisible = uiState.autoFitVisible
+        val fixedVisible = uiState.fixedVisible
+        autoFitVisible.set(uiState.state.pendingMode == PanelWidthMode.AUTO_FIT)
+        fixedVisible.set(uiState.state.pendingMode == PanelWidthMode.FIXED)
 
         val autoFitSpinner =
             JSpinner(
                 SpinnerNumberModel(
-                    widthState.pendingAutoFitMaxWidth,
+                    uiState.state.pendingAutoFitMaxWidth,
                     minAutoFitWidth,
                     MAX_AUTOFIT_WIDTH,
                     AUTOFIT_WIDTH_STEP,
@@ -200,16 +191,16 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
             )
         autoFitSpinner.addChangeListener {
             if (!suppressListeners) {
-                widthState.pendingAutoFitMaxWidth = autoFitSpinner.value as Int
+                uiState.state.pendingAutoFitMaxWidth = autoFitSpinner.value as Int
                 onModeChanged()
             }
         }
-        widthState.autoFitSpinner = autoFitSpinner
+        uiState.autoFitSpinner = autoFitSpinner
 
         val fixedSpinner =
             JSpinner(
                 SpinnerNumberModel(
-                    widthState.pendingFixedWidth,
+                    uiState.state.pendingFixedWidth,
                     MIN_FIXED_WIDTH,
                     MAX_AUTOFIT_WIDTH,
                     AUTOFIT_WIDTH_STEP,
@@ -217,14 +208,14 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
             )
         fixedSpinner.addChangeListener {
             if (!suppressListeners) {
-                widthState.pendingFixedWidth = fixedSpinner.value as Int
+                uiState.state.pendingFixedWidth = fixedSpinner.value as Int
                 onModeChanged()
             }
         }
-        widthState.fixedSpinner = fixedSpinner
+        uiState.fixedSpinner = fixedSpinner
 
         val comboBox = JComboBox(DefaultComboBoxModel(PanelWidthMode.entries.toTypedArray()))
-        comboBox.selectedItem = widthState.pendingMode
+        comboBox.selectedItem = uiState.state.pendingMode
         comboBox.isEnabled = licensed
         comboBox.renderer =
             object : DefaultListCellRenderer() {
@@ -253,13 +244,13 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
                     return label
                 }
             }
-        widthState.modeComboBox = comboBox
+        uiState.modeComboBox = comboBox
 
         comboBox.addActionListener {
             if (!suppressListeners) {
-                widthState.pendingMode = comboBox.selectedItem as PanelWidthMode
-                autoFitVisible.set(widthState.pendingMode == PanelWidthMode.AUTO_FIT)
-                fixedVisible.set(widthState.pendingMode == PanelWidthMode.FIXED)
+                uiState.state.pendingMode = comboBox.selectedItem as PanelWidthMode
+                autoFitVisible.set(uiState.state.pendingMode == PanelWidthMode.AUTO_FIT)
+                fixedVisible.set(uiState.state.pendingMode == PanelWidthMode.FIXED)
                 onModeChanged()
             }
         }
@@ -278,9 +269,9 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
         pendingHideRootPath != storedHideRootPath ||
             pendingHideRootVcs != storedHideRootVcs ||
             pendingHideHScrollbar != storedHideHScrollbar ||
-            projectWidth.isModified() ||
-            commitWidth.isModified() ||
-            gitWidth.isModified()
+            projectWidth.state.isModified() ||
+            commitWidth.state.isModified() ||
+            gitWidth.state.isModified()
 
     override fun apply() {
         if (!isModified()) return
@@ -290,9 +281,9 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
             pendingHideRootPath != storedHideRootPath ||
                 pendingHideRootVcs != storedHideRootVcs ||
                 pendingHideHScrollbar != storedHideHScrollbar
-        val projectWidthChanged = projectWidth.isModified()
-        val commitWidthChanged = commitWidth.isModified()
-        val gitWidthChanged = gitWidth.isModified()
+        val projectWidthChanged = projectWidth.state.isModified()
+        val commitWidthChanged = commitWidth.state.isModified()
+        val gitWidthChanged = gitWidth.state.isModified()
 
         state.hideProjectRootPath = pendingHideRootPath
         state.hideRootVcsAnnotations = pendingHideRootVcs
@@ -301,22 +292,22 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
         storedHideRootVcs = pendingHideRootVcs
         storedHideHScrollbar = pendingHideHScrollbar
 
-        state.projectPanelWidthMode = projectWidth.pendingMode.name
-        state.autoFitMaxWidth = projectWidth.pendingAutoFitMaxWidth
-        state.projectPanelFixedWidth = projectWidth.pendingFixedWidth
-        state.autoFitProjectPanelWidth = projectWidth.pendingMode == PanelWidthMode.AUTO_FIT
-        projectWidth.commitStored()
+        state.projectPanelWidthMode = projectWidth.state.pendingMode.name
+        state.autoFitMaxWidth = projectWidth.state.pendingAutoFitMaxWidth
+        state.projectPanelFixedWidth = projectWidth.state.pendingFixedWidth
+        state.autoFitProjectPanelWidth = projectWidth.state.pendingMode == PanelWidthMode.AUTO_FIT
+        projectWidth.state.commitStored()
 
-        state.commitPanelWidthMode = commitWidth.pendingMode.name
-        state.autoFitCommitMaxWidth = commitWidth.pendingAutoFitMaxWidth
-        state.commitPanelFixedWidth = commitWidth.pendingFixedWidth
-        state.autoFitCommitPanelWidth = commitWidth.pendingMode == PanelWidthMode.AUTO_FIT
-        commitWidth.commitStored()
+        state.commitPanelWidthMode = commitWidth.state.pendingMode.name
+        state.autoFitCommitMaxWidth = commitWidth.state.pendingAutoFitMaxWidth
+        state.commitPanelFixedWidth = commitWidth.state.pendingFixedWidth
+        state.autoFitCommitPanelWidth = commitWidth.state.pendingMode == PanelWidthMode.AUTO_FIT
+        commitWidth.state.commitStored()
 
-        state.gitPanelWidthMode = gitWidth.pendingMode.name
-        state.gitPanelAutoFitMaxWidth = gitWidth.pendingAutoFitMaxWidth
-        state.gitPanelFixedWidth = gitWidth.pendingFixedWidth
-        gitWidth.commitStored()
+        state.gitPanelWidthMode = gitWidth.state.pendingMode.name
+        state.gitPanelAutoFitMaxWidth = gitWidth.state.pendingAutoFitMaxWidth
+        state.gitPanelFixedWidth = gitWidth.state.pendingFixedWidth
+        gitWidth.state.commitStored()
 
         if (displayChanged || projectWidthChanged) {
             for (openProject in ProjectManager.getInstance().openProjects) {
@@ -358,20 +349,15 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
         projectWidth.reset()
         commitWidth.reset()
         gitWidth.reset()
-        updateGroupTitle(projectViewGroup, "Project View", projectWidth)
-        updateGroupTitle(commitPanelGroup, "Commit Panel", commitWidth)
-        updateGroupTitle(gitPanelGroup, "Git Panel", gitWidth)
+        updateGroupTitle(projectViewGroup, "Project View", projectWidth.state)
+        updateGroupTitle(commitPanelGroup, "Commit Panel", commitWidth.state)
+        updateGroupTitle(gitPanelGroup, "Git Panel", gitWidth.state)
         suppressListeners = false
     }
 
-    private class WidthModeState {
-        var pendingMode = PanelWidthMode.DEFAULT
-        var storedMode = PanelWidthMode.DEFAULT
-        var pendingAutoFitMaxWidth = DEFAULT_AUTO_FIT_MAX_WIDTH
-        var storedAutoFitMaxWidth = DEFAULT_AUTO_FIT_MAX_WIDTH
-        var pendingFixedWidth = DEFAULT_FIXED_WIDTH
-        var storedFixedWidth = DEFAULT_FIXED_WIDTH
-
+    private class WidthModeUiState(
+        val state: PanelWidthState = PanelWidthState(),
+    ) {
         val autoFitVisible = AtomicBooleanProperty(false)
         val fixedVisible = AtomicBooleanProperty(false)
 
@@ -379,39 +365,13 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
         var autoFitSpinner: JSpinner? = null
         var fixedSpinner: JSpinner? = null
 
-        fun load(
-            mode: PanelWidthMode,
-            autoFitMaxWidth: Int,
-            fixedWidth: Int,
-        ) {
-            storedMode = mode
-            pendingMode = mode
-            storedAutoFitMaxWidth = autoFitMaxWidth
-            pendingAutoFitMaxWidth = autoFitMaxWidth
-            storedFixedWidth = fixedWidth
-            pendingFixedWidth = fixedWidth
-        }
-
-        fun isModified(): Boolean =
-            pendingMode != storedMode ||
-                pendingAutoFitMaxWidth != storedAutoFitMaxWidth ||
-                pendingFixedWidth != storedFixedWidth
-
-        fun commitStored() {
-            storedMode = pendingMode
-            storedAutoFitMaxWidth = pendingAutoFitMaxWidth
-            storedFixedWidth = pendingFixedWidth
-        }
-
         fun reset() {
-            pendingMode = storedMode
-            pendingAutoFitMaxWidth = storedAutoFitMaxWidth
-            pendingFixedWidth = storedFixedWidth
-            modeComboBox?.selectedItem = storedMode
-            autoFitSpinner?.value = storedAutoFitMaxWidth
-            fixedSpinner?.value = storedFixedWidth
-            autoFitVisible.set(storedMode == PanelWidthMode.AUTO_FIT)
-            fixedVisible.set(storedMode == PanelWidthMode.FIXED)
+            state.reset()
+            modeComboBox?.selectedItem = state.storedMode
+            autoFitSpinner?.value = state.storedAutoFitMaxWidth
+            fixedSpinner?.value = state.storedFixedWidth
+            autoFitVisible.set(state.storedMode == PanelWidthMode.AUTO_FIT)
+            fixedVisible.set(state.storedMode == PanelWidthMode.FIXED)
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/settings/WorkspacePanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/WorkspacePanel.kt
@@ -1,0 +1,427 @@
+@file:Suppress("DialogTitleCapitalization")
+
+package dev.ayuislands.settings
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.observable.properties.AtomicBooleanProperty
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.ui.dsl.builder.CollapsibleRow
+import com.intellij.ui.dsl.builder.Panel
+import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.commitpanel.CommitPanelAutoFitManager
+import dev.ayuislands.gitpanel.GitPanelAutoFitManager
+import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.projectview.ProjectViewScrollbarManager
+import dev.ayuislands.settings.AyuIslandsState.Companion.DEFAULT_AUTO_FIT_MAX_WIDTH
+import dev.ayuislands.settings.AyuIslandsState.Companion.DEFAULT_FIXED_WIDTH
+import java.awt.Color
+import java.awt.Component
+import java.util.Locale
+import javax.swing.DefaultComboBoxModel
+import javax.swing.DefaultListCellRenderer
+import javax.swing.JCheckBox
+import javax.swing.JComboBox
+import javax.swing.JLabel
+import javax.swing.JList
+import javax.swing.JSpinner
+import javax.swing.SpinnerNumberModel
+import javax.swing.UIManager
+
+/** Workspace tab: tool window layout tweaks (Project View, Commit Panel, Git Panel). */
+class WorkspacePanel : AyuIslandsSettingsPanel {
+    private var pendingHideRootPath = false
+    private var storedHideRootPath = false
+    private var pendingHideRootVcs = false
+    private var storedHideRootVcs = false
+    private var pendingHideHScrollbar = false
+    private var storedHideHScrollbar = false
+
+    private var hideRootPathCheckbox: JCheckBox? = null
+    private var hideRootVcsCheckbox: JCheckBox? = null
+    private var hideHScrollbarCheckbox: JCheckBox? = null
+
+    private val projectWidth = WidthModeState()
+    private val commitWidth = WidthModeState()
+    private val gitWidth = WidthModeState()
+
+    private var projectViewGroup: CollapsibleRow? = null
+    private var commitPanelGroup: CollapsibleRow? = null
+    private var gitPanelGroup: CollapsibleRow? = null
+
+    private var suppressListeners = false
+
+    override fun buildPanel(
+        panel: Panel,
+        variant: AyuVariant,
+    ) {
+        val state = AyuIslandsSettings.getInstance().state
+        val licensed = LicenseChecker.isLicensedOrGrace()
+
+        storedHideRootPath = state.hideProjectRootPath
+        pendingHideRootPath = storedHideRootPath
+        storedHideRootVcs = state.hideRootVcsAnnotations
+        pendingHideRootVcs = storedHideRootVcs
+        storedHideHScrollbar = state.hideProjectViewHScrollbar
+        pendingHideHScrollbar = storedHideHScrollbar
+
+        projectWidth.load(
+            PanelWidthMode.fromString(state.projectPanelWidthMode),
+            state.autoFitMaxWidth,
+            state.projectPanelFixedWidth,
+        )
+        commitWidth.load(
+            PanelWidthMode.fromString(state.commitPanelWidthMode),
+            state.autoFitCommitMaxWidth,
+            state.commitPanelFixedWidth,
+        )
+        gitWidth.load(
+            PanelWidthMode.fromString(state.gitPanelWidthMode),
+            state.gitPanelAutoFitMaxWidth,
+            state.gitPanelFixedWidth,
+        )
+
+        projectViewGroup =
+            panel.collapsibleGroup("Project View") {
+                row {
+                    val cb =
+                        checkBox("Hide filesystem path")
+                            .comment("Remove the directory path shown next to the project name")
+                    cb.component.isSelected = pendingHideRootPath
+                    cb.component.isEnabled = licensed
+                    cb.component.addActionListener {
+                        pendingHideRootPath = cb.component.isSelected
+                    }
+                    hideRootPathCheckbox = cb.component
+                }
+                row {
+                    val cb =
+                        checkBox("Hide VCS annotations")
+                            .comment("Remove branch name and changed file count from the project root")
+                    cb.component.isSelected = pendingHideRootVcs
+                    cb.component.isEnabled = licensed
+                    cb.component.addActionListener {
+                        pendingHideRootVcs = cb.component.isSelected
+                    }
+                    hideRootVcsCheckbox = cb.component
+                }
+                row {
+                    val cb =
+                        checkBox("Hide horizontal scrollbar")
+                            .comment("Remove the bottom scrollbar from the Project tool window")
+                    cb.component.isSelected = pendingHideHScrollbar
+                    cb.component.isEnabled = licensed
+                    cb.component.addActionListener {
+                        pendingHideHScrollbar = cb.component.isSelected
+                    }
+                    hideHScrollbarCheckbox = cb.component
+                }
+                separator()
+                buildWidthModeGroup(this, projectWidth, MIN_PROJECT_AUTOFIT_WIDTH, licensed) {
+                    updateGroupTitle(projectViewGroup, "Project View", projectWidth)
+                }
+            }
+        projectViewGroup?.expanded = state.workspaceProjectViewExpanded
+        projectViewGroup?.addExpandedListener { state.workspaceProjectViewExpanded = it }
+        updateGroupTitle(projectViewGroup, "Project View", projectWidth)
+
+        commitPanelGroup =
+            panel.collapsibleGroup("Commit Panel") {
+                buildWidthModeGroup(this, commitWidth, MIN_COMMIT_AUTOFIT_WIDTH, licensed) {
+                    updateGroupTitle(commitPanelGroup, "Commit Panel", commitWidth)
+                }
+            }
+        commitPanelGroup?.expanded = state.workspaceCommitPanelExpanded
+        commitPanelGroup?.addExpandedListener { state.workspaceCommitPanelExpanded = it }
+        updateGroupTitle(commitPanelGroup, "Commit Panel", commitWidth)
+
+        gitPanelGroup =
+            panel.collapsibleGroup("Git Panel") {
+                buildWidthModeGroup(this, gitWidth, MIN_GIT_AUTOFIT_WIDTH, licensed) {
+                    updateGroupTitle(gitPanelGroup, "Git Panel", gitWidth)
+                }
+            }
+        gitPanelGroup?.expanded = state.workspaceGitPanelExpanded
+        gitPanelGroup?.addExpandedListener { state.workspaceGitPanelExpanded = it }
+        updateGroupTitle(gitPanelGroup, "Git Panel", gitWidth)
+    }
+
+    private fun widthSummary(widthState: WidthModeState): String =
+        when (widthState.pendingMode) {
+            PanelWidthMode.DEFAULT -> "Default"
+            PanelWidthMode.AUTO_FIT -> "Auto-fit \u00B7 max ${widthState.pendingAutoFitMaxWidth}px"
+            PanelWidthMode.FIXED -> "Fixed \u00B7 ${widthState.pendingFixedWidth}px"
+        }
+
+    private fun updateGroupTitle(
+        group: CollapsibleRow?,
+        baseName: String,
+        widthState: WidthModeState,
+    ) {
+        val summary = widthSummary(widthState)
+        val mutedHex = mutedColorHex()
+        group?.setTitle("<html>$baseName <font color='$mutedHex'>\u00B7 $summary</font></html>")
+    }
+
+    private fun mutedColorHex(): String {
+        val color =
+            UIManager.getColor("Label.disabledForeground")
+                ?: Color(FALLBACK_MUTED_RED, FALLBACK_MUTED_GREEN, FALLBACK_MUTED_BLUE)
+        return String.format(
+            Locale.ROOT,
+            "#%02x%02x%02x",
+            color.red,
+            color.green,
+            color.blue,
+        )
+    }
+
+    private fun buildWidthModeGroup(
+        panel: Panel,
+        widthState: WidthModeState,
+        minAutoFitWidth: Int,
+        licensed: Boolean,
+        onModeChanged: () -> Unit = {},
+    ) {
+        val autoFitVisible = widthState.autoFitVisible
+        val fixedVisible = widthState.fixedVisible
+        autoFitVisible.set(widthState.pendingMode == PanelWidthMode.AUTO_FIT)
+        fixedVisible.set(widthState.pendingMode == PanelWidthMode.FIXED)
+
+        val autoFitSpinner =
+            JSpinner(
+                SpinnerNumberModel(
+                    widthState.pendingAutoFitMaxWidth,
+                    minAutoFitWidth,
+                    MAX_AUTOFIT_WIDTH,
+                    AUTOFIT_WIDTH_STEP,
+                ),
+            )
+        autoFitSpinner.addChangeListener {
+            if (!suppressListeners) {
+                widthState.pendingAutoFitMaxWidth = autoFitSpinner.value as Int
+                onModeChanged()
+            }
+        }
+        widthState.autoFitSpinner = autoFitSpinner
+
+        val fixedSpinner =
+            JSpinner(
+                SpinnerNumberModel(
+                    widthState.pendingFixedWidth,
+                    MIN_FIXED_WIDTH,
+                    MAX_AUTOFIT_WIDTH,
+                    AUTOFIT_WIDTH_STEP,
+                ),
+            )
+        fixedSpinner.addChangeListener {
+            if (!suppressListeners) {
+                widthState.pendingFixedWidth = fixedSpinner.value as Int
+                onModeChanged()
+            }
+        }
+        widthState.fixedSpinner = fixedSpinner
+
+        val comboBox = JComboBox(DefaultComboBoxModel(PanelWidthMode.entries.toTypedArray()))
+        comboBox.selectedItem = widthState.pendingMode
+        comboBox.isEnabled = licensed
+        comboBox.renderer =
+            object : DefaultListCellRenderer() {
+                override fun getListCellRendererComponent(
+                    list: JList<*>?,
+                    value: Any?,
+                    index: Int,
+                    isSelected: Boolean,
+                    cellHasFocus: Boolean,
+                ): Component {
+                    val label =
+                        super.getListCellRendererComponent(
+                            list,
+                            value,
+                            index,
+                            isSelected,
+                            cellHasFocus,
+                        ) as JLabel
+                    label.text =
+                        when (value as? PanelWidthMode) {
+                            PanelWidthMode.DEFAULT -> "Default"
+                            PanelWidthMode.AUTO_FIT -> "Auto-fit"
+                            PanelWidthMode.FIXED -> "Fixed"
+                            null -> ""
+                        }
+                    return label
+                }
+            }
+        widthState.modeComboBox = comboBox
+
+        comboBox.addActionListener {
+            if (!suppressListeners) {
+                widthState.pendingMode = comboBox.selectedItem as PanelWidthMode
+                autoFitVisible.set(widthState.pendingMode == PanelWidthMode.AUTO_FIT)
+                fixedVisible.set(widthState.pendingMode == PanelWidthMode.FIXED)
+                onModeChanged()
+            }
+        }
+
+        panel.row {
+            cell(comboBox)
+            label("max").visibleIf(autoFitVisible)
+            cell(autoFitSpinner).visibleIf(autoFitVisible)
+            label("px").visibleIf(autoFitVisible)
+            cell(fixedSpinner).visibleIf(fixedVisible)
+            label("px").visibleIf(fixedVisible)
+        }
+    }
+
+    override fun isModified(): Boolean =
+        pendingHideRootPath != storedHideRootPath ||
+            pendingHideRootVcs != storedHideRootVcs ||
+            pendingHideHScrollbar != storedHideHScrollbar ||
+            projectWidth.isModified() ||
+            commitWidth.isModified() ||
+            gitWidth.isModified()
+
+    override fun apply() {
+        if (!isModified()) return
+        val state = AyuIslandsSettings.getInstance().state
+
+        val displayChanged =
+            pendingHideRootPath != storedHideRootPath ||
+                pendingHideRootVcs != storedHideRootVcs ||
+                pendingHideHScrollbar != storedHideHScrollbar
+        val projectWidthChanged = projectWidth.isModified()
+        val commitWidthChanged = commitWidth.isModified()
+        val gitWidthChanged = gitWidth.isModified()
+
+        state.hideProjectRootPath = pendingHideRootPath
+        state.hideRootVcsAnnotations = pendingHideRootVcs
+        state.hideProjectViewHScrollbar = pendingHideHScrollbar
+        storedHideRootPath = pendingHideRootPath
+        storedHideRootVcs = pendingHideRootVcs
+        storedHideHScrollbar = pendingHideHScrollbar
+
+        state.projectPanelWidthMode = projectWidth.pendingMode.name
+        state.autoFitMaxWidth = projectWidth.pendingAutoFitMaxWidth
+        state.projectPanelFixedWidth = projectWidth.pendingFixedWidth
+        state.autoFitProjectPanelWidth = projectWidth.pendingMode == PanelWidthMode.AUTO_FIT
+        projectWidth.commitStored()
+
+        state.commitPanelWidthMode = commitWidth.pendingMode.name
+        state.autoFitCommitMaxWidth = commitWidth.pendingAutoFitMaxWidth
+        state.commitPanelFixedWidth = commitWidth.pendingFixedWidth
+        state.autoFitCommitPanelWidth = commitWidth.pendingMode == PanelWidthMode.AUTO_FIT
+        commitWidth.commitStored()
+
+        state.gitPanelWidthMode = gitWidth.pendingMode.name
+        state.gitPanelAutoFitMaxWidth = gitWidth.pendingAutoFitMaxWidth
+        state.gitPanelFixedWidth = gitWidth.pendingFixedWidth
+        gitWidth.commitStored()
+
+        if (displayChanged || projectWidthChanged) {
+            for (openProject in ProjectManager.getInstance().openProjects) {
+                ApplicationManager.getApplication().invokeLater(
+                    { ProjectViewScrollbarManager.getInstance(openProject).apply() },
+                    openProject.disposed,
+                )
+            }
+        }
+
+        if (commitWidthChanged) {
+            for (openProject in ProjectManager.getInstance().openProjects) {
+                ApplicationManager.getApplication().invokeLater(
+                    { CommitPanelAutoFitManager.getInstance(openProject).apply() },
+                    openProject.disposed,
+                )
+            }
+        }
+
+        if (gitWidthChanged) {
+            for (openProject in ProjectManager.getInstance().openProjects) {
+                ApplicationManager.getApplication().invokeLater(
+                    { GitPanelAutoFitManager.getInstance(openProject).apply() },
+                    openProject.disposed,
+                )
+            }
+        }
+    }
+
+    override fun reset() {
+        pendingHideRootPath = storedHideRootPath
+        pendingHideRootVcs = storedHideRootVcs
+        pendingHideHScrollbar = storedHideHScrollbar
+
+        suppressListeners = true
+        hideRootPathCheckbox?.isSelected = storedHideRootPath
+        hideRootVcsCheckbox?.isSelected = storedHideRootVcs
+        hideHScrollbarCheckbox?.isSelected = storedHideHScrollbar
+        projectWidth.reset()
+        commitWidth.reset()
+        gitWidth.reset()
+        updateGroupTitle(projectViewGroup, "Project View", projectWidth)
+        updateGroupTitle(commitPanelGroup, "Commit Panel", commitWidth)
+        updateGroupTitle(gitPanelGroup, "Git Panel", gitWidth)
+        suppressListeners = false
+    }
+
+    private class WidthModeState {
+        var pendingMode = PanelWidthMode.DEFAULT
+        var storedMode = PanelWidthMode.DEFAULT
+        var pendingAutoFitMaxWidth = DEFAULT_AUTO_FIT_MAX_WIDTH
+        var storedAutoFitMaxWidth = DEFAULT_AUTO_FIT_MAX_WIDTH
+        var pendingFixedWidth = DEFAULT_FIXED_WIDTH
+        var storedFixedWidth = DEFAULT_FIXED_WIDTH
+
+        val autoFitVisible = AtomicBooleanProperty(false)
+        val fixedVisible = AtomicBooleanProperty(false)
+
+        var modeComboBox: JComboBox<PanelWidthMode>? = null
+        var autoFitSpinner: JSpinner? = null
+        var fixedSpinner: JSpinner? = null
+
+        fun load(
+            mode: PanelWidthMode,
+            autoFitMaxWidth: Int,
+            fixedWidth: Int,
+        ) {
+            storedMode = mode
+            pendingMode = mode
+            storedAutoFitMaxWidth = autoFitMaxWidth
+            pendingAutoFitMaxWidth = autoFitMaxWidth
+            storedFixedWidth = fixedWidth
+            pendingFixedWidth = fixedWidth
+        }
+
+        fun isModified(): Boolean =
+            pendingMode != storedMode ||
+                pendingAutoFitMaxWidth != storedAutoFitMaxWidth ||
+                pendingFixedWidth != storedFixedWidth
+
+        fun commitStored() {
+            storedMode = pendingMode
+            storedAutoFitMaxWidth = pendingAutoFitMaxWidth
+            storedFixedWidth = pendingFixedWidth
+        }
+
+        fun reset() {
+            pendingMode = storedMode
+            pendingAutoFitMaxWidth = storedAutoFitMaxWidth
+            pendingFixedWidth = storedFixedWidth
+            modeComboBox?.selectedItem = storedMode
+            autoFitSpinner?.value = storedAutoFitMaxWidth
+            fixedSpinner?.value = storedFixedWidth
+            autoFitVisible.set(storedMode == PanelWidthMode.AUTO_FIT)
+            fixedVisible.set(storedMode == PanelWidthMode.FIXED)
+        }
+    }
+
+    companion object {
+        private const val MIN_PROJECT_AUTOFIT_WIDTH = 200
+        private const val MIN_COMMIT_AUTOFIT_WIDTH = 269
+        private const val MIN_GIT_AUTOFIT_WIDTH = 200
+        private const val MIN_FIXED_WIDTH = 100
+        private const val MAX_AUTOFIT_WIDTH = 800
+        private const val AUTOFIT_WIDTH_STEP = 50
+        private const val FALLBACK_MUTED_RED = 0x6C
+        private const val FALLBACK_MUTED_GREEN = 0x73
+        private const val FALLBACK_MUTED_BLUE = 0x80
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/settings/WorkspacePanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/WorkspacePanel.kt
@@ -12,6 +12,7 @@ import dev.ayuislands.commitpanel.CommitPanelAutoFitManager
 import dev.ayuislands.gitpanel.GitPanelAutoFitManager
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.projectview.ProjectViewScrollbarManager
+import dev.ayuislands.toolwindow.AutoFitCalculator
 import java.awt.Color
 import java.awt.Component
 import java.util.Locale
@@ -116,7 +117,7 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
                     hideHScrollbarCheckbox = cb.component
                 }
                 separator()
-                buildWidthModeGroup(this, projectWidth, MIN_PROJECT_AUTOFIT_WIDTH, licensed) {
+                buildWidthModeGroup(this, projectWidth, AutoFitCalculator.MIN_PROJECT_AUTOFIT_WIDTH, licensed) {
                     updateGroupTitle(projectViewGroup, "Project View", projectWidth.state)
                 }
             }
@@ -126,7 +127,7 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
 
         commitPanelGroup =
             panel.collapsibleGroup("Commit Panel") {
-                buildWidthModeGroup(this, commitWidth, MIN_COMMIT_AUTOFIT_WIDTH, licensed) {
+                buildWidthModeGroup(this, commitWidth, AutoFitCalculator.MIN_COMMIT_AUTOFIT_WIDTH, licensed) {
                     updateGroupTitle(commitPanelGroup, "Commit Panel", commitWidth.state)
                 }
             }
@@ -136,7 +137,7 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
 
         gitPanelGroup =
             panel.collapsibleGroup("Git Panel") {
-                buildWidthModeGroup(this, gitWidth, MIN_GIT_AUTOFIT_WIDTH, licensed) {
+                buildWidthModeGroup(this, gitWidth, AutoFitCalculator.MIN_GIT_AUTOFIT_WIDTH, licensed) {
                     updateGroupTitle(gitPanelGroup, "Git Panel", gitWidth.state)
                 }
             }
@@ -201,7 +202,7 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
             JSpinner(
                 SpinnerNumberModel(
                     uiState.state.pendingFixedWidth,
-                    MIN_FIXED_WIDTH,
+                    AutoFitCalculator.MIN_FIXED_WIDTH,
                     MAX_AUTOFIT_WIDTH,
                     AUTOFIT_WIDTH_STEP,
                 ),
@@ -376,10 +377,6 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
     }
 
     companion object {
-        private const val MIN_PROJECT_AUTOFIT_WIDTH = 200
-        private const val MIN_COMMIT_AUTOFIT_WIDTH = 269
-        private const val MIN_GIT_AUTOFIT_WIDTH = 200
-        private const val MIN_FIXED_WIDTH = 100
         private const val MAX_AUTOFIT_WIDTH = 800
         private const val AUTOFIT_WIDTH_STEP = 50
         private const val FALLBACK_MUTED_RED = 0x6C

--- a/src/main/kotlin/dev/ayuislands/toolwindow/AutoFitCalculator.kt
+++ b/src/main/kotlin/dev/ayuislands/toolwindow/AutoFitCalculator.kt
@@ -1,11 +1,18 @@
 package dev.ayuislands.toolwindow
 
+import java.awt.Component
+import java.awt.Container
 import kotlin.math.abs
 
 /** Pure calculation utilities for tool window auto-fit, extracted for testability. */
 object AutoFitCalculator {
     const val AUTOFIT_PADDING = 20
     const val JITTER_THRESHOLD = 8
+
+    const val MIN_PROJECT_AUTOFIT_WIDTH = 253
+    const val MIN_COMMIT_AUTOFIT_WIDTH = 269
+    const val MIN_GIT_AUTOFIT_WIDTH = 200
+    const val MIN_FIXED_WIDTH = 100
 
     fun calculateDesiredWidth(
         maxRowWidth: Int,
@@ -20,4 +27,18 @@ object AutoFitCalculator {
         currentWidth: Int,
         desiredWidth: Int,
     ): Boolean = abs(desiredWidth - currentWidth) <= JITTER_THRESHOLD
+
+    fun findFirstOfType(
+        component: Component,
+        type: Class<*>,
+    ): Component? {
+        if (type.isInstance(component)) return component
+        if (component is Container) {
+            for (child in component.components) {
+                val found = findFirstOfType(child, type)
+                if (found != null) return found
+            }
+        }
+        return null
+    }
 }

--- a/src/main/kotlin/dev/ayuislands/toolwindow/AutoFitCalculator.kt
+++ b/src/main/kotlin/dev/ayuislands/toolwindow/AutoFitCalculator.kt
@@ -1,0 +1,23 @@
+package dev.ayuislands.toolwindow
+
+import kotlin.math.abs
+
+/** Pure calculation utilities for tool window auto-fit, extracted for testability. */
+object AutoFitCalculator {
+    const val AUTOFIT_PADDING = 20
+    const val JITTER_THRESHOLD = 8
+
+    fun calculateDesiredWidth(
+        maxRowWidth: Int,
+        maxWidth: Int,
+        minWidth: Int,
+    ): Int =
+        (maxRowWidth + AUTOFIT_PADDING)
+            .coerceAtMost(maxWidth)
+            .coerceAtLeast(minWidth)
+
+    fun isJitterOnly(
+        currentWidth: Int,
+        desiredWidth: Int,
+    ): Boolean = abs(desiredWidth - currentWidth) <= JITTER_THRESHOLD
+}

--- a/src/main/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitter.kt
+++ b/src/main/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitter.kt
@@ -1,0 +1,153 @@
+package dev.ayuislands.toolwindow
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ToolWindowManager
+import com.intellij.openapi.wm.ToolWindowType
+import com.intellij.openapi.wm.ex.ToolWindowEx
+import java.awt.Component
+import java.awt.Container
+import javax.swing.JTree
+import javax.swing.SwingUtilities
+import javax.swing.Timer
+import javax.swing.event.TreeExpansionEvent
+import javax.swing.event.TreeExpansionListener
+import kotlin.math.abs
+
+/**
+ * Reusable auto-fit logic for any tool window containing a JTree.
+ * Measures visible row widths and stretches the tool window to fit content,
+ * clamped between [minWidth] and the caller-supplied max width.
+ */
+class ToolWindowAutoFitter(
+    private val project: Project,
+    private val toolWindowId: String,
+    private val minWidth: Int,
+) {
+    private var expansionListener: TreeExpansionListener? = null
+    private var expansionTree: JTree? = null
+    private val debounceTimer =
+        Timer(DEBOUNCE_DELAY_MS) { applyAutoFitWidth(maxWidthProvider()) }
+            .apply { isRepeats = false }
+
+    /** Lambda to get current max width from settings (called at fit time, not init time). */
+    var maxWidthProvider: () -> Int = { DEFAULT_MAX_WIDTH }
+
+    fun applyAutoFitWidth(maxWidth: Int) {
+        val tree = findTree() ?: return
+        val toolWindow =
+            ToolWindowManager
+                .getInstance(project)
+                .getToolWindow(toolWindowId) as? ToolWindowEx
+                ?: return
+
+        var maxRowWidth = 0
+        for (row in 0 until tree.rowCount) {
+            val bounds = tree.getRowBounds(row) ?: continue
+            val rowRight = bounds.x + bounds.width
+            if (rowRight > maxRowWidth) {
+                maxRowWidth = rowRight
+            }
+        }
+
+        val desiredWidth =
+            (maxRowWidth + AUTOFIT_PADDING)
+                .coerceAtMost(maxWidth)
+                .coerceAtLeast(minWidth)
+        applyWidth(toolWindow, desiredWidth)
+    }
+
+    fun applyFixedWidth(targetWidth: Int) {
+        val toolWindow =
+            ToolWindowManager
+                .getInstance(project)
+                .getToolWindow(toolWindowId) as? ToolWindowEx
+                ?: return
+        applyWidth(toolWindow, targetWidth)
+    }
+
+    private fun applyWidth(
+        toolWindow: ToolWindowEx,
+        desiredWidth: Int,
+    ) {
+        val currentWidth = toolWindow.component.width
+        val delta = desiredWidth - currentWidth
+        if (abs(delta) <= JITTER_THRESHOLD) return
+
+        when (toolWindow.type) {
+            ToolWindowType.FLOATING, ToolWindowType.WINDOWED -> {
+                val window = SwingUtilities.getWindowAncestor(toolWindow.component) ?: return
+                window.setSize(desiredWidth, window.height)
+            }
+            else -> toolWindow.stretchWidth(delta)
+        }
+    }
+
+    fun installExpansionListener() {
+        val tree = findTree() ?: return
+        if (expansionTree === tree && expansionListener != null) return
+
+        removeExpansionListener()
+        expansionTree = tree
+        expansionListener =
+            object : TreeExpansionListener {
+                override fun treeExpanded(event: TreeExpansionEvent) {
+                    scheduleAutoFit()
+                }
+
+                override fun treeCollapsed(event: TreeExpansionEvent) {
+                    scheduleAutoFit()
+                }
+            }
+        tree.addTreeExpansionListener(expansionListener)
+    }
+
+    fun removeExpansionListener() {
+        val tree = expansionTree ?: return
+        val listener = expansionListener ?: return
+        tree.removeTreeExpansionListener(listener)
+        expansionTree = null
+        expansionListener = null
+        debounceTimer.stop()
+    }
+
+    fun scheduleAutoFit() {
+        debounceTimer.restart()
+    }
+
+    fun findTree(): JTree? {
+        val toolWindow =
+            ToolWindowManager
+                .getInstance(project)
+                .getToolWindow(toolWindowId)
+                ?: return null
+        val content =
+            toolWindow
+                .contentManager
+                .contents
+                .firstOrNull()
+                ?.component
+                ?: return null
+        return findFirstOfType(content, JTree::class.java) as? JTree
+    }
+
+    companion object {
+        private const val DEBOUNCE_DELAY_MS = 150
+        private const val AUTOFIT_PADDING = 20
+        private const val JITTER_THRESHOLD = 8
+        private const val DEFAULT_MAX_WIDTH = 400
+    }
+}
+
+private fun findFirstOfType(
+    component: Component,
+    type: Class<*>,
+): Component? {
+    if (type.isInstance(component)) return component
+    if (component is Container) {
+        for (child in component.components) {
+            val found = findFirstOfType(child, type)
+            if (found != null) return found
+        }
+    }
+    return null
+}

--- a/src/main/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitter.kt
+++ b/src/main/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitter.kt
@@ -11,7 +11,6 @@ import javax.swing.SwingUtilities
 import javax.swing.Timer
 import javax.swing.event.TreeExpansionEvent
 import javax.swing.event.TreeExpansionListener
-import kotlin.math.abs
 
 /**
  * Reusable auto-fit logic for any tool window containing a JTree.
@@ -49,10 +48,7 @@ class ToolWindowAutoFitter(
             }
         }
 
-        val desiredWidth =
-            (maxRowWidth + AUTOFIT_PADDING)
-                .coerceAtMost(maxWidth)
-                .coerceAtLeast(minWidth)
+        val desiredWidth = AutoFitCalculator.calculateDesiredWidth(maxRowWidth, maxWidth, minWidth)
         applyWidth(toolWindow, desiredWidth)
     }
 
@@ -70,8 +66,8 @@ class ToolWindowAutoFitter(
         desiredWidth: Int,
     ) {
         val currentWidth = toolWindow.component.width
+        if (AutoFitCalculator.isJitterOnly(currentWidth, desiredWidth)) return
         val delta = desiredWidth - currentWidth
-        if (abs(delta) <= JITTER_THRESHOLD) return
 
         when (toolWindow.type) {
             ToolWindowType.FLOATING, ToolWindowType.WINDOWED -> {
@@ -132,8 +128,6 @@ class ToolWindowAutoFitter(
 
     companion object {
         private const val DEBOUNCE_DELAY_MS = 150
-        private const val AUTOFIT_PADDING = 20
-        private const val JITTER_THRESHOLD = 8
         private const val DEFAULT_MAX_WIDTH = 400
     }
 }

--- a/src/main/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitter.kt
+++ b/src/main/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitter.kt
@@ -4,8 +4,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ToolWindowType
 import com.intellij.openapi.wm.ex.ToolWindowEx
-import java.awt.Component
-import java.awt.Container
+import dev.ayuislands.settings.PanelWidthMode
 import javax.swing.JTree
 import javax.swing.SwingUtilities
 import javax.swing.Timer
@@ -28,7 +27,7 @@ class ToolWindowAutoFitter(
         Timer(DEBOUNCE_DELAY_MS) { applyAutoFitWidth(maxWidthProvider()) }
             .apply { isRepeats = false }
 
-    /** Lambda to get current max width from settings (called at fit time, not init time). */
+    /** Lambda to get the current max width from settings (called at fit time, not init time). */
     var maxWidthProvider: () -> Int = { DEFAULT_MAX_WIDTH }
 
     fun applyAutoFitWidth(maxWidth: Int) {
@@ -78,6 +77,24 @@ class ToolWindowAutoFitter(
         }
     }
 
+    fun applyWidthMode(
+        mode: PanelWidthMode,
+        autoFitMaxWidth: Int,
+        fixedWidth: Int,
+    ) {
+        when (mode) {
+            PanelWidthMode.DEFAULT -> removeExpansionListener()
+            PanelWidthMode.AUTO_FIT -> {
+                installExpansionListener()
+                applyAutoFitWidth(autoFitMaxWidth)
+            }
+            PanelWidthMode.FIXED -> {
+                removeExpansionListener()
+                applyFixedWidth(fixedWidth)
+            }
+        }
+    }
+
     fun installExpansionListener() {
         val tree = findTree() ?: return
         if (expansionTree === tree && expansionListener != null) return
@@ -123,25 +140,11 @@ class ToolWindowAutoFitter(
                 .firstOrNull()
                 ?.component
                 ?: return null
-        return findFirstOfType(content, JTree::class.java) as? JTree
+        return AutoFitCalculator.findFirstOfType(content, JTree::class.java) as? JTree
     }
 
     companion object {
         private const val DEBOUNCE_DELAY_MS = 150
         private const val DEFAULT_MAX_WIDTH = 400
     }
-}
-
-private fun findFirstOfType(
-    component: Component,
-    type: Class<*>,
-): Component? {
-    if (type.isInstance(component)) return component
-    if (component is Container) {
-        for (child in component.components) {
-            val found = findFirstOfType(child, type)
-            if (found != null) return found
-        }
-    }
-    return null
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -20,7 +20,7 @@
       <li><b>4 curated font presets</b> — Victor Mono, Maple Mono, Monaspace Neon,
           Monaspace Xenon with one-click apply, live preview, and brew install</li>
       <li><b>6 theme variants</b> — Mirage, Dark, Light in Classic UI and Islands UI</li>
-      <li><b>500+ UI properties</b> hand-tuned per variant</li>
+      <li><b>Hundreds of UI properties</b> hand-tuned per variant</li>
       <li><b>40+ language syntaxes</b> individually crafted</li>
       <li>Built on <a href="https://github.com/ayu-theme/ayu-colors">ayu-colors</a>
           (MIT) — endorsed by the original author</li>
@@ -34,16 +34,41 @@
       <li>VCS/diff integration with 16-color terminal palette</li>
     </ul>
 
-    <h3>Premium — optional extras for deeper customization</h3>
-    <ul>
-      <li><b>Neon glow effects</b> — 3 styles, 4 animations, 8+ tool window targets</li>
-      <li><b>Per-element accent controls</b> — scrollbar, caret, links, tabs, and more</li>
-      <li><b>Indent Rainbow integration</b> — accent-colored guides with intensity presets</li>
-      <li><b>Plugin conflict detection</b> — auto-override for Atom Material Icons, CodeGlance Pro</li>
-    </ul>
+    <h3>Premium — make the IDE feel yours</h3>
+
+    <p><b>Glow</b> — a soft light beneath active tabs and editor panels,
+    like a backlit desk in a dark room. Pick from Soft, Sharp Neon, or Gradient styles.
+    Add animation — Pulse, Breathe, or Reactive — or keep it still.
+    Control intensity, width, and exactly which panels glow.</p>
+
+    <p><b>Accent control</b> — your accent color, your rules.
+    Decide exactly where it appears: scrollbars, links, the caret line,
+    search highlights, progress bars, bracket matches, inlay hints, tag matches.
+    Eight switches, each independent. Want accent on scrollbars but not links? Done.</p>
+
+    <p><b>Tab styling</b> — in Islands UI, choose how active tabs stand out:
+    a subtle underline, a full accent bar, or nothing at all.
+    In Classic UI, set the underline thickness from hairline to bold.</p>
+
+    <p><b>Bracket scope</b> — when your cursor lands on a bracket,
+    a colored stripe appears in the gutter showing the full scope at a glance.</p>
+
+    <p><b>Project View</b> — declutter the project panel: hide the filesystem path,
+    VCS annotations, horizontal scrollbar, or let auto-fit resize the panel
+    to match your longest filename. Small tweaks, big difference.</p>
+
+    <p><b>Plugin sync</b> — your accent color follows you into CodeGlance Pro
+    (minimap viewport) and Indent Rainbow (indent guides with 3 Ayu presets).
+    One palette, everywhere. More integrations in active development.</p>
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>2.3.0</h3>
+    <ul>
+      <li>[Paid] Auto-fit Project panel width — panel automatically resizes to fit the longest visible filename</li>
+      <li>[Paid] Project View tweaks now require a license (hide path, VCS annotations, scrollbar)</li>
+      <li>[Free] Improved Marketplace description with clearer premium feature explanations</li>
+    </ul>
     <h3>2.2.2</h3>
     <ul>
       <li>[Free] Fix diff/merge viewer using wrong default colors instead of theme palette</li>
@@ -183,6 +208,14 @@
         <!-- Project View scrollbar manager (per-project lifecycle) -->
         <projectService
                 serviceImplementation="dev.ayuislands.projectview.ProjectViewScrollbarManager"/>
+
+        <!-- Commit panel auto-fit manager (per-project lifecycle) -->
+        <projectService
+                serviceImplementation="dev.ayuislands.commitpanel.CommitPanelAutoFitManager"/>
+
+        <!-- Git panel auto-fit manager (per-project lifecycle) -->
+        <projectService
+                serviceImplementation="dev.ayuislands.gitpanel.GitPanelAutoFitManager"/>
 
         <!-- Plugin lifecycle -->
         <postStartupActivity

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -180,6 +180,10 @@
         <projectService
                 serviceImplementation="dev.ayuislands.glow.GlowOverlayManager"/>
 
+        <!-- Project View scrollbar manager (per-project lifecycle) -->
+        <projectService
+                serviceImplementation="dev.ayuislands.projectview.ProjectViewScrollbarManager"/>
+
         <!-- Plugin lifecycle -->
         <postStartupActivity
                 implementation="dev.ayuislands.AyuIslandsStartupActivity"/>

--- a/src/test/kotlin/dev/ayuislands/projectview/RootFragmentFilterTest.kt
+++ b/src/test/kotlin/dev/ayuislands/projectview/RootFragmentFilterTest.kt
@@ -1,0 +1,91 @@
+package dev.ayuislands.projectview
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class RootFragmentFilterTest {
+    private val projectName = "my-project"
+    private val basePath = "/Users/cloud/Developer/my-project"
+    private val tildeBasePath = "~/Developer/my-project"
+
+    @Test
+    fun `empty string is not kept`() {
+        assertFalse(RootFragmentFilter.isKeptFragment("", projectName, basePath, tildeBasePath))
+    }
+
+    @Test
+    fun `project name is kept`() {
+        assertTrue(RootFragmentFilter.isKeptFragment("my-project", projectName, basePath, tildeBasePath))
+    }
+
+    @Test
+    fun `absolute base path fragment is kept`() {
+        assertTrue(
+            RootFragmentFilter.isKeptFragment(
+                "[/Users/cloud/Developer/my-project]",
+                projectName,
+                basePath,
+                tildeBasePath,
+            ),
+        )
+    }
+
+    @Test
+    fun `tilde base path fragment is kept`() {
+        assertTrue(
+            RootFragmentFilter.isKeptFragment(
+                "[~/Developer/my-project]",
+                projectName,
+                basePath,
+                tildeBasePath,
+            ),
+        )
+    }
+
+    @Test
+    fun `VCS branch annotation is not kept`() {
+        assertFalse(
+            RootFragmentFilter.isKeptFragment(
+                "main",
+                projectName,
+                basePath,
+                tildeBasePath,
+            ),
+        )
+    }
+
+    @Test
+    fun `changed file count annotation is not kept`() {
+        assertFalse(
+            RootFragmentFilter.isKeptFragment(
+                "3 files",
+                projectName,
+                basePath,
+                tildeBasePath,
+            ),
+        )
+    }
+
+    @Test
+    fun `null basePath still matches project name`() {
+        assertTrue(RootFragmentFilter.isKeptFragment("my-project", projectName, null, null))
+    }
+
+    @Test
+    fun `null basePath rejects unrelated text`() {
+        assertFalse(RootFragmentFilter.isKeptFragment("feat/feature", projectName, null, null))
+    }
+
+    @Test
+    fun `whitespace-only after trim is not kept`() {
+        assertFalse(RootFragmentFilter.isKeptFragment("", projectName, basePath, tildeBasePath))
+    }
+
+    @Test
+    fun `exact basePath match is kept`() {
+        assertTrue(
+            RootFragmentFilter.isKeptFragment(basePath, projectName, basePath, tildeBasePath),
+        )
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateTest.kt
@@ -237,4 +237,21 @@ class AyuIslandsStateTest {
         assertFalse(state.trialExpiredNotified)
         assertFalse(state.proDefaultsApplied)
     }
+
+    @Test
+    fun `PanelWidthMode fromString parses valid names`() {
+        assertEquals(PanelWidthMode.DEFAULT, PanelWidthMode.fromString("DEFAULT"))
+        assertEquals(PanelWidthMode.AUTO_FIT, PanelWidthMode.fromString("AUTO_FIT"))
+        assertEquals(PanelWidthMode.FIXED, PanelWidthMode.fromString("FIXED"))
+    }
+
+    @Test
+    fun `PanelWidthMode fromString returns DEFAULT for null`() {
+        assertEquals(PanelWidthMode.DEFAULT, PanelWidthMode.fromString(null))
+    }
+
+    @Test
+    fun `PanelWidthMode fromString returns DEFAULT for unknown`() {
+        assertEquals(PanelWidthMode.DEFAULT, PanelWidthMode.fromString("NONEXISTENT"))
+    }
 }

--- a/src/test/kotlin/dev/ayuislands/settings/PanelWidthStateTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/PanelWidthStateTest.kt
@@ -1,0 +1,111 @@
+package dev.ayuislands.settings
+
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PanelWidthStateTest {
+    private lateinit var state: PanelWidthState
+
+    @BeforeTest
+    fun setUp() {
+        state = PanelWidthState()
+    }
+
+    @Test
+    fun `default state is not modified`() {
+        assertFalse(state.isModified())
+    }
+
+    @Test
+    fun `load sets both pending and stored`() {
+        state.load(PanelWidthMode.AUTO_FIT, 500, 300)
+
+        assertEquals(PanelWidthMode.AUTO_FIT, state.pendingMode)
+        assertEquals(PanelWidthMode.AUTO_FIT, state.storedMode)
+        assertEquals(500, state.pendingAutoFitMaxWidth)
+        assertEquals(500, state.storedAutoFitMaxWidth)
+        assertEquals(300, state.pendingFixedWidth)
+        assertEquals(300, state.storedFixedWidth)
+        assertFalse(state.isModified())
+    }
+
+    @Test
+    fun `changing pending mode marks as modified`() {
+        state.load(PanelWidthMode.DEFAULT, 400, 200)
+        state.pendingMode = PanelWidthMode.FIXED
+
+        assertTrue(state.isModified())
+    }
+
+    @Test
+    fun `changing pending auto-fit width marks as modified`() {
+        state.load(PanelWidthMode.AUTO_FIT, 400, 200)
+        state.pendingAutoFitMaxWidth = 600
+
+        assertTrue(state.isModified())
+    }
+
+    @Test
+    fun `changing pending fixed width marks as modified`() {
+        state.load(PanelWidthMode.FIXED, 400, 200)
+        state.pendingFixedWidth = 350
+
+        assertTrue(state.isModified())
+    }
+
+    @Test
+    fun `commitStored syncs stored to pending`() {
+        state.load(PanelWidthMode.DEFAULT, 400, 200)
+        state.pendingMode = PanelWidthMode.FIXED
+        state.pendingFixedWidth = 350
+        assertTrue(state.isModified())
+
+        state.commitStored()
+
+        assertFalse(state.isModified())
+        assertEquals(PanelWidthMode.FIXED, state.storedMode)
+        assertEquals(350, state.storedFixedWidth)
+    }
+
+    @Test
+    fun `reset reverts pending to stored`() {
+        state.load(PanelWidthMode.AUTO_FIT, 500, 300)
+        state.pendingMode = PanelWidthMode.FIXED
+        state.pendingAutoFitMaxWidth = 700
+        state.pendingFixedWidth = 400
+        assertTrue(state.isModified())
+
+        state.reset()
+
+        assertFalse(state.isModified())
+        assertEquals(PanelWidthMode.AUTO_FIT, state.pendingMode)
+        assertEquals(500, state.pendingAutoFitMaxWidth)
+        assertEquals(300, state.pendingFixedWidth)
+    }
+
+    @Test
+    fun `widthSummary formats default mode`() {
+        state.pendingMode = PanelWidthMode.DEFAULT
+
+        assertEquals("Default", PanelWidthState.widthSummary(state))
+    }
+
+    @Test
+    fun `widthSummary formats auto-fit mode with max width`() {
+        state.pendingMode = PanelWidthMode.AUTO_FIT
+        state.pendingAutoFitMaxWidth = 500
+
+        assertEquals("Auto-fit \u00B7 max 500px", PanelWidthState.widthSummary(state))
+    }
+
+    @Test
+    fun `widthSummary formats fixed mode with width`() {
+        state.pendingMode = PanelWidthMode.FIXED
+        state.pendingFixedWidth = 350
+
+        assertEquals("Fixed \u00B7 350px", PanelWidthState.widthSummary(state))
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/toolwindow/AutoFitCalculatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/toolwindow/AutoFitCalculatorTest.kt
@@ -1,8 +1,13 @@
 package dev.ayuislands.toolwindow
 
+import java.awt.FlowLayout
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.JTree
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class AutoFitCalculatorTest {
@@ -89,5 +94,45 @@ class AutoFitCalculatorTest {
     @Test
     fun `isJitterOnly returns true for equal widths`() {
         assertTrue(AutoFitCalculator.isJitterOnly(currentWidth = 300, desiredWidth = 300))
+    }
+
+    @Test
+    fun `findFirstOfType returns component when it matches type`() {
+        val label = JLabel("test")
+        val result = AutoFitCalculator.findFirstOfType(label, JLabel::class.java)
+        assertEquals(label, result)
+    }
+
+    @Test
+    fun `findFirstOfType finds nested component`() {
+        val tree = JTree()
+        val inner = JPanel(FlowLayout())
+        inner.add(tree)
+        val outer = JPanel(FlowLayout())
+        outer.add(JLabel("skip"))
+        outer.add(inner)
+
+        val result = AutoFitCalculator.findFirstOfType(outer, JTree::class.java)
+        assertEquals(tree, result)
+    }
+
+    @Test
+    fun `findFirstOfType returns null when type not found`() {
+        val panel = JPanel(FlowLayout())
+        panel.add(JLabel("only label"))
+
+        assertNull(AutoFitCalculator.findFirstOfType(panel, JTree::class.java))
+    }
+
+    @Test
+    fun `findFirstOfType returns first match in depth-first order`() {
+        val first = JLabel("first")
+        val second = JLabel("second")
+        val panel = JPanel(FlowLayout())
+        panel.add(first)
+        panel.add(second)
+
+        val result = AutoFitCalculator.findFirstOfType(panel, JLabel::class.java)
+        assertEquals(first, result)
     }
 }

--- a/src/test/kotlin/dev/ayuislands/toolwindow/AutoFitCalculatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/toolwindow/AutoFitCalculatorTest.kt
@@ -1,0 +1,93 @@
+package dev.ayuislands.toolwindow
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AutoFitCalculatorTest {
+    @Test
+    fun `calculateDesiredWidth adds padding to max row width`() {
+        val result =
+            AutoFitCalculator.calculateDesiredWidth(
+                maxRowWidth = 200,
+                maxWidth = 500,
+                minWidth = 100,
+            )
+        assertEquals(220, result)
+    }
+
+    @Test
+    fun `calculateDesiredWidth clamps to max width`() {
+        val result =
+            AutoFitCalculator.calculateDesiredWidth(
+                maxRowWidth = 600,
+                maxWidth = 500,
+                minWidth = 100,
+            )
+        assertEquals(500, result)
+    }
+
+    @Test
+    fun `calculateDesiredWidth clamps to min width`() {
+        val result =
+            AutoFitCalculator.calculateDesiredWidth(
+                maxRowWidth = 30,
+                maxWidth = 500,
+                minWidth = 200,
+            )
+        assertEquals(200, result)
+    }
+
+    @Test
+    fun `calculateDesiredWidth with zero row width returns min`() {
+        val result =
+            AutoFitCalculator.calculateDesiredWidth(
+                maxRowWidth = 0,
+                maxWidth = 500,
+                minWidth = 100,
+            )
+        assertEquals(100, result)
+    }
+
+    @Test
+    fun `calculateDesiredWidth min takes precedence over max when min greater than max`() {
+        val result =
+            AutoFitCalculator.calculateDesiredWidth(
+                maxRowWidth = 100,
+                maxWidth = 50,
+                minWidth = 200,
+            )
+        assertEquals(200, result)
+    }
+
+    @Test
+    fun `isJitterOnly returns true for small delta`() {
+        assertTrue(AutoFitCalculator.isJitterOnly(currentWidth = 300, desiredWidth = 305))
+    }
+
+    @Test
+    fun `isJitterOnly returns true at threshold boundary`() {
+        assertTrue(AutoFitCalculator.isJitterOnly(currentWidth = 300, desiredWidth = 308))
+    }
+
+    @Test
+    fun `isJitterOnly returns false for large delta`() {
+        assertFalse(AutoFitCalculator.isJitterOnly(currentWidth = 300, desiredWidth = 320))
+    }
+
+    @Test
+    fun `isJitterOnly handles negative delta`() {
+        assertTrue(AutoFitCalculator.isJitterOnly(currentWidth = 300, desiredWidth = 295))
+    }
+
+    @Test
+    fun `isJitterOnly returns false just above threshold`() {
+        assertFalse(AutoFitCalculator.isJitterOnly(currentWidth = 300, desiredWidth = 309))
+    }
+
+    @Test
+    fun `isJitterOnly returns true for equal widths`() {
+        assertTrue(AutoFitCalculator.isJitterOnly(currentWidth = 300, desiredWidth = 300))
+    }
+}


### PR DESCRIPTION
── Summary ─────────────────────────────────

Add Workspace settings tab with tool window auto-fit, fixed-width modes, and Project View display controls (hide path, VCS annotations, horizontal scrollbar). Extract testable domain logic from IDE glue classes to maintain coverage.

**Why**: Users had no control over tool window widths or Project View chrome. The dense root node (project name + path + branch + file count) couldn't be simplified. New premium controls give users a cleaner, more focused workspace.

── Changes ─────────────────────────────────

| Type | File | Description |
|------|------|-------------|
| Feat | `WorkspacePanel.kt:1` | New settings tab with collapsible groups for Project View, Commit, and Git panels |
| Feat | `AyuIslandsState.kt:10` | PanelWidthMode enum + 15 new persisted state fields for width modes, limits, expansion state |
| Feat | `ProjectViewScrollbarManager.kt:1` | Project service: hide h-scrollbar, hide path via Registry, strip VCS annotations via renderer wrapper |
| Feat | `ToolWindowAutoFitter.kt:1` | Reusable auto-fit: JTree row measurement, debounced resize, expansion listener |
| Feat | `CommitPanelAutoFitManager.kt:1` | Commit panel width management (Default/Auto-fit/Fixed) |
| Feat | `GitPanelAutoFitManager.kt:1` | Git panel width management (Default/Auto-fit/Fixed) |
| Feat | `PluginsPanel.kt:1` | Rename IntegrationsPanel, add intro comment, detect-or-hide plugin groups |
| Refactor | `PanelWidthState.kt:1` | Pure state machine extracted from WorkspacePanel for testability |
| Refactor | `AutoFitCalculator.kt:1` | Pure width calculation + jitter detection extracted from ToolWindowAutoFitter |
| Refactor | `RootFragmentFilter.kt:1` | Pure fragment filter extracted from RootLocationHidingRenderer |
| Test | `PanelWidthStateTest.kt:1` | 9 tests: load/modify/commit/reset/widthSummary |
| Test | `AutoFitCalculatorTest.kt:1` | 11 tests: padding, clamping, jitter threshold |
| Test | `RootFragmentFilterTest.kt:1` | 10 tests: project name, paths, VCS annotations, null basePath |
| Chore | `build.gradle.kts:118` | Kover excludes for IDE glue classes (6 new entries) |
| Chore | `proguard-rules.pro` | Keep rules for ProjectViewScrollbarManager inner classes |

── Validation ──────────────────────────────

```bash
./gradlew test              # All tests pass (30 total)
./gradlew koverVerify       # Coverage >= 80%
./gradlew buildPlugin       # Distribution ZIP produced
```

Manual: Settings > Ayu Islands > Workspace tab visible with intro comment, 3 collapsible groups, width mode controls. Plugins tab shows intro comment when plugins detected.

── Notes ───────────────────────────────────

- All new features are premium-gated via `LicenseChecker.isLicensedOrGrace()`
- Startup migration: old `autoFitProjectPanelWidth` boolean converts to `PanelWidthMode.AUTO_FIT`
- `RootLocationHidingRenderer` uses PropertyChangeListener guard to re-wrap after IDE resets the cell renderer
- Tool window IDs are hardcoded strings matching IntelliJ internals: `"Project"`, `"Commit"`, `"Git"`

## Summary by Sourcery

Introduce a new Workspace settings tab for tool window width modes and Project View chrome controls, backed by reusable auto-fit services and supporting state, while refining plugin integrations and Marketplace copy.

New Features:
- Add premium Project View options to hide filesystem path, VCS annotations, and the horizontal scrollbar, configurable per project.
- Add configurable width modes (Default, Auto-fit, Fixed) for Project, Commit, and Git tool windows with per-panel limits and migration from previous auto-fit booleans.
- Introduce a reusable ToolWindow auto-fit utility shared by Commit and Git panels and wired into project startup and Look & Feel changes.
- Add a Plugins settings tab that surfaces CodeGlance Pro and Indent Rainbow integrations only when the plugins are detected, with a fallback explanation when none are installed.

Enhancements:
- Refine premium feature descriptions and add 2.3.0 release notes in the plugin Marketplace metadata.
- Move the bracket-scope gutter highlight control from the integrations tab into the Elements settings tab for clearer organization.
- Improve font preset application by wrapping global editor scheme change notifications in a read action.
- Extract pure, testable domain logic for panel width state, auto-fit calculations, and Project View root fragment filtering out of IDE glue classes.

Build:
- Exclude Workspace and Plugins settings panels and ToolWindow auto-fit manager glue classes from coverage metrics, since they primarily wrap IDE APIs and Swing UI.

Deployment:
- Extend ProGuard keep rules for the new ProjectViewScrollbarManager service and related application listeners so they survive code shrinking.

Tests:
- Add unit tests for panel width state behaviour (load, modify, commit, reset, and summary formatting).
- Add unit tests covering auto-fit width calculation, clamping behaviour, and jitter detection thresholds.
- Add unit tests for Project View root fragment filtering to ensure only project name and path fragments are preserved.