### PR TITLE
feat: accent rotation, shuffle UI redesign, trial hardening

### DIFF
--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -12,6 +12,7 @@ import dev.ayuislands.font.FontPreset
 import dev.ayuislands.font.FontPresetApplicator
 import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.rotation.AccentRotationService
 import dev.ayuislands.settings.AyuIslandsSettings
 import javax.swing.SwingUtilities
 
@@ -52,6 +53,20 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
         // Auto-switch theme to match macOS Light/Dark mode
         if (settings.state.followSystemAppearance) {
             AppearanceSyncService.getInstance().syncIfNeeded()
+        }
+
+        // Start accent rotation if enabled (premium feature)
+        if (settings.state.accentRotationEnabled && LicenseChecker.isLicensedOrGrace()) {
+            val rotationService = AccentRotationService.getInstance()
+            val lastSwitch = settings.state.accentRotationLastSwitchMs
+            val intervalMs = settings.state.accentRotationIntervalHours * MS_PER_HOUR
+            val elapsed = System.currentTimeMillis() - lastSwitch
+            if (lastSwitch == 0L || elapsed >= intervalMs) {
+                rotationService.rotateNow()
+            } else {
+                val remainingMs = intervalMs - elapsed
+                rotationService.startRotationWithDelay(remainingMs)
+            }
         }
 
         // Show a one-time update notification if the plugin version changed
@@ -102,5 +117,6 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
 
     companion object {
         private val LOG = logger<AyuIslandsStartupActivity>()
+        private const val MS_PER_HOUR = 3_600_000L
     }
 }

--- a/src/main/kotlin/dev/ayuislands/font/FontPresetApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontPresetApplicator.kt
@@ -1,7 +1,6 @@
 package dev.ayuislands.font
 
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.colors.ModifiableFontPreferences
@@ -16,7 +15,7 @@ object FontPresetApplicator {
     private const val DEFAULT_FONT_SIZE = 13f
     private const val DEFAULT_LINE_SPACING = 1.2f
 
-    /** Resolve and apply the font preset from persisted settings state. */
+    /** Resolve and apply the font preset from the persisted settings state. */
     fun applyFromState() {
         val state = AyuIslandsSettings.getInstance().state
         if (!state.fontPresetEnabled) return
@@ -57,13 +56,11 @@ object FontPresetApplicator {
                 scheme.consoleLineSpacing = settings.lineSpacing
             }
 
-            ReadAction.run<Nothing> {
-                ApplicationManager
-                    .getApplication()
-                    .messageBus
-                    .syncPublisher(EditorColorsManager.TOPIC)
-                    .globalSchemeChange(null)
-            }
+            ApplicationManager
+                .getApplication()
+                .messageBus
+                .syncPublisher(EditorColorsManager.TOPIC)
+                .globalSchemeChange(null)
             LOG.info(
                 "Font preset applied: ${settings.preset.displayName} " +
                     "($resolvedFamily, subFamily=$subFamily, " +
@@ -91,13 +88,11 @@ object FontPresetApplicator {
             scheme.setConsoleFontSize(DEFAULT_FONT_SIZE)
             scheme.consoleLineSpacing = DEFAULT_LINE_SPACING
 
-            ReadAction.run<Nothing> {
-                ApplicationManager
-                    .getApplication()
-                    .messageBus
-                    .syncPublisher(EditorColorsManager.TOPIC)
-                    .globalSchemeChange(null)
-            }
+            ApplicationManager
+                .getApplication()
+                .messageBus
+                .syncPublisher(EditorColorsManager.TOPIC)
+                .globalSchemeChange(null)
             LOG.info("Font preset reverted to defaults")
         }
     }

--- a/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
@@ -21,6 +21,7 @@ import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.glow.GlowAnimation
 import dev.ayuislands.glow.GlowPreset
 import dev.ayuislands.glow.GlowStyle
+import dev.ayuislands.rotation.AccentRotationService
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.PanelWidthMode
 import java.io.ByteArrayInputStream
@@ -252,6 +253,14 @@ object LicenseChecker {
         state.gitPanelWidthMode = PanelWidthMode.DEFAULT.name
         state.hideProjectRootPath = false
         state.hideProjectViewHScrollbar = false
+
+        // Disable plugin integrations (premium features)
+        state.cgpIntegrationEnabled = false
+        state.irIntegrationEnabled = false
+
+        // Stop accent rotation (premium feature)
+        state.accentRotationEnabled = false
+        ApplicationManager.getApplication().getService(AccentRotationService::class.java)?.stopRotation()
 
         // Re-apply accent with reset toggles (accent color itself stays — it's free)
         try {

--- a/src/main/kotlin/dev/ayuislands/rotation/AccentRotationMode.kt
+++ b/src/main/kotlin/dev/ayuislands/rotation/AccentRotationMode.kt
@@ -1,0 +1,11 @@
+package dev.ayuislands.rotation
+
+enum class AccentRotationMode {
+    PRESET,
+    RANDOM,
+    ;
+
+    companion object {
+        fun fromName(name: String?): AccentRotationMode = entries.firstOrNull { it.name == name } ?: PRESET
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
+++ b/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
@@ -18,7 +18,7 @@ import javax.swing.SwingUtilities
 private const val MS_PER_HOUR = 3_600_000L
 
 /**
- * Returns the next preset index and hex color, wrapping at list end.
+ * Returns the next preset index and hex color, wrapping at the list end.
  * Extracted as internal for unit testing without IDE singletons.
  */
 internal fun nextPresetHex(

--- a/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
+++ b/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
@@ -1,0 +1,125 @@
+package dev.ayuislands.rotation
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.util.concurrency.AppExecutorUtil
+import dev.ayuislands.accent.AYU_ACCENT_PRESETS
+import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentColor
+import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.settings.AyuIslandsSettings
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import javax.swing.SwingUtilities
+
+private const val MS_PER_HOUR = 3_600_000L
+
+/**
+ * Returns the next preset index and hex color, wrapping at list end.
+ * Extracted as internal for unit testing without IDE singletons.
+ */
+internal fun nextPresetHex(
+    currentIndex: Int,
+    presets: List<AccentColor> = AYU_ACCENT_PRESETS,
+): Pair<Int, String> {
+    val nextIndex = (currentIndex + 1) % presets.size
+    return nextIndex to presets[nextIndex].hex
+}
+
+@Service
+class AccentRotationService : Disposable {
+    private var scheduledFuture: ScheduledFuture<*>? = null
+
+    fun startRotation() {
+        stopRotation()
+        val state = AyuIslandsSettings.getInstance().state
+        if (!state.accentRotationEnabled) return
+        if (!LicenseChecker.isLicensedOrGrace()) return
+
+        val intervalHours = state.accentRotationIntervalHours.toLong()
+        scheduledFuture =
+            AppExecutorUtil
+                .getAppScheduledExecutorService()
+                .scheduleWithFixedDelay(
+                    { rotateAccent() },
+                    intervalHours,
+                    intervalHours,
+                    TimeUnit.HOURS,
+                )
+        LOG.info("Accent rotation started: interval=${intervalHours}h, mode=${state.accentRotationMode}")
+    }
+
+    /**
+     * Start rotation with a custom initial delay (used after restart to schedule remaining time).
+     */
+    fun startRotationWithDelay(initialDelayMs: Long) {
+        stopRotation()
+        val state = AyuIslandsSettings.getInstance().state
+        if (!state.accentRotationEnabled) return
+        if (!LicenseChecker.isLicensedOrGrace()) return
+
+        val intervalMs = state.accentRotationIntervalHours * MS_PER_HOUR
+        scheduledFuture =
+            AppExecutorUtil
+                .getAppScheduledExecutorService()
+                .scheduleWithFixedDelay(
+                    { rotateAccent() },
+                    initialDelayMs,
+                    intervalMs,
+                    TimeUnit.MILLISECONDS,
+                )
+        LOG.info(
+            "Accent rotation started: initialDelay=${initialDelayMs}ms, interval=${state.accentRotationIntervalHours}h",
+        )
+    }
+
+    fun rotateNow() {
+        rotateAccent()
+        startRotation()
+    }
+
+    fun stopRotation() {
+        scheduledFuture?.cancel(false)
+        scheduledFuture = null
+    }
+
+    private fun rotateAccent() {
+        val variant = AyuVariant.detect() ?: return
+        val settings = AyuIslandsSettings.getInstance()
+        val state = settings.state
+        val mode = AccentRotationMode.fromName(state.accentRotationMode)
+
+        val newHex =
+            when (mode) {
+                AccentRotationMode.PRESET -> {
+                    val (nextIndex, hex) = nextPresetHex(state.accentRotationPresetIndex)
+                    state.accentRotationPresetIndex = nextIndex
+                    hex
+                }
+                AccentRotationMode.RANDOM -> ContrastAwareColorGenerator.generate(variant)
+            }
+
+        SwingUtilities.invokeLater {
+            settings.setAccentForVariant(variant, newHex)
+            state.accentRotationLastSwitchMs = System.currentTimeMillis()
+            AccentApplicator.apply(newHex)
+            LOG.info("Accent rotated: mode=$mode, color=$newHex")
+        }
+    }
+
+    override fun dispose() {
+        stopRotation()
+    }
+
+    companion object {
+        private val LOG = logger<AccentRotationService>()
+
+        fun getInstance(): AccentRotationService =
+            ApplicationManager
+                .getApplication()
+                .getService(AccentRotationService::class.java)
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/rotation/ContrastAwareColorGenerator.kt
+++ b/src/main/kotlin/dev/ayuislands/rotation/ContrastAwareColorGenerator.kt
@@ -1,0 +1,33 @@
+package dev.ayuislands.rotation
+
+import dev.ayuislands.accent.AyuVariant
+import java.security.SecureRandom
+
+object ContrastAwareColorGenerator {
+    private val random = SecureRandom()
+
+    private const val MIN_SATURATION = 0.70f
+    private const val MAX_SATURATION = 1.00f
+
+    private const val DARK_MIN_LIGHTNESS = 0.60f
+    private const val DARK_MAX_LIGHTNESS = 0.85f
+
+    private const val LIGHT_MIN_LIGHTNESS = 0.25f
+    private const val LIGHT_MAX_LIGHTNESS = 0.45f
+
+    private const val HUE_RANGE = 360f
+
+    fun generate(variant: AyuVariant): String {
+        val hue = random.nextFloat() * HUE_RANGE
+        val saturation = MIN_SATURATION + random.nextFloat() * (MAX_SATURATION - MIN_SATURATION)
+
+        val (minLightness, maxLightness) =
+            when (variant) {
+                AyuVariant.MIRAGE, AyuVariant.DARK -> DARK_MIN_LIGHTNESS to DARK_MAX_LIGHTNESS
+                AyuVariant.LIGHT -> LIGHT_MIN_LIGHTNESS to LIGHT_MAX_LIGHTNESS
+            }
+
+        val lightness = minLightness + random.nextFloat() * (maxLightness - minLightness)
+        return HslColor.toHex(hue, saturation, lightness)
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/rotation/HslColor.kt
+++ b/src/main/kotlin/dev/ayuislands/rotation/HslColor.kt
@@ -1,0 +1,90 @@
+package dev.ayuislands.rotation
+
+import java.awt.Color
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
+
+object HslColor {
+    private const val DEGREES_PER_SEGMENT = 60f
+    private const val FULL_CIRCLE = 360f
+    private const val MAX_RGB = 255f
+    private const val MAX_RGB_INT = 255
+    private const val SEGMENT_2 = 2f
+    private const val SEGMENT_3 = 3f
+    private const val SEGMENT_4 = 4f
+    private const val SEGMENT_5 = 5f
+    private const val HALF = 0.5f
+    private const val HUE_SECTOR_COUNT = 6f
+
+    fun toColor(
+        hue: Float,
+        saturation: Float,
+        lightness: Float,
+    ): Color {
+        val chroma = (1f - abs(SEGMENT_2 * lightness - 1f)) * saturation
+        val hueSegment = hue / DEGREES_PER_SEGMENT
+        val x = chroma * (1f - abs(hueSegment % SEGMENT_2 - 1f))
+
+        val (r1, g1, b1) =
+            when {
+                hueSegment < 1f -> Triple(chroma, x, 0f)
+                hueSegment < SEGMENT_2 -> Triple(x, chroma, 0f)
+                hueSegment < SEGMENT_3 -> Triple(0f, chroma, x)
+                hueSegment < SEGMENT_4 -> Triple(0f, x, chroma)
+                hueSegment < SEGMENT_5 -> Triple(x, 0f, chroma)
+                else -> Triple(chroma, 0f, x)
+            }
+
+        val m = lightness - chroma / SEGMENT_2
+        return Color(
+            ((r1 + m) * MAX_RGB).roundToInt().coerceIn(0, MAX_RGB_INT),
+            ((g1 + m) * MAX_RGB).roundToInt().coerceIn(0, MAX_RGB_INT),
+            ((b1 + m) * MAX_RGB).roundToInt().coerceIn(0, MAX_RGB_INT),
+        )
+    }
+
+    fun toHex(
+        hue: Float,
+        saturation: Float,
+        lightness: Float,
+    ): String {
+        val color = toColor(hue, saturation, lightness)
+        return "#%02X%02X%02X".format(color.red, color.green, color.blue)
+    }
+
+    fun fromColor(color: Color): Triple<Float, Float, Float> {
+        val r = color.red / MAX_RGB
+        val g = color.green / MAX_RGB
+        val b = color.blue / MAX_RGB
+
+        val maxComponent = max(r, max(g, b))
+        val minComponent = min(r, min(g, b))
+        val delta = maxComponent - minComponent
+
+        val lightness = (maxComponent + minComponent) / SEGMENT_2
+
+        if (delta == 0f) {
+            return Triple(0f, 0f, lightness)
+        }
+
+        val saturation =
+            if (lightness <= HALF) {
+                delta / (maxComponent + minComponent)
+            } else {
+                delta / (SEGMENT_2 - maxComponent - minComponent)
+            }
+
+        val hue =
+            when (maxComponent) {
+                r -> DEGREES_PER_SEGMENT * (((g - b) / delta) % HUE_SECTOR_COUNT)
+                g -> DEGREES_PER_SEGMENT * (((b - r) / delta) + SEGMENT_2)
+                else -> DEGREES_PER_SEGMENT * (((r - g) / delta) + SEGMENT_4)
+            }
+
+        val normalizedHue = if (hue < 0f) hue + FULL_CIRCLE else hue
+
+        return Triple(normalizedHue, saturation, lightness)
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
@@ -368,30 +368,22 @@ class AccentColorPanel(
         private val breatheTimer =
             Timer(BREATHE_INTERVAL_MS) { updateBreathe() }
         private val diceIcon = DiceIcon()
-        private val shuffleLabel = ShuffleLabel()
-        private val row: JPanel
 
         init {
             layout = null
             isOpaque = false
-            preferredSize = Dimension(SHUFFLE_COLUMN_WIDTH, 0)
+            preferredSize = Dimension(diceIcon.preferredSize.width, 0)
 
-            row = JPanel()
-            row.layout = BoxLayout(row, BoxLayout.X_AXIS)
-            row.isOpaque = false
-            row.maximumSize = Dimension(SHUFFLE_COLUMN_WIDTH, DICE_ICON_SIZE + BOUNCE_MAX_PIXELS * 2)
-            row.add(diceIcon)
-            row.add(Box.createHorizontalStrut(DICE_LABEL_GAP))
-            row.add(shuffleLabel)
-
-            add(row)
+            add(diceIcon)
 
             breatheTimer.start()
         }
 
         override fun doLayout() {
-            val rowHeight = row.preferredSize.height
-            row.setBounds(0, customLink.y, width, rowHeight)
+            val iconPref = diceIcon.preferredSize
+            val customCenterY = customLink.y + customLink.height / 2
+            val targetY = customCenterY - iconPref.height / 2
+            diceIcon.setBounds(0, targetY, iconPref.width, iconPref.height)
         }
 
         private fun updateBreathe() {
@@ -414,6 +406,7 @@ class AccentColorPanel(
         private inner class DiceIcon : JComponent() {
             private var bounceOffset = 0f
             private var bounceFrame = 0
+            private val shuffleTextWidth: Int
             private val bounceTimer =
                 Timer(ANIMATION_FRAME_MS) {
                     bounceFrame++
@@ -432,9 +425,15 @@ class AccentColorPanel(
             init {
                 cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
                 alignmentY = CENTER_ALIGNMENT
+
+                val labelFont = Font(Font.DIALOG, Font.PLAIN, LINK_FONT_SIZE.toInt())
+                val labelMetrics = getFontMetrics(labelFont)
+                shuffleTextWidth = labelMetrics.stringWidth(SHUFFLE_LABEL)
+
+                val totalWidth = DICE_ICON_SIZE + DICE_LABEL_GAP + shuffleTextWidth + 1
                 val diceHeight = DICE_ICON_SIZE + BOUNCE_MAX_PIXELS * 2
-                preferredSize = Dimension(DICE_ICON_SIZE, diceHeight)
-                maximumSize = Dimension(DICE_ICON_SIZE, diceHeight)
+                preferredSize = Dimension(totalWidth, diceHeight)
+                maximumSize = Dimension(totalWidth, diceHeight)
                 addMouseListener(
                     object : MouseAdapter() {
                         override fun mouseClicked(event: MouseEvent) {
@@ -470,52 +469,27 @@ class AccentColorPanel(
                             Color(DEFAULT_ACCENT_RGB)
                         }
 
+                    // Draw dice emoji with breathe glow
                     g2.composite = AlphaComposite.SrcOver.derive(glowAlpha)
                     g2.font = Font(Font.DIALOG, Font.PLAIN, DICE_FONT_SIZE)
                     g2.color = diceColor
 
                     val gv = g2.font.createGlyphVector(g2.fontRenderContext, DICE_TEXT)
                     val vb = gv.visualBounds
-                    val textX = ((width - vb.width) / 2.0 - vb.x).toFloat() + 2
-                    val textY = ((height - vb.height) / 2.0 - vb.y).toFloat() + bounceOffset
-                    g2.drawGlyphVector(gv, textX, textY)
-                } finally {
-                    g2.dispose()
-                }
-            }
-        }
+                    val emojiX = ((DICE_ICON_SIZE - vb.width) / 2.0 - vb.x).toFloat() + 2
+                    val emojiY = ((height - vb.height) / 2.0 - vb.y).toFloat() + bounceOffset
+                    g2.drawGlyphVector(gv, emojiX, emojiY)
 
-        private inner class ShuffleLabel : JComponent() {
-            init {
-                cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
-                alignmentY = CENTER_ALIGNMENT
-                val baseFont = font ?: Font(Font.DIALOG, Font.PLAIN, LINK_FONT_SIZE.toInt())
-                val metrics = getFontMetrics(baseFont.deriveFont(Font.PLAIN, LINK_FONT_SIZE))
-                preferredSize = Dimension(metrics.stringWidth(SHUFFLE_LABEL) + 1, PANEL_HEIGHT)
-                maximumSize = Dimension(metrics.stringWidth(SHUFFLE_LABEL) + 1, PANEL_HEIGHT)
-                addMouseListener(
-                    object : MouseAdapter() {
-                        override fun mouseClicked(event: MouseEvent) {
-                            if (!isEnabled) return
-                            diceIcon.triggerBounce()
-                            onShuffleTrigger?.invoke()
-                        }
-                    },
-                )
-            }
-
-            override fun paintComponent(graphics: Graphics) {
-                val g2 = graphics.create() as Graphics2D
-                try {
-                    g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON)
-
+                    // Draw "Shuffle" text at full opacity with link color
+                    g2.composite = AlphaComposite.SrcOver.derive(1f)
                     val linkColor = JBUI.CurrentTheme.Link.Foreground.ENABLED
                     g2.color = linkColor
-                    g2.font = g2.font.deriveFont(Font.PLAIN, LINK_FONT_SIZE)
+                    g2.font = Font(Font.DIALOG, Font.PLAIN, LINK_FONT_SIZE.toInt())
 
-                    val metrics = g2.fontMetrics
-                    val textY = (height - metrics.height) / 2 + metrics.ascent
-                    g2.drawString(SHUFFLE_LABEL, 0, textY)
+                    val labelMetrics = g2.fontMetrics
+                    val labelX = DICE_ICON_SIZE + DICE_LABEL_GAP
+                    val labelY = (height - labelMetrics.height) / 2 + labelMetrics.ascent
+                    g2.drawString(SHUFFLE_LABEL, labelX, labelY)
                 } finally {
                     g2.dispose()
                 }
@@ -698,7 +672,6 @@ class AccentColorPanel(
         private const val DEFAULT_ACCENT_RGB = 0x73D0FF
 
         private const val SHUFFLE_COLUMN_GAP = 4
-        private const val SHUFFLE_COLUMN_WIDTH = 86
         private const val DICE_FONT_SIZE = 20
         private const val DICE_ICON_SIZE = 40
         private const val DICE_LABEL_GAP = 2

--- a/src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
@@ -3,6 +3,8 @@ package dev.ayuislands.settings
 import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.util.ui.JBUI
 import dev.ayuislands.accent.AccentColor
+import dev.ayuislands.glow.GlowRenderer
+import dev.ayuislands.glow.GlowStyle
 import java.awt.AlphaComposite
 import java.awt.BasicStroke
 import java.awt.BorderLayout
@@ -14,6 +16,7 @@ import java.awt.Font
 import java.awt.Graphics
 import java.awt.Graphics2D
 import java.awt.GridLayout
+import java.awt.Rectangle
 import java.awt.RenderingHints
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
@@ -22,6 +25,7 @@ import javax.swing.Box
 import javax.swing.BoxLayout
 import javax.swing.JComponent
 import javax.swing.JPanel
+import javax.swing.Timer
 import javax.swing.UIManager
 
 /**
@@ -41,8 +45,10 @@ class AccentColorPanel(
     private val onPresetSelected: (AccentColor) -> Unit,
     private val onCustomTrigger: () -> Unit,
     private val onReset: () -> Unit,
+    private val onShuffleTrigger: (() -> Unit)? = null,
 ) : JPanel(BorderLayout(COLUMN_GAP, 0)) {
     private val presetList: List<AccentColor> = presets
+    private val heroGlowRenderer = GlowRenderer()
 
     var selectedPreset: String? = null
         set(value) {
@@ -74,6 +80,7 @@ class AccentColorPanel(
     private val shadeNameLabel: ShadeNameLabel
     private val customLink: CustomLink
     private val resetLabel: ResetLabel
+    private val shuffleButton: ShuffleButton?
     private val presetGrid: JPanel
 
     init {
@@ -83,6 +90,8 @@ class AccentColorPanel(
         shadeNameLabel = ShadeNameLabel()
         customLink = CustomLink()
         resetLabel = ResetLabel()
+        shuffleButton =
+            if (onShuffleTrigger != null) ShuffleButton() else null
 
         presetGrid = JPanel(GridLayout(GRID_ROWS, GRID_COLUMNS, GRID_GAP, GRID_GAP))
         presetGrid.isOpaque = false
@@ -95,6 +104,10 @@ class AccentColorPanel(
         linksRow.add(customLink)
         linksRow.add(Box.createHorizontalStrut(LINKS_GAP))
         linksRow.add(resetLabel)
+        if (shuffleButton != null) {
+            linksRow.add(Box.createHorizontalStrut(LINKS_GAP))
+            linksRow.add(shuffleButton)
+        }
 
         val leftColumn = JPanel()
         leftColumn.layout = BoxLayout(leftColumn, BoxLayout.Y_AXIS)
@@ -168,6 +181,11 @@ class AccentColorPanel(
                 val color = Color.decode(accent.hex)
                 val isSelected = accent.hex.equals(selectedPreset, ignoreCase = true)
                 val borderColor = Color(BORDER_RGB)
+
+                if (heroGlowActive && accent.hex.equals(heroGlowHex, ignoreCase = true)) {
+                    heroGlowRenderer.ensureCache(color, GlowStyle.SOFT, HERO_GLOW_INTENSITY, HERO_GLOW_WIDTH)
+                    heroGlowRenderer.paintGlow(g2, Rectangle(0, 0, width, height), HERO_GLOW_WIDTH, PANEL_ARC.toInt())
+                }
 
                 val shape =
                     RoundRectangle2D.Float(
@@ -308,6 +326,102 @@ class AccentColorPanel(
 
     private inner class ResetLabel : LinkLabel("Reset", onReset)
 
+    private inner class ShuffleButton : JComponent() {
+        private var glowAlpha = BREATHE_MIN_ALPHA
+        private var breathePhase = 0.0
+        private val breatheTimer =
+            Timer(BREATHE_INTERVAL_MS) { updateBreathe() }
+
+        init {
+            isOpaque = false
+            cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+            addMouseListener(
+                object : MouseAdapter() {
+                    override fun mouseClicked(event: MouseEvent) {
+                        if (!isEnabled) return
+                        onShuffleTrigger?.invoke()
+                    }
+                },
+            )
+            breatheTimer.start()
+        }
+
+        private fun updateBreathe() {
+            breathePhase += BREATHE_STEP
+            val sinNormalized =
+                (Math.sin(breathePhase).toFloat() + 1f) / 2f
+            glowAlpha = BREATHE_MIN_ALPHA + BREATHE_RANGE * sinNormalized
+            repaint()
+        }
+
+        override fun getPreferredSize(): Dimension {
+            val metrics =
+                getFontMetrics(
+                    font.deriveFont(Font.PLAIN, LINK_FONT_SIZE),
+                )
+            return Dimension(
+                metrics.stringWidth(SHUFFLE_LABEL) + SHUFFLE_DOT_TOTAL_WIDTH,
+                PANEL_HEIGHT,
+            )
+        }
+
+        override fun paintComponent(graphics: Graphics) {
+            val g2 = graphics.create() as Graphics2D
+            try {
+                g2.setRenderingHint(
+                    RenderingHints.KEY_ANTIALIASING,
+                    RenderingHints.VALUE_ANTIALIAS_ON,
+                )
+                g2.setRenderingHint(
+                    RenderingHints.KEY_TEXT_ANTIALIASING,
+                    RenderingHints.VALUE_TEXT_ANTIALIAS_ON,
+                )
+
+                val accentHex =
+                    selectedPreset ?: heroGlowHex ?: DEFAULT_ACCENT_HEX
+                val dotColor =
+                    try {
+                        Color.decode(accentHex)
+                    } catch (_: NumberFormatException) {
+                        Color(DEFAULT_ACCENT_RGB)
+                    }
+
+                g2.composite =
+                    AlphaComposite.SrcOver.derive(glowAlpha)
+                val dotY = (height - SHUFFLE_DOT_SIZE) / 2
+                g2.color = dotColor
+                g2.fillOval(0, dotY, SHUFFLE_DOT_SIZE, SHUFFLE_DOT_SIZE)
+
+                g2.composite =
+                    AlphaComposite.SrcOver.derive(1f)
+                val linkColor =
+                    JBUI.CurrentTheme.Link.Foreground.ENABLED
+                g2.color = linkColor
+                g2.font =
+                    g2.font.deriveFont(Font.PLAIN, LINK_FONT_SIZE)
+                val metrics = g2.fontMetrics
+                val textY =
+                    (height - metrics.height) / 2 + metrics.ascent
+                g2.drawString(
+                    SHUFFLE_LABEL,
+                    SHUFFLE_DOT_TOTAL_WIDTH,
+                    textY,
+                )
+            } finally {
+                g2.dispose()
+            }
+        }
+
+        fun dispose() {
+            breatheTimer.stop()
+        }
+    }
+
+    override fun removeNotify() {
+        super.removeNotify()
+        shuffleButton?.dispose()
+    }
+
     private fun paintDisabledOverlay(
         g2: Graphics2D,
         shape: RoundRectangle2D.Float,
@@ -334,5 +448,20 @@ class AccentColorPanel(
         private const val SELECTED_OVERLAY_ALPHA = 0.55f
         private const val DISABLED_OVERLAY_ALPHA = 0.45f
         private const val LINK_FONT_SIZE = 12f
+
+        private const val HERO_GLOW_INTENSITY = 30
+        private const val HERO_GLOW_WIDTH = 4
+
+        private const val BREATHE_INTERVAL_MS = 50
+        private const val BREATHE_STEP = 0.05
+        private const val BREATHE_MIN_ALPHA = 0.4f
+        private const val BREATHE_RANGE = 0.6f
+        private const val SHUFFLE_DOT_SIZE = 8
+        private const val SHUFFLE_DOT_GAP = 4
+        private const val SHUFFLE_DOT_TOTAL_WIDTH =
+            SHUFFLE_DOT_SIZE + SHUFFLE_DOT_GAP
+        private const val SHUFFLE_LABEL = "Shuffle"
+        private const val DEFAULT_ACCENT_HEX = "#73D0FF"
+        private const val DEFAULT_ACCENT_RGB = 0x73D0FF
     }
 }

--- a/src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
@@ -372,7 +372,7 @@ class AccentColorPanel(
         init {
             layout = null
             isOpaque = false
-            preferredSize = Dimension(diceIcon.preferredSize.width, 0)
+            preferredSize = Dimension(diceIcon.preferredSize.width + SHUFFLE_SIDE_PAD * 2, 0)
 
             add(diceIcon)
 
@@ -383,7 +383,8 @@ class AccentColorPanel(
             val iconPref = diceIcon.preferredSize
             val customCenterY = customLink.y + customLink.height / 2
             val targetY = customCenterY - iconPref.height / 2
-            diceIcon.setBounds(0, targetY, iconPref.width, iconPref.height)
+            val targetX = (width - iconPref.width) / 2
+            diceIcon.setBounds(targetX, targetY, iconPref.width, iconPref.height)
         }
 
         private fun updateBreathe() {
@@ -677,6 +678,7 @@ class AccentColorPanel(
         private const val DICE_LABEL_GAP = 2
         private const val DICE_TEXT = "\uD83C\uDFB2"
 
+        private const val SHUFFLE_SIDE_PAD = 6
         private const val ANIMATION_FRAME_MS = 16
         private const val SLIDE_TOTAL_FRAMES = 18
         private const val BOUNCE_MAX_PIXELS = 8

--- a/src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
@@ -369,26 +369,29 @@ class AccentColorPanel(
             Timer(BREATHE_INTERVAL_MS) { updateBreathe() }
         private val diceIcon = DiceIcon()
         private val shuffleLabel = ShuffleLabel()
+        private val row: JPanel
 
         init {
-            layout = BoxLayout(this, BoxLayout.Y_AXIS)
+            layout = null
             isOpaque = false
             preferredSize = Dimension(SHUFFLE_COLUMN_WIDTH, 0)
 
-            val row = JPanel()
+            row = JPanel()
             row.layout = BoxLayout(row, BoxLayout.X_AXIS)
             row.isOpaque = false
-            row.alignmentX = CENTER_ALIGNMENT
-            row.maximumSize = Dimension(SHUFFLE_COLUMN_WIDTH, DICE_ICON_SIZE)
+            row.maximumSize = Dimension(SHUFFLE_COLUMN_WIDTH, DICE_ICON_SIZE + BOUNCE_MAX_PIXELS * 2)
             row.add(diceIcon)
             row.add(Box.createHorizontalStrut(DICE_LABEL_GAP))
             row.add(shuffleLabel)
 
-            add(Box.createVerticalStrut(PANEL_HEIGHT + LEFT_COLUMN_GAP))
             add(row)
-            add(Box.createVerticalGlue())
 
             breatheTimer.start()
+        }
+
+        override fun doLayout() {
+            val rowHeight = row.preferredSize.height
+            row.setBounds(0, customLink.y, width, rowHeight)
         }
 
         private fun updateBreathe() {
@@ -429,8 +432,9 @@ class AccentColorPanel(
             init {
                 cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
                 alignmentY = CENTER_ALIGNMENT
-                preferredSize = Dimension(DICE_ICON_SIZE, DICE_ICON_SIZE)
-                maximumSize = Dimension(DICE_ICON_SIZE, DICE_ICON_SIZE)
+                val diceHeight = DICE_ICON_SIZE + BOUNCE_MAX_PIXELS * 2
+                preferredSize = Dimension(DICE_ICON_SIZE, diceHeight)
+                maximumSize = Dimension(DICE_ICON_SIZE, diceHeight)
                 addMouseListener(
                     object : MouseAdapter() {
                         override fun mouseClicked(event: MouseEvent) {
@@ -466,15 +470,14 @@ class AccentColorPanel(
                             Color(DEFAULT_ACCENT_RGB)
                         }
 
-                    g2.translate(0, bounceOffset.toInt())
                     g2.composite = AlphaComposite.SrcOver.derive(glowAlpha)
                     g2.font = Font(Font.DIALOG, Font.PLAIN, DICE_FONT_SIZE)
                     g2.color = diceColor
 
                     val gv = g2.font.createGlyphVector(g2.fontRenderContext, DICE_TEXT)
                     val vb = gv.visualBounds
-                    val textX = ((width - vb.width) / 2.0 - vb.x).toFloat()
-                    val textY = ((height - vb.height) / 2.0 - vb.y).toFloat()
+                    val textX = ((width - vb.width) / 2.0 - vb.x).toFloat() + 2
+                    val textY = ((height - vb.height) / 2.0 - vb.y).toFloat() + bounceOffset
                     g2.drawGlyphVector(gv, textX, textY)
                 } finally {
                     g2.dispose()
@@ -695,9 +698,9 @@ class AccentColorPanel(
         private const val DEFAULT_ACCENT_RGB = 0x73D0FF
 
         private const val SHUFFLE_COLUMN_GAP = 4
-        private const val SHUFFLE_COLUMN_WIDTH = 80
+        private const val SHUFFLE_COLUMN_WIDTH = 86
         private const val DICE_FONT_SIZE = 20
-        private const val DICE_ICON_SIZE = 34
+        private const val DICE_ICON_SIZE = 40
         private const val DICE_LABEL_GAP = 2
         private const val DICE_TEXT = "\uD83C\uDFB2"
 

--- a/src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
@@ -26,6 +26,7 @@ import javax.swing.BoxLayout
 import javax.swing.JComponent
 import javax.swing.JPanel
 import javax.swing.Timer
+import javax.swing.UIManager
 import kotlin.math.sin
 
 /**

--- a/src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
@@ -429,8 +429,8 @@ class AccentColorPanel(
             init {
                 cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
                 alignmentY = CENTER_ALIGNMENT
-                preferredSize = Dimension(DICE_ICON_SIZE + DICE_PAD, DICE_ICON_SIZE)
-                maximumSize = Dimension(DICE_ICON_SIZE + DICE_PAD, DICE_ICON_SIZE)
+                preferredSize = Dimension(DICE_ICON_SIZE, DICE_ICON_SIZE)
+                maximumSize = Dimension(DICE_ICON_SIZE, DICE_ICON_SIZE)
                 addMouseListener(
                     object : MouseAdapter() {
                         override fun mouseClicked(event: MouseEvent) {
@@ -471,10 +471,11 @@ class AccentColorPanel(
                     g2.font = Font(Font.DIALOG, Font.PLAIN, DICE_FONT_SIZE)
                     g2.color = diceColor
 
-                    val metrics = g2.fontMetrics
-                    val textX = (width - metrics.stringWidth(DICE_TEXT)) / 2 + DICE_PAD / 2
-                    val textY = (height - metrics.height) / 2 + metrics.ascent
-                    g2.drawString(DICE_TEXT, textX, textY)
+                    val gv = g2.font.createGlyphVector(g2.fontRenderContext, DICE_TEXT)
+                    val vb = gv.visualBounds
+                    val textX = ((width - vb.width) / 2.0 - vb.x).toFloat()
+                    val textY = ((height - vb.height) / 2.0 - vb.y).toFloat()
+                    g2.drawGlyphVector(gv, textX, textY)
                 } finally {
                     g2.dispose()
                 }
@@ -520,7 +521,11 @@ class AccentColorPanel(
     }
 
     private inner class ThirteenthSwatch : JComponent() {
-        private var targetSwatchWidth = PANEL_HEIGHT
+        private fun computeEqualSwatchWidth(): Int {
+            val gridAreaWidth = presetGrid.parent?.width ?: return PANEL_HEIGHT
+            if (gridAreaWidth <= 0) return PANEL_HEIGHT
+            return (gridAreaWidth - GRID_COLUMNS * GRID_GAP) / (GRID_COLUMNS + 1)
+        }
 
         var colorHex: String? = null
         private var slideProgress = 0f
@@ -555,18 +560,18 @@ class AccentColorPanel(
             if (colorHex == null || slideProgress <= 0f) {
                 return Dimension(0, PANEL_HEIGHT)
             }
-            val targetWidth = targetSwatchWidth
+            val targetWidth = computeEqualSwatchWidth()
             val animatedWidth = (targetWidth * easeOut(slideProgress)).toInt()
             return Dimension(animatedWidth, PANEL_HEIGHT)
         }
 
         override fun getMinimumSize(): Dimension = Dimension(0, PANEL_HEIGHT)
 
-        override fun getMaximumSize(): Dimension = Dimension(targetSwatchWidth, PANEL_HEIGHT)
+        override fun getMaximumSize(): Dimension = Dimension(computeEqualSwatchWidth(), PANEL_HEIGHT)
 
         fun slideIn(hex: String) {
             colorHex = hex
-            targetSwatchWidth = presetPanels.firstOrNull()?.width ?: PANEL_HEIGHT
+
             slideProgress = 0f
             isVisible = true
 
@@ -575,7 +580,7 @@ class AccentColorPanel(
 
         fun showImmediate(hex: String) {
             colorHex = hex
-            targetSwatchWidth = presetPanels.firstOrNull()?.width ?: PANEL_HEIGHT
+
             slideProgress = 1f
             isVisible = true
 
@@ -609,7 +614,7 @@ class AccentColorPanel(
                 val color = Color.decode(hex)
                 val borderColor = Color(BORDER_RGB)
 
-                val swatchWidth = targetSwatchWidth.coerceAtMost(width)
+                val swatchWidth = computeEqualSwatchWidth().coerceAtMost(width)
                 val swatchX = (width - swatchWidth).coerceAtLeast(0)
                 val row2Swatch = presetPanels.getOrNull(GRID_COLUMNS)
                 val swatchY = row2Swatch?.y ?: (PANEL_HEIGHT + GRID_GAP)
@@ -692,8 +697,7 @@ class AccentColorPanel(
         private const val SHUFFLE_COLUMN_GAP = 4
         private const val SHUFFLE_COLUMN_WIDTH = 80
         private const val DICE_FONT_SIZE = 20
-        private const val DICE_ICON_SIZE = 28
-        private const val DICE_PAD = 6
+        private const val DICE_ICON_SIZE = 34
         private const val DICE_LABEL_GAP = 2
         private const val DICE_TEXT = "\uD83C\uDFB2"
 

--- a/src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
@@ -89,10 +89,6 @@ class AccentColorPanel(
     private val thirteenthSwatch: ThirteenthSwatch?
     private val presetGrid: JPanel
 
-    /** Hex color currently shown in the 13th swatch, or null if hidden. */
-    val thirteenthSwatchColor: String?
-        get() = thirteenthSwatch?.colorHex
-
     init {
         isOpaque = false
 
@@ -135,10 +131,6 @@ class AccentColorPanel(
         } else {
             add(presetGrid, BorderLayout.CENTER)
         }
-    }
-
-    fun triggerBounce() {
-        shuffleLink?.triggerBounce()
     }
 
     fun showThirteenthSwatch(hex: String) {

--- a/src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
@@ -56,6 +56,20 @@ class AccentColorPanel(
             repaint()
         }
 
+    /** Hex color of the swatch that should have a hero glow border (set by rotation). */
+    var heroGlowHex: String? = null
+        set(value) {
+            field = value
+            repaint()
+        }
+
+    /** Whether hero glow is active (only during preset rotation mode). */
+    var heroGlowActive: Boolean = false
+        set(value) {
+            field = value
+            repaint()
+        }
+
     private val presetPanels: List<PresetComponent>
     private val shadeNameLabel: ShadeNameLabel
     private val customLink: CustomLink

--- a/src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
@@ -82,6 +82,10 @@ class AccentColorPanel(
             repaint()
         }
 
+    /** The current color hex of the 13th swatch, or null if hidden. */
+    val thirteenthSwatchColor: String?
+        get() = thirteenthSwatch?.colorHex
+
     private val presetPanels: List<PresetComponent>
     private val shadeNameLabel: ShadeNameLabel
     private val customLink: CustomLink

--- a/src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
@@ -11,7 +11,6 @@ import java.awt.BorderLayout
 import java.awt.Color
 import java.awt.Cursor
 import java.awt.Dimension
-import java.awt.FlowLayout
 import java.awt.Font
 import java.awt.Graphics
 import java.awt.Graphics2D
@@ -30,16 +29,18 @@ import javax.swing.UIManager
 import kotlin.math.sin
 
 /**
- * Accent color selection panel with two visual groups: action links (left) + preset grid (right).
+ * Accent color selection panel with three visual columns: links (left), shuffle (center), preset grid (right).
  *
  * Layout:
  * ```
- *   Lavender              [█][█][█][█][█][█]
- *   Custom…    Reset      [█][█][█][█][█][█]
+ *   Lavender                    [swatch][swatch][swatch][swatch]
+ *   Custom     🎲 Shuffle       [swatch][swatch][swatch][swatch]
+ *   Reset                       [swatch][swatch][swatch][swatch]
  * ```
  *
- * Left column shows the shade name in accent color (row 1) and action links (row 2).
- * The right side is the 2×6 preset color grid.
+ * Left column stacks vertically: shade name (row 1), Custom link (row 2), Reset link (row 3).
+ * Shuffle column contains a dice icon and "Shuffle" text, both clickable.
+ * The right side is the 4x3 preset color grid.
  */
 class AccentColorPanel(
     presets: List<AccentColor>,
@@ -81,7 +82,7 @@ class AccentColorPanel(
     private val shadeNameLabel: ShadeNameLabel
     private val customLink: CustomLink
     private val resetLabel: ResetLabel
-    private val shuffleButton: ShuffleButton?
+    private val shuffleColumn: ShuffleColumn?
     private val presetGrid: JPanel
 
     init {
@@ -91,8 +92,8 @@ class AccentColorPanel(
         shadeNameLabel = ShadeNameLabel()
         customLink = CustomLink()
         resetLabel = ResetLabel()
-        shuffleButton =
-            if (onShuffleTrigger != null) ShuffleButton() else null
+        shuffleColumn =
+            if (onShuffleTrigger != null) ShuffleColumn() else null
 
         presetGrid = JPanel(GridLayout(GRID_ROWS, GRID_COLUMNS, GRID_GAP, GRID_GAP))
         presetGrid.isOpaque = false
@@ -100,25 +101,26 @@ class AccentColorPanel(
             presetGrid.add(panel)
         }
 
-        val linksRow = JPanel(FlowLayout(FlowLayout.LEFT, 0, 0))
-        linksRow.isOpaque = false
-        linksRow.add(customLink)
-        linksRow.add(Box.createHorizontalStrut(LINKS_GAP))
-        linksRow.add(resetLabel)
-        if (shuffleButton != null) {
-            linksRow.add(Box.createHorizontalStrut(LINKS_GAP))
-            linksRow.add(shuffleButton)
-        }
-
         val leftColumn = JPanel()
         leftColumn.layout = BoxLayout(leftColumn, BoxLayout.Y_AXIS)
         leftColumn.isOpaque = false
         leftColumn.add(shadeNameLabel)
         leftColumn.add(Box.createVerticalStrut(LEFT_COLUMN_GAP))
-        leftColumn.add(linksRow)
+        leftColumn.add(customLink)
+        leftColumn.add(Box.createVerticalStrut(LEFT_COLUMN_GAP))
+        leftColumn.add(resetLabel)
 
         add(leftColumn, BorderLayout.WEST)
-        add(presetGrid, BorderLayout.CENTER)
+
+        if (shuffleColumn != null) {
+            val contentWrapper = JPanel(BorderLayout(SHUFFLE_COLUMN_GAP, 0))
+            contentWrapper.isOpaque = false
+            contentWrapper.add(shuffleColumn, BorderLayout.WEST)
+            contentWrapper.add(presetGrid, BorderLayout.CENTER)
+            add(contentWrapper, BorderLayout.CENTER)
+        } else {
+            add(presetGrid, BorderLayout.CENTER)
+        }
     }
 
     private fun getSelectedAccentHex(): String? = selectedPreset ?: customColor
@@ -323,27 +325,30 @@ class AccentColorPanel(
         }
     }
 
-    private inner class CustomLink : LinkLabel("Custom\u2026", onCustomTrigger)
+    private inner class CustomLink : LinkLabel("Custom", onCustomTrigger)
 
     private inner class ResetLabel : LinkLabel("Reset", onReset)
 
-    private inner class ShuffleButton : JComponent() {
+    private inner class ShuffleColumn : JComponent() {
         private var glowAlpha = BREATHE_MIN_ALPHA
         private var breathePhase = 0.0
         private val breatheTimer =
             Timer(BREATHE_INTERVAL_MS) { updateBreathe() }
 
         init {
+            layout = BoxLayout(this, BoxLayout.Y_AXIS)
             isOpaque = false
-            cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
-            addMouseListener(
-                object : MouseAdapter() {
-                    override fun mouseClicked(event: MouseEvent) {
-                        if (!isEnabled) return
-                        onShuffleTrigger?.invoke()
-                    }
-                },
-            )
+            preferredSize = Dimension(SHUFFLE_COLUMN_WIDTH, 0)
+
+            val diceLabel = DiceIcon()
+            val shuffleLabel = ShuffleLabel()
+
+            add(Box.createVerticalGlue())
+            add(diceLabel)
+            add(Box.createVerticalStrut(DICE_LABEL_GAP))
+            add(shuffleLabel)
+            add(Box.createVerticalGlue())
+
             breatheTimer.start()
         }
 
@@ -355,72 +360,94 @@ class AccentColorPanel(
             repaint()
         }
 
-        override fun getPreferredSize(): Dimension {
-            val metrics =
-                getFontMetrics(
-                    font.deriveFont(Font.PLAIN, LINK_FONT_SIZE),
-                )
-            return Dimension(
-                metrics.stringWidth(SHUFFLE_LABEL) + SHUFFLE_DOT_TOTAL_WIDTH,
-                PANEL_HEIGHT,
-            )
+        fun dispose() {
+            breatheTimer.stop()
         }
 
-        override fun paintComponent(graphics: Graphics) {
-            val g2 = graphics.create() as Graphics2D
-            try {
-                g2.setRenderingHint(
-                    RenderingHints.KEY_ANTIALIASING,
-                    RenderingHints.VALUE_ANTIALIAS_ON,
+        private inner class DiceIcon : JComponent() {
+            init {
+                cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+                alignmentX = CENTER_ALIGNMENT
+                preferredSize = Dimension(SHUFFLE_COLUMN_WIDTH, DICE_ICON_SIZE)
+                maximumSize = Dimension(SHUFFLE_COLUMN_WIDTH, DICE_ICON_SIZE)
+                addMouseListener(
+                    object : MouseAdapter() {
+                        override fun mouseClicked(event: MouseEvent) {
+                            if (!isEnabled) return
+                            onShuffleTrigger?.invoke()
+                        }
+                    },
                 )
-                g2.setRenderingHint(
-                    RenderingHints.KEY_TEXT_ANTIALIASING,
-                    RenderingHints.VALUE_TEXT_ANTIALIAS_ON,
-                )
+            }
 
-                val accentHex =
-                    selectedPreset ?: heroGlowHex ?: DEFAULT_ACCENT_HEX
-                val dotColor =
-                    try {
-                        Color.decode(accentHex)
-                    } catch (_: NumberFormatException) {
-                        Color(DEFAULT_ACCENT_RGB)
-                    }
+            override fun paintComponent(graphics: Graphics) {
+                val g2 = graphics.create() as Graphics2D
+                try {
+                    g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON)
 
-                g2.composite =
-                    AlphaComposite.SrcOver.derive(glowAlpha)
-                val dotY = (height - SHUFFLE_DOT_SIZE) / 2
-                g2.color = dotColor
-                g2.fillOval(0, dotY, SHUFFLE_DOT_SIZE, SHUFFLE_DOT_SIZE)
+                    val accentHex =
+                        selectedPreset ?: heroGlowHex ?: DEFAULT_ACCENT_HEX
+                    val diceColor =
+                        try {
+                            Color.decode(accentHex)
+                        } catch (_: NumberFormatException) {
+                            Color(DEFAULT_ACCENT_RGB)
+                        }
 
-                g2.composite =
-                    AlphaComposite.SrcOver.derive(1f)
-                val linkColor =
-                    JBUI.CurrentTheme.Link.Foreground.ENABLED
-                g2.color = linkColor
-                g2.font =
-                    g2.font.deriveFont(Font.PLAIN, LINK_FONT_SIZE)
-                val metrics = g2.fontMetrics
-                val textY =
-                    (height - metrics.height) / 2 + metrics.ascent
-                g2.drawString(
-                    SHUFFLE_LABEL,
-                    SHUFFLE_DOT_TOTAL_WIDTH,
-                    textY,
-                )
-            } finally {
-                g2.dispose()
+                    g2.composite = AlphaComposite.SrcOver.derive(glowAlpha)
+                    g2.font = Font(Font.DIALOG, Font.PLAIN, DICE_FONT_SIZE)
+                    g2.color = diceColor
+
+                    val metrics = g2.fontMetrics
+                    val textX = (width - metrics.stringWidth(DICE_TEXT)) / 2
+                    val textY = (height - metrics.height) / 2 + metrics.ascent
+                    g2.drawString(DICE_TEXT, textX, textY)
+                } finally {
+                    g2.dispose()
+                }
             }
         }
 
-        fun dispose() {
-            breatheTimer.stop()
+        private inner class ShuffleLabel : JComponent() {
+            init {
+                cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+                alignmentX = CENTER_ALIGNMENT
+                val metrics = getFontMetrics(font.deriveFont(Font.PLAIN, LINK_FONT_SIZE))
+                preferredSize = Dimension(SHUFFLE_COLUMN_WIDTH, metrics.height)
+                maximumSize = Dimension(SHUFFLE_COLUMN_WIDTH, metrics.height)
+                addMouseListener(
+                    object : MouseAdapter() {
+                        override fun mouseClicked(event: MouseEvent) {
+                            if (!isEnabled) return
+                            onShuffleTrigger?.invoke()
+                        }
+                    },
+                )
+            }
+
+            override fun paintComponent(graphics: Graphics) {
+                val g2 = graphics.create() as Graphics2D
+                try {
+                    g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON)
+
+                    val linkColor = JBUI.CurrentTheme.Link.Foreground.ENABLED
+                    g2.color = linkColor
+                    g2.font = g2.font.deriveFont(Font.PLAIN, LINK_FONT_SIZE)
+
+                    val metrics = g2.fontMetrics
+                    val textX = (width - metrics.stringWidth(SHUFFLE_LABEL)) / 2
+                    val textY = (height - metrics.height) / 2 + metrics.ascent
+                    g2.drawString(SHUFFLE_LABEL, textX, textY)
+                } finally {
+                    g2.dispose()
+                }
+            }
         }
     }
 
     override fun removeNotify() {
         super.removeNotify()
-        shuffleButton?.dispose()
+        shuffleColumn?.dispose()
     }
 
     private fun paintDisabledOverlay(
@@ -438,11 +465,10 @@ class AccentColorPanel(
         private const val PANEL_ARC = 8f
         private const val GRID_GAP = 2
         private const val LEFT_COLUMN_GAP = 4
-        private const val LINKS_GAP = 12
         private const val COLUMN_GAP = 16
         private const val LEFT_COLUMN_WIDTH = 120
-        private const val GRID_ROWS = 2
-        private const val GRID_COLUMNS = 6
+        private const val GRID_ROWS = 3
+        private const val GRID_COLUMNS = 4
         private const val SPECIMEN_FONT_SIZE = 15
         private const val BORDER_RGB = 0x4E5A6E
         private const val BORDER_INSET = 0.5f
@@ -457,12 +483,15 @@ class AccentColorPanel(
         private const val BREATHE_STEP = 0.05
         private const val BREATHE_MIN_ALPHA = 0.4f
         private const val BREATHE_RANGE = 0.6f
-        private const val SHUFFLE_DOT_SIZE = 8
-        private const val SHUFFLE_DOT_GAP = 4
-        private const val SHUFFLE_DOT_TOTAL_WIDTH =
-            SHUFFLE_DOT_SIZE + SHUFFLE_DOT_GAP
         private const val SHUFFLE_LABEL = "Shuffle"
         private const val DEFAULT_ACCENT_HEX = "#73D0FF"
         private const val DEFAULT_ACCENT_RGB = 0x73D0FF
+
+        private const val SHUFFLE_COLUMN_GAP = 12
+        private const val SHUFFLE_COLUMN_WIDTH = 56
+        private const val DICE_FONT_SIZE = 20
+        private const val DICE_ICON_SIZE = 24
+        private const val DICE_LABEL_GAP = 2
+        private const val DICE_TEXT = "\uD83C\uDFB2"
     }
 }

--- a/src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
@@ -1,6 +1,7 @@
 package dev.ayuislands.settings
 
 import com.intellij.openapi.editor.colors.EditorColorsManager
+import com.intellij.openapi.util.IconLoader
 import com.intellij.util.ui.JBUI
 import dev.ayuislands.accent.AccentColor
 import dev.ayuislands.glow.GlowRenderer
@@ -22,6 +23,7 @@ import java.awt.event.MouseEvent
 import java.awt.geom.RoundRectangle2D
 import javax.swing.Box
 import javax.swing.BoxLayout
+import javax.swing.Icon
 import javax.swing.JComponent
 import javax.swing.JPanel
 import javax.swing.Timer
@@ -30,17 +32,17 @@ import kotlin.math.exp
 import kotlin.math.sin
 
 /**
- * Accent color selection panel with three visual columns: links (left), shuffle (center), preset grid (right).
+ * Accent color selection panel with icon-labeled actions (left) and preset grid (right).
  *
  * Layout:
  * ```
- *   Lavender                    [swatch][swatch][swatch][swatch]
- *   Custom     🎲 Shuffle       [swatch][swatch][swatch][swatch]
- *   Reset                       [swatch][swatch][swatch][swatch]
+ *   🎨 Lavender    [swatch][swatch][swatch][swatch]
+ *   💉 Custom      [swatch][swatch][swatch][swatch]
+ *   🎲 Shuffle     [swatch][swatch][swatch][swatch]
  * ```
  *
- * Left column stacks vertically: shade name (row 1), Custom link (row 2), Reset link (row 3).
- * Shuffle column contains a dice icon and "Shuffle" text, both clickable.
+ * Left column: shade name (row 1), Custom link (row 2), Shuffle link (row 3).
+ * Each row has a Lucide SVG icon followed by text.
  * The right side is the 4x3 preset color grid.
  */
 class AccentColorPanel(
@@ -83,8 +85,7 @@ class AccentColorPanel(
     private val presetPanels: List<PresetComponent>
     private val shadeNameLabel: ShadeNameLabel
     private val customLink: CustomLink
-    private val resetLabel: ResetLabel
-    private val shuffleColumn: ShuffleColumn?
+    private val shuffleLink: ShuffleLink?
     private val thirteenthSwatch: ThirteenthSwatch?
     private val presetGrid: JPanel
 
@@ -98,9 +99,8 @@ class AccentColorPanel(
         presetPanels = presets.map { PresetComponent(it) }
         shadeNameLabel = ShadeNameLabel()
         customLink = CustomLink()
-        resetLabel = ResetLabel()
-        shuffleColumn =
-            if (onShuffleTrigger != null) ShuffleColumn() else null
+        shuffleLink =
+            if (onShuffleTrigger != null) ShuffleLink() else null
         thirteenthSwatch =
             if (onShuffleTrigger != null) ThirteenthSwatch() else null
 
@@ -117,31 +117,28 @@ class AccentColorPanel(
         leftColumn.add(Box.createVerticalStrut(LEFT_COLUMN_GAP))
         leftColumn.add(customLink)
         leftColumn.add(Box.createVerticalStrut(LEFT_COLUMN_GAP))
-        leftColumn.add(resetLabel)
+        if (shuffleLink != null) {
+            leftColumn.add(shuffleLink)
+        } else {
+            leftColumn.add(ResetLabel())
+        }
 
         add(leftColumn, BorderLayout.WEST)
 
-        if (shuffleColumn != null) {
-            val contentWrapper = JPanel(BorderLayout(SHUFFLE_COLUMN_GAP, 0))
-            contentWrapper.isOpaque = false
-            contentWrapper.add(shuffleColumn, BorderLayout.WEST)
-
-            if (thirteenthSwatch != null) {
-                thirteenthSwatch.isVisible = false
-
-                val gridArea = JPanel(BorderLayout(GRID_GAP, 0))
-                gridArea.isOpaque = false
-                gridArea.add(thirteenthSwatch, BorderLayout.WEST)
-                gridArea.add(presetGrid, BorderLayout.CENTER)
-                contentWrapper.add(gridArea, BorderLayout.CENTER)
-            } else {
-                contentWrapper.add(presetGrid, BorderLayout.CENTER)
-            }
-
-            add(contentWrapper, BorderLayout.CENTER)
+        if (thirteenthSwatch != null) {
+            thirteenthSwatch.isVisible = false
+            val gridArea = JPanel(BorderLayout(GRID_GAP, 0))
+            gridArea.isOpaque = false
+            gridArea.add(thirteenthSwatch, BorderLayout.WEST)
+            gridArea.add(presetGrid, BorderLayout.CENTER)
+            add(gridArea, BorderLayout.CENTER)
         } else {
             add(presetGrid, BorderLayout.CENTER)
         }
+    }
+
+    fun triggerBounce() {
+        shuffleLink?.triggerBounce()
     }
 
     fun showThirteenthSwatch(hex: String) {
@@ -264,7 +261,6 @@ class AccentColorPanel(
         override fun paintComponent(graphics: Graphics) {
             val shadeName = getSelectedShadeName()
             if (shadeName.isEmpty()) return
-
             val accentHex = getSelectedAccentHex() ?: return
 
             val g2 = graphics.create() as Graphics2D
@@ -272,14 +268,17 @@ class AccentColorPanel(
                 g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
                 g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON)
 
+                val iconY = (height - PALETTE_ICON.iconHeight) / 2
+                PALETTE_ICON.paintIcon(this, g2, 0, iconY)
+
                 val accentColor = Color.decode(accentHex)
                 val editorFamily = resolveEditorFontFamily()
                 g2.font = Font(editorFamily, Font.ITALIC, SPECIMEN_FONT_SIZE)
                 g2.color = accentColor
-
                 val metrics = g2.fontMetrics
+                val textX = PALETTE_ICON.iconWidth + ICON_TEXT_GAP
                 val textY = (height - metrics.height) / 2 + metrics.ascent
-                g2.drawString(shadeName, 0, textY)
+                g2.drawString(shadeName, textX, textY)
             } finally {
                 g2.dispose()
             }
@@ -289,6 +288,7 @@ class AccentColorPanel(
     private abstract inner class LinkLabel(
         private val text: String,
         private val onClick: () -> Unit,
+        private val icon: Icon? = null,
     ) : JComponent() {
         private var isHovered = false
 
@@ -327,30 +327,29 @@ class AccentColorPanel(
 
         override fun getPreferredSize(): Dimension {
             val metrics = getFontMetrics(font.deriveFont(Font.PLAIN, LINK_FONT_SIZE))
-            return Dimension(metrics.stringWidth(text) + 1, PANEL_HEIGHT)
+            val iconWidth = if (icon != null) icon.iconWidth + ICON_TEXT_GAP else 0
+            return Dimension(iconWidth + metrics.stringWidth(text) + 1, PANEL_HEIGHT)
         }
 
         override fun paintComponent(graphics: Graphics) {
             val g2 = graphics.create() as Graphics2D
             try {
                 g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON)
-
+                var textX = 0
+                if (icon != null) {
+                    val iconY = (height - icon.iconHeight) / 2
+                    icon.paintIcon(this, g2, 0, iconY)
+                    textX = icon.iconWidth + ICON_TEXT_GAP
+                }
                 val linkColor = JBUI.CurrentTheme.Link.Foreground.ENABLED
-                g2.color =
-                    if (isEnabled) {
-                        linkColor
-                    } else {
-                        UIManager.getColor("Label.disabledForeground") ?: Color.GRAY
-                    }
+                g2.color = if (isEnabled) linkColor else UIManager.getColor("Label.disabledForeground") ?: Color.GRAY
                 g2.font = g2.font.deriveFont(Font.PLAIN, LINK_FONT_SIZE)
-
                 val metrics = g2.fontMetrics
                 val textY = (height - metrics.height) / 2 + metrics.ascent
-                g2.drawString(text, 0, textY)
-
+                g2.drawString(text, textX, textY)
                 if (isHovered && isEnabled) {
                     val lineY = textY + 1
-                    g2.drawLine(0, lineY, metrics.stringWidth(text), lineY)
+                    g2.drawLine(textX, lineY, textX + metrics.stringWidth(text), lineY)
                 }
             } finally {
                 g2.dispose()
@@ -358,142 +357,73 @@ class AccentColorPanel(
         }
     }
 
-    private inner class CustomLink : LinkLabel("Custom", onCustomTrigger)
+    private inner class CustomLink : LinkLabel("Custom", onCustomTrigger, PIPETTE_ICON)
 
     private inner class ResetLabel : LinkLabel("Reset", onReset)
 
-    private inner class ShuffleColumn : JComponent() {
-        private var glowAlpha = BREATHE_MIN_ALPHA
-        private var breathePhase = 0.0
-        private val breatheTimer =
-            Timer(BREATHE_INTERVAL_MS) { updateBreathe() }
-        private val diceIcon = DiceIcon()
+    private inner class ShuffleLink : JComponent() {
+        private var bounceOffset = 0f
+        private var bounceFrame = 0
+        private val bounceTimer =
+            Timer(ANIMATION_FRAME_MS) {
+                bounceFrame++
+                if (bounceFrame > BOUNCE_TOTAL_FRAMES) {
+                    (it.source as Timer).stop()
+                    bounceOffset = 0f
+                } else {
+                    val t = bounceFrame / BOUNCE_TOTAL_FRAMES.toFloat()
+                    val decay = exp(-BOUNCE_DECAY_RATE * t)
+                    val oscillation = sin(t * Math.PI * BOUNCE_OSCILLATIONS)
+                    bounceOffset = (-BOUNCE_MAX_PIXELS * decay * oscillation).toFloat()
+                }
+                repaint()
+            }
 
         init {
-            layout = null
-            isOpaque = false
-            preferredSize = Dimension(diceIcon.preferredSize.width + SHUFFLE_SIDE_PAD * 2, 0)
-
-            add(diceIcon)
-
-            breatheTimer.start()
+            cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+            preferredSize = Dimension(LEFT_COLUMN_WIDTH, PANEL_HEIGHT)
+            addMouseListener(
+                object : MouseAdapter() {
+                    override fun mouseClicked(event: MouseEvent) {
+                        if (!isEnabled) return
+                        triggerBounce()
+                        onShuffleTrigger?.invoke()
+                    }
+                },
+            )
         }
 
-        override fun doLayout() {
-            val iconPref = diceIcon.preferredSize
-            val customCenterY = customLink.y + customLink.height / 2
-            val targetY = customCenterY - iconPref.height / 2
-            val targetX = (width - iconPref.width) / 2
-            diceIcon.setBounds(targetX, targetY, iconPref.width, iconPref.height)
-        }
-
-        private fun updateBreathe() {
-            breathePhase += BREATHE_STEP
-            val sinNormalized =
-                (sin(breathePhase).toFloat() + 1f) / 2f
-            glowAlpha = BREATHE_MIN_ALPHA + BREATHE_RANGE * sinNormalized
+        override fun setEnabled(enabled: Boolean) {
+            super.setEnabled(enabled)
+            cursor = if (enabled) Cursor.getPredefinedCursor(Cursor.HAND_CURSOR) else Cursor.getDefaultCursor()
             repaint()
         }
 
         fun triggerBounce() {
-            diceIcon.triggerBounce()
+            bounceFrame = 0
+            bounceOffset = 0f
+            bounceTimer.restart()
         }
 
         fun dispose() {
-            breatheTimer.stop()
-            diceIcon.disposeBounce()
+            bounceTimer.stop()
         }
 
-        private inner class DiceIcon : JComponent() {
-            private var bounceOffset = 0f
-            private var bounceFrame = 0
-            private val shuffleTextWidth: Int
-            private val bounceTimer =
-                Timer(ANIMATION_FRAME_MS) {
-                    bounceFrame++
-                    if (bounceFrame > BOUNCE_TOTAL_FRAMES) {
-                        (it.source as Timer).stop()
-                        bounceOffset = 0f
-                    } else {
-                        val t = bounceFrame / BOUNCE_TOTAL_FRAMES.toFloat()
-                        val decay = exp(-BOUNCE_DECAY_RATE * t)
-                        val oscillation = sin(t * Math.PI * BOUNCE_OSCILLATIONS)
-                        bounceOffset = (-BOUNCE_MAX_PIXELS * decay * oscillation).toFloat()
-                    }
-                    repaint()
-                }
-
-            init {
-                cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
-                alignmentY = CENTER_ALIGNMENT
-
-                val labelFont = Font(Font.DIALOG, Font.PLAIN, LINK_FONT_SIZE.toInt())
-                val labelMetrics = getFontMetrics(labelFont)
-                shuffleTextWidth = labelMetrics.stringWidth(SHUFFLE_LABEL)
-
-                val totalWidth = DICE_ICON_SIZE + DICE_LABEL_GAP + shuffleTextWidth + 1
-                val diceHeight = DICE_ICON_SIZE + BOUNCE_MAX_PIXELS * 2
-                preferredSize = Dimension(totalWidth, diceHeight)
-                maximumSize = Dimension(totalWidth, diceHeight)
-                addMouseListener(
-                    object : MouseAdapter() {
-                        override fun mouseClicked(event: MouseEvent) {
-                            if (!isEnabled) return
-                            triggerBounce()
-                            onShuffleTrigger?.invoke()
-                        }
-                    },
-                )
-            }
-
-            fun triggerBounce() {
-                bounceFrame = 0
-                bounceOffset = 0f
-                bounceTimer.restart()
-            }
-
-            fun disposeBounce() {
-                bounceTimer.stop()
-            }
-
-            override fun paintComponent(graphics: Graphics) {
-                val g2 = graphics.create() as Graphics2D
-                try {
-                    g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON)
-
-                    val accentHex =
-                        selectedPreset ?: heroGlowHex ?: DEFAULT_ACCENT_HEX
-                    val diceColor =
-                        try {
-                            Color.decode(accentHex)
-                        } catch (_: NumberFormatException) {
-                            Color(DEFAULT_ACCENT_RGB)
-                        }
-
-                    // Draw dice emoji with breathe glow
-                    g2.composite = AlphaComposite.SrcOver.derive(glowAlpha)
-                    g2.font = Font(Font.DIALOG, Font.PLAIN, DICE_FONT_SIZE)
-                    g2.color = diceColor
-
-                    val gv = g2.font.createGlyphVector(g2.fontRenderContext, DICE_TEXT)
-                    val vb = gv.visualBounds
-                    val emojiX = ((DICE_ICON_SIZE - vb.width) / 2.0 - vb.x).toFloat() + 2
-                    val emojiY = ((height - vb.height) / 2.0 - vb.y).toFloat() + bounceOffset
-                    g2.drawGlyphVector(gv, emojiX, emojiY)
-
-                    // Draw "Shuffle" text at full opacity with link color
-                    g2.composite = AlphaComposite.SrcOver.derive(1f)
-                    val linkColor = JBUI.CurrentTheme.Link.Foreground.ENABLED
-                    g2.color = linkColor
-                    g2.font = Font(Font.DIALOG, Font.PLAIN, LINK_FONT_SIZE.toInt())
-
-                    val labelMetrics = g2.fontMetrics
-                    val labelX = DICE_ICON_SIZE + DICE_LABEL_GAP
-                    val labelY = (height - labelMetrics.height) / 2 + labelMetrics.ascent
-                    g2.drawString(SHUFFLE_LABEL, labelX, labelY)
-                } finally {
-                    g2.dispose()
-                }
+        override fun paintComponent(graphics: Graphics) {
+            val g2 = graphics.create() as Graphics2D
+            try {
+                g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON)
+                val iconY = (height - DICES_ICON.iconHeight) / 2 + bounceOffset.toInt()
+                DICES_ICON.paintIcon(this, g2, 0, iconY)
+                val linkColor = JBUI.CurrentTheme.Link.Foreground.ENABLED
+                g2.color = if (isEnabled) linkColor else UIManager.getColor("Label.disabledForeground") ?: Color.GRAY
+                g2.font = g2.font.deriveFont(Font.PLAIN, LINK_FONT_SIZE)
+                val metrics = g2.fontMetrics
+                val textX = DICES_ICON.iconWidth + ICON_TEXT_GAP
+                val textY = (height - metrics.height) / 2 + metrics.ascent
+                g2.drawString(SHUFFLE_LABEL, textX, textY)
+            } finally {
+                g2.dispose()
             }
         }
     }
@@ -598,7 +528,6 @@ class AccentColorPanel(
                 val swatchY = row2Swatch?.y ?: (PANEL_HEIGHT + GRID_GAP)
                 val swatchHeight = row2Swatch?.height ?: PANEL_HEIGHT
 
-                // Hero glow
                 swatchGlowRenderer.ensureCache(color, GlowStyle.SOFT, HERO_GLOW_INTENSITY, HERO_GLOW_WIDTH)
                 swatchGlowRenderer.paintGlow(
                     g2,
@@ -631,7 +560,7 @@ class AccentColorPanel(
 
     override fun removeNotify() {
         super.removeNotify()
-        shuffleColumn?.dispose()
+        shuffleLink?.dispose()
         thirteenthSwatch?.disposeTimers()
     }
 
@@ -664,27 +593,19 @@ class AccentColorPanel(
         private const val HERO_GLOW_INTENSITY = 30
         private const val HERO_GLOW_WIDTH = 4
 
-        private const val BREATHE_INTERVAL_MS = 50
-        private const val BREATHE_STEP = 0.05
-        private const val BREATHE_MIN_ALPHA = 0.7f
-        private const val BREATHE_RANGE = 0.3f
         private const val SHUFFLE_LABEL = "Shuffle"
-        private const val DEFAULT_ACCENT_HEX = "#73D0FF"
-        private const val DEFAULT_ACCENT_RGB = 0x73D0FF
+        private const val ICON_TEXT_GAP = 4
 
-        private const val SHUFFLE_COLUMN_GAP = 4
-        private const val DICE_FONT_SIZE = 20
-        private const val DICE_ICON_SIZE = 40
-        private const val DICE_LABEL_GAP = 2
-        private const val DICE_TEXT = "\uD83C\uDFB2"
-
-        private const val SHUFFLE_SIDE_PAD = 6
         private const val ANIMATION_FRAME_MS = 16
         private const val SLIDE_TOTAL_FRAMES = 18
         private const val BOUNCE_MAX_PIXELS = 8
         private const val BOUNCE_TOTAL_FRAMES = 25
         private const val BOUNCE_DECAY_RATE = 4.0
         private const val BOUNCE_OSCILLATIONS = 3.0
+
+        private val PALETTE_ICON = IconLoader.getIcon("/icons/palette.svg", AccentColorPanel::class.java)
+        private val PIPETTE_ICON = IconLoader.getIcon("/icons/pipette.svg", AccentColorPanel::class.java)
+        private val DICES_ICON = IconLoader.getIcon("/icons/dices.svg", AccentColorPanel::class.java)
 
         private fun easeOut(t: Float): Float {
             val complement = 1f - t

--- a/src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
@@ -514,24 +514,22 @@ class AccentColorPanel(
                 val color = Color.decode(hex)
                 val borderColor = Color(BORDER_RGB)
 
-                val swatchWidth = computeEqualSwatchWidth().coerceAtMost(width)
-                val swatchX = (width - swatchWidth).coerceAtLeast(0)
-                val row2Swatch = presetPanels.getOrNull(GRID_COLUMNS)
-                val swatchY = row2Swatch?.y ?: (PANEL_HEIGHT + GRID_GAP)
-                val swatchHeight = row2Swatch?.height ?: PANEL_HEIGHT
+                // Paint relative to this component's own bounds (0,0 = top-left of ThirteenthSwatch)
+                val swatchWidth = width
+                val swatchHeight = height
 
                 swatchGlowRenderer.ensureCache(color, GlowStyle.SOFT, HERO_GLOW_INTENSITY, HERO_GLOW_WIDTH)
                 swatchGlowRenderer.paintGlow(
                     g2,
-                    Rectangle(swatchX, swatchY, swatchWidth, swatchHeight),
+                    Rectangle(0, 0, swatchWidth, swatchHeight),
                     HERO_GLOW_WIDTH,
                     PANEL_ARC.toInt(),
                 )
 
                 val shape =
                     RoundRectangle2D.Float(
-                        swatchX + BORDER_INSET,
-                        swatchY + BORDER_INSET,
+                        BORDER_INSET,
+                        BORDER_INSET,
                         swatchWidth.toFloat() - BORDER_INSET * 2,
                         swatchHeight.toFloat() - BORDER_INSET * 2,
                         PANEL_ARC,

--- a/src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
@@ -26,6 +26,7 @@ import javax.swing.JComponent
 import javax.swing.JPanel
 import javax.swing.Timer
 import javax.swing.UIManager
+import kotlin.math.exp
 import kotlin.math.sin
 
 /**
@@ -48,6 +49,7 @@ class AccentColorPanel(
     private val onCustomTrigger: () -> Unit,
     private val onReset: () -> Unit,
     private val onShuffleTrigger: (() -> Unit)? = null,
+    private val onThirteenthSwatchClicked: ((String) -> Unit)? = null,
 ) : JPanel(BorderLayout(COLUMN_GAP, 0)) {
     private val presetList: List<AccentColor> = presets
     private val heroGlowRenderer = GlowRenderer()
@@ -83,7 +85,12 @@ class AccentColorPanel(
     private val customLink: CustomLink
     private val resetLabel: ResetLabel
     private val shuffleColumn: ShuffleColumn?
+    private val thirteenthSwatch: ThirteenthSwatch?
     private val presetGrid: JPanel
+
+    /** Hex color currently shown in the 13th swatch, or null if hidden. */
+    val thirteenthSwatchColor: String?
+        get() = thirteenthSwatch?.colorHex
 
     init {
         isOpaque = false
@@ -94,6 +101,8 @@ class AccentColorPanel(
         resetLabel = ResetLabel()
         shuffleColumn =
             if (onShuffleTrigger != null) ShuffleColumn() else null
+        thirteenthSwatch =
+            if (onShuffleTrigger != null) ThirteenthSwatch() else null
 
         presetGrid = JPanel(GridLayout(GRID_ROWS, GRID_COLUMNS, GRID_GAP, GRID_GAP))
         presetGrid.isOpaque = false
@@ -115,12 +124,32 @@ class AccentColorPanel(
         if (shuffleColumn != null) {
             val contentWrapper = JPanel(BorderLayout(SHUFFLE_COLUMN_GAP, 0))
             contentWrapper.isOpaque = false
-            contentWrapper.add(shuffleColumn, BorderLayout.WEST)
+
+            val shuffleAndSwatch = JPanel(BorderLayout(GRID_GAP, 0))
+            shuffleAndSwatch.isOpaque = false
+            shuffleAndSwatch.add(shuffleColumn, BorderLayout.WEST)
+            if (thirteenthSwatch != null) {
+                shuffleAndSwatch.add(thirteenthSwatch, BorderLayout.CENTER)
+            }
+
+            contentWrapper.add(shuffleAndSwatch, BorderLayout.WEST)
             contentWrapper.add(presetGrid, BorderLayout.CENTER)
             add(contentWrapper, BorderLayout.CENTER)
         } else {
             add(presetGrid, BorderLayout.CENTER)
         }
+    }
+
+    fun showThirteenthSwatch(hex: String) {
+        thirteenthSwatch?.slideIn(hex)
+    }
+
+    fun showThirteenthSwatchImmediate(hex: String) {
+        thirteenthSwatch?.showImmediate(hex)
+    }
+
+    fun hideThirteenthSwatch() {
+        thirteenthSwatch?.hideSwatch()
     }
 
     private fun getSelectedAccentHex(): String? = selectedPreset ?: customColor
@@ -334,17 +363,17 @@ class AccentColorPanel(
         private var breathePhase = 0.0
         private val breatheTimer =
             Timer(BREATHE_INTERVAL_MS) { updateBreathe() }
+        private val diceIcon = DiceIcon()
 
         init {
             layout = BoxLayout(this, BoxLayout.Y_AXIS)
             isOpaque = false
             preferredSize = Dimension(SHUFFLE_COLUMN_WIDTH, 0)
 
-            val diceLabel = DiceIcon()
             val shuffleLabel = ShuffleLabel()
 
             add(Box.createVerticalGlue())
-            add(diceLabel)
+            add(diceIcon)
             add(Box.createVerticalStrut(DICE_LABEL_GAP))
             add(shuffleLabel)
             add(Box.createVerticalGlue())
@@ -360,11 +389,33 @@ class AccentColorPanel(
             repaint()
         }
 
+        fun triggerBounce() {
+            diceIcon.triggerBounce()
+        }
+
         fun dispose() {
             breatheTimer.stop()
+            diceIcon.disposeBounce()
         }
 
         private inner class DiceIcon : JComponent() {
+            private var bounceOffset = 0f
+            private var bounceFrame = 0
+            private val bounceTimer =
+                Timer(ANIMATION_FRAME_MS) {
+                    bounceFrame++
+                    if (bounceFrame > BOUNCE_TOTAL_FRAMES) {
+                        (it.source as Timer).stop()
+                        bounceOffset = 0f
+                    } else {
+                        val t = bounceFrame / BOUNCE_TOTAL_FRAMES.toFloat()
+                        val decay = exp(-BOUNCE_DECAY_RATE * t)
+                        val oscillation = sin(t * Math.PI * BOUNCE_OSCILLATIONS)
+                        bounceOffset = (-BOUNCE_MAX_PIXELS * decay * oscillation).toFloat()
+                    }
+                    repaint()
+                }
+
             init {
                 cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
                 alignmentX = CENTER_ALIGNMENT
@@ -374,10 +425,21 @@ class AccentColorPanel(
                     object : MouseAdapter() {
                         override fun mouseClicked(event: MouseEvent) {
                             if (!isEnabled) return
+                            triggerBounce()
                             onShuffleTrigger?.invoke()
                         }
                     },
                 )
+            }
+
+            fun triggerBounce() {
+                bounceFrame = 0
+                bounceOffset = 0f
+                bounceTimer.restart()
+            }
+
+            fun disposeBounce() {
+                bounceTimer.stop()
             }
 
             override fun paintComponent(graphics: Graphics) {
@@ -394,6 +456,7 @@ class AccentColorPanel(
                             Color(DEFAULT_ACCENT_RGB)
                         }
 
+                    g2.translate(0, bounceOffset.toInt())
                     g2.composite = AlphaComposite.SrcOver.derive(glowAlpha)
                     g2.font = Font(Font.DIALOG, Font.PLAIN, DICE_FONT_SIZE)
                     g2.color = diceColor
@@ -419,6 +482,7 @@ class AccentColorPanel(
                     object : MouseAdapter() {
                         override fun mouseClicked(event: MouseEvent) {
                             if (!isEnabled) return
+                            diceIcon.triggerBounce()
                             onShuffleTrigger?.invoke()
                         }
                     },
@@ -445,9 +509,132 @@ class AccentColorPanel(
         }
     }
 
+    private inner class ThirteenthSwatch : JComponent() {
+        var colorHex: String? = null
+        private var slideProgress = 0f
+        private val swatchGlowRenderer = GlowRenderer()
+        private val slideTimer =
+            Timer(ANIMATION_FRAME_MS) {
+                slideProgress += 1f / SLIDE_TOTAL_FRAMES
+                if (slideProgress >= 1f) {
+                    slideProgress = 1f
+                    (it.source as Timer).stop()
+                }
+                revalidate()
+                repaint()
+            }
+
+        init {
+            isOpaque = false
+            isVisible = false
+            cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+            addMouseListener(
+                object : MouseAdapter() {
+                    override fun mouseClicked(event: MouseEvent) {
+                        if (!isEnabled) return
+                        val hex = colorHex ?: return
+                        onThirteenthSwatchClicked?.invoke(hex)
+                    }
+                },
+            )
+        }
+
+        override fun getPreferredSize(): Dimension {
+            if (colorHex == null || slideProgress <= 0f) {
+                return Dimension(0, PANEL_HEIGHT)
+            }
+            val targetWidth = THIRTEENTH_SWATCH_WIDTH + GRID_GAP
+            val animatedWidth = (targetWidth * easeOut(slideProgress)).toInt()
+            return Dimension(animatedWidth, PANEL_HEIGHT)
+        }
+
+        override fun getMinimumSize(): Dimension = preferredSize
+
+        override fun getMaximumSize(): Dimension =
+            Dimension(
+                THIRTEENTH_SWATCH_WIDTH + GRID_GAP,
+                Short.MAX_VALUE.toInt(),
+            )
+
+        fun slideIn(hex: String) {
+            colorHex = hex
+            slideProgress = 0f
+            isVisible = true
+            slideTimer.restart()
+        }
+
+        fun showImmediate(hex: String) {
+            colorHex = hex
+            slideProgress = 1f
+            isVisible = true
+            slideTimer.stop()
+            revalidate()
+            repaint()
+        }
+
+        fun hideSwatch() {
+            slideTimer.stop()
+            colorHex = null
+            slideProgress = 0f
+            isVisible = false
+            revalidate()
+            parent?.repaint()
+        }
+
+        fun disposeTimers() {
+            slideTimer.stop()
+        }
+
+        override fun paintComponent(graphics: Graphics) {
+            val hex = colorHex ?: return
+            if (slideProgress <= 0f) return
+
+            val g2 = graphics.create() as Graphics2D
+            try {
+                g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+
+                val color = Color.decode(hex)
+                val borderColor = Color(BORDER_RGB)
+
+                val swatchWidth = THIRTEENTH_SWATCH_WIDTH.coerceAtMost(width)
+                val swatchX = (width - swatchWidth).coerceAtLeast(0)
+                val swatchHeight = height.coerceAtMost(PANEL_HEIGHT)
+
+                // Hero glow
+                swatchGlowRenderer.ensureCache(color, GlowStyle.SOFT, HERO_GLOW_INTENSITY, HERO_GLOW_WIDTH)
+                swatchGlowRenderer.paintGlow(
+                    g2,
+                    Rectangle(swatchX, 0, swatchWidth, swatchHeight),
+                    HERO_GLOW_WIDTH,
+                    PANEL_ARC.toInt(),
+                )
+
+                val shape =
+                    RoundRectangle2D.Float(
+                        swatchX + BORDER_INSET,
+                        BORDER_INSET,
+                        swatchWidth.toFloat() - BORDER_INSET * 2,
+                        swatchHeight.toFloat() - BORDER_INSET * 2,
+                        PANEL_ARC,
+                        PANEL_ARC,
+                    )
+
+                g2.color = color
+                g2.fill(shape)
+
+                g2.color = borderColor
+                g2.stroke = BasicStroke(1f)
+                g2.draw(shape)
+            } finally {
+                g2.dispose()
+            }
+        }
+    }
+
     override fun removeNotify() {
         super.removeNotify()
         shuffleColumn?.dispose()
+        thirteenthSwatch?.disposeTimers()
     }
 
     private fun paintDisabledOverlay(
@@ -493,5 +680,18 @@ class AccentColorPanel(
         private const val DICE_ICON_SIZE = 24
         private const val DICE_LABEL_GAP = 2
         private const val DICE_TEXT = "\uD83C\uDFB2"
+
+        private const val ANIMATION_FRAME_MS = 16
+        private const val SLIDE_TOTAL_FRAMES = 18
+        private const val BOUNCE_MAX_PIXELS = 8
+        private const val BOUNCE_TOTAL_FRAMES = 25
+        private const val BOUNCE_DECAY_RATE = 4.0
+        private const val BOUNCE_OSCILLATIONS = 3.0
+        private const val THIRTEENTH_SWATCH_WIDTH = 32
+
+        private fun easeOut(t: Float): Float {
+            val complement = 1f - t
+            return 1f - complement * complement * complement
+        }
     }
 }

--- a/src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
@@ -124,16 +124,20 @@ class AccentColorPanel(
         if (shuffleColumn != null) {
             val contentWrapper = JPanel(BorderLayout(SHUFFLE_COLUMN_GAP, 0))
             contentWrapper.isOpaque = false
+            contentWrapper.add(shuffleColumn, BorderLayout.WEST)
 
-            val shuffleAndSwatch = JPanel(BorderLayout(GRID_GAP, 0))
-            shuffleAndSwatch.isOpaque = false
-            shuffleAndSwatch.add(shuffleColumn, BorderLayout.WEST)
             if (thirteenthSwatch != null) {
-                shuffleAndSwatch.add(thirteenthSwatch, BorderLayout.CENTER)
+                thirteenthSwatch.isVisible = false
+
+                val gridArea = JPanel(BorderLayout(GRID_GAP, 0))
+                gridArea.isOpaque = false
+                gridArea.add(thirteenthSwatch, BorderLayout.WEST)
+                gridArea.add(presetGrid, BorderLayout.CENTER)
+                contentWrapper.add(gridArea, BorderLayout.CENTER)
+            } else {
+                contentWrapper.add(presetGrid, BorderLayout.CENTER)
             }
 
-            contentWrapper.add(shuffleAndSwatch, BorderLayout.WEST)
-            contentWrapper.add(presetGrid, BorderLayout.CENTER)
             add(contentWrapper, BorderLayout.CENTER)
         } else {
             add(presetGrid, BorderLayout.CENTER)
@@ -364,18 +368,24 @@ class AccentColorPanel(
         private val breatheTimer =
             Timer(BREATHE_INTERVAL_MS) { updateBreathe() }
         private val diceIcon = DiceIcon()
+        private val shuffleLabel = ShuffleLabel()
 
         init {
             layout = BoxLayout(this, BoxLayout.Y_AXIS)
             isOpaque = false
             preferredSize = Dimension(SHUFFLE_COLUMN_WIDTH, 0)
 
-            val shuffleLabel = ShuffleLabel()
+            val row = JPanel()
+            row.layout = BoxLayout(row, BoxLayout.X_AXIS)
+            row.isOpaque = false
+            row.alignmentX = CENTER_ALIGNMENT
+            row.maximumSize = Dimension(SHUFFLE_COLUMN_WIDTH, DICE_ICON_SIZE)
+            row.add(diceIcon)
+            row.add(Box.createHorizontalStrut(DICE_LABEL_GAP))
+            row.add(shuffleLabel)
 
-            add(Box.createVerticalGlue())
-            add(diceIcon)
-            add(Box.createVerticalStrut(DICE_LABEL_GAP))
-            add(shuffleLabel)
+            add(Box.createVerticalStrut(PANEL_HEIGHT + LEFT_COLUMN_GAP))
+            add(row)
             add(Box.createVerticalGlue())
 
             breatheTimer.start()
@@ -418,9 +428,9 @@ class AccentColorPanel(
 
             init {
                 cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
-                alignmentX = CENTER_ALIGNMENT
-                preferredSize = Dimension(SHUFFLE_COLUMN_WIDTH, DICE_ICON_SIZE)
-                maximumSize = Dimension(SHUFFLE_COLUMN_WIDTH, DICE_ICON_SIZE)
+                alignmentY = CENTER_ALIGNMENT
+                preferredSize = Dimension(DICE_ICON_SIZE + DICE_PAD, DICE_ICON_SIZE)
+                maximumSize = Dimension(DICE_ICON_SIZE + DICE_PAD, DICE_ICON_SIZE)
                 addMouseListener(
                     object : MouseAdapter() {
                         override fun mouseClicked(event: MouseEvent) {
@@ -462,7 +472,7 @@ class AccentColorPanel(
                     g2.color = diceColor
 
                     val metrics = g2.fontMetrics
-                    val textX = (width - metrics.stringWidth(DICE_TEXT)) / 2
+                    val textX = (width - metrics.stringWidth(DICE_TEXT)) / 2 + DICE_PAD / 2
                     val textY = (height - metrics.height) / 2 + metrics.ascent
                     g2.drawString(DICE_TEXT, textX, textY)
                 } finally {
@@ -474,10 +484,11 @@ class AccentColorPanel(
         private inner class ShuffleLabel : JComponent() {
             init {
                 cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
-                alignmentX = CENTER_ALIGNMENT
-                val metrics = getFontMetrics(font.deriveFont(Font.PLAIN, LINK_FONT_SIZE))
-                preferredSize = Dimension(SHUFFLE_COLUMN_WIDTH, metrics.height)
-                maximumSize = Dimension(SHUFFLE_COLUMN_WIDTH, metrics.height)
+                alignmentY = CENTER_ALIGNMENT
+                val baseFont = font ?: Font(Font.DIALOG, Font.PLAIN, LINK_FONT_SIZE.toInt())
+                val metrics = getFontMetrics(baseFont.deriveFont(Font.PLAIN, LINK_FONT_SIZE))
+                preferredSize = Dimension(metrics.stringWidth(SHUFFLE_LABEL) + 1, PANEL_HEIGHT)
+                maximumSize = Dimension(metrics.stringWidth(SHUFFLE_LABEL) + 1, PANEL_HEIGHT)
                 addMouseListener(
                     object : MouseAdapter() {
                         override fun mouseClicked(event: MouseEvent) {
@@ -499,9 +510,8 @@ class AccentColorPanel(
                     g2.font = g2.font.deriveFont(Font.PLAIN, LINK_FONT_SIZE)
 
                     val metrics = g2.fontMetrics
-                    val textX = (width - metrics.stringWidth(SHUFFLE_LABEL)) / 2
                     val textY = (height - metrics.height) / 2 + metrics.ascent
-                    g2.drawString(SHUFFLE_LABEL, textX, textY)
+                    g2.drawString(SHUFFLE_LABEL, 0, textY)
                 } finally {
                     g2.dispose()
                 }
@@ -510,6 +520,8 @@ class AccentColorPanel(
     }
 
     private inner class ThirteenthSwatch : JComponent() {
+        private var targetSwatchWidth = PANEL_HEIGHT
+
         var colorHex: String? = null
         private var slideProgress = 0f
         private val swatchGlowRenderer = GlowRenderer()
@@ -543,30 +555,30 @@ class AccentColorPanel(
             if (colorHex == null || slideProgress <= 0f) {
                 return Dimension(0, PANEL_HEIGHT)
             }
-            val targetWidth = THIRTEENTH_SWATCH_WIDTH + GRID_GAP
+            val targetWidth = targetSwatchWidth
             val animatedWidth = (targetWidth * easeOut(slideProgress)).toInt()
             return Dimension(animatedWidth, PANEL_HEIGHT)
         }
 
-        override fun getMinimumSize(): Dimension = preferredSize
+        override fun getMinimumSize(): Dimension = Dimension(0, PANEL_HEIGHT)
 
-        override fun getMaximumSize(): Dimension =
-            Dimension(
-                THIRTEENTH_SWATCH_WIDTH + GRID_GAP,
-                Short.MAX_VALUE.toInt(),
-            )
+        override fun getMaximumSize(): Dimension = Dimension(targetSwatchWidth, PANEL_HEIGHT)
 
         fun slideIn(hex: String) {
             colorHex = hex
+            targetSwatchWidth = presetPanels.firstOrNull()?.width ?: PANEL_HEIGHT
             slideProgress = 0f
             isVisible = true
+
             slideTimer.restart()
         }
 
         fun showImmediate(hex: String) {
             colorHex = hex
+            targetSwatchWidth = presetPanels.firstOrNull()?.width ?: PANEL_HEIGHT
             slideProgress = 1f
             isVisible = true
+
             slideTimer.stop()
             revalidate()
             repaint()
@@ -577,6 +589,7 @@ class AccentColorPanel(
             colorHex = null
             slideProgress = 0f
             isVisible = false
+
             revalidate()
             parent?.repaint()
         }
@@ -596,15 +609,17 @@ class AccentColorPanel(
                 val color = Color.decode(hex)
                 val borderColor = Color(BORDER_RGB)
 
-                val swatchWidth = THIRTEENTH_SWATCH_WIDTH.coerceAtMost(width)
+                val swatchWidth = targetSwatchWidth.coerceAtMost(width)
                 val swatchX = (width - swatchWidth).coerceAtLeast(0)
-                val swatchHeight = height.coerceAtMost(PANEL_HEIGHT)
+                val row2Swatch = presetPanels.getOrNull(GRID_COLUMNS)
+                val swatchY = row2Swatch?.y ?: (PANEL_HEIGHT + GRID_GAP)
+                val swatchHeight = row2Swatch?.height ?: PANEL_HEIGHT
 
                 // Hero glow
                 swatchGlowRenderer.ensureCache(color, GlowStyle.SOFT, HERO_GLOW_INTENSITY, HERO_GLOW_WIDTH)
                 swatchGlowRenderer.paintGlow(
                     g2,
-                    Rectangle(swatchX, 0, swatchWidth, swatchHeight),
+                    Rectangle(swatchX, swatchY, swatchWidth, swatchHeight),
                     HERO_GLOW_WIDTH,
                     PANEL_ARC.toInt(),
                 )
@@ -612,7 +627,7 @@ class AccentColorPanel(
                 val shape =
                     RoundRectangle2D.Float(
                         swatchX + BORDER_INSET,
-                        BORDER_INSET,
+                        swatchY + BORDER_INSET,
                         swatchWidth.toFloat() - BORDER_INSET * 2,
                         swatchHeight.toFloat() - BORDER_INSET * 2,
                         PANEL_ARC,
@@ -652,7 +667,7 @@ class AccentColorPanel(
         private const val PANEL_ARC = 8f
         private const val GRID_GAP = 2
         private const val LEFT_COLUMN_GAP = 4
-        private const val COLUMN_GAP = 16
+        private const val COLUMN_GAP = 6
         private const val LEFT_COLUMN_WIDTH = 120
         private const val GRID_ROWS = 3
         private const val GRID_COLUMNS = 4
@@ -668,16 +683,17 @@ class AccentColorPanel(
 
         private const val BREATHE_INTERVAL_MS = 50
         private const val BREATHE_STEP = 0.05
-        private const val BREATHE_MIN_ALPHA = 0.4f
-        private const val BREATHE_RANGE = 0.6f
+        private const val BREATHE_MIN_ALPHA = 0.7f
+        private const val BREATHE_RANGE = 0.3f
         private const val SHUFFLE_LABEL = "Shuffle"
         private const val DEFAULT_ACCENT_HEX = "#73D0FF"
         private const val DEFAULT_ACCENT_RGB = 0x73D0FF
 
-        private const val SHUFFLE_COLUMN_GAP = 12
-        private const val SHUFFLE_COLUMN_WIDTH = 56
+        private const val SHUFFLE_COLUMN_GAP = 4
+        private const val SHUFFLE_COLUMN_WIDTH = 80
         private const val DICE_FONT_SIZE = 20
-        private const val DICE_ICON_SIZE = 24
+        private const val DICE_ICON_SIZE = 28
+        private const val DICE_PAD = 6
         private const val DICE_LABEL_GAP = 2
         private const val DICE_TEXT = "\uD83C\uDFB2"
 
@@ -687,7 +703,6 @@ class AccentColorPanel(
         private const val BOUNCE_TOTAL_FRAMES = 25
         private const val BOUNCE_DECAY_RATE = 4.0
         private const val BOUNCE_OSCILLATIONS = 3.0
-        private const val THIRTEENTH_SWATCH_WIDTH = 32
 
         private fun easeOut(t: Float): Float {
             val complement = 1f - t

--- a/src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
@@ -26,7 +26,7 @@ import javax.swing.BoxLayout
 import javax.swing.JComponent
 import javax.swing.JPanel
 import javax.swing.Timer
-import javax.swing.UIManager
+import kotlin.math.sin
 
 /**
  * Accent color selection panel with two visual groups: action links (left) + preset grid (right).
@@ -38,7 +38,7 @@ import javax.swing.UIManager
  * ```
  *
  * Left column shows the shade name in accent color (row 1) and action links (row 2).
- * Right side is the 2×6 preset color grid.
+ * The right side is the 2×6 preset color grid.
  */
 class AccentColorPanel(
     presets: List<AccentColor>,
@@ -69,7 +69,7 @@ class AccentColorPanel(
             repaint()
         }
 
-    /** Whether hero glow is active (only during preset rotation mode). */
+    /** Whether the hero glow is active (only during preset rotation mode). */
     var heroGlowActive: Boolean = false
         set(value) {
             field = value
@@ -349,7 +349,7 @@ class AccentColorPanel(
         private fun updateBreathe() {
             breathePhase += BREATHE_STEP
             val sinNormalized =
-                (Math.sin(breathePhase).toFloat() + 1f) / 2f
+                (sin(breathePhase).toFloat() + 1f) / 2f
             glowAlpha = BREATHE_MIN_ALPHA + BREATHE_RANGE * sinNormalized
             repaint()
         }

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -4,11 +4,16 @@ import com.intellij.openapi.util.SystemInfo
 import com.intellij.ui.ColorPicker
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.dsl.builder.Align
+import com.intellij.ui.dsl.builder.Cell
 import com.intellij.ui.dsl.builder.Panel
+import com.intellij.ui.dsl.builder.selected
 import dev.ayuislands.accent.AYU_ACCENT_PRESETS
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.SystemAccentProvider
+import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.rotation.AccentRotationMode
+import dev.ayuislands.rotation.AccentRotationService
 import java.awt.Color
 
 /** Accent color section for the Ayu Islands settings panel. */
@@ -24,6 +29,14 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
     private var storedFollowSystem: Boolean = false
     private var followSystemCheckbox: JBCheckBox? = null
 
+    private var pendingRotationEnabled: Boolean = false
+    private var storedRotationEnabled: Boolean = false
+    private var pendingRotationMode: String = AccentRotationMode.PRESET.name
+    private var storedRotationMode: String = AccentRotationMode.PRESET.name
+    private var pendingRotationInterval: Int = AyuIslandsState.DEFAULT_ROTATION_INTERVAL_HOURS
+    private var storedRotationInterval: Int = AyuIslandsState.DEFAULT_ROTATION_INTERVAL_HOURS
+    private var rotationEnabledCheckbox: JBCheckBox? = null
+
     override fun buildPanel(
         panel: Panel,
         variant: AyuVariant,
@@ -35,6 +48,13 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
         storedFollowSystem = settings.state.followSystemAccent
         pendingFollowSystem = storedFollowSystem
 
+        storedRotationEnabled = settings.state.accentRotationEnabled
+        pendingRotationEnabled = storedRotationEnabled
+        storedRotationMode = settings.state.accentRotationMode ?: AccentRotationMode.PRESET.name
+        pendingRotationMode = storedRotationMode
+        storedRotationInterval = settings.state.accentRotationIntervalHours
+        pendingRotationInterval = storedRotationInterval
+
         val colorPanel =
             AccentColorPanel(
                 presets = AYU_ACCENT_PRESETS,
@@ -42,6 +62,11 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
                     pendingAccent = accent.hex
                     accentPanel?.selectedPreset = accent.hex
                     onAccentChanged?.invoke(accent.hex)
+                    if (pendingRotationEnabled) {
+                        pendingRotationEnabled = false
+                        rotationEnabledCheckbox?.isSelected = false
+                        updateHeroGlow()
+                    }
                 },
                 onCustomTrigger = { handleCustomTrigger() },
                 onReset = { handleReset() },
@@ -49,6 +74,7 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
         accentPanel = colorPanel
 
         applyInitialSelection(colorPanel, storedAccent)
+        updateHeroGlow()
 
         panel.group("Accent Color") {
             row {
@@ -63,6 +89,10 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
                     checkbox.addActionListener {
                         pendingFollowSystem = checkbox.isSelected
                         updatePanelEnabled()
+                        if (pendingFollowSystem && pendingRotationEnabled) {
+                            pendingRotationEnabled = false
+                            rotationEnabledCheckbox?.isSelected = false
+                        }
                         if (pendingFollowSystem) {
                             SystemAccentProvider.resolve()?.let { hex ->
                                 applyInitialSelection(colorPanel, hex)
@@ -79,6 +109,69 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
                 }
             }
             row { cell(colorPanel).resizableColumn().align(Align.FILL) }
+        }
+
+        panel.group("Accent Rotation") {
+            row { comment("Automatically change your accent color on a schedule.") }
+            lateinit var rotationCheckboxCell: Cell<JBCheckBox>
+            row {
+                rotationCheckboxCell =
+                    checkBox("Enable accent rotation")
+                val checkbox = rotationCheckboxCell.component
+                checkbox.isSelected = pendingRotationEnabled
+                checkbox.isEnabled = LicenseChecker.isLicensedOrGrace()
+                checkbox.addActionListener {
+                    pendingRotationEnabled = checkbox.isSelected
+                    if (pendingRotationEnabled && pendingFollowSystem) {
+                        pendingFollowSystem = false
+                        followSystemCheckbox?.isSelected = false
+                        updatePanelEnabled()
+                    }
+                }
+                rotationEnabledCheckbox = checkbox
+                if (!LicenseChecker.isLicensedOrGrace()) {
+                    comment("Pro feature")
+                }
+            }
+            row {
+                label("Mode:")
+                val modeCombo =
+                    comboBox(listOf("Preset cycle", "Random color"))
+                        .component
+                modeCombo.selectedIndex =
+                    if (pendingRotationMode == AccentRotationMode.RANDOM.name) 1 else 0
+                modeCombo.addActionListener {
+                    pendingRotationMode =
+                        if (modeCombo.selectedIndex == 1) {
+                            AccentRotationMode.RANDOM.name
+                        } else {
+                            AccentRotationMode.PRESET.name
+                        }
+                }
+            }.visibleIf(rotationCheckboxCell.selected)
+            row {
+                label("Interval:")
+                val intervalCombo =
+                    comboBox(
+                        listOf(
+                            "1 hour",
+                            "3 hours",
+                            "6 hours",
+                            "12 hours",
+                            "24 hours",
+                        ),
+                    ).component
+                intervalCombo.selectedIndex =
+                    INTERVAL_VALUES
+                        .indexOf(pendingRotationInterval)
+                        .coerceAtLeast(0)
+                intervalCombo.addActionListener {
+                    pendingRotationInterval =
+                        INTERVAL_VALUES.getOrElse(
+                            intervalCombo.selectedIndex,
+                        ) { AyuIslandsState.DEFAULT_ROTATION_INTERVAL_HOURS }
+                }
+            }.visibleIf(rotationCheckboxCell.selected)
         }
 
         updatePanelEnabled()
@@ -113,6 +206,11 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
             panel.customColor = hex
             panel.selectedPreset = null
             onAccentChanged?.invoke(hex)
+            if (pendingRotationEnabled) {
+                pendingRotationEnabled = false
+                rotationEnabledCheckbox?.isSelected = false
+                updateHeroGlow()
+            }
         }
     }
 
@@ -176,6 +274,9 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
 
     override fun isModified(): Boolean {
         if (pendingFollowSystem != storedFollowSystem) return true
+        if (pendingRotationEnabled != storedRotationEnabled) return true
+        if (pendingRotationMode != storedRotationMode) return true
+        if (pendingRotationInterval != storedRotationInterval) return true
         if (pendingFollowSystem) return false
         return pendingAccent != storedAccent
     }
@@ -205,17 +306,76 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
             AccentApplicator.apply(effectiveAccent)
         }
         storedAccent = effectiveAccent
+
+        val rotationChanged =
+            pendingRotationEnabled != storedRotationEnabled ||
+                pendingRotationMode != storedRotationMode ||
+                pendingRotationInterval != storedRotationInterval
+
+        if (rotationChanged) {
+            settings.state.accentRotationEnabled = pendingRotationEnabled
+            settings.state.accentRotationMode = pendingRotationMode
+            settings.state.accentRotationIntervalHours = pendingRotationInterval
+            storedRotationEnabled = pendingRotationEnabled
+            storedRotationMode = pendingRotationMode
+            storedRotationInterval = pendingRotationInterval
+
+            val service = AccentRotationService.getInstance()
+            if (pendingRotationEnabled) {
+                service.rotateNow()
+            } else {
+                service.stopRotation()
+            }
+        }
     }
 
     override fun reset() {
         pendingAccent = storedAccent
         pendingFollowSystem = storedFollowSystem
         followSystemCheckbox?.isSelected = storedFollowSystem
+        pendingRotationEnabled = storedRotationEnabled
+        pendingRotationMode = storedRotationMode
+        pendingRotationInterval = storedRotationInterval
+        rotationEnabledCheckbox?.isSelected = storedRotationEnabled
         accentPanel?.let { applyInitialSelection(it, storedAccent) }
+        updateHeroGlow()
         updatePanelEnabled()
     }
 
+    private fun updateHeroGlow() {
+        val panel = accentPanel ?: return
+        val settings = AyuIslandsSettings.getInstance()
+        val enabled = pendingRotationEnabled
+        val isPresetMode =
+            pendingRotationMode == AccentRotationMode.PRESET.name
+        if (enabled && isPresetMode) {
+            val index =
+                settings.state.accentRotationPresetIndex
+                    .coerceIn(0, AYU_ACCENT_PRESETS.size - 1)
+            panel.heroGlowHex = AYU_ACCENT_PRESETS[index].hex
+            panel.heroGlowActive = true
+        } else {
+            panel.heroGlowHex = null
+            panel.heroGlowActive = false
+        }
+    }
+
     companion object {
+        private const val INTERVAL_1H = 1
+        private const val INTERVAL_3H = 3
+        private const val INTERVAL_6H = 6
+        private const val INTERVAL_12H = 12
+        private const val INTERVAL_24H = 24
+
+        private val INTERVAL_VALUES =
+            listOf(
+                INTERVAL_1H,
+                INTERVAL_3H,
+                INTERVAL_6H,
+                INTERVAL_12H,
+                INTERVAL_24H,
+            )
+
         private fun colorToHex(color: Color): String = "#%02X%02X%02X".format(color.red, color.green, color.blue)
     }
 }

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -82,9 +82,8 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
                         rotationEnabledCheckbox?.isSelected = false
                         updateHeroGlow()
                     }
-                    accentPanel?.hideThirteenthSwatch()
-                    val settings = AyuIslandsSettings.getInstance()
-                    settings.state.lastShuffleColor = null
+                    accentPanel?.showThirteenthSwatchImmediate(accent.hex)
+                    AyuIslandsSettings.getInstance().state.lastShuffleColor = null
                 },
                 onCustomTrigger = { handleCustomTrigger() },
                 onReset = { handleReset() },
@@ -120,6 +119,8 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
         val lastShuffle = AyuIslandsSettings.getInstance().state.lastShuffleColor
         if (lastShuffle != null) {
             colorPanel.showThirteenthSwatchImmediate(lastShuffle)
+        } else if (storedAccent.isNotEmpty()) {
+            colorPanel.showThirteenthSwatchImmediate(storedAccent)
         }
 
         return colorPanel
@@ -282,7 +283,7 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
                 rotationEnabledCheckbox?.isSelected = false
                 updateHeroGlow()
             }
-            accentPanel?.hideThirteenthSwatch()
+            accentPanel?.showThirteenthSwatchImmediate(hex)
             AyuIslandsSettings.getInstance().state.lastShuffleColor = null
         }
     }
@@ -400,12 +401,9 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
                 val mode = AccentRotationMode.fromName(pendingRotationMode)
                 when (mode) {
                     AccentRotationMode.RANDOM -> {
-                        // Use 13th swatch color if visible, otherwise generate new
-                        val thirteenthColor = accentPanel?.thirteenthSwatchColor
-                        val rotationHex = thirteenthColor
-                            ?: ContrastAwareColorGenerator.generate(
-                                variant ?: return,
-                            )
+                        val rotationHex = ContrastAwareColorGenerator.generate(
+                            variant ?: return,
+                        )
                         settings.setAccentForVariant(currentVariant, rotationHex)
                         settings.state.accentRotationLastSwitchMs = System.currentTimeMillis()
                         AccentApplicator.apply(rotationHex)
@@ -420,19 +418,23 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
                         service.startRotation()
                     }
                     AccentRotationMode.PRESET -> {
-                        service.rotateNow()
-                        val presetIndex = settings.state.accentRotationPresetIndex
-                            .coerceIn(0, AYU_ACCENT_PRESETS.size - 1)
-                        val presetHex = AYU_ACCENT_PRESETS[presetIndex].hex
+                        val currentIndex = settings.state.accentRotationPresetIndex
+                        val nextIndex = (currentIndex + 1) % AYU_ACCENT_PRESETS.size
+                        settings.state.accentRotationPresetIndex = nextIndex
+                        val presetHex = AYU_ACCENT_PRESETS[nextIndex].hex
+                        settings.setAccentForVariant(currentVariant, presetHex)
+                        settings.state.accentRotationLastSwitchMs = System.currentTimeMillis()
+                        AccentApplicator.apply(presetHex)
                         storedAccent = presetHex
                         pendingAccent = presetHex
                         pendingCustomColor = null
                         accentPanel?.selectedPreset = presetHex
                         accentPanel?.customColor = null
-                        accentPanel?.hideThirteenthSwatch()
+                        accentPanel?.showThirteenthSwatchImmediate(presetHex)
                         settings.state.lastShuffleColor = null
                         updateHeroGlow()
                         onAccentChanged?.invoke(presetHex)
+                        service.startRotation()
                     }
                 }
             } else {

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -150,79 +150,74 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
                     "Automatically change your accent color on a schedule.",
                 )
             }
-            lateinit var rotationCheckboxCell: Cell<JBCheckBox>
-            row {
-                rotationCheckboxCell =
-                    checkBox("Enable accent rotation")
-                val checkbox = rotationCheckboxCell.component
-                checkbox.isSelected = pendingRotationEnabled
-                checkbox.isEnabled =
-                    LicenseChecker.isLicensedOrGrace()
-                checkbox.addActionListener {
-                    pendingRotationEnabled = checkbox.isSelected
-                    if (pendingRotationEnabled &&
-                        pendingFollowSystem
-                    ) {
-                        pendingFollowSystem = false
-                        followSystemCheckbox?.isSelected = false
-                        updatePanelEnabled()
-                    }
-                }
-                rotationEnabledCheckbox = checkbox
-                if (!LicenseChecker.isLicensedOrGrace()) {
-                    comment("Pro feature")
+            val rotationCheckboxCell = buildRotationEnableRow()
+            buildRotationModeRow(rotationCheckboxCell)
+            buildRotationIntervalRow(rotationCheckboxCell)
+        }
+    }
+
+    private fun Panel.buildRotationEnableRow(): Cell<JBCheckBox> {
+        lateinit var cell: Cell<JBCheckBox>
+        row {
+            cell = checkBox("Enable accent rotation")
+            val checkbox = cell.component
+            checkbox.isSelected = pendingRotationEnabled
+            checkbox.isEnabled =
+                LicenseChecker.isLicensedOrGrace()
+            checkbox.addActionListener {
+                pendingRotationEnabled = checkbox.isSelected
+                if (pendingRotationEnabled && pendingFollowSystem) {
+                    pendingFollowSystem = false
+                    followSystemCheckbox?.isSelected = false
+                    updatePanelEnabled()
                 }
             }
-            row {
-                label("Mode:")
-                val modeCombo =
-                    comboBox(
-                        listOf("Preset cycle", "Random color"),
-                    ).component
-                modeCombo.selectedIndex =
-                    if (pendingRotationMode ==
-                        AccentRotationMode.RANDOM.name
-                    ) {
-                        1
-                    } else {
-                        0
-                    }
-                modeCombo.addActionListener {
-                    pendingRotationMode =
-                        if (modeCombo.selectedIndex == 1) {
-                            AccentRotationMode.RANDOM.name
-                        } else {
-                            AccentRotationMode.PRESET.name
-                        }
-                }
-            }.visibleIf(rotationCheckboxCell.selected)
-            row {
-                label("Interval:")
-                val intervalCombo =
-                    comboBox(
-                        listOf(
-                            "1 hour",
-                            "3 hours",
-                            "6 hours",
-                            "12 hours",
-                            "24 hours",
-                        ),
-                    ).component
-                intervalCombo.selectedIndex =
-                    INTERVAL_VALUES
-                        .indexOf(pendingRotationInterval)
-                        .coerceAtLeast(0)
-                intervalCombo.addActionListener {
-                    pendingRotationInterval =
-                        INTERVAL_VALUES.getOrElse(
-                            intervalCombo.selectedIndex,
-                        ) {
-                            AyuIslandsState
-                                .DEFAULT_ROTATION_INTERVAL_HOURS
-                        }
-                }
-            }.visibleIf(rotationCheckboxCell.selected)
+            rotationEnabledCheckbox = checkbox
+            if (!LicenseChecker.isLicensedOrGrace()) {
+                comment("Pro feature")
+            }
         }
+        return cell
+    }
+
+    private fun Panel.buildRotationModeRow(rotationCheckboxCell: Cell<JBCheckBox>) {
+        row {
+            label("Mode:")
+            val modeCombo =
+                comboBox(
+                    listOf("Preset cycle", "Random color"),
+                ).component
+            modeCombo.selectedIndex =
+                if (pendingRotationMode == AccentRotationMode.RANDOM.name) 1 else 0
+            modeCombo.addActionListener {
+                pendingRotationMode =
+                    if (modeCombo.selectedIndex == 1) {
+                        AccentRotationMode.RANDOM.name
+                    } else {
+                        AccentRotationMode.PRESET.name
+                    }
+            }
+        }.visibleIf(rotationCheckboxCell.selected)
+    }
+
+    private fun Panel.buildRotationIntervalRow(rotationCheckboxCell: Cell<JBCheckBox>) {
+        row {
+            label("Interval:")
+            val intervalCombo =
+                comboBox(
+                    listOf("1 hour", "3 hours", "6 hours", "12 hours", "24 hours"),
+                ).component
+            intervalCombo.selectedIndex =
+                INTERVAL_VALUES
+                    .indexOf(pendingRotationInterval)
+                    .coerceAtLeast(0)
+            intervalCombo.addActionListener {
+                pendingRotationInterval =
+                    INTERVAL_VALUES.getOrElse(intervalCombo.selectedIndex) {
+                        AyuIslandsState.DEFAULT_ROTATION_INTERVAL_HOURS
+                    }
+            }
+        }.visibleIf(rotationCheckboxCell.selected)
     }
 
     private fun handleCustomTrigger() {

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -41,20 +41,34 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
         panel: Panel,
         variant: AyuVariant,
     ) {
+        initializeState(variant)
+        val colorPanel = createAccentColorPanel()
+        applyInitialSelection(colorPanel, storedAccent)
+        updateHeroGlow()
+        panel.buildAccentColorGroup(colorPanel)
+        panel.buildAccentRotationGroup()
+        updatePanelEnabled()
+    }
+
+    private fun initializeState(variant: AyuVariant) {
         this.variant = variant
         val settings = AyuIslandsSettings.getInstance()
         storedAccent = settings.getAccentForVariant(variant)
         pendingAccent = storedAccent
         storedFollowSystem = settings.state.followSystemAccent
         pendingFollowSystem = storedFollowSystem
-
         storedRotationEnabled = settings.state.accentRotationEnabled
         pendingRotationEnabled = storedRotationEnabled
-        storedRotationMode = settings.state.accentRotationMode ?: AccentRotationMode.PRESET.name
+        storedRotationMode =
+            settings.state.accentRotationMode
+                ?: AccentRotationMode.PRESET.name
         pendingRotationMode = storedRotationMode
-        storedRotationInterval = settings.state.accentRotationIntervalHours
+        storedRotationInterval =
+            settings.state.accentRotationIntervalHours
         pendingRotationInterval = storedRotationInterval
+    }
 
+    private fun createAccentColorPanel(): AccentColorPanel {
         val colorPanel =
             AccentColorPanel(
                 presets = AYU_ACCENT_PRESETS,
@@ -80,11 +94,11 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
                 },
             )
         accentPanel = colorPanel
+        return colorPanel
+    }
 
-        applyInitialSelection(colorPanel, storedAccent)
-        updateHeroGlow()
-
-        panel.group("Accent Color") {
+    private fun Panel.buildAccentColorGroup(colorPanel: AccentColorPanel) {
+        group("Accent Color") {
             row {
                 comment("Choose your accent color. Swatches are shared across all variants.")
             }
@@ -107,9 +121,18 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
                                 onAccentChanged?.invoke(hex)
                             }
                         } else {
-                            val manualAccent = getManualAccent(variant, settings)
+                            val settings =
+                                AyuIslandsSettings.getInstance()
+                            val manualAccent =
+                                getManualAccent(
+                                    variant ?: return@addActionListener,
+                                    settings,
+                                )
                             pendingAccent = manualAccent
-                            applyInitialSelection(colorPanel, manualAccent)
+                            applyInitialSelection(
+                                colorPanel,
+                                manualAccent,
+                            )
                             onAccentChanged?.invoke(manualAccent)
                         }
                     }
@@ -118,19 +141,28 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
             }
             row { cell(colorPanel).resizableColumn().align(Align.FILL) }
         }
+    }
 
-        panel.group("Accent Rotation") {
-            row { comment("Automatically change your accent color on a schedule.") }
+    private fun Panel.buildAccentRotationGroup() {
+        group("Accent Rotation") {
+            row {
+                comment(
+                    "Automatically change your accent color on a schedule.",
+                )
+            }
             lateinit var rotationCheckboxCell: Cell<JBCheckBox>
             row {
                 rotationCheckboxCell =
                     checkBox("Enable accent rotation")
                 val checkbox = rotationCheckboxCell.component
                 checkbox.isSelected = pendingRotationEnabled
-                checkbox.isEnabled = LicenseChecker.isLicensedOrGrace()
+                checkbox.isEnabled =
+                    LicenseChecker.isLicensedOrGrace()
                 checkbox.addActionListener {
                     pendingRotationEnabled = checkbox.isSelected
-                    if (pendingRotationEnabled && pendingFollowSystem) {
+                    if (pendingRotationEnabled &&
+                        pendingFollowSystem
+                    ) {
                         pendingFollowSystem = false
                         followSystemCheckbox?.isSelected = false
                         updatePanelEnabled()
@@ -144,10 +176,17 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
             row {
                 label("Mode:")
                 val modeCombo =
-                    comboBox(listOf("Preset cycle", "Random color"))
-                        .component
+                    comboBox(
+                        listOf("Preset cycle", "Random color"),
+                    ).component
                 modeCombo.selectedIndex =
-                    if (pendingRotationMode == AccentRotationMode.RANDOM.name) 1 else 0
+                    if (pendingRotationMode ==
+                        AccentRotationMode.RANDOM.name
+                    ) {
+                        1
+                    } else {
+                        0
+                    }
                 modeCombo.addActionListener {
                     pendingRotationMode =
                         if (modeCombo.selectedIndex == 1) {
@@ -177,12 +216,13 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
                     pendingRotationInterval =
                         INTERVAL_VALUES.getOrElse(
                             intervalCombo.selectedIndex,
-                        ) { AyuIslandsState.DEFAULT_ROTATION_INTERVAL_HOURS }
+                        ) {
+                            AyuIslandsState
+                                .DEFAULT_ROTATION_INTERVAL_HOURS
+                        }
                 }
             }.visibleIf(rotationCheckboxCell.selected)
         }
-
-        updatePanelEnabled()
     }
 
     private fun handleCustomTrigger() {

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -397,7 +397,44 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
 
             val service = AccentRotationService.getInstance()
             if (pendingRotationEnabled) {
-                service.rotateNow()
+                val mode = AccentRotationMode.fromName(pendingRotationMode)
+                when (mode) {
+                    AccentRotationMode.RANDOM -> {
+                        // Use 13th swatch color if visible, otherwise generate new
+                        val thirteenthColor = accentPanel?.thirteenthSwatchColor
+                        val rotationHex = thirteenthColor
+                            ?: ContrastAwareColorGenerator.generate(
+                                variant ?: return,
+                            )
+                        settings.setAccentForVariant(currentVariant, rotationHex)
+                        settings.state.accentRotationLastSwitchMs = System.currentTimeMillis()
+                        AccentApplicator.apply(rotationHex)
+                        storedAccent = rotationHex
+                        pendingAccent = rotationHex
+                        accentPanel?.selectedPreset = null
+                        accentPanel?.customColor = rotationHex
+                        pendingCustomColor = rotationHex
+                        settings.state.lastShuffleColor = rotationHex
+                        accentPanel?.showThirteenthSwatchImmediate(rotationHex)
+                        onAccentChanged?.invoke(rotationHex)
+                        service.startRotation()
+                    }
+                    AccentRotationMode.PRESET -> {
+                        service.rotateNow()
+                        val presetIndex = settings.state.accentRotationPresetIndex
+                            .coerceIn(0, AYU_ACCENT_PRESETS.size - 1)
+                        val presetHex = AYU_ACCENT_PRESETS[presetIndex].hex
+                        storedAccent = presetHex
+                        pendingAccent = presetHex
+                        pendingCustomColor = null
+                        accentPanel?.selectedPreset = presetHex
+                        accentPanel?.customColor = null
+                        accentPanel?.hideThirteenthSwatch()
+                        settings.state.lastShuffleColor = null
+                        updateHeroGlow()
+                        onAccentChanged?.invoke(presetHex)
+                    }
+                }
             } else {
                 service.stopRotation()
             }

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -70,6 +70,14 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
                 },
                 onCustomTrigger = { handleCustomTrigger() },
                 onReset = { handleReset() },
+                onShuffleTrigger = {
+                    pendingRotationEnabled = true
+                    pendingRotationMode = AccentRotationMode.PRESET.name
+                    rotationEnabledCheckbox?.isSelected = true
+                    val service = AccentRotationService.getInstance()
+                    service.rotateNow()
+                    updateHeroGlow()
+                },
             )
         accentPanel = colorPanel
 

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -94,6 +94,13 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
                     val settings = AyuIslandsSettings.getInstance()
                     settings.state.lastShuffleColor = randomHex
                     accentPanel?.showThirteenthSwatch(randomHex)
+                    // Auto-apply the shuffled color immediately
+                    pendingAccent = randomHex
+                    pendingCustomColor = randomHex
+                    accentPanel?.selectedPreset = null
+                    accentPanel?.customColor = randomHex
+                    // Trigger preview refresh
+                    onAccentChanged?.invoke(randomHex)
                 },
                 onThirteenthSwatchClicked = { hex ->
                     pendingAccent = hex

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -14,6 +14,7 @@ import dev.ayuislands.accent.SystemAccentProvider
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.rotation.AccentRotationMode
 import dev.ayuislands.rotation.AccentRotationService
+import dev.ayuislands.rotation.ContrastAwareColorGenerator
 import java.awt.Color
 
 /** Accent color section for the Ayu Islands settings panel. */
@@ -81,19 +82,39 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
                         rotationEnabledCheckbox?.isSelected = false
                         updateHeroGlow()
                     }
+                    accentPanel?.hideThirteenthSwatch()
+                    val settings = AyuIslandsSettings.getInstance()
+                    settings.state.lastShuffleColor = null
                 },
                 onCustomTrigger = { handleCustomTrigger() },
                 onReset = { handleReset() },
                 onShuffleTrigger = {
-                    pendingRotationEnabled = true
-                    pendingRotationMode = AccentRotationMode.PRESET.name
-                    rotationEnabledCheckbox?.isSelected = true
-                    val service = AccentRotationService.getInstance()
-                    service.rotateNow()
-                    updateHeroGlow()
+                    val currentVariant = variant ?: return@AccentColorPanel
+                    val randomHex = ContrastAwareColorGenerator.generate(currentVariant)
+                    val settings = AyuIslandsSettings.getInstance()
+                    settings.state.lastShuffleColor = randomHex
+                    accentPanel?.showThirteenthSwatch(randomHex)
+                },
+                onThirteenthSwatchClicked = { hex ->
+                    pendingAccent = hex
+                    accentPanel?.selectedPreset = null
+                    accentPanel?.customColor = hex
+                    pendingCustomColor = hex
+                    onAccentChanged?.invoke(hex)
+                    if (pendingRotationEnabled) {
+                        pendingRotationEnabled = false
+                        rotationEnabledCheckbox?.isSelected = false
+                        updateHeroGlow()
+                    }
                 },
             )
         accentPanel = colorPanel
+
+        val lastShuffle = AyuIslandsSettings.getInstance().state.lastShuffleColor
+        if (lastShuffle != null) {
+            colorPanel.showThirteenthSwatchImmediate(lastShuffle)
+        }
+
         return colorPanel
     }
 
@@ -254,6 +275,8 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
                 rotationEnabledCheckbox?.isSelected = false
                 updateHeroGlow()
             }
+            accentPanel?.hideThirteenthSwatch()
+            AyuIslandsSettings.getInstance().state.lastShuffleColor = null
         }
     }
 
@@ -264,6 +287,8 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
         panel.selectedPreset = null
         panel.customColor = null
         onAccentChanged?.invoke("")
+        accentPanel?.hideThirteenthSwatch()
+        AyuIslandsSettings.getInstance().state.lastShuffleColor = null
     }
 
     private val selectedPreset: String?

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAppearancePanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAppearancePanel.kt
@@ -2,15 +2,22 @@ package dev.ayuislands.settings
 
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.dsl.builder.Cell
 import com.intellij.ui.dsl.builder.Panel
+import com.intellij.ui.dsl.builder.selected
 import dev.ayuislands.AppearanceSyncService
 import dev.ayuislands.accent.AyuVariant
+import javax.swing.JComboBox
 
 /** System appearance section — visible on macOS only. */
 class AyuIslandsAppearancePanel : AyuIslandsSettingsPanel {
     private var pendingFollowAppearance: Boolean = false
     private var storedFollowAppearance: Boolean = false
     private var followAppearanceCheckbox: JBCheckBox? = null
+
+    private var pendingNightTheme: String = "Mirage"
+    private var storedNightTheme: String = "Mirage"
+    private var nightThemeCombo: JComboBox<String>? = null
 
     override fun buildPanel(
         panel: Panel,
@@ -20,37 +27,72 @@ class AyuIslandsAppearancePanel : AyuIslandsSettingsPanel {
         storedFollowAppearance = settings.state.followSystemAppearance
         pendingFollowAppearance = storedFollowAppearance
 
+        val currentDarkTheme = settings.state.lastDarkAppearanceTheme ?: "Ayu Mirage (Islands UI)"
+        val currentNight = if (currentDarkTheme.contains("Dark")) "Dark" else "Mirage"
+        storedNightTheme = currentNight
+        pendingNightTheme = currentNight
+
         if (!SystemInfo.isMac) return
 
         panel.group("System") {
             row { comment("Automatically switch between Light and Dark variants.") }
+            lateinit var checkboxCell: Cell<JBCheckBox>
             row {
-                val checkbox =
+                checkboxCell =
                     checkBox("Follow system appearance (Light / Dark)")
-                        .component
+                val checkbox = checkboxCell.component
                 checkbox.isSelected = pendingFollowAppearance
                 checkbox.addActionListener {
                     pendingFollowAppearance = checkbox.isSelected
                 }
                 followAppearanceCheckbox = checkbox
             }
+            row {
+                label("Night theme:")
+                val nightOptions = listOf("Mirage", "Dark")
+                val combo = comboBox(nightOptions).component
+                combo.selectedItem = currentNight
+                combo.addActionListener {
+                    pendingNightTheme = combo.selectedItem as? String ?: "Mirage"
+                }
+                nightThemeCombo = combo
+            }.visibleIf(checkboxCell.selected)
         }
     }
 
-    override fun isModified(): Boolean = pendingFollowAppearance != storedFollowAppearance
+    override fun isModified(): Boolean =
+        pendingFollowAppearance != storedFollowAppearance ||
+            pendingNightTheme != storedNightTheme
 
     override fun apply() {
         if (!isModified()) return
         val settings = AyuIslandsSettings.getInstance()
-        settings.state.followSystemAppearance = pendingFollowAppearance
-        storedFollowAppearance = pendingFollowAppearance
-        if (pendingFollowAppearance) {
-            AppearanceSyncService.getInstance().syncIfNeeded()
+
+        if (pendingFollowAppearance != storedFollowAppearance) {
+            settings.state.followSystemAppearance = pendingFollowAppearance
+            storedFollowAppearance = pendingFollowAppearance
+            if (pendingFollowAppearance) {
+                AppearanceSyncService.getInstance().syncIfNeeded()
+            }
+        }
+
+        if (pendingNightTheme != storedNightTheme) {
+            val currentDarkTheme = settings.state.lastDarkAppearanceTheme ?: ""
+            val isIslands = currentDarkTheme.contains("Islands UI")
+            val newDarkTheme =
+                when (pendingNightTheme) {
+                    "Dark" -> if (isIslands) "Ayu Dark (Islands UI)" else "Ayu Dark"
+                    else -> if (isIslands) "Ayu Mirage (Islands UI)" else "Ayu Mirage"
+                }
+            settings.state.lastDarkAppearanceTheme = newDarkTheme
+            storedNightTheme = pendingNightTheme
         }
     }
 
     override fun reset() {
         pendingFollowAppearance = storedFollowAppearance
         followAppearanceCheckbox?.isSelected = storedFollowAppearance
+        pendingNightTheme = storedNightTheme
+        nightThemeCombo?.selectedItem = storedNightTheme
     }
 }

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -6,6 +6,7 @@ import dev.ayuislands.glow.GlowAnimation
 import dev.ayuislands.glow.GlowPreset
 import dev.ayuislands.glow.GlowStyle
 import dev.ayuislands.indent.IndentPreset
+import dev.ayuislands.rotation.AccentRotationMode
 
 enum class PanelWidthMode {
     DEFAULT,
@@ -137,6 +138,13 @@ class AyuIslandsState : BaseState() {
     // Per-preset custom settings: key = preset name, value = "size|spacing|ligatures|weight"
     var fontPresetCustomizations by map<String, String>()
 
+    // Accent rotation
+    var accentRotationEnabled by property(false)
+    var accentRotationMode by string(AccentRotationMode.PRESET.name)
+    var accentRotationIntervalHours by property(DEFAULT_ROTATION_INTERVAL_HOURS)
+    var accentRotationLastSwitchMs by property(0L)
+    var accentRotationPresetIndex by property(0)
+
     // Update notification (shown once per version upgrade)
     var lastSeenVersion by string(null)
 
@@ -259,6 +267,7 @@ class AyuIslandsState : BaseState() {
         const val DEFAULT_GIT_AUTO_FIT_MIN_WIDTH = 400
         const val DEFAULT_GIT_AUTO_FIT_MAX_WIDTH = 500
         const val DEFAULT_FIXED_WIDTH = 300
+        const val DEFAULT_ROTATION_INTERVAL_HOURS = 6
         private const val DEFAULT_SOFT_INTENSITY = 20
         private const val DEFAULT_SHARP_NEON_INTENSITY = 50
         private const val DEFAULT_GRADIENT_INTENSITY = 30

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -145,6 +145,9 @@ class AyuIslandsState : BaseState() {
     var accentRotationLastSwitchMs by property(0L)
     var accentRotationPresetIndex by property(0)
 
+    // Last shuffle random color (13th swatch persistence)
+    var lastShuffleColor by string(null)
+
     // Update notification (shown once per version upgrade)
     var lastSeenVersion by string(null)
 

--- a/src/main/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitter.kt
+++ b/src/main/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitter.kt
@@ -86,6 +86,7 @@ class ToolWindowAutoFitter(
     ) {
         val currentWidth = toolWindow.component.width
         if (AutoFitCalculator.isJitterOnly(currentWidth, desiredWidth)) return
+        if (isSharingSidebar()) return
         val delta = desiredWidth - currentWidth
 
         when (toolWindow.type) {
@@ -94,6 +95,23 @@ class ToolWindowAutoFitter(
                 window.setSize(desiredWidth, window.height)
             }
             else -> toolWindow.stretchWidth(delta)
+        }
+    }
+
+    private fun isSharingSidebar(): Boolean {
+        val manager = ToolWindowManager.getInstance(project)
+        val ourWindow = manager.getToolWindow(toolWindowId) ?: return false
+        if (!ourWindow.isVisible) return false
+        val ourAnchor = ourWindow.anchor
+
+        return manager.toolWindowIdSet.any { id ->
+            id != toolWindowId &&
+                manager.getToolWindow(id)?.let { other ->
+                    other.isVisible &&
+                        other.anchor == ourAnchor &&
+                        other.type == ToolWindowType.DOCKED ||
+                        other.type == ToolWindowType.SLIDING
+                } == true
         }
     }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -215,6 +215,10 @@
         <applicationService
                 serviceImplementation="dev.ayuislands.AppearanceSyncService"/>
 
+        <!-- Accent rotation service (timer-based accent switching) -->
+        <applicationService
+                serviceImplementation="dev.ayuislands.rotation.AccentRotationService"/>
+
         <!-- Glow overlay manager (per-project lifecycle) -->
         <projectService
                 serviceImplementation="dev.ayuislands.glow.GlowOverlayManager"/>

--- a/src/main/resources/icons/dices.svg
+++ b/src/main/resources/icons/dices.svg
@@ -1,0 +1,18 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="16"
+  height="16"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="12" height="12" x="2" y="10" rx="2" ry="2" />
+  <path d="m17.92 14 3.5-3.5a2.24 2.24 0 0 0 0-3l-5-4.92a2.24 2.24 0 0 0-3 0L10 6" />
+  <path d="M6 18h.01" />
+  <path d="M10 14h.01" />
+  <path d="M15 6h.01" />
+  <path d="M18 9h.01" />
+</svg>

--- a/src/main/resources/icons/dices.svg
+++ b/src/main/resources/icons/dices.svg
@@ -2,7 +2,7 @@
   xmlns="http://www.w3.org/2000/svg"
   width="16"
   height="16"
-  viewBox="0 0 24 24"
+  viewBox="0 2 24 24"
   fill="none"
   stroke="#5C6773"
   stroke-width="2"

--- a/src/main/resources/icons/dices_dark.svg
+++ b/src/main/resources/icons/dices_dark.svg
@@ -4,7 +4,7 @@
   height="16"
   viewBox="0 0 24 24"
   fill="none"
-  stroke="#5C6773"
+  stroke="#BFBDB6"
   stroke-width="2"
   stroke-linecap="round"
   stroke-linejoin="round"

--- a/src/main/resources/icons/dices_dark.svg
+++ b/src/main/resources/icons/dices_dark.svg
@@ -2,7 +2,7 @@
   xmlns="http://www.w3.org/2000/svg"
   width="16"
   height="16"
-  viewBox="0 0 24 24"
+  viewBox="0 2 24 24"
   fill="none"
   stroke="#BFBDB6"
   stroke-width="2"

--- a/src/main/resources/icons/palette.svg
+++ b/src/main/resources/icons/palette.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="16"
+  height="16"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 22a1 1 0 0 1 0-20 10 9 0 0 1 10 9 5 5 0 0 1-5 5h-2.25a1.75 1.75 0 0 0-1.4 2.8l.3.4a1.75 1.75 0 0 1-1.4 2.8z" />
+  <circle cx="13.5" cy="6.5" r=".5" fill="currentColor" />
+  <circle cx="17.5" cy="10.5" r=".5" fill="currentColor" />
+  <circle cx="6.5" cy="12.5" r=".5" fill="currentColor" />
+  <circle cx="8.5" cy="7.5" r=".5" fill="currentColor" />
+</svg>

--- a/src/main/resources/icons/palette.svg
+++ b/src/main/resources/icons/palette.svg
@@ -2,7 +2,7 @@
   xmlns="http://www.w3.org/2000/svg"
   width="16"
   height="16"
-  viewBox="0 0 24 24"
+  viewBox="0 2 24 24"
   fill="none"
   stroke="#5C6773"
   stroke-width="2"

--- a/src/main/resources/icons/palette_dark.svg
+++ b/src/main/resources/icons/palette_dark.svg
@@ -4,14 +4,14 @@
   height="16"
   viewBox="0 0 24 24"
   fill="none"
-  stroke="#5C6773"
+  stroke="#BFBDB6"
   stroke-width="2"
   stroke-linecap="round"
   stroke-linejoin="round"
 >
   <path d="M12 22a1 1 0 0 1 0-20 10 9 0 0 1 10 9 5 5 0 0 1-5 5h-2.25a1.75 1.75 0 0 0-1.4 2.8l.3.4a1.75 1.75 0 0 1-1.4 2.8z" />
-  <circle cx="13.5" cy="6.5" r=".5" fill="#5C6773" />
-  <circle cx="17.5" cy="10.5" r=".5" fill="#5C6773" />
-  <circle cx="6.5" cy="12.5" r=".5" fill="#5C6773" />
-  <circle cx="8.5" cy="7.5" r=".5" fill="#5C6773" />
+  <circle cx="13.5" cy="6.5" r=".5" fill="#BFBDB6" />
+  <circle cx="17.5" cy="10.5" r=".5" fill="#BFBDB6" />
+  <circle cx="6.5" cy="12.5" r=".5" fill="#BFBDB6" />
+  <circle cx="8.5" cy="7.5" r=".5" fill="#BFBDB6" />
 </svg>

--- a/src/main/resources/icons/palette_dark.svg
+++ b/src/main/resources/icons/palette_dark.svg
@@ -2,7 +2,7 @@
   xmlns="http://www.w3.org/2000/svg"
   width="16"
   height="16"
-  viewBox="0 0 24 24"
+  viewBox="0 2 24 24"
   fill="none"
   stroke="#BFBDB6"
   stroke-width="2"

--- a/src/main/resources/icons/pipette.svg
+++ b/src/main/resources/icons/pipette.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="16"
+  height="16"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m12 9-8.414 8.414A2 2 0 0 0 3 18.828v1.344a2 2 0 0 1-.586 1.414A2 2 0 0 1 3.828 21h1.344a2 2 0 0 0 1.414-.586L15 12" />
+  <path d="m18 9 .4.4a1 1 0 1 1-3 3l-3.8-3.8a1 1 0 1 1 3-3l.4.4 3.4-3.4a1 1 0 1 1 3 3z" />
+  <path d="m2 22 .414-.414" />
+</svg>

--- a/src/main/resources/icons/pipette.svg
+++ b/src/main/resources/icons/pipette.svg
@@ -2,7 +2,7 @@
   xmlns="http://www.w3.org/2000/svg"
   width="16"
   height="16"
-  viewBox="0 0 24 24"
+  viewBox="0 2 24 24"
   fill="none"
   stroke="#5C6773"
   stroke-width="2"

--- a/src/main/resources/icons/pipette_dark.svg
+++ b/src/main/resources/icons/pipette_dark.svg
@@ -4,7 +4,7 @@
   height="16"
   viewBox="0 0 24 24"
   fill="none"
-  stroke="#5C6773"
+  stroke="#BFBDB6"
   stroke-width="2"
   stroke-linecap="round"
   stroke-linejoin="round"

--- a/src/main/resources/icons/pipette_dark.svg
+++ b/src/main/resources/icons/pipette_dark.svg
@@ -2,7 +2,7 @@
   xmlns="http://www.w3.org/2000/svg"
   width="16"
   height="16"
-  viewBox="0 0 24 24"
+  viewBox="0 2 24 24"
   fill="none"
   stroke="#BFBDB6"
   stroke-width="2"

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerProDefaultsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerProDefaultsTest.kt
@@ -11,6 +11,9 @@ import dev.ayuislands.glow.GlowStyle
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
 import dev.ayuislands.settings.PanelWidthMode
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
+import dev.ayuislands.rotation.AccentRotationService
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -18,6 +21,7 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.unmockkAll
+import io.mockk.verify
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -233,6 +237,49 @@ class LicenseCheckerProDefaultsTest {
         assertEquals("#CUSTOM1", state.mirageAccent)
     }
 
+    @Test
+    fun `revertToFreeDefaults resets cgpIntegrationEnabled to false`() {
+        state.cgpIntegrationEnabled = true
+        mockAccentApplicator()
+
+        LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
+
+        assertFalse(state.cgpIntegrationEnabled)
+    }
+
+    @Test
+    fun `revertToFreeDefaults resets irIntegrationEnabled to false`() {
+        state.irIntegrationEnabled = true
+        mockAccentApplicator()
+
+        LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
+
+        assertFalse(state.irIntegrationEnabled)
+    }
+
+    @Test
+    fun `revertToFreeDefaults resets accentRotationEnabled to false`() {
+        state.accentRotationEnabled = true
+        mockAccentApplicator()
+
+        LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
+
+        assertFalse(state.accentRotationEnabled)
+    }
+
+    @Test
+    fun `revertToFreeDefaults stops accent rotation service`() {
+        mockAccentApplicator()
+        val rotationService = mockk<AccentRotationService>(relaxed = true)
+        val app = mockk<Application>()
+        every { ApplicationManager.getApplication() } returns app
+        every { app.getService(AccentRotationService::class.java) } returns rotationService
+
+        LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
+
+        verify { rotationService.stopRotation() }
+    }
+
     // Fragile: this test mocks a 4-deep notification chain
     // (NotificationGroupManager→NotificationGroup→Notification→notify).
     // If the notification path in revertToFreeDefaults changes, update
@@ -246,6 +293,12 @@ class LicenseCheckerProDefaultsTest {
         every { settingsMock.getAccentForVariant(any()) } returns "#FFCC66"
         mockkObject(AccentApplicator)
         every { AccentApplicator.apply(any()) } throws RuntimeException("Test failure")
+
+        // Mock ApplicationManager for AccentRotationService.stopRotation() call
+        mockkStatic(ApplicationManager::class)
+        val app = mockk<Application>()
+        every { ApplicationManager.getApplication() } returns app
+        every { app.getService(AccentRotationService::class.java) } returns null
 
         // Mock NotificationGroupManager for the catch block's warning notification
         mockkStatic(NotificationGroupManager::class)
@@ -277,5 +330,11 @@ class LicenseCheckerProDefaultsTest {
         every { settingsMock.getAccentForVariant(any()) } returns "#FFCC66"
         mockkObject(AccentApplicator)
         every { AccentApplicator.apply(any()) } just runs
+
+        // Mock ApplicationManager for AccentRotationService.stopRotation() call
+        mockkStatic(ApplicationManager::class)
+        val app = mockk<Application>()
+        every { ApplicationManager.getApplication() } returns app
+        every { app.getService(AccentRotationService::class.java) } returns null
     }
 }

--- a/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
@@ -1,0 +1,64 @@
+package dev.ayuislands.rotation
+
+import dev.ayuislands.accent.AYU_ACCENT_PRESETS
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class AccentRotationServiceTest {
+    @Test
+    fun `nextPresetHex wraps from last preset back to first`() {
+        val (index, hex) = nextPresetHex(AYU_ACCENT_PRESETS.size - 1)
+        assertEquals(0, index)
+        assertEquals(AYU_ACCENT_PRESETS[0].hex, hex)
+    }
+
+    @Test
+    fun `nextPresetHex advances index by one`() {
+        val (index, hex) = nextPresetHex(0)
+        assertEquals(1, index)
+        assertEquals(AYU_ACCENT_PRESETS[1].hex, hex)
+    }
+
+    @Test
+    fun `nextPresetHex wraps index 11 to 0 for 12 presets`() {
+        assertEquals(12, AYU_ACCENT_PRESETS.size, "Expected 12 presets")
+        val (index, _) = nextPresetHex(11)
+        assertEquals(0, index)
+    }
+
+    @Test
+    fun `nextPresetHex returns valid hex for every index`() {
+        for (i in AYU_ACCENT_PRESETS.indices) {
+            val (_, hex) = nextPresetHex(i)
+            assertTrue(hex.matches(Regex("#[0-9A-Fa-f]{6}")), "Invalid hex: $hex at index $i")
+        }
+    }
+
+    @Test
+    fun `fromName PRESET round-trips`() {
+        assertEquals(AccentRotationMode.PRESET, AccentRotationMode.fromName("PRESET"))
+    }
+
+    @Test
+    fun `fromName RANDOM round-trips`() {
+        assertEquals(AccentRotationMode.RANDOM, AccentRotationMode.fromName("RANDOM"))
+    }
+
+    @Test
+    fun `fromName returns PRESET for null`() {
+        assertEquals(AccentRotationMode.PRESET, AccentRotationMode.fromName(null))
+    }
+
+    @Test
+    fun `fromName returns PRESET for unknown string`() {
+        assertEquals(AccentRotationMode.PRESET, AccentRotationMode.fromName("garbage"))
+    }
+
+    @Test
+    fun `all modes round-trip through name`() {
+        for (mode in AccentRotationMode.entries) {
+            assertEquals(mode, AccentRotationMode.fromName(mode.name))
+        }
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/rotation/ContrastAwareColorGeneratorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/rotation/ContrastAwareColorGeneratorTest.kt
@@ -1,0 +1,66 @@
+package dev.ayuislands.rotation
+
+import dev.ayuislands.accent.AyuVariant
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.awt.Color
+
+class ContrastAwareColorGeneratorTest {
+    @Test
+    fun `generate produces bright accents for DARK variant`() {
+        repeat(100) {
+            val hex = ContrastAwareColorGenerator.generate(AyuVariant.DARK)
+            val (_, _, lightness) = HslColor.fromColor(Color.decode(hex))
+            assertTrue(lightness in 0.55f..0.90f) {
+                "DARK lightness $lightness out of range for hex $hex"
+            }
+        }
+    }
+
+    @Test
+    fun `generate produces bright accents for MIRAGE variant`() {
+        repeat(100) {
+            val hex = ContrastAwareColorGenerator.generate(AyuVariant.MIRAGE)
+            val (_, _, lightness) = HslColor.fromColor(Color.decode(hex))
+            assertTrue(lightness in 0.55f..0.90f) {
+                "MIRAGE lightness $lightness out of range for hex $hex"
+            }
+        }
+    }
+
+    @Test
+    fun `generate produces dark accents for LIGHT variant`() {
+        repeat(100) {
+            val hex = ContrastAwareColorGenerator.generate(AyuVariant.LIGHT)
+            val (_, _, lightness) = HslColor.fromColor(Color.decode(hex))
+            assertTrue(lightness in 0.20f..0.50f) {
+                "LIGHT lightness $lightness out of range for hex $hex"
+            }
+        }
+    }
+
+    @Test
+    fun `all generated colors have high saturation`() {
+        for (variant in AyuVariant.entries) {
+            repeat(50) {
+                val hex = ContrastAwareColorGenerator.generate(variant)
+                val (_, saturation, _) = HslColor.fromColor(Color.decode(hex))
+                assertTrue(saturation >= 0.65f) {
+                    "Saturation $saturation too low for $variant hex $hex"
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `all generated colors match hex pattern`() {
+        for (variant in AyuVariant.entries) {
+            repeat(50) {
+                val hex = ContrastAwareColorGenerator.generate(variant)
+                assertTrue(hex.matches(Regex("#[0-9A-F]{6}"))) {
+                    "Invalid hex format: $hex"
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/rotation/HslColorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/rotation/HslColorTest.kt
@@ -1,0 +1,64 @@
+package dev.ayuislands.rotation
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.awt.Color
+
+class HslColorTest {
+    @Test
+    fun `toColor converts pure red at hue 0`() {
+        val color = HslColor.toColor(0f, 1f, 0.5f)
+        assertEquals(Color(255, 0, 0), color)
+    }
+
+    @Test
+    fun `toColor converts pure green at hue 120`() {
+        val color = HslColor.toColor(120f, 1f, 0.5f)
+        assertEquals(Color(0, 255, 0), color)
+    }
+
+    @Test
+    fun `toColor converts pure blue at hue 240`() {
+        val color = HslColor.toColor(240f, 1f, 0.5f)
+        assertEquals(Color(0, 0, 255), color)
+    }
+
+    @Test
+    fun `toColor converts grey at zero saturation`() {
+        val color = HslColor.toColor(0f, 0f, 0.5f)
+        assertEquals(Color(128, 128, 128), color)
+    }
+
+    @Test
+    fun `toColor converts black at zero lightness`() {
+        val color = HslColor.toColor(0f, 0f, 0f)
+        assertEquals(Color(0, 0, 0), color)
+    }
+
+    @Test
+    fun `toColor converts white at full lightness`() {
+        val color = HslColor.toColor(0f, 0f, 1f)
+        assertEquals(Color(255, 255, 255), color)
+    }
+
+    @Test
+    fun `toHex returns uppercase hex for pure red`() {
+        val hex = HslColor.toHex(0f, 1f, 0.5f)
+        assertEquals("#FF0000", hex)
+    }
+
+    @Test
+    fun `fromColor round-trips pure red`() {
+        val (hue, saturation, lightness) = HslColor.fromColor(Color(255, 0, 0))
+        assertEquals(0f, hue, 0.5f)
+        assertEquals(1f, saturation, 0.01f)
+        assertEquals(0.5f, lightness, 0.01f)
+    }
+
+    @Test
+    fun `fromColor round-trips grey`() {
+        val (hue, saturation, lightness) = HslColor.fromColor(Color(128, 128, 128))
+        assertEquals(0f, saturation, 0.01f)
+        assertEquals(0.5f, lightness, 0.02f)
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/rotation/HslColorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/rotation/HslColorTest.kt
@@ -57,7 +57,7 @@ class HslColorTest {
 
     @Test
     fun `fromColor round-trips grey`() {
-        val (hue, saturation, lightness) = HslColor.fromColor(Color(128, 128, 128))
+        val (_, saturation, lightness) = HslColor.fromColor(Color(128, 128, 128))
         assertEquals(0f, saturation, 0.01f)
         assertEquals(0.5f, lightness, 0.02f)
     }

--- a/src/test/kotlin/dev/ayuislands/settings/AccentColorPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AccentColorPanelTest.kt
@@ -24,9 +24,13 @@ class AccentColorPanelTest {
 
     private fun findLeftColumn(panel: AccentColorPanel): JPanel = panel.components[0] as JPanel
 
-    private fun findLinksRow(panel: AccentColorPanel): JPanel {
+    /** Left column children: [0]=shadeNameLabel, [1]=strut, [2]=customLink, [3]=strut, [4]=resetLabel/shuffleLink. */
+    private fun findLeftColumnChild(
+        panel: AccentColorPanel,
+        index: Int,
+    ): java.awt.Component {
         val leftColumn = findLeftColumn(panel)
-        return leftColumn.getComponent(2) as JPanel
+        return leftColumn.getComponent(index)
     }
 
     @Test
@@ -155,8 +159,7 @@ class AccentColorPanelTest {
                 onReset = { resetFired = true },
             )
 
-        val linksRow = findLinksRow(panel)
-        val resetLabel = linksRow.getComponent(2)
+        val resetLabel = findLeftColumnChild(panel, 4)
 
         val event = createMouseEvent(resetLabel)
         resetLabel.mouseListeners.forEach { listener -> listener.mouseClicked(event) }
@@ -175,8 +178,7 @@ class AccentColorPanelTest {
                 onReset = {},
             )
 
-        val linksRow = findLinksRow(panel)
-        val customLink = linksRow.getComponent(0)
+        val customLink = findLeftColumnChild(panel, 2)
 
         val event = createMouseEvent(customLink)
         customLink.mouseListeners.forEach { listener -> listener.mouseClicked(event) }


### PR DESCRIPTION
## Summary

Accent color system evolution: automatic rotation with preset cycling and contrast-aware random generation, complete shuffle UI redesign with heroic 13th swatch, and trial revert hardening.

**Phases:** 15, 15.1, 16
**25 files changed**, 1358 insertions, 77 deletions

## Changes

### Accent Rotation (Phase 15)
- `AccentRotationService` — automatic accent color cycling with configurable interval
- Two modes: sequential preset cycling (12 Ayu colors) and contrast-aware random generation
- `HslColor` + `ContrastAwareColorGenerator` for perceptually distinct random accents
- Night theme preference dropdown in Appearance panel
- License-gated behind `LicenseChecker.isLicensedOrGrace()`

### Shuffle UI Redesign (Phase 15.1)
- 4x3 preset grid replacing 2x6 layout
- 13th swatch as universal heroic accent indicator — always visible, shows current accent
- Dice bounce animation with slide-in reveal
- Icon-labeled left column (palette, pipette, dices) with theme-aware SVG variants
- Mode-aware rotation apply: shuffle auto-applies via `onAccentChanged` pipeline

### Trial Hardening (Phase 16)
- Fix trial revert edge cases
- 4 new unit tests for revert coverage

## Files

### New
- `AccentRotationService.kt`, `AccentRotationMode.kt`, `HslColor.kt`, `ContrastAwareColorGenerator.kt`
- `dices.svg`, `dices_dark.svg`, `palette.svg`, `palette_dark.svg`, `pipette.svg`, `pipette_dark.svg`
- `AccentRotationServiceTest.kt`, `ContrastAwareColorGeneratorTest.kt`, `HslColorTest.kt`

### Modified
- `AccentColorPanel.kt` — 4x3 grid, 13th swatch, dice animations
- `AyuIslandsAccentPanel.kt` — rotation settings, shuffle wiring
- `AyuIslandsAppearancePanel.kt` — night theme dropdown
- `LicenseChecker.kt` — revert fixes
- `AyuIslandsState.kt` — rotation state properties
- `plugin.xml` — rotation service registration

## Verification

- [x] Phase 15: verified (automated)
- [x] Phase 15.1: verified (automated)
- [x] Phase 16: verified (5/5 must-haves passed)
- [x] `./gradlew test` — full suite passes
- [x] `./gradlew buildPlugin` — builds successfully

## Test Plan

- [ ] Squash merge to main
- [ ] Verify CI passes on main
- [ ] Tag v2.3.2 and push for release

## Summary by Sourcery

Introduce configurable accent color rotation with new contrast-aware random generation, redesign the accent shuffle UI with a persistent 13th swatch, and harden trial/license downgrade behavior including rotation shutdown.

New Features:
- Add an accent rotation service with preset cycling and random color modes, scheduled execution, and IDE startup integration.
- Expose accent rotation settings in the accent panel, including enable toggle, mode selection, and rotation interval configuration.
- Add a macOS night-theme preference in the appearance panel to choose between Mirage and Dark for system-driven switching.
- Enhance the accent color panel with icon-labeled actions, a 4×3 preset grid, hero glow highlighting for rotated presets, and a 13th swatch that reflects the current or shuffled accent color.
- Provide contrast-aware random accent generation based on variant-aware HSL ranges for use by shuffle and rotation.

Bug Fixes:
- Ensure license downgrade reverts premium feature flags, including accent rotation, and stops any running rotation service.
- Prevent tool window auto-fit from resizing when the tool is sharing a sidebar with other visible tool windows.
- Fix trial revert edge cases around integrations and accent rotation service access in licensing tests.

Enhancements:
- Simplify font preset application by notifying global scheme changes without wrapping in a read action.
- Persist and restore the last shuffled accent color so the 13th swatch remains consistent across sessions.

Tests:
- Add unit tests for accent rotation scheduling helpers, rotation mode parsing, and the contrast-aware color generator’s lightness and saturation ranges.
- Add HSL color conversion tests to validate RGB↔HSL round-tripping and hex formatting.
- Extend licensing tests to cover new revert behavior, including disabling integrations and stopping the accent rotation service.
- Update accent color panel tests to accommodate the new left-column layout and labeled actions.