### PR TITLE
chore: prepare v2.3.6 release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.3.5
+pluginVersion=2.3.6
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -72,6 +72,10 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>2.3.6</h3>
+    <ul>
+      <li>Bug fixes</li>
+    </ul>
     <h3>2.3.5</h3>
     <ul>
       <li>Fix selection overlap bands when accent color is active on multi-row selections</li>


### PR DESCRIPTION
Bump version to 2.3.6, add changelog.

## Summary by Sourcery

Prepare the 2.3.6 plugin release with updated metadata and changelog entries.

New Features:
- Improve glow rendering reliability across IDE versions using defensive fallbacks.

Bug Fixes:
- Add missing ProGuard keep rules to prevent potential silent failures after obfuscation.

Build:
- Bump plugin version from 2.3.5 to 2.3.6 in build configuration.