### PR TITLE
ci(release): increase timeout to 25min

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     environment: production
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
11 IDE verify targets in single job now exceeds 15min with rotation package added.

## Summary by Sourcery

CI:
- Increase the GitHub Actions release workflow job timeout from 15 to 25 minutes to prevent premature job termination.