### PR TITLE
chore: set release-date to 20260319 for v2.3.0

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -174,7 +174,7 @@
 
     <product-descriptor
             code="PAYUISLANDS"
-            release-date="20260318"
+            release-date="20260319"
             release-version="23"
             optional="true"/>
 


### PR DESCRIPTION
## Summary
- Update `release-date` from `20260318` to `20260319` to match actual release day

## Context
Pre-release audit for v2.3.0. All verification passed:
- `buildPlugin` + `verifyPlugin` (11 IDEs) — PASS
- `test` + `koverVerify` (≥80%) — PASS
- 1 deprecated API (`ActionUtil.invokeAction`) — replacement only available in 2025.2+, cannot fix with `sinceBuild=251`
- Issue #51 — pre-existing (v2.2.2), deferred to 2.3.1

## After merge
Tag `v2.3.0` on main → `release.yml` publishes automatically

## Summary by Sourcery

Chores:
- Adjust the plugin.xml product descriptor release-date from 20260318 to 20260319 to match the actual release day.