### PR TITLE
fix: increase glow test coverage, suppress unstable API

### DIFF
--- a/src/main/kotlin/dev/ayuislands/AppearanceSyncService.kt
+++ b/src/main/kotlin/dev/ayuislands/AppearanceSyncService.kt
@@ -53,6 +53,7 @@ class AppearanceSyncService {
         LOG.info("Recorded manual appearance choice: $themeName")
     }
 
+    @Suppress("UnstableApiUsage") // installedThemes, UIThemeLookAndFeelInfo — no stable alternative
     private fun switchToTheme(targetThemeName: String) {
         val lafManager = LafManager.getInstance()
         val currentThemeName = AyuVariant.currentThemeName()

--- a/src/main/kotlin/dev/ayuislands/accent/elements/BracketFadeManager.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/BracketFadeManager.kt
@@ -85,7 +85,7 @@ object BracketFadeManager {
 
         val project = editor.project ?: return
 
-        // PSI access requires ReadAction (EDT alone is insufficient since 2025.1 threading model)
+        // PSI access requires ReadAction (EDT alone is not enough since 2025.1 threading model)
         val bracketRange =
             try {
                 ReadAction.compute<IntArray?, RuntimeException> {

--- a/src/test/kotlin/dev/ayuislands/glow/EditorTabGeometryTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/EditorTabGeometryTest.kt
@@ -1,10 +1,12 @@
 package dev.ayuislands.glow
 
 import java.awt.Color
+import javax.swing.JComponent
 import javax.swing.JLabel
 import javax.swing.JPanel
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class EditorTabGeometryTest {
     @Test
@@ -14,9 +16,7 @@ class EditorTabGeometryTest {
 
     @Test
     fun `calculateTabStripHeight returns default for empty host`() {
-        val emptyHost = JPanel()
-
-        val height = EditorTabGeometry.calculateTabStripHeight(emptyHost)
+        val height = EditorTabGeometry.calculateTabStripHeight(JPanel())
         assertEquals(EditorTabGeometry.DEFAULT_TAB_HEIGHT, height)
     }
 
@@ -29,7 +29,31 @@ class EditorTabGeometryTest {
         assertEquals(EditorTabGeometry.DEFAULT_TAB_HEIGHT, height)
     }
 
-    // Positive path (EditorTabs + TabLabel present) requires IDE component classes -- tested via runIde
+    @Test
+    fun `calculateTabStripHeight returns child y plus height when TabLabel found`() {
+        val host = JPanel()
+        // Class name contains "EditorTabs" for findChildByClassName match
+        val editorTabs = MockEditorTabs()
+        // Class name contains "TabLabel" for inner loop match
+        val tabLabel = MockTabLabel()
+        tabLabel.setBounds(0, 5, 100, 30)
+        editorTabs.add(tabLabel)
+        host.add(editorTabs)
+
+        val height = EditorTabGeometry.calculateTabStripHeight(host)
+        assertEquals(35, height) // y=5 + height=30
+    }
+
+    @Test
+    fun `calculateTabStripHeight returns default when EditorTabs present but no TabLabel child`() {
+        val host = JPanel()
+        val editorTabs = MockEditorTabs()
+        editorTabs.add(JLabel("not a tab label"))
+        host.add(editorTabs)
+
+        val height = EditorTabGeometry.calculateTabStripHeight(host)
+        assertEquals(EditorTabGeometry.DEFAULT_TAB_HEIGHT, height)
+    }
 
     @Test
     fun `safeDecodeColor returns decoded color for valid hex`() {
@@ -49,7 +73,14 @@ class EditorTabGeometryTest {
         val child = JLabel("test")
         panel.add(child)
 
-        val result = EditorTabGeometry.findEditorTabsComponent(child)
-        assertEquals(null, result)
+        assertNull(EditorTabGeometry.findEditorTabsComponent(child))
     }
+
+    // Mock classes — javaClass.name contains the substrings that
+    // ComponentHierarchyUtils.findChildByClassName matches against
+    @Suppress("unused") // Name matched via javaClass.name.contains("EditorTabs")
+    private class MockEditorTabs : JPanel()
+
+    @Suppress("unused") // Name matched via javaClass.name.contains("TabLabel")
+    private class MockTabLabel : JComponent()
 }

--- a/src/test/kotlin/dev/ayuislands/glow/FocusRingManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/FocusRingManagerTest.kt
@@ -1,5 +1,6 @@
 package dev.ayuislands.glow
 
+import java.awt.Color
 import javax.swing.JButton
 import javax.swing.JComboBox
 import javax.swing.JLabel
@@ -12,45 +13,104 @@ import kotlin.test.assertTrue
 class FocusRingManagerTest {
     @Test
     fun `isTextInputComponent returns true for JTextField`() {
-        val manager = FocusRingManager()
-        assertTrue(manager.isTextInputComponent(JTextField()))
+        assertTrue(FocusRingManager().isTextInputComponent(JTextField()))
     }
 
     @Test
     fun `isTextInputComponent returns true for JComboBox`() {
-        val manager = FocusRingManager()
-        assertTrue(manager.isTextInputComponent(JComboBox<String>()))
+        assertTrue(FocusRingManager().isTextInputComponent(JComboBox<String>()))
     }
 
     @Test
     fun `isTextInputComponent returns false for JPanel`() {
-        val manager = FocusRingManager()
-        assertFalse(manager.isTextInputComponent(JPanel()))
+        assertFalse(FocusRingManager().isTextInputComponent(JPanel()))
     }
 
     @Test
     fun `isTextInputComponent returns false for JLabel`() {
-        val manager = FocusRingManager()
-        assertFalse(manager.isTextInputComponent(JLabel()))
+        assertFalse(FocusRingManager().isTextInputComponent(JLabel()))
     }
 
     @Test
     fun `isTextInputComponent returns false for JButton`() {
-        val manager = FocusRingManager()
-        assertFalse(manager.isTextInputComponent(JButton()))
+        assertFalse(FocusRingManager().isTextInputComponent(JButton()))
     }
+
+    // Lifecycle safety tests
 
     @Test
     fun `removeFocusListeners is safe on fresh instance`() {
-        val manager = FocusRingManager()
-        manager.removeFocusListeners()
-        // No exception thrown -- safe to call on empty listener map
+        FocusRingManager().removeFocusListeners()
     }
 
     @Test
     fun `dispose is safe on fresh instance`() {
+        FocusRingManager().dispose()
+    }
+
+    // initializeFocusRingGlow / updateFocusRingGlow — exercise full code paths
+    // Window.getWindows() returns empty array in unit tests, but the methods
+    // still execute their full logic (loop body is skipped, not crashed)
+
+    @Test
+    fun `initializeFocusRingGlow completes without error`() {
+        val manager = FocusRingManager()
+        manager.initializeFocusRingGlow(
+            Color.ORANGE,
+            GlowStyle.SOFT,
+            50,
+        )
+        // No exception — method handles empty window list gracefully
+    }
+
+    @Test
+    fun `updateFocusRingGlow with enabled true completes without error`() {
+        val manager = FocusRingManager()
+        manager.updateFocusRingGlow(
+            Color.ORANGE,
+            GlowStyle.SOFT,
+            50,
+            enabled = true,
+        )
+    }
+
+    @Test
+    fun `updateFocusRingGlow with enabled false clears listeners`() {
+        val manager = FocusRingManager()
+        // First initialize, then disable
+        manager.initializeFocusRingGlow(Color.ORANGE, GlowStyle.SOFT, 50)
+        manager.updateFocusRingGlow(
+            Color.ORANGE,
+            GlowStyle.SOFT,
+            50,
+            enabled = false,
+        )
+        // No exception — disabled path removes listeners and skips window walk
+    }
+
+    @Test
+    fun `dispose after initialize completes without error`() {
+        val manager = FocusRingManager()
+        manager.initializeFocusRingGlow(Color.ORANGE, GlowStyle.SOFT, 50)
+        manager.dispose()
+    }
+
+    @Test
+    fun `double initialize is safe`() {
+        val manager = FocusRingManager()
+        manager.initializeFocusRingGlow(Color.ORANGE, GlowStyle.SOFT, 50)
+        manager.initializeFocusRingGlow(Color.RED, GlowStyle.SHARP_NEON, 80)
+    }
+
+    @Test
+    fun `update after dispose is safe`() {
         val manager = FocusRingManager()
         manager.dispose()
-        // No exception thrown -- clears empty maps
+        manager.updateFocusRingGlow(
+            Color.ORANGE,
+            GlowStyle.SOFT,
+            50,
+            enabled = true,
+        )
     }
 }


### PR DESCRIPTION
Follow-up to PR #91 — adds missing test coverage and @Suppress annotation.

## Summary by Sourcery

Increase coverage and robustness checks around glow UI utilities and align theme switching with unstable IntelliJ API usage.

Enhancements:
- Clarify threading model comment around PSI access in bracket fade handling.
- Mark theme switching logic with an UnstableApiUsage suppression to document reliance on non-stable IntelliJ APIs.

Tests:
- Expand FocusRingManager tests to cover initialization, updates, disposal, and lifecycle edge cases.
- Add EditorTabGeometry tests for tab strip height calculations with mock tab components and for safe editor tabs lookup behavior.