### PR TITLE
fix: restore ActionUtil.invokeAction call

### DIFF
--- a/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.actionSystem.ActionUiKind
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.actionSystem.Presentation
+import com.intellij.openapi.actionSystem.ex.ActionUtil
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.PathManager
@@ -154,7 +155,7 @@ object LicenseChecker {
                     ActionUiKind.NONE,
                     null,
                 )
-            action.actionPerformed(event)
+            ActionUtil.invokeAction(action, event, null)
         }, ModalityState.nonModal())
     }
 


### PR DESCRIPTION
## Summary
- Revert PR #62 change that replaced `ActionUtil.invokeAction(action, event, null)` with `action.actionPerformed(event)`
- `actionPerformed` is override-only — IDE warns against direct calls
- Bytecode decompilation of IntelliJ 2025.2.3 confirms `invokeAction(AnAction, AnActionEvent, Runnable)` is NOT deprecated — verifier false positive

## Test plan
- [x] `./gradlew buildPlugin` passes
- [x] `./gradlew verifyPlugin` passes
- [ ] Retag v2.3.0 after merge to re-trigger release

## Summary by Sourcery

Bug Fixes:
- Fix action invocation by delegating to ActionUtil.invokeAction rather than calling actionPerformed directly, aligning with IntelliJ platform expectations.