### PR TITLE
ci(build): add push trigger for main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,18 +3,14 @@ name: CI
 on:
   push:
     branches: [main]
-    paths-ignore:
+    paths-ignore: &skip-paths
       - '**/*.md'
       - 'LICENSE'
       - '.gitignore'
       - '.sourcery.yaml'
   pull_request:
     branches: [main]
-    paths-ignore:
-      - '**/*.md'
-      - 'LICENSE'
-      - '.gitignore'
-      - '.sourcery.yaml'
+    paths-ignore: *skip-paths
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,13 @@
 name: CI
 
 on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.sourcery.yaml'
   pull_request:
     branches: [main]
     paths-ignore:


### PR DESCRIPTION
## Summary

- Add `push: branches: [main]` trigger to CI workflow
- Previously only `pull_request` and `workflow_dispatch` triggered CI
- Merge commits to main were not validated — regressions could slip through undetected

## Test plan
- [ ] CI runs on this PR (pull_request trigger — existing)
- [ ] After merge, CI runs on the merge commit (push trigger — new)

## Summary by Sourcery

CI:
- Add a push trigger for the main branch to the CI workflow, ignoring non-code file changes such as docs and config metadata.