### PR TITLE
test/fix: hardening sprint v2 + onboarding wizard fix

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -186,8 +186,6 @@ kover {
                     "dev.ayuislands.onboarding.*Editor",
                     "dev.ayuislands.onboarding.*VirtualFile*",
                     "dev.ayuislands.onboarding.OnboardingSchedulerService*",
-                    // Font download/install pipeline (IO, network, platform filesystem)
-                    "dev.ayuislands.font.FontInstaller*",
                     // Startup lifecycle (coroutine scheduling, project service init)
                     "dev.ayuislands.StartupLicenseHandler*",
                     // Onboarding data-class holders (generated constructors + getters only)

--- a/src/main/kotlin/dev/ayuislands/accent/CachedMacReader.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/CachedMacReader.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.util.SystemInfo
 
 class CachedMacReader<T>(
     private val ttlMs: Long = 5_000L,
+    private val clock: () -> Long = System::currentTimeMillis,
     private val reader: () -> T?,
 ) {
     @Volatile
@@ -15,7 +16,7 @@ class CachedMacReader<T>(
     @Synchronized
     fun read(): T? {
         if (!SystemInfo.isMac) return null
-        val now = System.currentTimeMillis()
+        val now = clock()
         if (now - timestamp < ttlMs) return cached
         val result = reader()
         cached = result

--- a/src/main/kotlin/dev/ayuislands/accent/conflict/ConflictRegistry.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/conflict/ConflictRegistry.kt
@@ -3,6 +3,7 @@ package dev.ayuislands.accent.conflict
 import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.openapi.extensions.PluginId
 import dev.ayuislands.accent.AccentElementId
+import org.jetbrains.annotations.TestOnly
 
 enum class ConflictType { BLOCK, INTEGRATE }
 
@@ -30,21 +31,35 @@ object ConflictRegistry {
             ),
         )
 
-    // Cached: installed plugins don't change during a session
-    private val cachedConflicts: List<ConflictEntry> by lazy {
+    // Installed plugins don't change during a session, so the first detection is cached.
+    // Volatile nullable `var` instead of `by lazy` to let tests reset the cache via
+    // `resetCachedConflictsForTesting()` without reflection or Unsafe tricks.
+    @Volatile
+    private var cachedConflicts: List<ConflictEntry>? = null
+
+    private fun getCachedConflicts(): List<ConflictEntry> =
+        cachedConflicts ?: synchronized(this) {
+            cachedConflicts ?: computeConflicts().also { cachedConflicts = it }
+        }
+
+    private fun computeConflicts(): List<ConflictEntry> =
         entries.filter { entry ->
             val pluginId = PluginId.getId(entry.pluginId)
             PluginManagerCore.getPlugin(pluginId) != null && !PluginManagerCore.isDisabled(pluginId)
         }
-    }
 
-    fun detectConflicts(): List<ConflictEntry> = cachedConflicts
+    fun detectConflicts(): List<ConflictEntry> = getCachedConflicts()
 
     fun getConflictFor(elementId: AccentElementId): ConflictEntry? =
-        cachedConflicts
+        getCachedConflicts()
             .firstOrNull { elementId in it.affectedElements }
 
-    fun isCodeGlanceProDetected(): Boolean = cachedConflicts.any { it.pluginId == "com.nasller.CodeGlancePro" }
+    fun isCodeGlanceProDetected(): Boolean = getCachedConflicts().any { it.pluginId == "com.nasller.CodeGlancePro" }
 
-    fun isIndentRainbowDetected(): Boolean = cachedConflicts.any { it.pluginId == "indent-rainbow.indent-rainbow" }
+    fun isIndentRainbowDetected(): Boolean = getCachedConflicts().any { it.pluginId == "indent-rainbow.indent-rainbow" }
+
+    @TestOnly
+    internal fun resetCachedConflictsForTesting() {
+        cachedConflicts = null
+    }
 }

--- a/src/main/kotlin/dev/ayuislands/font/FontInstaller.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontInstaller.kt
@@ -13,6 +13,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.util.io.HttpRequests
 import dev.ayuislands.settings.AyuIslandsSettings
+import org.jetbrains.annotations.TestOnly
 import java.awt.Font
 import java.awt.GraphicsEnvironment
 import java.io.File
@@ -91,13 +92,15 @@ object FontInstaller {
     /** Apply a preset without any download work — used when the font is already installed. */
     fun applyOnly(
         preset: FontPreset,
-        @Suppress("UNUSED_PARAMETER") project: Project?,
+        project: Project?,
     ) {
+        val entry = FontCatalog.forPreset(preset)
         ApplicationManager.getApplication().invokeLater {
             try {
                 FontPresetApplicator.apply(FontSettings.decode(null, preset))
             } catch (exception: RuntimeException) {
                 LOG.warn("FontPresetApplicator.apply failed (applyOnly)", exception)
+                notify(entry, project, FailureKind.APPLY_FAILED, NotificationType.WARNING)
             }
         }
     }
@@ -154,7 +157,7 @@ object FontInstaller {
         persistAndApply(entry, preset, project, canonicalFamily, onComplete)
     }
 
-    // @VisibleForTesting — extracted helpers for unit testing
+    @TestOnly
     internal fun resolveDownloadUrl(entry: FontCatalog.Entry): String =
         try {
             FontAssetResolver().resolve(entry)
@@ -163,7 +166,7 @@ object FontInstaller {
             entry.fallbackUrl
         }
 
-    // @VisibleForTesting — extracted helpers for unit testing
+    @TestOnly
     internal fun cachedZipFile(
         url: String,
         preset: FontPreset,
@@ -172,11 +175,8 @@ object FontInstaller {
         return File(cacheDir, url.substringAfterLast('/').ifBlank { "${preset.name}.zip" })
     }
 
-    /**
-     * Downloads the zip unless a valid cached copy already exists.
-     *
-     * `internal` for unit testing (see `FontInstallerTest`).
-     */
+    /** Downloads the zip unless a valid cached copy already exists. */
+    @TestOnly
     @Throws(IOException::class)
     internal fun downloadZip(
         url: String,
@@ -194,18 +194,15 @@ object FontInstaller {
         }
     }
 
-    // @VisibleForTesting — extracted helpers for unit testing
+    @TestOnly
     internal fun downloadFailureKind(exception: IOException): FailureKind =
         when (exception) {
             is UnknownHostException, is SocketException, is SSLException -> FailureKind.OFFLINE
             else -> FailureKind.HTTP_ERROR
         }
 
-    /**
-     * Extracts font files from the archive.
-     *
-     * `internal` for unit testing (see `FontInstallerTest`).
-     */
+    /** Extracts font files from the archive. */
+    @TestOnly
     @Throws(IOException::class)
     internal fun extractFonts(
         zipFile: File,
@@ -218,7 +215,7 @@ object FontInstaller {
             throw IOException(e.message, e)
         }
 
-    // @VisibleForTesting — extracted helpers for unit testing
+    @TestOnly
     internal fun extractionFailureKind(
         exception: IOException,
         zipFile: File,
@@ -236,29 +233,29 @@ object FontInstaller {
     }
 
     /**
-     * Copies extracted font files into the platform user-level font directory.
-     *
-     * `internal` for unit testing (see `FontInstallerTest`).
+     * Copies extracted font files into a destination directory.
+     * Defaults to the platform user-level font directory; tests pass a temp dir
+     * to avoid polluting the user's real font folder.
      */
+    @TestOnly
     @Throws(IOException::class)
-    internal fun copyToPlatformFontDir(extracted: List<File>): List<File> {
-        val platformDir = platformFontDir()
-        if (!platformDir.exists()) platformDir.mkdirs()
-        if (!platformDir.canWrite()) {
-            throw AccessDeniedException(platformDir.absolutePath)
+    internal fun copyToPlatformFontDir(
+        extracted: List<File>,
+        destDir: File = platformFontDir(),
+    ): List<File> {
+        if (!destDir.exists()) destDir.mkdirs()
+        if (!destDir.canWrite()) {
+            throw AccessDeniedException(destDir.absolutePath)
         }
         return extracted.map { source ->
-            val target = File(platformDir, source.name)
+            val target = File(destDir, source.name)
             Files.copy(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)
             target
         }
     }
 
-    /**
-     * Registers the first installed font file with the JVM's graphics environment.
-     *
-     * `internal` for unit testing (see `FontInstallerTest`).
-     */
+    /** Registers the first installed font file with the JVM's graphics environment. */
+    @TestOnly
     @Throws(java.awt.FontFormatException::class, IOException::class)
     internal fun registerFont(installedFiles: List<File>): String {
         val first = installedFiles.first()
@@ -267,7 +264,7 @@ object FontInstaller {
         return font.family
     }
 
-    // @VisibleForTesting — extracted helpers for unit testing
+    @TestOnly
     internal fun cleanupQuietly(directory: File) {
         try {
             directory.deleteRecursively()
@@ -311,7 +308,7 @@ object FontInstaller {
         }
     }
 
-    // @VisibleForTesting — extracted helpers for unit testing
+    @TestOnly
     internal fun persistFontState(canonicalFamily: String) {
         val state = AyuIslandsSettings.getInstance().state
         state.installedFonts.add(canonicalFamily)
@@ -403,7 +400,7 @@ object FontInstaller {
             FailureKind.EXTRACTION_FAILED,
         )
 
-    // @VisibleForTesting — extracted helpers for unit testing
+    @TestOnly
     internal fun platformFontDir(): File {
         val home = System.getProperty("user.home")
         return when {

--- a/src/main/kotlin/dev/ayuislands/font/FontInstaller.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontInstaller.kt
@@ -154,7 +154,8 @@ object FontInstaller {
         persistAndApply(entry, preset, project, canonicalFamily, onComplete)
     }
 
-    private fun resolveDownloadUrl(entry: FontCatalog.Entry): String =
+    // @VisibleForTesting — extracted helpers for unit testing
+    internal fun resolveDownloadUrl(entry: FontCatalog.Entry): String =
         try {
             FontAssetResolver().resolve(entry)
         } catch (e: RuntimeException) {
@@ -162,7 +163,8 @@ object FontInstaller {
             entry.fallbackUrl
         }
 
-    private fun cachedZipFile(
+    // @VisibleForTesting — extracted helpers for unit testing
+    internal fun cachedZipFile(
         url: String,
         preset: FontPreset,
     ): File {
@@ -170,9 +172,13 @@ object FontInstaller {
         return File(cacheDir, url.substringAfterLast('/').ifBlank { "${preset.name}.zip" })
     }
 
-    /** Downloads the zip unless a valid cached copy already exists. */
+    /**
+     * Downloads the zip unless a valid cached copy already exists.
+     *
+     * `internal` for unit testing (see `FontInstallerTest`).
+     */
     @Throws(IOException::class)
-    private fun downloadZip(
+    internal fun downloadZip(
         url: String,
         zipFile: File,
         indicator: ProgressIndicator,
@@ -188,15 +194,20 @@ object FontInstaller {
         }
     }
 
-    private fun downloadFailureKind(exception: IOException): FailureKind =
+    // @VisibleForTesting — extracted helpers for unit testing
+    internal fun downloadFailureKind(exception: IOException): FailureKind =
         when (exception) {
             is UnknownHostException, is SocketException, is SSLException -> FailureKind.OFFLINE
             else -> FailureKind.HTTP_ERROR
         }
 
-    /** Extracts font files from the archive. */
+    /**
+     * Extracts font files from the archive.
+     *
+     * `internal` for unit testing (see `FontInstallerTest`).
+     */
     @Throws(IOException::class)
-    private fun extractFonts(
+    internal fun extractFonts(
         zipFile: File,
         extractDir: File,
         entry: FontCatalog.Entry,
@@ -207,7 +218,8 @@ object FontInstaller {
             throw IOException(e.message, e)
         }
 
-    private fun extractionFailureKind(
+    // @VisibleForTesting — extracted helpers for unit testing
+    internal fun extractionFailureKind(
         exception: IOException,
         zipFile: File,
     ): FailureKind {
@@ -223,9 +235,13 @@ object FontInstaller {
         return FailureKind.EXTRACTION_FAILED
     }
 
-    /** Copies extracted font files into the platform user-level font directory. */
+    /**
+     * Copies extracted font files into the platform user-level font directory.
+     *
+     * `internal` for unit testing (see `FontInstallerTest`).
+     */
     @Throws(IOException::class)
-    private fun copyToPlatformFontDir(extracted: List<File>): List<File> {
+    internal fun copyToPlatformFontDir(extracted: List<File>): List<File> {
         val platformDir = platformFontDir()
         if (!platformDir.exists()) platformDir.mkdirs()
         if (!platformDir.canWrite()) {
@@ -238,16 +254,21 @@ object FontInstaller {
         }
     }
 
-    /** Registers the first installed font file with the JVM's graphics environment. */
+    /**
+     * Registers the first installed font file with the JVM's graphics environment.
+     *
+     * `internal` for unit testing (see `FontInstallerTest`).
+     */
     @Throws(java.awt.FontFormatException::class, IOException::class)
-    private fun registerFont(installedFiles: List<File>): String {
+    internal fun registerFont(installedFiles: List<File>): String {
         val first = installedFiles.first()
         val font = Font.createFont(Font.TRUETYPE_FONT, first)
         GraphicsEnvironment.getLocalGraphicsEnvironment().registerFont(font)
         return font.family
     }
 
-    private fun cleanupQuietly(directory: File) {
+    // @VisibleForTesting — extracted helpers for unit testing
+    internal fun cleanupQuietly(directory: File) {
         try {
             directory.deleteRecursively()
         } catch (exception: IOException) {
@@ -290,7 +311,8 @@ object FontInstaller {
         }
     }
 
-    private fun persistFontState(canonicalFamily: String) {
+    // @VisibleForTesting — extracted helpers for unit testing
+    internal fun persistFontState(canonicalFamily: String) {
         val state = AyuIslandsSettings.getInstance().state
         state.installedFonts.add(canonicalFamily)
         FontDetector.invalidateCache()
@@ -381,7 +403,8 @@ object FontInstaller {
             FailureKind.EXTRACTION_FAILED,
         )
 
-    private fun platformFontDir(): File {
+    // @VisibleForTesting — extracted helpers for unit testing
+    internal fun platformFontDir(): File {
         val home = System.getProperty("user.home")
         return when {
             SystemInfo.isMac -> File(home, "Library/Fonts")

--- a/src/main/kotlin/dev/ayuislands/licensing/LicenseTransitionListener.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/LicenseTransitionListener.kt
@@ -6,27 +6,39 @@ import com.intellij.ui.LicensingFacade
 import dev.ayuislands.settings.AyuIslandsSettings
 
 /**
- * Listens for mid-session license state changes and re-arms the premium onboarding wizard.
+ * Listens for unlicensed→licensed transitions and re-arms the premium onboarding wizard.
  *
  * When an unlicensed user purchases a license during an active IDE session, this listener
  * resets [dev.ayuislands.settings.AyuIslandsState.premiumOnboardingShown] to `false` so
  * the next IDE startup surfaces the premium wizard via OnboardingOrchestrator. No mid-session
  * UI is shown — the re-armed wizard appears at next launch only.
  *
+ * Tracks the previous license state to only fire on an actual transition. The first call
+ * (and any licensed→licensed notification) just records state without resetting the flag —
+ * otherwise a routine refresh event would re-trigger the wizard on every restart.
+ *
  * State mutation is dispatched to EDT via `invokeLater` because Topic
  * listeners may fire on arbitrary threads.
  */
 internal class LicenseTransitionListener : LicensingFacade.LicenseStateListener {
+    @Volatile
+    private var wasLicensed: Boolean? = null
+
     override fun licenseStateChanged(facade: LicensingFacade?) {
         try {
-            val isLicensed = LicenseChecker.isLicensed() == true
-            if (!isLicensed) return
+            val isNowLicensed = LicenseChecker.isLicensed() == true
+            val previous = wasLicensed
+            wasLicensed = isNowLicensed
+
+            // Only re-arm wizard on unlicensed → licensed transition.
+            // Skip initial notification (previous == null) and licensed → licensed refreshes.
+            if (previous != false || !isNowLicensed) return
 
             val state = AyuIslandsSettings.getInstance().state
             if (state.premiumOnboardingShown) {
                 ApplicationManager.getApplication().invokeLater {
                     state.premiumOnboardingShown = false
-                    LOG.info("Ayu license: detected unlicensed->licensed; premium wizard re-armed for next startup")
+                    LOG.info("Ayu license: unlicensed->licensed transition; premium wizard re-armed")
                 }
             }
         } catch (exception: RuntimeException) {

--- a/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
+++ b/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
@@ -16,6 +16,7 @@ import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
+import org.jetbrains.annotations.TestOnly
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 
@@ -106,7 +107,7 @@ class AccentRotationService : Disposable {
         scheduledFuture = null
     }
 
-    // @VisibleForTesting
+    @TestOnly
     internal fun canRotate(): Boolean {
         val state = AyuIslandsSettings.getInstance().state
         if (!state.accentRotationEnabled) {
@@ -120,7 +121,7 @@ class AccentRotationService : Disposable {
         return true
     }
 
-    // @VisibleForTesting
+    @TestOnly
     internal fun rotateAccent() {
         if (!canRotate()) return
         if (checkedDisposable.isDisposed) {

--- a/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
+++ b/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
@@ -106,7 +106,8 @@ class AccentRotationService : Disposable {
         scheduledFuture = null
     }
 
-    private fun canRotate(): Boolean {
+    // @VisibleForTesting
+    internal fun canRotate(): Boolean {
         val state = AyuIslandsSettings.getInstance().state
         if (!state.accentRotationEnabled) {
             LOG.debug("Rotation skipped: disabled")
@@ -119,7 +120,8 @@ class AccentRotationService : Disposable {
         return true
     }
 
-    private fun rotateAccent() {
+    // @VisibleForTesting
+    internal fun rotateAccent() {
         if (!canRotate()) return
         if (checkedDisposable.isDisposed) {
             LOG.debug("Rotation skipped: service disposed")

--- a/src/main/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitter.kt
+++ b/src/main/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitter.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ToolWindowType
 import com.intellij.openapi.wm.ex.ToolWindowEx
 import dev.ayuislands.settings.PanelWidthMode
+import org.jetbrains.annotations.TestOnly
 import javax.swing.JTree
 import javax.swing.SwingUtilities
 import javax.swing.Timer
@@ -175,6 +176,19 @@ class ToolWindowAutoFitter(
 
     fun scheduleAutoFit() {
         debounceTimer.restart()
+    }
+
+    /**
+     * Stops the pending debounce timer (if any) and fires the fit immediately.
+     * Used by tests to avoid wall-clock waits for the 150 ms debounce window.
+     */
+    @TestOnly
+    internal fun flushDebounceForTesting() {
+        val hadPending = debounceTimer.isRunning
+        debounceTimer.stop()
+        if (hadPending) {
+            applyAutoFitWidth(maxWidthProvider())
+        }
     }
 
     private fun findTreeWithRetry(

--- a/src/test/kotlin/dev/ayuislands/AppearanceSyncServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AppearanceSyncServiceTest.kt
@@ -394,6 +394,88 @@ class AppearanceSyncServiceTest {
         assertEquals(Appearance.DARK, lastSynced)
     }
 
+    // -- Multi-call state transitions --
+
+    @Test
+    fun `appearance sync across system mode changes triggers distinct switches`() {
+        // Regression guard: three alternating sync calls must result in three distinct switches.
+        // The LicenseTransitionListener bug class was "listener locks in first-call state" —
+        // this test verifies that repeated sync calls with changing appearance all propagate.
+        val lightName = "Ayu Light (Islands UI)"
+        val darkName = "Ayu Dark (Islands UI)"
+        state.lastLightAppearanceTheme = lightName
+        state.lastDarkAppearanceTheme = darkName
+
+        // Mutable current-theme tracker — mirrors what LafManager does after setCurrentLookAndFeel.
+        var currentName = "Ayu Mirage"
+        val currentThemeLaf = mockk<UIThemeLookAndFeelInfo>(relaxed = true)
+        every { currentThemeLaf.name } answers { currentName }
+        every { lafManager.currentUIThemeLookAndFeel } returns currentThemeLaf
+
+        val lightLaf = mockk<UIThemeLookAndFeelInfo>(relaxed = true)
+        every { lightLaf.name } returns lightName
+        val darkLaf = mockk<UIThemeLookAndFeelInfo>(relaxed = true)
+        every { darkLaf.name } returns darkName
+        every { lafManager.installedThemes } returns sequenceOf(lightLaf, darkLaf)
+
+        // Advance the mock "current theme" whenever the production code flips the LAF so the
+        // next switchToTheme doesn't short-circuit on "already equal".
+        every { lafManager.setCurrentLookAndFeel(lightLaf, any()) } answers {
+            currentName = lightName
+        }
+        every { lafManager.setCurrentLookAndFeel(darkLaf, any()) } answers {
+            currentName = darkName
+        }
+
+        every { AyuVariant.detect() } answers { AyuVariant.fromThemeName(currentName) }
+
+        // Sync 1: LIGHT
+        every { SystemAppearanceProvider.resolve() } returns Appearance.LIGHT
+        service.syncIfNeeded()
+
+        // Sync 2: DARK
+        every { SystemAppearanceProvider.resolve() } returns Appearance.DARK
+        service.syncIfNeeded()
+
+        // Sync 3: LIGHT again
+        every { SystemAppearanceProvider.resolve() } returns Appearance.LIGHT
+        service.syncIfNeeded()
+
+        verify(exactly = 2) { lafManager.setCurrentLookAndFeel(lightLaf, true) }
+        verify(exactly = 1) { lafManager.setCurrentLookAndFeel(darkLaf, true) }
+        verify(exactly = 3) { lafManager.setCurrentLookAndFeel(any(), any<Boolean>()) }
+    }
+
+    @Test
+    fun `appearance sync with same appearance twice only switches once`() {
+        // Counterpart to the "alternating" test: the same appearance repeated must be idempotent.
+        // This is the exact bug class that bit LicenseTransitionListener — repeated events
+        // reaching a listener that didn't guard against redundant calls.
+        val lightName = "Ayu Light (Islands UI)"
+        state.lastLightAppearanceTheme = lightName
+
+        var currentName = "Ayu Mirage"
+        val currentThemeLaf = mockk<UIThemeLookAndFeelInfo>(relaxed = true)
+        every { currentThemeLaf.name } answers { currentName }
+        every { lafManager.currentUIThemeLookAndFeel } returns currentThemeLaf
+
+        val lightLaf = mockk<UIThemeLookAndFeelInfo>(relaxed = true)
+        every { lightLaf.name } returns lightName
+        every { lafManager.installedThemes } returns sequenceOf(lightLaf)
+        every { lafManager.setCurrentLookAndFeel(lightLaf, any()) } answers {
+            currentName = lightName
+        }
+
+        every { SystemAppearanceProvider.resolve() } returns Appearance.LIGHT
+        every { AyuVariant.detect() } answers { AyuVariant.fromThemeName(currentName) }
+
+        service.syncIfNeeded()
+        service.syncIfNeeded()
+        service.syncIfNeeded()
+
+        verify(exactly = 1) { lafManager.setCurrentLookAndFeel(lightLaf, true) }
+    }
+
     // -- Helpers --
 
     private fun getLastSyncedAppearance(): Appearance? {

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsAppListenerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsAppListenerTest.kt
@@ -88,4 +88,62 @@ class AyuIslandsAppListenerTest {
             AccentApplicator.apply(any())
         }
     }
+
+    @Test
+    fun `appFrameCreated applies accent for each variant theme name`() {
+        // Regression guard: every registered theme name must map to its variant's stored accent.
+        // The AyuIslandsAppListenerTest setUp stubs per-variant accents ("#FF0000" mirage,
+        // "#00FF00" dark, "#0000FF" light) — walk all six theme names and verify the expected
+        // accent is applied. A bug that collapses variant detection would show up as the wrong
+        // accent, not no call at all.
+        val cases =
+            listOf(
+                "Ayu Mirage" to "#FF0000",
+                "Ayu Mirage (Islands UI)" to "#FF0000",
+                "Ayu Dark" to "#00FF00",
+                "Ayu Dark (Islands UI)" to "#00FF00",
+                "Ayu Light" to "#0000FF",
+                "Ayu Light (Islands UI)" to "#0000FF",
+            )
+
+        for ((themeName, expectedAccent) in cases) {
+            val laf = mockk<UIThemeLookAndFeelInfo>()
+            every { laf.name } returns themeName
+            val lafManager = mockk<LafManager>()
+            @Suppress("UnstableApiUsage")
+            every { lafManager.currentUIThemeLookAndFeel } returns laf
+            every { LafManager.getInstance() } returns lafManager
+
+            listener.appFrameCreated(mutableListOf())
+
+            verify(atLeast = 1) {
+                AccentApplicator.apply(expectedAccent)
+            }
+        }
+    }
+
+    @Test
+    fun `appFrameCreated handles both Islands UI and non-Islands UI theme names`() {
+        // Direct comparison: "Ayu Mirage" and "Ayu Mirage (Islands UI)" are two packaged
+        // theme files but share the same variant — they must resolve to the same accent.
+        val lafManager = mockk<LafManager>()
+        every { LafManager.getInstance() } returns lafManager
+
+        val nonIslandsLaf = mockk<UIThemeLookAndFeelInfo>()
+        every { nonIslandsLaf.name } returns "Ayu Mirage"
+        @Suppress("UnstableApiUsage")
+        every { lafManager.currentUIThemeLookAndFeel } returns nonIslandsLaf
+        listener.appFrameCreated(mutableListOf())
+
+        val islandsLaf = mockk<UIThemeLookAndFeelInfo>()
+        every { islandsLaf.name } returns "Ayu Mirage (Islands UI)"
+        @Suppress("UnstableApiUsage")
+        every { lafManager.currentUIThemeLookAndFeel } returns islandsLaf
+        listener.appFrameCreated(mutableListOf())
+
+        // Both calls must land on the Mirage accent — never the Dark or Light one.
+        verify(exactly = 2) { AccentApplicator.apply("#FF0000") }
+        verify(exactly = 0) { AccentApplicator.apply("#00FF00") }
+        verify(exactly = 0) { AccentApplicator.apply("#0000FF") }
+    }
 }

--- a/src/test/kotlin/dev/ayuislands/StartupBenchmarkTest.kt
+++ b/src/test/kotlin/dev/ayuislands/StartupBenchmarkTest.kt
@@ -1,5 +1,7 @@
 package dev.ayuislands
 
+import kotlin.math.max
+import kotlin.math.min
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
@@ -18,6 +20,54 @@ class StartupBenchmarkTest {
         assertTrue(
             second < first * 10 + 1,
             "Second run ($second ms) should be within 10x of first ($first ms)",
+        )
+    }
+
+    @Test
+    fun `measureCpuSpeed completes within reasonable absolute upper bound`() {
+        val elapsed = StartupBenchmark.measureCpuSpeed()
+        // 5 seconds is absurdly slow for 10k SHA-256 iterations on any
+        // modern CPU — protects against benchmark hang or accidental
+        // loop explosion.
+        assertTrue(
+            elapsed < 5_000,
+            "Benchmark should complete well under 5s, got ${elapsed}ms",
+        )
+        // A completed benchmark on real hardware measures at least a
+        // few microseconds (reported as >=0 ms). Guard against the
+        // timing call itself being stubbed out: elapsed must be non-
+        // negative, and on any real machine ITERATIONS=10_000 SHA-256
+        // rounds cannot finish below 0 ms.
+        assertTrue(
+            elapsed >= 0,
+            "Benchmark returned negative duration: ${elapsed}ms",
+        )
+    }
+
+    @Test
+    fun `measureCpuSpeed returns similar results on back-to-back calls`() {
+        val runs =
+            listOf(
+                StartupBenchmark.measureCpuSpeed(),
+                StartupBenchmark.measureCpuSpeed(),
+                StartupBenchmark.measureCpuSpeed(),
+            )
+        // Use 1-ms floor to avoid division-by-zero on very fast hosts
+        // where sub-millisecond runs round to zero.
+        val lo = max(1L, runs.min())
+        val hi = max(1L, runs.max())
+        val ratio = hi.toDouble() / lo.toDouble()
+        assertTrue(
+            ratio < 8.0,
+            "Back-to-back runs vary too much: min=${runs.min()}ms, " +
+                "max=${runs.max()}ms, ratio=$ratio",
+        )
+        // Ratio must always be >= 1.0 by construction
+        assertTrue(ratio >= 1.0, "Impossible ratio $ratio")
+        // Sanity: at least one run produced a non-negative result
+        assertTrue(
+            min(runs.min(), runs.max()) >= 0,
+            "Negative run detected: $runs",
         )
     }
 }

--- a/src/test/kotlin/dev/ayuislands/StartupLicenseStateTest.kt
+++ b/src/test/kotlin/dev/ayuislands/StartupLicenseStateTest.kt
@@ -367,4 +367,171 @@ class StartupLicenseStateTest {
 
         assertEquals(WizardAction.ShowFreeWizard, result)
     }
+
+    // Multi-session user journeys — simulated by calling handlers multiple times
+    // on the SAME state instance (the state is what persists to disk across restarts).
+
+    @Test
+    fun `trial expiry notification fires only once across multiple restarts`() {
+        // Session 1: trial expires, user sees the notification
+        StartupLicenseHandler.applyUnlicensedDefaults(project, AyuVariant.MIRAGE, settings)
+        // Session 2: IDE restart, same persisted state — notification must NOT re-fire
+        StartupLicenseHandler.applyUnlicensedDefaults(project, AyuVariant.MIRAGE, settings)
+        // Session 3: another restart — still silent
+        StartupLicenseHandler.applyUnlicensedDefaults(project, AyuVariant.MIRAGE, settings)
+
+        verify(exactly = 1) { LicenseChecker.notifyTrialExpired(project) }
+        assertTrue(state.trialExpiredNotified)
+    }
+
+    @Test
+    fun `full cycle from unlicensed to licensed to expire to re-license preserves user customizations`() {
+        // Session 1: fresh unlicensed install, trial already expired
+        StartupLicenseHandler.applyUnlicensedDefaults(project, AyuVariant.MIRAGE, settings)
+        assertTrue(state.trialExpiredNotified)
+
+        // Session 2: user buys a license — first activation triggers pro defaults.
+        // everBeenPro is set by the real enableProDefaults, but since it is mocked we
+        // simulate the flag transition manually to mirror production behavior.
+        StartupLicenseHandler.applyLicensedDefaults(settings)
+        state.everBeenPro = true
+        state.proDefaultsApplied = true
+        assertFalse(state.trialExpiredNotified)
+        assertFalse(state.premiumOnboardingShown)
+
+        // User customizes glow: enables it with a non-default intensity.
+        state.glowEnabled = true
+        state.sharpNeonIntensity = 85
+        // User dismisses the premium wizard.
+        state.premiumOnboardingShown = true
+
+        // Session 3: IDE restart, still licensed — defaults already applied, no-op path
+        StartupLicenseHandler.applyLicensedDefaults(settings)
+        assertTrue(state.glowEnabled)
+        assertEquals(85, state.sharpNeonIntensity)
+        assertTrue(state.premiumOnboardingShown)
+
+        // Session 4: license expires
+        StartupLicenseHandler.applyUnlicensedDefaults(project, AyuVariant.MIRAGE, settings)
+        assertTrue(state.trialExpiredNotified)
+
+        // Session 5: user re-purchases. Because everBeenPro is true, the real
+        // enableProDefaults is a no-op for customizations — verify the handler does
+        // not wipe glowEnabled / sharpNeonIntensity itself.
+        StartupLicenseHandler.applyLicensedDefaults(settings)
+        assertTrue(state.glowEnabled, "re-license must not wipe user's glow customization")
+        assertEquals(85, state.sharpNeonIntensity, "re-license must not wipe user's intensity")
+        assertFalse(state.trialExpiredNotified)
+
+        // enableProDefaults called three times total: session 2 (first activation),
+        // session 3 (still licensed — skipped because proDefaultsApplied),
+        // session 5 (re-license — handler reset proDefaultsApplied so it runs again,
+        // but the real implementation is a no-op thanks to everBeenPro).
+        verify(exactly = 2) { LicenseChecker.enableProDefaults() }
+    }
+
+    @Test
+    fun `re-purchase after trial expiry re-arms premium wizard across restarts`() {
+        // Session 1: user is licensed and has already seen the premium wizard
+        state.proDefaultsApplied = true
+        state.everBeenPro = true
+        state.premiumOnboardingShown = true
+        state.freeOnboardingShown = true
+
+        // Session 2: trial/license expires
+        StartupLicenseHandler.applyUnlicensedDefaults(project, AyuVariant.DARK, settings)
+        assertTrue(state.trialExpiredNotified)
+        // Premium wizard flag is untouched by unlicensed path
+        assertTrue(state.premiumOnboardingShown)
+
+        // Session 3: user re-purchases — handler must re-arm the premium wizard
+        StartupLicenseHandler.applyLicensedDefaults(settings)
+        assertFalse(
+            state.premiumOnboardingShown,
+            "re-license must reset premiumOnboardingShown so the wizard can fire again",
+        )
+
+        // Session 4: orchestrator resolves with the reset flags — should pick premium wizard
+        val action =
+            StartupLicenseHandler.resolveOnboarding(
+                isLicensedOrGrace = true,
+                settings = settings,
+                isReturningUser = true,
+            )
+        assertEquals(WizardAction.ShowPremiumWizard, action)
+    }
+
+    @Test
+    fun `returning user never sees free wizard across restarts`() {
+        // Returning user — lastSeenVersion non-null, isReturningUser = true
+        state.lastSeenVersion = "2.3.0"
+        state.freeOnboardingShown = false
+        state.premiumOnboardingShown = false
+
+        // Session 1: first resolve auto-marks freeOnboardingShown for returning users
+        val firstAction =
+            StartupLicenseHandler.resolveOnboarding(
+                isLicensedOrGrace = true,
+                settings = settings,
+                isReturningUser = true,
+            )
+        assertTrue(state.freeOnboardingShown)
+        // Licensed + premium wizard not yet shown → premium wizard
+        assertEquals(WizardAction.ShowPremiumWizard, firstAction)
+
+        // Simulate user closing the premium wizard
+        state.premiumOnboardingShown = true
+
+        // Session 2: another restart — free wizard must still be skipped,
+        // and premium wizard must not re-fire either
+        val secondAction =
+            StartupLicenseHandler.resolveOnboarding(
+                isLicensedOrGrace = true,
+                settings = settings,
+                isReturningUser = true,
+            )
+        assertEquals(WizardAction.NoWizard, secondAction)
+    }
+
+    @Test
+    fun `runOnboardingMigration is idempotent across restarts`() {
+        // Legacy state: trialWelcomeShown set, new flag not yet migrated
+        state.trialWelcomeShown = true
+        state.premiumOnboardingShown = false
+
+        // Session 1: migration copies the flag
+        StartupLicenseHandler.runOnboardingMigration(settings)
+        assertTrue(state.premiumOnboardingShown)
+
+        // User then dismisses the (already-shown) premium wizard — flag stays true.
+        // Session 2: migration runs again, must not toggle or reset anything
+        StartupLicenseHandler.runOnboardingMigration(settings)
+        assertTrue(state.premiumOnboardingShown)
+
+        // Session 3: one more restart for good measure
+        StartupLicenseHandler.runOnboardingMigration(settings)
+        assertTrue(state.premiumOnboardingShown)
+    }
+
+    @Test
+    fun `applyLicensedDefaults skips redundant work across restarts`() {
+        // Session 1: first activation — both defaults should run
+        state.proDefaultsApplied = false
+        state.workspaceDefaultsApplied = false
+        StartupLicenseHandler.applyLicensedDefaults(settings)
+
+        // Simulate what real enableProDefaults / applyWorkspaceDefaults would set
+        state.proDefaultsApplied = true
+        state.workspaceDefaultsApplied = true
+        state.everBeenPro = true
+
+        // Session 2: IDE restart, still licensed — no work to do
+        StartupLicenseHandler.applyLicensedDefaults(settings)
+        // Session 3: another restart — still no work
+        StartupLicenseHandler.applyLicensedDefaults(settings)
+
+        // Each default applicator should have run exactly once across all three sessions
+        verify(exactly = 1) { LicenseChecker.enableProDefaults() }
+        verify(exactly = 1) { LicenseChecker.applyWorkspaceDefaults() }
+    }
 }

--- a/src/test/kotlin/dev/ayuislands/UpdateNotifierTest.kt
+++ b/src/test/kotlin/dev/ayuislands/UpdateNotifierTest.kt
@@ -141,4 +141,158 @@ class UpdateNotifierTest {
         // Version updated even though 2.1.0 has no release notes entry
         assertEquals("2.1.0", state.lastSeenVersion)
     }
+
+    @Test
+    fun `repeated startups with same version stay silent`() {
+        // lastSeen already matches current — line 21 should short-circuit every call.
+        state.lastSeenVersion = "2.4.0"
+        every {
+            PluginManagerCore.getPlugin(any<PluginId>())
+        } returns descriptor
+        every { descriptor.version } returns "2.4.0"
+
+        val notification = mockk<Notification>(relaxed = true)
+        val group = mockk<NotificationGroup>(relaxed = true)
+        val groupManager = mockk<NotificationGroupManager>(relaxed = true)
+        every { NotificationGroupManager.getInstance() } returns groupManager
+        every { groupManager.getNotificationGroup("Ayu Islands") } returns group
+        every {
+            group.createNotification(any<String>(), any<String>(), any<NotificationType>())
+        } returns notification
+
+        repeat(5) { UpdateNotifier.showIfUpdated(project) }
+
+        assertEquals("2.4.0", state.lastSeenVersion)
+        verify(exactly = 0) { notification.notify(any<Project>()) }
+        verify(exactly = 0) {
+            group.createNotification(any<String>(), any<String>(), any<NotificationType>())
+        }
+    }
+
+    @Test
+    fun `fresh install with release notes for current version stays silent`() {
+        // lastSeen == null means first install — state must update but notification must NOT fire,
+        // even when release notes exist for the current version.
+        state.lastSeenVersion = null
+        every {
+            PluginManagerCore.getPlugin(any<PluginId>())
+        } returns descriptor
+        every { descriptor.version } returns "2.4.0"
+
+        val notification = mockk<Notification>(relaxed = true)
+        val group = mockk<NotificationGroup>(relaxed = true)
+        val groupManager = mockk<NotificationGroupManager>(relaxed = true)
+        every { NotificationGroupManager.getInstance() } returns groupManager
+        every { groupManager.getNotificationGroup("Ayu Islands") } returns group
+        every {
+            group.createNotification(any<String>(), any<String>(), any<NotificationType>())
+        } returns notification
+
+        UpdateNotifier.showIfUpdated(project)
+
+        assertEquals("2.4.0", state.lastSeenVersion)
+        verify(exactly = 0) { notification.notify(any<Project>()) }
+        verify(exactly = 0) {
+            group.createNotification(any<String>(), any<String>(), any<NotificationType>())
+        }
+    }
+
+    @Test
+    fun `upgrade then subsequent startups show notification exactly once`() {
+        // Multi-session regression guard: mirrors the LicenseTransitionListener single-call trap.
+        // Session 1 upgrades from 2.3.7 to 2.4.0 — notification fires.
+        // Session 2 and 3 read the persisted state — must stay silent.
+        state.lastSeenVersion = "2.3.7"
+        every {
+            PluginManagerCore.getPlugin(any<PluginId>())
+        } returns descriptor
+        every { descriptor.version } returns "2.4.0"
+
+        val notification = mockk<Notification>(relaxed = true)
+        val group = mockk<NotificationGroup>(relaxed = true)
+        val groupManager = mockk<NotificationGroupManager>(relaxed = true)
+        every { NotificationGroupManager.getInstance() } returns groupManager
+        every { groupManager.getNotificationGroup("Ayu Islands") } returns group
+        every {
+            group.createNotification(any<String>(), any<String>(), any<NotificationType>())
+        } returns notification
+
+        // Session 1: upgrade
+        UpdateNotifier.showIfUpdated(project)
+        assertEquals("2.4.0", state.lastSeenVersion)
+
+        // Session 2: startup with persisted state
+        UpdateNotifier.showIfUpdated(project)
+
+        // Session 3: startup with persisted state
+        UpdateNotifier.showIfUpdated(project)
+
+        verify(exactly = 1) { notification.notify(any<Project>()) }
+        verify(exactly = 1) {
+            group.createNotification(any<String>(), any<String>(), any<NotificationType>())
+        }
+    }
+
+    @Test
+    fun `version skip shows release notes for target version only`() {
+        // User upgraded 2.3.5 -> 2.4.0 (skipped 2.3.6 and 2.3.7). The notification must describe
+        // the target version, not an intermediate one.
+        state.lastSeenVersion = "2.3.5"
+        every {
+            PluginManagerCore.getPlugin(any<PluginId>())
+        } returns descriptor
+        every { descriptor.version } returns "2.4.0"
+
+        val notification = mockk<Notification>(relaxed = true)
+        val group = mockk<NotificationGroup>(relaxed = true)
+        val groupManager = mockk<NotificationGroupManager>(relaxed = true)
+        every { NotificationGroupManager.getInstance() } returns groupManager
+        every { groupManager.getNotificationGroup("Ayu Islands") } returns group
+        every {
+            group.createNotification(any<String>(), any<String>(), any<NotificationType>())
+        } returns notification
+
+        UpdateNotifier.showIfUpdated(project)
+
+        assertEquals("2.4.0", state.lastSeenVersion)
+        verify(exactly = 1) {
+            group.createNotification(
+                "Ayu Islands updated to 2.4.0",
+                match<String> { body ->
+                    body.contains("Onboarding wizard") &&
+                        !body.contains("tool window width jumping") &&
+                        !body.contains("Bug fixes")
+                },
+                NotificationType.INFORMATION,
+            )
+        }
+        verify(exactly = 1) { notification.notify(project) }
+    }
+
+    @Test
+    fun `version with no release notes updates state but does not notify`() {
+        // Current version is not in RELEASE_NOTES — state must update but notification must NOT fire.
+        state.lastSeenVersion = "2.3.7"
+        every {
+            PluginManagerCore.getPlugin(any<PluginId>())
+        } returns descriptor
+        every { descriptor.version } returns "2.9.99"
+
+        val notification = mockk<Notification>(relaxed = true)
+        val group = mockk<NotificationGroup>(relaxed = true)
+        val groupManager = mockk<NotificationGroupManager>(relaxed = true)
+        every { NotificationGroupManager.getInstance() } returns groupManager
+        every { groupManager.getNotificationGroup("Ayu Islands") } returns group
+        every {
+            group.createNotification(any<String>(), any<String>(), any<NotificationType>())
+        } returns notification
+
+        UpdateNotifier.showIfUpdated(project)
+
+        assertEquals("2.9.99", state.lastSeenVersion)
+        verify(exactly = 0) { notification.notify(any<Project>()) }
+        verify(exactly = 0) {
+            group.createNotification(any<String>(), any<String>(), any<NotificationType>())
+        }
+    }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
@@ -1108,6 +1108,166 @@ class AccentApplicatorTest {
         verify { element2.apply(accent) }
     }
 
+    // Defensive dispatch regression tests — capture try-catch isolation.
+    // If a refactor removes the per-element try-catch in applyElements,
+    // revertAll, or neutralizeOrRevert, these tests must fail.
+
+    /**
+     * Regression guard for the per-element try-catch at line 220-227 of
+     * [AccentApplicator.applyElements]. If removed, the middle element's
+     * exception would propagate and the third element would never receive
+     * `apply`, breaking isolation between unrelated accent elements.
+     */
+    @Test
+    fun `applyElements continues dispatch when one element throws RuntimeException`() {
+        val first = createFakeAccentElement(AccentElementId.CARET_ROW, "Caret Row")
+        val second = createFakeAccentElement(AccentElementId.SCROLLBAR, "Scrollbar")
+        every { second.apply(any()) } throws IllegalStateException("simulated")
+        val third = createFakeAccentElement(AccentElementId.LINKS, "Links")
+        mockEpExtensionList(listOf(first, second, third))
+
+        val accent = Color.decode("#FFCC66")
+        // Must not propagate the simulated exception
+        invokeApplyElements(state, accent, AyuVariant.MIRAGE)
+
+        // Loop must have continued past the failing middle element
+        verify { first.apply(accent) }
+        verify { second.apply(accent) }
+        verify { third.apply(accent) }
+    }
+
+    /**
+     * Regression guard for the per-element try-catch at line 157-164 of
+     * [AccentApplicator.revertAll]. Revert failures on one element must
+     * not block revert for the rest.
+     */
+    @Test
+    fun `revertAll continues loop when one element throws`() {
+        val first = createFakeAccentElement(AccentElementId.CARET_ROW, "Caret Row")
+        val second = createFakeAccentElement(AccentElementId.SCROLLBAR, "Scrollbar")
+        every { second.revert() } throws IllegalStateException("revert failed")
+        val third = createFakeAccentElement(AccentElementId.LINKS, "Links")
+        mockEpExtensionList(listOf(first, second, third))
+
+        AccentApplicator.revertAll()
+
+        verify { first.revert() }
+        verify { second.revert() }
+        verify { third.revert() }
+    }
+
+    /**
+     * Regression guard for the try-catch at line 187-195 of
+     * [AccentApplicator.neutralizeOrRevert]. When an element is disabled,
+     * the neutral path runs — and its failure must not propagate out of
+     * [AccentApplicator.applyElements].
+     */
+    @Test
+    fun `neutralizeOrRevert catches exceptions from disabled elements`() {
+        val failing = createFakeAccentElement(AccentElementId.CARET_ROW, "Caret Row")
+        every { failing.applyNeutral(any()) } throws IllegalStateException("neutralize failed")
+        val trailing = createFakeAccentElement(AccentElementId.SCROLLBAR, "Scrollbar")
+        state.caretRow = false
+        mockEpExtensionList(listOf(failing, trailing))
+
+        val accent = Color.decode("#FFCC66")
+        // Must not throw despite failing.applyNeutral exploding
+        invokeApplyElements(state, accent, AyuVariant.MIRAGE)
+
+        // Loop continued and the trailing element was processed normally
+        verify { failing.applyNeutral(AyuVariant.MIRAGE) }
+        verify { trailing.apply(accent) }
+    }
+
+    /**
+     * Behaviour check for the disabled branch of
+     * [AccentApplicator.applyElements]: `apply` must not be called and
+     * the neutral path (applyNeutral on non-null variant) must run.
+     */
+    @Test
+    fun `applyElements skips disabled element without calling apply`() {
+        val element = createFakeAccentElement(AccentElementId.CARET_ROW, "Caret Row")
+        state.setToggle(AccentElementId.CARET_ROW, false)
+        mockEpExtensionList(listOf(element))
+
+        val accent = Color.decode("#FFCC66")
+        invokeApplyElements(state, accent, AyuVariant.MIRAGE)
+
+        verify(exactly = 0) { element.apply(any()) }
+        verify { element.applyNeutral(AyuVariant.MIRAGE) }
+    }
+
+    /**
+     * Behaviour check for the conflict branch of
+     * [AccentApplicator.applyElements]: when [ConflictRegistry] reports a
+     * conflict and the user has NOT opted into force-override, the element
+     * must be neutralized instead of applied.
+     */
+    @Test
+    fun `applyElements skips element when ConflictRegistry reports a conflict`() {
+        val element = createFakeAccentElement(AccentElementId.MATCHING_TAG, "Matching Tag")
+        val conflict =
+            ConflictEntry(
+                pluginDisplayName = "Atom Material Icons",
+                pluginId = "com.mallowigi",
+                affectedElements = setOf(AccentElementId.MATCHING_TAG),
+                type = ConflictType.BLOCK,
+            )
+        every { ConflictRegistry.getConflictFor(AccentElementId.MATCHING_TAG) } returns conflict
+        // forceOverrides does NOT contain the element id name
+        state.forceOverrides = mutableSetOf()
+        mockEpExtensionList(listOf(element))
+
+        val accent = Color.decode("#FFCC66")
+        invokeApplyElements(state, accent, AyuVariant.MIRAGE)
+
+        verify(exactly = 0) { element.apply(any()) }
+        verify { element.applyNeutral(AyuVariant.MIRAGE) }
+    }
+
+    /**
+     * Behaviour check for the force-override escape hatch in
+     * [AccentApplicator.applyElements]: if the user opts in via
+     * `forceOverrides`, the conflict is bypassed and the element applies
+     * normally.
+     */
+    @Test
+    fun `applyElements force-overrides conflict when user opted in`() {
+        val element = createFakeAccentElement(AccentElementId.MATCHING_TAG, "Matching Tag")
+        val conflict =
+            ConflictEntry(
+                pluginDisplayName = "Atom Material Icons",
+                pluginId = "com.mallowigi",
+                affectedElements = setOf(AccentElementId.MATCHING_TAG),
+                type = ConflictType.BLOCK,
+            )
+        every { ConflictRegistry.getConflictFor(AccentElementId.MATCHING_TAG) } returns conflict
+        state.forceOverrides = mutableSetOf(AccentElementId.MATCHING_TAG.name)
+        mockEpExtensionList(listOf(element))
+
+        val accent = Color.decode("#FFCC66")
+        invokeApplyElements(state, accent, AyuVariant.MIRAGE)
+
+        // Force override wins — apply called, neutralize path not taken
+        verify { element.apply(accent) }
+        verify(exactly = 0) { element.applyNeutral(any()) }
+    }
+
+    /**
+     * Builds a relaxed [AccentElement] mock with the given id and display
+     * name. Used by the defensive dispatch regression tests to assemble
+     * multi-element scenarios quickly and consistently.
+     */
+    private fun createFakeAccentElement(
+        id: AccentElementId,
+        displayName: String,
+    ): AccentElement {
+        val element = mockk<AccentElement>(relaxed = true)
+        every { element.id } returns id
+        every { element.displayName } returns displayName
+        return element
+    }
+
     // Tests for syncCodeGlanceProViewport full flow
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/accent/AyuVariantTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AyuVariantTest.kt
@@ -172,4 +172,37 @@ class AyuVariantTest {
 
         assertFalse(AyuVariant.isIslandsUi())
     }
+
+    @Test
+    fun `fromThemeName is case-sensitive`() {
+        // Platform theme-name lookup is exact-match; case folding would cause false positives
+        // against third-party themes that happen to share a prefix.
+        assertNull(AyuVariant.fromThemeName("ayu mirage"))
+        assertNull(AyuVariant.fromThemeName("AYU MIRAGE"))
+        assertNull(AyuVariant.fromThemeName("Ayu MIRAGE"))
+        assertNull(AyuVariant.fromThemeName("ayu dark"))
+        assertNull(AyuVariant.fromThemeName("AYU LIGHT (ISLANDS UI)"))
+    }
+
+    @Test
+    fun `fromThemeName rejects partial matches`() {
+        // Prefix/substring matching would collide with plugins that ship "Ayu Vim" or similar.
+        assertNull(AyuVariant.fromThemeName("Ayu"))
+        assertNull(AyuVariant.fromThemeName("Mirage"))
+        assertNull(AyuVariant.fromThemeName("Ayu Mirage Extended"))
+        assertNull(AyuVariant.fromThemeName("Ayu Mirage+"))
+        assertNull(AyuVariant.fromThemeName("Custom Ayu Mirage"))
+        assertNull(AyuVariant.fromThemeName("(Islands UI)"))
+    }
+
+    @Test
+    fun `fromThemeName with whitespace variations returns null`() {
+        // LafManager theme names are whitespace-exact; trimming or collapsing would mask typos
+        // in third-party theme definitions.
+        assertNull(AyuVariant.fromThemeName("  Ayu Mirage  "))
+        assertNull(AyuVariant.fromThemeName("Ayu  Mirage"))
+        assertNull(AyuVariant.fromThemeName("Ayu\tMirage"))
+        assertNull(AyuVariant.fromThemeName("Ayu Mirage "))
+        assertNull(AyuVariant.fromThemeName(" Ayu Mirage"))
+    }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/CachedMacReaderTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/CachedMacReaderTest.kt
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.condition.OS
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
 
 /**
  * Tests for [CachedMacReader].
@@ -47,5 +49,62 @@ class CachedMacReaderTest {
         val reader = CachedMacReader<String>(ttlMs = 0L) { null }
 
         assertNull(reader.read())
+    }
+
+    @Test
+    fun `cache expires after real ttlMs elapsed`() {
+        var callCount = 0
+        val reader =
+            CachedMacReader(ttlMs = 50L) {
+                callCount++
+                "fresh-$callCount"
+            }
+
+        // First read is a fresh fetch
+        assertEquals("fresh-1", reader.read())
+        assertEquals(1, callCount)
+
+        // Sleep past the TTL boundary
+        Thread.sleep(100)
+
+        // Should re-invoke the reader because the cache expired
+        assertEquals("fresh-2", reader.read())
+        assertEquals(2, callCount)
+    }
+
+    @Test
+    fun `cache returns same instance within TTL across multiple calls`() {
+        var callCount = 0
+        val reader =
+            CachedMacReader(ttlMs = 60_000L) {
+                callCount++
+                // Deliberately allocate a fresh object each invocation
+                // so === identity distinguishes cache hits from misses.
+                StringBuilder("value").toString()
+            }
+
+        val first = reader.read()
+        val second = reader.read()
+        val third = reader.read()
+        val fourth = reader.read()
+        val fifth = reader.read()
+
+        // Reader must have been invoked exactly once
+        assertEquals(1, callCount)
+
+        // All five results equal by value
+        assertEquals(first, second)
+        assertEquals(first, third)
+        assertEquals(first, fourth)
+        assertEquals(first, fifth)
+
+        // And they must be the SAME instance (cached, not re-read)
+        assertSame(first, second)
+        assertSame(first, third)
+        assertSame(first, fourth)
+        assertSame(first, fifth)
+
+        // Sanity: first cached value is non-null
+        assertTrue(first != null)
     }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/CachedMacReaderTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/CachedMacReaderTest.kt
@@ -52,22 +52,30 @@ class CachedMacReaderTest {
     }
 
     @Test
-    fun `cache expires after real ttlMs elapsed`() {
+    fun `cache expires after ttlMs elapsed (mocked clock)`() {
+        // Drive the clock manually instead of Thread.sleep — keeps the test
+        // deterministic on slow CI machines.
+        var nowMs = 1_000L
         var callCount = 0
         val reader =
-            CachedMacReader(ttlMs = 50L) {
+            CachedMacReader(
+                ttlMs = 50L,
+                clock = { nowMs },
+            ) {
                 callCount++
                 "fresh-$callCount"
             }
 
-        // First read is a fresh fetch
         assertEquals("fresh-1", reader.read())
         assertEquals(1, callCount)
 
-        // Sleep past the TTL boundary
-        Thread.sleep(100)
+        // Still inside TTL window — cache hit
+        nowMs += 49L
+        assertEquals("fresh-1", reader.read())
+        assertEquals(1, callCount)
 
-        // Should re-invoke the reader because the cache expired
+        // Cross the TTL boundary — cache must refresh
+        nowMs += 2L
         assertEquals("fresh-2", reader.read())
         assertEquals(2, callCount)
     }

--- a/src/test/kotlin/dev/ayuislands/accent/conflict/ConflictRegistryTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/conflict/ConflictRegistryTest.kt
@@ -16,16 +16,7 @@ import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
-/**
- * Tests for [ConflictRegistry].
- *
- * The `cachedConflicts` lazy delegate backing field is replaced via
- * `sun.misc.Unsafe` in tests that need a pristine cache, mirroring the
- * pattern used by `AccentApplicatorTest` for `EP_NAME`.
- */
 class ConflictRegistryTest {
-    private var originalLazy: Any? = null
-
     private fun getEntries(): List<ConflictEntry> {
         val field = ConflictRegistry::class.java.getDeclaredField("entries")
         field.isAccessible = true
@@ -35,65 +26,13 @@ class ConflictRegistryTest {
 
     @BeforeTest
     fun setUp() {
-        saveOriginalLazy()
+        ConflictRegistry.resetCachedConflictsForTesting()
     }
 
     @AfterTest
     fun tearDown() {
-        restoreOriginalLazy()
+        ConflictRegistry.resetCachedConflictsForTesting()
         unmockkAll()
-    }
-
-    private fun saveOriginalLazy() {
-        if (originalLazy != null) return
-        val field = ConflictRegistry::class.java.getDeclaredField("cachedConflicts\$delegate")
-        field.isAccessible = true
-        originalLazy = field.get(null)
-    }
-
-    private fun restoreOriginalLazy() {
-        val original = originalLazy ?: return
-        val field = ConflictRegistry::class.java.getDeclaredField("cachedConflicts\$delegate")
-        field.isAccessible = true
-        unsafeWriteStaticField(field, original)
-        originalLazy = null
-    }
-
-    /**
-     * Replaces the lazy delegate backing `cachedConflicts` so the next call
-     * to `detectConflicts` re-runs the filter logic against the currently
-     * mocked [PluginManagerCore]. Uses `sun.misc.Unsafe` because direct
-     * reflection on the `private static final` backing field is blocked on
-     * Java 21+.
-     */
-    private fun resetCachedConflicts() {
-        val field = ConflictRegistry::class.java.getDeclaredField("cachedConflicts\$delegate")
-        field.isAccessible = true
-        val fresh =
-            lazy {
-                val entriesField = ConflictRegistry::class.java.getDeclaredField("entries")
-                entriesField.isAccessible = true
-                @Suppress("UNCHECKED_CAST")
-                val allEntries = entriesField.get(null) as List<ConflictEntry>
-                allEntries.filter { entry ->
-                    val pluginId = PluginId.getId(entry.pluginId)
-                    PluginManagerCore.getPlugin(pluginId) != null &&
-                        !PluginManagerCore.isDisabled(pluginId)
-                }
-            }
-        unsafeWriteStaticField(field, fresh)
-    }
-
-    @Suppress("DEPRECATION")
-    private fun unsafeWriteStaticField(
-        field: java.lang.reflect.Field,
-        value: Any?,
-    ) {
-        val unsafeField = sun.misc.Unsafe::class.java.getDeclaredField("theUnsafe")
-        unsafeField.isAccessible = true
-        val unsafe = unsafeField.get(null) as sun.misc.Unsafe
-        val offset = unsafe.staticFieldOffset(field)
-        unsafe.putObject(field.declaringClass, offset, value)
     }
 
     @Test
@@ -120,11 +59,6 @@ class ConflictRegistryTest {
     }
 
     @Test
-    fun `detectConflicts does not throw`() {
-        assertNotNull(ConflictRegistry.detectConflicts())
-    }
-
-    @Test
     fun `getConflictFor returns null for non-conflicting element`() {
         val conflict = ConflictRegistry.getConflictFor(AccentElementId.LINKS)
         assertNull(conflict)
@@ -140,26 +74,12 @@ class ConflictRegistryTest {
         assertTrue(ir.affectedElements.isEmpty())
     }
 
-    @Test
-    fun `isCodeGlanceProDetected does not throw`() {
-        // In a test environment without real plugins, just verify the method executes
-        ConflictRegistry.isCodeGlanceProDetected()
-    }
-
-    @Test
-    fun `isIndentRainbowDetected does not throw`() {
-        ConflictRegistry.isIndentRainbowDetected()
-    }
-
     /**
      * Negative-path regression: a conflict entry whose `affectedElements`
-     * does NOT include the queried id must produce `null`. Captures the
-     * `elementId in it.affectedElements` filter contract without relying on
-     * the global `cachedConflicts`.
+     * does NOT include the queried id must produce `null`.
      */
     @Test
     fun `getConflictFor returns null when no entries affect the given element id`() {
-        // Hand-built entry that targets MATCHING_TAG only
         val entry =
             ConflictEntry(
                 pluginDisplayName = "Hypothetical Plugin",
@@ -169,27 +89,23 @@ class ConflictRegistryTest {
             )
         val entries = listOf(entry)
 
-        // Query for a DIFFERENT id — must return null
         val hit = entries.firstOrNull { AccentElementId.CARET_ROW in it.affectedElements }
         assertNull(hit, "Entry with non-matching affectedElements must not resolve")
 
-        // Sanity: the same predicate against a matching id returns the entry
         val match = entries.firstOrNull { AccentElementId.MATCHING_TAG in it.affectedElements }
         assertNotNull(match)
         assertEquals("Hypothetical Plugin", match.pluginDisplayName)
     }
 
     /**
-     * Happy-path regression for `detectConflicts`: when neither the
-     * CodeGlance Pro plugin nor the Indent Rainbow plugin is installed,
-     * the returned list must be empty.
+     * Happy-path regression for `detectConflicts`: when neither CodeGlance Pro
+     * nor Indent Rainbow is installed, the returned list must be empty.
      */
     @Test
     fun `detectConflicts returns empty list when no conflict plugins installed`() {
         mockkStatic(PluginManagerCore::class)
         every { PluginManagerCore.getPlugin(any<PluginId>()) } returns null
         every { PluginManagerCore.isDisabled(any<PluginId>()) } returns false
-        resetCachedConflicts()
 
         val conflicts = ConflictRegistry.detectConflicts()
 
@@ -197,26 +113,40 @@ class ConflictRegistryTest {
     }
 
     /**
-     * Caching regression: `detectConflicts` must consult the plugin
-     * registry only once per session. The second call must return the
-     * exact same list instance and must NOT trigger additional
-     * `PluginManagerCore.getPlugin` lookups.
+     * Caching regression: `detectConflicts` consults the plugin registry only
+     * once per session. The second call returns the exact same list instance
+     * and does NOT trigger additional `PluginManagerCore.getPlugin` lookups.
      */
     @Test
     fun `detectConflicts result is cached across calls`() {
         mockkStatic(PluginManagerCore::class)
         every { PluginManagerCore.getPlugin(any<PluginId>()) } returns null
         every { PluginManagerCore.isDisabled(any<PluginId>()) } returns false
-        resetCachedConflicts()
 
         val first = ConflictRegistry.detectConflicts()
         val second = ConflictRegistry.detectConflicts()
 
-        // Same object instance — cached via kotlin.lazy
         assertSame(first, second, "Cached result must be reused across calls")
-
-        // getPlugin was invoked once per known entry on the first call only.
-        // Registry currently has 2 entries, so 2 total invocations — not 4.
         verify(exactly = 2) { PluginManagerCore.getPlugin(any<PluginId>()) }
+    }
+
+    /**
+     * Reset hook regression: after `resetCachedConflictsForTesting`, the next
+     * call must re-run the filter against the current mock state.
+     */
+    @Test
+    fun `resetCachedConflictsForTesting clears cache so next call re-queries plugins`() {
+        mockkStatic(PluginManagerCore::class)
+        every { PluginManagerCore.getPlugin(any<PluginId>()) } returns null
+        every { PluginManagerCore.isDisabled(any<PluginId>()) } returns false
+
+        val firstBatch = ConflictRegistry.detectConflicts()
+        ConflictRegistry.resetCachedConflictsForTesting()
+        val secondBatch = ConflictRegistry.detectConflicts()
+
+        // Two separate computations: 2 entries x 2 calls = 4 lookups
+        verify(exactly = 4) { PluginManagerCore.getPlugin(any<PluginId>()) }
+        // Same content, different instances (cache was cleared)
+        assertEquals(firstBatch, secondBatch)
     }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/conflict/ConflictRegistryTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/conflict/ConflictRegistryTest.kt
@@ -1,22 +1,31 @@
 package dev.ayuislands.accent.conflict
 
+import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.openapi.extensions.PluginId
 import dev.ayuislands.accent.AccentElementId
+import io.mockk.every
+import io.mockk.mockkStatic
 import io.mockk.unmockkAll
+import io.mockk.verify
 import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 /**
  * Tests for [ConflictRegistry].
  *
- * The `cachedConflicts` lazy delegate cannot be reset on Java 21+ due to module
- * access restrictions. These tests verify the static `entries` configuration
- * which is the source of truth for conflict detection logic.
+ * The `cachedConflicts` lazy delegate backing field is replaced via
+ * `sun.misc.Unsafe` in tests that need a pristine cache, mirroring the
+ * pattern used by `AccentApplicatorTest` for `EP_NAME`.
  */
 class ConflictRegistryTest {
+    private var originalLazy: Any? = null
+
     private fun getEntries(): List<ConflictEntry> {
         val field = ConflictRegistry::class.java.getDeclaredField("entries")
         field.isAccessible = true
@@ -24,9 +33,67 @@ class ConflictRegistryTest {
         return field.get(ConflictRegistry) as List<ConflictEntry>
     }
 
+    @BeforeTest
+    fun setUp() {
+        saveOriginalLazy()
+    }
+
     @AfterTest
     fun tearDown() {
+        restoreOriginalLazy()
         unmockkAll()
+    }
+
+    private fun saveOriginalLazy() {
+        if (originalLazy != null) return
+        val field = ConflictRegistry::class.java.getDeclaredField("cachedConflicts\$delegate")
+        field.isAccessible = true
+        originalLazy = field.get(null)
+    }
+
+    private fun restoreOriginalLazy() {
+        val original = originalLazy ?: return
+        val field = ConflictRegistry::class.java.getDeclaredField("cachedConflicts\$delegate")
+        field.isAccessible = true
+        unsafeWriteStaticField(field, original)
+        originalLazy = null
+    }
+
+    /**
+     * Replaces the lazy delegate backing `cachedConflicts` so the next call
+     * to `detectConflicts` re-runs the filter logic against the currently
+     * mocked [PluginManagerCore]. Uses `sun.misc.Unsafe` because direct
+     * reflection on the `private static final` backing field is blocked on
+     * Java 21+.
+     */
+    private fun resetCachedConflicts() {
+        val field = ConflictRegistry::class.java.getDeclaredField("cachedConflicts\$delegate")
+        field.isAccessible = true
+        val fresh =
+            lazy {
+                val entriesField = ConflictRegistry::class.java.getDeclaredField("entries")
+                entriesField.isAccessible = true
+                @Suppress("UNCHECKED_CAST")
+                val allEntries = entriesField.get(null) as List<ConflictEntry>
+                allEntries.filter { entry ->
+                    val pluginId = PluginId.getId(entry.pluginId)
+                    PluginManagerCore.getPlugin(pluginId) != null &&
+                        !PluginManagerCore.isDisabled(pluginId)
+                }
+            }
+        unsafeWriteStaticField(field, fresh)
+    }
+
+    @Suppress("DEPRECATION")
+    private fun unsafeWriteStaticField(
+        field: java.lang.reflect.Field,
+        value: Any?,
+    ) {
+        val unsafeField = sun.misc.Unsafe::class.java.getDeclaredField("theUnsafe")
+        unsafeField.isAccessible = true
+        val unsafe = unsafeField.get(null) as sun.misc.Unsafe
+        val offset = unsafe.staticFieldOffset(field)
+        unsafe.putObject(field.declaringClass, offset, value)
     }
 
     @Test
@@ -82,5 +149,74 @@ class ConflictRegistryTest {
     @Test
     fun `isIndentRainbowDetected does not throw`() {
         ConflictRegistry.isIndentRainbowDetected()
+    }
+
+    /**
+     * Negative-path regression: a conflict entry whose `affectedElements`
+     * does NOT include the queried id must produce `null`. Captures the
+     * `elementId in it.affectedElements` filter contract without relying on
+     * the global `cachedConflicts`.
+     */
+    @Test
+    fun `getConflictFor returns null when no entries affect the given element id`() {
+        // Hand-built entry that targets MATCHING_TAG only
+        val entry =
+            ConflictEntry(
+                pluginDisplayName = "Hypothetical Plugin",
+                pluginId = "test.plugin.id",
+                affectedElements = setOf(AccentElementId.MATCHING_TAG),
+                type = ConflictType.BLOCK,
+            )
+        val entries = listOf(entry)
+
+        // Query for a DIFFERENT id — must return null
+        val hit = entries.firstOrNull { AccentElementId.CARET_ROW in it.affectedElements }
+        assertNull(hit, "Entry with non-matching affectedElements must not resolve")
+
+        // Sanity: the same predicate against a matching id returns the entry
+        val match = entries.firstOrNull { AccentElementId.MATCHING_TAG in it.affectedElements }
+        assertNotNull(match)
+        assertEquals("Hypothetical Plugin", match.pluginDisplayName)
+    }
+
+    /**
+     * Happy-path regression for `detectConflicts`: when neither the
+     * CodeGlance Pro plugin nor the Indent Rainbow plugin is installed,
+     * the returned list must be empty.
+     */
+    @Test
+    fun `detectConflicts returns empty list when no conflict plugins installed`() {
+        mockkStatic(PluginManagerCore::class)
+        every { PluginManagerCore.getPlugin(any<PluginId>()) } returns null
+        every { PluginManagerCore.isDisabled(any<PluginId>()) } returns false
+        resetCachedConflicts()
+
+        val conflicts = ConflictRegistry.detectConflicts()
+
+        assertTrue(conflicts.isEmpty(), "Expected no conflicts when plugins are absent")
+    }
+
+    /**
+     * Caching regression: `detectConflicts` must consult the plugin
+     * registry only once per session. The second call must return the
+     * exact same list instance and must NOT trigger additional
+     * `PluginManagerCore.getPlugin` lookups.
+     */
+    @Test
+    fun `detectConflicts result is cached across calls`() {
+        mockkStatic(PluginManagerCore::class)
+        every { PluginManagerCore.getPlugin(any<PluginId>()) } returns null
+        every { PluginManagerCore.isDisabled(any<PluginId>()) } returns false
+        resetCachedConflicts()
+
+        val first = ConflictRegistry.detectConflicts()
+        val second = ConflictRegistry.detectConflicts()
+
+        // Same object instance — cached via kotlin.lazy
+        assertSame(first, second, "Cached result must be reused across calls")
+
+        // getPlugin was invoked once per known entry on the first call only.
+        // Registry currently has 2 entries, so 2 total invocations — not 4.
+        verify(exactly = 2) { PluginManagerCore.getPlugin(any<PluginId>()) }
     }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/elements/BracketFadeManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/BracketFadeManagerTest.kt
@@ -664,4 +664,105 @@ class BracketFadeManagerTest {
         verify { mockMulticaster.addCaretListener(any(), any()) }
         verify { mockEditorFactory.addEditorFactoryListener(any(), any()) }
     }
+
+    // State-machine regression tests — capture that rapid caret moves and
+    // activate/deactivate/activate cycles do not leak highlighters or
+    // reuse stale disposables.
+
+    /**
+     * Regression guard for highlighter leaks: every caret move must dispose
+     * the previous highlighter before adding a new one, leaving exactly one
+     * entry in `activeHighlighters` for the editor.
+     */
+    @Test
+    fun `rapid caret moves cancel previous highlighter and keep only latest`() {
+        setPrivateField("currentColor", Color.ORANGE)
+
+        val mockContext = mockk<BraceHighlightingAndNavigationContext>(relaxed = true)
+        every {
+            BraceMatchingUtil.computeHighlightingAndNavigationContext(any(), any())
+        } returns mockContext
+        every { mockDocument.getLineNumber(any()) } returns 0
+
+        val highlighter1 = mockk<RangeHighlighter>(relaxed = true)
+        val highlighter2 = mockk<RangeHighlighter>(relaxed = true)
+        val highlighter3 = mockk<RangeHighlighter>(relaxed = true)
+        every { highlighter1.isValid } returns true
+        every { highlighter2.isValid } returns true
+        every { highlighter3.isValid } returns true
+
+        // Each call returns a distinct highlighter so we can assert which
+        // one the map ends up holding.
+        every {
+            mockMarkupModel.addRangeHighlighter(
+                any<Int>(),
+                any<Int>(),
+                any<Int>(),
+                any(),
+                any<HighlighterTargetArea>(),
+            )
+        } returnsMany listOf(highlighter1, highlighter2, highlighter3)
+
+        every { mockContext.currentBraceOffset() } returns 10
+        every { mockContext.navigationOffset() } returns 20
+        invokePrivate("handleCaretMove", mockEditor)
+
+        every { mockContext.currentBraceOffset() } returns 30
+        every { mockContext.navigationOffset() } returns 40
+        invokePrivate("handleCaretMove", mockEditor)
+
+        every { mockContext.currentBraceOffset() } returns 100
+        every { mockContext.navigationOffset() } returns 200
+        invokePrivate("handleCaretMove", mockEditor)
+
+        // Previous highlighters must have been removed from the markup model
+        verify { mockMarkupModel.removeHighlighter(highlighter1) }
+        verify { mockMarkupModel.removeHighlighter(highlighter2) }
+        // The latest highlighter should still be live (not removed)
+        verify(exactly = 0) { mockMarkupModel.removeHighlighter(highlighter3) }
+
+        // activeHighlighters map holds only the latest entry for this editor
+        val highlighters = getPrivateField<Map<Editor, List<RangeHighlighter>>>("activeHighlighters")
+        assertEquals(1, highlighters.size, "Expected exactly one editor tracked")
+        assertEquals(listOf(highlighter3), highlighters[mockEditor])
+
+        // And the latest call used the coordinates we asked for (100..200)
+        verify {
+            mockMarkupModel.addRangeHighlighter(
+                100,
+                201,
+                any<Int>(),
+                null,
+                HighlighterTargetArea.LINES_IN_RANGE,
+            )
+        }
+    }
+
+    /**
+     * Regression guard for deactivate/activate cycles: a fresh activate
+     * must produce a new disposable and the new colour — never reuse the
+     * disposed one.
+     */
+    @Test
+    fun `activate then deactivate then activate recreates state cleanly`() {
+        val firstDisposable = mockk<Disposable>(relaxed = true)
+        val secondDisposable = mockk<Disposable>(relaxed = true)
+        every { Disposer.newDisposable(any<String>()) } returnsMany
+            listOf(firstDisposable, secondDisposable)
+
+        BracketFadeManager.activate(Color.RED)
+        assertEquals(firstDisposable, getPrivateField<Disposable?>("disposable"))
+
+        BracketFadeManager.deactivate()
+        assertNull(getPrivateField<Disposable?>("disposable"))
+        assertNull(getPrivateField<Color?>("currentColor"))
+
+        BracketFadeManager.activate(Color.BLUE)
+
+        val refreshed = getPrivateField<Disposable?>("disposable")
+        assertNotNull(refreshed)
+        assertEquals(secondDisposable, refreshed)
+        assertTrue(refreshed !== firstDisposable, "New disposable must not be the disposed one")
+        assertEquals(Color.BLUE, getPrivateField<Color?>("currentColor"))
+    }
 }

--- a/src/test/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManagerTest.kt
@@ -6,12 +6,15 @@ import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ToolWindowType
 import com.intellij.openapi.wm.ex.ToolWindowEx
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener
+import com.intellij.ui.content.Content
+import com.intellij.ui.content.ContentManager
 import com.intellij.util.messages.MessageBus
 import com.intellij.util.messages.MessageBusConnection
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
 import dev.ayuislands.settings.PanelWidthMode
+import dev.ayuislands.toolwindow.AutoFitCalculator
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -20,7 +23,10 @@ import io.mockk.unmockkAll
 import io.mockk.verify
 import java.awt.FlowLayout
 import javax.swing.JPanel
+import javax.swing.JTree
 import javax.swing.SwingUtilities
+import javax.swing.event.TreeExpansionEvent
+import javax.swing.tree.TreePath
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -171,6 +177,144 @@ class CommitPanelAutoFitManagerTest {
                 ToolWindowManagerListener.TOPIC,
                 any(),
             )
+        }
+    }
+
+    @Test
+    fun `apply with AUTO_FIT installs expansion listener and stretches on expand`() {
+        SwingUtilities.invokeAndWait {
+            every {
+                LicenseChecker.isLicensedOrGrace()
+            } returns true
+            realState.commitPanelWidthMode =
+                PanelWidthMode.AUTO_FIT.name
+            realState.autoFitCommitMaxWidth = 500
+            realState.commitPanelAutoFitMinWidth = 269
+
+            mockCalculatorForWidth(280)
+            val tree = JTree()
+            val panel = JPanel(FlowLayout())
+            panel.add(tree)
+            panel.setSize(200, 400)
+            setupCommitToolWindow(panel)
+
+            val listenersBefore = tree.treeExpansionListeners.size
+            val manager = CommitPanelAutoFitManager(project)
+            manager.apply()
+
+            // Listener installed
+            assert(tree.treeExpansionListeners.size > listenersBefore) {
+                "Expected expansion listener to be installed"
+            }
+            // Immediate apply on mode change also stretches once
+            verify { toolWindowEx.stretchWidth(any()) }
+
+            // Fire a tree expansion event — goes through debounce
+            val path = TreePath(tree.model.root)
+            val event = TreeExpansionEvent(tree, path)
+            for (listener in tree.treeExpansionListeners) {
+                listener.treeExpanded(event)
+            }
+        }
+
+        // Allow debounce (150ms) to fire on EDT
+        Thread.sleep(400)
+        SwingUtilities.invokeAndWait { /* flush */ }
+
+        // Expect at least one stretch invocation after debounce fires
+        verify(atLeast = 1) { toolWindowEx.stretchWidth(any()) }
+    }
+
+    @Test
+    fun `listener is removed when mode switches from AUTO_FIT to DEFAULT`() {
+        SwingUtilities.invokeAndWait {
+            every {
+                LicenseChecker.isLicensedOrGrace()
+            } returns true
+            realState.commitPanelWidthMode =
+                PanelWidthMode.AUTO_FIT.name
+            realState.autoFitCommitMaxWidth = 500
+            realState.commitPanelAutoFitMinWidth = 269
+
+            mockCalculatorForWidth(280)
+            val tree = JTree()
+            val panel = JPanel(FlowLayout())
+            panel.add(tree)
+            panel.setSize(200, 400)
+            setupCommitToolWindow(panel)
+
+            val listenersBefore = tree.treeExpansionListeners.size
+            val manager = CommitPanelAutoFitManager(project)
+
+            // AUTO_FIT -> listener installed
+            manager.apply()
+            assert(tree.treeExpansionListeners.size > listenersBefore) {
+                "Expected listener installed after AUTO_FIT"
+            }
+
+            // Switch to DEFAULT -> listener must be removed
+            realState.commitPanelWidthMode =
+                PanelWidthMode.DEFAULT.name
+            manager.apply()
+            assert(tree.treeExpansionListeners.size == listenersBefore) {
+                "Expected listener removed after DEFAULT"
+            }
+
+            // Firing an expansion event now should NOT trigger stretch
+            // (use a fresh mock call counter via a second manager call).
+            // We verify by checking that no listener exists on the tree.
+        }
+    }
+
+    private fun setupCommitToolWindow(component: JPanel) {
+        val content =
+            mockk<Content>(relaxed = true) {
+                every { this@mockk.component } returns component
+            }
+        val contentManager =
+            mockk<ContentManager>(relaxed = true) {
+                every { contents } returns arrayOf(content)
+            }
+        every {
+            toolWindowManager.getToolWindow("Commit")
+        } returns toolWindowEx
+        every {
+            toolWindowEx.contentManager
+        } returns contentManager
+        every {
+            toolWindowEx.component
+        } returns component
+        every {
+            toolWindowEx.type
+        } returns ToolWindowType.DOCKED
+    }
+
+    private fun mockCalculatorForWidth(targetWidth: Int) {
+        mockkObject(AutoFitCalculator)
+        every {
+            AutoFitCalculator.measureTreeMaxRowWidth(any())
+        } returns targetWidth
+        every {
+            AutoFitCalculator.isJitterOnly(any(), any())
+        } answers {
+            val current = firstArg<Int>()
+            val desired = secondArg<Int>()
+            kotlin.math.abs(desired - current) <=
+                AutoFitCalculator.JITTER_THRESHOLD
+        }
+        every {
+            AutoFitCalculator.calculateDesiredWidth(
+                any(),
+                any(),
+                any(),
+            )
+        } answers {
+            val maxRow = firstArg<Int>()
+            val maxW = secondArg<Int>()
+            val minW = thirdArg<Int>()
+            (maxRow + AutoFitCalculator.AUTOFIT_PADDING)
+                .coerceAtMost(maxW)
+                .coerceAtLeast(minW)
         }
     }
 }

--- a/src/test/kotlin/dev/ayuislands/editor/EditorScrollbarManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/editor/EditorScrollbarManagerTest.kt
@@ -296,4 +296,50 @@ class EditorScrollbarManagerTest {
         // No crash
         manager.dispose()
     }
+
+    @Test
+    fun `multiple editors opened sequentially all have consistent scrollbar state`() {
+        realState.hideEditorHScrollbar = true
+
+        val scrollPane1 = JScrollPane()
+        val scrollPane2 = JScrollPane()
+        val scrollPane3 = JScrollPane()
+
+        val originalH1 = Dimension(scrollPane1.horizontalScrollBar.preferredSize)
+        val originalH2 = Dimension(scrollPane2.horizontalScrollBar.preferredSize)
+        val originalH3 = Dimension(scrollPane3.horizontalScrollBar.preferredSize)
+
+        val editor1 =
+            mockk<EditorEx>(relaxed = true) {
+                every { project } returns this@EditorScrollbarManagerTest.project
+                every { scrollPane } returns scrollPane1
+            }
+        val editor2 =
+            mockk<EditorEx>(relaxed = true) {
+                every { project } returns this@EditorScrollbarManagerTest.project
+                every { scrollPane } returns scrollPane2
+            }
+        val editor3 =
+            mockk<EditorEx>(relaxed = true) {
+                every { project } returns this@EditorScrollbarManagerTest.project
+                every { scrollPane } returns scrollPane3
+            }
+
+        every { editorFactory.allEditors } returns arrayOf(editor1, editor2, editor3)
+
+        val manager = createManager()
+        manager.apply()
+
+        // All three scrollbars must be hidden with zero preferred size
+        assertEquals(Dimension(0, 0), scrollPane1.horizontalScrollBar.preferredSize)
+        assertEquals(Dimension(0, 0), scrollPane2.horizontalScrollBar.preferredSize)
+        assertEquals(Dimension(0, 0), scrollPane3.horizontalScrollBar.preferredSize)
+
+        // Disposing the manager must restore every scrollbar to its original size
+        manager.dispose()
+
+        assertEquals(originalH1, scrollPane1.horizontalScrollBar.preferredSize)
+        assertEquals(originalH2, scrollPane2.horizontalScrollBar.preferredSize)
+        assertEquals(originalH3, scrollPane3.horizontalScrollBar.preferredSize)
+    }
 }

--- a/src/test/kotlin/dev/ayuislands/font/FontInstallerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/font/FontInstallerTest.kt
@@ -1,0 +1,291 @@
+package dev.ayuislands.font
+
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.util.SystemInfo
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import java.io.File
+import java.io.IOException
+import java.net.SocketException
+import java.net.UnknownHostException
+import java.util.zip.ZipEntry
+import java.util.zip.ZipException
+import java.util.zip.ZipOutputStream
+import javax.net.ssl.SSLException
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [FontInstaller] helpers. The full [FontInstaller.install] pipeline
+ * requires a real [com.intellij.openapi.project.Project] and live HTTP, so it is
+ * tested only indirectly by exercising the internal helpers that `runPipeline`
+ * delegates to.
+ */
+class FontInstallerTest {
+    private val tmpRoot: File = createTempDirectory("ayu-font-installer-test").toFile()
+
+    @AfterTest
+    fun cleanup() {
+        unmockkAll()
+        tmpRoot.deleteRecursively()
+    }
+
+    private fun makeZip(
+        name: String,
+        entries: Map<String, ByteArray>,
+    ): File {
+        val file = File(tmpRoot, name)
+        ZipOutputStream(file.outputStream().buffered()).use { zip ->
+            for ((entryName, data) in entries) {
+                zip.putNextEntry(ZipEntry(entryName))
+                zip.write(data)
+                zip.closeEntry()
+            }
+        }
+        return file
+    }
+
+    // ---- platformFontDir ----
+
+    @Test
+    fun `platformFontDir returns OS-specific path for current platform`() {
+        val dir = FontInstaller.platformFontDir()
+        val path = dir.absolutePath
+        when {
+            SystemInfo.isMac -> {
+                assertTrue(
+                    path.contains("Library/Fonts"),
+                    "macOS platform font dir should contain 'Library/Fonts', got: $path",
+                )
+            }
+            SystemInfo.isWindows -> {
+                assertTrue(
+                    path.contains("Fonts", ignoreCase = true),
+                    "Windows platform font dir should contain 'Fonts', got: $path",
+                )
+            }
+            else -> {
+                assertTrue(
+                    path.contains(".local/share/fonts"),
+                    "Linux platform font dir should contain '.local/share/fonts', got: $path",
+                )
+            }
+        }
+    }
+
+    // ---- cachedZipFile ----
+
+    @Test
+    fun `cachedZipFile derives filename from URL`() {
+        mockkStatic(PathManager::class)
+        every { PathManager.getTempPath() } returns tmpRoot.absolutePath
+
+        val url = "https://github.com/x/y/releases/download/v1/font.zip"
+        val file = FontInstaller.cachedZipFile(url, FontPreset.AMBIENT)
+
+        assertEquals("font.zip", file.name)
+        assertTrue(file.parentFile.absolutePath.endsWith("ayu-fonts"))
+    }
+
+    @Test
+    fun `cachedZipFile falls back to preset name for URL without filename`() {
+        mockkStatic(PathManager::class)
+        every { PathManager.getTempPath() } returns tmpRoot.absolutePath
+
+        val url = "https://example.com/path/"
+        val file = FontInstaller.cachedZipFile(url, FontPreset.WHISPER)
+
+        assertEquals("WHISPER.zip", file.name)
+    }
+
+    // ---- downloadFailureKind ----
+
+    @Test
+    fun `downloadFailureKind maps UnknownHostException to OFFLINE`() {
+        val kind = FontInstaller.downloadFailureKind(UnknownHostException("no DNS"))
+        assertEquals(FontInstaller.FailureKind.OFFLINE, kind)
+    }
+
+    @Test
+    fun `downloadFailureKind maps SocketException to OFFLINE`() {
+        val kind = FontInstaller.downloadFailureKind(SocketException("connection refused"))
+        assertEquals(FontInstaller.FailureKind.OFFLINE, kind)
+    }
+
+    @Test
+    fun `downloadFailureKind maps SSLException to OFFLINE`() {
+        val kind = FontInstaller.downloadFailureKind(SSLException("handshake failed"))
+        assertEquals(FontInstaller.FailureKind.OFFLINE, kind)
+    }
+
+    @Test
+    fun `downloadFailureKind maps generic IOException to HTTP_ERROR`() {
+        val kind = FontInstaller.downloadFailureKind(IOException("500 server error"))
+        assertEquals(FontInstaller.FailureKind.HTTP_ERROR, kind)
+    }
+
+    // ---- extractionFailureKind ----
+
+    @Test
+    fun `extractionFailureKind maps No matching files cause to ASSET_NOT_FOUND`() {
+        val cause = FontArchiveException("No matching files in archive")
+        val exception = IOException(cause.message, cause)
+        val zipFile = File(tmpRoot, "dummy.zip").apply { writeBytes(ByteArray(4)) }
+
+        val kind = FontInstaller.extractionFailureKind(exception, zipFile)
+
+        assertEquals(FontInstaller.FailureKind.ASSET_NOT_FOUND, kind)
+        // ASSET_NOT_FOUND path must not touch the cached zip
+        assertTrue(zipFile.exists(), "ASSET_NOT_FOUND must not delete cached zip")
+    }
+
+    @Test
+    fun `extractionFailureKind on ZipException deletes corrupt cache`() {
+        val zipFile = File(tmpRoot, "corrupt.zip").apply { writeBytes(ByteArray(8)) }
+        assertTrue(zipFile.exists())
+
+        val exception = IOException("wrap", ZipException("bad central directory"))
+        val kind = FontInstaller.extractionFailureKind(exception, zipFile)
+
+        assertEquals(FontInstaller.FailureKind.EXTRACTION_FAILED, kind)
+        assertFalse(zipFile.exists(), "Corrupt cache zip should be deleted on ZipException")
+    }
+
+    @Test
+    fun `extractionFailureKind on generic IOException keeps cache`() {
+        val zipFile = File(tmpRoot, "ok.zip").apply { writeBytes(ByteArray(4)) }
+        val exception = IOException("transient IO glitch")
+
+        val kind = FontInstaller.extractionFailureKind(exception, zipFile)
+
+        assertEquals(FontInstaller.FailureKind.EXTRACTION_FAILED, kind)
+        assertTrue(zipFile.exists(), "Non-zip IOException should not delete cache")
+    }
+
+    // ---- extractFonts (integration through real zip) ----
+
+    @Test
+    fun `extractFonts extracts only matching font files`() {
+        val payload = "fontdata".toByteArray()
+        val zip =
+            makeZip(
+                "maple.zip",
+                mapOf(
+                    "MapleMono-Regular.ttf" to payload,
+                    "README.md" to "docs".toByteArray(),
+                ),
+            )
+        val extractDir = File(tmpRoot, "extracted").apply { mkdirs() }
+        val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+
+        val extracted = FontInstaller.extractFonts(zip, extractDir, entry)
+
+        assertEquals(1, extracted.size)
+        assertEquals("MapleMono-Regular.ttf", extracted[0].name)
+        assertTrue(extracted[0].exists())
+    }
+
+    @Test
+    fun `extractFonts wraps No matching files in IOException with FontArchiveException cause`() {
+        val zip =
+            makeZip(
+                "empty.zip",
+                mapOf("README.md" to "docs".toByteArray()),
+            )
+        val extractDir = File(tmpRoot, "extracted-empty").apply { mkdirs() }
+        val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+
+        val thrown =
+            runCatching { FontInstaller.extractFonts(zip, extractDir, entry) }
+                .exceptionOrNull()
+
+        assertTrue(thrown is IOException, "Expected IOException, got: $thrown")
+        assertTrue(
+            thrown.cause is FontArchiveException,
+            "IOException cause should be FontArchiveException, got: ${thrown.cause}",
+        )
+        // Feed the wrapped exception back into extractionFailureKind to verify the full loop.
+        assertEquals(
+            FontInstaller.FailureKind.ASSET_NOT_FOUND,
+            FontInstaller.extractionFailureKind(thrown, zip),
+        )
+    }
+
+    // ---- copyToPlatformFontDir ----
+    //
+    // NOTE: copyToPlatformFontDir() internally calls platformFontDir() which
+    // reads real system paths. We cannot mock the private helper in isolation,
+    // so instead we verify the copy logic by creating a real source file and
+    // letting the real platformFontDir() receive the copy. To avoid polluting
+    // the user's actual font directory, we skip if the real font dir is not
+    // writable AND we clean up the file afterwards. If running on CI without
+    // a writable font dir, the test gracefully no-ops.
+
+    @Test
+    fun `copyToPlatformFontDir copies source files into real platform dir`() {
+        val platformDir = FontInstaller.platformFontDir()
+        if (!platformDir.exists()) platformDir.mkdirs()
+        if (!platformDir.canWrite()) {
+            // No writable platform font dir available (sandboxed CI). Skip gracefully.
+            return
+        }
+
+        val uniqueName = "ayu-islands-copy-test-${System.nanoTime()}.ttf"
+        val source = File(tmpRoot, uniqueName).apply { writeBytes(ByteArray(16) { it.toByte() }) }
+
+        try {
+            val copied = FontInstaller.copyToPlatformFontDir(listOf(source))
+
+            assertEquals(1, copied.size)
+            assertEquals(uniqueName, copied[0].name)
+            assertTrue(copied[0].exists(), "Copied file must exist in platform dir")
+            assertEquals(source.length(), copied[0].length())
+        } finally {
+            // Remove the sentinel file so we don't litter the user's font dir.
+            File(platformDir, uniqueName).delete()
+        }
+    }
+
+    // ---- cleanupQuietly ----
+
+    @Test
+    fun `cleanupQuietly removes directory recursively`() {
+        val dir =
+            File(tmpRoot, "to-cleanup").apply {
+                mkdirs()
+                File(this, "nested.txt").writeText("hi")
+            }
+        assertTrue(dir.exists())
+
+        FontInstaller.cleanupQuietly(dir)
+
+        assertFalse(dir.exists(), "Directory should be removed")
+    }
+
+    // ---- applyOnly ----
+
+    @Test
+    fun `applyOnly invokes FontPresetApplicator inside invokeLater`() {
+        mockkStatic(ApplicationManager::class)
+        mockkObject(FontPresetApplicator)
+        val appMock = mockk<Application>(relaxed = true)
+        every { ApplicationManager.getApplication() } returns appMock
+        // Run the Runnable synchronously so we can verify apply() was called.
+        every { appMock.invokeLater(any()) } answers { firstArg<Runnable>().run() }
+        every { FontPresetApplicator.apply(any()) } answers { /* no-op */ }
+
+        FontInstaller.applyOnly(FontPreset.AMBIENT, project = null)
+
+        verify(exactly = 1) { FontPresetApplicator.apply(any()) }
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/font/FontInstallerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/font/FontInstallerTest.kt
@@ -1,5 +1,7 @@
 package dev.ayuislands.font
 
+import com.intellij.notification.Notification
+import com.intellij.notification.Notifications
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.PathManager
@@ -55,8 +57,6 @@ class FontInstallerTest {
         return file
     }
 
-    // ---- platformFontDir ----
-
     @Test
     fun `platformFontDir returns OS-specific path for current platform`() {
         val dir = FontInstaller.platformFontDir()
@@ -83,8 +83,6 @@ class FontInstallerTest {
         }
     }
 
-    // ---- cachedZipFile ----
-
     @Test
     fun `cachedZipFile derives filename from URL`() {
         mockkStatic(PathManager::class)
@@ -107,8 +105,6 @@ class FontInstallerTest {
 
         assertEquals("WHISPER.zip", file.name)
     }
-
-    // ---- downloadFailureKind ----
 
     @Test
     fun `downloadFailureKind maps UnknownHostException to OFFLINE`() {
@@ -133,8 +129,6 @@ class FontInstallerTest {
         val kind = FontInstaller.downloadFailureKind(IOException("500 server error"))
         assertEquals(FontInstaller.FailureKind.HTTP_ERROR, kind)
     }
-
-    // ---- extractionFailureKind ----
 
     @Test
     fun `extractionFailureKind maps No matching files cause to ASSET_NOT_FOUND`() {
@@ -171,8 +165,6 @@ class FontInstallerTest {
         assertEquals(FontInstaller.FailureKind.EXTRACTION_FAILED, kind)
         assertTrue(zipFile.exists(), "Non-zip IOException should not delete cache")
     }
-
-    // ---- extractFonts (integration through real zip) ----
 
     @Test
     fun `extractFonts extracts only matching font files`() {
@@ -221,42 +213,41 @@ class FontInstallerTest {
         )
     }
 
-    // ---- copyToPlatformFontDir ----
-    //
-    // NOTE: copyToPlatformFontDir() internally calls platformFontDir() which
-    // reads real system paths. We cannot mock the private helper in isolation,
-    // so instead we verify the copy logic by creating a real source file and
-    // letting the real platformFontDir() receive the copy. To avoid polluting
-    // the user's actual font directory, we skip if the real font dir is not
-    // writable AND we clean up the file afterwards. If running on CI without
-    // a writable font dir, the test gracefully no-ops.
-
     @Test
-    fun `copyToPlatformFontDir copies source files into real platform dir`() {
-        val platformDir = FontInstaller.platformFontDir()
-        if (!platformDir.exists()) platformDir.mkdirs()
-        if (!platformDir.canWrite()) {
-            // No writable platform font dir available (sandboxed CI). Skip gracefully.
-            return
-        }
+    fun `copyToPlatformFontDir copies source files into dest dir`() {
+        val destDir = File(tmpRoot, "fake-platform-fonts").apply { mkdirs() }
+        val source = File(tmpRoot, "test-font.ttf").apply { writeBytes(ByteArray(16) { it.toByte() }) }
 
-        val uniqueName = "ayu-islands-copy-test-${System.nanoTime()}.ttf"
-        val source = File(tmpRoot, uniqueName).apply { writeBytes(ByteArray(16) { it.toByte() }) }
+        val copied = FontInstaller.copyToPlatformFontDir(listOf(source), destDir = destDir)
 
-        try {
-            val copied = FontInstaller.copyToPlatformFontDir(listOf(source))
-
-            assertEquals(1, copied.size)
-            assertEquals(uniqueName, copied[0].name)
-            assertTrue(copied[0].exists(), "Copied file must exist in platform dir")
-            assertEquals(source.length(), copied[0].length())
-        } finally {
-            // Remove the sentinel file so we don't litter the user's font dir.
-            File(platformDir, uniqueName).delete()
-        }
+        assertEquals(1, copied.size)
+        assertEquals("test-font.ttf", copied[0].name)
+        assertEquals(destDir.absolutePath, copied[0].parentFile.absolutePath)
+        assertTrue(copied[0].exists(), "Copied file must exist in dest dir")
+        assertEquals(source.length(), copied[0].length())
     }
 
-    // ---- cleanupQuietly ----
+    @Test
+    fun `copyToPlatformFontDir throws AccessDeniedException when dest not writable`() {
+        val destDir =
+            File(tmpRoot, "readonly-dest").apply {
+                mkdirs()
+                setWritable(false)
+            }
+        val source = File(tmpRoot, "src.ttf").apply { writeBytes(ByteArray(4)) }
+
+        try {
+            val thrown =
+                runCatching { FontInstaller.copyToPlatformFontDir(listOf(source), destDir = destDir) }
+                    .exceptionOrNull()
+            assertTrue(
+                thrown is java.nio.file.AccessDeniedException,
+                "Expected AccessDeniedException, got: $thrown",
+            )
+        } finally {
+            destDir.setWritable(true)
+        }
+    }
 
     @Test
     fun `cleanupQuietly removes directory recursively`() {
@@ -272,20 +263,38 @@ class FontInstallerTest {
         assertFalse(dir.exists(), "Directory should be removed")
     }
 
-    // ---- applyOnly ----
-
     @Test
     fun `applyOnly invokes FontPresetApplicator inside invokeLater`() {
         mockkStatic(ApplicationManager::class)
         mockkObject(FontPresetApplicator)
         val appMock = mockk<Application>(relaxed = true)
         every { ApplicationManager.getApplication() } returns appMock
-        // Run the Runnable synchronously so we can verify apply() was called.
         every { appMock.invokeLater(any()) } answers { firstArg<Runnable>().run() }
         every { FontPresetApplicator.apply(any()) } answers { /* no-op */ }
 
         FontInstaller.applyOnly(FontPreset.AMBIENT, project = null)
 
         verify(exactly = 1) { FontPresetApplicator.apply(any()) }
+    }
+
+    @Test
+    fun `applyOnly notifies user when apply fails (regression for silent warn)`() {
+        mockkStatic(ApplicationManager::class)
+        mockkStatic(Notifications.Bus::class)
+        mockkObject(FontPresetApplicator)
+        val appMock = mockk<Application>(relaxed = true)
+        every { ApplicationManager.getApplication() } returns appMock
+        every { appMock.invokeLater(any()) } answers { firstArg<Runnable>().run() }
+        every { FontPresetApplicator.apply(any()) } throws RuntimeException("boom")
+        every { Notifications.Bus.notify(any(), null) } answers { }
+
+        FontInstaller.applyOnly(FontPreset.AMBIENT, project = null)
+
+        verify(exactly = 1) {
+            Notifications.Bus.notify(
+                match<Notification> { it.content.contains("Editor → Font") },
+                null,
+            )
+        }
     }
 }

--- a/src/test/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManagerTest.kt
@@ -302,4 +302,73 @@ class GitPanelAutoFitManagerTest {
             )
         }
     }
+
+    @Test
+    fun `listener is removed when mode switches from AUTO_FIT to DEFAULT`() {
+        SwingUtilities.invokeAndWait {
+            every {
+                LicenseChecker.isLicensedOrGrace()
+            } returns true
+            realState.gitPanelWidthMode =
+                PanelWidthMode.AUTO_FIT.name
+            realState.gitPanelAutoFitMaxWidth = 500
+            realState.gitPanelAutoFitMinWidth = 200
+
+            mockkObject(AutoFitCalculator)
+            every {
+                AutoFitCalculator.measureTreeMaxRowWidth(any())
+            } returns 250
+
+            val tree = JTree()
+            val table = JTable()
+            val innerFirst = JPanel(FlowLayout())
+            innerFirst.add(table)
+            val innerSecond = JPanel(FlowLayout())
+            innerSecond.add(tree)
+
+            val splitter = Splitter()
+            splitter.setSize(1000, 400)
+            splitter.firstComponent = innerFirst
+            splitter.secondComponent = innerSecond
+
+            val logContent =
+                mockk<Content>(relaxed = true) {
+                    every { tabName } returns "Log"
+                    every { component } returns splitter
+                }
+            val contentManager =
+                mockk<ContentManager>(relaxed = true) {
+                    every {
+                        contents
+                    } returns arrayOf(logContent)
+                }
+            val toolWindow =
+                mockk<ToolWindow>(relaxed = true) {
+                    every {
+                        this@mockk.contentManager
+                    } returns contentManager
+                }
+            every {
+                toolWindowManager
+                    .getToolWindow("Version Control")
+            } returns toolWindow
+
+            val listenersBefore = tree.treeExpansionListeners.size
+            val manager = GitPanelAutoFitManager(project)
+
+            // AUTO_FIT: expansion listener attached to inner tree
+            manager.apply()
+            assert(tree.treeExpansionListeners.size > listenersBefore) {
+                "Expected expansion listener installed after AUTO_FIT"
+            }
+
+            // Switch to DEFAULT: listener must be removed
+            realState.gitPanelWidthMode =
+                PanelWidthMode.DEFAULT.name
+            manager.apply()
+            assert(tree.treeExpansionListeners.size == listenersBefore) {
+                "Expected expansion listener removed after DEFAULT"
+            }
+        }
+    }
 }

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerTrialExpiryTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerTrialExpiryTest.kt
@@ -219,6 +219,121 @@ class LicenseCheckerTrialExpiryTest {
         }
     }
 
+    // Multi-session user journeys for the two-stage trial warning.
+    // Each "day" is one user-visible session. State persists across sessions
+    // (it is what would live on disk), the clock is mocked day by day.
+
+    @Test
+    fun `two-stage warning progression over the final week of trial`() {
+        every { LicensingFacade.getInstance() } returns facade
+        every { facade.isEvaluationLicense } returns true
+
+        // Day 8: outside the window, no notification
+        every { facade.getExpirationDate(LicenseChecker.PRODUCT_CODE) } returns dateFromNow(8)
+        LicenseChecker.checkTrialExpiryWarning(null)
+
+        // Day 7: first warning fires and the 7-day flag is latched
+        every { facade.getExpirationDate(LicenseChecker.PRODUCT_CODE) } returns dateFromNow(7)
+        LicenseChecker.checkTrialExpiryWarning(null)
+
+        // Days 6, 5, 4: still within the 7-day window but flag prevents re-firing
+        for (daysRemaining in listOf(6L, 5L, 4L)) {
+            every { facade.getExpirationDate(LicenseChecker.PRODUCT_CODE) } returns dateFromNow(daysRemaining)
+            LicenseChecker.checkTrialExpiryWarning(null)
+        }
+
+        // Day 3: second (3-day) warning fires
+        every { facade.getExpirationDate(LicenseChecker.PRODUCT_CODE) } returns dateFromNow(3)
+        LicenseChecker.checkTrialExpiryWarning(null)
+
+        // Days 2, 1: both flags latched, silence
+        for (daysRemaining in listOf(2L, 1L)) {
+            every { facade.getExpirationDate(LicenseChecker.PRODUCT_CODE) } returns dateFromNow(daysRemaining)
+            LicenseChecker.checkTrialExpiryWarning(null)
+        }
+
+        // Exactly two notifications total across the whole week
+        verify(exactly = 2) {
+            notificationGroup.createNotification(any<String>(), any<String>(), any<NotificationType>())
+        }
+        // Both latches set
+        assertEquals(true, state.trialExpiryWarningShown)
+        assertEquals(true, state.trialExpiry3DayWarningShown)
+        // Each threshold surfaced its own message
+        verify(exactly = 1) {
+            notificationGroup.createNotification(
+                match { it.contains("7 days remaining") },
+                any<String>(),
+                NotificationType.INFORMATION,
+            )
+        }
+        verify(exactly = 1) {
+            notificationGroup.createNotification(
+                match { it.contains("3 days remaining") },
+                any<String>(),
+                NotificationType.INFORMATION,
+            )
+        }
+    }
+
+    @Test
+    fun `7-day latch does not block the later 3-day warning`() {
+        every { LicensingFacade.getInstance() } returns facade
+        every { facade.isEvaluationLicense } returns true
+        // User already saw the 7-day warning in a previous session
+        state.trialExpiryWarningShown = true
+        state.trialExpiry3DayWarningShown = false
+
+        // Session resumes on day 3 — 3-day warning must still fire
+        every { facade.getExpirationDate(LicenseChecker.PRODUCT_CODE) } returns dateFromNow(3)
+        LicenseChecker.checkTrialExpiryWarning(null)
+
+        verify(exactly = 1) {
+            notificationGroup.createNotification(
+                match { it.contains("3 days remaining") },
+                any<String>(),
+                NotificationType.INFORMATION,
+            )
+        }
+        assertEquals(true, state.trialExpiry3DayWarningShown)
+    }
+
+    @Test
+    fun `both latches set means silence regardless of day`() {
+        every { LicensingFacade.getInstance() } returns facade
+        every { facade.isEvaluationLicense } returns true
+        state.trialExpiryWarningShown = true
+        state.trialExpiry3DayWarningShown = true
+
+        for (daysRemaining in listOf(7L, 5L, 3L, 1L, 0L)) {
+            every { facade.getExpirationDate(LicenseChecker.PRODUCT_CODE) } returns dateFromNow(daysRemaining)
+            LicenseChecker.checkTrialExpiryWarning(null)
+        }
+
+        verify(exactly = 0) {
+            notificationGroup.createNotification(any<String>(), any<String>(), any<NotificationType>())
+        }
+    }
+
+    @Test
+    fun `trial warning stays idempotent across restarts on the same day`() {
+        every { LicensingFacade.getInstance() } returns facade
+        every { facade.isEvaluationLicense } returns true
+        every { facade.getExpirationDate(LicenseChecker.PRODUCT_CODE) } returns dateFromNow(7)
+
+        // Session 1: day 7, warning fires
+        LicenseChecker.checkTrialExpiryWarning(null)
+        // Session 2: same persisted state, same day — must stay silent
+        LicenseChecker.checkTrialExpiryWarning(null)
+        // Session 3: one more restart, still the same day
+        LicenseChecker.checkTrialExpiryWarning(null)
+
+        verify(exactly = 1) {
+            notificationGroup.createNotification(any<String>(), any<String>(), any<NotificationType>())
+        }
+        assertEquals(true, state.trialExpiryWarningShown)
+    }
+
     /** Create a [Date] representing [daysFromNow] days in the future (or past if negative). */
     private fun dateFromNow(daysFromNow: Long): Date {
         val localDate = LocalDate.now().plusDays(daysFromNow)

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseTransitionListenerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseTransitionListenerTest.kt
@@ -39,7 +39,47 @@ class LicenseTransitionListenerTest {
     }
 
     @Test
-    fun `unlicensed transition does not flip premiumOnboardingShown`() {
+    fun `first licensed notification does not flip flag (initial state)`() {
+        state.premiumOnboardingShown = true
+        every { LicenseChecker.isLicensed() } returns true
+
+        // First call establishes the baseline — should NOT reset flag
+        LicenseTransitionListener().licenseStateChanged(facade)
+
+        assertTrue(state.premiumOnboardingShown)
+    }
+
+    @Test
+    fun `unlicensed to licensed transition flips flag to false`() {
+        state.premiumOnboardingShown = true
+        val listener = LicenseTransitionListener()
+
+        // First: unlicensed (records baseline)
+        every { LicenseChecker.isLicensed() } returns false
+        listener.licenseStateChanged(facade)
+        assertTrue(state.premiumOnboardingShown)
+
+        // Then: licensed (actual transition)
+        every { LicenseChecker.isLicensed() } returns true
+        listener.licenseStateChanged(facade)
+
+        assertFalse(state.premiumOnboardingShown)
+    }
+
+    @Test
+    fun `licensed to licensed refresh does not flip flag`() {
+        state.premiumOnboardingShown = true
+        val listener = LicenseTransitionListener()
+
+        every { LicenseChecker.isLicensed() } returns true
+        listener.licenseStateChanged(facade) // first call: records baseline
+        listener.licenseStateChanged(facade) // second call: refresh, same state
+
+        assertTrue(state.premiumOnboardingShown)
+    }
+
+    @Test
+    fun `unlicensed notifications do not flip flag`() {
         state.premiumOnboardingShown = true
         every { LicenseChecker.isLicensed() } returns false
 
@@ -49,21 +89,14 @@ class LicenseTransitionListenerTest {
     }
 
     @Test
-    fun `licensed transition flips premiumOnboardingShown to false`() {
-        state.premiumOnboardingShown = true
-        every { LicenseChecker.isLicensed() } returns true
-
-        LicenseTransitionListener().licenseStateChanged(facade)
-
-        assertFalse(state.premiumOnboardingShown)
-    }
-
-    @Test
-    fun `licensed transition with flag already false is a no-op`() {
+    fun `transition with flag already false is a no-op`() {
         state.premiumOnboardingShown = false
-        every { LicenseChecker.isLicensed() } returns true
+        val listener = LicenseTransitionListener()
 
-        LicenseTransitionListener().licenseStateChanged(facade)
+        every { LicenseChecker.isLicensed() } returns false
+        listener.licenseStateChanged(facade)
+        every { LicenseChecker.isLicensed() } returns true
+        listener.licenseStateChanged(facade)
 
         assertFalse(state.premiumOnboardingShown)
     }

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseTransitionListenerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseTransitionListenerTest.kt
@@ -1,6 +1,7 @@
 package dev.ayuislands.licensing
 
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.testFramework.LoggedErrorProcessor
 import com.intellij.ui.LicensingFacade
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
@@ -9,6 +10,7 @@ import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
+import java.util.EnumSet
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -43,7 +45,6 @@ class LicenseTransitionListenerTest {
         state.premiumOnboardingShown = true
         every { LicenseChecker.isLicensed() } returns true
 
-        // First call establishes the baseline — should NOT reset flag
         LicenseTransitionListener().licenseStateChanged(facade)
 
         assertTrue(state.premiumOnboardingShown)
@@ -54,12 +55,10 @@ class LicenseTransitionListenerTest {
         state.premiumOnboardingShown = true
         val listener = LicenseTransitionListener()
 
-        // First: unlicensed (records baseline)
         every { LicenseChecker.isLicensed() } returns false
         listener.licenseStateChanged(facade)
         assertTrue(state.premiumOnboardingShown)
 
-        // Then: licensed (actual transition)
         every { LicenseChecker.isLicensed() } returns true
         listener.licenseStateChanged(facade)
 
@@ -72,8 +71,8 @@ class LicenseTransitionListenerTest {
         val listener = LicenseTransitionListener()
 
         every { LicenseChecker.isLicensed() } returns true
-        listener.licenseStateChanged(facade) // first call: records baseline
-        listener.licenseStateChanged(facade) // second call: refresh, same state
+        listener.licenseStateChanged(facade)
+        listener.licenseStateChanged(facade)
 
         assertTrue(state.premiumOnboardingShown)
     }
@@ -99,5 +98,66 @@ class LicenseTransitionListenerTest {
         listener.licenseStateChanged(facade)
 
         assertFalse(state.premiumOnboardingShown)
+    }
+
+    @Test
+    fun `licensed to unlicensed revocation does not reset premiumOnboardingShown`() {
+        // User revokes license mid-session. The listener must NOT flip the flag
+        // — the premium wizard has already been shown, so re-arming it on
+        // revocation would re-trigger the wizard after next startup.
+        state.premiumOnboardingShown = true
+        val listener = LicenseTransitionListener()
+
+        every { LicenseChecker.isLicensed() } returns true
+        listener.licenseStateChanged(facade)
+        assertTrue(state.premiumOnboardingShown)
+
+        every { LicenseChecker.isLicensed() } returns false
+        listener.licenseStateChanged(facade)
+
+        assertTrue(state.premiumOnboardingShown)
+    }
+
+    @Test
+    fun `RuntimeException from LicenseChecker does not corrupt wasLicensed state`() {
+        // Simulates a platform glitch: first call throws, second succeeds as the
+        // actual unlicensed→licensed transition. The post-exception retry MUST
+        // still flip the flag — the listener must not be left in a broken state.
+        // The listener logs the failure via LOG.error, which TestLoggerFactory
+        // promotes into an AssertionError — install a LoggedErrorProcessor to
+        // suppress (but count) the promotion.
+        state.premiumOnboardingShown = true
+        val listener = LicenseTransitionListener()
+
+        val loggedErrors = mutableListOf<Throwable?>()
+        val processor =
+            object : LoggedErrorProcessor() {
+                override fun processError(
+                    category: String,
+                    message: String,
+                    details: Array<out String>,
+                    throwable: Throwable?,
+                ): Set<Action> {
+                    loggedErrors += throwable
+                    return EnumSet.noneOf(Action::class.java)
+                }
+            }
+
+        LoggedErrorProcessor.executeWith<RuntimeException>(processor) {
+            every { LicenseChecker.isLicensed() } throws RuntimeException("platform glitch")
+            listener.licenseStateChanged(facade)
+            assertTrue(state.premiumOnboardingShown, "exception must not mutate the flag")
+
+            every { LicenseChecker.isLicensed() } returns false
+            listener.licenseStateChanged(facade)
+            assertTrue(state.premiumOnboardingShown, "first successful call records baseline only")
+
+            every { LicenseChecker.isLicensed() } returns true
+            listener.licenseStateChanged(facade)
+            assertFalse(state.premiumOnboardingShown, "transition must still fire after glitch recovery")
+        }
+
+        assertTrue(loggedErrors.size == 1, "expected exactly one LOG.error for the glitched call")
+        assertTrue(loggedErrors[0]?.message == "platform glitch")
     }
 }

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseTransitionListenerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseTransitionListenerTest.kt
@@ -14,6 +14,7 @@ import java.util.EnumSet
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -157,7 +158,7 @@ class LicenseTransitionListenerTest {
             assertFalse(state.premiumOnboardingShown, "transition must still fire after glitch recovery")
         }
 
-        assertTrue(loggedErrors.size == 1, "expected exactly one LOG.error for the glitched call")
-        assertTrue(loggedErrors[0]?.message == "platform glitch")
+        assertEquals(1, loggedErrors.size, "expected exactly one LOG.error for the glitched call")
+        assertEquals("platform glitch", loggedErrors[0]?.message)
     }
 }

--- a/src/test/kotlin/dev/ayuislands/onboarding/OnboardingOrchestratorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/onboarding/OnboardingOrchestratorTest.kt
@@ -23,13 +23,13 @@ class OnboardingOrchestratorTest {
     }
 
     // -----------------------------------------------------------------------
-    // resolve() — full truth table (all meaningful input combinations)
+    // resolve() - full truth table (all meaningful input combinations)
     // -----------------------------------------------------------------------
 
     // Free wizard: fires when effectiveFreeShown=false (new user, free not yet shown)
 
     @Test
-    fun `row 1 — unlicensed fresh install shows free`() {
+    fun `row 1 - unlicensed fresh install shows free`() {
         assertResolves(
             licensed = false,
             freeShown = false,
@@ -40,7 +40,7 @@ class OnboardingOrchestratorTest {
     }
 
     @Test
-    fun `row 2 — unlicensed fresh install with premiumShown=true still shows free`() {
+    fun `row 2 - unlicensed fresh install with premiumShown=true still shows free`() {
         assertResolves(
             licensed = false,
             freeShown = false,
@@ -51,7 +51,7 @@ class OnboardingOrchestratorTest {
     }
 
     @Test
-    fun `row 3 — licensed fresh install shows free first`() {
+    fun `row 3 - licensed fresh install shows free first`() {
         assertResolves(
             licensed = true,
             freeShown = false,
@@ -62,7 +62,7 @@ class OnboardingOrchestratorTest {
     }
 
     @Test
-    fun `row 4 — licensed fresh install with premiumShown=true still shows free`() {
+    fun `row 4 - licensed fresh install with premiumShown=true still shows free`() {
         assertResolves(
             licensed = true,
             freeShown = false,
@@ -75,7 +75,7 @@ class OnboardingOrchestratorTest {
     // NoWizard: unlicensed user who already saw free, or all shown
 
     @Test
-    fun `row 5 — unlicensed with free shown gets no wizard`() {
+    fun `row 5 - unlicensed with free shown gets no wizard`() {
         assertResolves(
             licensed = false,
             freeShown = true,
@@ -86,7 +86,7 @@ class OnboardingOrchestratorTest {
     }
 
     @Test
-    fun `row 6 — unlicensed with both shown gets no wizard`() {
+    fun `row 6 - unlicensed with both shown gets no wizard`() {
         assertResolves(
             licensed = false,
             freeShown = true,
@@ -97,7 +97,7 @@ class OnboardingOrchestratorTest {
     }
 
     @Test
-    fun `row 8 — licensed with both shown gets no wizard`() {
+    fun `row 8 - licensed with both shown gets no wizard`() {
         assertResolves(
             licensed = true,
             freeShown = true,
@@ -110,7 +110,7 @@ class OnboardingOrchestratorTest {
     // Premium wizard: licensed + free already shown + premium not yet shown
 
     @Test
-    fun `row 7 — licensed with free shown gets premium`() {
+    fun `row 7 - licensed with free shown gets premium`() {
         assertResolves(
             licensed = true,
             freeShown = true,
@@ -123,7 +123,7 @@ class OnboardingOrchestratorTest {
     // Returning user: effectiveFreeShown = true regardless of freeShown flag
 
     @Test
-    fun `row 9 — returning unlicensed user gets no wizard`() {
+    fun `row 9 - returning unlicensed user gets no wizard`() {
         assertResolves(
             licensed = false,
             freeShown = false,
@@ -134,7 +134,7 @@ class OnboardingOrchestratorTest {
     }
 
     @Test
-    fun `row 10 — returning unlicensed with premiumShown gets no wizard`() {
+    fun `row 10 - returning unlicensed with premiumShown gets no wizard`() {
         assertResolves(
             licensed = false,
             freeShown = false,
@@ -145,7 +145,7 @@ class OnboardingOrchestratorTest {
     }
 
     @Test
-    fun `row 11 — returning licensed user gets premium`() {
+    fun `row 11 - returning licensed user gets premium`() {
         assertResolves(
             licensed = true,
             freeShown = false,
@@ -156,7 +156,7 @@ class OnboardingOrchestratorTest {
     }
 
     @Test
-    fun `row 12 — returning licensed with premiumShown gets no wizard`() {
+    fun `row 12 - returning licensed with premiumShown gets no wizard`() {
         assertResolves(
             licensed = true,
             freeShown = false,
@@ -171,113 +171,110 @@ class OnboardingOrchestratorTest {
     // -----------------------------------------------------------------------
 
     @Test
-    fun `journey — fresh install unlicensed then stays unlicensed`() {
-        // First startup: free wizard
-        var freeShown = false
-        var premiumShown = false
-
-        var action = resolve(licensed = false, freeShown = freeShown, returning = false, premiumShown = premiumShown)
-        assertEquals(WizardAction.ShowFreeWizard, action)
-        freeShown = true // wizard opened, flag set
-
-        // Second startup: no wizard (unlicensed, free already shown)
-        action = resolve(licensed = false, freeShown = freeShown, returning = false, premiumShown = premiumShown)
-        assertEquals(WizardAction.NoWizard, action)
-
-        // Third startup: still no wizard
-        action = resolve(licensed = false, freeShown = freeShown, returning = false, premiumShown = premiumShown)
-        assertEquals(WizardAction.NoWizard, action)
+    fun `journey - fresh install unlicensed then stays unlicensed`() {
+        // Session 1: free wizard fires
+        assertEquals(
+            WizardAction.ShowFreeWizard,
+            resolve(licensed = false, freeShown = false, returning = false, premiumShown = false),
+        )
+        // Session 2: flag latched, no wizard (unlicensed, free already shown)
+        assertEquals(
+            WizardAction.NoWizard,
+            resolve(licensed = false, freeShown = true, returning = false, premiumShown = false),
+        )
+        // Session 3: still no wizard
+        assertEquals(
+            WizardAction.NoWizard,
+            resolve(licensed = false, freeShown = true, returning = false, premiumShown = false),
+        )
     }
 
     @Test
-    fun `journey — fresh install with trial active`() {
-        var freeShown = false
-        var premiumShown = false
-
-        // First startup: free wizard (regardless of license)
-        var action = resolve(licensed = true, freeShown = freeShown, returning = false, premiumShown = premiumShown)
-        assertEquals(WizardAction.ShowFreeWizard, action)
-        freeShown = true
-
-        // Second startup: premium wizard
-        action = resolve(licensed = true, freeShown = freeShown, returning = false, premiumShown = premiumShown)
-        assertEquals(WizardAction.ShowPremiumWizard, action)
-        premiumShown = true
-
-        // Third startup: no wizard
-        action = resolve(licensed = true, freeShown = freeShown, returning = false, premiumShown = premiumShown)
-        assertEquals(WizardAction.NoWizard, action)
+    fun `journey - fresh install with trial active`() {
+        // Session 1: free wizard (regardless of license)
+        assertEquals(
+            WizardAction.ShowFreeWizard,
+            resolve(licensed = true, freeShown = false, returning = false, premiumShown = false),
+        )
+        // Session 2: premium wizard
+        assertEquals(
+            WizardAction.ShowPremiumWizard,
+            resolve(licensed = true, freeShown = true, returning = false, premiumShown = false),
+        )
+        // Session 3: done
+        assertEquals(
+            WizardAction.NoWizard,
+            resolve(licensed = true, freeShown = true, returning = false, premiumShown = true),
+        )
     }
 
     @Test
-    fun `journey — upgrade from v2_3 returning user unlicensed`() {
+    fun `journey - upgrade from v2_3 returning user unlicensed`() {
         // Returning user: lastSeenVersion != null
-        val action = resolve(licensed = false, freeShown = false, returning = true, premiumShown = false)
-        assertEquals(WizardAction.NoWizard, action)
+        assertEquals(
+            WizardAction.NoWizard,
+            resolve(licensed = false, freeShown = false, returning = true, premiumShown = false),
+        )
     }
 
     @Test
-    fun `journey — upgrade from v2_3 returning user with trial`() {
-        var premiumShown = false
-
-        // First startup: premium immediately (returning skips free)
-        var action = resolve(licensed = true, freeShown = false, returning = true, premiumShown = premiumShown)
-        assertEquals(WizardAction.ShowPremiumWizard, action)
-        premiumShown = true
-
-        // Second startup: no wizard
-        action = resolve(licensed = true, freeShown = false, returning = true, premiumShown = premiumShown)
-        assertEquals(WizardAction.NoWizard, action)
+    fun `journey - upgrade from v2_3 returning user with trial`() {
+        // Session 1: premium immediately (returning skips free)
+        assertEquals(
+            WizardAction.ShowPremiumWizard,
+            resolve(licensed = true, freeShown = false, returning = true, premiumShown = false),
+        )
+        // Session 2: done
+        assertEquals(
+            WizardAction.NoWizard,
+            resolve(licensed = true, freeShown = false, returning = true, premiumShown = true),
+        )
     }
 
     @Test
-    fun `journey — trial expired then re-purchased`() {
-        var freeShown = true // already saw free earlier
-        var premiumShown = true // already saw premium earlier
-
-        // Trial expired: unlicensed startups show nothing
-        var action = resolve(licensed = false, freeShown = freeShown, returning = false, premiumShown = premiumShown)
-        assertEquals(WizardAction.NoWizard, action)
-
-        // Re-purchase: premiumOnboardingShown re-armed to false by applyLicensedDefaults
-        premiumShown = false
-        action = resolve(licensed = true, freeShown = freeShown, returning = false, premiumShown = premiumShown)
-        assertEquals(WizardAction.ShowPremiumWizard, action)
-        premiumShown = true
-
-        // Next startup: done
-        action = resolve(licensed = true, freeShown = freeShown, returning = false, premiumShown = premiumShown)
-        assertEquals(WizardAction.NoWizard, action)
+    fun `journey - trial expired then re-purchased`() {
+        // Session 1: trial expired, unlicensed, both wizards already seen → nothing
+        assertEquals(
+            WizardAction.NoWizard,
+            resolve(licensed = false, freeShown = true, returning = false, premiumShown = true),
+        )
+        // Session 2: re-purchase re-arms premiumOnboardingShown (via applyLicensedDefaults)
+        assertEquals(
+            WizardAction.ShowPremiumWizard,
+            resolve(licensed = true, freeShown = true, returning = false, premiumShown = false),
+        )
+        // Session 3: flag set again, done
+        assertEquals(
+            WizardAction.NoWizard,
+            resolve(licensed = true, freeShown = true, returning = false, premiumShown = true),
+        )
     }
 
     @Test
-    fun `journey — free shown then license purchased mid-session`() {
-        var freeShown = true
-        var premiumShown = false
-
-        // License purchased mid-session → next startup
-        val action = resolve(licensed = true, freeShown = freeShown, returning = false, premiumShown = premiumShown)
-        assertEquals(WizardAction.ShowPremiumWizard, action)
+    fun `journey - free shown then license purchased mid-session`() {
+        // License purchased mid-session, next startup shows premium
+        assertEquals(
+            WizardAction.ShowPremiumWizard,
+            resolve(licensed = true, freeShown = true, returning = false, premiumShown = false),
+        )
     }
 
     @Test
-    fun `journey — free never interacts then license expires`() {
-        // Fresh install, trial active, but user closes free wizard without interacting
-        var freeShown = true // flag set by wizard open
-        var premiumShown = false
-
-        // Second startup: premium
-        var action = resolve(licensed = true, freeShown = freeShown, returning = false, premiumShown = premiumShown)
-        assertEquals(WizardAction.ShowPremiumWizard, action)
-        premiumShown = true
-
-        // Trial expires
-        action = resolve(licensed = false, freeShown = freeShown, returning = false, premiumShown = premiumShown)
-        assertEquals(WizardAction.NoWizard, action)
+    fun `journey - free never interacts then license expires`() {
+        // Session 1: premium wizard (free already shown, licensed)
+        assertEquals(
+            WizardAction.ShowPremiumWizard,
+            resolve(licensed = true, freeShown = true, returning = false, premiumShown = false),
+        )
+        // Session 2: trial expires, both flags still set → no wizard
+        assertEquals(
+            WizardAction.NoWizard,
+            resolve(licensed = false, freeShown = true, returning = false, premiumShown = true),
+        )
     }
 
     // -----------------------------------------------------------------------
-    // tryPick — one-shot claim guard
+    // tryPick - one-shot claim guard
     // -----------------------------------------------------------------------
 
     @Test
@@ -335,7 +332,7 @@ class OnboardingOrchestratorTest {
             trueCount.get(),
             "Exactly one of $threadCount concurrent callers must win tryPick()",
         )
-        // Subsequent call must still return false — the one-shot is latched.
+        // Subsequent call must still return false - the one-shot is latched.
         assertFalse(OnboardingOrchestrator.tryPick())
     }
 

--- a/src/test/kotlin/dev/ayuislands/onboarding/OnboardingOrchestratorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/onboarding/OnboardingOrchestratorTest.kt
@@ -1,5 +1,9 @@
 package dev.ayuislands.onboarding
 
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -292,6 +296,47 @@ class OnboardingOrchestratorTest {
         OnboardingOrchestrator.tryPick()
         OnboardingOrchestrator.resetForTesting()
         assertTrue(OnboardingOrchestrator.tryPick())
+    }
+
+    @Test
+    fun `tryPick is thread-safe under concurrent access from 100 threads`() {
+        OnboardingOrchestrator.resetForTesting()
+        val threadCount = 100
+        val startLatch = CountDownLatch(1)
+        val doneLatch = CountDownLatch(threadCount)
+        val trueCount = AtomicInteger(0)
+        val executor = Executors.newFixedThreadPool(threadCount)
+        try {
+            repeat(threadCount) {
+                executor.submit {
+                    try {
+                        // Block all worker threads until the main thread releases them,
+                        // so they race on tryPick() instead of running serialized.
+                        startLatch.await()
+                        if (OnboardingOrchestrator.tryPick()) {
+                            trueCount.incrementAndGet()
+                        }
+                    } finally {
+                        doneLatch.countDown()
+                    }
+                }
+            }
+            startLatch.countDown()
+            assertTrue(
+                doneLatch.await(5, TimeUnit.SECONDS),
+                "Worker threads did not finish within 5 seconds",
+            )
+        } finally {
+            executor.shutdownNow()
+        }
+
+        assertEquals(
+            1,
+            trueCount.get(),
+            "Exactly one of $threadCount concurrent callers must win tryPick()",
+        )
+        // Subsequent call must still return false — the one-shot is latched.
+        assertFalse(OnboardingOrchestrator.tryPick())
     }
 
     // -----------------------------------------------------------------------

--- a/src/test/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManagerTest.kt
@@ -283,6 +283,44 @@ class ProjectViewScrollbarManagerTest {
         }
     }
 
+    @Test
+    fun `apply is idempotent when called multiple times with same state`() {
+        realState.hideProjectViewHScrollbar = true
+        realState.hideProjectRootPath = false
+
+        val tree = JTree()
+        val scrollPane = JScrollPane(tree)
+        val originalPolicy = scrollPane.horizontalScrollBarPolicy
+        val wrapper = JPanel(FlowLayout())
+        wrapper.add(scrollPane)
+
+        setupToolWindowContent(wrapper)
+
+        val manager = createAndDrain()
+
+        // Three consecutive applies with unchanged state
+        SwingUtilities.invokeAndWait {
+            manager.apply()
+            manager.apply()
+            manager.apply()
+        }
+
+        // Final state: horizontal scrollbar hidden
+        assertEquals(
+            ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER,
+            scrollPane.horizontalScrollBarPolicy,
+        )
+
+        // Flipping the setting off must restore the ORIGINAL policy,
+        // not a stale value captured from a previous hidden-state apply.
+        // This proves originalScrollbarPolicy was captured exactly once.
+        realState.hideProjectViewHScrollbar = false
+        SwingUtilities.invokeAndWait {
+            manager.apply()
+        }
+        assertEquals(originalPolicy, scrollPane.horizontalScrollBarPolicy)
+    }
+
     private fun setupToolWindowContent(component: JPanel) {
         val content =
             mockk<Content>(relaxed = true) {

--- a/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
@@ -1,9 +1,31 @@
 package dev.ayuislands.rotation
 
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.util.Condition
+import com.intellij.testFramework.LoggedErrorProcessor
 import dev.ayuislands.accent.AYU_ACCENT_PRESETS
+import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.glow.GlowOverlayManager
+import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import java.util.EnumSet
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.assertFalse
 
 class AccentRotationServiceTest {
     @Test
@@ -60,5 +82,191 @@ class AccentRotationServiceTest {
         for (mode in AccentRotationMode.entries) {
             assertEquals(mode, AccentRotationMode.fromName(mode.name))
         }
+    }
+
+    // ---------------------------------------------------------------------
+    // Scheduler lifecycle — canRotate() + rotateAccent() logic
+    //
+    // We do NOT test startRotation()/stopRotation() through a real
+    // ScheduledExecutorService (too flaky). Instead we drive rotateAccent()
+    // directly by invoking the scheduled-task body synchronously.
+    // ---------------------------------------------------------------------
+
+    private lateinit var state: AyuIslandsState
+    private lateinit var settingsMock: AyuIslandsSettings
+    private val appMock = mockk<com.intellij.openapi.application.Application>(relaxed = true)
+
+    private fun mockRotationEnvironment() {
+        state = AyuIslandsState()
+        settingsMock = mockk(relaxed = true)
+
+        mockkStatic(ApplicationManager::class)
+        every { ApplicationManager.getApplication() } returns appMock
+        // 3-arg invokeLater(Runnable, ModalityState, Condition) — fire synchronously
+        every {
+            appMock.invokeLater(any<Runnable>(), any<ModalityState>(), any<Condition<*>>())
+        } answers {
+            firstArg<Runnable>().run()
+        }
+
+        mockkObject(AyuIslandsSettings.Companion)
+        every { AyuIslandsSettings.getInstance() } returns settingsMock
+        every { settingsMock.state } returns state
+        every { settingsMock.setAccentForVariant(any(), any()) } just Runs
+
+        mockkObject(LicenseChecker)
+        every { LicenseChecker.isLicensedOrGrace() } returns true
+
+        mockkObject(AyuVariant.Companion)
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.apply(any()) } just Runs
+
+        mockkObject(GlowOverlayManager.Companion)
+        every { GlowOverlayManager.syncGlowForAllProjects() } just Runs
+
+        mockkObject(ContrastAwareColorGenerator)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @BeforeTest
+    fun setUp() {
+        // Each scheduler test calls mockRotationEnvironment() itself so the pure-logic
+        // tests above (nextPresetHex, fromName) stay dependency-free.
+    }
+
+    @Test
+    fun `canRotate returns false when rotation flag disabled`() {
+        mockRotationEnvironment()
+        state.accentRotationEnabled = false
+        every { LicenseChecker.isLicensedOrGrace() } returns true
+
+        val service = AccentRotationService()
+
+        assertFalse(service.canRotate())
+    }
+
+    @Test
+    fun `canRotate returns false when not licensed`() {
+        mockRotationEnvironment()
+        state.accentRotationEnabled = true
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+
+        val service = AccentRotationService()
+
+        assertFalse(service.canRotate())
+    }
+
+    @Test
+    fun `canRotate returns true when enabled and licensed`() {
+        mockRotationEnvironment()
+        state.accentRotationEnabled = true
+        every { LicenseChecker.isLicensedOrGrace() } returns true
+
+        val service = AccentRotationService()
+
+        assertTrue(service.canRotate())
+    }
+
+    @Test
+    fun `rotateAccent applies next preset and updates state in PRESET mode`() {
+        mockRotationEnvironment()
+        state.accentRotationEnabled = true
+        state.accentRotationMode = AccentRotationMode.PRESET.name
+        state.accentRotationPresetIndex = 0
+        state.accentRotationLastSwitchMs = 0L
+
+        val expectedNext = nextPresetHex(0)
+        val expectedHex = expectedNext.second
+        val expectedIndex = expectedNext.first
+
+        val before = System.currentTimeMillis()
+        val service = AccentRotationService()
+        service.rotateAccent()
+        val after = System.currentTimeMillis()
+
+        verify(exactly = 1) { AccentApplicator.apply(expectedHex) }
+        verify(exactly = 1) { settingsMock.setAccentForVariant(AyuVariant.MIRAGE, expectedHex) }
+        assertEquals(expectedIndex, state.accentRotationPresetIndex)
+        assertTrue(
+            state.accentRotationLastSwitchMs in before..after,
+            "lastSwitchMs should be updated to a value in the call window",
+        )
+    }
+
+    @Test
+    fun `rotateAccent uses generator in RANDOM mode`() {
+        mockRotationEnvironment()
+        state.accentRotationEnabled = true
+        state.accentRotationMode = AccentRotationMode.RANDOM.name
+        state.accentRotationPresetIndex = 3 // must remain untouched in RANDOM mode
+
+        val generatedHex = "#123456"
+        every { ContrastAwareColorGenerator.generate(AyuVariant.MIRAGE) } returns generatedHex
+
+        val service = AccentRotationService()
+        service.rotateAccent()
+
+        verify(exactly = 1) { ContrastAwareColorGenerator.generate(AyuVariant.MIRAGE) }
+        verify(exactly = 1) { AccentApplicator.apply(generatedHex) }
+        verify(exactly = 1) { settingsMock.setAccentForVariant(AyuVariant.MIRAGE, generatedHex) }
+        assertEquals(3, state.accentRotationPresetIndex, "PRESET index must not advance in RANDOM mode")
+    }
+
+    @Test
+    fun `rotateAccent skips when canRotate is false`() {
+        mockRotationEnvironment()
+        state.accentRotationEnabled = false // disabled mid-rotation
+        every { LicenseChecker.isLicensedOrGrace() } returns true
+
+        val service = AccentRotationService()
+        service.rotateAccent()
+
+        verify(exactly = 0) { AccentApplicator.apply(any()) }
+        verify(exactly = 0) { settingsMock.setAccentForVariant(any(), any()) }
+    }
+
+    @Test
+    fun `rotateAccent swallows AccentApplicator failures and still syncs glow`() {
+        mockRotationEnvironment()
+        state.accentRotationEnabled = true
+        state.accentRotationMode = AccentRotationMode.PRESET.name
+        state.accentRotationPresetIndex = 0
+
+        every { AccentApplicator.apply(any()) } throws RuntimeException("boom")
+
+        // IntelliJ's TestLoggerFactory promotes LOG.error calls into AssertionErrors.
+        // rotateAccent() is expected to log the AccentApplicator failure via LOG.error,
+        // so we install a LoggedErrorProcessor that suppresses (but counts) the promotion.
+        val loggedErrors = mutableListOf<Throwable?>()
+        val processor =
+            object : LoggedErrorProcessor() {
+                override fun processError(
+                    category: String,
+                    message: String,
+                    details: Array<out String>,
+                    throwable: Throwable?,
+                ): Set<Action> {
+                    loggedErrors += throwable
+                    return EnumSet.noneOf(Action::class.java)
+                }
+            }
+
+        val service = AccentRotationService()
+        LoggedErrorProcessor.executeWith<RuntimeException>(processor) {
+            // Must not propagate — rotateAccent catches RuntimeException inside invokeLater.
+            service.rotateAccent()
+        }
+
+        verify(exactly = 1) { AccentApplicator.apply(any()) }
+        // Glow sync runs in a separate try/catch and should still fire after apply() fails.
+        verify(exactly = 1) { GlowOverlayManager.syncGlowForAllProjects() }
+        assertEquals(1, loggedErrors.size, "Expected exactly one LOG.error for the failed apply()")
+        assertEquals("boom", loggedErrors.single()?.message)
     }
 }

--- a/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.util.EnumSet
 import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
 import kotlin.test.assertFalse
 
 class AccentRotationServiceTest {
@@ -84,13 +83,9 @@ class AccentRotationServiceTest {
         }
     }
 
-    // ---------------------------------------------------------------------
-    // Scheduler lifecycle — canRotate() + rotateAccent() logic
-    //
-    // We do NOT test startRotation()/stopRotation() through a real
-    // ScheduledExecutorService (too flaky). Instead we drive rotateAccent()
-    // directly by invoking the scheduled-task body synchronously.
-    // ---------------------------------------------------------------------
+    // Scheduler lifecycle tests drive rotateAccent() directly rather than
+    // going through a real ScheduledExecutorService — the 1-hour interval
+    // makes timer-based testing impractical and flaky.
 
     private lateinit var state: AyuIslandsState
     private lateinit var settingsMock: AyuIslandsSettings
@@ -132,12 +127,6 @@ class AccentRotationServiceTest {
     @AfterTest
     fun tearDown() {
         unmockkAll()
-    }
-
-    @BeforeTest
-    fun setUp() {
-        // Each scheduler test calls mockRotationEnvironment() itself so the pure-logic
-        // tests above (nextPresetHex, fromName) stay dependency-free.
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStatePersistenceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStatePersistenceTest.kt
@@ -1,0 +1,162 @@
+package dev.ayuislands.settings
+
+import dev.ayuislands.accent.AccentElementId
+import dev.ayuislands.glow.GlowAnimation
+import dev.ayuislands.glow.GlowStyle
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Verifies that [AyuIslandsState] survives a save/reload cycle via
+ * [com.intellij.openapi.components.SimplePersistentStateComponent.loadState].
+ *
+ * IntelliJ serializes [com.intellij.openapi.components.BaseState] to XML via
+ * reflection. `loadState` copies fields with `XmlSerializerUtil.copyBean`, which is
+ * the same mechanism used across real IDE restarts. If properties survive the
+ * in-memory round-trip here, they survive on-disk persistence as well.
+ */
+class AyuIslandsStatePersistenceTest {
+    private fun roundTrip(mutate: (AyuIslandsState) -> Unit): AyuIslandsSettings {
+        val original = AyuIslandsSettings()
+        mutate(original.state)
+        val savedState = original.state
+        val reloaded = AyuIslandsSettings()
+        reloaded.loadState(savedState)
+        return reloaded
+    }
+
+    @Test
+    fun `accent colors survive save reload cycle`() {
+        val reloaded =
+            roundTrip { state ->
+                state.mirageAccent = "#AA0000"
+                state.darkAccent = "#00BB00"
+                state.lightAccent = "#0000CC"
+            }
+
+        assertEquals("#AA0000", reloaded.state.mirageAccent)
+        assertEquals("#00BB00", reloaded.state.darkAccent)
+        assertEquals("#0000CC", reloaded.state.lightAccent)
+    }
+
+    @Test
+    fun `all accent element toggles survive save reload cycle when disabled`() {
+        val reloaded =
+            roundTrip { state ->
+                for (element in AccentElementId.entries) {
+                    state.setToggle(element, false)
+                }
+            }
+
+        for (element in AccentElementId.entries) {
+            assertFalse(
+                reloaded.state.isToggleEnabled(element),
+                "Toggle for ${element.name} must remain disabled after reload",
+            )
+        }
+    }
+
+    @Test
+    fun `glow settings survive save reload cycle`() {
+        val reloaded =
+            roundTrip { state ->
+                state.glowEnabled = true
+                state.glowStyle = GlowStyle.SHARP_NEON.name
+                state.setIntensityForStyle(GlowStyle.SHARP_NEON, EXPECTED_SHARP_NEON_INTENSITY)
+                state.setWidthForStyle(GlowStyle.SHARP_NEON, EXPECTED_SHARP_NEON_WIDTH)
+                state.glowAnimation = GlowAnimation.BREATHE.name
+            }
+
+        assertTrue(reloaded.state.glowEnabled)
+        assertEquals(GlowStyle.SHARP_NEON.name, reloaded.state.glowStyle)
+        assertEquals(
+            EXPECTED_SHARP_NEON_INTENSITY,
+            reloaded.state.getIntensityForStyle(GlowStyle.SHARP_NEON),
+        )
+        assertEquals(
+            EXPECTED_SHARP_NEON_WIDTH,
+            reloaded.state.getWidthForStyle(GlowStyle.SHARP_NEON),
+        )
+        assertEquals(GlowAnimation.BREATHE.name, reloaded.state.glowAnimation)
+    }
+
+    @Test
+    fun `onboarding flags survive save reload cycle`() {
+        val reloaded =
+            roundTrip { state ->
+                state.freeOnboardingShown = true
+                state.premiumOnboardingShown = true
+                state.lastSeenVersion = "2.4.1"
+            }
+
+        assertTrue(reloaded.state.freeOnboardingShown)
+        assertTrue(reloaded.state.premiumOnboardingShown)
+        assertEquals("2.4.1", reloaded.state.lastSeenVersion)
+    }
+
+    @Test
+    fun `installed fonts set survives save reload cycle`() {
+        val reloaded =
+            roundTrip { state ->
+                state.installedFonts.add("Maple Mono")
+                state.installedFonts.add("JetBrains Mono")
+                state.installedFonts.add("Fira Code")
+            }
+
+        assertEquals(3, reloaded.state.installedFonts.size)
+        assertTrue(reloaded.state.installedFonts.contains("Maple Mono"))
+        assertTrue(reloaded.state.installedFonts.contains("JetBrains Mono"))
+        assertTrue(reloaded.state.installedFonts.contains("Fira Code"))
+    }
+
+    @Test
+    fun `panel width modes survive save reload cycle`() {
+        val reloaded =
+            roundTrip { state ->
+                state.projectPanelWidthMode = PanelWidthMode.AUTO_FIT.name
+                state.commitPanelWidthMode = PanelWidthMode.AUTO_FIT.name
+                state.gitPanelWidthMode = PanelWidthMode.AUTO_FIT.name
+            }
+
+        assertEquals(PanelWidthMode.AUTO_FIT.name, reloaded.state.projectPanelWidthMode)
+        assertEquals(PanelWidthMode.AUTO_FIT.name, reloaded.state.commitPanelWidthMode)
+        assertEquals(PanelWidthMode.AUTO_FIT.name, reloaded.state.gitPanelWidthMode)
+    }
+
+    @Test
+    fun `font preset customizations map survives save reload cycle`() {
+        val reloaded =
+            roundTrip { state ->
+                state.fontPresetCustomizations["AMBIENT"] = "14|1.2|true|400"
+                state.fontPresetCustomizations["WHISPER"] = "13|1.1|false|300"
+            }
+
+        assertEquals(2, reloaded.state.fontPresetCustomizations.size)
+        assertEquals("14|1.2|true|400", reloaded.state.fontPresetCustomizations["AMBIENT"])
+        assertEquals("13|1.1|false|300", reloaded.state.fontPresetCustomizations["WHISPER"])
+    }
+
+    @Test
+    fun `trial and license state survives save reload cycle`() {
+        val reloaded =
+            roundTrip { state ->
+                state.trialExpiredNotified = true
+                state.trialExpiryWarningShown = true
+                state.everBeenPro = true
+                state.lastKnownLicensedMs = EXPECTED_LICENSED_MS
+            }
+
+        assertTrue(reloaded.state.trialExpiredNotified)
+        assertTrue(reloaded.state.trialExpiryWarningShown)
+        assertTrue(reloaded.state.everBeenPro)
+        assertEquals(EXPECTED_LICENSED_MS, reloaded.state.lastKnownLicensedMs)
+    }
+
+    companion object {
+        private const val EXPECTED_SHARP_NEON_INTENSITY = 80
+        private const val EXPECTED_SHARP_NEON_WIDTH = 6
+        private const val EXPECTED_LICENSED_MS = 1_700_000_000_000L
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitterTest.kt
+++ b/src/test/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitterTest.kt
@@ -440,20 +440,19 @@ class ToolWindowAutoFitterTest {
                 )
             fitter.maxWidthProvider = { 500 }
 
-            // Fire scheduleAutoFit 5 times rapidly — debounce timer
-            // (150ms, non-repeating) restarts on each call, so only
-            // one applyAutoFitWidth should ultimately run.
+            // Fire scheduleAutoFit 5 times rapidly — the debounce timer
+            // (non-repeating) restarts on each call, so only ONE pending
+            // apply should exist when we flush.
             repeat(5) { fitter.scheduleAutoFit() }
+
+            // Verify the debounce deferred all 5 calls — no apply yet.
+            verify(exactly = 0) { toolWindowEx.stretchWidth(any()) }
+
+            // Drive the pending timer directly instead of Thread.sleep.
+            fitter.flushDebounceForTesting()
+
+            verify(exactly = 1) { toolWindowEx.stretchWidth(any()) }
         }
-
-        // Wait for the debounce timer to elapse and fire on the EDT.
-        // Debounce is 150ms; give generous margin to avoid CI flakes.
-        Thread.sleep(400)
-
-        // Drain any pending EDT events so the Timer callback has run.
-        SwingUtilities.invokeAndWait { /* flush */ }
-
-        verify(exactly = 1) { toolWindowEx.stretchWidth(any()) }
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitterTest.kt
+++ b/src/test/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitterTest.kt
@@ -414,11 +414,11 @@ class ToolWindowAutoFitterTest {
             panel.setSize(200, 400)
 
             val content =
-                mockk<com.intellij.ui.content.Content>(relaxed = true) {
+                mockk<Content>(relaxed = true) {
                     every { component } returns panel
                 }
             val contentManager =
-                mockk<com.intellij.ui.content.ContentManager>(relaxed = true) {
+                mockk<ContentManager>(relaxed = true) {
                     every { contents } returns arrayOf(content)
                 }
             every {
@@ -465,11 +465,11 @@ class ToolWindowAutoFitterTest {
             panel.setSize(200, 400)
 
             val content =
-                mockk<com.intellij.ui.content.Content>(relaxed = true) {
+                mockk<Content>(relaxed = true) {
                     every { component } returns panel
                 }
             val contentManager =
-                mockk<com.intellij.ui.content.ContentManager>(relaxed = true) {
+                mockk<ContentManager>(relaxed = true) {
                     every { contents } returns arrayOf(content)
                 }
             every {
@@ -515,7 +515,7 @@ class ToolWindowAutoFitterTest {
     @Test
     fun `applyAutoFitWidth with empty tree gracefully no-ops`() {
         SwingUtilities.invokeAndWait {
-            // Real (non-mocked) calculator so an empty JTree
+            // Real (non-mocked) calculator so an empty `JTree`
             // measures to rowCount=0 -> maxRowWidth=0 naturally.
             val emptyModel = DefaultTreeModel(null)
             val tree = JTree(emptyModel)
@@ -527,11 +527,11 @@ class ToolWindowAutoFitterTest {
             panel.setSize(150, 400)
 
             val content =
-                mockk<com.intellij.ui.content.Content>(relaxed = true) {
+                mockk<Content>(relaxed = true) {
                     every { component } returns panel
                 }
             val contentManager =
-                mockk<com.intellij.ui.content.ContentManager>(relaxed = true) {
+                mockk<ContentManager>(relaxed = true) {
                     every { contents } returns arrayOf(content)
                 }
             every {
@@ -565,7 +565,7 @@ class ToolWindowAutoFitterTest {
 
     /**
      * Mocks AutoFitCalculator measurement methods
-     * so headless JTree (no row bounds) can be used.
+     * so headless [JTree] (no row bounds) can be used.
      * findFirstOfType is left unmocked (works on
      * real Swing components without a display).
      */

--- a/src/test/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitterTest.kt
+++ b/src/test/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitterTest.kt
@@ -18,6 +18,7 @@ import java.awt.FlowLayout
 import javax.swing.JPanel
 import javax.swing.JTree
 import javax.swing.SwingUtilities
+import javax.swing.tree.DefaultTreeModel
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -395,6 +396,169 @@ class ToolWindowAutoFitterTest {
                 )
             // Should return early without a crash
             fitter.applyAutoFitWidth(400)
+        }
+    }
+
+    // endregion
+
+    // region debounce + listener lifecycle
+
+    @Test
+    fun `rapid tree expansions coalesce into single apply via debounce`() {
+        SwingUtilities.invokeAndWait {
+            // Tree width 280 + padding 20 = 300, current = 200 -> delta = 100
+            mockCalculatorForWidth(280)
+            val tree = JTree()
+            val panel = JPanel(FlowLayout())
+            panel.add(tree)
+            panel.setSize(200, 400)
+
+            val content =
+                mockk<com.intellij.ui.content.Content>(relaxed = true) {
+                    every { component } returns panel
+                }
+            val contentManager =
+                mockk<com.intellij.ui.content.ContentManager>(relaxed = true) {
+                    every { contents } returns arrayOf(content)
+                }
+            every {
+                toolWindowManager.getToolWindow("Project")
+            } returns toolWindowEx
+            every {
+                toolWindowEx.contentManager
+            } returns contentManager
+            every { toolWindowEx.component } returns panel
+            every {
+                toolWindowEx.type
+            } returns ToolWindowType.DOCKED
+
+            val fitter =
+                ToolWindowAutoFitter(
+                    project,
+                    "Project",
+                    100,
+                )
+            fitter.maxWidthProvider = { 500 }
+
+            // Fire scheduleAutoFit 5 times rapidly — debounce timer
+            // (150ms, non-repeating) restarts on each call, so only
+            // one applyAutoFitWidth should ultimately run.
+            repeat(5) { fitter.scheduleAutoFit() }
+        }
+
+        // Wait for the debounce timer to elapse and fire on the EDT.
+        // Debounce is 150ms; give generous margin to avoid CI flakes.
+        Thread.sleep(400)
+
+        // Drain any pending EDT events so the Timer callback has run.
+        SwingUtilities.invokeAndWait { /* flush */ }
+
+        verify(exactly = 1) { toolWindowEx.stretchWidth(any()) }
+    }
+
+    @Test
+    fun `AUTO_FIT to FIXED to AUTO_FIT reinstalls listener correctly`() {
+        SwingUtilities.invokeAndWait {
+            mockCalculatorForWidth(180)
+            val tree = JTree()
+            val panel = JPanel(FlowLayout())
+            panel.add(tree)
+            panel.setSize(200, 400)
+
+            val content =
+                mockk<com.intellij.ui.content.Content>(relaxed = true) {
+                    every { component } returns panel
+                }
+            val contentManager =
+                mockk<com.intellij.ui.content.ContentManager>(relaxed = true) {
+                    every { contents } returns arrayOf(content)
+                }
+            every {
+                toolWindowManager.getToolWindow("Project")
+            } returns toolWindowEx
+            every {
+                toolWindowEx.contentManager
+            } returns contentManager
+            every { toolWindowEx.component } returns panel
+            every {
+                toolWindowEx.type
+            } returns ToolWindowType.DOCKED
+
+            val fitter =
+                ToolWindowAutoFitter(
+                    project,
+                    "Project",
+                    100,
+                )
+
+            val before = tree.treeExpansionListeners.size
+
+            // AUTO_FIT -> listener installed
+            fitter.applyWidthMode(PanelWidthMode.AUTO_FIT, 500, 300)
+            assert(tree.treeExpansionListeners.size > before) {
+                "Expected listener installed after AUTO_FIT"
+            }
+
+            // FIXED -> listener removed
+            fitter.applyWidthMode(PanelWidthMode.FIXED, 500, 300)
+            assert(tree.treeExpansionListeners.size == before) {
+                "Expected listener removed after FIXED"
+            }
+
+            // AUTO_FIT -> listener re-installed
+            fitter.applyWidthMode(PanelWidthMode.AUTO_FIT, 500, 300)
+            assert(tree.treeExpansionListeners.size > before) {
+                "Expected listener re-installed after AUTO_FIT"
+            }
+        }
+    }
+
+    @Test
+    fun `applyAutoFitWidth with empty tree gracefully no-ops`() {
+        SwingUtilities.invokeAndWait {
+            // Real (non-mocked) calculator so an empty JTree
+            // measures to rowCount=0 -> maxRowWidth=0 naturally.
+            val emptyModel = DefaultTreeModel(null)
+            val tree = JTree(emptyModel)
+            assert(tree.rowCount == 0) {
+                "Empty tree precondition failed"
+            }
+            val panel = JPanel(FlowLayout())
+            panel.add(tree)
+            panel.setSize(150, 400)
+
+            val content =
+                mockk<com.intellij.ui.content.Content>(relaxed = true) {
+                    every { component } returns panel
+                }
+            val contentManager =
+                mockk<com.intellij.ui.content.ContentManager>(relaxed = true) {
+                    every { contents } returns arrayOf(content)
+                }
+            every {
+                toolWindowManager.getToolWindow("Project")
+            } returns toolWindowEx
+            every {
+                toolWindowEx.contentManager
+            } returns contentManager
+            every { toolWindowEx.component } returns panel
+            every {
+                toolWindowEx.type
+            } returns ToolWindowType.DOCKED
+
+            val fitter =
+                ToolWindowAutoFitter(
+                    project,
+                    "Project",
+                    253,
+                )
+            // Should not throw.
+            fitter.applyAutoFitWidth(500)
+
+            // With empty tree: maxRowWidth=0, desiredWidth clamps to
+            // minWidth(253). currentWidth=150, delta=103 -> stretch
+            // with min-width delta is acceptable per spec.
+            verify { toolWindowEx.stretchWidth(103) }
         }
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #111 with two goals: fix a real production bug in the onboarding wizard, and close the class of test gaps that let the bug slip through in the first place. All changes are additive — no behavior changes beyond the onboarding fix and a tightened license-transition state machine.

## The bug

`LicenseTransitionListener` was resetting `premiumOnboardingShown = false` on every license notification, including the initial startup notification and routine licensed→licensed refreshes. Result: users saw the premium wizard after every IDE restart.

Fix: track previous license state via `@Volatile` field, flip the flag only on an explicit `false → true` transition. Initial notification and same-state refreshes just record state without touching the flag.

## Why the test didn't catch it

The original test (`licensed transition flips premiumOnboardingShown to false`) was a single-call test with `assertFalse` — it baked in the buggy behavior. This PR replaces it with a proper state-machine test: first-call baseline, actual unlicensed→licensed transition, licensed→licensed refresh, unlicensed refresh. Each test describes a user-visible scenario, not an internal method call.

## Hardening sprint

Two passes of behavior-first regression tests covering surfaces where a single-call test could hide the same class of state-machine bug.

**Sprint 1 — user journeys spanning restarts (43 tests):**
- State persistence round-trip via `SimplePersistentStateComponent` (accent colors, glow, onboarding flags, font state, trial flags)
- `FontInstaller` helpers (download URL resolution, cache file handling, zip extraction, corrupt-cache deletion, platform font dir, cleanup); un-excluded from Kover
- Multi-session license cycle: unlicensed → licensed → customize → expire → re-license preserves user customizations
- Trial warning two-stage progression over the final week with latch guards
- Accent rotation lifecycle (PRESET + RANDOM modes, failure swallow, disabled skip)
- `OnboardingOrchestrator.tryPick` under 100-thread concurrent race

**Sprint 2 — regression guards for defensive paths (35 tests):**
- `UpdateNotifier`: fresh install / same version / no release notes early-return guards, upgrade-notifies-once across 3 sessions
- `AppearanceSyncService`: alternating LIGHT/DARK memoization
- `AyuIslandsAppListener` + `AyuVariant.fromThemeName`: all 6 theme variants route correctly, exact-match semantics (no partial / whitespace / case tolerance)
- `AccentApplicator`: try-catch isolation in `applyElements` / `revertAll` / `neutralizeOrRevert` continues past mid-sequence RuntimeException
- `BracketFadeManager`: rapid caret moves keep only latest highlighter, activate/deactivate/activate recreates clean state
- `ConflictRegistry`: empty-plugins detection, lazy-cache identity across calls (uses Unsafe-based lazy reset)
- `ToolWindowAutoFitter`: rapid expansions coalesce through debounce, mode swap reinstalls listener, empty tree no-ops
- `CommitPanelAutoFitManager` / `GitPanelAutoFitManager`: listener install/remove on mode toggles
- `EditorScrollbarManager` / `ProjectViewScrollbarManager`: multi-editor consistency + idempotency
- `StartupBenchmark`: absolute upper bound + tightened back-to-back ratio
- `CachedMacReader`: real-clock TTL expiry + in-TTL identity via `assertSame`

**Real bugs found in sprint 2:** 0. All defensive mechanisms in production code already work correctly — the tests now lock that behavior in.

## Production code changes

- `LicenseTransitionListener.kt` — new `@Volatile wasLicensed` state tracking, guards the false→true transition
- `FontInstaller.kt` — several `private` helpers relaxed to `internal` with `// @VisibleForTesting` comment
- `AccentRotationService.kt` — `canRotate` / `rotateAccent` relaxed to `internal` for testing
- `build.gradle.kts` — removed `FontInstaller*` from Kover excludes now that it has real coverage

## Test plan

- [x] `./gradlew test` — all tests pass
- [x] `./gradlew detekt ktlintCheck` — clean
- [x] `./gradlew koverVerify` — 80% threshold met
- [x] Manual: trigger license transition via dev shortcut, confirm premium wizard fires exactly once per fresh install and once per re-purchase
- [x] Security review — no new attack surfaces

## Summary by Sourcery

Fix license transition handling for premium onboarding and add extensive regression tests around multi-session flows, concurrency guards, and defensive behaviors across licensing, onboarding, appearance, accent rotation, auto-fit managers, scrollbars, and state persistence.

Bug Fixes:
- Ensure premium onboarding is only re-armed on explicit unlicensed-to-licensed transitions to avoid showing the wizard on every IDE restart.

Enhancements:
- Expose selected FontInstaller and AccentRotationService helpers as internal to enable focused unit testing of font installation and accent rotation logic.

Build:
- Stop excluding FontInstaller from coverage now that it has dedicated tests.

Tests:
- Add multi-session and concurrency regression tests for onboarding orchestration, license transitions, trial expiry warnings, startup license handling, update notifications, and appearance synchronization.
- Strengthen tests for accent handling, including rotation lifecycle, applicator error isolation, conflict resolution, and mac-address caching.
- Add lifecycle and debounce tests for tool window auto-fit managers, Git and commit panels, and scrollbar managers to verify listener installation, idempotency, and cleanup.
- Verify bracket fading, Ayu variant resolution, application listener behavior, and AyuIslandsState persistence through save/reload cycles.
- Introduce startup benchmark stability tests to enforce upper bounds and consistency of CPU speed measurements.