### PR TITLE
fix: drop deprecated ActionUtil.invokeAction

### DIFF
--- a/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
@@ -8,7 +8,6 @@ import com.intellij.openapi.actionSystem.ActionUiKind
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.actionSystem.Presentation
-import com.intellij.openapi.actionSystem.ex.ActionUtil
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.PathManager
@@ -155,7 +154,7 @@ object LicenseChecker {
                     ActionUiKind.NONE,
                     null,
                 )
-            ActionUtil.invokeAction(action, event, null)
+            action.actionPerformed(event)
         }, ModalityState.nonModal())
     }
 


### PR DESCRIPTION
## Summary
- Replace deprecated `ActionUtil.invokeAction(action, event, null)` with direct `action.actionPerformed(event)` in `LicenseChecker`
- Remove unused `ActionUtil` import
- Clears all deprecated-usages.txt warnings across 12 verified IDEs

## Context
Pre-release cleanup for v2.3.0. The 3-arg `invokeAction` overload was deprecated in 2025.2+. Since `onDone` was always `null`, the direct call is equivalent.

## Test plan
- [x] `./gradlew buildPlugin` passes
- [x] `./gradlew verifyPlugin` passes — 0 deprecated usages
- [x] `./gradlew test` passes
- [x] ktlint + detekt pass

## Summary by Sourcery

Replace a deprecated action invocation helper in the license checker with a direct action call to remove deprecated API usage.

Bug Fixes:
- Eliminate use of the deprecated three-argument ActionUtil.invokeAction overload in LicenseChecker.

Enhancements:
- Simplify LicenseChecker by calling actionPerformed directly and removing an unused ActionUtil import.