### PR TITLE
feat(workspace): Git panel splitter auto-fit + trial re-activation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.2.2
+pluginVersion=2.3.0
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -67,7 +67,7 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
             settings.state.projectViewMigrated = true
         }
 
-        // Migrate old boolean auto-fit fields to new PanelWidthMode enum
+        // Migrate old boolean auto-fit fields to the new PanelWidthMode enum
         settings.state.migrateWidthModes()
 
         // Eagerly initialize Project View customizer — its init block subscribes
@@ -111,15 +111,22 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
         LOG.info("Ayu Islands license check: ${licenseStateLabel(licenseState)}")
 
         SwingUtilities.invokeLater {
-            // Reset the notification flag if the license becomes valid again (user purchased)
+            // Reset flags if the license becomes valid again (user purchased or new eval period)
             if (licenseState == true && settings.state.trialExpiredNotified) {
                 settings.state.trialExpiredNotified = false
+                settings.state.proDefaultsApplied = false
+                settings.state.trialWelcomeShown = false
             }
 
             // One-time: enable all Pro features when the license first activates
             if (licenseState == true && !settings.state.proDefaultsApplied) {
                 LicenseChecker.enableProDefaults()
                 LOG.info("Ayu Islands Pro defaults enabled (first-time license activation)")
+
+                if (!settings.state.trialWelcomeShown) {
+                    LicenseChecker.notifyTrialWelcome(project)
+                    settings.state.trialWelcomeShown = true
+                }
             }
 
             // null = facade not initialized (grace period, treat as licensed)

--- a/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
@@ -1,8 +1,6 @@
 package dev.ayuislands
 
-import com.intellij.ide.BrowserUtil
 import com.intellij.ide.plugins.PluginManagerCore
-import com.intellij.notification.NotificationAction
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.extensions.PluginId
@@ -11,8 +9,6 @@ import dev.ayuislands.settings.AyuIslandsSettings
 
 internal object UpdateNotifier {
     private const val PLUGIN_ID = "com.ayuislands.theme"
-    private const val MARKETPLACE_URL =
-        "https://plugins.jetbrains.com/plugin/30373-ayu-islands"
 
     fun showIfUpdated(project: Project) {
         val descriptor =
@@ -38,12 +34,6 @@ internal object UpdateNotifier {
                 "Ayu Islands updated to $currentVersion",
                 notes,
                 NotificationType.INFORMATION,
-            ).addAction(
-                NotificationAction.createSimpleExpiring(
-                    "What's new",
-                ) {
-                    BrowserUtil.browse(MARKETPLACE_URL)
-                },
             ).notify(project)
     }
 
@@ -52,8 +42,11 @@ internal object UpdateNotifier {
     private val RELEASE_NOTES =
         mapOf(
             "2.3.0" to
-                "Workspace controls: auto-fit Project View, Commit, and Git panels. " +
-                "30-day premium trial \u2014 all features unlocked on first install.",
+                "<ul>" +
+                "<li>Auto-fit with min/max for Project, Commit, and Git panels</li>" +
+                "<li>Git panel: branches and file changes auto-resize</li>" +
+                "<li>30-day premium trial \u2014 all features unlocked</li>" +
+                "</ul>",
             "2.2.1" to
                 "VCS modified-line colors corrected to canonical ayu palette " +
                 "for Mirage and Dark variants.",

--- a/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
@@ -51,6 +51,9 @@ internal object UpdateNotifier {
 
     private val RELEASE_NOTES =
         mapOf(
+            "2.3.0" to
+                "Workspace controls: auto-fit Project View, Commit, and Git panels. " +
+                "30-day premium trial \u2014 all features unlocked on first install.",
             "2.2.1" to
                 "VCS modified-line colors corrected to canonical ayu palette " +
                 "for Mirage and Dark variants.",

--- a/src/main/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManager.kt
+++ b/src/main/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManager.kt
@@ -23,6 +23,7 @@ class CommitPanelAutoFitManager(
             minWidth = AutoFitCalculator.MIN_COMMIT_AUTOFIT_WIDTH,
         ).apply {
             maxWidthProvider = { AyuIslandsSettings.getInstance().state.autoFitCommitMaxWidth }
+            minWidthProvider = { AyuIslandsSettings.getInstance().state.commitPanelAutoFitMinWidth }
         }
 
     init {

--- a/src/main/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManager.kt
+++ b/src/main/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManager.kt
@@ -2,6 +2,7 @@ package dev.ayuislands.gitpanel
 
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Splitter
 import com.intellij.openapi.wm.ToolWindowManager
@@ -48,11 +49,15 @@ class GitPanelAutoFitManager(
     }
 
     fun apply() {
-        if (!LicenseChecker.isLicensedOrGrace()) return
+        if (!LicenseChecker.isLicensedOrGrace()) {
+            LOG.info("[GitAutoFit] apply() skipped — not licensed")
+            return
+        }
         val mode =
             PanelWidthMode.fromString(
                 AyuIslandsSettings.getInstance().state.gitPanelWidthMode,
             )
+        LOG.info("[GitAutoFit] apply() called — mode=$mode")
         when (mode) {
             PanelWidthMode.DEFAULT -> removeExpansionListeners()
             PanelWidthMode.AUTO_FIT -> {
@@ -67,69 +72,135 @@ class GitPanelAutoFitManager(
     }
 
     private fun fitSplitters() {
-        val logContent = findLogTabContent() ?: return
-        val splitters =
-            AutoFitCalculator
-                .findAllOfType(logContent, Splitter::class.java)
-                .filterIsInstance<Splitter>()
+        val logContent = findLogTabContent()
+        if (logContent == null) {
+            LOG.info("[GitAutoFit] fitSplitters() — findLogTabContent() returned null")
+            return
+        }
+        LOG.info(
+            "[GitAutoFit] fitSplitters() — logContent type=${logContent::class.java.name}, " +
+                "size=${logContent.width}x${logContent.height}",
+        )
+
+        // Dump shallow hierarchy (3 levels) for debugging
+        dumpComponentTree(logContent, depth = 0, maxDepth = 3)
+
+        val allSplitters =
+            AutoFitCalculator.findAllOfType(logContent, Splitter::class.java)
+        LOG.info(
+            "[GitAutoFit] findAllOfType(Splitter) found ${allSplitters.size} instances: " +
+                allSplitters.joinToString { "${it::class.java.name}(w=${it.width})" },
+        )
+
+        val splitters = allSplitters.filterIsInstance<Splitter>()
+        LOG.info("[GitAutoFit] filterIsInstance<Splitter> kept ${splitters.size}")
+
         val state = AyuIslandsSettings.getInstance().state
         val maxWidth = state.gitPanelAutoFitMaxWidth
+        val minWidth = state.gitPanelAutoFitMinWidth
 
-        for (splitter in splitters) {
-            if (splitter.width <= 0) continue
-            fitSplitter(splitter, maxWidth)
+        for ((index, splitter) in splitters.withIndex()) {
+            if (splitter.width <= 0) {
+                LOG.info("[GitAutoFit] splitter[$index] width=${splitter.width} — skipping (<=0)")
+                continue
+            }
+            LOG.info(
+                "[GitAutoFit] splitter[$index] width=${splitter.width}, " +
+                    "proportion=${splitter.proportion}, " +
+                    "firstComponent=${splitter.firstComponent?.javaClass?.name}, " +
+                    "secondComponent=${splitter.secondComponent?.javaClass?.name}",
+            )
+            fitSplitter(splitter, maxWidth, minWidth)
         }
     }
 
     private fun fitSplitter(
         splitter: Splitter,
         maxWidth: Int,
+        minWidth: Int,
     ) {
-        val firstHasTable =
-            AutoFitCalculator.findFirstOfType(
-                splitter.firstComponent,
-                JTable::class.java,
-            ) != null
+        val first = splitter.firstComponent
+        val second = splitter.secondComponent
+        if (first == null || second == null) {
+            LOG.info("[GitAutoFit] fitSplitter — skipping, first=${first != null}, second=${second != null}")
+            return
+        }
+
+        val firstHasTable = AutoFitCalculator.findFirstOfType(first, JTable::class.java) != null
+        val firstHasTree = AutoFitCalculator.findFirstOfType(first, JTree::class.java) != null
+        val secondHasTable = AutoFitCalculator.findFirstOfType(second, JTable::class.java) != null
+        val secondHasTree = AutoFitCalculator.findFirstOfType(second, JTree::class.java) != null
+
+        LOG.info(
+            "[GitAutoFit] fitSplitter — firstHasTable=$firstHasTable, firstHasTree=$firstHasTree, " +
+                "secondHasTable=$secondHasTable, secondHasTree=$secondHasTree",
+        )
 
         if (firstHasTable) {
             // Inner splitter: left=JTable (log), right=JTree (file changes)
             val tree =
                 AutoFitCalculator.findFirstOfType(
-                    splitter.secondComponent,
+                    second,
                     JTree::class.java,
-                ) as? JTree ?: return
+                ) as? JTree
+            if (tree == null) {
+                LOG.info("[GitAutoFit] inner splitter — no JTree in secondComponent, skipping")
+                return
+            }
             val maxRowWidth = measureTreeMaxRowWidth(tree)
             val desiredWidth =
                 AutoFitCalculator.calculateDesiredWidth(
                     maxRowWidth,
                     maxWidth,
-                    AutoFitCalculator.MIN_GIT_AUTOFIT_WIDTH,
+                    minWidth,
                 )
             val currentWidth = ((1.0f - splitter.proportion) * splitter.width).toInt()
-            if (AutoFitCalculator.isJitterOnly(currentWidth, desiredWidth)) return
+            LOG.info(
+                "[GitAutoFit] inner splitter — maxRowWidth=$maxRowWidth, desiredWidth=$desiredWidth, " +
+                    "currentWidth=$currentWidth, splitterWidth=${splitter.width}, " +
+                    "proportion=${splitter.proportion}",
+            )
+            if (AutoFitCalculator.isJitterOnly(currentWidth, desiredWidth)) {
+                LOG.info("[GitAutoFit] inner splitter — jitter only, skipping")
+                return
+            }
             val proportion =
                 (1.0f - desiredWidth.toFloat() / splitter.width.toFloat())
                     .coerceIn(MIN_INNER_PROPORTION, MAX_INNER_PROPORTION)
+            LOG.info("[GitAutoFit] inner splitter — setting proportion to $proportion")
             splitter.proportion = proportion
         } else {
             // Outer splitter: left=JTree (branches), right=inner splitter or log
             val tree =
                 AutoFitCalculator.findFirstOfType(
-                    splitter.firstComponent,
+                    first,
                     JTree::class.java,
-                ) as? JTree ?: return
+                ) as? JTree
+            if (tree == null) {
+                LOG.info("[GitAutoFit] outer splitter — no JTree in firstComponent, skipping")
+                return
+            }
             val maxRowWidth = measureTreeMaxRowWidth(tree)
             val desiredWidth =
                 AutoFitCalculator.calculateDesiredWidth(
                     maxRowWidth,
                     maxWidth,
-                    AutoFitCalculator.MIN_GIT_AUTOFIT_WIDTH,
+                    minWidth,
                 )
             val currentWidth = (splitter.proportion * splitter.width).toInt()
-            if (AutoFitCalculator.isJitterOnly(currentWidth, desiredWidth)) return
+            LOG.info(
+                "[GitAutoFit] outer splitter — maxRowWidth=$maxRowWidth, desiredWidth=$desiredWidth, " +
+                    "currentWidth=$currentWidth, splitterWidth=${splitter.width}, " +
+                    "proportion=${splitter.proportion}",
+            )
+            if (AutoFitCalculator.isJitterOnly(currentWidth, desiredWidth)) {
+                LOG.info("[GitAutoFit] outer splitter — jitter only, skipping")
+                return
+            }
             val proportion =
                 (desiredWidth.toFloat() / splitter.width.toFloat())
                     .coerceIn(MIN_OUTER_PROPORTION, MAX_OUTER_PROPORTION)
+            LOG.info("[GitAutoFit] outer splitter — setting proportion to $proportion")
             splitter.proportion = proportion
         }
     }
@@ -144,6 +215,7 @@ class GitPanelAutoFitManager(
 
         for (splitter in splitters) {
             if (splitter.width <= 0) continue
+            if (splitter.firstComponent == null || splitter.secondComponent == null) continue
             val firstHasTable =
                 AutoFitCalculator.findFirstOfType(
                     splitter.firstComponent,
@@ -198,16 +270,35 @@ class GitPanelAutoFitManager(
     }
 
     private fun findLogTabContent(): java.awt.Component? {
-        val toolWindow =
-            ToolWindowManager
-                .getInstance(project)
-                .getToolWindow("Git")
-                ?: return null
-        return toolWindow
-            .contentManager
-            .contents
-            .firstOrNull { it.tabName == "Log" }
-            ?.component
+        val manager = ToolWindowManager.getInstance(project)
+        val allIds = manager.toolWindowIds.toList()
+        LOG.info("[GitAutoFit] findLogTabContent — registered tool window IDs: $allIds")
+        val toolWindow = manager.getToolWindow("Version Control")
+        if (toolWindow == null) {
+            LOG.info("[GitAutoFit] findLogTabContent — getToolWindow('Git') returned null")
+            return null
+        }
+        LOG.info("[GitAutoFit] findLogTabContent — Git tool window found, isVisible=${toolWindow.isVisible}")
+
+        val contents = toolWindow.contentManager.contents
+        LOG.info(
+            "[GitAutoFit] findLogTabContent — ${contents.size} content tabs: " +
+                contents.joinToString { "'${it.tabName}' (displayName='${it.displayName}')" },
+        )
+
+        val logContent =
+            contents.firstOrNull { it.tabName == "Log" }
+        if (logContent == null) {
+            LOG.info("[GitAutoFit] findLogTabContent — no tab with tabName='Log' found")
+            return null
+        }
+
+        val component = logContent.component
+        LOG.info(
+            "[GitAutoFit] findLogTabContent — Log tab component: ${component.javaClass.name}, " +
+                "size=${component.width}x${component.height}",
+        )
+        return component
     }
 
     private fun measureTreeMaxRowWidth(tree: JTree): Int {
@@ -220,11 +311,36 @@ class GitPanelAutoFitManager(
         return maxRowWidth
     }
 
+    private fun dumpComponentTree(
+        component: java.awt.Component,
+        depth: Int,
+        maxDepth: Int,
+    ) {
+        if (depth > maxDepth) return
+        val indent = "  ".repeat(depth)
+        val extra =
+            if (component is Splitter) {
+                " [SPLITTER prop=${component.proportion}]"
+            } else {
+                ""
+            }
+        LOG.info(
+            "[GitAutoFit] TREE $indent${component::class.java.name} " +
+                "(${component.width}x${component.height})$extra",
+        )
+        if (component is java.awt.Container) {
+            for (child in component.components) {
+                dumpComponentTree(child, depth + 1, maxDepth)
+            }
+        }
+    }
+
     override fun dispose() {
         removeExpansionListeners()
     }
 
     companion object {
+        private val LOG = logger<GitPanelAutoFitManager>()
         private const val DEBOUNCE_DELAY_MS = 150
         private const val MIN_OUTER_PROPORTION = 0.05f
         private const val MAX_OUTER_PROPORTION = 0.5f

--- a/src/main/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManager.kt
+++ b/src/main/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManager.kt
@@ -3,27 +3,30 @@ package dev.ayuislands.gitpanel
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.Splitter
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.PanelWidthMode
 import dev.ayuislands.toolwindow.AutoFitCalculator
-import dev.ayuislands.toolwindow.ToolWindowAutoFitter
+import javax.swing.JTable
+import javax.swing.JTree
+import javax.swing.Timer
+import javax.swing.event.TreeExpansionEvent
+import javax.swing.event.TreeExpansionListener
 
-/** Per-project service that manages Git tool window width (auto-fit or fixed). */
+/** Per-project service that manages Git panel internal splitter proportions (auto-fit or fixed). */
 @Service(Service.Level.PROJECT)
 class GitPanelAutoFitManager(
     private val project: Project,
 ) : Disposable {
-    private val autoFitter =
-        ToolWindowAutoFitter(
-            project = project,
-            toolWindowId = "Git",
-            minWidth = AutoFitCalculator.MIN_GIT_AUTOFIT_WIDTH,
-        ).apply {
-            maxWidthProvider = { AyuIslandsSettings.getInstance().state.gitPanelAutoFitMaxWidth }
-        }
+    private val debounceTimer =
+        Timer(DEBOUNCE_DELAY_MS) { fitSplitters() }
+            .apply { isRepeats = false }
+
+    private val expansionListeners =
+        mutableListOf<Pair<JTree, TreeExpansionListener>>()
 
     init {
         project.messageBus.connect(this).subscribe(
@@ -46,19 +49,188 @@ class GitPanelAutoFitManager(
 
     fun apply() {
         if (!LicenseChecker.isLicensedOrGrace()) return
+        val mode =
+            PanelWidthMode.fromString(
+                AyuIslandsSettings.getInstance().state.gitPanelWidthMode,
+            )
+        when (mode) {
+            PanelWidthMode.DEFAULT -> removeExpansionListeners()
+            PanelWidthMode.AUTO_FIT -> {
+                installExpansionListeners()
+                fitSplitters()
+            }
+            PanelWidthMode.FIXED -> {
+                removeExpansionListeners()
+                setFixedProportions()
+            }
+        }
+    }
+
+    private fun fitSplitters() {
+        val logContent = findLogTabContent() ?: return
+        val splitters =
+            AutoFitCalculator
+                .findAllOfType(logContent, Splitter::class.java)
+                .filterIsInstance<Splitter>()
         val state = AyuIslandsSettings.getInstance().state
-        autoFitter.applyWidthMode(
-            PanelWidthMode.fromString(state.gitPanelWidthMode),
-            state.gitPanelAutoFitMaxWidth,
-            state.gitPanelFixedWidth,
-        )
+        val maxWidth = state.gitPanelAutoFitMaxWidth
+
+        for (splitter in splitters) {
+            if (splitter.width <= 0) continue
+            fitSplitter(splitter, maxWidth)
+        }
+    }
+
+    private fun fitSplitter(
+        splitter: Splitter,
+        maxWidth: Int,
+    ) {
+        val firstHasTable =
+            AutoFitCalculator.findFirstOfType(
+                splitter.firstComponent,
+                JTable::class.java,
+            ) != null
+
+        if (firstHasTable) {
+            // Inner splitter: left=JTable (log), right=JTree (file changes)
+            val tree =
+                AutoFitCalculator.findFirstOfType(
+                    splitter.secondComponent,
+                    JTree::class.java,
+                ) as? JTree ?: return
+            val maxRowWidth = measureTreeMaxRowWidth(tree)
+            val desiredWidth =
+                AutoFitCalculator.calculateDesiredWidth(
+                    maxRowWidth,
+                    maxWidth,
+                    AutoFitCalculator.MIN_GIT_AUTOFIT_WIDTH,
+                )
+            val currentWidth = ((1.0f - splitter.proportion) * splitter.width).toInt()
+            if (AutoFitCalculator.isJitterOnly(currentWidth, desiredWidth)) return
+            val proportion =
+                (1.0f - desiredWidth.toFloat() / splitter.width.toFloat())
+                    .coerceIn(MIN_INNER_PROPORTION, MAX_INNER_PROPORTION)
+            splitter.proportion = proportion
+        } else {
+            // Outer splitter: left=JTree (branches), right=inner splitter or log
+            val tree =
+                AutoFitCalculator.findFirstOfType(
+                    splitter.firstComponent,
+                    JTree::class.java,
+                ) as? JTree ?: return
+            val maxRowWidth = measureTreeMaxRowWidth(tree)
+            val desiredWidth =
+                AutoFitCalculator.calculateDesiredWidth(
+                    maxRowWidth,
+                    maxWidth,
+                    AutoFitCalculator.MIN_GIT_AUTOFIT_WIDTH,
+                )
+            val currentWidth = (splitter.proportion * splitter.width).toInt()
+            if (AutoFitCalculator.isJitterOnly(currentWidth, desiredWidth)) return
+            val proportion =
+                (desiredWidth.toFloat() / splitter.width.toFloat())
+                    .coerceIn(MIN_OUTER_PROPORTION, MAX_OUTER_PROPORTION)
+            splitter.proportion = proportion
+        }
+    }
+
+    private fun setFixedProportions() {
+        val logContent = findLogTabContent() ?: return
+        val splitters =
+            AutoFitCalculator
+                .findAllOfType(logContent, Splitter::class.java)
+                .filterIsInstance<Splitter>()
+        val fixedWidth = AyuIslandsSettings.getInstance().state.gitPanelFixedWidth
+
+        for (splitter in splitters) {
+            if (splitter.width <= 0) continue
+            val firstHasTable =
+                AutoFitCalculator.findFirstOfType(
+                    splitter.firstComponent,
+                    JTable::class.java,
+                ) != null
+
+            if (firstHasTable) {
+                val proportion =
+                    (1.0f - fixedWidth.toFloat() / splitter.width.toFloat())
+                        .coerceIn(MIN_INNER_PROPORTION, MAX_INNER_PROPORTION)
+                splitter.proportion = proportion
+            } else {
+                val proportion =
+                    (fixedWidth.toFloat() / splitter.width.toFloat())
+                        .coerceIn(MIN_OUTER_PROPORTION, MAX_OUTER_PROPORTION)
+                splitter.proportion = proportion
+            }
+        }
+    }
+
+    private fun installExpansionListeners() {
+        val logContent = findLogTabContent() ?: return
+        val trees =
+            AutoFitCalculator
+                .findAllOfType(logContent, JTree::class.java)
+                .filterIsInstance<JTree>()
+
+        val tracked = expansionListeners.map { it.first }.toSet()
+        for (tree in trees) {
+            if (tree in tracked) continue
+            val listener =
+                object : TreeExpansionListener {
+                    override fun treeExpanded(event: TreeExpansionEvent) {
+                        debounceTimer.restart()
+                    }
+
+                    override fun treeCollapsed(event: TreeExpansionEvent) {
+                        debounceTimer.restart()
+                    }
+                }
+            tree.addTreeExpansionListener(listener)
+            expansionListeners.add(tree to listener)
+        }
+    }
+
+    private fun removeExpansionListeners() {
+        for ((tree, listener) in expansionListeners) {
+            tree.removeTreeExpansionListener(listener)
+        }
+        expansionListeners.clear()
+        debounceTimer.stop()
+    }
+
+    private fun findLogTabContent(): java.awt.Component? {
+        val toolWindow =
+            ToolWindowManager
+                .getInstance(project)
+                .getToolWindow("Git")
+                ?: return null
+        return toolWindow
+            .contentManager
+            .contents
+            .firstOrNull { it.tabName == "Log" }
+            ?.component
+    }
+
+    private fun measureTreeMaxRowWidth(tree: JTree): Int {
+        var maxRowWidth = 0
+        for (row in 0 until tree.rowCount) {
+            val bounds = tree.getRowBounds(row) ?: continue
+            val rowRight = bounds.x + bounds.width
+            if (rowRight > maxRowWidth) maxRowWidth = rowRight
+        }
+        return maxRowWidth
     }
 
     override fun dispose() {
-        autoFitter.removeExpansionListener()
+        removeExpansionListeners()
     }
 
     companion object {
+        private const val DEBOUNCE_DELAY_MS = 150
+        private const val MIN_OUTER_PROPORTION = 0.05f
+        private const val MAX_OUTER_PROPORTION = 0.5f
+        private const val MIN_INNER_PROPORTION = 0.5f
+        private const val MAX_INNER_PROPORTION = 0.95f
+
         fun getInstance(project: Project): GitPanelAutoFitManager =
             project.getService(
                 GitPanelAutoFitManager::class.java,

--- a/src/main/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManager.kt
+++ b/src/main/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManager.kt
@@ -2,7 +2,6 @@ package dev.ayuislands.gitpanel
 
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
-import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Splitter
 import com.intellij.openapi.wm.ToolWindowManager
@@ -49,15 +48,11 @@ class GitPanelAutoFitManager(
     }
 
     fun apply() {
-        if (!LicenseChecker.isLicensedOrGrace()) {
-            LOG.info("[GitAutoFit] apply() skipped — not licensed")
-            return
-        }
+        if (!LicenseChecker.isLicensedOrGrace()) return
         val mode =
             PanelWidthMode.fromString(
                 AyuIslandsSettings.getInstance().state.gitPanelWidthMode,
             )
-        LOG.info("[GitAutoFit] apply() called — mode=$mode")
         when (mode) {
             PanelWidthMode.DEFAULT -> removeExpansionListeners()
             PanelWidthMode.AUTO_FIT -> {
@@ -72,44 +67,18 @@ class GitPanelAutoFitManager(
     }
 
     private fun fitSplitters() {
-        val logContent = findLogTabContent()
-        if (logContent == null) {
-            LOG.info("[GitAutoFit] fitSplitters() — findLogTabContent() returned null")
-            return
-        }
-        LOG.info(
-            "[GitAutoFit] fitSplitters() — logContent type=${logContent::class.java.name}, " +
-                "size=${logContent.width}x${logContent.height}",
-        )
-
-        // Dump shallow hierarchy (3 levels) for debugging
-        dumpComponentTree(logContent, depth = 0, maxDepth = 3)
-
-        val allSplitters =
-            AutoFitCalculator.findAllOfType(logContent, Splitter::class.java)
-        LOG.info(
-            "[GitAutoFit] findAllOfType(Splitter) found ${allSplitters.size} instances: " +
-                allSplitters.joinToString { "${it::class.java.name}(w=${it.width})" },
-        )
-
-        val splitters = allSplitters.filterIsInstance<Splitter>()
-        LOG.info("[GitAutoFit] filterIsInstance<Splitter> kept ${splitters.size}")
+        val logContent = findLogTabContent() ?: return
+        val splitters =
+            AutoFitCalculator
+                .findAllOfType(logContent, Splitter::class.java)
+                .filterIsInstance<Splitter>()
 
         val state = AyuIslandsSettings.getInstance().state
         val maxWidth = state.gitPanelAutoFitMaxWidth
         val minWidth = state.gitPanelAutoFitMinWidth
 
-        for ((index, splitter) in splitters.withIndex()) {
-            if (splitter.width <= 0) {
-                LOG.info("[GitAutoFit] splitter[$index] width=${splitter.width} — skipping (<=0)")
-                continue
-            }
-            LOG.info(
-                "[GitAutoFit] splitter[$index] width=${splitter.width}, " +
-                    "proportion=${splitter.proportion}, " +
-                    "firstComponent=${splitter.firstComponent?.javaClass?.name}, " +
-                    "secondComponent=${splitter.secondComponent?.javaClass?.name}",
-            )
+        for (splitter in splitters) {
+            if (splitter.width <= 0) continue
             fitSplitter(splitter, maxWidth, minWidth)
         }
     }
@@ -121,87 +90,34 @@ class GitPanelAutoFitManager(
     ) {
         val first = splitter.firstComponent
         val second = splitter.secondComponent
-        if (first == null || second == null) {
-            LOG.info("[GitAutoFit] fitSplitter — skipping, first=${first != null}, second=${second != null}")
-            return
-        }
+        if (first == null || second == null) return
 
         val firstHasTable = AutoFitCalculator.findFirstOfType(first, JTable::class.java) != null
-        val firstHasTree = AutoFitCalculator.findFirstOfType(first, JTree::class.java) != null
-        val secondHasTable = AutoFitCalculator.findFirstOfType(second, JTable::class.java) != null
-        val secondHasTree = AutoFitCalculator.findFirstOfType(second, JTree::class.java) != null
-
-        LOG.info(
-            "[GitAutoFit] fitSplitter — firstHasTable=$firstHasTable, firstHasTree=$firstHasTree, " +
-                "secondHasTable=$secondHasTable, secondHasTree=$secondHasTree",
-        )
 
         if (firstHasTable) {
             // Inner splitter: left=JTable (log), right=JTree (file changes)
             val tree =
-                AutoFitCalculator.findFirstOfType(
-                    second,
-                    JTree::class.java,
-                ) as? JTree
-            if (tree == null) {
-                LOG.info("[GitAutoFit] inner splitter — no JTree in secondComponent, skipping")
-                return
-            }
+                AutoFitCalculator.findFirstOfType(second, JTree::class.java) as? JTree ?: return
             val maxRowWidth = measureTreeMaxRowWidth(tree)
             val desiredWidth =
-                AutoFitCalculator.calculateDesiredWidth(
-                    maxRowWidth,
-                    maxWidth,
-                    minWidth,
-                )
+                AutoFitCalculator.calculateDesiredWidth(maxRowWidth, maxWidth, minWidth)
             val currentWidth = ((1.0f - splitter.proportion) * splitter.width).toInt()
-            LOG.info(
-                "[GitAutoFit] inner splitter — maxRowWidth=$maxRowWidth, desiredWidth=$desiredWidth, " +
-                    "currentWidth=$currentWidth, splitterWidth=${splitter.width}, " +
-                    "proportion=${splitter.proportion}",
-            )
-            if (AutoFitCalculator.isJitterOnly(currentWidth, desiredWidth)) {
-                LOG.info("[GitAutoFit] inner splitter — jitter only, skipping")
-                return
-            }
-            val proportion =
+            if (AutoFitCalculator.isJitterOnly(currentWidth, desiredWidth)) return
+            splitter.proportion =
                 (1.0f - desiredWidth.toFloat() / splitter.width.toFloat())
                     .coerceIn(MIN_INNER_PROPORTION, MAX_INNER_PROPORTION)
-            LOG.info("[GitAutoFit] inner splitter — setting proportion to $proportion")
-            splitter.proportion = proportion
         } else {
             // Outer splitter: left=JTree (branches), right=inner splitter or log
             val tree =
-                AutoFitCalculator.findFirstOfType(
-                    first,
-                    JTree::class.java,
-                ) as? JTree
-            if (tree == null) {
-                LOG.info("[GitAutoFit] outer splitter — no JTree in firstComponent, skipping")
-                return
-            }
+                AutoFitCalculator.findFirstOfType(first, JTree::class.java) as? JTree ?: return
             val maxRowWidth = measureTreeMaxRowWidth(tree)
             val desiredWidth =
-                AutoFitCalculator.calculateDesiredWidth(
-                    maxRowWidth,
-                    maxWidth,
-                    minWidth,
-                )
+                AutoFitCalculator.calculateDesiredWidth(maxRowWidth, maxWidth, minWidth)
             val currentWidth = (splitter.proportion * splitter.width).toInt()
-            LOG.info(
-                "[GitAutoFit] outer splitter — maxRowWidth=$maxRowWidth, desiredWidth=$desiredWidth, " +
-                    "currentWidth=$currentWidth, splitterWidth=${splitter.width}, " +
-                    "proportion=${splitter.proportion}",
-            )
-            if (AutoFitCalculator.isJitterOnly(currentWidth, desiredWidth)) {
-                LOG.info("[GitAutoFit] outer splitter — jitter only, skipping")
-                return
-            }
-            val proportion =
+            if (AutoFitCalculator.isJitterOnly(currentWidth, desiredWidth)) return
+            splitter.proportion =
                 (desiredWidth.toFloat() / splitter.width.toFloat())
                     .coerceIn(MIN_OUTER_PROPORTION, MAX_OUTER_PROPORTION)
-            LOG.info("[GitAutoFit] outer splitter — setting proportion to $proportion")
-            splitter.proportion = proportion
         }
     }
 
@@ -223,15 +139,13 @@ class GitPanelAutoFitManager(
                 ) != null
 
             if (firstHasTable) {
-                val proportion =
+                splitter.proportion =
                     (1.0f - fixedWidth.toFloat() / splitter.width.toFloat())
                         .coerceIn(MIN_INNER_PROPORTION, MAX_INNER_PROPORTION)
-                splitter.proportion = proportion
             } else {
-                val proportion =
+                splitter.proportion =
                     (fixedWidth.toFloat() / splitter.width.toFloat())
                         .coerceIn(MIN_OUTER_PROPORTION, MAX_OUTER_PROPORTION)
-                splitter.proportion = proportion
             }
         }
     }
@@ -270,35 +184,16 @@ class GitPanelAutoFitManager(
     }
 
     private fun findLogTabContent(): java.awt.Component? {
-        val manager = ToolWindowManager.getInstance(project)
-        val allIds = manager.toolWindowIds.toList()
-        LOG.info("[GitAutoFit] findLogTabContent — registered tool window IDs: $allIds")
-        val toolWindow = manager.getToolWindow("Version Control")
-        if (toolWindow == null) {
-            LOG.info("[GitAutoFit] findLogTabContent — getToolWindow('Git') returned null")
-            return null
-        }
-        LOG.info("[GitAutoFit] findLogTabContent — Git tool window found, isVisible=${toolWindow.isVisible}")
-
-        val contents = toolWindow.contentManager.contents
-        LOG.info(
-            "[GitAutoFit] findLogTabContent — ${contents.size} content tabs: " +
-                contents.joinToString { "'${it.tabName}' (displayName='${it.displayName}')" },
-        )
-
-        val logContent =
-            contents.firstOrNull { it.tabName == "Log" }
-        if (logContent == null) {
-            LOG.info("[GitAutoFit] findLogTabContent — no tab with tabName='Log' found")
-            return null
-        }
-
-        val component = logContent.component
-        LOG.info(
-            "[GitAutoFit] findLogTabContent — Log tab component: ${component.javaClass.name}, " +
-                "size=${component.width}x${component.height}",
-        )
-        return component
+        val toolWindow =
+            ToolWindowManager
+                .getInstance(project)
+                .getToolWindow(TOOL_WINDOW_ID)
+                ?: return null
+        return toolWindow
+            .contentManager
+            .contents
+            .firstOrNull { it.tabName == "Log" }
+            ?.component
     }
 
     private fun measureTreeMaxRowWidth(tree: JTree): Int {
@@ -311,36 +206,12 @@ class GitPanelAutoFitManager(
         return maxRowWidth
     }
 
-    private fun dumpComponentTree(
-        component: java.awt.Component,
-        depth: Int,
-        maxDepth: Int,
-    ) {
-        if (depth > maxDepth) return
-        val indent = "  ".repeat(depth)
-        val extra =
-            if (component is Splitter) {
-                " [SPLITTER prop=${component.proportion}]"
-            } else {
-                ""
-            }
-        LOG.info(
-            "[GitAutoFit] TREE $indent${component::class.java.name} " +
-                "(${component.width}x${component.height})$extra",
-        )
-        if (component is java.awt.Container) {
-            for (child in component.components) {
-                dumpComponentTree(child, depth + 1, maxDepth)
-            }
-        }
-    }
-
     override fun dispose() {
         removeExpansionListeners()
     }
 
     companion object {
-        private val LOG = logger<GitPanelAutoFitManager>()
+        private const val TOOL_WINDOW_ID = "Version Control"
         private const val DEBOUNCE_DELAY_MS = 150
         private const val MIN_OUTER_PROPORTION = 0.05f
         private const val MAX_OUTER_PROPORTION = 0.5f

--- a/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
@@ -18,6 +18,9 @@ import com.intellij.ui.LicensingFacade
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.glow.GlowAnimation
+import dev.ayuislands.glow.GlowPreset
+import dev.ayuislands.glow.GlowStyle
 import dev.ayuislands.settings.AyuIslandsSettings
 import java.io.ByteArrayInputStream
 import java.nio.charset.StandardCharsets
@@ -33,6 +36,7 @@ object LicenseChecker {
     const val PRODUCT_CODE = "PAYUISLANDS"
 
     private val LOG = logger<LicenseChecker>()
+    private const val NOTIFICATION_GROUP = "Ayu Islands"
     private const val TIMESTAMP_VALIDITY_PERIOD_MS = 3_600_000L // 1 hour
 
     // JetBrains public root CAs for license verification.
@@ -154,14 +158,39 @@ object LicenseChecker {
         }, ModalityState.nonModal())
     }
 
-    /** Show one-time balloon notification after trial expiry. */
+    /** Show one-time conversion-oriented notification after trial expiry. */
     fun notifyTrialExpired(project: Project?) {
         NotificationGroupManager
             .getInstance()
-            .getNotificationGroup("Ayu Islands")
+            .getNotificationGroup(NOTIFICATION_GROUP)
             .createNotification(
-                "Ayu Islands trial has expired",
-                "Free features remain available. Paid features have been reverted to defaults.",
+                "Your Ayu Islands trial has ended",
+                "Glow, accent control, workspace tweaks, and plugin sync " +
+                    "have been reverted to free defaults. " +
+                    "Get a license to bring them back \u2014 yours forever.",
+                NotificationType.INFORMATION,
+            ).addAction(
+                object : com.intellij.notification.NotificationAction("Buy license") {
+                    override fun actionPerformed(
+                        e: AnActionEvent,
+                        notification: com.intellij.notification.Notification,
+                    ) {
+                        notification.expire()
+                        requestLicense(NOTIFICATION_GROUP)
+                    }
+                },
+            ).notify(project)
+    }
+
+    /** Show one-time welcome notification for new trial/license activations. */
+    fun notifyTrialWelcome(project: Project?) {
+        NotificationGroupManager
+            .getInstance()
+            .getNotificationGroup(NOTIFICATION_GROUP)
+            .createNotification(
+                "Welcome to Ayu Islands premium",
+                "All premium features are unlocked for 30 days. " +
+                    "Try a mood preset \u2014 open Settings \u2192 Ayu Islands.",
                 NotificationType.INFORMATION,
             ).notify(project)
     }
@@ -170,6 +199,11 @@ object LicenseChecker {
     fun enableProDefaults() {
         val state = AyuIslandsSettings.getInstance().state
         state.glowEnabled = true
+        state.glowStyle = GlowStyle.SHARP_NEON.name
+        state.glowPreset = GlowPreset.CUSTOM.name
+        state.sharpNeonIntensity = PRO_DEFAULT_NEON_INTENSITY
+        state.sharpNeonWidth = PRO_DEFAULT_NEON_WIDTH
+        state.glowAnimation = GlowAnimation.BREATHE.name
         state.glowEditor = true
         state.glowProject = true
         state.glowTerminal = true
@@ -213,6 +247,8 @@ object LicenseChecker {
     private const val STAMP_SIGNATURE_INDEX = 3
     private const val STAMP_CERT_INDEX = 4
     private const val STAMP_INTERMEDIATE_START_INDEX = 5
+    private const val PRO_DEFAULT_NEON_INTENSITY = 100
+    private const val PRO_DEFAULT_NEON_WIDTH = 2
 
     /** Dev mode: requires BOTH system property AND Gradle sandbox environment. */
     private fun isDevBuild(): Boolean {

--- a/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
@@ -164,13 +164,13 @@ object LicenseChecker {
             .getInstance()
             .getNotificationGroup(NOTIFICATION_GROUP)
             .createNotification(
-                "Your Ayu Islands trial has ended",
-                "Glow, accent control, workspace tweaks, and plugin sync " +
-                    "have been reverted to free defaults. " +
-                    "Get a license to bring them back \u2014 yours forever.",
+                "Ayu Islands trial ended",
+                "Glow, accent toggles, auto-fit, and plugin sync " +
+                    "reverted to defaults. " +
+                    "A license brings them back \u2014 one-time, forever.",
                 NotificationType.INFORMATION,
             ).addAction(
-                object : com.intellij.notification.NotificationAction("Buy license") {
+                object : com.intellij.notification.NotificationAction("Get license") {
                     override fun actionPerformed(
                         e: AnActionEvent,
                         notification: com.intellij.notification.Notification,
@@ -188,9 +188,9 @@ object LicenseChecker {
             .getInstance()
             .getNotificationGroup(NOTIFICATION_GROUP)
             .createNotification(
-                "Welcome to Ayu Islands premium",
-                "All premium features are unlocked for 30 days. " +
-                    "Try a mood preset \u2014 open Settings \u2192 Ayu Islands.",
+                "Ayu Islands Premium is unlocked",
+                "30 days of glow, auto-fit, accent control, and plugin sync. " +
+                    "Open Settings \u2192 Ayu Islands to explore.",
                 NotificationType.INFORMATION,
             ).notify(project)
     }

--- a/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
+++ b/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
@@ -37,6 +37,7 @@ class ProjectViewScrollbarManager(
             minWidth = AutoFitCalculator.MIN_PROJECT_AUTOFIT_WIDTH,
         ).apply {
             maxWidthProvider = { AyuIslandsSettings.getInstance().state.autoFitMaxWidth }
+            minWidthProvider = { AyuIslandsSettings.getInstance().state.projectPanelAutoFitMinWidth }
         }
 
     init {

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -29,6 +29,7 @@ class AyuIslandsState : BaseState() {
     var lastLightAppearanceTheme by string("Ayu Light (Islands UI)")
     var trialExpiredNotified by property(false)
     var proDefaultsApplied by property(false)
+    var trialWelcomeShown by property(false)
 
     // Per-element accent toggles (all ON by default)
     var inlayHints by property(true)
@@ -122,6 +123,7 @@ class AyuIslandsState : BaseState() {
     var commitPanelFixedWidth by property(DEFAULT_FIXED_WIDTH)
     var gitPanelWidthMode by string(PanelWidthMode.DEFAULT.name)
     var gitPanelAutoFitMaxWidth by property(DEFAULT_AUTO_FIT_MAX_WIDTH)
+    var gitPanelAutoFitMinWidth by property(DEFAULT_GIT_AUTO_FIT_MIN_WIDTH)
     var gitPanelFixedWidth by property(DEFAULT_FIXED_WIDTH)
 
     // Migration: existing users with hideProjectRootPath=true expect VCS hidden too
@@ -253,6 +255,7 @@ class AyuIslandsState : BaseState() {
     companion object {
         const val DEFAULT_TAB_UNDERLINE_HEIGHT = 4
         const val DEFAULT_AUTO_FIT_MAX_WIDTH = 400
+        const val DEFAULT_GIT_AUTO_FIT_MIN_WIDTH = 200
         const val DEFAULT_FIXED_WIDTH = 300
         private const val DEFAULT_SOFT_INTENSITY = 20
         private const val DEFAULT_SHARP_NEON_INTENSITY = 50

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -118,11 +118,13 @@ class AyuIslandsState : BaseState() {
 
     // Panel width mode (3-state: DEFAULT / AUTO_FIT / FIXED)
     var projectPanelWidthMode by string(PanelWidthMode.DEFAULT.name)
+    var projectPanelAutoFitMinWidth by property(DEFAULT_PROJECT_AUTO_FIT_MIN_WIDTH)
     var projectPanelFixedWidth by property(DEFAULT_FIXED_WIDTH)
     var commitPanelWidthMode by string(PanelWidthMode.DEFAULT.name)
+    var commitPanelAutoFitMinWidth by property(DEFAULT_COMMIT_AUTO_FIT_MIN_WIDTH)
     var commitPanelFixedWidth by property(DEFAULT_FIXED_WIDTH)
     var gitPanelWidthMode by string(PanelWidthMode.DEFAULT.name)
-    var gitPanelAutoFitMaxWidth by property(DEFAULT_AUTO_FIT_MAX_WIDTH)
+    var gitPanelAutoFitMaxWidth by property(DEFAULT_GIT_AUTO_FIT_MAX_WIDTH)
     var gitPanelAutoFitMinWidth by property(DEFAULT_GIT_AUTO_FIT_MIN_WIDTH)
     var gitPanelFixedWidth by property(DEFAULT_FIXED_WIDTH)
 
@@ -255,7 +257,10 @@ class AyuIslandsState : BaseState() {
     companion object {
         const val DEFAULT_TAB_UNDERLINE_HEIGHT = 4
         const val DEFAULT_AUTO_FIT_MAX_WIDTH = 400
-        const val DEFAULT_GIT_AUTO_FIT_MIN_WIDTH = 200
+        const val DEFAULT_PROJECT_AUTO_FIT_MIN_WIDTH = 250
+        const val DEFAULT_COMMIT_AUTO_FIT_MIN_WIDTH = 250
+        const val DEFAULT_GIT_AUTO_FIT_MIN_WIDTH = 400
+        const val DEFAULT_GIT_AUTO_FIT_MAX_WIDTH = 500
         const val DEFAULT_FIXED_WIDTH = 300
         private const val DEFAULT_SOFT_INTENSITY = 20
         private const val DEFAULT_SHARP_NEON_INTENSITY = 50

--- a/src/main/kotlin/dev/ayuislands/settings/PanelWidthState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/PanelWidthState.kt
@@ -2,7 +2,7 @@ package dev.ayuislands.settings
 
 import dev.ayuislands.settings.AyuIslandsState.Companion.DEFAULT_AUTO_FIT_MAX_WIDTH
 import dev.ayuislands.settings.AyuIslandsState.Companion.DEFAULT_FIXED_WIDTH
-import dev.ayuislands.settings.AyuIslandsState.Companion.DEFAULT_GIT_AUTO_FIT_MIN_WIDTH
+import dev.ayuislands.settings.AyuIslandsState.Companion.DEFAULT_PROJECT_AUTO_FIT_MIN_WIDTH
 
 /**
  * Pure state machine for tool window width mode tracking.
@@ -13,8 +13,8 @@ class PanelWidthState {
     var storedMode = PanelWidthMode.DEFAULT
     var pendingAutoFitMaxWidth = DEFAULT_AUTO_FIT_MAX_WIDTH
     var storedAutoFitMaxWidth = DEFAULT_AUTO_FIT_MAX_WIDTH
-    var pendingAutoFitMinWidth = DEFAULT_GIT_AUTO_FIT_MIN_WIDTH
-    var storedAutoFitMinWidth = DEFAULT_GIT_AUTO_FIT_MIN_WIDTH
+    var pendingAutoFitMinWidth = DEFAULT_PROJECT_AUTO_FIT_MIN_WIDTH
+    var storedAutoFitMinWidth = DEFAULT_PROJECT_AUTO_FIT_MIN_WIDTH
     var pendingFixedWidth = DEFAULT_FIXED_WIDTH
     var storedFixedWidth = DEFAULT_FIXED_WIDTH
 
@@ -22,7 +22,7 @@ class PanelWidthState {
         mode: PanelWidthMode,
         autoFitMaxWidth: Int,
         fixedWidth: Int,
-        autoFitMinWidth: Int = DEFAULT_GIT_AUTO_FIT_MIN_WIDTH,
+        autoFitMinWidth: Int = DEFAULT_PROJECT_AUTO_FIT_MIN_WIDTH,
     ) {
         storedMode = mode
         pendingMode = mode
@@ -58,15 +58,9 @@ class PanelWidthState {
         fun widthSummary(state: PanelWidthState): String =
             when (state.pendingMode) {
                 PanelWidthMode.DEFAULT -> "Default"
-                PanelWidthMode.AUTO_FIT -> {
-                    val minPart =
-                        if (state.pendingAutoFitMinWidth != DEFAULT_GIT_AUTO_FIT_MIN_WIDTH) {
-                            "min ${state.pendingAutoFitMinWidth} \u00B7 "
-                        } else {
-                            ""
-                        }
-                    "Auto-fit \u00B7 ${minPart}max ${state.pendingAutoFitMaxWidth}px"
-                }
+                PanelWidthMode.AUTO_FIT ->
+                    "Auto-fit \u00B7 min ${state.pendingAutoFitMinWidth} \u00B7 " +
+                        "max ${state.pendingAutoFitMaxWidth}px"
                 PanelWidthMode.FIXED -> "Fixed \u00B7 ${state.pendingFixedWidth}px"
             }
     }

--- a/src/main/kotlin/dev/ayuislands/settings/PanelWidthState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/PanelWidthState.kt
@@ -6,7 +6,7 @@ import dev.ayuislands.settings.AyuIslandsState.Companion.DEFAULT_GIT_AUTO_FIT_MI
 
 /**
  * Pure state machine for tool window width mode tracking.
- * Extracted from WorkspacePanel for testability — no Swing dependencies.
+ * Extracted from the WorkspacePanel for testability — no Swing dependencies.
  */
 class PanelWidthState {
     var pendingMode = PanelWidthMode.DEFAULT

--- a/src/main/kotlin/dev/ayuislands/settings/PanelWidthState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/PanelWidthState.kt
@@ -2,6 +2,7 @@ package dev.ayuislands.settings
 
 import dev.ayuislands.settings.AyuIslandsState.Companion.DEFAULT_AUTO_FIT_MAX_WIDTH
 import dev.ayuislands.settings.AyuIslandsState.Companion.DEFAULT_FIXED_WIDTH
+import dev.ayuislands.settings.AyuIslandsState.Companion.DEFAULT_GIT_AUTO_FIT_MIN_WIDTH
 
 /**
  * Pure state machine for tool window width mode tracking.
@@ -12,6 +13,8 @@ class PanelWidthState {
     var storedMode = PanelWidthMode.DEFAULT
     var pendingAutoFitMaxWidth = DEFAULT_AUTO_FIT_MAX_WIDTH
     var storedAutoFitMaxWidth = DEFAULT_AUTO_FIT_MAX_WIDTH
+    var pendingAutoFitMinWidth = DEFAULT_GIT_AUTO_FIT_MIN_WIDTH
+    var storedAutoFitMinWidth = DEFAULT_GIT_AUTO_FIT_MIN_WIDTH
     var pendingFixedWidth = DEFAULT_FIXED_WIDTH
     var storedFixedWidth = DEFAULT_FIXED_WIDTH
 
@@ -19,11 +22,14 @@ class PanelWidthState {
         mode: PanelWidthMode,
         autoFitMaxWidth: Int,
         fixedWidth: Int,
+        autoFitMinWidth: Int = DEFAULT_GIT_AUTO_FIT_MIN_WIDTH,
     ) {
         storedMode = mode
         pendingMode = mode
         storedAutoFitMaxWidth = autoFitMaxWidth
         pendingAutoFitMaxWidth = autoFitMaxWidth
+        storedAutoFitMinWidth = autoFitMinWidth
+        pendingAutoFitMinWidth = autoFitMinWidth
         storedFixedWidth = fixedWidth
         pendingFixedWidth = fixedWidth
     }
@@ -31,17 +37,20 @@ class PanelWidthState {
     fun isModified(): Boolean =
         pendingMode != storedMode ||
             pendingAutoFitMaxWidth != storedAutoFitMaxWidth ||
+            pendingAutoFitMinWidth != storedAutoFitMinWidth ||
             pendingFixedWidth != storedFixedWidth
 
     fun commitStored() {
         storedMode = pendingMode
         storedAutoFitMaxWidth = pendingAutoFitMaxWidth
+        storedAutoFitMinWidth = pendingAutoFitMinWidth
         storedFixedWidth = pendingFixedWidth
     }
 
     fun reset() {
         pendingMode = storedMode
         pendingAutoFitMaxWidth = storedAutoFitMaxWidth
+        pendingAutoFitMinWidth = storedAutoFitMinWidth
         pendingFixedWidth = storedFixedWidth
     }
 
@@ -49,7 +58,15 @@ class PanelWidthState {
         fun widthSummary(state: PanelWidthState): String =
             when (state.pendingMode) {
                 PanelWidthMode.DEFAULT -> "Default"
-                PanelWidthMode.AUTO_FIT -> "Auto-fit \u00B7 max ${state.pendingAutoFitMaxWidth}px"
+                PanelWidthMode.AUTO_FIT -> {
+                    val minPart =
+                        if (state.pendingAutoFitMinWidth != DEFAULT_GIT_AUTO_FIT_MIN_WIDTH) {
+                            "min ${state.pendingAutoFitMinWidth} \u00B7 "
+                        } else {
+                            ""
+                        }
+                    "Auto-fit \u00B7 ${minPart}max ${state.pendingAutoFitMaxWidth}px"
+                }
                 PanelWidthMode.FIXED -> "Fixed \u00B7 ${state.pendingFixedWidth}px"
             }
     }

--- a/src/main/kotlin/dev/ayuislands/settings/WorkspacePanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/WorkspacePanel.kt
@@ -26,6 +26,10 @@ import javax.swing.JSpinner
 import javax.swing.SpinnerNumberModel
 import javax.swing.UIManager
 
+private const val PROJECT_VIEW_TITLE = "Project View"
+private const val COMMIT_PANEL_TITLE = "Commit Panel"
+private const val GIT_PANEL_TITLE = "Git Panel"
+
 /** Workspace tab: tool window layout tweaks (Project View, Commit Panel, Git Panel). */
 class WorkspacePanel : AyuIslandsSettingsPanel {
     private var pendingHideRootPath = false
@@ -67,11 +71,13 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
             PanelWidthMode.fromString(state.projectPanelWidthMode),
             state.autoFitMaxWidth,
             state.projectPanelFixedWidth,
+            state.projectPanelAutoFitMinWidth,
         )
         commitWidth.state.load(
             PanelWidthMode.fromString(state.commitPanelWidthMode),
             state.autoFitCommitMaxWidth,
             state.commitPanelFixedWidth,
+            state.commitPanelAutoFitMinWidth,
         )
         gitWidth.state.load(
             PanelWidthMode.fromString(state.gitPanelWidthMode),
@@ -83,7 +89,7 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
         panel.row { comment("Customize tool window width and Project View display options.") }
 
         projectViewGroup =
-            panel.collapsibleGroup("Project View") {
+            panel.collapsibleGroup(PROJECT_VIEW_TITLE) {
                 row {
                     val cb =
                         checkBox("Hide filesystem path")
@@ -120,30 +126,40 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
                 separator()
                 buildWidthModeGroup(
                     this,
-                    WidthModeGroupConfig(projectWidth, AutoFitCalculator.MIN_PROJECT_AUTOFIT_WIDTH, licensed) {
-                        updateGroupTitle(projectViewGroup, "Project View", projectWidth.state)
+                    WidthModeGroupConfig(
+                        projectWidth,
+                        AutoFitCalculator.MIN_PROJECT_AUTOFIT_WIDTH,
+                        licensed,
+                        showMinSpinner = true,
+                    ) {
+                        updateGroupTitle(projectViewGroup, PROJECT_VIEW_TITLE, projectWidth.state)
                     },
                 )
             }
         projectViewGroup?.expanded = state.workspaceProjectViewExpanded
         projectViewGroup?.addExpandedListener { state.workspaceProjectViewExpanded = it }
-        updateGroupTitle(projectViewGroup, "Project View", projectWidth.state)
+        updateGroupTitle(projectViewGroup, PROJECT_VIEW_TITLE, projectWidth.state)
 
         commitPanelGroup =
-            panel.collapsibleGroup("Commit Panel") {
+            panel.collapsibleGroup(COMMIT_PANEL_TITLE) {
                 buildWidthModeGroup(
                     this,
-                    WidthModeGroupConfig(commitWidth, AutoFitCalculator.MIN_COMMIT_AUTOFIT_WIDTH, licensed) {
-                        updateGroupTitle(commitPanelGroup, "Commit Panel", commitWidth.state)
+                    WidthModeGroupConfig(
+                        commitWidth,
+                        AutoFitCalculator.MIN_COMMIT_AUTOFIT_WIDTH,
+                        licensed,
+                        showMinSpinner = true,
+                    ) {
+                        updateGroupTitle(commitPanelGroup, COMMIT_PANEL_TITLE, commitWidth.state)
                     },
                 )
             }
         commitPanelGroup?.expanded = state.workspaceCommitPanelExpanded
         commitPanelGroup?.addExpandedListener { state.workspaceCommitPanelExpanded = it }
-        updateGroupTitle(commitPanelGroup, "Commit Panel", commitWidth.state)
+        updateGroupTitle(commitPanelGroup, COMMIT_PANEL_TITLE, commitWidth.state)
 
         gitPanelGroup =
-            panel.collapsibleGroup("Git Panel") {
+            panel.collapsibleGroup(GIT_PANEL_TITLE) {
                 buildWidthModeGroup(
                     this,
                     WidthModeGroupConfig(
@@ -152,13 +168,13 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
                         licensed,
                         showMinSpinner = true,
                     ) {
-                        updateGroupTitle(gitPanelGroup, "Git Panel", gitWidth.state)
+                        updateGroupTitle(gitPanelGroup, GIT_PANEL_TITLE, gitWidth.state)
                     },
                 )
             }
         gitPanelGroup?.expanded = state.workspaceGitPanelExpanded
         gitPanelGroup?.addExpandedListener { state.workspaceGitPanelExpanded = it }
-        updateGroupTitle(gitPanelGroup, "Git Panel", gitWidth.state)
+        updateGroupTitle(gitPanelGroup, GIT_PANEL_TITLE, gitWidth.state)
     }
 
     private fun updateGroupTitle(
@@ -192,75 +208,24 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
         val onModeChanged: () -> Unit = {},
     )
 
-    private fun buildWidthModeGroup(
-        panel: Panel,
-        config: WidthModeGroupConfig,
-    ) {
-        val uiState = config.uiState
-        val autoFitVisible = uiState.autoFitVisible
-        val fixedVisible = uiState.fixedVisible
-        autoFitVisible.set(uiState.state.pendingMode == PanelWidthMode.AUTO_FIT)
-        fixedVisible.set(uiState.state.pendingMode == PanelWidthMode.FIXED)
-
-        val autoFitSpinner =
-            JSpinner(
-                SpinnerNumberModel(
-                    uiState.state.pendingAutoFitMaxWidth,
-                    config.minAutoFitWidth,
-                    MAX_AUTOFIT_WIDTH,
-                    AUTOFIT_WIDTH_STEP,
-                ),
-            )
-        autoFitSpinner.addChangeListener {
-            if (!suppressListeners) {
-                uiState.state.pendingAutoFitMaxWidth = autoFitSpinner.value as Int
-                config.onModeChanged()
+    private fun createSpinner(
+        value: Int,
+        min: Int,
+        onChange: (Int) -> Unit,
+    ): JSpinner =
+        JSpinner(SpinnerNumberModel(value, min, MAX_AUTOFIT_WIDTH, AUTOFIT_WIDTH_STEP)).also { spinner ->
+            spinner.addChangeListener {
+                if (!suppressListeners) onChange(spinner.value as Int)
             }
         }
-        uiState.autoFitSpinner = autoFitSpinner
 
-        val minSpinner =
-            if (config.showMinSpinner) {
-                JSpinner(
-                    SpinnerNumberModel(
-                        uiState.state.pendingAutoFitMinWidth,
-                        MIN_GIT_MIN_WIDTH,
-                        MAX_AUTOFIT_WIDTH,
-                        AUTOFIT_WIDTH_STEP,
-                    ),
-                ).also { spinner ->
-                    spinner.addChangeListener {
-                        if (!suppressListeners) {
-                            uiState.state.pendingAutoFitMinWidth = spinner.value as Int
-                            config.onModeChanged()
-                        }
-                    }
-                    uiState.minSpinner = spinner
-                }
-            } else {
-                null
-            }
-
-        val fixedSpinner =
-            JSpinner(
-                SpinnerNumberModel(
-                    uiState.state.pendingFixedWidth,
-                    AutoFitCalculator.MIN_FIXED_WIDTH,
-                    MAX_AUTOFIT_WIDTH,
-                    AUTOFIT_WIDTH_STEP,
-                ),
-            )
-        fixedSpinner.addChangeListener {
-            if (!suppressListeners) {
-                uiState.state.pendingFixedWidth = fixedSpinner.value as Int
-                config.onModeChanged()
-            }
-        }
-        uiState.fixedSpinner = fixedSpinner
-
+    private fun createModeComboBox(
+        selectedMode: PanelWidthMode,
+        enabled: Boolean,
+    ): JComboBox<PanelWidthMode> {
         val comboBox = JComboBox(DefaultComboBoxModel(PanelWidthMode.entries.toTypedArray()))
-        comboBox.selectedItem = uiState.state.pendingMode
-        comboBox.isEnabled = config.licensed
+        comboBox.selectedItem = selectedMode
+        comboBox.isEnabled = enabled
         comboBox.renderer =
             object : DefaultListCellRenderer() {
                 override fun getListCellRendererComponent(
@@ -288,6 +253,44 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
                     return label
                 }
             }
+        return comboBox
+    }
+
+    private fun buildWidthModeGroup(
+        panel: Panel,
+        config: WidthModeGroupConfig,
+    ) {
+        val uiState = config.uiState
+        val autoFitVisible = uiState.autoFitVisible
+        val fixedVisible = uiState.fixedVisible
+        autoFitVisible.set(uiState.state.pendingMode == PanelWidthMode.AUTO_FIT)
+        fixedVisible.set(uiState.state.pendingMode == PanelWidthMode.FIXED)
+
+        val autoFitSpinner =
+            createSpinner(uiState.state.pendingAutoFitMaxWidth, config.minAutoFitWidth) {
+                uiState.state.pendingAutoFitMaxWidth = it
+                config.onModeChanged()
+            }
+        uiState.autoFitSpinner = autoFitSpinner
+
+        val minSpinner =
+            if (config.showMinSpinner) {
+                createSpinner(uiState.state.pendingAutoFitMinWidth, MIN_AUTOFIT_MIN_WIDTH) {
+                    uiState.state.pendingAutoFitMinWidth = it
+                    config.onModeChanged()
+                }.also { uiState.minSpinner = it }
+            } else {
+                null
+            }
+
+        val fixedSpinner =
+            createSpinner(uiState.state.pendingFixedWidth, AutoFitCalculator.MIN_FIXED_WIDTH) {
+                uiState.state.pendingFixedWidth = it
+                config.onModeChanged()
+            }
+        uiState.fixedSpinner = fixedSpinner
+
+        val comboBox = createModeComboBox(uiState.state.pendingMode, config.licensed)
         uiState.modeComboBox = comboBox
 
         comboBox.addActionListener {
@@ -342,12 +345,14 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
 
         state.projectPanelWidthMode = projectWidth.state.pendingMode.name
         state.autoFitMaxWidth = projectWidth.state.pendingAutoFitMaxWidth
+        state.projectPanelAutoFitMinWidth = projectWidth.state.pendingAutoFitMinWidth
         state.projectPanelFixedWidth = projectWidth.state.pendingFixedWidth
         state.autoFitProjectPanelWidth = projectWidth.state.pendingMode == PanelWidthMode.AUTO_FIT
         projectWidth.state.commitStored()
 
         state.commitPanelWidthMode = commitWidth.state.pendingMode.name
         state.autoFitCommitMaxWidth = commitWidth.state.pendingAutoFitMaxWidth
+        state.commitPanelAutoFitMinWidth = commitWidth.state.pendingAutoFitMinWidth
         state.commitPanelFixedWidth = commitWidth.state.pendingFixedWidth
         state.autoFitCommitPanelWidth = commitWidth.state.pendingMode == PanelWidthMode.AUTO_FIT
         commitWidth.state.commitStored()
@@ -398,9 +403,9 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
         projectWidth.reset()
         commitWidth.reset()
         gitWidth.reset()
-        updateGroupTitle(projectViewGroup, "Project View", projectWidth.state)
-        updateGroupTitle(commitPanelGroup, "Commit Panel", commitWidth.state)
-        updateGroupTitle(gitPanelGroup, "Git Panel", gitWidth.state)
+        updateGroupTitle(projectViewGroup, PROJECT_VIEW_TITLE, projectWidth.state)
+        updateGroupTitle(commitPanelGroup, COMMIT_PANEL_TITLE, commitWidth.state)
+        updateGroupTitle(gitPanelGroup, GIT_PANEL_TITLE, gitWidth.state)
         suppressListeners = false
     }
 
@@ -428,7 +433,7 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
 
     companion object {
         private const val MAX_AUTOFIT_WIDTH = 800
-        private const val MIN_GIT_MIN_WIDTH = 50
+        private const val MIN_AUTOFIT_MIN_WIDTH = 50
         private const val AUTOFIT_WIDTH_STEP = 50
         private const val FALLBACK_MUTED_RED = 0x6C
         private const val FALLBACK_MUTED_GREEN = 0x73

--- a/src/main/kotlin/dev/ayuislands/settings/WorkspacePanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/WorkspacePanel.kt
@@ -269,6 +269,11 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
         val autoFitSpinner =
             createSpinner(uiState.state.pendingAutoFitMaxWidth, config.minAutoFitWidth) {
                 uiState.state.pendingAutoFitMaxWidth = it
+                val currentMin = uiState.minSpinner
+                if (currentMin != null && it < uiState.state.pendingAutoFitMinWidth) {
+                    uiState.state.pendingAutoFitMinWidth = it
+                    currentMin.value = it
+                }
                 config.onModeChanged()
             }
         uiState.autoFitSpinner = autoFitSpinner
@@ -277,6 +282,10 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
             if (config.showMinSpinner) {
                 createSpinner(uiState.state.pendingAutoFitMinWidth, MIN_AUTOFIT_MIN_WIDTH) {
                     uiState.state.pendingAutoFitMinWidth = it
+                    if (it > uiState.state.pendingAutoFitMaxWidth) {
+                        uiState.state.pendingAutoFitMaxWidth = it
+                        autoFitSpinner.value = it
+                    }
                     config.onModeChanged()
                 }.also { uiState.minSpinner = it }
             } else {

--- a/src/main/kotlin/dev/ayuislands/settings/WorkspacePanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/WorkspacePanel.kt
@@ -77,6 +77,7 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
             PanelWidthMode.fromString(state.gitPanelWidthMode),
             state.gitPanelAutoFitMaxWidth,
             state.gitPanelFixedWidth,
+            state.gitPanelAutoFitMinWidth,
         )
 
         panel.row { comment("Customize tool window width and Project View display options.") }
@@ -117,9 +118,12 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
                     hideHScrollbarCheckbox = cb.component
                 }
                 separator()
-                buildWidthModeGroup(this, projectWidth, AutoFitCalculator.MIN_PROJECT_AUTOFIT_WIDTH, licensed) {
-                    updateGroupTitle(projectViewGroup, "Project View", projectWidth.state)
-                }
+                buildWidthModeGroup(
+                    this,
+                    WidthModeGroupConfig(projectWidth, AutoFitCalculator.MIN_PROJECT_AUTOFIT_WIDTH, licensed) {
+                        updateGroupTitle(projectViewGroup, "Project View", projectWidth.state)
+                    },
+                )
             }
         projectViewGroup?.expanded = state.workspaceProjectViewExpanded
         projectViewGroup?.addExpandedListener { state.workspaceProjectViewExpanded = it }
@@ -127,9 +131,12 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
 
         commitPanelGroup =
             panel.collapsibleGroup("Commit Panel") {
-                buildWidthModeGroup(this, commitWidth, AutoFitCalculator.MIN_COMMIT_AUTOFIT_WIDTH, licensed) {
-                    updateGroupTitle(commitPanelGroup, "Commit Panel", commitWidth.state)
-                }
+                buildWidthModeGroup(
+                    this,
+                    WidthModeGroupConfig(commitWidth, AutoFitCalculator.MIN_COMMIT_AUTOFIT_WIDTH, licensed) {
+                        updateGroupTitle(commitPanelGroup, "Commit Panel", commitWidth.state)
+                    },
+                )
             }
         commitPanelGroup?.expanded = state.workspaceCommitPanelExpanded
         commitPanelGroup?.addExpandedListener { state.workspaceCommitPanelExpanded = it }
@@ -137,9 +144,17 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
 
         gitPanelGroup =
             panel.collapsibleGroup("Git Panel") {
-                buildWidthModeGroup(this, gitWidth, AutoFitCalculator.MIN_GIT_AUTOFIT_WIDTH, licensed) {
-                    updateGroupTitle(gitPanelGroup, "Git Panel", gitWidth.state)
-                }
+                buildWidthModeGroup(
+                    this,
+                    WidthModeGroupConfig(
+                        gitWidth,
+                        AutoFitCalculator.MIN_GIT_AUTOFIT_WIDTH,
+                        licensed,
+                        showMinSpinner = true,
+                    ) {
+                        updateGroupTitle(gitPanelGroup, "Git Panel", gitWidth.state)
+                    },
+                )
             }
         gitPanelGroup?.expanded = state.workspaceGitPanelExpanded
         gitPanelGroup?.addExpandedListener { state.workspaceGitPanelExpanded = it }
@@ -169,13 +184,19 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
         )
     }
 
+    private data class WidthModeGroupConfig(
+        val uiState: WidthModeUiState,
+        val minAutoFitWidth: Int,
+        val licensed: Boolean,
+        val showMinSpinner: Boolean = false,
+        val onModeChanged: () -> Unit = {},
+    )
+
     private fun buildWidthModeGroup(
         panel: Panel,
-        uiState: WidthModeUiState,
-        minAutoFitWidth: Int,
-        licensed: Boolean,
-        onModeChanged: () -> Unit = {},
+        config: WidthModeGroupConfig,
     ) {
+        val uiState = config.uiState
         val autoFitVisible = uiState.autoFitVisible
         val fixedVisible = uiState.fixedVisible
         autoFitVisible.set(uiState.state.pendingMode == PanelWidthMode.AUTO_FIT)
@@ -185,7 +206,7 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
             JSpinner(
                 SpinnerNumberModel(
                     uiState.state.pendingAutoFitMaxWidth,
-                    minAutoFitWidth,
+                    config.minAutoFitWidth,
                     MAX_AUTOFIT_WIDTH,
                     AUTOFIT_WIDTH_STEP,
                 ),
@@ -193,10 +214,32 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
         autoFitSpinner.addChangeListener {
             if (!suppressListeners) {
                 uiState.state.pendingAutoFitMaxWidth = autoFitSpinner.value as Int
-                onModeChanged()
+                config.onModeChanged()
             }
         }
         uiState.autoFitSpinner = autoFitSpinner
+
+        val minSpinner =
+            if (config.showMinSpinner) {
+                JSpinner(
+                    SpinnerNumberModel(
+                        uiState.state.pendingAutoFitMinWidth,
+                        MIN_GIT_MIN_WIDTH,
+                        MAX_AUTOFIT_WIDTH,
+                        AUTOFIT_WIDTH_STEP,
+                    ),
+                ).also { spinner ->
+                    spinner.addChangeListener {
+                        if (!suppressListeners) {
+                            uiState.state.pendingAutoFitMinWidth = spinner.value as Int
+                            config.onModeChanged()
+                        }
+                    }
+                    uiState.minSpinner = spinner
+                }
+            } else {
+                null
+            }
 
         val fixedSpinner =
             JSpinner(
@@ -210,14 +253,14 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
         fixedSpinner.addChangeListener {
             if (!suppressListeners) {
                 uiState.state.pendingFixedWidth = fixedSpinner.value as Int
-                onModeChanged()
+                config.onModeChanged()
             }
         }
         uiState.fixedSpinner = fixedSpinner
 
         val comboBox = JComboBox(DefaultComboBoxModel(PanelWidthMode.entries.toTypedArray()))
         comboBox.selectedItem = uiState.state.pendingMode
-        comboBox.isEnabled = licensed
+        comboBox.isEnabled = config.licensed
         comboBox.renderer =
             object : DefaultListCellRenderer() {
                 override fun getListCellRendererComponent(
@@ -252,12 +295,16 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
                 uiState.state.pendingMode = comboBox.selectedItem as PanelWidthMode
                 autoFitVisible.set(uiState.state.pendingMode == PanelWidthMode.AUTO_FIT)
                 fixedVisible.set(uiState.state.pendingMode == PanelWidthMode.FIXED)
-                onModeChanged()
+                config.onModeChanged()
             }
         }
 
         panel.row {
             cell(comboBox)
+            if (minSpinner != null) {
+                label("min").visibleIf(autoFitVisible)
+                cell(minSpinner).visibleIf(autoFitVisible)
+            }
             label("max").visibleIf(autoFitVisible)
             cell(autoFitSpinner).visibleIf(autoFitVisible)
             label("px").visibleIf(autoFitVisible)
@@ -307,6 +354,7 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
 
         state.gitPanelWidthMode = gitWidth.state.pendingMode.name
         state.gitPanelAutoFitMaxWidth = gitWidth.state.pendingAutoFitMaxWidth
+        state.gitPanelAutoFitMinWidth = gitWidth.state.pendingAutoFitMinWidth
         state.gitPanelFixedWidth = gitWidth.state.pendingFixedWidth
         gitWidth.state.commitStored()
 
@@ -364,12 +412,14 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
 
         var modeComboBox: JComboBox<PanelWidthMode>? = null
         var autoFitSpinner: JSpinner? = null
+        var minSpinner: JSpinner? = null
         var fixedSpinner: JSpinner? = null
 
         fun reset() {
             state.reset()
             modeComboBox?.selectedItem = state.storedMode
             autoFitSpinner?.value = state.storedAutoFitMaxWidth
+            minSpinner?.value = state.storedAutoFitMinWidth
             fixedSpinner?.value = state.storedFixedWidth
             autoFitVisible.set(state.storedMode == PanelWidthMode.AUTO_FIT)
             fixedVisible.set(state.storedMode == PanelWidthMode.FIXED)
@@ -378,6 +428,7 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
 
     companion object {
         private const val MAX_AUTOFIT_WIDTH = 800
+        private const val MIN_GIT_MIN_WIDTH = 50
         private const val AUTOFIT_WIDTH_STEP = 50
         private const val FALLBACK_MUTED_RED = 0x6C
         private const val FALLBACK_MUTED_GREEN = 0x73

--- a/src/main/kotlin/dev/ayuislands/toolwindow/AutoFitCalculator.kt
+++ b/src/main/kotlin/dev/ayuislands/toolwindow/AutoFitCalculator.kt
@@ -41,4 +41,26 @@ object AutoFitCalculator {
         }
         return null
     }
+
+    fun findAllOfType(
+        component: Component,
+        type: Class<*>,
+    ): List<Component> {
+        val results = mutableListOf<Component>()
+        collectOfType(component, type, results)
+        return results
+    }
+
+    private fun collectOfType(
+        component: Component,
+        type: Class<*>,
+        results: MutableList<Component>,
+    ) {
+        if (type.isInstance(component)) results.add(component)
+        if (component is Container) {
+            for (child in component.components) {
+                collectOfType(child, type, results)
+            }
+        }
+    }
 }

--- a/src/main/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitter.kt
+++ b/src/main/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitter.kt
@@ -30,6 +30,9 @@ class ToolWindowAutoFitter(
     /** Lambda to get the current max width from settings (called at fit time, not init time). */
     var maxWidthProvider: () -> Int = { DEFAULT_MAX_WIDTH }
 
+    /** Lambda to get the current min width from settings (called at fit time, not init time). */
+    var minWidthProvider: () -> Int = { minWidth }
+
     fun applyAutoFitWidth(maxWidth: Int) {
         val tree = findTree() ?: return
         val toolWindow =
@@ -47,7 +50,7 @@ class ToolWindowAutoFitter(
             }
         }
 
-        val desiredWidth = AutoFitCalculator.calculateDesiredWidth(maxRowWidth, maxWidth, minWidth)
+        val desiredWidth = AutoFitCalculator.calculateDesiredWidth(maxRowWidth, maxWidth, minWidthProvider())
         applyWidth(toolWindow, desiredWidth)
     }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -11,7 +11,7 @@
 
     <p>Warm, refined palettes purpose-built for Islands UI with deep IDE integration.
     Not just a color port — a unified aesthetic system.
-    Free to install — 30-day premium trial included.</p>
+    Free to install — all premium features unlocked for 30 days, no credit card.</p>
 
     <h3>What makes this different</h3>
     <ul>
@@ -36,9 +36,6 @@
       <li><b>VCS/diff colors</b> hand-matched to the palette, 16-color terminal scheme</li>
     </ul>
 
-    <p>Every premium feature is unlocked free for 30 days — no credit card,
-    no time-limited nag screens. Use it, decide later.</p>
-
     <h3>Premium — make the IDE feel yours</h3>
 
     <p><b>Try everything free for 30 days.</b> No credit card. Install, explore, decide later.</p>
@@ -49,7 +46,10 @@
     Control intensity, width, and exactly which panels glow.</p>
 
     <p><b>Workspace</b> — take control of your tool window layout.
-    Auto-fit or set a fixed width for Project View, Commit, and Git panels.
+    Auto-fit or set a fixed width for Project View, Commit, and Git panels —
+    each with configurable min and max bounds.
+    The Git panel goes deeper: auto-resize the branches tree and file changes
+    tree independently.
     Hide the filesystem path, VCS annotations, and horizontal scrollbar
     from the Project View. Three panels, one settings tab, zero wasted space.</p>
 
@@ -64,7 +64,7 @@
 
     <p><b>Plugin sync</b> — your accent color follows you into CodeGlance Pro
     (minimap viewport) and Indent Rainbow (indent guides with 3 Ayu presets).
-    One palette, everywhere. More integrations in active development.</p>
+    One palette, everywhere.</p>
 
     <p><b>Bracket scope</b> — when your cursor lands on a bracket,
     a colored stripe appears in the gutter showing the full scope at a glance.</p>
@@ -73,10 +73,11 @@
     <change-notes><![CDATA[
     <h3>2.3.0</h3>
     <ul>
-      <li>[Paid] Auto-fit Project panel width — the panel automatically resizes to fit the longest visible filename</li>
+      <li>[Paid] Auto-fit with configurable min/max width for Project View, Commit, and Git panels</li>
+      <li>[Paid] Git panel internal splitter control — auto-resize branches tree and file changes tree</li>
       <li>[Paid] Project View tweaks now require a license (hide path, VCS annotations, scrollbar)</li>
-      <li>[Free] 30-day premium trial — every premium feature unlocked on the first install, no credit card</li>
-      <li>[Free] Improved Marketplace description with clearer premium feature explanations</li>
+      <li>[Free] 30-day premium trial — every premium feature unlocked on first install, no credit card</li>
+      <li>[Free] Returning users get a fresh trial with premium defaults re-applied</li>
     </ul>
     <h3>2.2.2</h3>
     <ul>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -10,7 +10,8 @@
     <p><i>Ayu meets Islands UI — warmth meets beauty in every JetBrains IDE.</i></p>
 
     <p>Warm, refined palettes purpose-built for Islands UI with deep IDE integration.
-    Not just a color port — a unified aesthetic system.</p>
+    Not just a color port — a unified aesthetic system.
+    Free to install — 30-day premium trial included.</p>
 
     <h3>What makes this different</h3>
     <ul>
@@ -21,25 +22,36 @@
           Monaspace Xenon with one-click apply, live preview, and brew install</li>
       <li><b>6 theme variants</b> — Mirage, Dark, Light in Classic UI and Islands UI</li>
       <li><b>Hundreds of UI properties</b> hand-tuned per variant</li>
-      <li><b>40+ language syntaxes</b> individually crafted</li>
+      <li><b>40+ language syntaxes</b> — individually crafted per language:
+          Kotlin, Rust, Go, Python, TypeScript, C#, HCL, and more</li>
       <li>Built on <a href="https://github.com/ayu-theme/ayu-colors">ayu-colors</a>
           (MIT) — endorsed by the original author</li>
     </ul>
 
     <h3>Free — a complete theme, not a teaser</h3>
     <ul>
-      <li>All 6 themes with full syntax highlighting</li>
-      <li>12 accent color presets + custom color picker + macOS system accent sync</li>
-      <li>Font presets with size, weight, spacing, and ligature customization</li>
-      <li>VCS/diff integration with 16-color terminal palette</li>
+      <li><b>6 themes</b> — Mirage, Dark, Light in Classic and Islands UI with full syntax highlighting</li>
+      <li><b>12 accent presets</b> + custom color picker + macOS system accent sync</li>
+      <li><b>4 font presets</b> — Whisper, Ambient, Neon, Cyberpunk with one-click apply and per-preset customization</li>
+      <li><b>VCS/diff colors</b> hand-matched to the palette, 16-color terminal scheme</li>
     </ul>
 
+    <p>Every premium feature is unlocked free for 30 days — no credit card,
+    no time-limited nag screens. Use it, decide later.</p>
+
     <h3>Premium — make the IDE feel yours</h3>
+
+    <p><b>Try everything free for 30 days.</b> No credit card. Install, explore, decide later.</p>
 
     <p><b>Glow</b> — a soft light beneath active tabs and editor panels,
     like a backlit desk in a dark room. Pick from Soft, Sharp Neon, or Gradient styles.
     Add animation — Pulse, Breathe, or Reactive — or keep it still.
     Control intensity, width, and exactly which panels glow.</p>
+
+    <p><b>Workspace</b> — take control of your tool window layout.
+    Auto-fit or set a fixed width for Project View, Commit, and Git panels.
+    Hide the filesystem path, VCS annotations, and horizontal scrollbar
+    from the Project View. Three panels, one settings tab, zero wasted space.</p>
 
     <p><b>Accent control</b> — your accent color, your rules.
     Decide exactly where it appears: scrollbars, links, the caret line,
@@ -50,29 +62,26 @@
     a subtle underline, a full accent bar, or nothing at all.
     In Classic UI, set the underline thickness from hairline to bold.</p>
 
-    <p><b>Bracket scope</b> — when your cursor lands on a bracket,
-    a colored stripe appears in the gutter showing the full scope at a glance.</p>
-
-    <p><b>Project View</b> — declutter the project panel: hide the filesystem path,
-    VCS annotations, horizontal scrollbar, or let auto-fit resize the panel
-    to match your longest filename. Small tweaks, big difference.</p>
-
     <p><b>Plugin sync</b> — your accent color follows you into CodeGlance Pro
     (minimap viewport) and Indent Rainbow (indent guides with 3 Ayu presets).
     One palette, everywhere. More integrations in active development.</p>
+
+    <p><b>Bracket scope</b> — when your cursor lands on a bracket,
+    a colored stripe appears in the gutter showing the full scope at a glance.</p>
   ]]></description>
 
     <change-notes><![CDATA[
     <h3>2.3.0</h3>
     <ul>
-      <li>[Paid] Auto-fit Project panel width — panel automatically resizes to fit the longest visible filename</li>
+      <li>[Paid] Auto-fit Project panel width — the panel automatically resizes to fit the longest visible filename</li>
       <li>[Paid] Project View tweaks now require a license (hide path, VCS annotations, scrollbar)</li>
+      <li>[Free] 30-day premium trial — every premium feature unlocked on the first install, no credit card</li>
       <li>[Free] Improved Marketplace description with clearer premium feature explanations</li>
     </ul>
     <h3>2.2.2</h3>
     <ul>
-      <li>[Free] Fix diff/merge viewer using wrong default colors instead of theme palette</li>
-      <li>[Free] Fix black toolbar in merge conflict gutter on light themes</li>
+      <li>[Free] Fix diff/merge viewer using wrong default colors instead of the theme palette</li>
+      <li>[Free] Fix the black toolbar in the merge conflict gutter on light themes</li>
       <li>[Free] Improve diff modified-line background visibility across all variants</li>
     </ul>
     <h3>2.2.1</h3>
@@ -164,8 +173,8 @@
 
     <product-descriptor
             code="PAYUISLANDS"
-            release-date="20260311"
-            release-version="22"
+            release-date="20260318"
+            release-version="23"
             optional="true"/>
 
     <extensionPoints>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -76,7 +76,7 @@
       <li>[Paid] Auto-fit with configurable min/max width for Project View, Commit, and Git panels</li>
       <li>[Paid] Git panel internal splitter control — auto-resize branches tree and file changes tree</li>
       <li>[Paid] Project View tweaks now require a license (hide path, VCS annotations, scrollbar)</li>
-      <li>[Free] 30-day premium trial — every premium feature unlocked on first install, no credit card</li>
+      <li>[Free] 30-day premium trial — every premium feature unlocked on the first install, no credit card</li>
       <li>[Free] Returning users get a fresh trial with premium defaults re-applied</li>
     </ul>
     <h3>2.2.2</h3>

--- a/src/test/kotlin/dev/ayuislands/settings/PanelWidthStateTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/PanelWidthStateTest.kt
@@ -21,15 +21,25 @@ class PanelWidthStateTest {
 
     @Test
     fun `load sets both pending and stored`() {
-        state.load(PanelWidthMode.AUTO_FIT, 500, 300)
+        state.load(PanelWidthMode.AUTO_FIT, 500, 300, 200)
 
         assertEquals(PanelWidthMode.AUTO_FIT, state.pendingMode)
         assertEquals(PanelWidthMode.AUTO_FIT, state.storedMode)
         assertEquals(500, state.pendingAutoFitMaxWidth)
         assertEquals(500, state.storedAutoFitMaxWidth)
+        assertEquals(200, state.pendingAutoFitMinWidth)
+        assertEquals(200, state.storedAutoFitMinWidth)
         assertEquals(300, state.pendingFixedWidth)
         assertEquals(300, state.storedFixedWidth)
         assertFalse(state.isModified())
+    }
+
+    @Test
+    fun `changing pending min width marks as modified`() {
+        state.load(PanelWidthMode.AUTO_FIT, 400, 200, 250)
+        state.pendingAutoFitMinWidth = 300
+
+        assertTrue(state.isModified())
     }
 
     @Test
@@ -94,11 +104,12 @@ class PanelWidthStateTest {
     }
 
     @Test
-    fun `widthSummary formats auto-fit mode with max width`() {
+    fun `widthSummary formats auto-fit mode with min and max width`() {
         state.pendingMode = PanelWidthMode.AUTO_FIT
+        state.pendingAutoFitMinWidth = 250
         state.pendingAutoFitMaxWidth = 500
 
-        assertEquals("Auto-fit \u00B7 max 500px", PanelWidthState.widthSummary(state))
+        assertEquals("Auto-fit \u00B7 min 250 \u00B7 max 500px", PanelWidthState.widthSummary(state))
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/toolwindow/AutoFitCalculatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/toolwindow/AutoFitCalculatorTest.kt
@@ -5,6 +5,7 @@ import javax.swing.JLabel
 import javax.swing.JPanel
 import javax.swing.JTree
 import kotlin.test.Test
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
@@ -134,5 +135,38 @@ class AutoFitCalculatorTest {
 
         val result = AutoFitCalculator.findFirstOfType(panel, JLabel::class.java)
         assertEquals(first, result)
+    }
+
+    @Test
+    fun `findAllOfType returns all matching components`() {
+        val label1 = JLabel("a")
+        val label2 = JLabel("b")
+        val inner = JPanel(FlowLayout())
+        inner.add(label2)
+        val outer = JPanel(FlowLayout())
+        outer.add(label1)
+        outer.add(inner)
+
+        val results = AutoFitCalculator.findAllOfType(outer, JLabel::class.java)
+        assertEquals(2, results.size)
+        assertContains(results, label1)
+        assertContains(results, label2)
+    }
+
+    @Test
+    fun `findAllOfType returns empty list when no matches`() {
+        val panel = JPanel(FlowLayout())
+        panel.add(JLabel("only label"))
+
+        val results = AutoFitCalculator.findAllOfType(panel, JTree::class.java)
+        assertTrue(results.isEmpty())
+    }
+
+    @Test
+    fun `findAllOfType includes root component if it matches`() {
+        val tree = JTree()
+        val results = AutoFitCalculator.findAllOfType(tree, JTree::class.java)
+        assertEquals(1, results.size)
+        assertEquals(tree, results.first())
     }
 }


### PR DESCRIPTION
── Summary ─────────────────────────────────

Git panel auto-fit was broken — `stretchWidth()` is a no-op for bottom-docked tool windows. This PR rewrites `GitPanelAutoFitManager` to manipulate internal `Splitter` proportions directly, adds configurable min/max width controls for all three workspace panels, and implements trial re-activation so returning users get fresh premium defaults.

**Context**: v2.3.0 release — workspace controls + 30-day trial

── Changes ─────────────────────────────────

| Type | File | Description |
|------|------|-------------|
| Feat | `gitpanel/GitPanelAutoFitManager.kt` | Rewrite: splitter proportions instead of stretchWidth for branches + file changes trees |
| Feat | `toolwindow/AutoFitCalculator.kt` | Add `findAllOfType` recursive component search utility |
| Feat | `toolwindow/ToolWindowAutoFitter.kt:34` | Add `minWidthProvider` lambda for dynamic min width |
| Feat | `settings/AyuIslandsState.kt` | Add min width fields for Project, Commit, Git panels + Git-specific defaults (min=400, max=500) |
| Feat | `settings/PanelWidthState.kt` | Track `pendingAutoFitMinWidth` / `storedAutoFitMinWidth` |
| Feat | `settings/WorkspacePanel.kt` | Min spinner for all panels (Auto-fit only), refactor to `WidthModeGroupConfig` + `createSpinner`/`createModeComboBox` helpers |
| Feat | `licensing/LicenseChecker.kt` | Set glow defaults (Sharp Neon, Breathe), polish notification copy |
| Feat | `AyuIslandsStartupActivity.kt:115` | Trial re-activation: reset `proDefaultsApplied` + `trialWelcomeShown` on license recovery |
| Refactor | `UpdateNotifier.kt` | Inline changelog as HTML bullets, remove browser redirect |
| Chore | `commitpanel/CommitPanelAutoFitManager.kt:25` | Wire `minWidthProvider` from state |
| Chore | `projectview/ProjectViewScrollbarManager.kt:40` | Wire `minWidthProvider` from state |
| Docs | `plugin.xml` | Update description (workspace + trial), v2.3.0 changelog |
| Chore | `gradle.properties` | Version bump to 2.3.0 |

── Validation ──────────────────────────────

```bash
./gradlew test koverVerify buildPlugin
# All pass, coverage ≥80%, ZIP produced

./gradlew verifyPlugin
# Check deprecated-usages.txt + experimental-api-usages.txt
```

Manual:
- Open Git tool window → Log tab → verify branches + file changes trees auto-resize
- Settings → Ayu Islands → Workspace → all 3 panels show min/max spinners in Auto-fit mode
- Install fresh → verify "Ayu Islands Premium is unlocked" notification appears
- Update notification shows inline changelog (no browser redirect)

── Notes ───────────────────────────────────

- Tool window ID is `"Version Control"` (not `"Git"`) in IntelliJ 2025.3
- Git panel uses `com.intellij.openapi.ui.Splitter` (not `com.intellij.ui.Splitter`)
- Splitters with `secondComponent=null` are skipped (lazy-loaded details panel)
- Trial re-activation only fires when `trialExpiredNotified=true` — paid users unaffected

## Summary by Sourcery

Implement configurable auto-fit behavior for workspace panels and enhance licensing behavior around premium trials and defaults.

New Features:
- Add min/max auto-fit width controls for Project View, Commit, and Git panels, including Git-specific defaults.
- Rework Git panel sizing to control internal splitter proportions so branches and file changes trees auto-resize correctly.
- Introduce recursive UI component search utilities to support splitter and tree detection.
- Enable one-time welcome notifications and glow defaults when premium trial or license activates, including re-activation of trials for returning users.

Bug Fixes:
- Restore functional auto-fit behavior for the Git panel when docked at the bottom by avoiding stretchWidth no-ops.

Enhancements:
- Refine workspace settings UI with reusable helpers and titles while surfacing a minimum width spinner in auto-fit mode.
- Improve glow feature defaults to use Sharp Neon with Breathe animation for new premium activations.
- Inline update changelog content into notifications instead of redirecting to the marketplace, and add 2.3.0 release notes.

Build:
- Bump plugin version to 2.3.0 and update product descriptor metadata.

Documentation:
- Update plugin description and changelog to highlight workspace controls and the 30-day premium trial.

Chores:
- Wire new minimum auto-fit width settings through existing auto-fit managers for the Commit and Project panels.