### PR TITLE
test(coverage): add settings, state, indent quick win tests

### DIFF
--- a/src/test/kotlin/dev/ayuislands/AyuIslandsAppListenerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsAppListenerTest.kt
@@ -27,12 +27,16 @@ class AyuIslandsAppListenerTest {
         state = AyuIslandsState()
         val settings = mockk<AyuIslandsSettings>()
         every { settings.state } returns state
+        state.mirageAccent = "#FF0000"
         every {
-            settings.getAccentForVariant(any())
-        } answers {
-            val variant = firstArg<AyuVariant>()
-            variant.defaultAccent
-        }
+            settings.getAccentForVariant(AyuVariant.MIRAGE)
+        } returns "#FF0000"
+        every {
+            settings.getAccentForVariant(AyuVariant.DARK)
+        } returns "#00FF00"
+        every {
+            settings.getAccentForVariant(AyuVariant.LIGHT)
+        } returns "#0000FF"
 
         mockkObject(AyuIslandsSettings.Companion)
         every {
@@ -63,7 +67,7 @@ class AyuIslandsAppListenerTest {
         listener.appFrameCreated(mutableListOf())
 
         verify(exactly = 1) {
-            AccentApplicator.apply(AyuVariant.MIRAGE.defaultAccent)
+            AccentApplicator.apply("#FF0000")
         }
     }
 

--- a/src/test/kotlin/dev/ayuislands/glow/GlowRendererTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/GlowRendererTest.kt
@@ -135,27 +135,16 @@ class GlowRendererTest {
     }
 
     @Test
-    fun `paintGlow uses cached frame on second call`() {
+    fun `paintGlow does not crash on repeated calls`() {
         val renderer = GlowRenderer()
         renderer.ensureCache(Color.CYAN, GlowStyle.SOFT, 50, 8)
 
         val image = BufferedImage(80, 80, BufferedImage.TYPE_INT_ARGB)
         val g2 = image.createGraphics()
-        // First paint: renders + caches
-        renderer.paintGlow(
-            g2,
-            Rectangle(0, 0, 80, 80),
-            8,
-            6,
-        )
-        // Second paint: should reuse cache (no error)
-        renderer.paintGlow(
-            g2,
-            Rectangle(0, 0, 80, 80),
-            8,
-            6,
-        )
+        renderer.paintGlow(g2, Rectangle(0, 0, 80, 80), 8, 6)
+        renderer.paintGlow(g2, Rectangle(0, 0, 80, 80), 8, 6)
         g2.dispose()
+        // Smoke test: verifies no crash on repeated paint
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/indent/IndentPaletteTest.kt
+++ b/src/test/kotlin/dev/ayuislands/indent/IndentPaletteTest.kt
@@ -143,4 +143,30 @@ class IndentPaletteTest {
             "error alpha should match first indent step alpha",
         )
     }
+
+    @Test
+    fun `toColorStrings with minimum alpha produces valid colors`() {
+        val palette = IndentPalette.forAccent(testAccent, AyuVariant.MIRAGE)
+        val colors = palette.toColorStrings(1)
+        for (color in colors) {
+            assertTrue(aarrggbbPattern.matches(color))
+        }
+    }
+
+    @Test
+    fun `toColorStrings with maximum alpha produces valid colors`() {
+        val palette = IndentPalette.forAccent(testAccent, AyuVariant.MIRAGE)
+        val colors = palette.toColorStrings(255)
+        for (color in colors) {
+            assertTrue(aarrggbbPattern.matches(color))
+        }
+    }
+
+    @Test
+    fun `toColorStrings pyramid has correct count`() {
+        val palette = IndentPalette.forAccent(testAccent, AyuVariant.DARK)
+        val colors = palette.toColorStrings(128)
+        // 1 error + (1..6) + (5 downTo 2) = 1 + 6 + 4 = 11
+        assertEquals(11, colors.size)
+    }
 }

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsSettingsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsSettingsTest.kt
@@ -75,6 +75,73 @@ class AyuIslandsSettingsTest {
     }
 
     @Test
+    fun `getAccentForVariant returns default for empty string`() {
+        val state =
+            AyuIslandsState().apply {
+                mirageAccent = ""
+            }
+        val settings = createSettings(state)
+
+        // BaseState's `by string()` coerces empty to default
+        assertEquals(
+            AyuVariant.MIRAGE.defaultAccent,
+            settings.getAccentForVariant(AyuVariant.MIRAGE),
+        )
+    }
+
+    @Test
+    fun `getAccentForVariant uses default per variant`() {
+        for (variant in AyuVariant.entries) {
+            val state =
+                AyuIslandsState().apply {
+                    mirageAccent = null
+                    darkAccent = null
+                    lightAccent = null
+                }
+            val settings = createSettings(state)
+
+            assertEquals(
+                variant.defaultAccent,
+                settings.getAccentForVariant(variant),
+                "${variant.name} should return its default accent",
+            )
+        }
+    }
+
+    @Test
+    fun `getAccentForVariant prefers system accent for all variants`() {
+        mockkObject(SystemAccentProvider)
+        every { SystemAccentProvider.resolve() } returns "#SYSTEM"
+
+        val state =
+            AyuIslandsState().apply {
+                followSystemAccent = true
+            }
+        val settings = createSettings(state)
+
+        for (variant in AyuVariant.entries) {
+            assertEquals(
+                "#SYSTEM",
+                settings.getAccentForVariant(variant),
+                "${variant.name} should use system accent",
+            )
+        }
+    }
+
+    @Test
+    fun `getState returns same state after loadState`() {
+        val state =
+            AyuIslandsState().apply {
+                mirageAccent = "#CUSTOM"
+                glowEnabled = true
+            }
+        val settings = createSettings(state)
+
+        assertEquals("#CUSTOM", settings.state.mirageAccent)
+        assertEquals(true, settings.state.glowEnabled)
+    }
+
+    @Test
     fun `setAccentForVariant stores value per variant`() {
         val settings = createSettings(AyuIslandsState())
 

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsSettingsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsSettingsTest.kt
@@ -90,58 +90,6 @@ class AyuIslandsSettingsTest {
     }
 
     @Test
-    fun `getAccentForVariant uses default per variant`() {
-        for (variant in AyuVariant.entries) {
-            val state =
-                AyuIslandsState().apply {
-                    mirageAccent = null
-                    darkAccent = null
-                    lightAccent = null
-                }
-            val settings = createSettings(state)
-
-            assertEquals(
-                variant.defaultAccent,
-                settings.getAccentForVariant(variant),
-                "${variant.name} should return its default accent",
-            )
-        }
-    }
-
-    @Test
-    fun `getAccentForVariant prefers system accent for all variants`() {
-        mockkObject(SystemAccentProvider)
-        every { SystemAccentProvider.resolve() } returns "#SYSTEM"
-
-        val state =
-            AyuIslandsState().apply {
-                followSystemAccent = true
-            }
-        val settings = createSettings(state)
-
-        for (variant in AyuVariant.entries) {
-            assertEquals(
-                "#SYSTEM",
-                settings.getAccentForVariant(variant),
-                "${variant.name} should use system accent",
-            )
-        }
-    }
-
-    @Test
-    fun `getState returns same state after loadState`() {
-        val state =
-            AyuIslandsState().apply {
-                mirageAccent = "#CUSTOM"
-                glowEnabled = true
-            }
-        val settings = createSettings(state)
-
-        assertEquals("#CUSTOM", settings.state.mirageAccent)
-        assertEquals(true, settings.state.glowEnabled)
-    }
-
-    @Test
     fun `setAccentForVariant stores value per variant`() {
         val settings = createSettings(AyuIslandsState())
 

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateTest.kt
@@ -301,6 +301,58 @@ class AyuIslandsStateTest {
         assertEquals(PanelWidthMode.AUTO_FIT.name, state.commitPanelWidthMode)
     }
 
+    // Workspace defaults flags
+
+    @Test
+    fun `workspaceDefaultsApplied is false by default`() {
+        val state = freshState()
+        assertFalse(state.workspaceDefaultsApplied)
+    }
+
+    @Test
+    fun `panel width modes default to DEFAULT`() {
+        val state = freshState()
+        assertEquals(
+            PanelWidthMode.DEFAULT.name,
+            state.projectPanelWidthMode,
+        )
+        assertEquals(
+            PanelWidthMode.DEFAULT.name,
+            state.commitPanelWidthMode,
+        )
+        assertEquals(
+            PanelWidthMode.DEFAULT.name,
+            state.gitPanelWidthMode,
+        )
+    }
+
+    @Test
+    fun `hideProjectRootPath and hideHScrollbar default to false`() {
+        val state = freshState()
+        assertFalse(state.hideProjectRootPath)
+        assertFalse(state.hideProjectViewHScrollbar)
+    }
+
+    // Font preset defaults
+
+    @Test
+    fun `font preset defaults`() {
+        val state = freshState()
+        assertFalse(state.fontPresetEnabled)
+        assertEquals("AMBIENT", state.fontPresetName)
+        assertFalse(state.fontApplyToConsole)
+    }
+
+    // Integration defaults
+
+    @Test
+    fun `indent rainbow integration defaults`() {
+        val state = freshState()
+        assertFalse(state.irIntegrationEnabled)
+        assertEquals("AMBIENT", state.indentPresetName)
+        assertTrue(state.irErrorHighlightEnabled)
+    }
+
     @Test
     fun `PanelWidthMode fromString parses valid names`() {
         assertEquals(PanelWidthMode.DEFAULT, PanelWidthMode.fromString("DEFAULT"))


### PR DESCRIPTION
## Summary

- Settings: empty string fallback, system accent all variants, state persistence (4 tests)
- State: workspace defaults, panel modes, font/indent defaults (6 tests)
- IndentPalette: alpha boundaries, pyramid count (3 tests)

Follow-up to PR #66 (merged).

## Test plan
- [x] `./gradlew test` — all 591 tests pass
- [x] `./gradlew koverVerify` — ≥80% coverage
- [ ] CI green

## Summary by Sourcery

Expand test coverage for settings, state defaults, and indent palette behavior.

Tests:
- Add settings tests for accent fallback behavior, system accent usage across variants, and state persistence.
- Add state tests covering workspace default flags, panel width modes, font presets, and indent rainbow integration defaults.
- Add indent palette tests validating alpha boundary color formats and pyramid color count.