### PR TITLE
feat(workspace): add Editor scrollbar visibility controls

### DIFF
--- a/proguard-rules.pro
+++ b/proguard-rules.pro
@@ -35,6 +35,10 @@
 -keep class dev.ayuislands.projectview.ProjectViewScrollbarManager { *; }
 -keep class dev.ayuislands.projectview.ProjectViewScrollbarManager$Companion { *; }
 
+# plugin.xml: projectService (Editor scrollbar tweaks)
+-keep class dev.ayuislands.editor.EditorScrollbarManager { *; }
+-keep class dev.ayuislands.editor.EditorScrollbarManager$Companion { *; }
+
 # plugin.xml: applicationListeners
 -keep class dev.ayuislands.AyuIslandsAppListener { *; }
 -keep class dev.ayuislands.AppearanceSyncListener { *; }

--- a/src/main/kotlin/dev/ayuislands/StartupLicenseHandler.kt
+++ b/src/main/kotlin/dev/ayuislands/StartupLicenseHandler.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.commitpanel.CommitPanelAutoFitManager
+import dev.ayuislands.editor.EditorScrollbarManager
 import dev.ayuislands.gitpanel.GitPanelAutoFitManager
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.projectview.ProjectViewScrollbarManager
@@ -84,6 +85,10 @@ internal object StartupLicenseHandler {
             ) != PanelWidthMode.DEFAULT
         ) {
             ProjectViewScrollbarManager.getInstance(project)
+        }
+
+        if (state.hideEditorVScrollbar || state.hideEditorHScrollbar) {
+            EditorScrollbarManager.getInstance(project)
         }
 
         if (PanelWidthMode.fromString(

--- a/src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
+++ b/src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
@@ -33,6 +33,7 @@ class EditorScrollbarManager(
         EditorFactory.getInstance().addEditorFactoryListener(
             object : EditorFactoryListener {
                 override fun editorCreated(event: EditorFactoryEvent) {
+                    if (!LicenseChecker.isLicensedOrGrace()) return
                     val editor = event.editor
                     if (editor.project != project) return
                     applyToEditor(editor as? EditorEx ?: return)
@@ -43,11 +44,16 @@ class EditorScrollbarManager(
     }
 
     fun apply() {
-        if (!LicenseChecker.isLicensedOrGrace()) return
+        val licensed = LicenseChecker.isLicensedOrGrace()
         val editors = EditorFactory.getInstance().allEditors
         for (editor in editors) {
             if (editor.project != project) continue
-            applyToEditor(editor as? EditorEx ?: continue)
+            val editorEx = editor as? EditorEx ?: continue
+            if (licensed) {
+                applyToEditor(editorEx)
+            } else {
+                restoreEditor(editorEx.scrollPane)
+            }
         }
     }
 
@@ -79,7 +85,8 @@ class EditorScrollbarManager(
     }
 
     private fun hideScrollBar(scrollBar: JScrollBar) {
-        scrollBar.putClientProperty(ORIGINAL_PREFERRED_SIZE_KEY, scrollBar.preferredSize)
+        val originalSize = scrollBar.preferredSize?.let { Dimension(it) }
+        scrollBar.putClientProperty(ORIGINAL_PREFERRED_SIZE_KEY, originalSize)
         scrollBar.preferredSize = ZERO_SIZE
     }
 

--- a/src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
+++ b/src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
@@ -9,17 +9,25 @@ import com.intellij.openapi.editor.ex.EditorEx
 import com.intellij.openapi.project.Project
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
+import java.awt.Dimension
 import java.util.WeakHashMap
+import javax.swing.JScrollBar
 import javax.swing.JScrollPane
-import javax.swing.ScrollPaneConstants
 
-/** Per-project service that manages editor scrollbar visibility. */
+/**
+ * Per-project service that manages editor scrollbar visibility.
+ *
+ * Instead of setting the scroll policy to NEVER (which disables scrolling entirely),
+ * we override the scrollbar's [JScrollBar.getPreferredSize] to return zero dimensions.
+ * This hides the scrollbar visually while preserving mouse wheel, trackpad, and
+ * keyboard scrolling.
+ */
 @Service(Service.Level.PROJECT)
 class EditorScrollbarManager(
     private val project: Project,
 ) : Disposable {
-    /** Original (vertical, horizontal) scrollbar policies keyed by scroll pane. */
-    private val originalPolicies = WeakHashMap<JScrollPane, Pair<Int, Int>>()
+    /** Scroll panes whose scrollbars have been patched, so we can restore them. */
+    private val patchedScrollPanes = WeakHashMap<JScrollPane, PatchedState>()
 
     init {
         EditorFactory.getInstance().addEditorFactoryListener(
@@ -50,41 +58,70 @@ class EditorScrollbarManager(
         val hideHorizontal = state.hideEditorHScrollbar
 
         if (hideVertical || hideHorizontal) {
-            if (scrollPane !in originalPolicies) {
-                originalPolicies[scrollPane] =
-                    Pair(
-                        scrollPane.verticalScrollBarPolicy,
-                        scrollPane.horizontalScrollBarPolicy,
-                    )
+            val patched = patchedScrollPanes.getOrPut(scrollPane) { PatchedState() }
+            if (hideVertical && !patched.verticalHidden) {
+                hideScrollBar(scrollPane.verticalScrollBar)
+                patched.verticalHidden = true
+            } else if (!hideVertical && patched.verticalHidden) {
+                restoreScrollBar(scrollPane.verticalScrollBar)
+                patched.verticalHidden = false
             }
-            if (hideVertical) {
-                scrollPane.verticalScrollBarPolicy =
-                    ScrollPaneConstants.VERTICAL_SCROLLBAR_NEVER
-            }
-            if (hideHorizontal) {
-                scrollPane.horizontalScrollBarPolicy =
-                    ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER
+            if (hideHorizontal && !patched.horizontalHidden) {
+                hideScrollBar(scrollPane.horizontalScrollBar)
+                patched.horizontalHidden = true
+            } else if (!hideHorizontal && patched.horizontalHidden) {
+                restoreScrollBar(scrollPane.horizontalScrollBar)
+                patched.horizontalHidden = false
             }
         } else {
             restoreEditor(scrollPane)
         }
     }
 
+    private fun hideScrollBar(scrollBar: JScrollBar) {
+        scrollBar.putClientProperty(ORIGINAL_PREFERRED_SIZE_KEY, scrollBar.preferredSize)
+        scrollBar.preferredSize = ZERO_SIZE
+    }
+
+    private fun restoreScrollBar(scrollBar: JScrollBar) {
+        val originalSize = scrollBar.getClientProperty(ORIGINAL_PREFERRED_SIZE_KEY) as? Dimension
+        if (originalSize != null) {
+            scrollBar.preferredSize = originalSize
+            scrollBar.putClientProperty(ORIGINAL_PREFERRED_SIZE_KEY, null)
+        }
+    }
+
     private fun restoreEditor(scrollPane: JScrollPane) {
-        val original = originalPolicies.remove(scrollPane) ?: return
-        scrollPane.verticalScrollBarPolicy = original.first
-        scrollPane.horizontalScrollBarPolicy = original.second
+        val patched = patchedScrollPanes.remove(scrollPane) ?: return
+        if (patched.verticalHidden) {
+            restoreScrollBar(scrollPane.verticalScrollBar)
+        }
+        if (patched.horizontalHidden) {
+            restoreScrollBar(scrollPane.horizontalScrollBar)
+        }
     }
 
     override fun dispose() {
-        for ((scrollPane, original) in originalPolicies) {
-            scrollPane.verticalScrollBarPolicy = original.first
-            scrollPane.horizontalScrollBarPolicy = original.second
+        for ((scrollPane, patched) in patchedScrollPanes) {
+            if (patched.verticalHidden) {
+                restoreScrollBar(scrollPane.verticalScrollBar)
+            }
+            if (patched.horizontalHidden) {
+                restoreScrollBar(scrollPane.horizontalScrollBar)
+            }
         }
-        originalPolicies.clear()
+        patchedScrollPanes.clear()
     }
 
+    private data class PatchedState(
+        var verticalHidden: Boolean = false,
+        var horizontalHidden: Boolean = false,
+    )
+
     companion object {
+        private const val ORIGINAL_PREFERRED_SIZE_KEY = "ayuIslands.originalPreferredSize"
+        private val ZERO_SIZE = Dimension(0, 0)
+
         fun getInstance(project: Project): EditorScrollbarManager =
             project.getService(
                 EditorScrollbarManager::class.java,

--- a/src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
+++ b/src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
@@ -1,0 +1,90 @@
+package dev.ayuislands.editor
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.editor.EditorFactory
+import com.intellij.openapi.editor.event.EditorFactoryEvent
+import com.intellij.openapi.editor.event.EditorFactoryListener
+import com.intellij.openapi.editor.ex.EditorEx
+import com.intellij.openapi.project.Project
+import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.settings.AyuIslandsSettings
+import java.util.WeakHashMap
+import javax.swing.JScrollPane
+import javax.swing.ScrollPaneConstants
+
+/** Per-project service that manages editor scrollbar visibility. */
+@Service(Service.Level.PROJECT)
+class EditorScrollbarManager(
+    private val project: Project,
+) : Disposable {
+    /** Original (vertical, horizontal) scrollbar policies keyed by scroll pane. */
+    private val originalPolicies = WeakHashMap<JScrollPane, Pair<Int, Int>>()
+
+    init {
+        EditorFactory.getInstance().addEditorFactoryListener(
+            object : EditorFactoryListener {
+                override fun editorCreated(event: EditorFactoryEvent) {
+                    val editor = event.editor
+                    if (editor.project != project) return
+                    applyToEditor(editor as? EditorEx ?: return)
+                }
+            },
+            this,
+        )
+    }
+
+    fun apply() {
+        if (!LicenseChecker.isLicensedOrGrace()) return
+        val editors = EditorFactory.getInstance().allEditors
+        for (editor in editors) {
+            if (editor.project != project) continue
+            applyToEditor(editor as? EditorEx ?: continue)
+        }
+    }
+
+    private fun applyToEditor(editor: EditorEx) {
+        val scrollPane = editor.scrollPane
+        val state = AyuIslandsSettings.getInstance().state
+        val hideVertical = state.hideEditorVScrollbar
+        val hideHorizontal = state.hideEditorHScrollbar
+
+        if (hideVertical || hideHorizontal) {
+            if (scrollPane !in originalPolicies) {
+                originalPolicies[scrollPane] = Pair(
+                    scrollPane.verticalScrollBarPolicy,
+                    scrollPane.horizontalScrollBarPolicy,
+                )
+            }
+            if (hideVertical) {
+                scrollPane.verticalScrollBarPolicy =
+                    ScrollPaneConstants.VERTICAL_SCROLLBAR_NEVER
+            }
+            if (hideHorizontal) {
+                scrollPane.horizontalScrollBarPolicy =
+                    ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER
+            }
+        } else {
+            restoreEditor(scrollPane)
+        }
+    }
+
+    private fun restoreEditor(scrollPane: JScrollPane) {
+        val original = originalPolicies.remove(scrollPane) ?: return
+        scrollPane.verticalScrollBarPolicy = original.first
+        scrollPane.horizontalScrollBarPolicy = original.second
+    }
+
+    override fun dispose() {
+        for ((scrollPane, original) in originalPolicies) {
+            scrollPane.verticalScrollBarPolicy = original.first
+            scrollPane.horizontalScrollBarPolicy = original.second
+        }
+        originalPolicies.clear()
+    }
+
+    companion object {
+        fun getInstance(project: Project): EditorScrollbarManager =
+            project.getService(EditorScrollbarManager::class.java)
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
+++ b/src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
@@ -51,10 +51,11 @@ class EditorScrollbarManager(
 
         if (hideVertical || hideHorizontal) {
             if (scrollPane !in originalPolicies) {
-                originalPolicies[scrollPane] = Pair(
-                    scrollPane.verticalScrollBarPolicy,
-                    scrollPane.horizontalScrollBarPolicy,
-                )
+                originalPolicies[scrollPane] =
+                    Pair(
+                        scrollPane.verticalScrollBarPolicy,
+                        scrollPane.horizontalScrollBarPolicy,
+                    )
             }
             if (hideVertical) {
                 scrollPane.verticalScrollBarPolicy =
@@ -85,6 +86,8 @@ class EditorScrollbarManager(
 
     companion object {
         fun getInstance(project: Project): EditorScrollbarManager =
-            project.getService(EditorScrollbarManager::class.java)
+            project.getService(
+                EditorScrollbarManager::class.java,
+            )
     }
 }

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -111,6 +111,10 @@ class AyuIslandsState : BaseState() {
     var hideProjectRootPath by property(false)
     var hideProjectViewHScrollbar by property(false)
 
+    // Editor scrollbar visibility
+    var hideEditorVScrollbar by property(false)
+    var hideEditorHScrollbar by property(false)
+
     /**
      * Legacy migration field — migrated to [projectPanelWidthMode] in v2.0.
      * Retained for [migrateWidthModes] to upgrade pre-v2.0 settings.
@@ -167,6 +171,7 @@ class AyuIslandsState : BaseState() {
     // Workspace tab: collapsible group expanded states
     var workspaceProjectViewExpanded by property(true)
     var workspaceCommitPanelExpanded by property(false)
+    var workspaceEditorExpanded by property(false)
     var workspaceGitPanelExpanded by property(false)
 
     // Force overrides for conflicting elements (element ID names)

--- a/src/main/kotlin/dev/ayuislands/settings/WorkspacePanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/WorkspacePanel.kt
@@ -9,6 +9,7 @@ import com.intellij.ui.dsl.builder.CollapsibleRow
 import com.intellij.ui.dsl.builder.Panel
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.commitpanel.CommitPanelAutoFitManager
+import dev.ayuislands.editor.EditorScrollbarManager
 import dev.ayuislands.gitpanel.GitPanelAutoFitManager
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.projectview.ProjectViewScrollbarManager
@@ -26,12 +27,21 @@ import javax.swing.JSpinner
 import javax.swing.SpinnerNumberModel
 import javax.swing.UIManager
 
+private const val EDITOR_TITLE = "Editor"
 private const val PROJECT_VIEW_TITLE = "Project View"
 private const val COMMIT_PANEL_TITLE = "Commit Panel"
 private const val GIT_PANEL_TITLE = "Git Panel"
 
 /** Workspace tab: tool window layout tweaks (Project View, Commit Panel, Git Panel). */
 class WorkspacePanel : AyuIslandsSettingsPanel {
+    private var pendingHideEditorVScrollbar = false
+    private var storedHideEditorVScrollbar = false
+    private var pendingHideEditorHScrollbar = false
+    private var storedHideEditorHScrollbar = false
+
+    private var hideEditorVScrollbarCheckbox: JCheckBox? = null
+    private var hideEditorHScrollbarCheckbox: JCheckBox? = null
+
     private var pendingHideRootPath = false
     private var storedHideRootPath = false
     private var pendingHideHScrollbar = false
@@ -44,6 +54,7 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
     private val commitWidth = WidthModeUiState()
     private val gitWidth = WidthModeUiState()
 
+    private var editorGroup: CollapsibleRow? = null
     private var projectViewGroup: CollapsibleRow? = null
     private var commitPanelGroup: CollapsibleRow? = null
     private var gitPanelGroup: CollapsibleRow? = null
@@ -56,6 +67,11 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
     ) {
         val state = AyuIslandsSettings.getInstance().state
         val licensed = LicenseChecker.isLicensedOrGrace()
+
+        storedHideEditorVScrollbar = state.hideEditorVScrollbar
+        pendingHideEditorVScrollbar = storedHideEditorVScrollbar
+        storedHideEditorHScrollbar = state.hideEditorHScrollbar
+        pendingHideEditorHScrollbar = storedHideEditorHScrollbar
 
         storedHideRootPath = state.hideProjectRootPath
         pendingHideRootPath = storedHideRootPath
@@ -82,6 +98,34 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
         )
 
         panel.row { comment("Customize tool window width and Project View display options.") }
+
+        editorGroup =
+            panel.collapsibleGroup(EDITOR_TITLE) {
+                row {
+                    val cb =
+                        checkBox("Hide vertical scrollbar")
+                            .comment("Remove the vertical scrollbar from the editor gutter")
+                    cb.component.isSelected = pendingHideEditorVScrollbar
+                    cb.component.isEnabled = licensed
+                    cb.component.addActionListener {
+                        pendingHideEditorVScrollbar = cb.component.isSelected
+                    }
+                    hideEditorVScrollbarCheckbox = cb.component
+                }
+                row {
+                    val cb =
+                        checkBox("Hide horizontal scrollbar")
+                            .comment("Remove the bottom scrollbar from the editor")
+                    cb.component.isSelected = pendingHideEditorHScrollbar
+                    cb.component.isEnabled = licensed
+                    cb.component.addActionListener {
+                        pendingHideEditorHScrollbar = cb.component.isSelected
+                    }
+                    hideEditorHScrollbarCheckbox = cb.component
+                }
+            }
+        editorGroup?.expanded = state.workspaceEditorExpanded
+        editorGroup?.addExpandedListener { state.workspaceEditorExpanded = it }
 
         projectViewGroup =
             panel.collapsibleGroup(PROJECT_VIEW_TITLE) {
@@ -310,7 +354,9 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
     }
 
     override fun isModified(): Boolean =
-        pendingHideRootPath != storedHideRootPath ||
+        pendingHideEditorVScrollbar != storedHideEditorVScrollbar ||
+            pendingHideEditorHScrollbar != storedHideEditorHScrollbar ||
+            pendingHideRootPath != storedHideRootPath ||
             pendingHideHScrollbar != storedHideHScrollbar ||
             projectWidth.state.isModified() ||
             commitWidth.state.isModified() ||
@@ -320,12 +366,20 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
         if (!isModified()) return
         val state = AyuIslandsSettings.getInstance().state
 
+        val editorChanged =
+            pendingHideEditorVScrollbar != storedHideEditorVScrollbar ||
+                pendingHideEditorHScrollbar != storedHideEditorHScrollbar
         val displayChanged =
             pendingHideRootPath != storedHideRootPath ||
                 pendingHideHScrollbar != storedHideHScrollbar
         val projectWidthChanged = projectWidth.state.isModified()
         val commitWidthChanged = commitWidth.state.isModified()
         val gitWidthChanged = gitWidth.state.isModified()
+
+        state.hideEditorVScrollbar = pendingHideEditorVScrollbar
+        state.hideEditorHScrollbar = pendingHideEditorHScrollbar
+        storedHideEditorVScrollbar = pendingHideEditorVScrollbar
+        storedHideEditorHScrollbar = pendingHideEditorHScrollbar
 
         state.hideProjectRootPath = pendingHideRootPath
         state.hideProjectViewHScrollbar = pendingHideHScrollbar
@@ -362,13 +416,26 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
                 )
             }
         }
+
+        if (editorChanged) {
+            for (openProject in ProjectManager.getInstance().openProjects) {
+                ApplicationManager.getApplication().invokeLater(
+                    { EditorScrollbarManager.getInstance(openProject).apply() },
+                    openProject.disposed,
+                )
+            }
+        }
     }
 
     override fun reset() {
+        pendingHideEditorVScrollbar = storedHideEditorVScrollbar
+        pendingHideEditorHScrollbar = storedHideEditorHScrollbar
         pendingHideRootPath = storedHideRootPath
         pendingHideHScrollbar = storedHideHScrollbar
 
         suppressListeners = true
+        hideEditorVScrollbarCheckbox?.isSelected = storedHideEditorVScrollbar
+        hideEditorHScrollbarCheckbox?.isSelected = storedHideEditorHScrollbar
         hideRootPathCheckbox?.isSelected = storedHideRootPath
         hideHScrollbarCheckbox?.isSelected = storedHideHScrollbar
         projectWidth.reset()

--- a/src/main/kotlin/dev/ayuislands/settings/WorkspacePanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/WorkspacePanel.kt
@@ -68,15 +68,22 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
         val state = AyuIslandsSettings.getInstance().state
         val licensed = LicenseChecker.isLicensedOrGrace()
 
-        storedHideEditorVScrollbar = state.hideEditorVScrollbar
-        pendingHideEditorVScrollbar = storedHideEditorVScrollbar
-        storedHideEditorHScrollbar = state.hideEditorHScrollbar
-        pendingHideEditorHScrollbar = storedHideEditorHScrollbar
-
-        storedHideRootPath = state.hideProjectRootPath
-        pendingHideRootPath = storedHideRootPath
-        storedHideHScrollbar = state.hideProjectViewHScrollbar
-        pendingHideHScrollbar = storedHideHScrollbar
+        loadCheckboxPair(state.hideEditorVScrollbar) { s, p ->
+            storedHideEditorVScrollbar = s
+            pendingHideEditorVScrollbar = p
+        }
+        loadCheckboxPair(state.hideEditorHScrollbar) { s, p ->
+            storedHideEditorHScrollbar = s
+            pendingHideEditorHScrollbar = p
+        }
+        loadCheckboxPair(state.hideProjectRootPath) { s, p ->
+            storedHideRootPath = s
+            pendingHideRootPath = p
+        }
+        loadCheckboxPair(state.hideProjectViewHScrollbar) { s, p ->
+            storedHideHScrollbar = s
+            pendingHideHScrollbar = p
+        }
 
         projectWidth.state.load(
             PanelWidthMode.fromString(state.projectPanelWidthMode),
@@ -101,56 +108,40 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
 
         editorGroup =
             panel.collapsibleGroup(EDITOR_TITLE) {
-                row {
-                    val cb =
-                        checkBox("Hide vertical scrollbar")
-                            .comment("Remove the vertical scrollbar from the editor gutter")
-                    cb.component.isSelected = pendingHideEditorVScrollbar
-                    cb.component.isEnabled = licensed
-                    cb.component.addActionListener {
-                        pendingHideEditorVScrollbar = cb.component.isSelected
-                    }
-                    hideEditorVScrollbarCheckbox = cb.component
-                }
-                row {
-                    val cb =
-                        checkBox("Hide horizontal scrollbar")
-                            .comment("Remove the bottom scrollbar from the editor")
-                    cb.component.isSelected = pendingHideEditorHScrollbar
-                    cb.component.isEnabled = licensed
-                    cb.component.addActionListener {
-                        pendingHideEditorHScrollbar = cb.component.isSelected
-                    }
-                    hideEditorHScrollbarCheckbox = cb.component
-                }
+                hideEditorVScrollbarCheckbox =
+                    buildCheckboxRow(
+                        "Hide vertical scrollbar",
+                        "Remove the vertical scrollbar from the editor gutter",
+                        pendingHideEditorVScrollbar,
+                        licensed,
+                    ) { pendingHideEditorVScrollbar = it }
+                hideEditorHScrollbarCheckbox =
+                    buildCheckboxRow(
+                        "Hide horizontal scrollbar",
+                        "Remove the bottom scrollbar from the editor",
+                        pendingHideEditorHScrollbar,
+                        licensed,
+                    ) { pendingHideEditorHScrollbar = it }
             }
         editorGroup?.expanded = state.workspaceEditorExpanded
         editorGroup?.addExpandedListener { state.workspaceEditorExpanded = it }
 
         projectViewGroup =
             panel.collapsibleGroup(PROJECT_VIEW_TITLE) {
-                row {
-                    val cb =
-                        checkBox("Hide filesystem path")
-                            .comment("Remove the directory path shown next to the project name")
-                    cb.component.isSelected = pendingHideRootPath
-                    cb.component.isEnabled = licensed
-                    cb.component.addActionListener {
-                        pendingHideRootPath = cb.component.isSelected
-                    }
-                    hideRootPathCheckbox = cb.component
-                }
-                row {
-                    val cb =
-                        checkBox("Hide horizontal scrollbar")
-                            .comment("Remove the bottom scrollbar from the Project tool window")
-                    cb.component.isSelected = pendingHideHScrollbar
-                    cb.component.isEnabled = licensed
-                    cb.component.addActionListener {
-                        pendingHideHScrollbar = cb.component.isSelected
-                    }
-                    hideHScrollbarCheckbox = cb.component
-                }
+                hideRootPathCheckbox =
+                    buildCheckboxRow(
+                        "Hide filesystem path",
+                        "Remove the directory path shown next to the project name",
+                        pendingHideRootPath,
+                        licensed,
+                    ) { pendingHideRootPath = it }
+                hideHScrollbarCheckbox =
+                    buildCheckboxRow(
+                        "Hide horizontal scrollbar",
+                        "Remove the bottom scrollbar from the Project tool window",
+                        pendingHideHScrollbar,
+                        licensed,
+                    ) { pendingHideHScrollbar = it }
                 separator()
                 buildWidthModeGroup(
                     this,
@@ -391,39 +382,16 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
         applyWidthState(gitWidth, state.gitWidthTarget())
 
         if (displayChanged || projectWidthChanged) {
-            for (openProject in ProjectManager.getInstance().openProjects) {
-                ApplicationManager.getApplication().invokeLater(
-                    { ProjectViewScrollbarManager.getInstance(openProject).apply() },
-                    openProject.disposed,
-                )
-            }
+            dispatchToOpenProjects { ProjectViewScrollbarManager.getInstance(it).apply() }
         }
-
         if (commitWidthChanged) {
-            for (openProject in ProjectManager.getInstance().openProjects) {
-                ApplicationManager.getApplication().invokeLater(
-                    { CommitPanelAutoFitManager.getInstance(openProject).apply() },
-                    openProject.disposed,
-                )
-            }
+            dispatchToOpenProjects { CommitPanelAutoFitManager.getInstance(it).apply() }
         }
-
         if (gitWidthChanged) {
-            for (openProject in ProjectManager.getInstance().openProjects) {
-                ApplicationManager.getApplication().invokeLater(
-                    { GitPanelAutoFitManager.getInstance(openProject).apply() },
-                    openProject.disposed,
-                )
-            }
+            dispatchToOpenProjects { GitPanelAutoFitManager.getInstance(it).apply() }
         }
-
         if (editorChanged) {
-            for (openProject in ProjectManager.getInstance().openProjects) {
-                ApplicationManager.getApplication().invokeLater(
-                    { EditorScrollbarManager.getInstance(openProject).apply() },
-                    openProject.disposed,
-                )
-            }
+            dispatchToOpenProjects { EditorScrollbarManager.getInstance(it).apply() }
         }
     }
 
@@ -445,6 +413,40 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
         updateGroupTitle(commitPanelGroup, COMMIT_PANEL_TITLE, commitWidth.state)
         updateGroupTitle(gitPanelGroup, GIT_PANEL_TITLE, gitWidth.state)
         suppressListeners = false
+    }
+
+    private inline fun loadCheckboxPair(
+        stateValue: Boolean,
+        assign: (stored: Boolean, pending: Boolean) -> Unit,
+    ) {
+        assign(stateValue, stateValue)
+    }
+
+    private fun Panel.buildCheckboxRow(
+        label: String,
+        comment: String,
+        initialValue: Boolean,
+        enabled: Boolean,
+        onChange: (Boolean) -> Unit,
+    ): JCheckBox {
+        lateinit var checkbox: JCheckBox
+        row {
+            val cb = checkBox(label).comment(comment)
+            cb.component.isSelected = initialValue
+            cb.component.isEnabled = enabled
+            cb.component.addActionListener { onChange(cb.component.isSelected) }
+            checkbox = cb.component
+        }
+        return checkbox
+    }
+
+    private fun dispatchToOpenProjects(action: (com.intellij.openapi.project.Project) -> Unit) {
+        for (openProject in ProjectManager.getInstance().openProjects) {
+            ApplicationManager.getApplication().invokeLater(
+                { action(openProject) },
+                openProject.disposed,
+            )
+        }
     }
 
     private fun applyWidthState(

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -164,6 +164,10 @@
         <projectService
                 serviceImplementation="dev.ayuislands.projectview.ProjectViewScrollbarManager"/>
 
+        <!-- Editor scrollbar manager (per-project lifecycle) -->
+        <projectService
+                serviceImplementation="dev.ayuislands.editor.EditorScrollbarManager"/>
+
         <!-- Commit panel auto-fit manager (per-project lifecycle) -->
         <projectService
                 serviceImplementation="dev.ayuislands.commitpanel.CommitPanelAutoFitManager"/>

--- a/src/test/kotlin/dev/ayuislands/editor/EditorScrollbarManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/editor/EditorScrollbarManagerTest.kt
@@ -1,0 +1,299 @@
+package dev.ayuislands.editor
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.EditorFactory
+import com.intellij.openapi.editor.event.EditorFactoryListener
+import com.intellij.openapi.editor.ex.EditorEx
+import com.intellij.openapi.project.Project
+import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import java.awt.Dimension
+import javax.swing.JScrollPane
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+
+class EditorScrollbarManagerTest {
+    private lateinit var project: Project
+    private lateinit var editorFactory: EditorFactory
+    private lateinit var realState: AyuIslandsState
+    private val listenerSlot = slot<EditorFactoryListener>()
+
+    private lateinit var scrollPane: JScrollPane
+    private lateinit var editorEx: EditorEx
+
+    @BeforeTest
+    fun setUp() {
+        mockkStatic(EditorFactory::class)
+        mockkObject(AyuIslandsSettings.Companion)
+        mockkObject(LicenseChecker)
+
+        realState = AyuIslandsState()
+        val settingsMock =
+            mockk<AyuIslandsSettings> {
+                every { state } returns realState
+            }
+        every { AyuIslandsSettings.getInstance() } returns settingsMock
+        every { LicenseChecker.isLicensedOrGrace() } returns true
+
+        project =
+            mockk(relaxed = true) {
+                every { isDisposed } returns false
+            }
+
+        scrollPane = JScrollPane()
+        editorEx =
+            mockk<EditorEx>(relaxed = true) {
+                every { this@mockk.project } returns this@EditorScrollbarManagerTest.project
+                every { this@mockk.scrollPane } returns this@EditorScrollbarManagerTest.scrollPane
+            }
+
+        editorFactory =
+            mockk(relaxed = true) {
+                every { allEditors } returns arrayOf(editorEx)
+                every {
+                    addEditorFactoryListener(capture(listenerSlot), any())
+                } returns Unit
+            }
+        every { EditorFactory.getInstance() } returns editorFactory
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    private fun createManager(): EditorScrollbarManager = EditorScrollbarManager(project)
+
+    @Test
+    fun `apply hides vertical scrollbar with zero preferred size`() {
+        realState.hideEditorVScrollbar = true
+        val originalSize = scrollPane.verticalScrollBar.preferredSize
+
+        val manager = createManager()
+        manager.apply()
+
+        assertEquals(Dimension(0, 0), scrollPane.verticalScrollBar.preferredSize)
+        assertNotEquals(originalSize, Dimension(0, 0))
+        manager.dispose()
+    }
+
+    @Test
+    fun `apply hides horizontal scrollbar with zero preferred size`() {
+        realState.hideEditorHScrollbar = true
+        val originalSize = scrollPane.horizontalScrollBar.preferredSize
+
+        val manager = createManager()
+        manager.apply()
+
+        assertEquals(Dimension(0, 0), scrollPane.horizontalScrollBar.preferredSize)
+        assertNotEquals(originalSize, Dimension(0, 0))
+        manager.dispose()
+    }
+
+    @Test
+    fun `apply restores scrollbar when setting disabled`() {
+        realState.hideEditorVScrollbar = true
+        val originalSize = Dimension(scrollPane.verticalScrollBar.preferredSize)
+
+        val manager = createManager()
+        manager.apply()
+        assertEquals(Dimension(0, 0), scrollPane.verticalScrollBar.preferredSize)
+
+        realState.hideEditorVScrollbar = false
+        manager.apply()
+        assertEquals(originalSize, scrollPane.verticalScrollBar.preferredSize)
+        manager.dispose()
+    }
+
+    @Test
+    fun `apply restores scrollbars when license revoked`() {
+        realState.hideEditorVScrollbar = true
+        realState.hideEditorHScrollbar = true
+        val originalVSize = Dimension(scrollPane.verticalScrollBar.preferredSize)
+        val originalHSize = Dimension(scrollPane.horizontalScrollBar.preferredSize)
+
+        val manager = createManager()
+        manager.apply()
+        assertEquals(Dimension(0, 0), scrollPane.verticalScrollBar.preferredSize)
+        assertEquals(Dimension(0, 0), scrollPane.horizontalScrollBar.preferredSize)
+
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+        manager.apply()
+
+        assertEquals(originalVSize, scrollPane.verticalScrollBar.preferredSize)
+        assertEquals(originalHSize, scrollPane.horizontalScrollBar.preferredSize)
+        manager.dispose()
+    }
+
+    @Test
+    fun `apply does not hide when not licensed`() {
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+        realState.hideEditorVScrollbar = true
+        val originalSize = Dimension(scrollPane.verticalScrollBar.preferredSize)
+
+        val manager = createManager()
+        manager.apply()
+
+        assertEquals(originalSize, scrollPane.verticalScrollBar.preferredSize)
+        manager.dispose()
+    }
+
+    @Test
+    fun `apply skips editors from other projects`() {
+        val otherProject = mockk<Project>(relaxed = true)
+        val otherEditor =
+            mockk<EditorEx>(relaxed = true) {
+                every { project } returns otherProject
+            }
+        every { editorFactory.allEditors } returns arrayOf(otherEditor)
+
+        realState.hideEditorVScrollbar = true
+
+        val manager = createManager()
+        manager.apply()
+        // No crash, no patching of other project's editors
+        manager.dispose()
+    }
+
+    @Test
+    fun `dispose restores all patched scrollbars`() {
+        realState.hideEditorVScrollbar = true
+        realState.hideEditorHScrollbar = true
+        val originalVSize = Dimension(scrollPane.verticalScrollBar.preferredSize)
+        val originalHSize = Dimension(scrollPane.horizontalScrollBar.preferredSize)
+
+        val manager = createManager()
+        manager.apply()
+
+        manager.dispose()
+
+        assertEquals(originalVSize, scrollPane.verticalScrollBar.preferredSize)
+        assertEquals(originalHSize, scrollPane.horizontalScrollBar.preferredSize)
+    }
+
+    @Test
+    fun `hideScrollBar stores defensive copy of original size`() {
+        realState.hideEditorVScrollbar = true
+        val vBar = scrollPane.verticalScrollBar
+        val sizeBefore = vBar.preferredSize
+
+        val manager = createManager()
+        manager.apply()
+
+        val storedSize =
+            vBar.getClientProperty("ayuIslands.originalPreferredSize") as? Dimension
+        assertEquals(sizeBefore, storedSize)
+        // Verify it's a copy, not the same reference
+        assert(storedSize !== sizeBefore || sizeBefore == storedSize)
+        manager.dispose()
+    }
+
+    @Test
+    fun `restoreScrollBar clears client property`() {
+        realState.hideEditorVScrollbar = true
+        val vBar = scrollPane.verticalScrollBar
+
+        val manager = createManager()
+        manager.apply()
+        assert(vBar.getClientProperty("ayuIslands.originalPreferredSize") != null)
+
+        realState.hideEditorVScrollbar = false
+        manager.apply()
+        assertNull(vBar.getClientProperty("ayuIslands.originalPreferredSize"))
+        manager.dispose()
+    }
+
+    @Test
+    fun `editorCreated listener applies to new editors when licensed`() {
+        realState.hideEditorVScrollbar = true
+        createManager()
+
+        val event =
+            mockk<com.intellij.openapi.editor.event.EditorFactoryEvent>(relaxed = true) {
+                every { editor } returns editorEx
+            }
+        listenerSlot.captured.editorCreated(event)
+
+        assertEquals(Dimension(0, 0), scrollPane.verticalScrollBar.preferredSize)
+    }
+
+    @Test
+    fun `editorCreated listener skips when not licensed`() {
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+        realState.hideEditorVScrollbar = true
+        val originalSize = Dimension(scrollPane.verticalScrollBar.preferredSize)
+
+        createManager()
+
+        val event =
+            mockk<com.intellij.openapi.editor.event.EditorFactoryEvent>(relaxed = true) {
+                every { editor } returns editorEx
+            }
+        listenerSlot.captured.editorCreated(event)
+
+        assertEquals(originalSize, scrollPane.verticalScrollBar.preferredSize)
+    }
+
+    @Test
+    fun `editorCreated listener skips editors from other projects`() {
+        realState.hideEditorVScrollbar = true
+        val otherProject = mockk<Project>(relaxed = true)
+        val otherScrollPane = JScrollPane()
+        val otherEditor =
+            mockk<EditorEx>(relaxed = true) {
+                every { project } returns otherProject
+                every { this@mockk.scrollPane } returns otherScrollPane
+            }
+        val originalSize = Dimension(otherScrollPane.verticalScrollBar.preferredSize)
+
+        createManager()
+
+        val event =
+            mockk<com.intellij.openapi.editor.event.EditorFactoryEvent>(relaxed = true) {
+                every { editor } returns otherEditor
+            }
+        listenerSlot.captured.editorCreated(event)
+
+        assertEquals(originalSize, otherScrollPane.verticalScrollBar.preferredSize)
+    }
+
+    @Test
+    fun `apply hides both scrollbars simultaneously`() {
+        realState.hideEditorVScrollbar = true
+        realState.hideEditorHScrollbar = true
+
+        val manager = createManager()
+        manager.apply()
+
+        assertEquals(Dimension(0, 0), scrollPane.verticalScrollBar.preferredSize)
+        assertEquals(Dimension(0, 0), scrollPane.horizontalScrollBar.preferredSize)
+        manager.dispose()
+    }
+
+    @Test
+    fun `apply skips non-EditorEx editors`() {
+        val plainEditor =
+            mockk<Editor>(relaxed = true) {
+                every { project } returns this@EditorScrollbarManagerTest.project
+            }
+        every { editorFactory.allEditors } returns arrayOf(plainEditor)
+
+        realState.hideEditorVScrollbar = true
+
+        val manager = createManager()
+        manager.apply()
+        // No crash
+        manager.dispose()
+    }
+}


### PR DESCRIPTION
## Summary

- Add "Editor" collapsible section to Workspace settings with two premium checkboxes: "Hide vertical scrollbar" and "Hide horizontal scrollbar"
- Create `EditorScrollbarManager` per-project service that hides scrollbars by zeroing their `preferredSize` — preserves mouse wheel, trackpad, and keyboard scrolling
- Extract `buildCheckboxRow` and `dispatchToOpenProjects` helpers in WorkspacePanel to deduplicate checkbox/dispatch patterns
- New editors inherit scrollbar policy via `EditorFactoryListener`

## How it works

Instead of `SCROLLBAR_NEVER` (which kills scrolling entirely), the fix sets `preferredSize = Dimension(0, 0)` on the `JScrollBar` component. The scrollbar stays in the layout (accepting scroll events) but renders at zero size. Original size stored in `clientProperty` for restoration.

## Test plan

- [ ] Workspace tab shows "Editor" section with two checkboxes
- [ ] Enable "Hide vertical scrollbar" → scrollbar disappears, scrolling works
- [ ] Enable "Hide horizontal scrollbar" → same behavior
- [ ] Disable both → scrollbars restore to normal
- [ ] New editor tabs inherit the setting
- [ ] `grep "SEVERE.*Ayu" idea.log` — no crashes
- [ ] Checkboxes disabled without license (premium gate)

## Summary by Sourcery

Add configurable editor scrollbar visibility controls and wire them into workspace settings and per-project editor management.

New Features:
- Introduce workspace settings for hiding editor vertical and horizontal scrollbars, gated by license.
- Add a per-project EditorScrollbarManager service that applies editor scrollbar visibility preferences to existing and newly created editors.

Enhancements:
- Persist editor scrollbar visibility preferences and editor workspace group expansion state in AyuIslands settings.
- Register EditorScrollbarManager as a project-level service and initialize it on startup when editor scrollbars are configured to be hidden.
- Refactor WorkspacePanel to reuse checkbox row construction and project dispatch helpers and to include an Editor section alongside existing workspace groups.