### PR TITLE
fix(glow): sync glow overlays after accent rotation

### DIFF
--- a/src/main/kotlin/dev/ayuislands/AyuIslandsLafListener.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsLafListener.kt
@@ -11,13 +11,13 @@ import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.projectview.ProjectViewScrollbarManager
 import dev.ayuislands.settings.AyuIslandsSettings
 
-/** Re-applies accent color on theme change. */
+/** Re-applies accent, font, glow, and scrollbar settings on theme change. */
 class AyuIslandsLafListener : LafManagerListener {
     @Suppress("UnstableApiUsage")
     override fun lookAndFeelChanged(source: LafManager) {
         val variant = AyuVariant.detect()
         if (variant == null) {
-            // Switched away from the Ayu theme -- clean up accent overrides and glow overlays
+            // Switched away from the Ayu theme -- clean up accent, font, and glow overrides
             AccentApplicator.revertAll()
             FontPresetApplicator.revert()
             GlowOverlayManager.syncGlowForAllProjects()

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsLafListener.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsLafListener.kt
@@ -11,6 +11,7 @@ import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.projectview.ProjectViewScrollbarManager
 import dev.ayuislands.settings.AyuIslandsSettings
 
+
 /** Re-applies accent color on theme change. */
 class AyuIslandsLafListener : LafManagerListener {
     @Suppress("UnstableApiUsage")
@@ -20,7 +21,7 @@ class AyuIslandsLafListener : LafManagerListener {
             // Switched away from the Ayu theme -- clean up accent overrides and glow overlays
             AccentApplicator.revertAll()
             FontPresetApplicator.revert()
-            updateGlowForAllProjects()
+            GlowOverlayManager.syncGlowForAllProjects()
             return
         }
 
@@ -44,7 +45,7 @@ class AyuIslandsLafListener : LafManagerListener {
         reapplyProjectViewScrollbar()
 
         // Update glow overlays with new accent color
-        updateGlowForAllProjects()
+        GlowOverlayManager.syncGlowForAllProjects()
     }
 
     private fun reapplyProjectViewScrollbar() {
@@ -54,16 +55,6 @@ class AyuIslandsLafListener : LafManagerListener {
                 ProjectViewScrollbarManager.getInstance(openProject).apply()
             } catch (exception: RuntimeException) {
                 LOG.warn("Failed to re-apply scrollbar for project ${openProject.name}: ${exception.message}")
-            }
-        }
-    }
-
-    private fun updateGlowForAllProjects() {
-        for (openProject in ProjectManager.getInstance().openProjects) {
-            try {
-                GlowOverlayManager.getInstance(openProject).updateGlow()
-            } catch (exception: RuntimeException) {
-                LOG.warn("Failed to update glow for project ${openProject.name}: ${exception.message}")
             }
         }
     }

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsLafListener.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsLafListener.kt
@@ -11,7 +11,6 @@ import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.projectview.ProjectViewScrollbarManager
 import dev.ayuislands.settings.AyuIslandsSettings
 
-
 /** Re-applies accent color on theme change. */
 class AyuIslandsLafListener : LafManagerListener {
     @Suppress("UnstableApiUsage")

--- a/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
@@ -44,7 +44,7 @@ import javax.swing.UIManager
  * GlowIslandBorder (border-based island glow) was evaluated and removed: the GlassPane approach
  * is more robust (independent of component border chains, no layout interference).
  * GlowPanel (standalone glow JPanel) was removed: preview uses GlowRenderer directly.
- * GlowPreset (named configurations) was removed: deferred feature, flat state properties suffice.
+ * GlowPreset (named configurations) was simplified to an enum selecting flat state properties.
  */
 @Suppress("TooManyFunctions") // Overlay lifecycle requires many small helpers
 class GlowOverlayManager(

--- a/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
@@ -3,10 +3,10 @@ package dev.ayuislands.glow
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.fileEditor.FileEditorManager
-import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.fileEditor.FileEditorManagerEvent
 import com.intellij.openapi.fileEditor.FileEditorManagerListener
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowManager
@@ -82,7 +82,8 @@ class GlowOverlayManager(
                     getInstance(project).updateGlow()
                 } catch (exception: RuntimeException) {
                     logger<GlowOverlayManager>().warn(
-                        "Failed to sync glow for project ${project.name}: ${exception.message}",
+                        "Failed to sync glow for project ${project.name}",
+                        exception,
                     )
                 }
             }

--- a/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
@@ -3,6 +3,7 @@ package dev.ayuislands.glow
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.fileEditor.FileEditorManagerEvent
 import com.intellij.openapi.fileEditor.FileEditorManagerListener
 import com.intellij.openapi.project.Project
@@ -74,6 +75,18 @@ class GlowOverlayManager(
         private const val KEY_TAB_BACKGROUND = "EditorTabs.underlinedTabBackground"
 
         fun getInstance(project: Project): GlowOverlayManager = project.getService(GlowOverlayManager::class.java)
+
+        fun syncGlowForAllProjects() {
+            for (project in ProjectManager.getInstance().openProjects) {
+                try {
+                    getInstance(project).updateGlow()
+                } catch (exception: RuntimeException) {
+                    logger<GlowOverlayManager>().warn(
+                        "Failed to sync glow for project ${project.name}: ${exception.message}",
+                    )
+                }
+            }
+        }
 
         private fun safeDecodeColor(hex: String): Color =
             try {
@@ -309,7 +322,7 @@ class GlowOverlayManager(
 
     private fun findTabBarHeight(host: JComponent): Int {
         // EditorsSplitters has one child: EditorTabs (full JBTabsImpl tabbed pane).
-        // EditorTabs.height = entire editor area — NOT the tab strip.
+        // EditorTabs.height = the entire editor area — NOT the tab strip.
         // Walk into EditorTabs and find a TabLabel — its (y + height) is the strip height.
         val editorTabs =
             host.components.firstOrNull {
@@ -396,8 +409,7 @@ class GlowOverlayManager(
         log.info("Glow overlay attached: $id (host: ${host.javaClass.simpleName})")
     }
 
-    private fun removeOverlay(id: String) {
-        val entry = overlays.remove(id) ?: return
+    private fun detachOverlayEntry(entry: OverlayEntry) {
         entry.glassPane.stopAnimation()
         entry.componentListener?.let { entry.host.removeComponentListener(it) }
         entry.hierarchyBoundsListener?.let { entry.host.removeHierarchyBoundsListener(it) }
@@ -408,6 +420,11 @@ class GlowOverlayManager(
             entry.glassPane.width,
             entry.glassPane.height,
         )
+    }
+
+    private fun removeOverlay(id: String) {
+        val entry = overlays.remove(id) ?: return
+        detachOverlayEntry(entry)
         if (activeGlowId == id) activeGlowId = null
         log.info("Glow overlay removed: $id")
     }
@@ -601,16 +618,7 @@ class GlowOverlayManager(
 
     private fun removeAllOverlays() {
         for ((_, entry) in overlays) {
-            entry.glassPane.stopAnimation()
-            entry.componentListener?.let { entry.host.removeComponentListener(it) }
-            entry.hierarchyBoundsListener?.let { entry.host.removeHierarchyBoundsListener(it) }
-            entry.layeredPane.remove(entry.glassPane)
-            entry.layeredPane.repaint(
-                entry.glassPane.x,
-                entry.glassPane.y,
-                entry.glassPane.width,
-                entry.glassPane.height,
-            )
+            detachOverlayEntry(entry)
         }
         overlays.clear()
 

--- a/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
@@ -18,7 +18,9 @@ import com.intellij.ui.LicensingFacade
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.AyuVariant
+import com.intellij.openapi.project.ProjectManager
 import dev.ayuislands.glow.GlowAnimation
+import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.glow.GlowPreset
 import dev.ayuislands.glow.GlowStyle
 import dev.ayuislands.rotation.AccentRotationService
@@ -266,6 +268,9 @@ object LicenseChecker {
         try {
             val accentHex = AyuIslandsSettings.getInstance().getAccentForVariant(variant)
             AccentApplicator.apply(accentHex)
+            for (project in ProjectManager.getInstance().openProjects) {
+                GlowOverlayManager.getInstance(project).updateGlow()
+            }
         } catch (exception: RuntimeException) {
             LOG.warn("Revert to free defaults failed", exception)
             NotificationGroupManager

--- a/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
@@ -280,7 +280,11 @@ object LicenseChecker {
                 ).notify(null)
         }
 
-        GlowOverlayManager.syncGlowForAllProjects()
+        try {
+            GlowOverlayManager.syncGlowForAllProjects()
+        } catch (exception: RuntimeException) {
+            LOG.warn("Glow sync after license revert failed", exception)
+        }
     }
 
     private const val KEY_PREFIX_LENGTH = 4

--- a/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
@@ -18,7 +18,6 @@ import com.intellij.ui.LicensingFacade
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.AyuVariant
-import com.intellij.openapi.project.ProjectManager
 import dev.ayuislands.glow.GlowAnimation
 import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.glow.GlowPreset
@@ -268,9 +267,6 @@ object LicenseChecker {
         try {
             val accentHex = AyuIslandsSettings.getInstance().getAccentForVariant(variant)
             AccentApplicator.apply(accentHex)
-            for (project in ProjectManager.getInstance().openProjects) {
-                GlowOverlayManager.getInstance(project).updateGlow()
-            }
         } catch (exception: RuntimeException) {
             LOG.warn("Revert to free defaults failed", exception)
             NotificationGroupManager
@@ -283,6 +279,8 @@ object LicenseChecker {
                     NotificationType.WARNING,
                 ).notify(null)
         }
+
+        GlowOverlayManager.syncGlowForAllProjects()
     }
 
     private const val KEY_PREFIX_LENGTH = 4

--- a/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
+++ b/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
@@ -174,7 +174,6 @@ class AccentRotationService : Disposable {
                     state.accentRotationLastSwitchMs =
                         System.currentTimeMillis()
                     AccentApplicator.apply(newHex.second)
-                    GlowOverlayManager.syncGlowForAllProjects()
                     LOG.info(
                         "Accent rotated: " +
                             "mode=$mode, color=${newHex.second}",
@@ -183,6 +182,15 @@ class AccentRotationService : Disposable {
                     LOG.error(
                         "Accent rotation failed: " +
                             "mode=$mode, color=${newHex.second}",
+                        exception,
+                    )
+                }
+
+                try {
+                    GlowOverlayManager.syncGlowForAllProjects()
+                } catch (exception: RuntimeException) {
+                    LOG.warn(
+                        "Glow sync after accent rotation failed",
                         exception,
                     )
                 }

--- a/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
+++ b/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
@@ -38,9 +38,10 @@ internal fun nextPresetHex(
 class AccentRotationService : Disposable {
     private val checkedDisposable: CheckedDisposable =
         Disposer.newCheckedDisposable(this)
-    private val disposed = Condition<Any?> {
-        checkedDisposable.isDisposed
-    }
+    private val disposed =
+        Condition<Any?> {
+            checkedDisposable.isDisposed
+        }
 
     @Volatile
     private var scheduledFuture: ScheduledFuture<*>? = null
@@ -153,13 +154,14 @@ class AccentRotationService : Disposable {
                             .generate(variant)
             }
 
-        val app = ApplicationManager.getApplication()
-            ?: run {
-                LOG.debug(
-                    "Rotation skipped: app shutting down",
-                )
-                return
-            }
+        val app =
+            ApplicationManager.getApplication()
+                ?: run {
+                    LOG.debug(
+                        "Rotation skipped: app shutting down",
+                    )
+                    return
+                }
         app.invokeLater(
             {
                 try {

--- a/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
+++ b/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
@@ -178,7 +178,7 @@ class AccentRotationService : Disposable {
                         "Accent rotated: " +
                             "mode=$mode, color=${newHex.second}",
                     )
-                } catch (exception: Exception) {
+                } catch (exception: RuntimeException) {
                     LOG.error(
                         "Accent rotation failed: " +
                             "mode=$mode, color=${newHex.second}",

--- a/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
+++ b/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
@@ -13,8 +13,10 @@ import dev.ayuislands.accent.AYU_ACCENT_PRESETS
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentColor
 import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
+import com.intellij.openapi.project.ProjectManager
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 
@@ -173,6 +175,9 @@ class AccentRotationService : Disposable {
                     state.accentRotationLastSwitchMs =
                         System.currentTimeMillis()
                     AccentApplicator.apply(newHex.second)
+                    for (project in ProjectManager.getInstance().openProjects) {
+                        GlowOverlayManager.getInstance(project).updateGlow()
+                    }
                     LOG.info(
                         "Accent rotated: " +
                             "mode=$mode, color=${newHex.second}",

--- a/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
+++ b/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
@@ -16,7 +16,6 @@ import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
-import com.intellij.openapi.project.ProjectManager
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 
@@ -175,9 +174,7 @@ class AccentRotationService : Disposable {
                     state.accentRotationLastSwitchMs =
                         System.currentTimeMillis()
                     AccentApplicator.apply(newHex.second)
-                    for (project in ProjectManager.getInstance().openProjects) {
-                        GlowOverlayManager.getInstance(project).updateGlow()
-                    }
+                    GlowOverlayManager.syncGlowForAllProjects()
                     LOG.info(
                         "Accent rotated: " +
                             "mode=$mode, color=${newHex.second}",

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerProDefaultsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerProDefaultsTest.kt
@@ -7,8 +7,8 @@ import com.intellij.openapi.application.ApplicationManager
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.AyuVariant
-import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.glow.GlowAnimation
+import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.glow.GlowPreset
 import dev.ayuislands.glow.GlowStyle
 import dev.ayuislands.rotation.AccentRotationService

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerProDefaultsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerProDefaultsTest.kt
@@ -4,10 +4,10 @@ import com.intellij.notification.NotificationGroup
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.project.ProjectManager
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.glow.GlowAnimation
 import dev.ayuislands.glow.GlowPreset
 import dev.ayuislands.glow.GlowStyle
@@ -276,8 +276,6 @@ class LicenseCheckerProDefaultsTest {
         every { ApplicationManager.getApplication() } returns app
         every { app.getService(AccentRotationService::class.java) } returns rotationService
 
-        // ProjectManager already mocked by mockAccentApplicator()
-
         LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
 
         verify { rotationService.stopRotation() }
@@ -303,11 +301,9 @@ class LicenseCheckerProDefaultsTest {
         every { ApplicationManager.getApplication() } returns app
         every { app.getService(AccentRotationService::class.java) } returns null
 
-        // Mock ProjectManager so glow sync loop finds no open projects
-        mockkStatic(ProjectManager::class)
-        val projectManager = mockk<ProjectManager>()
-        every { ProjectManager.getInstance() } returns projectManager
-        every { projectManager.openProjects } returns emptyArray()
+        // Mock GlowOverlayManager.syncGlowForAllProjects() (static companion method)
+        mockkObject(GlowOverlayManager.Companion)
+        every { GlowOverlayManager.syncGlowForAllProjects() } just runs
 
         // Mock NotificationGroupManager for the catch block's warning notification
         mockkStatic(NotificationGroupManager::class)
@@ -346,10 +342,8 @@ class LicenseCheckerProDefaultsTest {
         every { ApplicationManager.getApplication() } returns app
         every { app.getService(AccentRotationService::class.java) } returns null
 
-        // Mock ProjectManager so glow sync loop finds no open projects
-        mockkStatic(ProjectManager::class)
-        val projectManager = mockk<ProjectManager>()
-        every { ProjectManager.getInstance() } returns projectManager
-        every { projectManager.openProjects } returns emptyArray()
+        // Mock GlowOverlayManager.syncGlowForAllProjects() (static companion method)
+        mockkObject(GlowOverlayManager.Companion)
+        every { GlowOverlayManager.syncGlowForAllProjects() } just runs
     }
 }

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerProDefaultsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerProDefaultsTest.kt
@@ -301,7 +301,7 @@ class LicenseCheckerProDefaultsTest {
         every { ApplicationManager.getApplication() } returns app
         every { app.getService(AccentRotationService::class.java) } returns null
 
-        // Mock GlowOverlayManager.syncGlowForAllProjects() (static companion method)
+        // Mock GlowOverlayManager.syncGlowForAllProjects()
         mockkObject(GlowOverlayManager.Companion)
         every { GlowOverlayManager.syncGlowForAllProjects() } just runs
 
@@ -342,7 +342,7 @@ class LicenseCheckerProDefaultsTest {
         every { ApplicationManager.getApplication() } returns app
         every { app.getService(AccentRotationService::class.java) } returns null
 
-        // Mock GlowOverlayManager.syncGlowForAllProjects() (static companion method)
+        // Mock GlowOverlayManager.syncGlowForAllProjects()
         mockkObject(GlowOverlayManager.Companion)
         every { GlowOverlayManager.syncGlowForAllProjects() } just runs
     }

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerProDefaultsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerProDefaultsTest.kt
@@ -4,6 +4,7 @@ import com.intellij.notification.NotificationGroup
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.ProjectManager
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.AyuVariant
@@ -275,6 +276,8 @@ class LicenseCheckerProDefaultsTest {
         every { ApplicationManager.getApplication() } returns app
         every { app.getService(AccentRotationService::class.java) } returns rotationService
 
+        // ProjectManager already mocked by mockAccentApplicator()
+
         LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
 
         verify { rotationService.stopRotation() }
@@ -299,6 +302,12 @@ class LicenseCheckerProDefaultsTest {
         val app = mockk<Application>()
         every { ApplicationManager.getApplication() } returns app
         every { app.getService(AccentRotationService::class.java) } returns null
+
+        // Mock ProjectManager so glow sync loop finds no open projects
+        mockkStatic(ProjectManager::class)
+        val projectManager = mockk<ProjectManager>()
+        every { ProjectManager.getInstance() } returns projectManager
+        every { projectManager.openProjects } returns emptyArray()
 
         // Mock NotificationGroupManager for the catch block's warning notification
         mockkStatic(NotificationGroupManager::class)
@@ -336,5 +345,11 @@ class LicenseCheckerProDefaultsTest {
         val app = mockk<Application>()
         every { ApplicationManager.getApplication() } returns app
         every { app.getService(AccentRotationService::class.java) } returns null
+
+        // Mock ProjectManager so glow sync loop finds no open projects
+        mockkStatic(ProjectManager::class)
+        val projectManager = mockk<ProjectManager>()
+        every { ProjectManager.getInstance() } returns projectManager
+        every { projectManager.openProjects } returns emptyArray()
     }
 }


### PR DESCRIPTION
## Summary

- Glow overlays now stay in sync with accent color after rotation fires
- Previously, `AccentRotationService.rotateAccent()` and `LicenseChecker.revertToFreeDefaults()` called `AccentApplicator.apply()` without updating glow overlays — causing accent and glow colors to diverge
- Extracted `GlowOverlayManager.syncGlowForAllProjects()` companion method to centralize the glow sync loop (replaces duplicated loops in `AyuIslandsLafListener`, `AccentRotationService`, `LicenseChecker`)
- Narrowed `try` block in `LicenseChecker.revertToFreeDefaults()` so glow sync failures don't mask accent-apply errors
- Extracted `detachOverlayEntry()` to deduplicate `removeOverlay`/`removeAllOverlays` cleanup logic
- Simplified test mocks: mock companion method instead of `ProjectManager`

## Test plan

- [x] `./gradlew buildPlugin` passes
- [x] `./gradlew test` passes
- [x] Manual: enable accent rotation → verify glow color matches accent after rotation fires