### PR TITLE
fix: correct release-version to 23

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -184,8 +184,8 @@
 
     <product-descriptor
             code="PAYUISLANDS"
-            release-date="20260323"
-            release-version="24"
+            release-date="20260319"
+            release-version="23"
             optional="true"/>
 
     <extensionPoints>


### PR DESCRIPTION
release-version must match plugin version prefix: 2.3.x → 23. Was incorrectly set to 24.

## Summary by Sourcery

Bug Fixes:
- Correct the PAYUISLANDS product descriptor release version from 24 to 23 and adjust the associated release date.