### PR TITLE
Release v2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.4.1] - 2026-04-11
+
+### Fixed
+- Fix font install retry getting stuck on corrupted download cache
+
 ## [2.4.0] - 2026-04-10
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.4.0
+pluginVersion=2.4.1
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
@@ -41,6 +41,10 @@ internal object UpdateNotifier {
 
     private val RELEASE_NOTES =
         mapOf(
+            "2.4.1" to
+                "<ul>" +
+                "<li>Fix font install retry on corrupted cache</li>" +
+                "</ul>",
             "2.4.0" to
                 "<ul>" +
                 "<li>Onboarding wizard with preset cards and accent picker</li>" +

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -72,6 +72,10 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>2.4.1</h3>
+    <ul>
+      <li>Fix font install retry getting stuck on corrupted download cache</li>
+    </ul>
     <h3>2.4.0</h3>
     <ul>
       <li>Onboarding wizard — full-tab welcome experience with preset cards, theme variant picker, and accent swatches</li>


### PR DESCRIPTION
## Summary
- Fix font install retry getting stuck on corrupted download cache

Patch release — internal hardening from PR review + SVGLoader→ImageLoader migration.

## Summary by Sourcery

Release plugin version 2.4.1 with updated notes and metadata

Bug Fixes:
- Prevent font installation retries from getting stuck when the download cache is corrupted

Build:
- Bump plugin version to 2.4.1 in build properties

Documentation:
- Add 2.4.1 entry to changelog and plugin change notes describing the font install retry fix