### PR TITLE
chore: bump version to 2.3.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.3.0
+pluginVersion=2.3.1
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -71,6 +71,10 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>2.3.1</h3>
+    <ul>
+      <li>Bug fixes</li>
+    </ul>
     <h3>2.3.0</h3>
     <ul>
       <li>[Paid] Auto-fit with configurable min/max width for Project View, Commit, and Git panels</li>


### PR DESCRIPTION
## Summary
- Bump pluginVersion to 2.3.1
- Add changelog entry for patch release

## Test plan
- [x] `./gradlew buildPlugin` passes
- [x] `./gradlew verifyPlugin` passes
- [ ] Tag v2.3.1 after merge to trigger release

## Summary by Sourcery

Bump the plugin version to 2.3.1 and document the patch release.

Build:
- Update pluginVersion in gradle.properties to 2.3.1.

Documentation:
- Add changelog entry for the 2.3.1 patch release in plugin.xml.