### PR TITLE
docs: add Code of Conduct and Security Policy

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,84 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [GitHub Discussions](https://github.com/barad1tos/ayu-jetbrains/discussions). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,53 @@
+# Security Policy
+
+## Scope
+
+Ayu Islands is a JetBrains IDE **UI theme plugin**. It contains no networking code, no data storage, and no authentication logic. The relevant security surface is limited to:
+
+- Malicious code injection via theme JSON/XML definition files
+- Supply chain attacks through Gradle dependencies
+- Plugin distribution integrity (JetBrains Marketplace signing and verification)
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| 2.x.x   | Yes      |
+| < 2.0   | No       |
+
+Only the latest major release line receives security fixes.
+
+## Reporting a Vulnerability
+
+**Preferred: GitHub Private Vulnerability Reporting**
+
+Use the ["Report a vulnerability"](https://github.com/barad1tos/ayu-jetbrains/security/advisories/new) button in this repository's Security tab. This keeps your report confidential until a fix is available.
+
+Please include:
+- Description of the vulnerability
+- Steps to reproduce
+- Affected versions
+- Potential impact
+
+## What to Expect
+
+- Acknowledgment within **7 days**
+- Assessment and response within **30 days**
+- For confirmed issues: a fix in the next release
+- Credit in the changelog (unless you prefer anonymity)
+
+## What Qualifies
+
+- Code injection vectors in theme definition files
+- Dependency vulnerabilities in the Gradle build chain
+- Issues with plugin signing or distribution integrity
+
+## What Does NOT Qualify
+
+- Cosmetic bugs (wrong colors, UI glitches) — use [regular issue templates](https://github.com/barad1tos/ayu-jetbrains/issues/new/choose)
+- JetBrains IDE vulnerabilities — report those to [JetBrains](https://www.jetbrains.com/privacy-security/)
+- Theoretical attacks requiring physical access to the developer's machine
+
+## Bug Bounty
+
+This is a solo-developer open source project. There is no monetary bug bounty, but confirmed reporters will be credited in the release notes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thanks for your interest in contributing! Whether it's a bug fix, a new language highlight, or a color tweak — all contributions are welcome.
 
+By participating, you agree to uphold our [Code of Conduct](.github/CODE_OF_CONDUCT.md).
+
 ## Getting Started
 
 1. Fork the repository and clone it locally


### PR DESCRIPTION
## Summary
- Add Contributor Covenant v2.1 as `.github/CODE_OF_CONDUCT.md` with GitHub Discussions as enforcement contact
- Add `.github/SECURITY.md` scoped for a theme plugin (private vulnerability reporting, supported versions, response timeline)
- Cross-reference CoC from `CONTRIBUTING.md`

Closes the two remaining items on the [Community Standards](https://github.com/barad1tos/ayu-jetbrains/community) checklist.

## Manual step after merge
Enable **Private Vulnerability Reporting** in repo Settings > Security for the SECURITY.md "Report a vulnerability" link to work.

## Test plan
- [x] Verify green checkmarks on `/community` page after merge
- [x] Verify "Report a vulnerability" button appears in Security tab (after enabling the setting)

## Summary by Sourcery

Add community and security governance documentation for the project.

Documentation:
- Introduce a Contributor Covenant v2.1 Code of Conduct with GitHub Discussions as the enforcement contact.
- Add a SECURITY policy detailing scope, supported versions, reporting process, and response expectations for vulnerabilities.
- Reference the Code of Conduct from CONTRIBUTING guidelines for contributors.