### PR TITLE
fix: pre-release bugs for v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 - [Paid] Auto-fit with configurable min/max width for Project View, Commit, and Git panels
-- [Paid] Git panel internal splitter control — auto-resize branches tree and file changes tree
+- [Paid] Git panel internal splitter control — auto-resizes the branches tree and file changes tree
 - [Free] 30-day premium trial — every premium feature unlocked on the first install, no credit card
 - [Free] Returning users get a fresh trial with premium defaults re-applied
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,22 @@
 # Changelog
 
+## [2.3.0] - 2026-03-19
+
+### Added
+- [Paid] Auto-fit with configurable min/max width for Project View, Commit, and Git panels
+- [Paid] Git panel internal splitter control — auto-resize branches tree and file changes tree
+- [Free] 30-day premium trial — every premium feature unlocked on the first install, no credit card
+- [Free] Returning users get a fresh trial with premium defaults re-applied
+
+### Changed
+- [Paid] Project View cleanup — hide filesystem path and horizontal scrollbar
+
 ## [2.2.2] - 2026-03-14
 
 ### Fixed
 
 - [Free] Fix diff/merge viewer using wrong default colors instead of theme palette
-- [Free] Fix black toolbar in merge conflict gutter on light themes
+- [Free] Fix black toolbar in the merge conflict gutter on light themes
 - [Free] Improve diff modified-line background visibility across all variants
 
 ## [2.2.1] - 2026-03-11

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -123,6 +123,13 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
                 LicenseChecker.enableProDefaults()
                 LOG.info("Ayu Islands Pro defaults enabled (first-time license activation)")
 
+                // Initialize services that depend on pro defaults (auto-fit, project view, glow).
+                // These were skipped during early init because state was still at free defaults.
+                ProjectViewScrollbarManager.getInstance(project).apply()
+                CommitPanelAutoFitManager.getInstance(project).apply()
+                GitPanelAutoFitManager.getInstance(project).apply()
+                GlowOverlayManager.getInstance(project).initialize()
+
                 if (!settings.state.trialWelcomeShown) {
                     LicenseChecker.notifyTrialWelcome(project)
                     settings.state.trialWelcomeShown = true

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -50,7 +50,7 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
             LOG.info("Ayu Islands detected third-party plugins: ${conflicts.joinToString { it.pluginDisplayName }}")
         }
 
-        // Check license state
+        // Check license state and initialize workspace services (inside EDT callback)
         checkLicenseState(project, variant, settings)
 
         // Auto-switch theme to match macOS Light/Dark mode
@@ -60,29 +60,6 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
 
         // Show a one-time update notification if the plugin version changed
         SwingUtilities.invokeLater { UpdateNotifier.showIfUpdated(project) }
-
-        // Migrate old boolean auto-fit fields to the new PanelWidthMode enum
-        settings.state.migrateWidthModes()
-
-        // Eagerly initialize Project View customizer — its init block subscribes
-        // to ToolWindowManagerListener, which will apply() when the tree is ready.
-        val pvState = settings.state
-        val hasProjectViewCustomizations =
-            pvState.hideProjectViewHScrollbar ||
-                pvState.hideProjectRootPath
-        if (hasProjectViewCustomizations ||
-            PanelWidthMode.fromString(pvState.projectPanelWidthMode) != PanelWidthMode.DEFAULT
-        ) {
-            ProjectViewScrollbarManager.getInstance(project)
-        }
-
-        if (PanelWidthMode.fromString(pvState.commitPanelWidthMode) != PanelWidthMode.DEFAULT) {
-            CommitPanelAutoFitManager.getInstance(project)
-        }
-
-        if (PanelWidthMode.fromString(pvState.gitPanelWidthMode) != PanelWidthMode.DEFAULT) {
-            GitPanelAutoFitManager.getInstance(project)
-        }
 
         // Initialize the glow overlay system if the glow is enabled
         // Uses ApplicationManager.invokeLater with project.disposed condition to skip
@@ -109,6 +86,12 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
             } else {
                 applyUnlicensedDefaults(project, variant, settings)
             }
+
+            // Migrate width modes before service init reads them
+            settings.state.migrateWidthModes()
+
+            // Initialize workspace services after defaults are applied (no race)
+            initWorkspaceServices(project, settings)
         }
     }
 
@@ -137,10 +120,6 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
             LicenseChecker.applyWorkspaceDefaults()
             LOG.info("Ayu Islands workspace defaults migrated for existing user")
         }
-
-        // Workspace services (ProjectView, Commit, Git panels) are initialized
-        // via eager service creation + ToolWindowManagerListener in execute() above.
-        // ProjectViewState API is persistent — no deferred re-apply needed.
     }
 
     private fun applyUnlicensedDefaults(
@@ -154,6 +133,30 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
         if (!settings.state.trialExpiredNotified) {
             LicenseChecker.notifyTrialExpired(project)
             settings.state.trialExpiredNotified = true
+        }
+    }
+
+    private fun initWorkspaceServices(
+        project: Project,
+        settings: AyuIslandsSettings,
+    ) {
+        if (project.isDisposed) return
+        val pvState = settings.state
+        val hasProjectViewCustomizations =
+            pvState.hideProjectViewHScrollbar ||
+                pvState.hideProjectRootPath
+        if (hasProjectViewCustomizations ||
+            PanelWidthMode.fromString(pvState.projectPanelWidthMode) != PanelWidthMode.DEFAULT
+        ) {
+            ProjectViewScrollbarManager.getInstance(project)
+        }
+
+        if (PanelWidthMode.fromString(pvState.commitPanelWidthMode) != PanelWidthMode.DEFAULT) {
+            CommitPanelAutoFitManager.getInstance(project)
+        }
+
+        if (PanelWidthMode.fromString(pvState.gitPanelWidthMode) != PanelWidthMode.DEFAULT) {
+            GitPanelAutoFitManager.getInstance(project)
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -112,14 +112,14 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
 
         SwingUtilities.invokeLater {
             // Reset flags if the license becomes valid again (user purchased or new eval period)
-            if (licenseState == true && settings.state.trialExpiredNotified) {
+            if (licenseState != false && settings.state.trialExpiredNotified) {
                 settings.state.trialExpiredNotified = false
                 settings.state.proDefaultsApplied = false
                 settings.state.trialWelcomeShown = false
             }
 
             // One-time: enable all Pro features when the license first activates
-            if (licenseState == true && !settings.state.proDefaultsApplied) {
+            if (licenseState != false && !settings.state.proDefaultsApplied) {
                 LicenseChecker.enableProDefaults()
                 LOG.info("Ayu Islands Pro defaults enabled (first-time license activation)")
 

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -123,8 +123,8 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
                 LicenseChecker.enableProDefaults()
                 LOG.info("Ayu Islands Pro defaults enabled (first-time license activation)")
 
-                // Initialize services that depend on pro defaults (auto-fit, project view, glow).
-                // These were skipped during early init because state was still at free defaults.
+                // Initialize services that depend on pro-defaults (auto-fit, project view, glow).
+                // These were skipped during early init because the state was still at free defaults.
                 ProjectViewScrollbarManager.getInstance(project).apply()
                 CommitPanelAutoFitManager.getInstance(project).apply()
                 GitPanelAutoFitManager.getInstance(project).apply()
@@ -134,6 +134,15 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
                     LicenseChecker.notifyTrialWelcome(project)
                     settings.state.trialWelcomeShown = true
                 }
+            }
+
+            // Migration: apply workspace defaults for existing licensed users upgrading to 2.3.0
+            if (licenseState != false && !settings.state.workspaceDefaultsApplied) {
+                LicenseChecker.applyWorkspaceDefaults()
+                ProjectViewScrollbarManager.getInstance(project).apply()
+                CommitPanelAutoFitManager.getInstance(project).apply()
+                GitPanelAutoFitManager.getInstance(project).apply()
+                LOG.info("Ayu Islands workspace defaults migrated for existing user")
             }
 
             // null = facade not initialized (grace period, treat as licensed)

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -111,53 +111,84 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
         LOG.info("Ayu Islands license check: ${licenseStateLabel(licenseState)}")
 
         SwingUtilities.invokeLater {
-            // Reset flags if the license becomes valid again (user purchased or new eval period)
-            if (licenseState != false && settings.state.trialExpiredNotified) {
-                settings.state.trialExpiredNotified = false
-                settings.state.proDefaultsApplied = false
-                settings.state.trialWelcomeShown = false
+            if (licenseState != false) {
+                applyLicensedDefaults(project, settings)
+            } else {
+                applyUnlicensedDefaults(project, variant, settings)
             }
+        }
+    }
 
-            // One-time: enable all Pro features when the license first activates
-            if (licenseState != false && !settings.state.proDefaultsApplied) {
-                LicenseChecker.enableProDefaults()
-                LOG.info("Ayu Islands Pro defaults enabled (first-time license activation)")
+    private fun applyLicensedDefaults(
+        project: Project,
+        settings: AyuIslandsSettings,
+    ) {
+        if (settings.state.trialExpiredNotified) {
+            settings.state.trialExpiredNotified = false
+            settings.state.proDefaultsApplied = false
+            settings.state.trialWelcomeShown = false
+        }
 
-                // Initialize services that depend on pro-defaults (auto-fit, project view, glow).
-                // These were skipped during early init because the state was still at free defaults.
+        if (!settings.state.proDefaultsApplied) {
+            LicenseChecker.enableProDefaults()
+            LOG.info("Ayu Islands Pro defaults enabled (first-time license activation)")
+
+            if (!settings.state.trialWelcomeShown) {
+                LicenseChecker.notifyTrialWelcome(project)
+                settings.state.trialWelcomeShown = true
+            }
+        }
+
+        // Migration: workspace defaults for existing users upgrading to 2.3.0
+        if (!settings.state.workspaceDefaultsApplied) {
+            LicenseChecker.applyWorkspaceDefaults()
+            LOG.info("Ayu Islands workspace defaults migrated for existing user")
+        }
+
+        scheduleWorkspaceApply(project)
+    }
+
+    private fun applyUnlicensedDefaults(
+        project: Project,
+        variant: AyuVariant,
+        settings: AyuIslandsSettings,
+    ) {
+        LicenseChecker.revertToFreeDefaults(variant)
+        LOG.info("Ayu Islands reverted to free defaults for ${variant.name}")
+
+        if (!settings.state.trialExpiredNotified) {
+            LicenseChecker.notifyTrialExpired(project)
+            settings.state.trialExpiredNotified = true
+        }
+    }
+
+    /**
+     * Schedule workspace service initialization after tool windows are ready.
+     * Tool windows are lazily created — they may not exist when checkLicenseState
+     * runs on the EDT. A single invokeLater defers until the current EDT queue drains.
+     */
+    private fun scheduleWorkspaceApply(project: Project) {
+        SwingUtilities.invokeLater {
+            if (project.isDisposed) return@invokeLater
+            val state = AyuIslandsSettings.getInstance().state
+            val hasProjectViewTweaks =
+                state.hideProjectViewHScrollbar ||
+                    state.hideProjectRootPath ||
+                    state.hideRootVcsAnnotations
+            val pvMode = PanelWidthMode.fromString(state.projectPanelWidthMode)
+            if (hasProjectViewTweaks || pvMode != PanelWidthMode.DEFAULT) {
                 ProjectViewScrollbarManager.getInstance(project).apply()
+            }
+            if (PanelWidthMode.fromString(state.commitPanelWidthMode) != PanelWidthMode.DEFAULT) {
                 CommitPanelAutoFitManager.getInstance(project).apply()
+            }
+            if (PanelWidthMode.fromString(state.gitPanelWidthMode) != PanelWidthMode.DEFAULT) {
                 GitPanelAutoFitManager.getInstance(project).apply()
+            }
+            if (state.glowEnabled) {
                 GlowOverlayManager.getInstance(project).initialize()
-
-                if (!settings.state.trialWelcomeShown) {
-                    LicenseChecker.notifyTrialWelcome(project)
-                    settings.state.trialWelcomeShown = true
-                }
             }
-
-            // Migration: apply workspace defaults for existing licensed users upgrading to 2.3.0
-            if (licenseState != false && !settings.state.workspaceDefaultsApplied) {
-                LicenseChecker.applyWorkspaceDefaults()
-                ProjectViewScrollbarManager.getInstance(project).apply()
-                CommitPanelAutoFitManager.getInstance(project).apply()
-                GitPanelAutoFitManager.getInstance(project).apply()
-                LOG.info("Ayu Islands workspace defaults migrated for existing user")
-            }
-
-            // null = facade not initialized (grace period, treat as licensed)
-            // true = licensed or trial active
-            // false = not licensed (trial expired or never purchased)
-            if (licenseState == false) {
-                LicenseChecker.revertToFreeDefaults(variant)
-                LOG.info("Ayu Islands reverted to free defaults for ${variant.name}")
-
-                // One-time balloon notification
-                if (!settings.state.trialExpiredNotified) {
-                    LicenseChecker.notifyTrialExpired(project)
-                    settings.state.trialExpiredNotified = true
-                }
-            }
+            LOG.info("Ayu Islands workspace services applied (deferred)")
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -61,12 +61,6 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
         // Show a one-time update notification if the plugin version changed
         SwingUtilities.invokeLater { UpdateNotifier.showIfUpdated(project) }
 
-        // Migrate: users with old hideProjectRootPath=true expect VCS also hidden
-        if (settings.state.hideProjectRootPath && !settings.state.projectViewMigrated) {
-            settings.state.hideRootVcsAnnotations = true
-            settings.state.projectViewMigrated = true
-        }
-
         // Migrate old boolean auto-fit fields to the new PanelWidthMode enum
         settings.state.migrateWidthModes()
 
@@ -75,8 +69,7 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
         val pvState = settings.state
         val hasProjectViewCustomizations =
             pvState.hideProjectViewHScrollbar ||
-                pvState.hideProjectRootPath ||
-                pvState.hideRootVcsAnnotations
+                pvState.hideProjectRootPath
         if (hasProjectViewCustomizations ||
             PanelWidthMode.fromString(pvState.projectPanelWidthMode) != PanelWidthMode.DEFAULT
         ) {
@@ -145,7 +138,9 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
             LOG.info("Ayu Islands workspace defaults migrated for existing user")
         }
 
-        scheduleWorkspaceApply(project)
+        // Workspace services (ProjectView, Commit, Git panels) are initialized
+        // via eager service creation + ToolWindowManagerListener in execute() above.
+        // ProjectViewState API is persistent — no deferred re-apply needed.
     }
 
     private fun applyUnlicensedDefaults(
@@ -159,36 +154,6 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
         if (!settings.state.trialExpiredNotified) {
             LicenseChecker.notifyTrialExpired(project)
             settings.state.trialExpiredNotified = true
-        }
-    }
-
-    /**
-     * Schedule workspace service initialization after tool windows are ready.
-     * Tool windows are lazily created — they may not exist when checkLicenseState
-     * runs on the EDT. A single invokeLater defers until the current EDT queue drains.
-     */
-    private fun scheduleWorkspaceApply(project: Project) {
-        SwingUtilities.invokeLater {
-            if (project.isDisposed) return@invokeLater
-            val state = AyuIslandsSettings.getInstance().state
-            val hasProjectViewTweaks =
-                state.hideProjectViewHScrollbar ||
-                    state.hideProjectRootPath ||
-                    state.hideRootVcsAnnotations
-            val pvMode = PanelWidthMode.fromString(state.projectPanelWidthMode)
-            if (hasProjectViewTweaks || pvMode != PanelWidthMode.DEFAULT) {
-                ProjectViewScrollbarManager.getInstance(project).apply()
-            }
-            if (PanelWidthMode.fromString(state.commitPanelWidthMode) != PanelWidthMode.DEFAULT) {
-                CommitPanelAutoFitManager.getInstance(project).apply()
-            }
-            if (PanelWidthMode.fromString(state.gitPanelWidthMode) != PanelWidthMode.DEFAULT) {
-                GitPanelAutoFitManager.getInstance(project).apply()
-            }
-            if (state.glowEnabled) {
-                GlowOverlayManager.getInstance(project).initialize()
-            }
-            LOG.info("Ayu Islands workspace services applied (deferred)")
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManager.kt
+++ b/src/main/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManager.kt
@@ -196,15 +196,7 @@ class GitPanelAutoFitManager(
             ?.component
     }
 
-    private fun measureTreeMaxRowWidth(tree: JTree): Int {
-        var maxRowWidth = 0
-        for (row in 0 until tree.rowCount) {
-            val bounds = tree.getRowBounds(row) ?: continue
-            val rowRight = bounds.x + bounds.width
-            if (rowRight > maxRowWidth) maxRowWidth = rowRight
-        }
-        return maxRowWidth
-    }
+    private fun measureTreeMaxRowWidth(tree: JTree): Int = AutoFitCalculator.measureTreeMaxRowWidth(tree)
 
     override fun dispose() {
         removeExpansionListeners()

--- a/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
@@ -22,6 +22,7 @@ import dev.ayuislands.glow.GlowAnimation
 import dev.ayuislands.glow.GlowPreset
 import dev.ayuislands.glow.GlowStyle
 import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.PanelWidthMode
 import java.io.ByteArrayInputStream
 import java.nio.charset.StandardCharsets
 import java.security.Signature
@@ -212,6 +213,12 @@ object LicenseChecker {
         state.glowGit = true
         state.glowServices = true
         state.glowFocusRing = true
+        state.projectPanelWidthMode = PanelWidthMode.AUTO_FIT.name
+        state.commitPanelWidthMode = PanelWidthMode.AUTO_FIT.name
+        state.gitPanelWidthMode = PanelWidthMode.AUTO_FIT.name
+        state.hideProjectRootPath = true
+        state.hideRootVcsAnnotations = true
+        state.hideProjectViewHScrollbar = true
         state.proDefaultsApplied = true
     }
 
@@ -229,6 +236,14 @@ object LicenseChecker {
         for (id in AccentElementId.entries) {
             state.setToggle(id, true)
         }
+
+        // Reset workspace settings to free defaults
+        state.projectPanelWidthMode = PanelWidthMode.DEFAULT.name
+        state.commitPanelWidthMode = PanelWidthMode.DEFAULT.name
+        state.gitPanelWidthMode = PanelWidthMode.DEFAULT.name
+        state.hideProjectRootPath = false
+        state.hideRootVcsAnnotations = false
+        state.hideProjectViewHScrollbar = false
 
         // Re-apply accent with reset toggles (accent color itself stays — it's free)
         try {

--- a/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
@@ -217,7 +217,7 @@ object LicenseChecker {
         state.proDefaultsApplied = true
     }
 
-    /** Apply workspace defaults (auto-fit, hide path/VCS). Idempotent via the flag. */
+    /** Apply workspace defaults (auto-fit, hide path/VCS). Callers must guard with workspaceDefaultsApplied flag. */
     fun applyWorkspaceDefaults() {
         val state = AyuIslandsSettings.getInstance().state
         state.projectPanelWidthMode = PanelWidthMode.AUTO_FIT.name
@@ -256,6 +256,15 @@ object LicenseChecker {
             AccentApplicator.apply(accentHex)
         } catch (exception: RuntimeException) {
             LOG.warn("Revert to free defaults failed", exception)
+            NotificationGroupManager
+                .getInstance()
+                .getNotificationGroup(NOTIFICATION_GROUP)
+                .createNotification(
+                    "Accent revert incomplete",
+                    "Some accent colors could not be reverted. " +
+                        "Restart your IDE to complete the reset.",
+                    NotificationType.WARNING,
+                ).notify(null)
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
@@ -213,13 +213,20 @@ object LicenseChecker {
         state.glowGit = true
         state.glowServices = true
         state.glowFocusRing = true
+        applyWorkspaceDefaults()
+        state.proDefaultsApplied = true
+    }
+
+    /** Apply workspace defaults (auto-fit, hide path/VCS). Idempotent via flag. */
+    fun applyWorkspaceDefaults() {
+        val state = AyuIslandsSettings.getInstance().state
         state.projectPanelWidthMode = PanelWidthMode.AUTO_FIT.name
         state.commitPanelWidthMode = PanelWidthMode.AUTO_FIT.name
         state.gitPanelWidthMode = PanelWidthMode.AUTO_FIT.name
         state.hideProjectRootPath = true
         state.hideRootVcsAnnotations = true
         state.hideProjectViewHScrollbar = true
-        state.proDefaultsApplied = true
+        state.workspaceDefaultsApplied = true
     }
 
     /** Revert paid features to free defaults for the given variant. */

--- a/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
@@ -217,14 +217,13 @@ object LicenseChecker {
         state.proDefaultsApplied = true
     }
 
-    /** Apply workspace defaults (auto-fit, hide path/VCS). Idempotent via flag. */
+    /** Apply workspace defaults (auto-fit, hide path/VCS). Idempotent via the flag. */
     fun applyWorkspaceDefaults() {
         val state = AyuIslandsSettings.getInstance().state
         state.projectPanelWidthMode = PanelWidthMode.AUTO_FIT.name
         state.commitPanelWidthMode = PanelWidthMode.AUTO_FIT.name
         state.gitPanelWidthMode = PanelWidthMode.AUTO_FIT.name
         state.hideProjectRootPath = true
-        state.hideRootVcsAnnotations = true
         state.hideProjectViewHScrollbar = true
         state.workspaceDefaultsApplied = true
     }
@@ -249,7 +248,6 @@ object LicenseChecker {
         state.commitPanelWidthMode = PanelWidthMode.DEFAULT.name
         state.gitPanelWidthMode = PanelWidthMode.DEFAULT.name
         state.hideProjectRootPath = false
-        state.hideRootVcsAnnotations = false
         state.hideProjectViewHScrollbar = false
 
         // Re-apply accent with reset toggles (accent color itself stays — it's free)

--- a/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
+++ b/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
@@ -120,10 +120,10 @@ class ProjectViewScrollbarManager(
         val registryKey =
             try {
                 Registry.get(SHOW_URL_KEY)
-            } catch (ignored: MissingResourceException) {
+            } catch (_: MissingResourceException) {
                 LOG.warn(
                     "Registry key '$SHOW_URL_KEY' not " +
-                        "found — IDE may have removed it",
+                        "found — the IDE may have removed it",
                 )
                 return
             }
@@ -239,7 +239,7 @@ class ProjectViewScrollbarManager(
         if (registryKeyModified) {
             try {
                 Registry.get(SHOW_URL_KEY).resetToDefault()
-            } catch (ignored: MissingResourceException) {
+            } catch (_: MissingResourceException) {
                 LOG.warn(
                     "Registry key '$SHOW_URL_KEY' not " +
                         "found during dispose",

--- a/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
+++ b/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
@@ -116,7 +116,7 @@ class ProjectViewScrollbarManager(
         val hidePath = AyuIslandsSettings.getInstance().state.hideProjectRootPath
 
         // ProjectViewImpl.isShowURL() reads directly from this Registry key.
-        // Only resetToDefault when WE changed it — don't override user's choice.
+        // Only resetToDefault when WE changed it — don't override the user's choice.
         val registryKey =
             try {
                 Registry.get(SHOW_URL_KEY)

--- a/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
+++ b/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
@@ -28,6 +28,7 @@ class ProjectViewScrollbarManager(
     private val project: Project,
 ) : Disposable {
     private var originalScrollbarPolicy: Int? = null
+    private var registryKeyModified = false
     private var trackedTree: JTree? = null
     private var rendererListener: PropertyChangeListener? = null
     private val autoFitter =
@@ -113,11 +114,14 @@ class ProjectViewScrollbarManager(
         val hidePath = AyuIslandsSettings.getInstance().state.hideProjectRootPath
 
         // ProjectViewImpl.isShowURL() reads directly from this Registry key.
+        // Only resetToDefault when WE changed it — don't override user's choice.
         val registryKey = Registry.get(SHOW_URL_KEY)
         if (hidePath) {
             registryKey.setValue(false)
-        } else {
+            registryKeyModified = true
+        } else if (registryKeyModified) {
             registryKey.resetToDefault()
+            registryKeyModified = false
         }
 
         val tree = findProjectTree() ?: return
@@ -221,7 +225,10 @@ class ProjectViewScrollbarManager(
                 originalScrollbarPolicy!!
             originalScrollbarPolicy = null
         }
-        Registry.get(SHOW_URL_KEY).resetToDefault()
+        if (registryKeyModified) {
+            Registry.get(SHOW_URL_KEY).resetToDefault()
+            registryKeyModified = false
+        }
         val tree = findProjectTree()
         if (tree != null) {
             unwrapRenderer(tree)

--- a/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
+++ b/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
@@ -3,6 +3,7 @@ package dev.ayuislands.projectview
 import com.intellij.ide.projectView.ProjectView
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.registry.Registry
 import com.intellij.openapi.wm.ToolWindowManager
@@ -16,6 +17,7 @@ import dev.ayuislands.toolwindow.AutoFitCalculator
 import dev.ayuislands.toolwindow.ToolWindowAutoFitter
 import java.awt.Component
 import java.beans.PropertyChangeListener
+import java.util.MissingResourceException
 import javax.swing.JScrollPane
 import javax.swing.JTree
 import javax.swing.ScrollPaneConstants
@@ -115,7 +117,16 @@ class ProjectViewScrollbarManager(
 
         // ProjectViewImpl.isShowURL() reads directly from this Registry key.
         // Only resetToDefault when WE changed it — don't override user's choice.
-        val registryKey = Registry.get(SHOW_URL_KEY)
+        val registryKey =
+            try {
+                Registry.get(SHOW_URL_KEY)
+            } catch (ignored: MissingResourceException) {
+                LOG.warn(
+                    "Registry key '$SHOW_URL_KEY' not " +
+                        "found — IDE may have removed it",
+                )
+                return
+            }
         if (hidePath) {
             registryKey.setValue(false)
             registryKeyModified = true
@@ -226,7 +237,14 @@ class ProjectViewScrollbarManager(
             originalScrollbarPolicy = null
         }
         if (registryKeyModified) {
-            Registry.get(SHOW_URL_KEY).resetToDefault()
+            try {
+                Registry.get(SHOW_URL_KEY).resetToDefault()
+            } catch (ignored: MissingResourceException) {
+                LOG.warn(
+                    "Registry key '$SHOW_URL_KEY' not " +
+                        "found during dispose",
+                )
+            }
             registryKeyModified = false
         }
         val tree = findProjectTree()
@@ -236,6 +254,7 @@ class ProjectViewScrollbarManager(
     }
 
     companion object {
+        private val LOG = logger<ProjectViewScrollbarManager>()
         private const val SHOW_URL_KEY = "project.tree.structure.show.url"
 
         fun getInstance(project: Project): ProjectViewScrollbarManager =

--- a/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
+++ b/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
@@ -19,6 +19,7 @@ import java.beans.PropertyChangeListener
 import javax.swing.JScrollPane
 import javax.swing.JTree
 import javax.swing.ScrollPaneConstants
+import javax.swing.SwingUtilities
 import javax.swing.tree.TreeCellRenderer
 
 /** Per-project service that manages Project tool window tweaks (scrollbar, root path). */
@@ -61,6 +62,19 @@ class ProjectViewScrollbarManager(
                     apply()
                 }
             },
+        )
+
+        // Initial apply: tool window may already be open when this service is created.
+        // Timer ensures Project View content is fully rendered before we touch it.
+        java.util.Timer().schedule(
+            object : java.util.TimerTask() {
+                override fun run() {
+                    SwingUtilities.invokeLater {
+                        if (!project.isDisposed) apply()
+                    }
+                }
+            },
+            INITIAL_APPLY_DELAY_MS,
         )
     }
 
@@ -245,6 +259,7 @@ class ProjectViewScrollbarManager(
     companion object {
         private const val SHOW_URL_KEY =
             "project.tree.structure.show.url"
+        private const val INITIAL_APPLY_DELAY_MS = 2000L
 
         fun getInstance(project: Project): ProjectViewScrollbarManager =
             project.getService(

--- a/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
+++ b/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
@@ -28,7 +28,6 @@ class ProjectViewScrollbarManager(
     private val project: Project,
 ) : Disposable {
     private var originalScrollbarPolicy: Int? = null
-    private var registryKeyModified = false
     private var trackedTree: JTree? = null
     private var rendererListener: PropertyChangeListener? = null
     private val autoFitter =
@@ -54,7 +53,6 @@ class ProjectViewScrollbarManager(
                     val widthMode = PanelWidthMode.fromString(state.projectPanelWidthMode)
                     val allFeaturesDisabled =
                         !state.hideProjectRootPath &&
-                            !state.hideRootVcsAnnotations &&
                             !state.hideProjectViewHScrollbar
                     if (allFeaturesDisabled && widthMode == PanelWidthMode.DEFAULT) {
                         return
@@ -64,18 +62,10 @@ class ProjectViewScrollbarManager(
             },
         )
 
-        // Initial apply: tool window may already be open when this service is created.
-        // Timer ensures Project View content is fully rendered before we touch it.
-        java.util.Timer().schedule(
-            object : java.util.TimerTask() {
-                override fun run() {
-                    SwingUtilities.invokeLater {
-                        if (!project.isDisposed) apply()
-                    }
-                }
-            },
-            INITIAL_APPLY_DELAY_MS,
-        )
+        // Initial apply: a tool window may already be open when this service is created.
+        SwingUtilities.invokeLater {
+            if (!project.isDisposed) apply()
+        }
     }
 
     fun apply() {
@@ -120,48 +110,39 @@ class ProjectViewScrollbarManager(
     }
 
     private fun applyRootDisplay() {
-        applyFilesystemPathVisibility()
-        applyVcsAnnotationVisibility()
-        ProjectView.getInstance(project).refresh()
-    }
+        val hidePath = AyuIslandsSettings.getInstance().state.hideProjectRootPath
 
-    private fun applyFilesystemPathVisibility() {
-        val shouldHide =
-            AyuIslandsSettings.getInstance().state.hideProjectRootPath
+        // ProjectViewImpl.isShowURL() reads directly from this Registry key.
         val registryKey = Registry.get(SHOW_URL_KEY)
-        if (shouldHide) {
+        if (hidePath) {
             registryKey.setValue(false)
-            registryKeyModified = true
-        } else if (registryKeyModified) {
+        } else {
             registryKey.resetToDefault()
-            registryKeyModified = false
         }
-    }
 
-    private fun applyVcsAnnotationVisibility() {
-        val shouldHideVcs =
-            AyuIslandsSettings.getInstance().state.hideRootVcsAnnotations
         val tree = findProjectTree() ?: return
-        if (shouldHideVcs) {
+
+        if (hidePath) {
             installRendererWrapper(tree)
             installRendererGuard(tree)
         } else {
             removeRendererGuard()
             unwrapRenderer(tree)
         }
+
+        // Force full tree rebuild to pick up Registry change
+        ProjectView.getInstance(project).currentProjectViewPane?.updateFromRoot(true)
     }
 
     private fun installRendererWrapper(tree: JTree) {
         val current = tree.cellRenderer
-        if (current !is RootLocationHidingRenderer) {
-            tree.cellRenderer =
-                RootLocationHidingRenderer(current, project)
-        }
+        if (current is RootFilteringRenderer) return
+        tree.cellRenderer = RootFilteringRenderer(current, project)
     }
 
     private fun unwrapRenderer(tree: JTree) {
         val current = tree.cellRenderer
-        if (current is RootLocationHidingRenderer) {
+        if (current is RootFilteringRenderer) {
             tree.cellRenderer = current.delegate
         }
     }
@@ -177,17 +158,11 @@ class ProjectViewScrollbarManager(
                     val newRenderer =
                         event.newValue as? TreeCellRenderer
                             ?: return@PropertyChangeListener
-                    if (newRenderer !is RootLocationHidingRenderer &&
-                        AyuIslandsSettings
-                            .getInstance()
-                            .state
-                            .hideRootVcsAnnotations
+                    if (newRenderer !is RootFilteringRenderer &&
+                        AyuIslandsSettings.getInstance().state.hideProjectRootPath
                     ) {
                         tree.cellRenderer =
-                            RootLocationHidingRenderer(
-                                newRenderer,
-                                project,
-                            )
+                            RootFilteringRenderer(newRenderer, project)
                     }
                 }
             }
@@ -246,10 +221,7 @@ class ProjectViewScrollbarManager(
                 originalScrollbarPolicy!!
             originalScrollbarPolicy = null
         }
-        if (registryKeyModified) {
-            Registry.get(SHOW_URL_KEY).resetToDefault()
-            registryKeyModified = false
-        }
+        Registry.get(SHOW_URL_KEY).resetToDefault()
         val tree = findProjectTree()
         if (tree != null) {
             unwrapRenderer(tree)
@@ -257,9 +229,7 @@ class ProjectViewScrollbarManager(
     }
 
     companion object {
-        private const val SHOW_URL_KEY =
-            "project.tree.structure.show.url"
-        private const val INITIAL_APPLY_DELAY_MS = 2000L
+        private const val SHOW_URL_KEY = "project.tree.structure.show.url"
 
         fun getInstance(project: Project): ProjectViewScrollbarManager =
             project.getService(
@@ -269,11 +239,10 @@ class ProjectViewScrollbarManager(
 }
 
 /**
- * Strips VCS annotations (branch name, changed file count)
- * from the project root node. Rebuilds the component keeping
- * only the project name and filesystem path fragments.
+ * Filters root node path fragments.
+ * Reads settings LIVE on every render — no state caching needed.
  */
-private class RootLocationHidingRenderer(
+private class RootFilteringRenderer(
     val delegate: TreeCellRenderer,
     private val project: Project,
 ) : TreeCellRenderer {
@@ -297,18 +266,22 @@ private class RootLocationHidingRenderer(
                 hasFocus,
             )
         if (row == 0 && component is SimpleColoredComponent) {
-            stripVcsFragments(component)
+            filterRootFragments(component)
         }
         return component
     }
 
-    private fun stripVcsFragments(component: SimpleColoredComponent) {
-        val projectName = project.name
+    private fun filterRootFragments(component: SimpleColoredComponent) {
+        if (!AyuIslandsSettings.getInstance().state.hideProjectRootPath) return
+
         val basePath = project.basePath
         val tildeBasePath =
-            basePath?.replace(
-                System.getProperty("user.home"),
-                "~",
+            basePath?.replace(System.getProperty("user.home"), "~")
+        val context =
+            RootNodeContext(
+                projectName = project.name,
+                basePath = basePath,
+                tildeBasePath = tildeBasePath,
             )
         val kept =
             mutableListOf<Pair<String, SimpleTextAttributes>>()
@@ -317,11 +290,14 @@ private class RootLocationHidingRenderer(
             iter.next()
             val text = iter.fragment
             val trimmed = text.trim()
-            if (RootFragmentFilter.isKeptFragment(trimmed, projectName, basePath, tildeBasePath)) {
+            if (!RootFragmentFilter.isPathFragment(trimmed, context)) {
                 kept.add(text to iter.textAttributes)
             }
         }
+
+        val savedIcon = component.icon
         component.clear()
+        component.icon = savedIcon
         for ((text, attrs) in kept) {
             component.append(text, attrs)
         }

--- a/src/main/kotlin/dev/ayuislands/projectview/RootFragmentFilter.kt
+++ b/src/main/kotlin/dev/ayuislands/projectview/RootFragmentFilter.kt
@@ -1,17 +1,21 @@
 package dev.ayuislands.projectview
 
-/** Pure logic for filtering VCS annotation fragments from project root node. */
+/** Context needed to classify root node fragments. */
+data class RootNodeContext(
+    val projectName: String,
+    val basePath: String?,
+    val tildeBasePath: String?,
+)
+
+/** Pure logic for filtering root node path fragments. */
 object RootFragmentFilter {
-    fun isKeptFragment(
+    fun isPathFragment(
         trimmed: String,
-        projectName: String,
-        basePath: String?,
-        tildeBasePath: String?,
+        context: RootNodeContext,
     ): Boolean {
         if (trimmed.isEmpty()) return false
-        if (trimmed == projectName) return true
-        if (basePath != null && trimmed.contains(basePath)) return true
-        if (tildeBasePath != null && trimmed.contains(tildeBasePath)) return true
-        return false
+        if (trimmed == context.projectName) return false
+        return (context.basePath != null && trimmed.contains(context.basePath)) ||
+            (context.tildeBasePath != null && trimmed.contains(context.tildeBasePath))
     }
 }

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -108,7 +108,6 @@ class AyuIslandsState : BaseState() {
 
     // Project View tweaks
     var hideProjectRootPath by property(false)
-    var hideRootVcsAnnotations by property(false)
     var hideProjectViewHScrollbar by property(false)
     var autoFitProjectPanelWidth by property(false)
     var autoFitMaxWidth by property(DEFAULT_AUTO_FIT_MAX_WIDTH)
@@ -128,9 +127,6 @@ class AyuIslandsState : BaseState() {
     var gitPanelAutoFitMaxWidth by property(DEFAULT_GIT_AUTO_FIT_MAX_WIDTH)
     var gitPanelAutoFitMinWidth by property(DEFAULT_GIT_AUTO_FIT_MIN_WIDTH)
     var gitPanelFixedWidth by property(DEFAULT_FIXED_WIDTH)
-
-    // Migration: existing users with hideProjectRootPath=true expect VCS hidden too
-    var projectViewMigrated by property(false)
 
     // Font preset
     var fontPresetEnabled by property(false)

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -29,6 +29,7 @@ class AyuIslandsState : BaseState() {
     var lastLightAppearanceTheme by string("Ayu Light (Islands UI)")
     var trialExpiredNotified by property(false)
     var proDefaultsApplied by property(false)
+    var workspaceDefaultsApplied by property(false)
     var trialWelcomeShown by property(false)
 
     // Per-element accent toggles (all ON by default)

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -63,14 +63,14 @@ class AyuIslandsState : BaseState() {
     // Animation
     var glowAnimation by string(GlowAnimation.NONE.name)
 
-    // Per-island toggles (editor ON by default, others OFF)
+    // Per-island toggles (all ON by default — glow visibility is controlled by glowEnabled)
     var glowEditor by property(true)
-    var glowProject by property(false)
-    var glowTerminal by property(false)
-    var glowRun by property(false)
-    var glowDebug by property(false)
-    var glowGit by property(false)
-    var glowServices by property(false)
+    var glowProject by property(true)
+    var glowTerminal by property(true)
+    var glowRun by property(true)
+    var glowDebug by property(true)
+    var glowGit by property(true)
+    var glowServices by property(true)
 
     // Tab glow mode: MINIMAL (underline only), FULL (underline + tinted bg), OFF
     var glowTabMode by string("MINIMAL")

--- a/src/main/kotlin/dev/ayuislands/settings/WorkspacePanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/WorkspacePanel.kt
@@ -34,13 +34,10 @@ private const val GIT_PANEL_TITLE = "Git Panel"
 class WorkspacePanel : AyuIslandsSettingsPanel {
     private var pendingHideRootPath = false
     private var storedHideRootPath = false
-    private var pendingHideRootVcs = false
-    private var storedHideRootVcs = false
     private var pendingHideHScrollbar = false
     private var storedHideHScrollbar = false
 
     private var hideRootPathCheckbox: JCheckBox? = null
-    private var hideRootVcsCheckbox: JCheckBox? = null
     private var hideHScrollbarCheckbox: JCheckBox? = null
 
     private val projectWidth = WidthModeUiState()
@@ -62,8 +59,6 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
 
         storedHideRootPath = state.hideProjectRootPath
         pendingHideRootPath = storedHideRootPath
-        storedHideRootVcs = state.hideRootVcsAnnotations
-        pendingHideRootVcs = storedHideRootVcs
         storedHideHScrollbar = state.hideProjectViewHScrollbar
         pendingHideHScrollbar = storedHideHScrollbar
 
@@ -100,17 +95,6 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
                         pendingHideRootPath = cb.component.isSelected
                     }
                     hideRootPathCheckbox = cb.component
-                }
-                row {
-                    val cb =
-                        checkBox("Hide VCS annotations")
-                            .comment("Remove branch name and changed file count from the project root")
-                    cb.component.isSelected = pendingHideRootVcs
-                    cb.component.isEnabled = licensed
-                    cb.component.addActionListener {
-                        pendingHideRootVcs = cb.component.isSelected
-                    }
-                    hideRootVcsCheckbox = cb.component
                 }
                 row {
                     val cb =
@@ -327,7 +311,6 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
 
     override fun isModified(): Boolean =
         pendingHideRootPath != storedHideRootPath ||
-            pendingHideRootVcs != storedHideRootVcs ||
             pendingHideHScrollbar != storedHideHScrollbar ||
             projectWidth.state.isModified() ||
             commitWidth.state.isModified() ||
@@ -339,38 +322,19 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
 
         val displayChanged =
             pendingHideRootPath != storedHideRootPath ||
-                pendingHideRootVcs != storedHideRootVcs ||
                 pendingHideHScrollbar != storedHideHScrollbar
         val projectWidthChanged = projectWidth.state.isModified()
         val commitWidthChanged = commitWidth.state.isModified()
         val gitWidthChanged = gitWidth.state.isModified()
 
         state.hideProjectRootPath = pendingHideRootPath
-        state.hideRootVcsAnnotations = pendingHideRootVcs
         state.hideProjectViewHScrollbar = pendingHideHScrollbar
         storedHideRootPath = pendingHideRootPath
-        storedHideRootVcs = pendingHideRootVcs
         storedHideHScrollbar = pendingHideHScrollbar
 
-        state.projectPanelWidthMode = projectWidth.state.pendingMode.name
-        state.autoFitMaxWidth = projectWidth.state.pendingAutoFitMaxWidth
-        state.projectPanelAutoFitMinWidth = projectWidth.state.pendingAutoFitMinWidth
-        state.projectPanelFixedWidth = projectWidth.state.pendingFixedWidth
-        state.autoFitProjectPanelWidth = projectWidth.state.pendingMode == PanelWidthMode.AUTO_FIT
-        projectWidth.state.commitStored()
-
-        state.commitPanelWidthMode = commitWidth.state.pendingMode.name
-        state.autoFitCommitMaxWidth = commitWidth.state.pendingAutoFitMaxWidth
-        state.commitPanelAutoFitMinWidth = commitWidth.state.pendingAutoFitMinWidth
-        state.commitPanelFixedWidth = commitWidth.state.pendingFixedWidth
-        state.autoFitCommitPanelWidth = commitWidth.state.pendingMode == PanelWidthMode.AUTO_FIT
-        commitWidth.state.commitStored()
-
-        state.gitPanelWidthMode = gitWidth.state.pendingMode.name
-        state.gitPanelAutoFitMaxWidth = gitWidth.state.pendingAutoFitMaxWidth
-        state.gitPanelAutoFitMinWidth = gitWidth.state.pendingAutoFitMinWidth
-        state.gitPanelFixedWidth = gitWidth.state.pendingFixedWidth
-        gitWidth.state.commitStored()
+        applyWidthState(projectWidth, state.projectWidthTarget())
+        applyWidthState(commitWidth, state.commitWidthTarget())
+        applyWidthState(gitWidth, state.gitWidthTarget())
 
         if (displayChanged || projectWidthChanged) {
             for (openProject in ProjectManager.getInstance().openProjects) {
@@ -402,12 +366,10 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
 
     override fun reset() {
         pendingHideRootPath = storedHideRootPath
-        pendingHideRootVcs = storedHideRootVcs
         pendingHideHScrollbar = storedHideHScrollbar
 
         suppressListeners = true
         hideRootPathCheckbox?.isSelected = storedHideRootPath
-        hideRootVcsCheckbox?.isSelected = storedHideRootVcs
         hideHScrollbarCheckbox?.isSelected = storedHideHScrollbar
         projectWidth.reset()
         commitWidth.reset()
@@ -417,6 +379,58 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
         updateGroupTitle(gitPanelGroup, GIT_PANEL_TITLE, gitWidth.state)
         suppressListeners = false
     }
+
+    private fun applyWidthState(
+        uiState: WidthModeUiState,
+        target: WidthTarget,
+    ) {
+        val pending = uiState.state
+        target.setMode(pending.pendingMode.name)
+        target.setMaxWidth(pending.pendingAutoFitMaxWidth)
+        target.setMinWidth(pending.pendingAutoFitMinWidth)
+        target.setFixedWidth(pending.pendingFixedWidth)
+        target.setLegacyAutoFit?.invoke(pending.pendingMode == PanelWidthMode.AUTO_FIT)
+        pending.commitStored()
+    }
+
+    /**
+     * Setter bundle for writing [PanelWidthState] values to the corresponding
+     * [AyuIslandsState] properties. Each panel (project/commit/git) provides
+     * its own instance via the extension functions below.
+     */
+    private class WidthTarget(
+        val setMode: (String) -> Unit,
+        val setMaxWidth: (Int) -> Unit,
+        val setMinWidth: (Int) -> Unit,
+        val setFixedWidth: (Int) -> Unit,
+        val setLegacyAutoFit: ((Boolean) -> Unit)? = null,
+    )
+
+    private fun AyuIslandsState.projectWidthTarget(): WidthTarget =
+        WidthTarget(
+            setMode = { projectPanelWidthMode = it },
+            setMaxWidth = { autoFitMaxWidth = it },
+            setMinWidth = { projectPanelAutoFitMinWidth = it },
+            setFixedWidth = { projectPanelFixedWidth = it },
+            setLegacyAutoFit = { autoFitProjectPanelWidth = it },
+        )
+
+    private fun AyuIslandsState.commitWidthTarget(): WidthTarget =
+        WidthTarget(
+            setMode = { commitPanelWidthMode = it },
+            setMaxWidth = { autoFitCommitMaxWidth = it },
+            setMinWidth = { commitPanelAutoFitMinWidth = it },
+            setFixedWidth = { commitPanelFixedWidth = it },
+            setLegacyAutoFit = { autoFitCommitPanelWidth = it },
+        )
+
+    private fun AyuIslandsState.gitWidthTarget(): WidthTarget =
+        WidthTarget(
+            setMode = { gitPanelWidthMode = it },
+            setMaxWidth = { gitPanelAutoFitMaxWidth = it },
+            setMinWidth = { gitPanelAutoFitMinWidth = it },
+            setFixedWidth = { gitPanelFixedWidth = it },
+        )
 
     private class WidthModeUiState(
         val state: PanelWidthState = PanelWidthState(),

--- a/src/main/kotlin/dev/ayuislands/toolwindow/AutoFitCalculator.kt
+++ b/src/main/kotlin/dev/ayuislands/toolwindow/AutoFitCalculator.kt
@@ -2,6 +2,7 @@ package dev.ayuislands.toolwindow
 
 import java.awt.Component
 import java.awt.Container
+import javax.swing.JTree
 import kotlin.math.abs
 
 /** Pure calculation utilities for tool window auto-fit, extracted for testability. */
@@ -22,6 +23,16 @@ object AutoFitCalculator {
         (maxRowWidth + AUTOFIT_PADDING)
             .coerceAtMost(maxWidth)
             .coerceAtLeast(minWidth)
+
+    fun measureTreeMaxRowWidth(tree: JTree): Int {
+        var maxRowWidth = 0
+        for (row in 0 until tree.rowCount) {
+            val bounds = tree.getRowBounds(row) ?: continue
+            val rowRight = bounds.x + bounds.width
+            if (rowRight > maxRowWidth) maxRowWidth = rowRight
+        }
+        return maxRowWidth
+    }
 
     fun isJitterOnly(
         currentWidth: Int,

--- a/src/main/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitter.kt
+++ b/src/main/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitter.kt
@@ -40,19 +40,9 @@ class ToolWindowAutoFitter(
             "applyAutoFitWidth must be called on EDT"
         }
         findTreeWithRetry { tree ->
-            val toolWindow =
-                ToolWindowManager
-                    .getInstance(project)
-                    .getToolWindow(toolWindowId)
-            val toolWindowEx = toolWindow as? ToolWindowEx
-            if (toolWindowEx == null) {
-                LOG.warn(
-                    "Auto-fit: '$toolWindowId' is not " +
-                        "ToolWindowEx (type: " +
-                        "${toolWindow?.javaClass?.name})",
-                )
-                return@findTreeWithRetry
-            }
+            val toolWindowEx =
+                resolveToolWindowEx("Auto-fit")
+                    ?: return@findTreeWithRetry
 
             var maxRowWidth = 0
             for (row in 0 until tree.rowCount) {
@@ -77,6 +67,11 @@ class ToolWindowAutoFitter(
         assert(SwingUtilities.isEventDispatchThread()) {
             "applyFixedWidth must be called on EDT"
         }
+        val toolWindowEx = resolveToolWindowEx("Fixed-width") ?: return
+        applyWidth(toolWindowEx, targetWidth)
+    }
+
+    private fun resolveToolWindowEx(context: String): ToolWindowEx? {
         val toolWindow =
             ToolWindowManager
                 .getInstance(project)
@@ -84,13 +79,12 @@ class ToolWindowAutoFitter(
         val toolWindowEx = toolWindow as? ToolWindowEx
         if (toolWindowEx == null) {
             LOG.warn(
-                "Fixed-width: '$toolWindowId' is not " +
+                "$context: '$toolWindowId' is not " +
                     "ToolWindowEx (type: " +
                     "${toolWindow?.javaClass?.name})",
             )
-            return
         }
-        applyWidth(toolWindowEx, targetWidth)
+        return toolWindowEx
     }
 
     private fun applyWidth(

--- a/src/main/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitter.kt
+++ b/src/main/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitter.kt
@@ -136,6 +136,7 @@ class ToolWindowAutoFitter(
         retriesLeft: Int = MAX_RETRIES,
         onFound: (JTree) -> Unit,
     ) {
+        if (project.isDisposed) return
         val tree = findTree()
         if (tree != null) {
             onFound(tree)
@@ -143,7 +144,9 @@ class ToolWindowAutoFitter(
         }
         if (retriesLeft > 0) {
             Timer((MAX_RETRIES - retriesLeft + 1) * RETRY_DELAY_MS) {
-                findTreeWithRetry(retriesLeft - 1, onFound)
+                if (!project.isDisposed) {
+                    findTreeWithRetry(retriesLeft - 1, onFound)
+                }
             }.apply {
                 isRepeats = false
                 start()

--- a/src/main/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitter.kt
+++ b/src/main/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitter.kt
@@ -1,5 +1,6 @@
 package dev.ayuislands.toolwindow
 
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ToolWindowType
@@ -23,6 +24,7 @@ class ToolWindowAutoFitter(
 ) {
     private var expansionListener: TreeExpansionListener? = null
     private var expansionTree: JTree? = null
+    private var retryTimer: Timer? = null
     private val debounceTimer =
         Timer(DEBOUNCE_DELAY_MS) { applyAutoFitWidth(maxWidthProvider()) }
             .apply { isRepeats = false }
@@ -34,12 +36,23 @@ class ToolWindowAutoFitter(
     var minWidthProvider: () -> Int = { minWidth }
 
     fun applyAutoFitWidth(maxWidth: Int) {
+        assert(SwingUtilities.isEventDispatchThread()) {
+            "applyAutoFitWidth must be called on EDT"
+        }
         findTreeWithRetry { tree ->
             val toolWindow =
                 ToolWindowManager
                     .getInstance(project)
-                    .getToolWindow(toolWindowId) as? ToolWindowEx
-                    ?: return@findTreeWithRetry
+                    .getToolWindow(toolWindowId)
+            val toolWindowEx = toolWindow as? ToolWindowEx
+            if (toolWindowEx == null) {
+                LOG.warn(
+                    "Auto-fit: '$toolWindowId' is not " +
+                        "ToolWindowEx (type: " +
+                        "${toolWindow?.javaClass?.name})",
+                )
+                return@findTreeWithRetry
+            }
 
             var maxRowWidth = 0
             for (row in 0 until tree.rowCount) {
@@ -50,18 +63,34 @@ class ToolWindowAutoFitter(
                 }
             }
 
-            val desiredWidth = AutoFitCalculator.calculateDesiredWidth(maxRowWidth, maxWidth, minWidthProvider())
-            applyWidth(toolWindow, desiredWidth)
+            val desiredWidth =
+                AutoFitCalculator.calculateDesiredWidth(
+                    maxRowWidth,
+                    maxWidth,
+                    minWidthProvider(),
+                )
+            applyWidth(toolWindowEx, desiredWidth)
         }
     }
 
     fun applyFixedWidth(targetWidth: Int) {
+        assert(SwingUtilities.isEventDispatchThread()) {
+            "applyFixedWidth must be called on EDT"
+        }
         val toolWindow =
             ToolWindowManager
                 .getInstance(project)
-                .getToolWindow(toolWindowId) as? ToolWindowEx
-                ?: return
-        applyWidth(toolWindow, targetWidth)
+                .getToolWindow(toolWindowId)
+        val toolWindowEx = toolWindow as? ToolWindowEx
+        if (toolWindowEx == null) {
+            LOG.warn(
+                "Fixed-width: '$toolWindowId' is not " +
+                    "ToolWindowEx (type: " +
+                    "${toolWindow?.javaClass?.name})",
+            )
+            return
+        }
+        applyWidth(toolWindowEx, targetWidth)
     }
 
     private fun applyWidth(
@@ -120,6 +149,8 @@ class ToolWindowAutoFitter(
     }
 
     fun removeExpansionListener() {
+        retryTimer?.stop()
+        retryTimer = null
         val tree = expansionTree ?: return
         val listener = expansionListener ?: return
         tree.removeTreeExpansionListener(listener)
@@ -143,14 +174,25 @@ class ToolWindowAutoFitter(
             return
         }
         if (retriesLeft > 0) {
-            Timer((MAX_RETRIES - retriesLeft + 1) * RETRY_DELAY_MS) {
-                if (!project.isDisposed) {
-                    findTreeWithRetry(retriesLeft - 1, onFound)
+            retryTimer?.stop()
+            retryTimer =
+                Timer(
+                    (MAX_RETRIES - retriesLeft + 1) *
+                        RETRY_DELAY_MS,
+                ) {
+                    if (!project.isDisposed) {
+                        findTreeWithRetry(retriesLeft - 1, onFound)
+                    }
+                }.apply {
+                    isRepeats = false
+                    start()
                 }
-            }.apply {
-                isRepeats = false
-                start()
-            }
+        } else {
+            LOG.info(
+                "Auto-fit: tree not found for " +
+                    "'$toolWindowId' after " +
+                    "$MAX_RETRIES retries",
+            )
         }
     }
 
@@ -171,6 +213,7 @@ class ToolWindowAutoFitter(
     }
 
     companion object {
+        private val LOG = logger<ToolWindowAutoFitter>()
         private const val DEBOUNCE_DELAY_MS = 150
         private const val DEFAULT_MAX_WIDTH = 400
         private const val MAX_RETRIES = 3

--- a/src/main/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitter.kt
+++ b/src/main/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitter.kt
@@ -34,24 +34,25 @@ class ToolWindowAutoFitter(
     var minWidthProvider: () -> Int = { minWidth }
 
     fun applyAutoFitWidth(maxWidth: Int) {
-        val tree = findTree() ?: return
-        val toolWindow =
-            ToolWindowManager
-                .getInstance(project)
-                .getToolWindow(toolWindowId) as? ToolWindowEx
-                ?: return
+        findTreeWithRetry { tree ->
+            val toolWindow =
+                ToolWindowManager
+                    .getInstance(project)
+                    .getToolWindow(toolWindowId) as? ToolWindowEx
+                    ?: return@findTreeWithRetry
 
-        var maxRowWidth = 0
-        for (row in 0 until tree.rowCount) {
-            val bounds = tree.getRowBounds(row) ?: continue
-            val rowRight = bounds.x + bounds.width
-            if (rowRight > maxRowWidth) {
-                maxRowWidth = rowRight
+            var maxRowWidth = 0
+            for (row in 0 until tree.rowCount) {
+                val bounds = tree.getRowBounds(row) ?: continue
+                val rowRight = bounds.x + bounds.width
+                if (rowRight > maxRowWidth) {
+                    maxRowWidth = rowRight
+                }
             }
-        }
 
-        val desiredWidth = AutoFitCalculator.calculateDesiredWidth(maxRowWidth, maxWidth, minWidthProvider())
-        applyWidth(toolWindow, desiredWidth)
+            val desiredWidth = AutoFitCalculator.calculateDesiredWidth(maxRowWidth, maxWidth, minWidthProvider())
+            applyWidth(toolWindow, desiredWidth)
+        }
     }
 
     fun applyFixedWidth(targetWidth: Int) {
@@ -99,22 +100,23 @@ class ToolWindowAutoFitter(
     }
 
     fun installExpansionListener() {
-        val tree = findTree() ?: return
-        if (expansionTree === tree && expansionListener != null) return
+        findTreeWithRetry { tree ->
+            if (expansionTree === tree && expansionListener != null) return@findTreeWithRetry
 
-        removeExpansionListener()
-        expansionTree = tree
-        expansionListener =
-            object : TreeExpansionListener {
-                override fun treeExpanded(event: TreeExpansionEvent) {
-                    scheduleAutoFit()
-                }
+            removeExpansionListener()
+            expansionTree = tree
+            expansionListener =
+                object : TreeExpansionListener {
+                    override fun treeExpanded(event: TreeExpansionEvent) {
+                        scheduleAutoFit()
+                    }
 
-                override fun treeCollapsed(event: TreeExpansionEvent) {
-                    scheduleAutoFit()
+                    override fun treeCollapsed(event: TreeExpansionEvent) {
+                        scheduleAutoFit()
+                    }
                 }
-            }
-        tree.addTreeExpansionListener(expansionListener)
+            tree.addTreeExpansionListener(expansionListener)
+        }
     }
 
     fun removeExpansionListener() {
@@ -128,6 +130,25 @@ class ToolWindowAutoFitter(
 
     fun scheduleAutoFit() {
         debounceTimer.restart()
+    }
+
+    private fun findTreeWithRetry(
+        retriesLeft: Int = MAX_RETRIES,
+        onFound: (JTree) -> Unit,
+    ) {
+        val tree = findTree()
+        if (tree != null) {
+            onFound(tree)
+            return
+        }
+        if (retriesLeft > 0) {
+            Timer((MAX_RETRIES - retriesLeft + 1) * RETRY_DELAY_MS) {
+                findTreeWithRetry(retriesLeft - 1, onFound)
+            }.apply {
+                isRepeats = false
+                start()
+            }
+        }
     }
 
     fun findTree(): JTree? {
@@ -149,5 +170,7 @@ class ToolWindowAutoFitter(
     companion object {
         private const val DEBOUNCE_DELAY_MS = 150
         private const val DEFAULT_MAX_WIDTH = 400
+        private const val MAX_RETRIES = 3
+        private const val RETRY_DELAY_MS = 200
     }
 }

--- a/src/main/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitter.kt
+++ b/src/main/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitter.kt
@@ -44,15 +44,8 @@ class ToolWindowAutoFitter(
                 resolveToolWindowEx("Auto-fit")
                     ?: return@findTreeWithRetry
 
-            var maxRowWidth = 0
-            for (row in 0 until tree.rowCount) {
-                val bounds = tree.getRowBounds(row) ?: continue
-                val rowRight = bounds.x + bounds.width
-                if (rowRight > maxRowWidth) {
-                    maxRowWidth = rowRight
-                }
-            }
-
+            val maxRowWidth =
+                AutoFitCalculator.measureTreeMaxRowWidth(tree)
             val desiredWidth =
                 AutoFitCalculator.calculateDesiredWidth(
                     maxRowWidth,

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -50,7 +50,7 @@
     each with configurable min and max bounds.
     The Git panel goes deeper: auto-resize the branches tree and file changes
     tree independently.
-    Hide the filesystem path, VCS annotations, and horizontal scrollbar
+    Hide the filesystem path and horizontal scrollbar
     from the Project View. Three panels, one settings tab, zero wasted space.</p>
 
     <p><b>Accent control</b> — your accent color, your rules.
@@ -75,7 +75,7 @@
     <ul>
       <li>[Paid] Auto-fit with configurable min/max width for Project View, Commit, and Git panels</li>
       <li>[Paid] Git panel internal splitter control — auto-resize branches tree and file changes tree</li>
-      <li>[Paid] Project View tweaks now require a license (hide path, VCS annotations, scrollbar)</li>
+      <li>[Paid] Project View cleanup — hide the filesystem path and horizontal scrollbar</li>
       <li>[Free] 30-day premium trial — every premium feature unlocked on the first install, no credit card</li>
       <li>[Free] Returning users get a fresh trial with premium defaults re-applied</li>
     </ul>

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerTest.kt
@@ -139,14 +139,16 @@ class LicenseCheckerTest {
         every { AyuIslandsSettings.getInstance() } returns settingsMock
         every { settingsMock.state } returns realState
 
-        // Verify defaults before — most glow island flags start as false
+        // Verify defaults before — glowEnabled and proDefaultsApplied start false,
+        // but all island toggles default to true (visibility controlled by glowEnabled)
         assertFalse(realState.glowEnabled)
-        assertFalse(realState.glowProject)
-        assertFalse(realState.glowTerminal)
-        assertFalse(realState.glowRun)
-        assertFalse(realState.glowDebug)
-        assertFalse(realState.glowGit)
-        assertFalse(realState.glowServices)
+        assertTrue(realState.glowEditor)
+        assertTrue(realState.glowProject)
+        assertTrue(realState.glowTerminal)
+        assertTrue(realState.glowRun)
+        assertTrue(realState.glowDebug)
+        assertTrue(realState.glowGit)
+        assertTrue(realState.glowServices)
         assertFalse(realState.proDefaultsApplied)
 
         LicenseChecker.enableProDefaults()

--- a/src/test/kotlin/dev/ayuislands/projectview/RootFragmentFilterTest.kt
+++ b/src/test/kotlin/dev/ayuislands/projectview/RootFragmentFilterTest.kt
@@ -9,83 +9,56 @@ class RootFragmentFilterTest {
     private val basePath = "/Users/cloud/Developer/my-project"
     private val tildeBasePath = "~/Developer/my-project"
 
-    @Test
-    fun `empty string is not kept`() {
-        assertFalse(RootFragmentFilter.isKeptFragment("", projectName, basePath, tildeBasePath))
-    }
-
-    @Test
-    fun `project name is kept`() {
-        assertTrue(RootFragmentFilter.isKeptFragment("my-project", projectName, basePath, tildeBasePath))
-    }
-
-    @Test
-    fun `absolute base path fragment is kept`() {
-        assertTrue(
-            RootFragmentFilter.isKeptFragment(
-                "[/Users/cloud/Developer/my-project]",
-                projectName,
-                basePath,
-                tildeBasePath,
-            ),
+    private fun context() =
+        RootNodeContext(
+            projectName = projectName,
+            basePath = basePath,
+            tildeBasePath = tildeBasePath,
         )
-    }
 
-    @Test
-    fun `tilde base path fragment is kept`() {
-        assertTrue(
-            RootFragmentFilter.isKeptFragment(
-                "[~/Developer/my-project]",
-                projectName,
-                basePath,
-                tildeBasePath,
-            ),
+    private fun isPath(trimmed: String): Boolean =
+        RootFragmentFilter.isPathFragment(
+            trimmed,
+            context(),
         )
+
+    @Test
+    fun `empty string is not a path fragment`() {
+        assertFalse(isPath(""))
     }
 
     @Test
-    fun `VCS branch annotation is not kept`() {
-        assertFalse(
-            RootFragmentFilter.isKeptFragment(
-                "main",
-                projectName,
-                basePath,
-                tildeBasePath,
-            ),
-        )
+    fun `project name is not a path fragment`() {
+        assertFalse(isPath("my-project"))
     }
 
     @Test
-    fun `changed file count annotation is not kept`() {
-        assertFalse(
-            RootFragmentFilter.isKeptFragment(
-                "3 files",
-                projectName,
-                basePath,
-                tildeBasePath,
-            ),
-        )
+    fun `tilde basePath is a path fragment`() {
+        assertTrue(isPath("[~/Developer/my-project]"))
     }
 
     @Test
-    fun `null basePath still matches project name`() {
-        assertTrue(RootFragmentFilter.isKeptFragment("my-project", projectName, null, null))
+    fun `absolute basePath is a path fragment`() {
+        assertTrue(isPath("[/Users/cloud/Developer/my-project]"))
     }
 
     @Test
-    fun `null basePath rejects unrelated text`() {
-        assertFalse(RootFragmentFilter.isKeptFragment("feat/feature", projectName, null, null))
+    fun `exact basePath is a path fragment`() {
+        assertTrue(isPath(basePath))
     }
 
     @Test
-    fun `whitespace-only after trim is not kept`() {
-        assertFalse(RootFragmentFilter.isKeptFragment("", projectName, basePath, tildeBasePath))
+    fun `unrelated text is not a path fragment`() {
+        assertFalse(isPath("main"))
+        assertFalse(isPath("3 files"))
+        assertFalse(isPath("feat/feature"))
     }
 
     @Test
-    fun `exact basePath match is kept`() {
-        assertTrue(
-            RootFragmentFilter.isKeptFragment(basePath, projectName, basePath, tildeBasePath),
-        )
+    fun `null basePath never matches path`() {
+        val ctx = RootNodeContext(projectName, null, null)
+        assertFalse(RootFragmentFilter.isPathFragment("anything", ctx))
+        assertFalse(RootFragmentFilter.isPathFragment(projectName, ctx))
+        assertFalse(RootFragmentFilter.isPathFragment("", ctx))
     }
 }

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateTest.kt
@@ -174,15 +174,15 @@ class AyuIslandsStateTest {
     }
 
     @Test
-    fun `glowEditor is on by default, other islands are off`() {
+    fun `all island toggles are on by default`() {
         val state = freshState()
         assertTrue(state.glowEditor)
-        assertFalse(state.glowProject)
-        assertFalse(state.glowTerminal)
-        assertFalse(state.glowRun)
-        assertFalse(state.glowDebug)
-        assertFalse(state.glowGit)
-        assertFalse(state.glowServices)
+        assertTrue(state.glowProject)
+        assertTrue(state.glowTerminal)
+        assertTrue(state.glowRun)
+        assertTrue(state.glowDebug)
+        assertTrue(state.glowGit)
+        assertTrue(state.glowServices)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Fix timer-based initial apply for Project View service creation
- Defer workspace defaults apply + reduce cognitive complexity
- Migrate workspace defaults for existing licensed users
- Init pro services after defaults apply
- Auto-fit retries when tool window tree is not yet rendered
- Trial users get pro defaults with workspace defaults and all glow targets enabled
- Remove non-functional VCS annotations toggle (IntelliJ Git plugin doesn't register ProjectViewNodeDecorator — VCS info never appears on tree nodes)
- Fix icon loss when filtering root path fragments (SimpleColoredComponent.clear() was resetting icon)
- Extract WidthTarget in WorkspacePanel to deduplicate width state apply blocks
- Expand wildcard imports in LicenseChecker (detekt compliance)

## Test plan

- [ ] `./gradlew buildPlugin` passes
- [ ] `./gradlew test` passes
- [ ] `./gradlew verifyPlugin` passes
- [ ] Settings > Ayu Islands > Workspace: no "Hide VCS annotations" checkbox
- [ ] "Hide filesystem path" toggle works: path disappears, icon stays
- [ ] Auto-fit applies on IDE startup for all three panels
- [ ] Trial users get pro defaults on first install

## Summary by Sourcery

Refine Project View workspace behavior and licensing defaults ahead of the 2.3.0 release.

Bug Fixes:
- Preserve Project View root node icons when hiding filesystem path fragments.
- Ensure Project View root path hiding applies reliably on initial service creation and on renderer changes.
- Make auto-fit width apply even when tool window trees are not yet rendered by adding retry logic.

Enhancements:
- Remove the non-functional Project View VCS annotations toggle and associated state.
- Extract a reusable width target helper to centralize panel width state application for Project, Commit, and Git panels.
- Adjust workspace and glow defaults so trial and licensed users receive Pro-style workspace settings and glow coverage by default.
- Introduce a dedicated workspace defaults migration path for existing licensed users and reset workspace settings when reverting to free mode.
- Simplify root node fragment filtering logic to focus on path fragments, with updated tests to match the new behavior.

Documentation:
- Update changelog and plugin description to reflect 2.3.0 features and the revised Project View cleanup behavior.