### PR TITLE
fix(docs): correct 'Island UI' typo to 'Islands UI'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ By participating, you agree to uphold our [Code of Conduct](.github/CODE_OF_COND
 
 Each color variant (Mirage, Dark, Light) has **two** `.theme.json` files:
 - Base variant (e.g. `ayu-islands-mirage.theme.json`)
-- Island UI variant (e.g. `ayu-islands-mirage-islands.theme.json`)
+- Islands UI variant (e.g. `ayu-islands-mirage-islands.theme.json`)
 
 **Always edit both files** when making color changes — users may have either variant active.
 


### PR DESCRIPTION
## Summary

- Fix inconsistent naming: 'Island UI' → 'Islands UI' in CONTRIBUTING.md
- Addresses Sourcery review comment from #89

## Test plan

- [ ] Verify CONTRIBUTING.md renders correctly

## Summary by Sourcery

Documentation:
- Fix CONTRIBUTING.md to consistently refer to the "Islands UI" variant.