### PR TITLE
ci(build): lightweight push pipeline for main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,13 @@ jobs:
           ! git grep -rIl '<<<<<<<\|>>>>>>>' -- \
             ':!*.md' ':!.github/workflows/*' \
             || { echo "::error::Merge conflict markers found"; exit 1; }
+      - name: Detect private keys
+        run: |
+          pattern="BEGIN.*(RSA |DSA |EC |OPENSSH )?PRIVATE KEY"
+          ! git grep -rIlE "$pattern" \
+            -- ':!*.md' ':!.pre-commit-config.yaml' \
+            ':!.github/workflows/*' \
+            || { echo "::error::Private key detected"; exit 1; }
 
   gha-security:
     name: GHA security (zizmor)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,9 +116,10 @@ jobs:
       - name: Compile and build plugin
         run: ./gradlew buildPlugin
 
-  # ── Tier 3: Parallel analysis (after build) ────────────
+  # ── Tier 3: Parallel analysis (after build, PRs only) ──
   analyze:
     name: Analyze
+    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 10
@@ -162,9 +163,10 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-  # ── Tier 4: Full IDE verification (2 parallel groups) ──
+  # ── Tier 4: Full IDE verification (PRs only) ──────────
   verify:
     name: Verify (${{ matrix.group }})
+    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 20
@@ -218,11 +220,11 @@ jobs:
           for r in "${results[@]}"; do
             name="${r%%=*}"
             status="${r##*=}"
-            if [[ "$status" != "success" ]]; then
+            if [[ "$status" == "success" || "$status" == "skipped" ]]; then
+              echo "✓ $name ($status)"
+            else
               echo "::error::$name: $status"
               failed=1
-            else
-              echo "✓ $name"
             fi
           done
           if [[ "$failed" -eq 1 ]]; then


### PR DESCRIPTION
## Summary

- Push to main now runs only lint + build + test (~4 min)
- Analyze and verifyPlugin (11 IDEs) run on PRs only — already validated pre-merge
- Gate accepts skipped jobs on push events
- Follow-up to PR #68

## Test plan
- [ ] CI runs full pipeline on this PR (pull_request event)
- [ ] After merge, push event skips analyze + verify

## Summary by Sourcery

Restrict expensive CI jobs to pull_request events and allow the gate job to pass when those jobs are skipped on pushes to main.

CI:
- Run analyze and verify jobs only for non-push events (e.g., pull_request) to keep push pipelines lightweight.
- Treat skipped downstream jobs as acceptable in the gate step so push workflows can succeed without running full verification.