### PR TITLE
test(BAR-138): add 75 regression tests for v2.3.0 bugs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -148,7 +148,7 @@ kover {
                     "dev.ayuislands.AyuIslandsStartupActivity*",
                     "dev.ayuislands.AyuIslandsLafListener*",
                     "dev.ayuislands.AppearanceSyncListener*",
-                    // LicenseChecker: public API tested, private crypto is JetBrains boilerplate
+                    // LicenseChecker: public API tested; private crypto is JetBrains boilerplate
                     "dev.ayuislands.licensing.LicenseChecker*",
                     // IDE glue: Swing UI DSL panel (pure rendering, no extractable logic)
                     "dev.ayuislands.settings.WorkspacePanel*",

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -8,15 +8,11 @@ import com.intellij.openapi.startup.ProjectActivity
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.conflict.ConflictRegistry
-import dev.ayuislands.commitpanel.CommitPanelAutoFitManager
 import dev.ayuislands.font.FontPreset
 import dev.ayuislands.font.FontPresetApplicator
-import dev.ayuislands.gitpanel.GitPanelAutoFitManager
 import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.licensing.LicenseChecker
-import dev.ayuislands.projectview.ProjectViewScrollbarManager
 import dev.ayuislands.settings.AyuIslandsSettings
-import dev.ayuislands.settings.PanelWidthMode
 import javax.swing.SwingUtilities
 
 internal class AyuIslandsStartupActivity : ProjectActivity {
@@ -82,81 +78,16 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
 
         SwingUtilities.invokeLater {
             if (licenseState != false) {
-                applyLicensedDefaults(project, settings)
+                StartupLicenseHandler.applyLicensedDefaults(project, settings)
             } else {
-                applyUnlicensedDefaults(project, variant, settings)
+                StartupLicenseHandler.applyUnlicensedDefaults(project, variant, settings)
             }
 
             // Migrate width modes before service init reads them
             settings.state.migrateWidthModes()
 
             // Initialize workspace services after defaults are applied (no race)
-            initWorkspaceServices(project, settings)
-        }
-    }
-
-    internal fun applyLicensedDefaults(
-        project: Project,
-        settings: AyuIslandsSettings,
-    ) {
-        if (settings.state.trialExpiredNotified) {
-            settings.state.trialExpiredNotified = false
-            settings.state.proDefaultsApplied = false
-            settings.state.trialWelcomeShown = false
-        }
-
-        if (!settings.state.proDefaultsApplied) {
-            LicenseChecker.enableProDefaults()
-            LOG.info("Ayu Islands Pro defaults enabled (first-time license activation)")
-
-            if (!settings.state.trialWelcomeShown) {
-                LicenseChecker.notifyTrialWelcome(project)
-                settings.state.trialWelcomeShown = true
-            }
-        }
-
-        // Migration: workspace defaults for existing users upgrading to 2.3.0
-        if (!settings.state.workspaceDefaultsApplied) {
-            LicenseChecker.applyWorkspaceDefaults()
-            LOG.info("Ayu Islands workspace defaults migrated for existing user")
-        }
-    }
-
-    internal fun applyUnlicensedDefaults(
-        project: Project,
-        variant: AyuVariant,
-        settings: AyuIslandsSettings,
-    ) {
-        LicenseChecker.revertToFreeDefaults(variant)
-        LOG.info("Ayu Islands reverted to free defaults for ${variant.name}")
-
-        if (!settings.state.trialExpiredNotified) {
-            LicenseChecker.notifyTrialExpired(project)
-            settings.state.trialExpiredNotified = true
-        }
-    }
-
-    internal fun initWorkspaceServices(
-        project: Project,
-        settings: AyuIslandsSettings,
-    ) {
-        if (project.isDisposed) return
-        val pvState = settings.state
-        val hasProjectViewCustomizations =
-            pvState.hideProjectViewHScrollbar ||
-                pvState.hideProjectRootPath
-        if (hasProjectViewCustomizations ||
-            PanelWidthMode.fromString(pvState.projectPanelWidthMode) != PanelWidthMode.DEFAULT
-        ) {
-            ProjectViewScrollbarManager.getInstance(project)
-        }
-
-        if (PanelWidthMode.fromString(pvState.commitPanelWidthMode) != PanelWidthMode.DEFAULT) {
-            CommitPanelAutoFitManager.getInstance(project)
-        }
-
-        if (PanelWidthMode.fromString(pvState.gitPanelWidthMode) != PanelWidthMode.DEFAULT) {
-            GitPanelAutoFitManager.getInstance(project)
+            StartupLicenseHandler.initWorkspaceServices(project, settings)
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -95,7 +95,7 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
         }
     }
 
-    private fun applyLicensedDefaults(
+    internal fun applyLicensedDefaults(
         project: Project,
         settings: AyuIslandsSettings,
     ) {
@@ -122,7 +122,7 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
         }
     }
 
-    private fun applyUnlicensedDefaults(
+    internal fun applyUnlicensedDefaults(
         project: Project,
         variant: AyuVariant,
         settings: AyuIslandsSettings,
@@ -136,7 +136,7 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
         }
     }
 
-    private fun initWorkspaceServices(
+    internal fun initWorkspaceServices(
         project: Project,
         settings: AyuIslandsSettings,
     ) {

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -77,17 +77,19 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
         LOG.info("Ayu Islands license check: ${licenseStateLabel(licenseState)}")
 
         SwingUtilities.invokeLater {
-            if (licenseState != false) {
-                StartupLicenseHandler.applyLicensedDefaults(project, settings)
-            } else {
-                StartupLicenseHandler.applyUnlicensedDefaults(project, variant, settings)
+            if (project.isDisposed) return@invokeLater
+            try {
+                if (licenseState != false) {
+                    StartupLicenseHandler.applyLicensedDefaults(project, settings)
+                } else {
+                    StartupLicenseHandler.applyUnlicensedDefaults(project, variant, settings)
+                }
+
+                settings.state.migrateWidthModes()
+                StartupLicenseHandler.initWorkspaceServices(project, settings)
+            } catch (e: RuntimeException) {
+                LOG.error("License defaults failed", e)
             }
-
-            // Migrate width modes before service init reads them
-            settings.state.migrateWidthModes()
-
-            // Initialize workspace services after defaults are applied (no race)
-            StartupLicenseHandler.initWorkspaceServices(project, settings)
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/StartupLicenseHandler.kt
+++ b/src/main/kotlin/dev/ayuislands/StartupLicenseHandler.kt
@@ -11,7 +11,7 @@ import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.PanelWidthMode
 
 /**
- * Pure license-state branching logic, extracted from
+ * License-state dispatch logic, extracted from
  * [AyuIslandsStartupActivity] for testability.
  */
 internal object StartupLicenseHandler {
@@ -70,7 +70,10 @@ internal object StartupLicenseHandler {
         project: Project,
         settings: AyuIslandsSettings,
     ) {
-        if (project.isDisposed) return
+        if (project.isDisposed) {
+            LOG.info("Skipping workspace services — project disposed")
+            return
+        }
         val state = settings.state
         val hasProjectViewCustomizations =
             state.hideProjectViewHScrollbar ||

--- a/src/main/kotlin/dev/ayuislands/StartupLicenseHandler.kt
+++ b/src/main/kotlin/dev/ayuislands/StartupLicenseHandler.kt
@@ -1,0 +1,100 @@
+package dev.ayuislands
+
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.commitpanel.CommitPanelAutoFitManager
+import dev.ayuislands.gitpanel.GitPanelAutoFitManager
+import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.projectview.ProjectViewScrollbarManager
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.PanelWidthMode
+
+/**
+ * Pure license-state branching logic, extracted from
+ * [AyuIslandsStartupActivity] for testability.
+ */
+internal object StartupLicenseHandler {
+    private val LOG = logger<StartupLicenseHandler>()
+
+    fun applyLicensedDefaults(
+        project: Project,
+        settings: AyuIslandsSettings,
+    ) {
+        if (settings.state.trialExpiredNotified) {
+            settings.state.trialExpiredNotified = false
+            settings.state.proDefaultsApplied = false
+            settings.state.trialWelcomeShown = false
+        }
+
+        if (!settings.state.proDefaultsApplied) {
+            LicenseChecker.enableProDefaults()
+            LOG.info(
+                "Ayu Islands Pro defaults enabled " +
+                    "(first-time license activation)",
+            )
+
+            if (!settings.state.trialWelcomeShown) {
+                LicenseChecker.notifyTrialWelcome(project)
+                settings.state.trialWelcomeShown = true
+            }
+        }
+
+        if (!settings.state.workspaceDefaultsApplied) {
+            LicenseChecker.applyWorkspaceDefaults()
+            LOG.info(
+                "Ayu Islands workspace defaults " +
+                    "migrated for existing user",
+            )
+        }
+    }
+
+    fun applyUnlicensedDefaults(
+        project: Project,
+        variant: AyuVariant,
+        settings: AyuIslandsSettings,
+    ) {
+        LicenseChecker.revertToFreeDefaults(variant)
+        LOG.info(
+            "Ayu Islands reverted to free defaults " +
+                "for ${variant.name}",
+        )
+
+        if (!settings.state.trialExpiredNotified) {
+            LicenseChecker.notifyTrialExpired(project)
+            settings.state.trialExpiredNotified = true
+        }
+    }
+
+    fun initWorkspaceServices(
+        project: Project,
+        settings: AyuIslandsSettings,
+    ) {
+        if (project.isDisposed) return
+        val state = settings.state
+        val hasProjectViewCustomizations =
+            state.hideProjectViewHScrollbar ||
+                state.hideProjectRootPath
+        if (hasProjectViewCustomizations ||
+            PanelWidthMode.fromString(
+                state.projectPanelWidthMode,
+            ) != PanelWidthMode.DEFAULT
+        ) {
+            ProjectViewScrollbarManager.getInstance(project)
+        }
+
+        if (PanelWidthMode.fromString(
+                state.commitPanelWidthMode,
+            ) != PanelWidthMode.DEFAULT
+        ) {
+            CommitPanelAutoFitManager.getInstance(project)
+        }
+
+        if (PanelWidthMode.fromString(
+                state.gitPanelWidthMode,
+            ) != PanelWidthMode.DEFAULT
+        ) {
+            GitPanelAutoFitManager.getInstance(project)
+        }
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
@@ -217,7 +217,10 @@ object LicenseChecker {
         state.proDefaultsApplied = true
     }
 
-    /** Apply workspace defaults (auto-fit, hide path/VCS). Callers must guard with workspaceDefaultsApplied flag. */
+    /**
+     * Apply workspace defaults (auto-fit, hide path/VCS).
+     * Callers must guard with the workspaceDefaultsApplied flag.
+     */
     fun applyWorkspaceDefaults() {
         val state = AyuIslandsSettings.getInstance().state
         state.projectPanelWidthMode = PanelWidthMode.AUTO_FIT.name

--- a/src/test/kotlin/dev/ayuislands/StartupLicenseStateTest.kt
+++ b/src/test/kotlin/dev/ayuislands/StartupLicenseStateTest.kt
@@ -2,7 +2,10 @@ package dev.ayuislands
 
 import com.intellij.openapi.project.Project
 import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.commitpanel.CommitPanelAutoFitManager
+import dev.ayuislands.gitpanel.GitPanelAutoFitManager
 import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.projectview.ProjectViewScrollbarManager
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
 import dev.ayuislands.settings.PanelWidthMode
@@ -205,5 +208,67 @@ class StartupLicenseStateTest {
         state.gitPanelWidthMode = PanelWidthMode.DEFAULT.name
 
         StartupLicenseHandler.initWorkspaceServices(project, settings)
+    }
+
+    @Test
+    fun `initWorkspaceServices inits ProjectView when hideRootPath enabled`() {
+        every { project.isDisposed } returns false
+        mockkObject(ProjectViewScrollbarManager.Companion)
+        every {
+            ProjectViewScrollbarManager.getInstance(project)
+        } returns mockk(relaxed = true)
+
+        state.hideProjectRootPath = true
+        state.projectPanelWidthMode = PanelWidthMode.DEFAULT.name
+        state.commitPanelWidthMode = PanelWidthMode.DEFAULT.name
+        state.gitPanelWidthMode = PanelWidthMode.DEFAULT.name
+
+        StartupLicenseHandler.initWorkspaceServices(project, settings)
+
+        verify(exactly = 1) {
+            ProjectViewScrollbarManager.getInstance(project)
+        }
+    }
+
+    @Test
+    fun `initWorkspaceServices inits CommitPanel when mode is AUTO_FIT`() {
+        every { project.isDisposed } returns false
+        mockkObject(CommitPanelAutoFitManager.Companion)
+        every {
+            CommitPanelAutoFitManager.getInstance(project)
+        } returns mockk(relaxed = true)
+
+        state.hideProjectViewHScrollbar = false
+        state.hideProjectRootPath = false
+        state.projectPanelWidthMode = PanelWidthMode.DEFAULT.name
+        state.commitPanelWidthMode = PanelWidthMode.AUTO_FIT.name
+        state.gitPanelWidthMode = PanelWidthMode.DEFAULT.name
+
+        StartupLicenseHandler.initWorkspaceServices(project, settings)
+
+        verify(exactly = 1) {
+            CommitPanelAutoFitManager.getInstance(project)
+        }
+    }
+
+    @Test
+    fun `initWorkspaceServices inits GitPanel when mode is FIXED`() {
+        every { project.isDisposed } returns false
+        mockkObject(GitPanelAutoFitManager.Companion)
+        every {
+            GitPanelAutoFitManager.getInstance(project)
+        } returns mockk(relaxed = true)
+
+        state.hideProjectViewHScrollbar = false
+        state.hideProjectRootPath = false
+        state.projectPanelWidthMode = PanelWidthMode.DEFAULT.name
+        state.commitPanelWidthMode = PanelWidthMode.DEFAULT.name
+        state.gitPanelWidthMode = PanelWidthMode.FIXED.name
+
+        StartupLicenseHandler.initWorkspaceServices(project, settings)
+
+        verify(exactly = 1) {
+            GitPanelAutoFitManager.getInstance(project)
+        }
     }
 }

--- a/src/test/kotlin/dev/ayuislands/StartupLicenseStateTest.kt
+++ b/src/test/kotlin/dev/ayuislands/StartupLicenseStateTest.kt
@@ -1,5 +1,6 @@
 package dev.ayuislands
 
+import com.intellij.openapi.project.Project
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
@@ -21,8 +22,7 @@ import kotlin.test.assertTrue
 class StartupLicenseStateTest {
     private lateinit var state: AyuIslandsState
     private lateinit var settings: AyuIslandsSettings
-    private val activity = AyuIslandsStartupActivity()
-    private val project = mockk<com.intellij.openapi.project.Project>(relaxed = true)
+    private val project = mockk<Project>(relaxed = true)
 
     @BeforeTest
     fun setUp() {
@@ -52,7 +52,7 @@ class StartupLicenseStateTest {
     fun `licensed state calls enableProDefaults when not yet applied`() {
         state.proDefaultsApplied = false
 
-        activity.applyLicensedDefaults(project, settings)
+        StartupLicenseHandler.applyLicensedDefaults(project, settings)
 
         verify(exactly = 1) { LicenseChecker.enableProDefaults() }
     }
@@ -61,7 +61,7 @@ class StartupLicenseStateTest {
     fun `licensed state skips enableProDefaults when already applied`() {
         state.proDefaultsApplied = true
 
-        activity.applyLicensedDefaults(project, settings)
+        StartupLicenseHandler.applyLicensedDefaults(project, settings)
 
         verify(exactly = 0) { LicenseChecker.enableProDefaults() }
     }
@@ -71,7 +71,7 @@ class StartupLicenseStateTest {
         state.trialExpiredNotified = true
         state.proDefaultsApplied = true
 
-        activity.applyLicensedDefaults(project, settings)
+        StartupLicenseHandler.applyLicensedDefaults(project, settings)
 
         assertFalse(state.trialExpiredNotified)
     }
@@ -81,9 +81,8 @@ class StartupLicenseStateTest {
         state.trialExpiredNotified = true
         state.proDefaultsApplied = true
 
-        activity.applyLicensedDefaults(project, settings)
+        StartupLicenseHandler.applyLicensedDefaults(project, settings)
 
-        // proDefaultsApplied was reset to false, so enableProDefaults should be called
         verify(exactly = 1) { LicenseChecker.enableProDefaults() }
     }
 
@@ -93,10 +92,11 @@ class StartupLicenseStateTest {
         state.proDefaultsApplied = true
         state.trialWelcomeShown = true
 
-        activity.applyLicensedDefaults(project, settings)
+        StartupLicenseHandler.applyLicensedDefaults(project, settings)
 
-        // trialWelcomeShown was reset, so the welcome notification should be shown again
-        verify(exactly = 1) { LicenseChecker.notifyTrialWelcome(project) }
+        verify(exactly = 1) {
+            LicenseChecker.notifyTrialWelcome(project)
+        }
     }
 
     @Test
@@ -104,9 +104,11 @@ class StartupLicenseStateTest {
         state.proDefaultsApplied = false
         state.trialWelcomeShown = false
 
-        activity.applyLicensedDefaults(project, settings)
+        StartupLicenseHandler.applyLicensedDefaults(project, settings)
 
-        verify(exactly = 1) { LicenseChecker.notifyTrialWelcome(project) }
+        verify(exactly = 1) {
+            LicenseChecker.notifyTrialWelcome(project)
+        }
         assertTrue(state.trialWelcomeShown)
     }
 
@@ -115,7 +117,7 @@ class StartupLicenseStateTest {
         state.proDefaultsApplied = false
         state.trialWelcomeShown = true
 
-        activity.applyLicensedDefaults(project, settings)
+        StartupLicenseHandler.applyLicensedDefaults(project, settings)
 
         verify(exactly = 0) { LicenseChecker.notifyTrialWelcome(any()) }
     }
@@ -125,7 +127,7 @@ class StartupLicenseStateTest {
         state.proDefaultsApplied = true
         state.workspaceDefaultsApplied = false
 
-        activity.applyLicensedDefaults(project, settings)
+        StartupLicenseHandler.applyLicensedDefaults(project, settings)
 
         verify(exactly = 1) { LicenseChecker.applyWorkspaceDefaults() }
     }
@@ -135,7 +137,7 @@ class StartupLicenseStateTest {
         state.proDefaultsApplied = true
         state.workspaceDefaultsApplied = true
 
-        activity.applyLicensedDefaults(project, settings)
+        StartupLicenseHandler.applyLicensedDefaults(project, settings)
 
         verify(exactly = 0) { LicenseChecker.applyWorkspaceDefaults() }
     }
@@ -144,26 +146,42 @@ class StartupLicenseStateTest {
 
     @Test
     fun `unlicensed state calls revertToFreeDefaults`() {
-        activity.applyUnlicensedDefaults(project, AyuVariant.MIRAGE, settings)
+        StartupLicenseHandler.applyUnlicensedDefaults(
+            project,
+            AyuVariant.MIRAGE,
+            settings,
+        )
 
-        verify(exactly = 1) { LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE) }
+        verify(exactly = 1) {
+            LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
+        }
     }
 
     @Test
     fun `unlicensed state sets trialExpiredNotified flag`() {
         state.trialExpiredNotified = false
 
-        activity.applyUnlicensedDefaults(project, AyuVariant.DARK, settings)
+        StartupLicenseHandler.applyUnlicensedDefaults(
+            project,
+            AyuVariant.DARK,
+            settings,
+        )
 
         assertTrue(state.trialExpiredNotified)
-        verify(exactly = 1) { LicenseChecker.notifyTrialExpired(project) }
+        verify(exactly = 1) {
+            LicenseChecker.notifyTrialExpired(project)
+        }
     }
 
     @Test
     fun `unlicensed state skips notification when already notified`() {
         state.trialExpiredNotified = true
 
-        activity.applyUnlicensedDefaults(project, AyuVariant.LIGHT, settings)
+        StartupLicenseHandler.applyUnlicensedDefaults(
+            project,
+            AyuVariant.LIGHT,
+            settings,
+        )
 
         verify(exactly = 0) { LicenseChecker.notifyTrialExpired(any()) }
     }
@@ -174,8 +192,7 @@ class StartupLicenseStateTest {
     fun `initWorkspaceServices skips when project is disposed`() {
         every { project.isDisposed } returns true
 
-        // Should return immediately without error
-        activity.initWorkspaceServices(project, settings)
+        StartupLicenseHandler.initWorkspaceServices(project, settings)
     }
 
     @Test
@@ -187,7 +204,6 @@ class StartupLicenseStateTest {
         state.commitPanelWidthMode = PanelWidthMode.DEFAULT.name
         state.gitPanelWidthMode = PanelWidthMode.DEFAULT.name
 
-        // Should not throw — no services initialized
-        activity.initWorkspaceServices(project, settings)
+        StartupLicenseHandler.initWorkspaceServices(project, settings)
     }
 }

--- a/src/test/kotlin/dev/ayuislands/StartupLicenseStateTest.kt
+++ b/src/test/kotlin/dev/ayuislands/StartupLicenseStateTest.kt
@@ -1,0 +1,193 @@
+package dev.ayuislands
+
+import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
+import dev.ayuislands.settings.PanelWidthMode
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.runs
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class StartupLicenseStateTest {
+    private lateinit var state: AyuIslandsState
+    private lateinit var settings: AyuIslandsSettings
+    private val activity = AyuIslandsStartupActivity()
+    private val project = mockk<com.intellij.openapi.project.Project>(relaxed = true)
+
+    @BeforeTest
+    fun setUp() {
+        state = AyuIslandsState()
+        settings = mockk<AyuIslandsSettings>()
+        every { settings.state } returns state
+
+        mockkObject(AyuIslandsSettings.Companion)
+        every { AyuIslandsSettings.getInstance() } returns settings
+
+        mockkObject(LicenseChecker)
+        every { LicenseChecker.enableProDefaults() } just runs
+        every { LicenseChecker.applyWorkspaceDefaults() } just runs
+        every { LicenseChecker.revertToFreeDefaults(any()) } just runs
+        every { LicenseChecker.notifyTrialWelcome(any()) } just runs
+        every { LicenseChecker.notifyTrialExpired(any()) } just runs
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    // applyLicensedDefaults
+
+    @Test
+    fun `licensed state calls enableProDefaults when not yet applied`() {
+        state.proDefaultsApplied = false
+
+        activity.applyLicensedDefaults(project, settings)
+
+        verify(exactly = 1) { LicenseChecker.enableProDefaults() }
+    }
+
+    @Test
+    fun `licensed state skips enableProDefaults when already applied`() {
+        state.proDefaultsApplied = true
+
+        activity.applyLicensedDefaults(project, settings)
+
+        verify(exactly = 0) { LicenseChecker.enableProDefaults() }
+    }
+
+    @Test
+    fun `re-license after expiry resets trialExpiredNotified flag`() {
+        state.trialExpiredNotified = true
+        state.proDefaultsApplied = true
+
+        activity.applyLicensedDefaults(project, settings)
+
+        assertFalse(state.trialExpiredNotified)
+    }
+
+    @Test
+    fun `re-license after expiry resets proDefaultsApplied to re-apply defaults`() {
+        state.trialExpiredNotified = true
+        state.proDefaultsApplied = true
+
+        activity.applyLicensedDefaults(project, settings)
+
+        // proDefaultsApplied was reset to false, so enableProDefaults should be called
+        verify(exactly = 1) { LicenseChecker.enableProDefaults() }
+    }
+
+    @Test
+    fun `re-license after expiry resets trialWelcomeShown`() {
+        state.trialExpiredNotified = true
+        state.proDefaultsApplied = true
+        state.trialWelcomeShown = true
+
+        activity.applyLicensedDefaults(project, settings)
+
+        // trialWelcomeShown was reset, so the welcome notification should be shown again
+        verify(exactly = 1) { LicenseChecker.notifyTrialWelcome(project) }
+    }
+
+    @Test
+    fun `first activation shows trial welcome notification`() {
+        state.proDefaultsApplied = false
+        state.trialWelcomeShown = false
+
+        activity.applyLicensedDefaults(project, settings)
+
+        verify(exactly = 1) { LicenseChecker.notifyTrialWelcome(project) }
+        assertTrue(state.trialWelcomeShown)
+    }
+
+    @Test
+    fun `subsequent activation skips trial welcome notification`() {
+        state.proDefaultsApplied = false
+        state.trialWelcomeShown = true
+
+        activity.applyLicensedDefaults(project, settings)
+
+        verify(exactly = 0) { LicenseChecker.notifyTrialWelcome(any()) }
+    }
+
+    @Test
+    fun `workspace migration runs when not yet applied`() {
+        state.proDefaultsApplied = true
+        state.workspaceDefaultsApplied = false
+
+        activity.applyLicensedDefaults(project, settings)
+
+        verify(exactly = 1) { LicenseChecker.applyWorkspaceDefaults() }
+    }
+
+    @Test
+    fun `workspace migration skips when already applied`() {
+        state.proDefaultsApplied = true
+        state.workspaceDefaultsApplied = true
+
+        activity.applyLicensedDefaults(project, settings)
+
+        verify(exactly = 0) { LicenseChecker.applyWorkspaceDefaults() }
+    }
+
+    // applyUnlicensedDefaults
+
+    @Test
+    fun `unlicensed state calls revertToFreeDefaults`() {
+        activity.applyUnlicensedDefaults(project, AyuVariant.MIRAGE, settings)
+
+        verify(exactly = 1) { LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE) }
+    }
+
+    @Test
+    fun `unlicensed state sets trialExpiredNotified flag`() {
+        state.trialExpiredNotified = false
+
+        activity.applyUnlicensedDefaults(project, AyuVariant.DARK, settings)
+
+        assertTrue(state.trialExpiredNotified)
+        verify(exactly = 1) { LicenseChecker.notifyTrialExpired(project) }
+    }
+
+    @Test
+    fun `unlicensed state skips notification when already notified`() {
+        state.trialExpiredNotified = true
+
+        activity.applyUnlicensedDefaults(project, AyuVariant.LIGHT, settings)
+
+        verify(exactly = 0) { LicenseChecker.notifyTrialExpired(any()) }
+    }
+
+    // initWorkspaceServices
+
+    @Test
+    fun `initWorkspaceServices skips when project is disposed`() {
+        every { project.isDisposed } returns true
+
+        // Should return immediately without error
+        activity.initWorkspaceServices(project, settings)
+    }
+
+    @Test
+    fun `initWorkspaceServices skips all services when no customizations`() {
+        every { project.isDisposed } returns false
+        state.hideProjectViewHScrollbar = false
+        state.hideProjectRootPath = false
+        state.projectPanelWidthMode = PanelWidthMode.DEFAULT.name
+        state.commitPanelWidthMode = PanelWidthMode.DEFAULT.name
+        state.gitPanelWidthMode = PanelWidthMode.DEFAULT.name
+
+        // Should not throw — no services initialized
+        activity.initWorkspaceServices(project, settings)
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManagerTest.kt
@@ -1,0 +1,176 @@
+package dev.ayuislands.commitpanel
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ToolWindowManager
+import com.intellij.openapi.wm.ToolWindowType
+import com.intellij.openapi.wm.ex.ToolWindowEx
+import com.intellij.openapi.wm.ex.ToolWindowManagerListener
+import com.intellij.util.messages.MessageBus
+import com.intellij.util.messages.MessageBusConnection
+import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
+import dev.ayuislands.settings.PanelWidthMode
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import java.awt.FlowLayout
+import javax.swing.JPanel
+import javax.swing.SwingUtilities
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+class CommitPanelAutoFitManagerTest {
+    private lateinit var project: Project
+    private lateinit var toolWindowManager: ToolWindowManager
+    private lateinit var toolWindowEx: ToolWindowEx
+    private lateinit var settingsMock: AyuIslandsSettings
+    private lateinit var realState: AyuIslandsState
+    private lateinit var connection: MessageBusConnection
+
+    @BeforeTest
+    fun setUp() {
+        mockkStatic(ToolWindowManager::class)
+        mockkObject(AyuIslandsSettings.Companion)
+        mockkObject(LicenseChecker)
+
+        realState = AyuIslandsState()
+        settingsMock =
+            mockk<AyuIslandsSettings> {
+                every { state } returns realState
+            }
+        every {
+            AyuIslandsSettings.getInstance()
+        } returns settingsMock
+
+        connection = mockk(relaxed = true)
+        val messageBus =
+            mockk<MessageBus> {
+                every {
+                    connect(any<Disposable>())
+                } returns connection
+            }
+
+        project =
+            mockk(relaxed = true) {
+                every { isDisposed } returns false
+                every { this@mockk.messageBus } returns messageBus
+            }
+
+        toolWindowManager = mockk(relaxed = true)
+        every {
+            ToolWindowManager.getInstance(project)
+        } returns toolWindowManager
+
+        toolWindowEx = mockk(relaxed = true)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `apply does nothing when not licensed`() {
+        SwingUtilities.invokeAndWait {
+            every {
+                LicenseChecker.isLicensedOrGrace()
+            } returns false
+
+            val manager = CommitPanelAutoFitManager(project)
+            manager.apply()
+
+            // No ToolWindowManager interaction expected
+            verify(exactly = 0) {
+                toolWindowManager.getToolWindow(any())
+            }
+        }
+    }
+
+    @Test
+    fun `apply with DEFAULT mode does not stretch`() {
+        SwingUtilities.invokeAndWait {
+            every {
+                LicenseChecker.isLicensedOrGrace()
+            } returns true
+            realState.commitPanelWidthMode =
+                PanelWidthMode.DEFAULT.name
+
+            // No tool window needed; DEFAULT just removes
+            // expansion listener (no-op if none installed)
+            every {
+                toolWindowManager.getToolWindow("Commit")
+            } returns null
+
+            val manager = CommitPanelAutoFitManager(project)
+            manager.apply()
+
+            // Should not call stretchWidth
+            verify(exactly = 0) {
+                toolWindowEx.stretchWidth(any())
+            }
+        }
+    }
+
+    @Test
+    fun `apply with FIXED mode calls stretchWidth`() {
+        SwingUtilities.invokeAndWait {
+            every {
+                LicenseChecker.isLicensedOrGrace()
+            } returns true
+            realState.commitPanelWidthMode =
+                PanelWidthMode.FIXED.name
+            realState.commitPanelFixedWidth = 350
+
+            val panel = JPanel(FlowLayout())
+            panel.setSize(200, 400)
+            every {
+                toolWindowManager.getToolWindow("Commit")
+            } returns toolWindowEx
+            every {
+                toolWindowEx.component
+            } returns panel
+            every {
+                toolWindowEx.type
+            } returns ToolWindowType.DOCKED
+
+            val manager = CommitPanelAutoFitManager(project)
+            manager.apply()
+
+            verify { toolWindowEx.stretchWidth(any()) }
+        }
+    }
+
+    @Test
+    fun `dispose removes expansion listener safely`() {
+        SwingUtilities.invokeAndWait {
+            every {
+                LicenseChecker.isLicensedOrGrace()
+            } returns true
+            every {
+                toolWindowManager.getToolWindow("Commit")
+            } returns null
+
+            val manager = CommitPanelAutoFitManager(project)
+            // Should not throw
+            manager.dispose()
+        }
+    }
+
+    @Test
+    fun `init subscribes to ToolWindowManagerListener`() {
+        CommitPanelAutoFitManager(project)
+
+        verify {
+            connection.subscribe(
+                ToolWindowManagerListener.TOPIC,
+                any(),
+            )
+        }
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManagerTest.kt
@@ -165,7 +165,8 @@ class GitPanelAutoFitManagerTest {
             manager.apply()
 
             // Inner splitter (firstHasTable=true):
-            // a proportion = 1.0 - desired/total
+            // proportion = (1.0 - desired/total)
+            //   .coerceIn(0.5, 0.95)
             // desired = (250+20).coerceAtMost(500)
             //                   .coerceAtLeast(200) = 270
             // expected ≈ 1.0 - 270/1000 = 0.73

--- a/src/test/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManagerTest.kt
@@ -164,13 +164,16 @@ class GitPanelAutoFitManagerTest {
             val manager = GitPanelAutoFitManager(project)
             manager.apply()
 
-            // Splitter proportion should have been set
-            // (inner splitter: firstHasTable=true)
+            // Inner splitter (firstHasTable=true):
+            // proportion = 1.0 - desired/total
+            // desired = (250+20).coerceAtMost(500)
+            //                   .coerceAtLeast(200) = 270
+            // expected ≈ 1.0 - 270/1000 = 0.73
             val proportion = splitter.proportion
             assertTrue(
-                proportion in 0.5f..0.95f,
-                "Expected inner proportion in " +
-                    "[0.5, 0.95] but got $proportion",
+                proportion in 0.7f..0.76f,
+                "Expected inner proportion ~0.73 " +
+                    "but got $proportion",
             )
         }
     }

--- a/src/test/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManagerTest.kt
@@ -165,7 +165,7 @@ class GitPanelAutoFitManagerTest {
             manager.apply()
 
             // Inner splitter (firstHasTable=true):
-            // proportion = 1.0 - desired/total
+            // a proportion = 1.0 - desired/total
             // desired = (250+20).coerceAtMost(500)
             //                   .coerceAtLeast(200) = 270
             // expected ≈ 1.0 - 270/1000 = 0.73

--- a/src/test/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManagerTest.kt
@@ -1,0 +1,301 @@
+package dev.ayuislands.gitpanel
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.Splitter
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowManager
+import com.intellij.openapi.wm.ex.ToolWindowManagerListener
+import com.intellij.ui.content.Content
+import com.intellij.ui.content.ContentManager
+import com.intellij.util.messages.MessageBus
+import com.intellij.util.messages.MessageBusConnection
+import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
+import dev.ayuislands.settings.PanelWidthMode
+import dev.ayuislands.toolwindow.AutoFitCalculator
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import java.awt.FlowLayout
+import javax.swing.JPanel
+import javax.swing.JTable
+import javax.swing.JTree
+import javax.swing.SwingUtilities
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class GitPanelAutoFitManagerTest {
+    private lateinit var project: Project
+    private lateinit var toolWindowManager: ToolWindowManager
+    private lateinit var settingsMock: AyuIslandsSettings
+    private lateinit var realState: AyuIslandsState
+    private lateinit var connection: MessageBusConnection
+
+    @BeforeTest
+    fun setUp() {
+        mockkStatic(ToolWindowManager::class)
+        mockkObject(AyuIslandsSettings.Companion)
+        mockkObject(LicenseChecker)
+
+        realState = AyuIslandsState()
+        settingsMock =
+            mockk<AyuIslandsSettings> {
+                every { state } returns realState
+            }
+        every {
+            AyuIslandsSettings.getInstance()
+        } returns settingsMock
+
+        connection = mockk(relaxed = true)
+        val messageBus =
+            mockk<MessageBus> {
+                every {
+                    connect(any<Disposable>())
+                } returns connection
+            }
+
+        project =
+            mockk(relaxed = true) {
+                every { isDisposed } returns false
+                every { this@mockk.messageBus } returns messageBus
+            }
+
+        toolWindowManager = mockk(relaxed = true)
+        every {
+            ToolWindowManager.getInstance(project)
+        } returns toolWindowManager
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `apply does nothing when not licensed`() {
+        every {
+            LicenseChecker.isLicensedOrGrace()
+        } returns false
+
+        val manager = GitPanelAutoFitManager(project)
+        manager.apply()
+
+        // No tool window interaction
+        verify(exactly = 0) {
+            toolWindowManager.getToolWindow(any())
+        }
+    }
+
+    @Test
+    fun `apply with DEFAULT removes listeners`() {
+        every {
+            LicenseChecker.isLicensedOrGrace()
+        } returns true
+        realState.gitPanelWidthMode =
+            PanelWidthMode.DEFAULT.name
+
+        every {
+            toolWindowManager.getToolWindow("Version Control")
+        } returns null
+
+        val manager = GitPanelAutoFitManager(project)
+        manager.apply()
+        // No crash = listener removal path works
+    }
+
+    @Test
+    fun `apply with AUTO_FIT fits splitters`() {
+        SwingUtilities.invokeAndWait {
+            every {
+                LicenseChecker.isLicensedOrGrace()
+            } returns true
+            realState.gitPanelWidthMode =
+                PanelWidthMode.AUTO_FIT.name
+            realState.gitPanelAutoFitMaxWidth = 500
+            realState.gitPanelAutoFitMinWidth = 200
+
+            mockkObject(AutoFitCalculator)
+            every {
+                AutoFitCalculator.measureTreeMaxRowWidth(any())
+            } returns 250
+
+            // Build a splitter hierarchy inside a "Log" tab
+            val tree = JTree()
+            val table = JTable()
+            val innerFirst = JPanel(FlowLayout())
+            innerFirst.add(table)
+            val innerSecond = JPanel(FlowLayout())
+            innerSecond.add(tree)
+
+            val splitter = Splitter()
+            splitter.setSize(1000, 400)
+            splitter.firstComponent = innerFirst
+            splitter.secondComponent = innerSecond
+
+            val logContent =
+                mockk<Content>(relaxed = true) {
+                    every { tabName } returns "Log"
+                    every { component } returns splitter
+                }
+            val contentManager =
+                mockk<ContentManager>(relaxed = true) {
+                    every {
+                        contents
+                    } returns arrayOf(logContent)
+                }
+            val toolWindow =
+                mockk<ToolWindow>(relaxed = true) {
+                    every {
+                        this@mockk.contentManager
+                    } returns contentManager
+                }
+            every {
+                toolWindowManager
+                    .getToolWindow("Version Control")
+            } returns toolWindow
+
+            val manager = GitPanelAutoFitManager(project)
+            manager.apply()
+
+            // Splitter proportion should have been set
+            // (inner splitter: firstHasTable=true)
+            val proportion = splitter.proportion
+            assertTrue(
+                proportion in 0.5f..0.95f,
+                "Expected inner proportion in " +
+                    "[0.5, 0.95] but got $proportion",
+            )
+        }
+    }
+
+    @Test
+    fun `fitSplitter handles null components gracefully`() {
+        SwingUtilities.invokeAndWait {
+            every {
+                LicenseChecker.isLicensedOrGrace()
+            } returns true
+            realState.gitPanelWidthMode =
+                PanelWidthMode.AUTO_FIT.name
+
+            // Splitter with null components (lazy-loaded)
+            val splitter = Splitter()
+            splitter.setSize(1000, 400)
+            // firstComponent and secondComponent are null
+
+            val logContent =
+                mockk<Content>(relaxed = true) {
+                    every { tabName } returns "Log"
+                    every { component } returns splitter
+                }
+            val contentManager =
+                mockk<ContentManager>(relaxed = true) {
+                    every {
+                        contents
+                    } returns arrayOf(logContent)
+                }
+            val toolWindow =
+                mockk<ToolWindow>(relaxed = true) {
+                    every {
+                        this@mockk.contentManager
+                    } returns contentManager
+                }
+            every {
+                toolWindowManager
+                    .getToolWindow("Version Control")
+            } returns toolWindow
+
+            val manager = GitPanelAutoFitManager(project)
+            // Should not throw
+            manager.apply()
+        }
+    }
+
+    @Test
+    fun `apply with FIXED mode sets proportions`() {
+        SwingUtilities.invokeAndWait {
+            every {
+                LicenseChecker.isLicensedOrGrace()
+            } returns true
+            realState.gitPanelWidthMode =
+                PanelWidthMode.FIXED.name
+            realState.gitPanelFixedWidth = 300
+
+            val tree = JTree()
+            val panel = JPanel(FlowLayout())
+            panel.add(tree)
+
+            // Outer splitter: first has tree (no table)
+            val splitter = Splitter()
+            splitter.setSize(1000, 400)
+            splitter.firstComponent = panel
+            splitter.secondComponent = JPanel()
+
+            val logContent =
+                mockk<Content>(relaxed = true) {
+                    every { tabName } returns "Log"
+                    every { component } returns splitter
+                }
+            val contentManager =
+                mockk<ContentManager>(relaxed = true) {
+                    every {
+                        contents
+                    } returns arrayOf(logContent)
+                }
+            val toolWindow =
+                mockk<ToolWindow>(relaxed = true) {
+                    every {
+                        this@mockk.contentManager
+                    } returns contentManager
+                }
+            every {
+                toolWindowManager
+                    .getToolWindow("Version Control")
+            } returns toolWindow
+
+            val manager = GitPanelAutoFitManager(project)
+            manager.apply()
+
+            // Outer proportion = fixedWidth / splitterWidth
+            // = 300/1000 = 0.3, coerced to [0.05, 0.5]
+            val proportion = splitter.proportion
+            assertTrue(
+                proportion in 0.05f..0.5f,
+                "Expected outer proportion in " +
+                    "[0.05, 0.5] but got $proportion",
+            )
+        }
+    }
+
+    @Test
+    fun `dispose removes expansion listeners safely`() {
+        every {
+            LicenseChecker.isLicensedOrGrace()
+        } returns true
+        every {
+            toolWindowManager.getToolWindow("Version Control")
+        } returns null
+
+        val manager = GitPanelAutoFitManager(project)
+        // Should not throw
+        manager.dispose()
+    }
+
+    @Test
+    fun `init subscribes to ToolWindowManagerListener`() {
+        GitPanelAutoFitManager(project)
+
+        verify {
+            connection.subscribe(
+                ToolWindowManagerListener.TOPIC,
+                any(),
+            )
+        }
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/glow/GlowTargetToggleTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/GlowTargetToggleTest.kt
@@ -1,0 +1,120 @@
+package dev.ayuislands.glow
+
+import dev.ayuislands.settings.AyuIslandsState
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class GlowTargetToggleTest {
+    private val allIslandIds = listOf("Editor", "Project", "Terminal", "Run", "Debug", "Git", "Services")
+
+    private fun freshState(): AyuIslandsState = AyuIslandsState()
+
+    // BAR-143 regression #4: default trial state has all targets ON
+
+    @Test
+    fun `all glow targets are ON by default for fresh state`() {
+        val state = freshState()
+        for (id in allIslandIds) {
+            assertTrue(state.isIslandEnabled(id), "$id should be enabled by default")
+        }
+        assertTrue(state.glowFocusRing, "Focus ring should be enabled by default")
+    }
+
+    // Enable all / Disable all
+
+    @Test
+    fun `enable all sets every island to true`() {
+        val state = freshState()
+        for (id in allIslandIds) {
+            state.setIslandEnabled(id, false)
+        }
+
+        for (id in allIslandIds) {
+            state.setIslandEnabled(id, true)
+        }
+
+        for (id in allIslandIds) {
+            assertTrue(state.isIslandEnabled(id), "$id should be enabled after enable-all")
+        }
+    }
+
+    @Test
+    fun `disable all sets every island to false`() {
+        val state = freshState()
+        for (id in allIslandIds) {
+            assertTrue(state.isIslandEnabled(id), "$id should start enabled")
+        }
+
+        for (id in allIslandIds) {
+            state.setIslandEnabled(id, false)
+        }
+
+        for (id in allIslandIds) {
+            assertFalse(state.isIslandEnabled(id), "$id should be disabled after disable-all")
+        }
+    }
+
+    @Test
+    fun `enable all works regardless of glow preset`() {
+        val state = freshState()
+        for (presetName in GlowPreset.entries.map { it.name }) {
+            state.glowPreset = presetName
+
+            for (id in allIslandIds) {
+                state.setIslandEnabled(id, false)
+            }
+            for (id in allIslandIds) {
+                state.setIslandEnabled(id, true)
+            }
+
+            for (id in allIslandIds) {
+                assertTrue(
+                    state.isIslandEnabled(id),
+                    "$id should be enabled with preset $presetName",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `disabling individual target preserves others`() {
+        val state = freshState()
+
+        state.setIslandEnabled("Terminal", false)
+
+        assertTrue(state.isIslandEnabled("Editor"))
+        assertTrue(state.isIslandEnabled("Project"))
+        assertFalse(state.isIslandEnabled("Terminal"))
+        assertTrue(state.isIslandEnabled("Run"))
+        assertTrue(state.isIslandEnabled("Debug"))
+        assertTrue(state.isIslandEnabled("Git"))
+        assertTrue(state.isIslandEnabled("Services"))
+    }
+
+    @Test
+    fun `glow targets are independent of glowEnabled flag`() {
+        val state = freshState()
+        state.glowEnabled = false
+
+        for (id in allIslandIds) {
+            assertTrue(state.isIslandEnabled(id), "$id should be true even when glow is disabled")
+        }
+    }
+
+    @Test
+    fun `Git alias IDs all affect the same glow property`() {
+        val state = freshState()
+        val gitAliases = listOf("Git", "Version Control", "Commit")
+
+        state.setIslandEnabled("Git", false)
+        for (alias in gitAliases) {
+            assertFalse(state.isIslandEnabled(alias), "$alias should be false after disabling Git")
+        }
+
+        state.setIslandEnabled("Version Control", true)
+        for (alias in gitAliases) {
+            assertTrue(state.isIslandEnabled(alias), "$alias should be true after enabling via Version Control")
+        }
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerProDefaultsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerProDefaultsTest.kt
@@ -233,6 +233,11 @@ class LicenseCheckerProDefaultsTest {
         assertEquals("#CUSTOM1", state.mirageAccent)
     }
 
+    // Fragile: this test mocks a 4-deep notification chain
+    // (NotificationGroupManager→NotificationGroup→Notification→notify).
+    // If the notification path in revertToFreeDefaults changes, update
+    // the mock setup below rather than deleting the test — it covers
+    // an important error-handling path (AccentApplicator crash recovery).
     @Test
     fun `revertToFreeDefaults handles AccentApplicator failure gracefully`() {
         val settingsMock = mockk<AyuIslandsSettings>()

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerProDefaultsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerProDefaultsTest.kt
@@ -1,0 +1,276 @@
+package dev.ayuislands.licensing
+
+import com.intellij.notification.NotificationGroup
+import com.intellij.notification.NotificationGroupManager
+import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentElementId
+import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.glow.GlowAnimation
+import dev.ayuislands.glow.GlowPreset
+import dev.ayuislands.glow.GlowStyle
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
+import dev.ayuislands.settings.PanelWidthMode
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.unmockkAll
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class LicenseCheckerProDefaultsTest {
+    private lateinit var state: AyuIslandsState
+
+    @BeforeTest
+    fun setUp() {
+        state = AyuIslandsState()
+        val settingsMock = mockk<AyuIslandsSettings>()
+        mockkObject(AyuIslandsSettings.Companion)
+        every { AyuIslandsSettings.getInstance() } returns settingsMock
+        every { settingsMock.state } returns state
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    // enableProDefaults — glow settings
+
+    @Test
+    fun `enableProDefaults enables glow`() {
+        assertFalse(state.glowEnabled)
+        LicenseChecker.enableProDefaults()
+        assertTrue(state.glowEnabled)
+    }
+
+    @Test
+    fun `enableProDefaults sets glow style to SHARP_NEON`() {
+        LicenseChecker.enableProDefaults()
+        assertEquals(GlowStyle.SHARP_NEON.name, state.glowStyle)
+    }
+
+    @Test
+    fun `enableProDefaults sets glow preset to CUSTOM`() {
+        LicenseChecker.enableProDefaults()
+        assertEquals(GlowPreset.CUSTOM.name, state.glowPreset)
+    }
+
+    @Test
+    fun `enableProDefaults sets animation to BREATHE`() {
+        LicenseChecker.enableProDefaults()
+        assertEquals(GlowAnimation.BREATHE.name, state.glowAnimation)
+    }
+
+    @Test
+    fun `enableProDefaults sets intensity to 100 and width to 2`() {
+        LicenseChecker.enableProDefaults()
+        assertEquals(100, state.sharpNeonIntensity)
+        assertEquals(2, state.sharpNeonWidth)
+    }
+
+    @Test
+    fun `enableProDefaults sets all island toggles to true`() {
+        state.glowEditor = false
+        state.glowProject = false
+        state.glowTerminal = false
+        state.glowRun = false
+        state.glowDebug = false
+        state.glowGit = false
+        state.glowServices = false
+
+        LicenseChecker.enableProDefaults()
+
+        assertTrue(state.glowEditor)
+        assertTrue(state.glowProject)
+        assertTrue(state.glowTerminal)
+        assertTrue(state.glowRun)
+        assertTrue(state.glowDebug)
+        assertTrue(state.glowGit)
+        assertTrue(state.glowServices)
+    }
+
+    @Test
+    fun `enableProDefaults enables focus ring`() {
+        state.glowFocusRing = false
+        LicenseChecker.enableProDefaults()
+        assertTrue(state.glowFocusRing)
+    }
+
+    @Test
+    fun `enableProDefaults sets proDefaultsApplied flag`() {
+        assertFalse(state.proDefaultsApplied)
+        LicenseChecker.enableProDefaults()
+        assertTrue(state.proDefaultsApplied)
+    }
+
+    // enableProDefaults — workspace defaults (BAR-140 regression #2)
+
+    @Test
+    fun `enableProDefaults sets all panel width modes to AUTO_FIT`() {
+        assertEquals(PanelWidthMode.DEFAULT.name, state.projectPanelWidthMode)
+        assertEquals(PanelWidthMode.DEFAULT.name, state.commitPanelWidthMode)
+        assertEquals(PanelWidthMode.DEFAULT.name, state.gitPanelWidthMode)
+
+        LicenseChecker.enableProDefaults()
+
+        assertEquals(PanelWidthMode.AUTO_FIT.name, state.projectPanelWidthMode)
+        assertEquals(PanelWidthMode.AUTO_FIT.name, state.commitPanelWidthMode)
+        assertEquals(PanelWidthMode.AUTO_FIT.name, state.gitPanelWidthMode)
+    }
+
+    @Test
+    fun `enableProDefaults hides project root path and horizontal scrollbar`() {
+        assertFalse(state.hideProjectRootPath)
+        assertFalse(state.hideProjectViewHScrollbar)
+
+        LicenseChecker.enableProDefaults()
+
+        assertTrue(state.hideProjectRootPath)
+        assertTrue(state.hideProjectViewHScrollbar)
+    }
+
+    @Test
+    fun `enableProDefaults sets workspaceDefaultsApplied flag`() {
+        assertFalse(state.workspaceDefaultsApplied)
+        LicenseChecker.enableProDefaults()
+        assertTrue(state.workspaceDefaultsApplied)
+    }
+
+    // applyWorkspaceDefaults (standalone)
+
+    @Test
+    fun `applyWorkspaceDefaults sets all three panel modes to AUTO_FIT`() {
+        LicenseChecker.applyWorkspaceDefaults()
+
+        assertEquals(PanelWidthMode.AUTO_FIT.name, state.projectPanelWidthMode)
+        assertEquals(PanelWidthMode.AUTO_FIT.name, state.commitPanelWidthMode)
+        assertEquals(PanelWidthMode.AUTO_FIT.name, state.gitPanelWidthMode)
+    }
+
+    @Test
+    fun `applyWorkspaceDefaults hides root path and scrollbar`() {
+        LicenseChecker.applyWorkspaceDefaults()
+
+        assertTrue(state.hideProjectRootPath)
+        assertTrue(state.hideProjectViewHScrollbar)
+    }
+
+    @Test
+    fun `applyWorkspaceDefaults sets workspaceDefaultsApplied flag`() {
+        LicenseChecker.applyWorkspaceDefaults()
+        assertTrue(state.workspaceDefaultsApplied)
+    }
+
+    // revertToFreeDefaults
+
+    @Test
+    fun `revertToFreeDefaults disables glow`() {
+        state.glowEnabled = true
+        mockAccentApplicator()
+
+        LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
+
+        assertFalse(state.glowEnabled)
+    }
+
+    @Test
+    fun `revertToFreeDefaults resets tab mode to MINIMAL`() {
+        state.glowTabMode = "FULL"
+        mockAccentApplicator()
+
+        LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
+
+        assertEquals("MINIMAL", state.glowTabMode)
+    }
+
+    @Test
+    fun `revertToFreeDefaults resets all element toggles to true`() {
+        for (id in AccentElementId.entries) {
+            state.setToggle(id, false)
+        }
+        mockAccentApplicator()
+
+        LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
+
+        for (id in AccentElementId.entries) {
+            assertTrue(state.isToggleEnabled(id), "${id.name} should be reset to true")
+        }
+    }
+
+    @Test
+    fun `revertToFreeDefaults resets all workspace settings to defaults`() {
+        state.projectPanelWidthMode = PanelWidthMode.AUTO_FIT.name
+        state.commitPanelWidthMode = PanelWidthMode.AUTO_FIT.name
+        state.gitPanelWidthMode = PanelWidthMode.AUTO_FIT.name
+        state.hideProjectRootPath = true
+        state.hideProjectViewHScrollbar = true
+        mockAccentApplicator()
+
+        LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
+
+        assertEquals(PanelWidthMode.DEFAULT.name, state.projectPanelWidthMode)
+        assertEquals(PanelWidthMode.DEFAULT.name, state.commitPanelWidthMode)
+        assertEquals(PanelWidthMode.DEFAULT.name, state.gitPanelWidthMode)
+        assertFalse(state.hideProjectRootPath)
+        assertFalse(state.hideProjectViewHScrollbar)
+    }
+
+    @Test
+    fun `revertToFreeDefaults preserves accent color`() {
+        state.mirageAccent = "#CUSTOM1"
+        mockAccentApplicator()
+
+        LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
+
+        assertEquals("#CUSTOM1", state.mirageAccent)
+    }
+
+    @Test
+    fun `revertToFreeDefaults handles AccentApplicator failure gracefully`() {
+        val settingsMock = mockk<AyuIslandsSettings>()
+        every { AyuIslandsSettings.getInstance() } returns settingsMock
+        every { settingsMock.state } returns state
+        every { settingsMock.getAccentForVariant(any()) } returns "#FFCC66"
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.apply(any()) } throws RuntimeException("Test failure")
+
+        // Mock NotificationGroupManager for the catch block's warning notification
+        mockkStatic(NotificationGroupManager::class)
+        val notificationManager = mockk<NotificationGroupManager>()
+        val notificationGroup = mockk<NotificationGroup>()
+        every { NotificationGroupManager.getInstance() } returns notificationManager
+        every { notificationManager.getNotificationGroup(any()) } returns notificationGroup
+        val notification = mockk<com.intellij.notification.Notification>(relaxed = true)
+        every {
+            notificationGroup.createNotification(
+                any<String>(),
+                any<String>(),
+                any<com.intellij.notification.NotificationType>(),
+            )
+        } returns notification
+        every { notification.notify(any()) } just runs
+
+        // Should not throw — exception is caught internally
+        LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
+
+        // State changes still applied before the accent re-apply
+        assertFalse(state.glowEnabled)
+    }
+
+    private fun mockAccentApplicator() {
+        val settingsMock = mockk<AyuIslandsSettings>()
+        every { AyuIslandsSettings.getInstance() } returns settingsMock
+        every { settingsMock.state } returns state
+        every { settingsMock.getAccentForVariant(any()) } returns "#FFCC66"
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.apply(any()) } just runs
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManagerTest.kt
@@ -1,0 +1,309 @@
+package dev.ayuislands.projectview
+
+import com.intellij.ide.projectView.ProjectView
+import com.intellij.ide.projectView.impl.AbstractProjectViewPane
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.registry.Registry
+import com.intellij.openapi.util.registry.RegistryValue
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowManager
+import com.intellij.openapi.wm.ex.ToolWindowManagerListener
+import com.intellij.ui.content.Content
+import com.intellij.ui.content.ContentManager
+import com.intellij.util.messages.MessageBus
+import com.intellij.util.messages.MessageBusConnection
+import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import java.awt.FlowLayout
+import java.util.MissingResourceException
+import javax.swing.JPanel
+import javax.swing.JScrollPane
+import javax.swing.JTree
+import javax.swing.ScrollPaneConstants
+import javax.swing.SwingUtilities
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ProjectViewScrollbarManagerTest {
+    private lateinit var project: Project
+    private lateinit var toolWindowManager: ToolWindowManager
+    private lateinit var settingsMock: AyuIslandsSettings
+    private lateinit var realState: AyuIslandsState
+    private lateinit var connection: MessageBusConnection
+    private lateinit var registryValue: RegistryValue
+
+    @BeforeTest
+    fun setUp() {
+        mockkStatic(ToolWindowManager::class)
+        mockkStatic(Registry::class)
+        mockkStatic(ProjectView::class)
+        mockkObject(AyuIslandsSettings.Companion)
+        mockkObject(LicenseChecker)
+
+        realState = AyuIslandsState()
+        settingsMock =
+            mockk<AyuIslandsSettings> {
+                every { state } returns realState
+            }
+        every {
+            AyuIslandsSettings.getInstance()
+        } returns settingsMock
+
+        registryValue = mockk(relaxed = true)
+        every {
+            Registry.get(any<String>())
+        } returns registryValue
+
+        val projectView =
+            mockk<ProjectView>(relaxed = true) {
+                every {
+                    currentProjectViewPane
+                } returns
+                    mockk<AbstractProjectViewPane>(
+                        relaxed = true,
+                    )
+            }
+        every {
+            ProjectView.getInstance(any())
+        } returns projectView
+
+        connection = mockk(relaxed = true)
+        val messageBus =
+            mockk<MessageBus> {
+                every {
+                    connect(any<Disposable>())
+                } returns connection
+            }
+
+        project =
+            mockk(relaxed = true) {
+                every { isDisposed } returns false
+                every { this@mockk.messageBus } returns messageBus
+                every { name } returns "TestProject"
+                every { basePath } returns "/tmp/test"
+            }
+
+        toolWindowManager = mockk(relaxed = true)
+        every {
+            ToolWindowManager.getInstance(project)
+        } returns toolWindowManager
+
+        // Default: no tool window available
+        every {
+            toolWindowManager.getToolWindow("Project")
+        } returns null
+
+        // Default: licensed
+        every {
+            LicenseChecker.isLicensedOrGrace()
+        } returns true
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    /**
+     * Creates manager and drains init{}'s invokeLater.
+     * Must NOT be called from EDT (invokeAndWait blocks).
+     */
+    private fun createAndDrain(): ProjectViewScrollbarManager {
+        val manager =
+            ProjectViewScrollbarManager(project)
+        // Drain the invokeLater posted by init{}
+        SwingUtilities.invokeAndWait {}
+        return manager
+    }
+
+    @Test
+    fun `apply does nothing when not licensed`() {
+        every {
+            LicenseChecker.isLicensedOrGrace()
+        } returns false
+
+        val manager = createAndDrain()
+
+        SwingUtilities.invokeAndWait {
+            manager.apply()
+        }
+
+        // No tool window interaction beyond init drain
+        // (which also exited early due to no license)
+    }
+
+    @Test
+    fun `applyScrollbar hides horizontal scrollbar`() {
+        realState.hideProjectViewHScrollbar = true
+        realState.hideProjectRootPath = false
+
+        val tree = JTree()
+        val scrollPane = JScrollPane(tree)
+        val wrapper = JPanel(FlowLayout())
+        wrapper.add(scrollPane)
+
+        setupToolWindowContent(wrapper)
+
+        val manager = createAndDrain()
+
+        SwingUtilities.invokeAndWait {
+            manager.apply()
+        }
+
+        assertEquals(
+            ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER,
+            scrollPane.horizontalScrollBarPolicy,
+        )
+    }
+
+    @Test
+    fun `applyScrollbar restores original policy`() {
+        val tree = JTree()
+        val scrollPane = JScrollPane(tree)
+        val originalPolicy =
+            scrollPane.horizontalScrollBarPolicy
+        val wrapper = JPanel(FlowLayout())
+        wrapper.add(scrollPane)
+
+        setupToolWindowContent(wrapper)
+
+        // First hide the scrollbar
+        realState.hideProjectViewHScrollbar = true
+        realState.hideProjectRootPath = false
+        val manager = createAndDrain()
+
+        SwingUtilities.invokeAndWait {
+            manager.apply()
+        }
+
+        // Then restore it
+        realState.hideProjectViewHScrollbar = false
+        SwingUtilities.invokeAndWait {
+            manager.apply()
+        }
+
+        assertEquals(
+            originalPolicy,
+            scrollPane.horizontalScrollBarPolicy,
+        )
+    }
+
+    @Test
+    fun `applyRootDisplay handles missing Registry key`() {
+        realState.hideProjectRootPath = true
+        realState.hideProjectViewHScrollbar = false
+
+        every {
+            Registry.get(any<String>())
+        } throws
+            MissingResourceException(
+                "Not found",
+                "Registry",
+                "project.tree.structure.show.url",
+            )
+
+        val manager = createAndDrain()
+
+        SwingUtilities.invokeAndWait {
+            // Should not throw
+            manager.apply()
+        }
+    }
+
+    @Test
+    fun `dispose restores scrollbar policy`() {
+        // Scrollbar-only test: disable root path
+        // hiding to avoid Registry interaction
+        // (Registry mocking is unreliable in this
+        // test environment — see comment below)
+        realState.hideProjectViewHScrollbar = false
+        realState.hideProjectRootPath = false
+
+        val tree = JTree()
+        val scrollPane = JScrollPane(tree)
+        val originalPolicy =
+            scrollPane.horizontalScrollBarPolicy
+        val wrapper = JPanel(FlowLayout())
+        wrapper.add(scrollPane)
+
+        setupToolWindowContent(wrapper)
+
+        val manager = createAndDrain()
+
+        // Enable scrollbar hiding and apply
+        realState.hideProjectViewHScrollbar = true
+        SwingUtilities.invokeAndWait {
+            manager.apply()
+        }
+
+        assertEquals(
+            ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER,
+            scrollPane.horizontalScrollBarPolicy,
+        )
+
+        // Dispose should restore original policy
+        SwingUtilities.invokeAndWait {
+            manager.dispose()
+        }
+
+        assertEquals(
+            originalPolicy,
+            scrollPane.horizontalScrollBarPolicy,
+        )
+    }
+
+    // Registry.resetToDefault verification skipped:
+    // mockkStatic(Registry::class) interacts poorly
+    // with JetBrains test framework — Registry.get()
+    // returns the real RegistryValue instead of the
+    // mock in some test orderings. The Registry
+    // interaction is verified implicitly through
+    // applyRootDisplay handles missing Registry key
+    // test (which confirms the try/catch path works).
+
+    @Test
+    fun `init subscribes to ToolWindowManagerListener`() {
+        createAndDrain()
+
+        verify {
+            connection.subscribe(
+                ToolWindowManagerListener.TOPIC,
+                any(),
+            )
+        }
+    }
+
+    private fun setupToolWindowContent(component: JPanel) {
+        val content =
+            mockk<Content>(relaxed = true) {
+                every {
+                    this@mockk.component
+                } returns component
+            }
+        val contentManager =
+            mockk<ContentManager>(relaxed = true) {
+                every {
+                    contents
+                } returns arrayOf(content)
+            }
+        val toolWindow =
+            mockk<ToolWindow>(relaxed = true) {
+                every {
+                    this@mockk.contentManager
+                } returns contentManager
+            }
+        every {
+            toolWindowManager.getToolWindow("Project")
+        } returns toolWindow
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateTest.kt
@@ -238,6 +238,69 @@ class AyuIslandsStateTest {
         assertFalse(state.proDefaultsApplied)
     }
 
+    // migrateWidthModes (BAR-142)
+
+    @Test
+    fun `migrateWidthModes converts legacy autoFitProjectPanelWidth to AUTO_FIT mode`() {
+        val state = freshState()
+        state.autoFitProjectPanelWidth = true
+        state.projectPanelWidthMode = PanelWidthMode.DEFAULT.name
+
+        state.migrateWidthModes()
+
+        assertEquals(PanelWidthMode.AUTO_FIT.name, state.projectPanelWidthMode)
+    }
+
+    @Test
+    fun `migrateWidthModes converts legacy autoFitCommitPanelWidth to AUTO_FIT mode`() {
+        val state = freshState()
+        state.autoFitCommitPanelWidth = true
+        state.commitPanelWidthMode = PanelWidthMode.DEFAULT.name
+
+        state.migrateWidthModes()
+
+        assertEquals(PanelWidthMode.AUTO_FIT.name, state.commitPanelWidthMode)
+    }
+
+    @Test
+    fun `migrateWidthModes skips project when mode already set to non-DEFAULT`() {
+        val state = freshState()
+        state.autoFitProjectPanelWidth = true
+        state.projectPanelWidthMode = PanelWidthMode.FIXED.name
+
+        state.migrateWidthModes()
+
+        assertEquals(PanelWidthMode.FIXED.name, state.projectPanelWidthMode)
+    }
+
+    @Test
+    fun `migrateWidthModes skips when legacy flags are false`() {
+        val state = freshState()
+        state.autoFitProjectPanelWidth = false
+        state.autoFitCommitPanelWidth = false
+        state.projectPanelWidthMode = PanelWidthMode.DEFAULT.name
+        state.commitPanelWidthMode = PanelWidthMode.DEFAULT.name
+
+        state.migrateWidthModes()
+
+        assertEquals(PanelWidthMode.DEFAULT.name, state.projectPanelWidthMode)
+        assertEquals(PanelWidthMode.DEFAULT.name, state.commitPanelWidthMode)
+    }
+
+    @Test
+    fun `migrateWidthModes handles both panels simultaneously`() {
+        val state = freshState()
+        state.autoFitProjectPanelWidth = true
+        state.autoFitCommitPanelWidth = true
+        state.projectPanelWidthMode = PanelWidthMode.DEFAULT.name
+        state.commitPanelWidthMode = PanelWidthMode.DEFAULT.name
+
+        state.migrateWidthModes()
+
+        assertEquals(PanelWidthMode.AUTO_FIT.name, state.projectPanelWidthMode)
+        assertEquals(PanelWidthMode.AUTO_FIT.name, state.commitPanelWidthMode)
+    }
+
     @Test
     fun `PanelWidthMode fromString parses valid names`() {
         assertEquals(PanelWidthMode.DEFAULT, PanelWidthMode.fromString("DEFAULT"))

--- a/src/test/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitterTest.kt
+++ b/src/test/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitterTest.kt
@@ -24,6 +24,11 @@ import kotlin.test.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
+// EDT note: tests use SwingUtilities.invokeAndWait because
+// ToolWindowAutoFitter asserts EDT in applyAutoFitWidth/applyFixedWidth.
+// Pure calculation logic is already extracted into AutoFitCalculator
+// (tested without EDT in AutoFitCalculatorTest). If these tests flake
+// on CI, the EDT assertion can be relaxed — but so far it hasn't.
 class ToolWindowAutoFitterTest {
     private lateinit var project: Project
     private lateinit var toolWindowManager: ToolWindowManager

--- a/src/test/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitterTest.kt
+++ b/src/test/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitterTest.kt
@@ -8,7 +8,6 @@ import com.intellij.openapi.wm.ex.ToolWindowEx
 import com.intellij.ui.content.Content
 import com.intellij.ui.content.ContentManager
 import dev.ayuislands.settings.PanelWidthMode
-import io.mockk.answers
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject

--- a/src/test/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitterTest.kt
+++ b/src/test/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitterTest.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.wm.ex.ToolWindowEx
 import com.intellij.ui.content.Content
 import com.intellij.ui.content.ContentManager
 import dev.ayuislands.settings.PanelWidthMode
+import io.mockk.answers
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -73,7 +74,7 @@ class ToolWindowAutoFitterTest {
                 400,
                 300,
             )
-            // DEFAULT mode should not look up tree
+            // DEFAULT mode should not look up a tree
             // (no crash = listener removal path hit)
         }
     }
@@ -114,7 +115,7 @@ class ToolWindowAutoFitterTest {
                 400,
                 300,
             )
-            // Should reach applyAutoFitWidth without crash
+            // Should reach applyAutoFitWidth without a crash
         }
     }
 
@@ -393,7 +394,7 @@ class ToolWindowAutoFitterTest {
                     "Project",
                     253,
                 )
-            // Should return early without crash
+            // Should return early without a crash
             fitter.applyAutoFitWidth(400)
         }
     }
@@ -404,7 +405,7 @@ class ToolWindowAutoFitterTest {
      * Mocks AutoFitCalculator measurement methods
      * so headless JTree (no row bounds) can be used.
      * findFirstOfType is left unmocked (works on
-     * real Swing components without display).
+     * real Swing components without a display).
      */
     private fun mockCalculatorForWidth(targetWidth: Int) {
         mockkObject(AutoFitCalculator)

--- a/src/test/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitterTest.kt
+++ b/src/test/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitterTest.kt
@@ -1,0 +1,432 @@
+package dev.ayuislands.toolwindow
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowManager
+import com.intellij.openapi.wm.ToolWindowType
+import com.intellij.openapi.wm.ex.ToolWindowEx
+import com.intellij.ui.content.Content
+import com.intellij.ui.content.ContentManager
+import dev.ayuislands.settings.PanelWidthMode
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import java.awt.FlowLayout
+import javax.swing.JPanel
+import javax.swing.JTree
+import javax.swing.SwingUtilities
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class ToolWindowAutoFitterTest {
+    private lateinit var project: Project
+    private lateinit var toolWindowManager: ToolWindowManager
+    private lateinit var toolWindowEx: ToolWindowEx
+
+    @BeforeTest
+    fun setUp() {
+        mockkStatic(ToolWindowManager::class)
+        project =
+            mockk(relaxed = true) {
+                every { isDisposed } returns false
+            }
+        toolWindowManager = mockk(relaxed = true)
+        every {
+            ToolWindowManager.getInstance(project)
+        } returns toolWindowManager
+        toolWindowEx = mockk(relaxed = true)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    // region applyWidthMode
+
+    @Test
+    fun `applyWidthMode DEFAULT removes listener`() {
+        SwingUtilities.invokeAndWait {
+            every {
+                toolWindowManager.getToolWindow("Project")
+            } returns null
+
+            val fitter =
+                ToolWindowAutoFitter(
+                    project,
+                    "Project",
+                    253,
+                )
+            fitter.applyWidthMode(
+                PanelWidthMode.DEFAULT,
+                400,
+                300,
+            )
+            // DEFAULT mode should not look up tree
+            // (no crash = listener removal path hit)
+        }
+    }
+
+    @Test
+    fun `applyWidthMode AUTO_FIT installs listener`() {
+        SwingUtilities.invokeAndWait {
+            val tree = JTree()
+            val panel = JPanel(FlowLayout())
+            panel.add(tree)
+            val content =
+                mockk<Content>(relaxed = true) {
+                    every { component } returns panel
+                }
+            val contentManager =
+                mockk<ContentManager>(relaxed = true) {
+                    every { contents } returns arrayOf(content)
+                }
+            every {
+                toolWindowManager.getToolWindow("Project")
+            } returns toolWindowEx
+            every {
+                toolWindowEx.contentManager
+            } returns contentManager
+            every { toolWindowEx.component } returns panel
+            every {
+                toolWindowEx.type
+            } returns ToolWindowType.DOCKED
+
+            val fitter =
+                ToolWindowAutoFitter(
+                    project,
+                    "Project",
+                    253,
+                )
+            fitter.applyWidthMode(
+                PanelWidthMode.AUTO_FIT,
+                400,
+                300,
+            )
+            // Should reach applyAutoFitWidth without crash
+        }
+    }
+
+    @Test
+    fun `applyWidthMode FIXED removes listener`() {
+        SwingUtilities.invokeAndWait {
+            val panel = JPanel(FlowLayout())
+            panel.setSize(200, 400)
+            every {
+                toolWindowManager.getToolWindow("Commit")
+            } returns toolWindowEx
+            every { toolWindowEx.component } returns panel
+            every {
+                toolWindowEx.type
+            } returns ToolWindowType.DOCKED
+
+            val fitter =
+                ToolWindowAutoFitter(
+                    project,
+                    "Commit",
+                    269,
+                )
+            fitter.applyWidthMode(
+                PanelWidthMode.FIXED,
+                400,
+                350,
+            )
+            // Should call applyFixedWidth ->
+            // stretchWidth with delta
+            verify { toolWindowEx.stretchWidth(any()) }
+        }
+    }
+
+    // endregion
+
+    // region findTree
+
+    @Test
+    fun `findTree returns null when no tool window`() {
+        every {
+            toolWindowManager.getToolWindow("Project")
+        } returns null
+
+        val fitter =
+            ToolWindowAutoFitter(
+                project,
+                "Project",
+                253,
+            )
+        assertNull(fitter.findTree())
+    }
+
+    @Test
+    fun `findTree returns null when no contents`() {
+        val contentManager =
+            mockk<ContentManager>(relaxed = true) {
+                every { contents } returns emptyArray()
+            }
+        val toolWindow =
+            mockk<ToolWindow>(relaxed = true) {
+                every { this@mockk.contentManager } returns
+                    contentManager
+            }
+        every {
+            toolWindowManager.getToolWindow("Project")
+        } returns toolWindow
+
+        val fitter =
+            ToolWindowAutoFitter(
+                project,
+                "Project",
+                253,
+            )
+        assertNull(fitter.findTree())
+    }
+
+    @Test
+    fun `findTree returns JTree from hierarchy`() {
+        val tree = JTree()
+        val inner = JPanel(FlowLayout())
+        inner.add(tree)
+        val outer = JPanel(FlowLayout())
+        outer.add(inner)
+
+        val content =
+            mockk<Content>(relaxed = true) {
+                every { component } returns outer
+            }
+        val contentManager =
+            mockk<ContentManager>(relaxed = true) {
+                every { contents } returns arrayOf(content)
+            }
+        val toolWindow =
+            mockk<ToolWindow>(relaxed = true) {
+                every { this@mockk.contentManager } returns
+                    contentManager
+            }
+        every {
+            toolWindowManager.getToolWindow("Project")
+        } returns toolWindow
+
+        val fitter =
+            ToolWindowAutoFitter(
+                project,
+                "Project",
+                253,
+            )
+        assertNotNull(fitter.findTree())
+    }
+
+    // endregion
+
+    // region applyAutoFitWidth
+
+    @Test
+    fun `applyAutoFitWidth skips stretch for jitter`() {
+        SwingUtilities.invokeAndWait {
+            // Tree width 180 + padding 20 = 200
+            // Current = 200 -> delta = 0 -> jitter
+            mockCalculatorForWidth(180)
+            val tree = JTree()
+            val panel = JPanel(FlowLayout())
+            panel.add(tree)
+            panel.setSize(200, 400)
+
+            val content =
+                mockk<Content>(relaxed = true) {
+                    every { component } returns panel
+                }
+            val contentManager =
+                mockk<ContentManager>(relaxed = true) {
+                    every { contents } returns arrayOf(content)
+                }
+            every {
+                toolWindowManager.getToolWindow("Project")
+            } returns toolWindowEx
+            every {
+                toolWindowEx.contentManager
+            } returns contentManager
+            every {
+                toolWindowEx.component
+            } returns panel
+            every {
+                toolWindowEx.type
+            } returns ToolWindowType.DOCKED
+
+            val fitter =
+                ToolWindowAutoFitter(
+                    project,
+                    "Project",
+                    100,
+                )
+            fitter.applyAutoFitWidth(500)
+            verify(exactly = 0) {
+                toolWindowEx.stretchWidth(any())
+            }
+        }
+    }
+
+    @Test
+    fun `applyAutoFitWidth calls stretch for delta`() {
+        SwingUtilities.invokeAndWait {
+            // Tree width 280 + padding 20 = 300
+            // Current = 200 -> delta = 100
+            mockCalculatorForWidth(280)
+            val tree = JTree()
+            val panel = JPanel(FlowLayout())
+            panel.add(tree)
+            panel.setSize(200, 400)
+
+            val content =
+                mockk<Content>(relaxed = true) {
+                    every { component } returns panel
+                }
+            val contentManager =
+                mockk<ContentManager>(relaxed = true) {
+                    every { contents } returns arrayOf(content)
+                }
+            every {
+                toolWindowManager.getToolWindow("Project")
+            } returns toolWindowEx
+            every {
+                toolWindowEx.contentManager
+            } returns contentManager
+            every {
+                toolWindowEx.component
+            } returns panel
+            every {
+                toolWindowEx.type
+            } returns ToolWindowType.DOCKED
+
+            val fitter =
+                ToolWindowAutoFitter(
+                    project,
+                    "Project",
+                    100,
+                )
+            fitter.applyAutoFitWidth(500)
+            verify { toolWindowEx.stretchWidth(100) }
+        }
+    }
+
+    // endregion
+
+    // region removeExpansionListener
+
+    @Test
+    fun `removeExpansionListener is safe when nothing installed`() {
+        val fitter =
+            ToolWindowAutoFitter(
+                project,
+                "Project",
+                253,
+            )
+        // Should not throw
+        fitter.removeExpansionListener()
+    }
+
+    // endregion
+
+    // region installExpansionListener
+
+    @Test
+    fun `installExpansionListener adds listener to tree`() {
+        SwingUtilities.invokeAndWait {
+            val tree = JTree()
+            val panel = JPanel(FlowLayout())
+            panel.add(tree)
+            val content =
+                mockk<Content>(relaxed = true) {
+                    every { component } returns panel
+                }
+            val contentManager =
+                mockk<ContentManager>(relaxed = true) {
+                    every { contents } returns arrayOf(content)
+                }
+            every {
+                toolWindowManager.getToolWindow("Project")
+            } returns toolWindowEx
+            every {
+                toolWindowEx.contentManager
+            } returns contentManager
+
+            val listenersBefore =
+                tree.treeExpansionListeners.size
+            val fitter =
+                ToolWindowAutoFitter(
+                    project,
+                    "Project",
+                    253,
+                )
+            fitter.installExpansionListener()
+            val listenersAfter =
+                tree.treeExpansionListeners.size
+            assert(listenersAfter > listenersBefore) {
+                "Expected listener to be added"
+            }
+        }
+    }
+
+    // endregion
+
+    // region project disposed
+
+    @Test
+    fun `applyAutoFitWidth no-ops when project disposed`() {
+        SwingUtilities.invokeAndWait {
+            every { project.isDisposed } returns true
+            every {
+                toolWindowManager.getToolWindow("Project")
+            } returns null
+
+            val fitter =
+                ToolWindowAutoFitter(
+                    project,
+                    "Project",
+                    253,
+                )
+            // Should return early without crash
+            fitter.applyAutoFitWidth(400)
+        }
+    }
+
+    // endregion
+
+    /**
+     * Mocks AutoFitCalculator measurement methods
+     * so headless JTree (no row bounds) can be used.
+     * findFirstOfType is left unmocked (works on
+     * real Swing components without display).
+     */
+    private fun mockCalculatorForWidth(targetWidth: Int) {
+        mockkObject(AutoFitCalculator)
+        every {
+            AutoFitCalculator.measureTreeMaxRowWidth(any())
+        } returns targetWidth
+        every {
+            AutoFitCalculator.isJitterOnly(any(), any())
+        } answers {
+            val current = firstArg<Int>()
+            val desired = secondArg<Int>()
+            kotlin.math.abs(desired - current) <=
+                AutoFitCalculator.JITTER_THRESHOLD
+        }
+        every {
+            AutoFitCalculator.calculateDesiredWidth(
+                any(),
+                any(),
+                any(),
+            )
+        } answers {
+            val maxRow = firstArg<Int>()
+            val maxW = secondArg<Int>()
+            val minW = thirdArg<Int>()
+            (maxRow + AutoFitCalculator.AUTOFIT_PADDING)
+                .coerceAtMost(maxW)
+                .coerceAtLeast(minW)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **75 new unit tests** covering all 6 BAR-138 sub-issues (BAR-139 through BAR-144)
- Covers 5 regression scenarios from v2.3.0 pre-release audit: trial defaults, workspace defaults, auto-fit retry, glow enable/disable all, glow target defaults
- 3 production changes: StartupActivity methods `private`→`internal` for testability, LicenseChecker wildcard imports fixed, docstring line length fixed

## New Test Files (8)

| File | Tests | BAR Issue |
|------|-------|-----------|
| `LicenseCheckerProDefaultsTest.kt` | 20 | BAR-140 |
| `StartupLicenseStateTest.kt` | 14 | BAR-139 |
| `GlowTargetToggleTest.kt` | 7 | BAR-143 |
| `AyuIslandsStateTest.kt` (additions) | +5 | BAR-142 |
| `ToolWindowAutoFitterTest.kt` | 11 | BAR-141 |
| `CommitPanelAutoFitManagerTest.kt` | 5 | BAR-144 |
| `GitPanelAutoFitManagerTest.kt` | 7 | BAR-144 |
| `ProjectViewScrollbarManagerTest.kt` | 6 | BAR-144 |

## Test plan
- [x] `./gradlew test` — all 571 tests pass
- [x] `./gradlew koverVerify` — ≥80% coverage maintained
- [x] ktlint + detekt pass (no wildcard imports)
- [ ] CI green on push

## Summary by Sourcery

Add regression test coverage for licensing-driven defaults, glow targets, and auto-fit behaviors, with minimal production tweaks for testability and docs clarity.

Bug Fixes:
- Guard licensing workspace defaults and panel width migrations with regression tests to prevent BAR-142/BAR-140 regressions.
- Verify glow target defaults and toggling semantics to prevent BAR-143 regressions across editor, project, terminal, run, debug, git, and services panes.

Enhancements:
- Relax AyuIslandsStartupActivity helper visibility to enable direct unit testing of licensed and unlicensed startup flows.
- Refine LicenseChecker documentation comment for workspace defaults behavior.

Build:
- Adjust Kover filters comment for LicenseChecker coverage exclusion.

Tests:
- Add extensive unit tests for license-based pro and workspace defaults, including revert-to-free flows and failure handling.
- Add tests for startup licensing state transitions, trial notifications, and workspace service initialization guards.
- Add tests for tool window auto-fit behavior, including jitter handling, splitter proportions, and listener management for project view, commit panel, and git panel.
- Extend AyuIslandsState tests to cover width mode migration from legacy auto-fit flags.
- Add tests for project view scrollbar and root path visibility management driven by settings state.
- Add tests for glow target default state, bulk enable/disable behavior, and alias handling for Git-related targets.