### PR TITLE
chore: prepare v2.3.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.3.4] - 2026-03-26
+
+### Fixed
+- Fix glow color desyncing from accent after rotation
+
 ## [2.3.3] - 2026-03-25
 
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.3.3
+pluginVersion=2.3.4
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
@@ -41,6 +41,10 @@ internal object UpdateNotifier {
 
     private val RELEASE_NOTES =
         mapOf(
+            "2.3.4" to
+                "<ul>" +
+                "<li>Fix glow color desyncing from accent after rotation</li>" +
+                "</ul>",
             "2.3.3" to
                 "<ul>" +
                 "<li>Fix \u201CWrite-unsafe context\u201D crash during accent rotation with Indent Rainbow</li>" +

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -72,6 +72,10 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>2.3.4</h3>
+    <ul>
+      <li>Fix glow color desyncing from accent after rotation</li>
+    </ul>
     <h3>2.3.3</h3>
     <ul>
       <li>Fix "Write-unsafe context" crash during accent rotation with Indent Rainbow</li>


### PR DESCRIPTION
## Summary

- Bump pluginVersion to 2.3.4
- Fix glow color desyncing from accent after rotation

## Test plan

- [x] `./gradlew clean buildPlugin` passes
- [x] `./gradlew verifyPlugin` passes across 11 IDEs
- [ ] Tag `v2.3.4` after merge → CI publishes to Marketplace

## Summary by Sourcery

Prepare the 2.3.4 plugin release with an updated version and release notes.

Bug Fixes:
- Document and ship a fix for glow color desynchronizing from the accent color after rotation.

Build:
- Bump pluginVersion to 2.3.4 for the new release.

Documentation:
- Add 2.3.4 entry to the changelog and plugin change notes.