### PR TITLE
test(coverage): boost Codecov for AppListener and GlowRenderer

### DIFF
--- a/src/test/kotlin/dev/ayuislands/AyuIslandsAppListenerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsAppListenerTest.kt
@@ -63,7 +63,7 @@ class AyuIslandsAppListenerTest {
         listener.appFrameCreated(mutableListOf())
 
         verify(exactly = 1) {
-            AccentApplicator.apply("#FFCC66")
+            AccentApplicator.apply(AyuVariant.MIRAGE.defaultAccent)
         }
     }
 

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsAppListenerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsAppListenerTest.kt
@@ -1,0 +1,87 @@
+package dev.ayuislands
+
+import com.intellij.ide.ui.LafManager
+import com.intellij.ide.ui.laf.UIThemeLookAndFeelInfo
+import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+class AyuIslandsAppListenerTest {
+    private lateinit var state: AyuIslandsState
+    private val listener = AyuIslandsAppListener()
+
+    @BeforeTest
+    fun setUp() {
+        state = AyuIslandsState()
+        val settings = mockk<AyuIslandsSettings>()
+        every { settings.state } returns state
+        every {
+            settings.getAccentForVariant(any())
+        } answers {
+            val variant = firstArg<AyuVariant>()
+            variant.defaultAccent
+        }
+
+        mockkObject(AyuIslandsSettings.Companion)
+        every {
+            AyuIslandsSettings.getInstance()
+        } returns settings
+
+        mockkStatic(LafManager::class)
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.apply(any()) } just runs
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `appFrameCreated applies accent for Ayu theme`() {
+        val laf = mockk<UIThemeLookAndFeelInfo>()
+        every { laf.name } returns "Ayu Mirage (Islands UI)"
+        val lafManager = mockk<LafManager>()
+        @Suppress("UnstableApiUsage")
+        every {
+            lafManager.currentUIThemeLookAndFeel
+        } returns laf
+        every { LafManager.getInstance() } returns lafManager
+
+        listener.appFrameCreated(mutableListOf())
+
+        verify(exactly = 1) {
+            AccentApplicator.apply("#FFCC66")
+        }
+    }
+
+    @Test
+    fun `appFrameCreated skips non-Ayu theme`() {
+        val laf = mockk<UIThemeLookAndFeelInfo>()
+        every { laf.name } returns "Darcula"
+        val lafManager = mockk<LafManager>()
+        @Suppress("UnstableApiUsage")
+        every {
+            lafManager.currentUIThemeLookAndFeel
+        } returns laf
+        every { LafManager.getInstance() } returns lafManager
+
+        listener.appFrameCreated(mutableListOf())
+
+        verify(exactly = 0) {
+            AccentApplicator.apply(any())
+        }
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/glow/GlowRendererTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/GlowRendererTest.kt
@@ -90,6 +90,65 @@ class GlowRendererTest {
     }
 
     @Test
+    fun `ensureCache boosts alpha for light theme`() {
+        val renderer = GlowRenderer()
+        javax.swing.UIManager.put(
+            "Panel.background",
+            Color(240, 240, 240),
+        )
+        renderer.ensureCache(Color.RED, GlowStyle.SOFT, 40, 12)
+        val lightAlpha = renderer.cachedBaseAlpha
+
+        javax.swing.UIManager.put(
+            "Panel.background",
+            Color(30, 30, 30),
+        )
+        renderer.invalidateCache()
+        renderer.ensureCache(Color.RED, GlowStyle.SOFT, 40, 12)
+        val darkAlpha = renderer.cachedBaseAlpha
+
+        assertTrue(
+            lightAlpha > darkAlpha,
+            "Light theme alpha ($lightAlpha) should be " +
+                "higher than dark ($darkAlpha)",
+        )
+    }
+
+    @Test
+    fun `ensureCache is idempotent for same params`() {
+        val renderer = GlowRenderer()
+        renderer.ensureCache(Color.RED, GlowStyle.SOFT, 40, 12)
+        val alpha1 = renderer.cachedBaseAlpha
+        renderer.ensureCache(Color.RED, GlowStyle.SOFT, 40, 12)
+        val alpha2 = renderer.cachedBaseAlpha
+        assertEquals(alpha1, alpha2)
+    }
+
+    @Test
+    fun `paintGlow uses cached frame on second call`() {
+        val renderer = GlowRenderer()
+        renderer.ensureCache(Color.CYAN, GlowStyle.SOFT, 50, 8)
+
+        val image = BufferedImage(80, 80, BufferedImage.TYPE_INT_ARGB)
+        val g2 = image.createGraphics()
+        // First paint: renders + caches
+        renderer.paintGlow(
+            g2,
+            Rectangle(0, 0, 80, 80),
+            8,
+            6,
+        )
+        // Second paint: should reuse cache (no error)
+        renderer.paintGlow(
+            g2,
+            Rectangle(0, 0, 80, 80),
+            8,
+            6,
+        )
+        g2.dispose()
+    }
+
+    @Test
     fun `paintGlow skips rendering for zero-size bounds`() {
         val renderer = GlowRenderer()
         renderer.ensureCache(Color.RED, GlowStyle.SOFT, 40, 12)

--- a/src/test/kotlin/dev/ayuislands/glow/GlowRendererTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/GlowRendererTest.kt
@@ -92,26 +92,36 @@ class GlowRendererTest {
     @Test
     fun `ensureCache boosts alpha for light theme`() {
         val renderer = GlowRenderer()
-        javax.swing.UIManager.put(
-            "Panel.background",
-            Color(240, 240, 240),
-        )
-        renderer.ensureCache(Color.RED, GlowStyle.SOFT, 40, 12)
-        val lightAlpha = renderer.cachedBaseAlpha
+        val uiMgr = javax.swing.UIManager.getDefaults()
+        val original = uiMgr.getColor("Panel.background")
+        try {
+            uiMgr.put("Panel.background", Color(240, 240, 240))
+            renderer.ensureCache(
+                Color.RED,
+                GlowStyle.SOFT,
+                40,
+                12,
+            )
+            val lightAlpha = renderer.cachedBaseAlpha
 
-        javax.swing.UIManager.put(
-            "Panel.background",
-            Color(30, 30, 30),
-        )
-        renderer.invalidateCache()
-        renderer.ensureCache(Color.RED, GlowStyle.SOFT, 40, 12)
-        val darkAlpha = renderer.cachedBaseAlpha
+            uiMgr.put("Panel.background", Color(30, 30, 30))
+            renderer.invalidateCache()
+            renderer.ensureCache(
+                Color.RED,
+                GlowStyle.SOFT,
+                40,
+                12,
+            )
+            val darkAlpha = renderer.cachedBaseAlpha
 
-        assertTrue(
-            lightAlpha > darkAlpha,
-            "Light theme alpha ($lightAlpha) should be " +
-                "higher than dark ($darkAlpha)",
-        )
+            assertTrue(
+                lightAlpha > darkAlpha,
+                "Light theme alpha ($lightAlpha) should " +
+                    "be higher than dark ($darkAlpha)",
+            )
+        } finally {
+            uiMgr.put("Panel.background", original)
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Add `AyuIslandsAppListenerTest` — covers `appFrameCreated` for Ayu and non-Ayu themes (0% → ~100%)
- Add GlowRenderer tests — light theme alpha boost, ensureCache idempotency, frame cache reuse path

## Test plan
- [x] `./gradlew test` — all tests pass
- [x] `./gradlew koverVerify` — ≥80% coverage
- [ ] CI green

## Summary by Sourcery

Increase test coverage for AyuIslands application listener and GlowRenderer behavior.

Tests:
- Add tests for AyuIslandsAppListener to cover accent application for Ayu themes and skipping for non-Ayu themes.
- Add GlowRenderer tests for light-theme alpha boosting, idempotent cache behavior, and cached frame reuse on subsequent paints.