### PR TITLE
chore: prepare v2.3.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2.3.3] - 2026-03-25
+
+### Fixed
+- Fix "Write-unsafe context" crash during accent rotation with Indent Rainbow
+- Harden rotation lifecycle: dispose guard, wider exception catch, null-safe Application access
+
+### Changed
+- Rewrite Marketplace description with benefit-led copy
+- Trim embedded changelog to last 3 releases with GitHub link
+- Fix Shuffle UI label: Paid → Free in changelog and update notifier
+
 ## [2.3.0] - 2026-03-19
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.3.2
+pluginVersion=2.3.3
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
@@ -41,6 +41,11 @@ internal object UpdateNotifier {
 
     private val RELEASE_NOTES =
         mapOf(
+            "2.3.3" to
+                "<ul>" +
+                "<li>Fix \u201CWrite-unsafe context\u201D crash during accent rotation with Indent Rainbow</li>" +
+                "<li>Rewrite Marketplace description</li>" +
+                "</ul>",
             "2.3.2" to
                 "<ul>" +
                 "<li>[Paid] Accent rotation \u2014 automatic preset cycling or contrast-aware random</li>" +

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -72,6 +72,11 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>2.3.3</h3>
+    <ul>
+      <li>Fix "Write-unsafe context" crash during accent rotation with Indent Rainbow</li>
+      <li>Rewrite Marketplace description</li>
+    </ul>
     <h3>2.3.2</h3>
     <ul>
       <li>[Paid] Accent rotation — automatic preset cycling or contrast-aware random</li>


### PR DESCRIPTION
── Summary ─────────────────────────────────

Prepare v2.3.3 patch release. Ships the write-unsafe context fix from PR #80 and hardened rotation lifecycle from PR #81, along with the rewritten Marketplace description.

── Changes ─────────────────────────────────

| Type | Change | Files |
|------|--------|-------|
| Chore | Bump pluginVersion 2.3.2 → 2.3.3 | `gradle.properties:3` |
| Docs | Add 2.3.3 changelog entry (crash fix + description rewrite) | `CHANGELOG.md:3` |
| Chore | Add 2.3.3 to in-IDE update notifier | `UpdateNotifier.kt:44` |
| Chore | Add 2.3.3 change-notes to plugin.xml | `plugin.xml:75` |

── Validation ──────────────────────────────

```bash
# Build succeeds
./gradlew buildPlugin

# Tests pass
./gradlew test

# Coverage threshold met
./gradlew koverVerify

# Version is correct in built artifact
zipinfo -1 build/distributions/*.zip | head -1
# Expected: ayu-jetbrains/

grep pluginVersion gradle.properties
# Expected: pluginVersion=2.3.3
```

── Notes ────────────────────────────────────

- After merge: tag `v2.3.3` on main to trigger release workflow
- Release workflow publishes to JetBrains Marketplace automatically

## Summary by Sourcery

Prepare the 2.3.3 patch release of the Ayu Islands plugin with updated metadata and release notes.

Bug Fixes:
- Document the fix for the write-unsafe context crash during accent rotation with Indent Rainbow.

Enhancements:
- Update in-IDE release notes and plugin change notes to describe the 2.3.3 crash fix and description rewrite.

Build:
- Bump the plugin version from 2.3.2 to 2.3.3 in build configuration.

Documentation:
- Add a 2.3.3 changelog entry covering the crash fix, hardened rotation lifecycle, Marketplace description rewrite, and related UI label corrections.