### PR TITLE
Add community section and GitHub Discussions links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,14 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
+  - name: Feature Requests & Voting
+    url: https://github.com/barad1tos/ayu-jetbrains/discussions/categories/feature-requests
+    about: Suggest and vote on features in Discussions
+  - name: Q&A
+    url: https://github.com/barad1tos/ayu-jetbrains/discussions/categories/q-a
+    about: Ask questions about setup and configuration
+  - name: Show Your Setup
+    url: https://github.com/barad1tos/ayu-jetbrains/discussions/categories/show-and-tell
+    about: Share your Ayu Islands screenshots and config
   - name: Plugin reviews
     url: https://plugins.jetbrains.com/plugin/30373-ayu-islands/reviews
     about: Leave a review or read feedback on JetBrains Marketplace

--- a/README.md
+++ b/README.md
@@ -117,6 +117,17 @@ Output: `build/distributions/ayu-jetbrains-<version>.zip`
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines and [CHANGELOG.md](CHANGELOG.md) for the release history.
 
+## Community
+
+Got ideas, questions, or a setup you're proud of?
+
+- [**Feature Requests**](https://github.com/barad1tos/ayu-jetbrains/discussions/categories/feature-requests) — suggest and vote on what's next
+- [**Show Your Setup**](https://github.com/barad1tos/ayu-jetbrains/discussions/categories/show-and-tell) — share your config and screenshots
+- [**Q&A**](https://github.com/barad1tos/ayu-jetbrains/discussions/categories/q-a) — ask anything about Ayu Islands
+- [**Ideas & Direction**](https://github.com/barad1tos/ayu-jetbrains/discussions/categories/ideas) — discuss the big picture
+
+Found a bug? [Open an issue](https://github.com/barad1tos/ayu-jetbrains/issues/new?template=bug_report.yml) with our bug report template.
+
 ## Credits
 
 - Built on [Ayu](https://ayutheme.com) by Ike Ku ([@dempfi](https://github.com/dempfi)) — color palettes from [ayu-theme/ayu-colors](https://github.com/ayu-theme/ayu-colors) (MIT)

--- a/src/main/kotlin/dev/ayuislands/StartupLicenseHandler.kt
+++ b/src/main/kotlin/dev/ayuislands/StartupLicenseHandler.kt
@@ -7,6 +7,7 @@ import dev.ayuislands.commitpanel.CommitPanelAutoFitManager
 import dev.ayuislands.editor.EditorScrollbarManager
 import dev.ayuislands.gitpanel.GitPanelAutoFitManager
 import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.onboarding.OnboardingNotifier
 import dev.ayuislands.projectview.ProjectViewScrollbarManager
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.PanelWidthMode
@@ -36,7 +37,7 @@ internal object StartupLicenseHandler {
             )
 
             if (!settings.state.trialWelcomeShown) {
-                LicenseChecker.notifyTrialWelcome(project)
+                OnboardingNotifier.showWelcome(project)
                 settings.state.trialWelcomeShown = true
             }
         }

--- a/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
@@ -106,19 +106,6 @@ object LicenseChecker {
             ).notify(project)
     }
 
-    /** Show one-time welcome notification for new trial/license activations. */
-    fun notifyTrialWelcome(project: Project?) {
-        NotificationGroupManager
-            .getInstance()
-            .getNotificationGroup(NOTIFICATION_GROUP)
-            .createNotification(
-                "Ayu Islands Premium is unlocked",
-                "30 days of glow, auto-fit, accent control, and plugin sync. " +
-                    "Open Settings \u2192 Ayu Islands to explore.",
-                NotificationType.INFORMATION,
-            ).notify(project)
-    }
-
     /** Enable all Pro features on the first license activation (one-time). */
     fun enableProDefaults() {
         val state = AyuIslandsSettings.getInstance().state

--- a/src/main/kotlin/dev/ayuislands/onboarding/OnboardingNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/onboarding/OnboardingNotifier.kt
@@ -1,0 +1,96 @@
+package dev.ayuislands.onboarding
+
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationAction
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.options.ShowSettingsUtil
+import com.intellij.openapi.project.Project
+import dev.ayuislands.font.FontPreset
+import dev.ayuislands.font.FontPresetApplicator
+import dev.ayuislands.font.FontSettings
+import dev.ayuislands.glow.GlowOverlayManager
+import dev.ayuislands.glow.GlowPreset
+import dev.ayuislands.settings.AyuIslandsSettings
+
+/** Shows an actionable welcome notification with one-click preset buttons. */
+object OnboardingNotifier {
+    private val LOG = logger<OnboardingNotifier>()
+    private const val NOTIFICATION_GROUP = "Ayu Islands"
+
+    /** Display the trial welcome notification with Whisper, Neon, and Open Settings actions. */
+    fun showWelcome(project: Project) {
+        NotificationGroupManager
+            .getInstance()
+            .getNotificationGroup(NOTIFICATION_GROUP)
+            .createNotification(
+                "Welcome to Ayu Islands Premium",
+                "Your 30-day trial is active. Try a preset \u2014 it changes glow and font in one click.",
+                NotificationType.INFORMATION,
+            ).addAction(
+                object : NotificationAction("Whisper") {
+                    override fun actionPerformed(
+                        event: AnActionEvent,
+                        notification: Notification,
+                    ) {
+                        notification.expire()
+                        ApplicationManager.getApplication().invokeLater {
+                            applyPreset(project, GlowPreset.WHISPER, FontPreset.WHISPER)
+                        }
+                    }
+                },
+            ).addAction(
+                object : NotificationAction("Neon") {
+                    override fun actionPerformed(
+                        event: AnActionEvent,
+                        notification: Notification,
+                    ) {
+                        notification.expire()
+                        ApplicationManager.getApplication().invokeLater {
+                            applyPreset(project, GlowPreset.NEON, FontPreset.NEON)
+                        }
+                    }
+                },
+            ).addAction(
+                object : NotificationAction("Open Settings") {
+                    override fun actionPerformed(
+                        event: AnActionEvent,
+                        notification: Notification,
+                    ) {
+                        notification.expire()
+                        ShowSettingsUtil.getInstance().showSettingsDialog(project, "Ayu Islands")
+                    }
+                },
+            ).notify(project)
+    }
+
+    private fun applyPreset(
+        project: Project,
+        glowPreset: GlowPreset,
+        fontPreset: FontPreset,
+    ) {
+        val state = AyuIslandsSettings.getInstance().state
+
+        state.glowEnabled = true
+        state.glowStyle = glowPreset.style!!.name
+        state.glowPreset = glowPreset.name
+        state.setIntensityForStyle(glowPreset.style!!, glowPreset.intensity!!)
+        state.setWidthForStyle(glowPreset.style!!, glowPreset.width!!)
+        state.glowAnimation = glowPreset.animation!!.name
+
+        state.fontPresetEnabled = true
+        state.fontPresetName = fontPreset.name
+
+        FontPresetApplicator.apply(
+            FontSettings.decode(null, fontPreset).copy(applyToConsole = state.fontApplyToConsole),
+        )
+
+        GlowOverlayManager.getInstance(project).initialize()
+        GlowOverlayManager.syncGlowForAllProjects()
+
+        LOG.info("Onboarding preset applied: ${glowPreset.name}")
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/onboarding/OnboardingNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/onboarding/OnboardingNotifier.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DialogTitleCapitalization")
+
 package dev.ayuislands.onboarding
 
 import com.intellij.notification.Notification
@@ -72,14 +74,18 @@ object OnboardingNotifier {
         glowPreset: GlowPreset,
         fontPreset: FontPreset,
     ) {
+        val style = glowPreset.style ?: return
+        val intensity = glowPreset.intensity ?: return
+        val width = glowPreset.width ?: return
+        val animation = glowPreset.animation ?: return
         val state = AyuIslandsSettings.getInstance().state
 
         state.glowEnabled = true
-        state.glowStyle = glowPreset.style!!.name
+        state.glowStyle = style.name
         state.glowPreset = glowPreset.name
-        state.setIntensityForStyle(glowPreset.style!!, glowPreset.intensity!!)
-        state.setWidthForStyle(glowPreset.style!!, glowPreset.width!!)
-        state.glowAnimation = glowPreset.animation!!.name
+        state.setIntensityForStyle(style, intensity)
+        state.setWidthForStyle(style, width)
+        state.glowAnimation = animation.name
 
         state.fontPresetEnabled = true
         state.fontPresetName = fontPreset.name

--- a/src/test/kotlin/dev/ayuislands/StartupLicenseStateTest.kt
+++ b/src/test/kotlin/dev/ayuislands/StartupLicenseStateTest.kt
@@ -5,6 +5,7 @@ import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.commitpanel.CommitPanelAutoFitManager
 import dev.ayuislands.gitpanel.GitPanelAutoFitManager
 import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.onboarding.OnboardingNotifier
 import dev.ayuislands.projectview.ProjectViewScrollbarManager
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
@@ -40,8 +41,10 @@ class StartupLicenseStateTest {
         every { LicenseChecker.enableProDefaults() } just runs
         every { LicenseChecker.applyWorkspaceDefaults() } just runs
         every { LicenseChecker.revertToFreeDefaults(any()) } just runs
-        every { LicenseChecker.notifyTrialWelcome(any()) } just runs
         every { LicenseChecker.notifyTrialExpired(any()) } just runs
+
+        mockkObject(OnboardingNotifier)
+        every { OnboardingNotifier.showWelcome(any()) } just runs
     }
 
     @AfterTest
@@ -98,7 +101,7 @@ class StartupLicenseStateTest {
         StartupLicenseHandler.applyLicensedDefaults(project, settings)
 
         verify(exactly = 1) {
-            LicenseChecker.notifyTrialWelcome(project)
+            OnboardingNotifier.showWelcome(project)
         }
     }
 
@@ -110,7 +113,7 @@ class StartupLicenseStateTest {
         StartupLicenseHandler.applyLicensedDefaults(project, settings)
 
         verify(exactly = 1) {
-            LicenseChecker.notifyTrialWelcome(project)
+            OnboardingNotifier.showWelcome(project)
         }
         assertTrue(state.trialWelcomeShown)
     }
@@ -122,7 +125,7 @@ class StartupLicenseStateTest {
 
         StartupLicenseHandler.applyLicensedDefaults(project, settings)
 
-        verify(exactly = 0) { LicenseChecker.notifyTrialWelcome(any()) }
+        verify(exactly = 0) { OnboardingNotifier.showWelcome(any()) }
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Enable GitHub Discussions with seed post ([#104](https://github.com/barad1tos/ayu-jetbrains/discussions/104))
- Add Discussion category links (Feature Requests, Q&A, Show Your Setup) to issue template config
- Add Community section to README before Credits
- Enable blank issues for edge cases

## Manual steps after merge

Categories need to be configured in GitHub Settings > Discussions (API doesn't support category mutations):

1. Create **Feature Requests** category
2. Rename **Show and tell** → **Show Your Setup**
3. Rename **Ideas** → **Ideas & Direction**
4. Optionally delete **General** and **Polls**

## Test plan

- [ ] Visit `/discussions` — seed post visible
- [ ] Visit `/issues/new/choose` — Discussion links appear alongside bug/feature templates
- [ ] README Community section renders with working links

## Summary by Sourcery

Introduce an interactive onboarding notification for new premium trials and surface GitHub Discussions as the primary community channel.

New Features:
- Add an OnboardingNotifier that shows a welcome notification with one-click presets and settings shortcut when a premium trial is activated.
- Expose GitHub Discussions categories (Feature Requests, Q&A, Show Your Setup, Ideas & Direction) via README and issue template contact links.
- Enable blank GitHub issues for edge cases not covered by templates.

Enhancements:
- Route trial welcome handling in StartupLicenseHandler through the new onboarding notifier instead of LicenseChecker.
- Log preset applications during onboarding to aid in understanding user paths.

Documentation:
- Add a Community section to the README highlighting Discussions categories and guiding users to the bug report template.

Tests:
- Update StartupLicenseStateTest to mock and verify use of the new onboarding notifier instead of the previous license checker notification.