### PR TITLE
fix(auto-fit): eliminate width oscillation on panel switch

### DIFF
--- a/src/main/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManager.kt
+++ b/src/main/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManager.kt
@@ -34,6 +34,7 @@ class CommitPanelAutoFitManager(
                     toolWindowManager: ToolWindowManager,
                     changeType: ToolWindowManagerListener.ToolWindowManagerEventType,
                 ) {
+                    if (changeType == ToolWindowManagerListener.ToolWindowManagerEventType.MovedOrResized) return
                     val tw = toolWindowManager.getToolWindow("Commit") ?: return
                     if (!tw.isVisible) return
                     val mode =

--- a/src/main/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManager.kt
+++ b/src/main/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManager.kt
@@ -34,6 +34,8 @@ class CommitPanelAutoFitManager(
                     toolWindowManager: ToolWindowManager,
                     changeType: ToolWindowManagerListener.ToolWindowManagerEventType,
                 ) {
+                    val tw = toolWindowManager.getToolWindow("Commit") ?: return
+                    if (!tw.isVisible) return
                     val mode =
                         PanelWidthMode.fromString(
                             AyuIslandsSettings.getInstance().state.commitPanelWidthMode,

--- a/src/main/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManager.kt
+++ b/src/main/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManager.kt
@@ -36,12 +36,14 @@ class GitPanelAutoFitManager(
                     toolWindowManager: ToolWindowManager,
                     changeType: ToolWindowManagerListener.ToolWindowManagerEventType,
                 ) {
+                    val tw = toolWindowManager.getToolWindow("Version Control") ?: return
+                    if (!tw.isVisible) return
                     val mode =
                         PanelWidthMode.fromString(
                             AyuIslandsSettings.getInstance().state.gitPanelWidthMode,
                         )
                     if (mode == PanelWidthMode.DEFAULT) return
-                    apply()
+                    debounceTimer.restart()
                 }
             },
         )

--- a/src/main/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManager.kt
+++ b/src/main/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManager.kt
@@ -36,6 +36,7 @@ class GitPanelAutoFitManager(
                     toolWindowManager: ToolWindowManager,
                     changeType: ToolWindowManagerListener.ToolWindowManagerEventType,
                 ) {
+                    if (changeType == ToolWindowManagerListener.ToolWindowManagerEventType.MovedOrResized) return
                     val tw = toolWindowManager.getToolWindow("Version Control") ?: return
                     if (!tw.isVisible) return
                     val mode =

--- a/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
+++ b/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
@@ -52,6 +52,7 @@ class ProjectViewScrollbarManager(
                     toolWindowManager: ToolWindowManager,
                     changeType: ToolWindowManagerListener.ToolWindowManagerEventType,
                 ) {
+                    if (changeType == ToolWindowManagerListener.ToolWindowManagerEventType.MovedOrResized) return
                     val tw = toolWindowManager.getToolWindow("Project") ?: return
                     if (!tw.isVisible) return
                     val state =

--- a/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
+++ b/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
@@ -32,6 +32,7 @@ class ProjectViewScrollbarManager(
     private var originalScrollbarPolicy: Int? = null
     private var registryKeyModified = false
     private var trackedTree: JTree? = null
+    private var lastAppliedHidePath: Boolean? = null
     private var rendererListener: PropertyChangeListener? = null
     private val autoFitter =
         ToolWindowAutoFitter(
@@ -51,6 +52,8 @@ class ProjectViewScrollbarManager(
                     toolWindowManager: ToolWindowManager,
                     changeType: ToolWindowManagerListener.ToolWindowManagerEventType,
                 ) {
+                    val tw = toolWindowManager.getToolWindow("Project") ?: return
+                    if (!tw.isVisible) return
                     val state =
                         AyuIslandsSettings.getInstance().state
                     val widthMode = PanelWidthMode.fromString(state.projectPanelWidthMode)
@@ -114,6 +117,8 @@ class ProjectViewScrollbarManager(
 
     private fun applyRootDisplay() {
         val hidePath = AyuIslandsSettings.getInstance().state.hideProjectRootPath
+        if (hidePath == lastAppliedHidePath) return
+        lastAppliedHidePath = hidePath
 
         // ProjectViewImpl.isShowURL() reads directly from this Registry key.
         // Only resetToDefault when WE changed it — don't override the user's choice.

--- a/src/main/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitter.kt
+++ b/src/main/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitter.kt
@@ -25,6 +25,7 @@ class ToolWindowAutoFitter(
     private var expansionListener: TreeExpansionListener? = null
     private var expansionTree: JTree? = null
     private var retryTimer: Timer? = null
+    private var isApplying = false
     private val debounceTimer =
         Timer(DEBOUNCE_DELAY_MS) { applyAutoFitWidth(maxWidthProvider()) }
             .apply { isRepeats = false }
@@ -84,17 +85,22 @@ class ToolWindowAutoFitter(
         toolWindow: ToolWindowEx,
         desiredWidth: Int,
     ) {
+        if (isApplying) return
         val currentWidth = toolWindow.component.width
         if (AutoFitCalculator.isJitterOnly(currentWidth, desiredWidth)) return
         if (isSharingSidebar()) return
-        val delta = desiredWidth - currentWidth
-
-        when (toolWindow.type) {
-            ToolWindowType.FLOATING, ToolWindowType.WINDOWED -> {
-                val window = SwingUtilities.getWindowAncestor(toolWindow.component) ?: return
-                window.setSize(desiredWidth, window.height)
+        isApplying = true
+        try {
+            val delta = desiredWidth - currentWidth
+            when (toolWindow.type) {
+                ToolWindowType.FLOATING, ToolWindowType.WINDOWED -> {
+                    val window = SwingUtilities.getWindowAncestor(toolWindow.component) ?: return
+                    window.setSize(desiredWidth, window.height)
+                }
+                else -> toolWindow.stretchWidth(delta)
             }
-            else -> toolWindow.stretchWidth(delta)
+        } finally {
+            isApplying = false
         }
     }
 


### PR DESCRIPTION
## Summary

- Add `MovedOrResized` changeType filter to all auto-fit stateChanged handlers — breaks the `stretchWidth → stateChanged → stretchWidth` feedback loop
- Add tool window visibility guards so managers only react to their own TW
- Add reentrancy guard (`isApplying`) in `ToolWindowAutoFitter.applyWidth()` 
- Add `lastAppliedHidePath` idempotency guard to skip redundant `updateFromRoot(true)` calls
- Route `GitPanelAutoFitManager` stateChanged through debounce timer

## Problem

When switching between tool window panels (Commit ↔ Notifications ↔ AI Chat), the sidebar width oscillated visibly (301→501→301→501...) instead of settling at the desired 401px. Confirmed via instrumented logging: 1749 cascade events per session, 502 MovedOrResized re-triggers, 84 applied width changes from a single user action.

## Test plan

- [ ] Switch between Commit, Notifications, AI Chat panels — width should settle immediately
- [ ] Auto-fit still works on tree expand/collapse in Project/Commit/Git panels
- [ ] Glow overlay follows width changes smoothly
- [ ] `grep "SEVERE.*Ayu" idea.log` — no crashes

## Summary by Sourcery

Prevent auto-fit feedback loops and redundant updates when adjusting tool window widths and visibility.

Bug Fixes:
- Eliminate width oscillation feedback loops when switching between tool window panels by guarding auto-fit application and filtering move/resize events.
- Avoid redundant project root display updates by tracking the last applied hide/show state.
- Ensure auto-fit handlers react only to visible instances of their own tool windows and debounce Git panel width adjustments to prevent cascades.