### PR TITLE
chore: prepare v2.3.5 release (#85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.3.5] - 2026-03-26
+
+### Fixed
+- Fix selection overlap bands when accent color is active on multi-row selections
+
 ## [2.3.4] - 2026-03-26
 
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.3.4
+pluginVersion=2.3.5
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -72,6 +72,10 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>2.3.5</h3>
+    <ul>
+      <li>Fix selection overlap bands when accent color is active on multi-row selections</li>
+    </ul>
     <h3>2.3.4</h3>
     <ul>
       <li>Fix glow color desyncing from accent after rotation</li>


### PR DESCRIPTION
## Summary

- Bump version to 2.3.5
- Add changelog entry for selection overlap fix
- Closes #51

## Changes

- Fix selection overlap bands when accent color is active on multi-row selections

## Summary by Sourcery

Prepare the 2.3.5 plugin release with updated metadata and notes.

Bug Fixes:
- Correct selection overlap bands when the accent color is active on multi-row selections.

Build:
- Bump plugin version to 2.3.5 in build configuration and plugin metadata.

Documentation:
- Add 2.3.5 entry to the changelog documenting the selection overlap fix.