### PR TITLE
fix(accent): use opaque pre-blended selection colors to fix overlap bands (#51)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,220 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Ayu Islands is a JetBrains IDE theme plugin providing Ayu color variants with Islands UI. Theme files (JSON/XML) plus Kotlin runtime code for accent color customization.
+
+License: BSL-1.1 (converts to Apache 2.0 on 2030-02-24).
+
+## Build Commands
+
+```bash
+./gradlew buildPlugin      # Build distribution ZIP → build/distributions/
+./gradlew runIde           # Launch sandboxed IDE with plugin loaded (manual testing)
+./gradlew verifyPlugin     # Verify against IC-2025.1, IC-2025.2.3, IU-2025.3.3, PS/WS/CL-2025.3.3
+./gradlew publishPlugin    # Publish to Marketplace (requires PUBLISH_TOKEN env var)
+./gradlew test             # Run unit tests (excludes integration tests)
+./gradlew koverVerify      # Enforce 80% line coverage minimum
+```
+
+Automated tests are not required during active development. Default validation: `./gradlew buildPlugin` succeeds + manual behavior verification in `runIde`. Add automated tests only when explicitly requested.
+
+## Architecture
+
+### Two-File Theme System
+
+Each theme variant consists of exactly two files:
+
+1. **`.theme.json`** — UI theme: colors palette, Islands UI config (arc radius, border width, gaps), component styling for 750+ UI properties
+2. **`.xml`** — Editor color scheme: syntax highlighting per language, terminal colors, VCS/diff colors, console output colors
+
+They are linked: the `.theme.json` references its editor scheme via `"editorScheme": "/themes/AyuIslandsMirage.xml"`.
+
+### Registration
+
+Themes are registered in `src/main/resources/META-INF/plugin.xml` as `<themeProvider>` extensions. Each variant gets one `<themeProvider>` entry pointing to its `.theme.json`.
+
+### Current variants
+
+- **Ayu Islands Mirage** (dark): `ayu-islands-mirage.theme.json` + `AyuIslandsMirage.xml`
+- **Ayu Islands Mirage (Islands UI)**: `ayu-islands-mirage-islands.theme.json` + `AyuIslandsMirage.xml`
+- **Ayu Islands Dark**: `ayu-islands-dark.theme.json` + `AyuIslandsDark.xml`
+- **Ayu Islands Dark (Islands UI)**: `ayu-islands-dark-islands.theme.json` + `AyuIslandsDark.xml`
+- **Ayu Islands Light**: `ayu-islands-light.theme.json` + `AyuIslandsLight.xml`
+- **Ayu Islands Light (Islands UI)**: `ayu-islands-light-islands.theme.json` + `AyuIslandsLight.xml`
+
+Each color variant has two UI sub-variants. Dark variants use `ExperimentalDark`/base parent; Light variants use `ExperimentalLight`/`IntelliJ` parent. **Always apply changes to BOTH `.theme.json` files per variant.**
+
+### Color System in .theme.json
+
+The `"colors"` block defines named tokens (e.g., `"Gray1.5": "#1F2430"`, `"ForegroundDefault": "#CCCAC2"`). Other tokens can reference these by name (e.g., `"BackgroundDark": "Gray1.5"`). All UI properties in the file reference these semantic tokens — never use raw hex values in UI sections.
+
+The `"parentTheme": "ExperimentalDark"` provides the Islands Dark base; overrides are layered on top.
+
+### Color Scheme XML Structure
+
+- Dark variants: `parent_scheme="Darcula"` — inherits from Darcula, overrides specific attributes
+- Light variant: `parent_scheme="Default"` — inherits from Default (IntelliJ light), overrides specific attributes
+- Attributes use FOREGROUND, BACKGROUND, FONT_TYPE (1=bold, 2=italic, 3=bold+italic), EFFECT_TYPE, EFFECT_COLOR
+- Language-specific scopes: Java, Kotlin, Scala, C#/.NET, Rust, Go, Python, JS/TS, Ruby, PHP, Dart, HCL/Terraform, HTML, CSS, XML, JSON, YAML, Bash, Markdown, Django Templates, RegExp
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `gradle.properties` | Plugin version, sinceBuild, platform version — edit here for version bumps |
+| `src/main/resources/META-INF/plugin.xml` | Plugin descriptor, theme registration, marketplace metadata |
+| `src/main/resources/themes/ayu-islands-mirage.theme.json` | Mirage UI theme (ExperimentalDark parent) |
+| `src/main/resources/themes/ayu-islands-mirage-islands.theme.json` | Mirage UI theme (Islands Dark parent) |
+| `src/main/resources/themes/AyuIslandsMirage.xml` | Mirage editor color scheme |
+| `src/main/resources/themes/ayu-islands-dark.theme.json` | Dark UI theme (ExperimentalDark parent) |
+| `src/main/resources/themes/ayu-islands-dark-islands.theme.json` | Dark UI theme (Islands Dark parent) |
+| `src/main/resources/themes/AyuIslandsDark.xml` | Dark editor color scheme |
+| `src/main/resources/themes/ayu-islands-light.theme.json` | Light UI theme (IntelliJ parent) |
+| `src/main/resources/themes/ayu-islands-light-islands.theme.json` | Light UI theme (ExperimentalLight parent) |
+| `src/main/resources/themes/AyuIslandsLight.xml` | Light editor color scheme |
+| `build.gradle.kts` | Gradle build with `org.jetbrains.intellij.platform` v2.11.0 |
+
+## Adding a New Theme Variant
+
+1. Create `src/main/resources/themes/<name>.theme.json` with `parentTheme`, `colors`, and UI overrides
+2. Create `src/main/resources/themes/<Name>.xml` with `parent_scheme` and attribute overrides
+3. Link them: set `"editorScheme"` in the `.theme.json` to point to the `.xml`
+4. Register in `plugin.xml`: add a new `<themeProvider>` with unique `id` and `path`
+
+## CI/CD
+
+- **build.yml**: runs on push to `main` + PRs — `buildPlugin` + `verifyPlugin`, uploads ZIP artifact
+  - **Analyze** job: `./gradlew ktlintCheck detekt compileKotlin -Pkotlin.compiler.option.allWarningsAsErrors=true`
+  - **theme-consistency** job (Tier 1): runs `scripts/check-consistency.py` (XML cross-variant) and `scripts/check-json-consistency.py` (JSON pair consistency)
+- **release.yml**: triggers on `v*` tags — builds, verifies, publishes to Marketplace, creates GitHub Release
+- Required secret: `JETBRAINS_MARKETPLACE_TOKEN`
+
+## Pre-commit Hooks
+
+Hooks run via `prek` (pre-commit Rust reimplementation) through the global `core.hooksPath` → `~/.config/codex-hooks/pre-commit`. Config: `.pre-commit-config.yaml`.
+
+**Active hooks on Kotlin files:**
+- `ktlint` — code style (function signature formatting, import ordering)
+- `detekt` — static analysis (MagicNumber, complexity, naming)
+- `no-commit-to-branch` — blocks direct commits to `main`
+
+**Do NOT run `pre-commit install`** — it conflicts with global `core.hooksPath`. Hooks are already wired through `prek`. To test hooks manually: `prek run --hook-stage pre-commit`.
+
+**Before committing Kotlin changes**, always run: `./gradlew ktlintCheck detekt` to catch issues early. CI runs these with `-Pkotlin.compiler.option.allWarningsAsErrors=true` which is stricter than local defaults.
+
+## Gotchas (Lessons Learned)
+
+### Always change BOTH .theme.json files per variant
+
+Each color variant (Mirage, Dark) has TWO UI sub-variants: one with `parentTheme: "ExperimentalDark"` and one with `parentTheme: "Islands Dark"`. The user may have either active. **If you only edit one file, the change will be invisible if the user is on the other sub-variant.** This was the root cause of hours of debugging where changes "didn't work".
+
+### Testing theme changes in a running IDE
+
+1. **Always delete BOTH `build/` AND `.gradle/`** — Gradle's `.gradle/` directory caches incremental Kotlin compilation that survives `clean`, `--no-build-cache`, and `--rerun-tasks`. Only `rm -rf .gradle` guarantees a fresh compile.
+2. Build and install:
+   ```bash
+   rm -rf build .gradle
+   ./gradlew buildPlugin --no-build-cache --rerun-tasks
+   ```
+3. **Verify bytecode before deploying** — `javap -c -p <Class>.class | grep -c "<ExpectedSymbol>"` on the built JAR. If count is 0, the build used stale cache.
+4. Install directly to plugins dir and restart:
+   ```bash
+   rm -rf "$PYCHARM_PLUGINS/ayu-jetbrains"
+   unzip -o build/distributions/*.zip -d "$PYCHARM_PLUGINS/"
+   pkill -f "PyCharm" && sleep 3 && open -a "PyCharm"
+   ```
+   Where `PYCHARM_PLUGINS` = `~/Library/Application Support/JetBrains/PyCharm<version>/plugins`
+3. If changes still invisible, delete cached editor schemes:
+   ```bash
+   rm -f "$PYCHARM_COLORS/_@user_Ayu Islands Dark.icls"
+   ```
+   Where `PYCHARM_COLORS` = `~/Library/Application Support/JetBrains/PyCharm<version>/colors`
+
+### Use diagnostic markers to verify theme loading
+
+When debugging, set a UI element to an unmissable color (e.g. `StatusBar.background: "#FF6A00"` — bright orange). If the marker doesn't appear after install+restart, the theme file isn't being loaded.
+
+### .theme.json controls UI chrome, .xml controls editor text
+
+- **`.theme.json`** → UI elements: tables, lists, tool windows, popups, status bar
+- **`.xml` editor scheme** → code syntax, terminal, diff colors, inline annotations
+- **Git Log** commit text uses `Table.foreground` from `.theme.json` (NOT the XML scheme)
+- PyCharm caches editor schemes as `_@user_*.icls` files in the `colors/` directory — these override plugin XML
+
+### ProjectView hide-path uses Registry, NOT ProjectViewState
+
+- **`ProjectViewImpl.isShowURL()`** reads directly from `Registry.is("project.tree.structure.show.url")` — confirmed by bytecode decompilation of `app-client.jar` in IC-2025.2
+- `ProjectViewState.showURL` is **NOT read** by the Project View renderer — it's a separate per-project persistence that doesn't affect rendering
+- **Registry keys persist** across IDE restarts in `options/ide.general.xml` — always use `Registry.get(key).resetToDefault()` for cleanup, never track originals in instance fields (fields die on restart, Registry survives)
+- VCS annotations (branch name, file count) are handled by `RootFilteringRenderer` wrapper — separate from path visibility
+- **Always decompile with `javap -c`** before trusting SO/docs about JetBrains internal APIs: `jar xf app-client.jar com/intellij/.../TargetClass.class && javap -c TargetClass.class`
+
+### AccentApplicator runtime rules
+
+- **NEVER use `SwingUtilities.updateComponentTreeUI()`** — triggers ActionToolbar.updateUI → "Slow operations on EDT" SEVERE crash. Use `window.repaint()` instead
+- `ProjectActivity.execute()` runs on a background coroutine — wrap EDT operations in `SwingUtilities.invokeLater`
+- When UIManager changes "don't work": check `idea.log` for SEVERE **before** debugging keys or theme files
+- **Editor scrollbars bypass UIManager** — `OpaqueAwareScrollBar` installs `ColorKey.FUNCTION_KEY` that resolves colors from `EditorColorsScheme.getColor()` instead of UIManager. Must set scrollbar colors in BOTH UIManager (tool windows) AND `EditorColorsManager.getInstance().globalScheme.setColor(ColorKey.find(key), color)` (editor)
+
+### Tool window auto-fit architecture
+
+- `ToolWindowAutoFitter` (in `dev.ayuislands.toolwindow`) is a reusable utility: pass `toolWindowId`, `minWidth`, and `maxWidthProvider` lambda. Used by both `ProjectViewScrollbarManager` and `CommitPanelAutoFitManager`.
+- To add auto-fit for a new tool window: create a `@Service(Service.Level.PROJECT)` that instantiates `ToolWindowAutoFitter`, subscribes to `ToolWindowManagerListener`, and registers in `plugin.xml` + `AyuIslandsStartupActivity`.
+- Known tool window IDs: `"Project"` (min 253px), `"Commit"` (min 269px), `"Version Control"` (min 269px). Min widths are empirical — measured from toolbar icon overlap threshold.
+- **Git tool window ID is `"Version Control"`, not `"Git"`** — despite the UI label showing "Git", `ToolWindowManager.getInstance(project).getToolWindow("Git")` returns null. Always use `"Version Control"` as the ID.
+- **`Splitter.firstComponent`/`secondComponent` can be null** — tool window panels are lazy-loaded. When traversing a `Splitter` hierarchy (e.g. Git panel's branches/files split), always null-check both components. They may not exist until the user expands that section.
+
+### macOS path gotchas
+
+- Zsh glob with `~` fails when path contains spaces (`~/Library/Application Support/JetBrains/*/plugins/` → "no matches found"). Use `find "$HOME/Library" ...` or explicit `/Users/cloud/...` with double quotes instead.
+
+### Verify installed JAR matches source
+
+`unzip -o` can silently fail to overwrite. After installing plugin to PyCharm, verify bytecode:
+```bash
+cd /tmp && jar xf "$PYCHARM_PLUGINS/ayu-jetbrains/lib/ayu-jetbrains-*.jar" dev/ayuislands/accent/AccentApplicator.class && javap -c -p dev/ayuislands/accent/AccentApplicator.class | grep -A2 "keyword"
+```
+
+### Color token system
+
+Two foreground tiers:
+- `ForegroundDefault` (#9DA5B0) — muted, for general UI text including tables
+- `ForegroundBright` (#BFBDB6) — bright, for overlays (popups, tooltips, notifications, selected states)
+
+All UI foreground values should reference these tokens, not hardcoded hex. The only exception is `TrialWidget.Default.borderColor` (border, not foreground).
+
+## Changelog Rules (plugin.xml, CHANGELOG.md, UpdateNotifier)
+
+- **User-facing only** — changelog entries describe what changes FOR THE USER, not internal code details
+- No implementation details (API names, class renames, refactors, code centralization) — users don't care
+- No "fix compilation errors", "centralize X into Y", "rewrite internals" — invisible to users
+- Good: "Fix glow color desyncing from accent after rotation"
+- Bad: "Centralize glow sync into GlowOverlayManager.syncGlowForAllProjects()"
+
+## Development Philosophy
+
+- **New features are premium by default** — the free tier (6 themes, accent presets, font presets) is already generous. All new functionality should be gated behind `LicenseChecker.isLicensedOrGrace()` unless the user explicitly marks it as free. This applies to new settings, integrations, and UI enhancements alike.
+- Breaking changes are acceptable when they improve architecture and code clarity
+- Prefer direct refactors over compatibility shims, fallback paths, or migration layers unless explicitly requested
+- Automated tests only when explicitly requested — default validation is manual + successful build
+- **Coverage excludes must be justified** — only exclude truly untestable classes (IDE singletons like `EditorColorsManager`, pure Swing rendering panels). Domain logic adjacent to IDE glue must be extracted into testable files, not excluded.
+- **NEVER use `@Suppress` to hide lint/detekt warnings** — fix the root cause instead (extract constants, restructure code, etc.). The only exception is when the user explicitly asks for a suppression.
+- **Avoid releasing with deprecated or experimental API warnings.** Before every release, run `./gradlew verifyPlugin` and review `deprecated-usages.txt` / `experimental-api-usages.txt` in `build/reports/pluginVerifier/`. Replace deprecated APIs with their non-deprecated alternatives. When replacing, verify the alternative exists in the target `platformVersion` (decompile with `javap` from Gradle cache). Experimental API usage (`UIThemeLookAndFeelInfo`, `LafManager.getInstalledThemes`) is unavoidable — it's the core theme API with no alternative.
+
+## Git Workflow
+
+- **Never commit directly to `main`** — pre-commit hook enforces this
+- All work happens on feature branches (e.g. `feat/issue-templates`, `fix/scrollbar-color`)
+- Merge to `main` only through Pull Requests
+- Release tags (`v*`) are created on `main` after PR merge
+
+## Conventions
+
+- Commit messages: conventional commits (`feat:`, `fix:`, `chore:`)
+- Java 21 target (required by platform 2025.1+)
+- `buildSearchableOptions` is disabled (accent settings use runtime application, not indexed options)
+- `untilBuild` is explicitly null — plugin supports future IDE versions without upper bound
+- **Never commit `.planning/` to the repository** — planning/state docs (ROADMAP.md, STATE.md, PLAN.md, SUMMARY.md, etc.) are local-only and excluded via global gitignore. Never use `git add -f` to force-add them.

--- a/src/main/kotlin/dev/ayuislands/accent/elements/SearchResultsElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/SearchResultsElement.kt
@@ -12,16 +12,17 @@ class SearchResultsElement : AccentElement {
     private data class SelectionKey(
         val key: String,
         val alpha: Int,
+        val backgroundKey: String,
     )
 
     private val selectionKeys =
         listOf(
-            SelectionKey("List.selectionBackground", ACTIVE_ALPHA),
-            SelectionKey("List.selectionInactiveBackground", INACTIVE_ALPHA),
-            SelectionKey("Tree.selectionBackground", ACTIVE_ALPHA),
-            SelectionKey("Tree.selectionInactiveBackground", INACTIVE_ALPHA),
-            SelectionKey("Table.selectionBackground", ACTIVE_ALPHA),
-            SelectionKey("Table.selectionInactiveBackground", INACTIVE_ALPHA),
+            SelectionKey("List.selectionBackground", ACTIVE_ALPHA, "List.background"),
+            SelectionKey("List.selectionInactiveBackground", INACTIVE_ALPHA, "List.background"),
+            SelectionKey("Tree.selectionBackground", ACTIVE_ALPHA, "Tree.background"),
+            SelectionKey("Tree.selectionInactiveBackground", INACTIVE_ALPHA, "Tree.background"),
+            SelectionKey("Table.selectionBackground", ACTIVE_ALPHA, "Table.background"),
+            SelectionKey("Table.selectionInactiveBackground", INACTIVE_ALPHA, "Table.background"),
         )
 
     companion object {
@@ -31,8 +32,20 @@ class SearchResultsElement : AccentElement {
 
     override fun apply(color: Color) {
         for (selection in selectionKeys) {
-            UIManager.put(selection.key, Color(color.red, color.green, color.blue, selection.alpha))
+            UIManager.put(selection.key, blendWithBackground(color, selection.alpha, selection.backgroundKey))
         }
+    }
+
+    private fun blendWithBackground(accent: Color, alpha: Int, backgroundKey: String): Color {
+        val bg = UIManager.getColor(backgroundKey)
+            ?: UIManager.getColor("Panel.background")
+            ?: Color.BLACK
+        val ratio = alpha / 255f
+        return Color(
+            (bg.red + (accent.red - bg.red) * ratio + 0.5f).toInt(),
+            (bg.green + (accent.green - bg.green) * ratio + 0.5f).toInt(),
+            (bg.blue + (accent.blue - bg.blue) * ratio + 0.5f).toInt(),
+        )
     }
 
     override fun revert() {

--- a/src/main/kotlin/dev/ayuislands/accent/elements/SearchResultsElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/SearchResultsElement.kt
@@ -12,17 +12,16 @@ class SearchResultsElement : AccentElement {
     private data class SelectionKey(
         val key: String,
         val alpha: Int,
-        val backgroundKey: String,
     )
 
     private val selectionKeys =
         listOf(
-            SelectionKey("List.selectionBackground", ACTIVE_ALPHA, "List.background"),
-            SelectionKey("List.selectionInactiveBackground", INACTIVE_ALPHA, "List.background"),
-            SelectionKey("Tree.selectionBackground", ACTIVE_ALPHA, "Tree.background"),
-            SelectionKey("Tree.selectionInactiveBackground", INACTIVE_ALPHA, "Tree.background"),
-            SelectionKey("Table.selectionBackground", ACTIVE_ALPHA, "Table.background"),
-            SelectionKey("Table.selectionInactiveBackground", INACTIVE_ALPHA, "Table.background"),
+            SelectionKey("List.selectionBackground", ACTIVE_ALPHA),
+            SelectionKey("List.selectionInactiveBackground", INACTIVE_ALPHA),
+            SelectionKey("Tree.selectionBackground", ACTIVE_ALPHA),
+            SelectionKey("Tree.selectionInactiveBackground", INACTIVE_ALPHA),
+            SelectionKey("Table.selectionBackground", ACTIVE_ALPHA),
+            SelectionKey("Table.selectionInactiveBackground", INACTIVE_ALPHA),
         )
 
     companion object {
@@ -32,19 +31,20 @@ class SearchResultsElement : AccentElement {
 
     override fun apply(color: Color) {
         for (selection in selectionKeys) {
-            UIManager.put(selection.key, blendWithBackground(color, selection.alpha, selection.backgroundKey))
+            val backgroundKey = selection.key.substringBefore(".selection") + ".background"
+            UIManager.put(selection.key, blendWithBackground(color, selection.alpha, backgroundKey))
         }
     }
 
     private fun blendWithBackground(accent: Color, alpha: Int, backgroundKey: String): Color {
         val bg = UIManager.getColor(backgroundKey)
             ?: UIManager.getColor("Panel.background")
-            ?: Color.BLACK
+            ?: accent
         val ratio = alpha / 255f
         return Color(
-            (bg.red + (accent.red - bg.red) * ratio + 0.5f).toInt(),
-            (bg.green + (accent.green - bg.green) * ratio + 0.5f).toInt(),
-            (bg.blue + (accent.blue - bg.blue) * ratio + 0.5f).toInt(),
+            (bg.red + (accent.red - bg.red) * ratio + 0.5f).toInt().coerceIn(0, 255),
+            (bg.green + (accent.green - bg.green) * ratio + 0.5f).toInt().coerceIn(0, 255),
+            (bg.blue + (accent.blue - bg.blue) * ratio + 0.5f).toInt().coerceIn(0, 255),
         )
     }
 

--- a/src/main/kotlin/dev/ayuislands/accent/elements/SearchResultsElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/SearchResultsElement.kt
@@ -27,6 +27,8 @@ class SearchResultsElement : AccentElement {
     companion object {
         private const val ACTIVE_ALPHA = 0x26
         private const val INACTIVE_ALPHA = 0x1A
+        private const val MAX_CHANNEL_VALUE = 255
+        private const val ROUNDING_BIAS = 0.5f
     }
 
     override fun apply(color: Color) {
@@ -36,15 +38,20 @@ class SearchResultsElement : AccentElement {
         }
     }
 
-    private fun blendWithBackground(accent: Color, alpha: Int, backgroundKey: String): Color {
-        val bg = UIManager.getColor(backgroundKey)
-            ?: UIManager.getColor("Panel.background")
-            ?: accent
-        val ratio = alpha / 255f
+    private fun blendWithBackground(
+        accent: Color,
+        alpha: Int,
+        backgroundKey: String,
+    ): Color {
+        val bg =
+            UIManager.getColor(backgroundKey)
+                ?: UIManager.getColor("Panel.background")
+                ?: accent
+        val ratio = alpha.toFloat() / MAX_CHANNEL_VALUE
         return Color(
-            (bg.red + (accent.red - bg.red) * ratio + 0.5f).toInt().coerceIn(0, 255),
-            (bg.green + (accent.green - bg.green) * ratio + 0.5f).toInt().coerceIn(0, 255),
-            (bg.blue + (accent.blue - bg.blue) * ratio + 0.5f).toInt().coerceIn(0, 255),
+            (bg.red + (accent.red - bg.red) * ratio + ROUNDING_BIAS).toInt().coerceIn(0, MAX_CHANNEL_VALUE),
+            (bg.green + (accent.green - bg.green) * ratio + ROUNDING_BIAS).toInt().coerceIn(0, MAX_CHANNEL_VALUE),
+            (bg.blue + (accent.blue - bg.blue) * ratio + ROUNDING_BIAS).toInt().coerceIn(0, MAX_CHANNEL_VALUE),
         )
     }
 

--- a/src/test/kotlin/dev/ayuislands/accent/elements/AccentElementsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/AccentElementsTest.kt
@@ -627,6 +627,69 @@ class AccentElementsTest {
         verify { BracketFadeManager.deactivate() }
     }
 
+    // SearchResultsElement blend coverage
+
+    @Test
+    fun `SearchResultsElement apply produces opaque blended colors`() {
+        val treeBg = Color(31, 36, 48) // typical dark theme Tree.background
+        every { UIManager.getColor("Tree.background") } returns treeBg
+        every { UIManager.getColor("List.background") } returns treeBg
+        every { UIManager.getColor("Table.background") } returns treeBg
+
+        val colorSlots = mutableListOf<Any?>()
+        every { UIManager.put(any<String>(), captureNullable(colorSlots)) } returns null
+
+        val element = SearchResultsElement()
+        element.apply(testColor)
+
+        val colors = colorSlots.filterIsInstance<Color>()
+        assertTrue(colors.isNotEmpty(), "Should have put Color values into UIManager")
+        for (color in colors) {
+            assertEquals(
+                255,
+                color.alpha,
+                "Selection color must be opaque (alpha=255), got ${color.alpha}",
+            )
+        }
+    }
+
+    @Test
+    fun `SearchResultsElement apply falls back to Panel background`() {
+        every { UIManager.getColor("Tree.background") } returns null
+        every { UIManager.getColor("List.background") } returns null
+        every { UIManager.getColor("Table.background") } returns null
+        every { UIManager.getColor("Panel.background") } returns Color(30, 30, 30)
+
+        val colorSlots = mutableListOf<Any?>()
+        every { UIManager.put(any<String>(), captureNullable(colorSlots)) } returns null
+
+        val element = SearchResultsElement()
+        element.apply(testColor)
+
+        val colors = colorSlots.filterIsInstance<Color>()
+        assertTrue(colors.isNotEmpty(), "Should produce colors even with fallback")
+        for (color in colors) {
+            assertEquals(255, color.alpha, "Fallback colors must be opaque")
+        }
+    }
+
+    @Test
+    fun `SearchResultsElement apply falls back to accent when no background available`() {
+        every { UIManager.getColor(any<String>()) } returns null
+
+        val colorSlots = mutableListOf<Any?>()
+        every { UIManager.put(any<String>(), captureNullable(colorSlots)) } returns null
+
+        val element = SearchResultsElement()
+        element.apply(testColor)
+
+        val colors = colorSlots.filterIsInstance<Color>()
+        assertTrue(colors.isNotEmpty(), "Should produce colors with accent fallback")
+        for (color in colors) {
+            assertEquals(255, color.alpha, "Accent-fallback colors must be opaque")
+        }
+    }
+
     // AccentElementId enum coverage
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #51 — visible horizontal bands between adjacent selected rows in Tree/List/Table views when accent color is active.

## Root Cause

`SearchResultsElement.apply()` set UIManager selection colors with **alpha transparency** (`Color(r, g, b, alpha=0x26)`). JetBrains' `DefaultTreeUI.paint()` renders multi-row selection by painting overlapping rounded rect + corner-fill rect. With semi-transparent colors, the overlap zone gets **double-painted** → visible darker horizontal bands.

## Fix

Replace alpha-based `Color(r, g, b, alpha)` with **opaque pre-blended color**: `blend(accent, componentBackground, alpha/255f)`. The visual result on the theme background is identical, but opaque colors eliminate double-paint artifacts.

- Added `blendWithBackground()` helper that resolves component background from UIManager (e.g., `Tree.background`) and computes the opaque blend
- Updated `SelectionKey` to carry the background key for each component type
- All 6 selection keys affected: List/Tree/Table × active/inactive

## Test Plan

- [x] Set any accent color in Ayu Islands settings
- [x] In Project tree, Shift+click to select multiple adjacent rows
- [x] Verify no visible horizontal bands between selected rows
- [x] Verify selection color still matches accent tint
- [x] Single-row selection looks the same as before
- [x] Test with both focused and unfocused tree windows

## Summary by Sourcery

Update accent-based selection colors to avoid visual artifacts when multiple rows are selected.

Bug Fixes:
- Remove horizontal banding artifacts between adjacent selected rows by using opaque, pre-blended selection colors instead of semi-transparent ones.

Enhancements:
- Derive selection colors by blending the accent color with the appropriate component background for lists, trees, and tables.