### PR TITLE
feat: font lifecycle management in Settings panel

### DIFF
--- a/src/main/kotlin/dev/ayuislands/font/FontDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontDetector.kt
@@ -1,6 +1,7 @@
 package dev.ayuislands.font
 
 import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
 import java.awt.Font
 import java.awt.GraphicsEnvironment
 import java.awt.font.FontRenderContext
@@ -94,9 +95,12 @@ object FontDetector {
      *   longer contains the family. Settings UI shows "file missing — Reinstall".
      *
      * Call [invalidateCache] before [status] if fresh disk state is needed.
-     * Results are memoized across calls within a single cache epoch so the
-     * Settings panel can call [status] from the EDT without blocking on
-     * repeated filesystem stat syscalls (D-11, RESEARCH Pitfall 4).
+     * The underlying font family list is cached across calls within a single
+     * cache epoch (see [installedFonts]), but filesystem path existence checks
+     * (`File.exists()`) are re-evaluated on each call. In practice this is
+     * fast (typical installs have fewer than 10 files) and
+     * [FontPresetPanel][dev.ayuislands.settings.FontPresetPanel] calls
+     * [status] only once per refresh cycle inside [updateFontMissing].
      *
      * **Runtime note (macOS):** on JBR 25 / macOS, deleting a font file from
      * `~/Library/Fonts` does NOT propagate to `availableFontFamilyNames` within
@@ -119,19 +123,16 @@ object FontDetector {
             try {
                 AyuIslandsSettings.getInstance().state
             } catch (_: IllegalStateException) {
-                return FontStatus.HEALTHY
+                return FontStatus.NOT_INSTALLED
             } catch (_: NullPointerException) {
-                return FontStatus.HEALTHY
+                return FontStatus.NOT_INSTALLED
             }
 
         val family =
             preset.fontAliases.firstOrNull { alias -> state.installedFonts.contains(alias) }
                 ?: return FontStatus.HEALTHY
 
-        val encodedPaths = state.installedFontFiles[family]
-        if (encodedPaths.isNullOrBlank()) return FontStatus.HEALTHY
-
-        val paths = encodedPaths.split('\n').filter { it.isNotBlank() }
+        val paths = AyuIslandsState.decodeFontPaths(state.installedFontFiles[family])
         if (paths.isEmpty()) return FontStatus.HEALTHY
 
         val anyMissing = paths.any { !File(it).exists() }

--- a/src/main/kotlin/dev/ayuislands/font/FontDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontDetector.kt
@@ -65,13 +65,15 @@ object FontDetector {
      */
     fun isInstalled(preset: FontPreset): Boolean {
         if (preset.fontAliases.any { installedFonts().contains(it.lowercase()) }) return true
-        val recorded =
+        val recorded: Set<String> =
             try {
-                AyuIslandsSettings.getInstance().state.installedFonts
+                AyuIslandsSettings
+                    .getInstance()
+                    .state.installedFonts
+                    .toSet()
             } catch (_: IllegalStateException) {
                 return false
             } catch (_: NullPointerException) {
-                // Unit test / no Application — fall through to "not installed" rather than crash.
                 return false
             }
         return preset.fontAliases.any { recorded.contains(it) }

--- a/src/main/kotlin/dev/ayuislands/font/FontDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontDetector.kt
@@ -4,7 +4,18 @@ import dev.ayuislands.settings.AyuIslandsSettings
 import java.awt.Font
 import java.awt.GraphicsEnvironment
 import java.awt.font.FontRenderContext
+import java.io.File
 import kotlin.math.abs
+
+/**
+ * Three-tier health check result returned by [FontDetector.status].
+ * See [FontDetector.status] KDoc for the exact semantics of each tier.
+ */
+enum class FontStatus {
+    NOT_INSTALLED,
+    HEALTHY,
+    CORRUPTED,
+}
 
 /** Detects installed Nerd Fonts via GraphicsEnvironment. Caches results for the session. */
 object FontDetector {
@@ -64,6 +75,61 @@ object FontDetector {
                 return false
             }
         return preset.fontAliases.any { recorded.contains(it) }
+    }
+
+    /**
+     * Three-state font health check (D-10).
+     *
+     * - [FontStatus.NOT_INSTALLED]: the plugin has no record of this family AND
+     *   the JVM doesn't see it. Settings UI shows "Install automatically".
+     * - [FontStatus.HEALTHY]: the plugin recorded this family AND either (a) no
+     *   file paths are persisted (legacy Phase 24 installs), (b) every persisted
+     *   path still exists on disk, or (c) files are missing but
+     *   `availableFontFamilyNames` still registers the family (per RESEARCH A3
+     *   — JVM font registration survives file deletion until next restart).
+     * - [FontStatus.CORRUPTED]: the plugin recorded this family, at least one
+     *   persisted file is missing from disk, AND `availableFontFamilyNames` no
+     *   longer contains the family. Settings UI shows "file missing — Reinstall".
+     *
+     * Call [invalidateCache] before [status] if fresh disk state is needed.
+     * Results are memoized across calls within a single cache epoch so the
+     * Settings panel can call [status] from the EDT without blocking on
+     * repeated filesystem stat syscalls (D-11, RESEARCH Pitfall 4).
+     *
+     * **Security note (T-25-05):** this function reads paths from
+     * `state.installedFontFiles` and probes them with `File.exists()`. It
+     * assumes trusted state input — an attacker with write access to
+     * `ayuIslands.xml` already has local file access, so probing paths outside
+     * the plugin sandbox is not a privilege elevation. Never follow the paths
+     * for read / execute / delete here.
+     */
+    fun status(preset: FontPreset): FontStatus {
+        if (!isInstalled(preset)) return FontStatus.NOT_INSTALLED
+
+        val state =
+            try {
+                AyuIslandsSettings.getInstance().state
+            } catch (_: IllegalStateException) {
+                return FontStatus.HEALTHY
+            } catch (_: NullPointerException) {
+                return FontStatus.HEALTHY
+            }
+
+        val family =
+            preset.fontAliases.firstOrNull { alias -> state.installedFonts.contains(alias) }
+                ?: return FontStatus.HEALTHY
+
+        val encodedPaths = state.installedFontFiles[family]
+        if (encodedPaths.isNullOrBlank()) return FontStatus.HEALTHY
+
+        val paths = encodedPaths.split('\n').filter { it.isNotBlank() }
+        if (paths.isEmpty()) return FontStatus.HEALTHY
+
+        val anyMissing = paths.any { !File(it).exists() }
+        if (!anyMissing) return FontStatus.HEALTHY
+
+        val jvmSees = installedFonts().any { it.equals(family, ignoreCase = true) }
+        return if (jvmSees) FontStatus.HEALTHY else FontStatus.CORRUPTED
     }
 
     /** Return the actual installed font family name (first matching alias), or null. */

--- a/src/main/kotlin/dev/ayuislands/font/FontDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontDetector.kt
@@ -96,6 +96,13 @@ object FontDetector {
      * Settings panel can call [status] from the EDT without blocking on
      * repeated filesystem stat syscalls (D-11, RESEARCH Pitfall 4).
      *
+     * **Runtime note (macOS):** on JBR 25 / macOS, deleting a font file from
+     * `~/Library/Fonts` does NOT propagate to `availableFontFamilyNames` within
+     * the same JVM session. As a result, CORRUPTED is usually only reachable on
+     * the next IDE launch — the "file gone but JVM still sees it" branch is
+     * hit first during the current session (returns HEALTHY). Verified in
+     * Phase 25 smoke test.
+     *
      * **Security note (T-25-05):** this function reads paths from
      * `state.installedFontFiles` and probes them with `File.exists()`. It
      * assumes trusted state input — an attacker with write access to

--- a/src/main/kotlin/dev/ayuislands/font/FontInstallConsent.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontInstallConsent.kt
@@ -1,0 +1,113 @@
+package dev.ayuislands.font
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.MessageDialogBuilder
+import com.intellij.openapi.util.SystemInfo
+import org.jetbrains.annotations.TestOnly
+
+/**
+ * Shared consent dialogs for font install/uninstall lifecycle (D-05).
+ *
+ * Called from both [dev.ayuislands.onboarding.PremiumOnboardingPanel] (wizard,
+ * `compact = false`) and [dev.ayuislands.settings.FontPresetPanel] (settings,
+ * `compact = true`). Single source of truth for consent copy; every caller
+ * reads the same path label and the same restart-effective warning so users
+ * see consistent wording whether they trigger a lifecycle action from the
+ * wizard or from Settings.
+ *
+ * The `compact` flag (D-06) shortens the message for the Settings modal
+ * context where the user is already in a technical surface and the license
+ * blurb / admin-rights reassurance would be noise.
+ *
+ * **Uninstall warning contract (D-07):** the uninstall dialog MUST include
+ * the phrase "IDE restart" and the absolute platform font directory path,
+ * because `java.awt.GraphicsEnvironment` has NO unregister API. A deleted
+ * font file is not fully unregistered from the JVM until the next IDE
+ * startup. See RESEARCH.md A3.
+ */
+object FontInstallConsent {
+    /**
+     * Show an install consent dialog. Returns `true` if the user accepts.
+     *
+     * @param entry the [FontCatalog.Entry] describing the font to install
+     * @param project project scope for the modal; may be `null` in wizards
+     *   that fire before any project window exists
+     * @param compact shorter copy suitable for Settings; default is the
+     *   full wizard copy with license blurb and admin-rights reassurance
+     */
+    fun confirmInstall(
+        entry: FontCatalog.Entry,
+        project: Project?,
+        compact: Boolean = false,
+    ): Boolean {
+        val message = buildInstallMessage(entry, compact)
+        return MessageDialogBuilder
+            .yesNo("Install ${entry.displayName}?", message)
+            .yesText("Install")
+            .noText("Cancel")
+            .ask(project)
+    }
+
+    /**
+     * Show an uninstall consent dialog. Returns `true` if the user accepts.
+     *
+     * @param entry the [FontCatalog.Entry] describing the font to remove
+     * @param project project scope for the modal; may be `null`
+     * @param absolutePath absolute filesystem path of [FontInstaller.platformFontDir];
+     *   MUST be shown verbatim in the dialog (not a symbolic label) so the
+     *   user knows exactly which folder the plugin will touch
+     */
+    fun confirmUninstall(
+        entry: FontCatalog.Entry,
+        project: Project?,
+        absolutePath: String,
+    ): Boolean {
+        val message = buildUninstallMessage(entry, absolutePath)
+        return MessageDialogBuilder
+            .yesNo("Remove ${entry.displayName}?", message)
+            .yesText("Remove")
+            .noText("Cancel")
+            .asWarning()
+            .ask(project)
+    }
+
+    /**
+     * Human-readable label for the platform user-level font directory,
+     * used in the wizard consent copy where the exact absolute path
+     * would be noisy. Settings panel uses the absolute path directly
+     * via [FontInstaller.platformFontDir].
+     */
+    fun platformFontDirLabel(): String =
+        when {
+            SystemInfo.isMac -> "~/Library/Fonts"
+            SystemInfo.isWindows -> "%LOCALAPPDATA%\\Microsoft\\Windows\\Fonts"
+            else -> "~/.local/share/fonts"
+        }
+
+    @TestOnly
+    internal fun buildInstallMessage(
+        entry: FontCatalog.Entry,
+        compact: Boolean,
+    ): String =
+        if (compact) {
+            "Download ${entry.displayName} (~${entry.approxSizeMb} MB) to " +
+                "${platformFontDirLabel()}?"
+        } else {
+            "Ayu Islands will download ${entry.displayName} (~${entry.approxSizeMb} MB, " +
+                "SIL Open Font License) from GitHub and install it to:\n\n" +
+                "    ${platformFontDirLabel()}\n\n" +
+                "This is a user-level install — no admin rights required.\n" +
+                "You can remove it anytime from that folder."
+        }
+
+    @TestOnly
+    internal fun buildUninstallMessage(
+        entry: FontCatalog.Entry,
+        absolutePath: String,
+    ): String =
+        "Ayu Islands will delete ${entry.displayName} files from:\n\n" +
+            "    $absolutePath\n\n" +
+            "The font will be removed from the editor immediately, but " +
+            "full uninstall (including the JVM font registry) only takes " +
+            "effect after an IDE restart."
+}

--- a/src/main/kotlin/dev/ayuislands/font/FontInstaller.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontInstaller.kt
@@ -154,7 +154,7 @@ object FontInstaller {
         }
 
         LOG.info("Font installed: $canonicalFamily (preset=${preset.name})")
-        persistAndApply(entry, preset, project, canonicalFamily, onComplete)
+        persistAndApply(entry, project, canonicalFamily, installedFiles, onComplete)
     }
 
     @TestOnly
@@ -275,9 +275,9 @@ object FontInstaller {
 
     private fun persistAndApply(
         entry: FontCatalog.Entry,
-        preset: FontPreset,
         project: Project?,
         canonicalFamily: String,
+        installedFiles: List<File>,
         onComplete: (InstallResult) -> Unit,
     ) {
         val ge = GraphicsEnvironment.getLocalGraphicsEnvironment()
@@ -288,7 +288,7 @@ object FontInstaller {
         if (dropdownStale) {
             notify(entry, project, FailureKind.DROPDOWN_STALE, NotificationType.WARNING)
             ApplicationManager.getApplication().invokeLater {
-                persistFontState(canonicalFamily)
+                persistFontState(canonicalFamily, installedFiles)
                 onComplete(InstallResult.Success(canonicalFamily))
             }
             return
@@ -296,8 +296,8 @@ object FontInstaller {
 
         ApplicationManager.getApplication().invokeLater {
             try {
-                persistFontState(canonicalFamily)
-                FontPresetApplicator.apply(FontSettings.decode(null, preset))
+                persistFontState(canonicalFamily, installedFiles)
+                FontPresetApplicator.apply(FontSettings.decode(null, entry.preset))
                 verifyApplied(entry, canonicalFamily, project)
                 onComplete(InstallResult.Success(canonicalFamily))
             } catch (e: RuntimeException) {
@@ -309,9 +309,17 @@ object FontInstaller {
     }
 
     @TestOnly
-    internal fun persistFontState(canonicalFamily: String) {
+    internal fun persistFontState(
+        canonicalFamily: String,
+        installedFiles: List<File>,
+    ) {
         val state = AyuIslandsSettings.getInstance().state
         state.installedFonts.add(canonicalFamily)
+        state.installedFontFiles[canonicalFamily] =
+            installedFiles.joinToString("\n") { it.absolutePath }
+        // D-09: reinstalling a previously-deleted font clears the guard so future
+        // seeder runs treat this family as first-class again.
+        state.explicitlyUninstalledFonts.remove(canonicalFamily)
         FontDetector.invalidateCache()
     }
 

--- a/src/main/kotlin/dev/ayuislands/font/FontInstaller.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontInstaller.kt
@@ -13,6 +13,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.util.io.HttpRequests
 import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
 import org.jetbrains.annotations.TestOnly
 import java.awt.Font
 import java.awt.GraphicsEnvironment
@@ -316,7 +317,7 @@ object FontInstaller {
         val state = AyuIslandsSettings.getInstance().state
         state.installedFonts.add(canonicalFamily)
         state.installedFontFiles[canonicalFamily] =
-            installedFiles.joinToString("\n") { it.absolutePath }
+            AyuIslandsState.encodeFontPaths(installedFiles)
         // D-09: reinstalling a previously-deleted font clears the guard so future
         // seeder runs treat this family as first-class again.
         state.explicitlyUninstalledFonts.remove(canonicalFamily)

--- a/src/main/kotlin/dev/ayuislands/font/FontUninstaller.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontUninstaller.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
 import org.jetbrains.annotations.TestOnly
 import java.io.File
 import java.io.IOException
@@ -59,9 +60,10 @@ object FontUninstaller {
     private const val GH_ISSUES_URL = "https://github.com/AyuIslands/ayu-jetbrains/issues"
 
     sealed class UninstallResult {
-        /** All persisted files successfully deleted. */
+        abstract val familyName: String
+
         data class Success(
-            val familyName: String,
+            override val familyName: String,
             val filesRemoved: Int,
         ) : UninstallResult()
 
@@ -69,20 +71,23 @@ object FontUninstaller {
          * Some files could not be deleted (file lock, permission denied).
          * State was still mutated — the family is removed from `AyuIslandsState.installedFonts`
          * and added to `AyuIslandsState.explicitlyUninstalledFonts`. The stale file(s) will
-         * be fully released after the next IDE restart (JVM font registry is not reversible
-         * in-session — see RESEARCH.md A3 and D-07).
+         * be fully released after the next IDE restart.
          */
         data class Partial(
-            val familyName: String,
+            override val familyName: String,
             val failedPaths: List<String>,
-        ) : UninstallResult()
+        ) : UninstallResult() {
+            init {
+                require(failedPaths.isNotEmpty()) { "Partial with no failed paths is a Success" }
+            }
+        }
 
         /**
          * Uninstall could not proceed (e.g., path-traversal guard rejected the persisted
-         * paths). State was NOT mutated. The user should report this as a bug.
+         * paths). State was NOT mutated.
          */
         data class Failure(
-            val familyName: String,
+            override val familyName: String,
             val message: String,
         ) : UninstallResult()
     }
@@ -114,8 +119,7 @@ object FontUninstaller {
         val state = AyuIslandsSettings.getInstance().state
         val family = entry.familyName
 
-        val encodedPaths = state.installedFontFiles[family].orEmpty()
-        val rawPaths = encodedPaths.split('\n').filter { it.isNotBlank() }
+        val rawPaths = AyuIslandsState.decodeFontPaths(state.installedFontFiles[family])
 
         // D-08 path-traversal guard (T-25-01): reject any path that escapes
         // platformFontDir. Runs BEFORE any File.delete() call so a malicious
@@ -161,14 +165,17 @@ object FontUninstaller {
             state.explicitlyUninstalledFonts.add(family)
             FontDetector.invalidateCache()
 
-            // D-07 step 6: revert active editor font if it matches the deleted family.
-            val activeEditorFont =
-                EditorColorsManager
-                    .getInstance()
-                    .globalScheme
-                    .editorFontName
-            if (activeEditorFont.equals(family, ignoreCase = true)) {
-                FontPresetApplicator.revert()
+            try {
+                val activeEditorFont =
+                    EditorColorsManager
+                        .getInstance()
+                        .globalScheme
+                        .editorFontName
+                if (activeEditorFont.equals(family, ignoreCase = true)) {
+                    FontPresetApplicator.revert()
+                }
+            } catch (e: RuntimeException) {
+                LOG.warn("FontPresetApplicator.revert() failed during uninstall of $family", e)
             }
 
             val result: UninstallResult =
@@ -198,8 +205,7 @@ object FontUninstaller {
                     LOG.warn("Could not canonicalize $rawPath", e)
                     return@partition false
                 }
-            canonical == platformDirCanonical ||
-                canonical.startsWith(platformDirCanonical + File.separator)
+            canonical.startsWith(platformDirCanonical + File.separator)
         }
 
     private fun deleteSafely(safePaths: List<String>): List<String> {
@@ -224,8 +230,8 @@ object FontUninstaller {
         onComplete: (UninstallResult) -> Unit,
         message: String,
     ) {
-        notifyUninstall(project, message, NotificationType.ERROR)
         ApplicationManager.getApplication().invokeLater {
+            notifyUninstall(project, message, NotificationType.ERROR)
             onComplete(UninstallResult.Failure(entry.familyName, message))
         }
     }

--- a/src/main/kotlin/dev/ayuislands/font/FontUninstaller.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontUninstaller.kt
@@ -1,0 +1,257 @@
+package dev.ayuislands.font
+
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationType
+import com.intellij.notification.Notifications
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.editor.colors.EditorColorsManager
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.Task
+import com.intellij.openapi.project.Project
+import dev.ayuislands.settings.AyuIslandsSettings
+import org.jetbrains.annotations.TestOnly
+import java.io.File
+import java.io.IOException
+
+/**
+ * Filesystem delete pipeline for curated font presets (D-07).
+ *
+ * Separation from [FontInstaller] is deliberate — install and uninstall are
+ * opposite lifecycle operations with independent test surfaces and different
+ * failure modes. [FontInstaller.persistFontState] remains the sole writer of
+ * `state.installedFonts` on the install path (D-14); this object is the sole
+ * remover via [runUninstallPipeline].
+ *
+ * Pipeline:
+ * 1. Consent dialog via [FontInstallConsent.confirmUninstall] — **caller responsibility**.
+ *    This object ASSUMES consent has been obtained. Consent is NOT inside the
+ *    pipeline because `Task.Backgroundable.queue` indirection would surface the
+ *    dialog from a background thread, which either deadlocks on EDT or silently
+ *    skips. See threat T-25-10.
+ * 2. Off-EDT filesystem work in [Task.Backgroundable], matching [FontInstaller.install]'s
+ *    threading.
+ * 3. Reads authoritative paths from [AyuIslandsState.installedFontFiles] — never
+ *    re-derives from regex (D-08).
+ * 4. Rejects any persisted path not canonically under [FontInstaller.platformFontDir]
+ *    (path-traversal guard, T-25-01). Rejection returns [UninstallResult.Failure]
+ *    WITHOUT mutating state.
+ * 5. State mutation on EDT: removes from [AyuIslandsState.installedFonts], adds to
+ *    [AyuIslandsState.explicitlyUninstalledFonts] (D-09 guard), clears the
+ *    [AyuIslandsState.installedFontFiles] entry, calls [FontDetector.invalidateCache].
+ * 6. Conditionally calls [FontPresetApplicator.revert] when the deleted family
+ *    matches the active editor font name.
+ * 7. Notifies outcome — success, partial (file lock), or failure (path rejection).
+ *
+ * **Residual risk (T-25-11):** TOCTOU between canonical-path check and
+ * `File.delete()` via symlink swap. Accepted — requires local fs write access
+ * to race the delete in milliseconds, and the attacker can already delete the
+ * target directly.
+ *
+ * No exception ever escapes to the caller; `onComplete` always fires with an
+ * [UninstallResult].
+ */
+object FontUninstaller {
+    private val LOG = logger<FontUninstaller>()
+    private const val NOTIFICATION_GROUP = "Ayu Islands"
+    private const val NOTIFICATION_TITLE = "Ayu Islands — Font remove"
+    private const val GH_ISSUES_URL = "https://github.com/AyuIslands/ayu-jetbrains/issues"
+
+    sealed class UninstallResult {
+        /** All persisted files successfully deleted. */
+        data class Success(
+            val familyName: String,
+            val filesRemoved: Int,
+        ) : UninstallResult()
+
+        /**
+         * Some files could not be deleted (file lock, permission denied).
+         * State was still mutated — the family is removed from [AyuIslandsState.installedFonts]
+         * and added to [AyuIslandsState.explicitlyUninstalledFonts]. The stale file(s) will
+         * be fully released after the next IDE restart (JVM font registry is not reversible
+         * in-session — see RESEARCH.md A3 and D-07).
+         */
+        data class Partial(
+            val familyName: String,
+            val failedPaths: List<String>,
+        ) : UninstallResult()
+
+        /**
+         * Uninstall could not proceed (e.g., path-traversal guard rejected the persisted
+         * paths). State was NOT mutated. The user should report this as a bug.
+         */
+        data class Failure(
+            val familyName: String,
+            val message: String,
+        ) : UninstallResult()
+    }
+
+    fun uninstall(
+        preset: FontPreset,
+        project: Project?,
+        onComplete: (UninstallResult) -> Unit,
+    ) {
+        val entry = FontCatalog.forPreset(preset)
+        val task =
+            object : Task.Backgroundable(project, "Removing ${entry.displayName}…", true) {
+                override fun run(indicator: ProgressIndicator) {
+                    runUninstallPipeline(entry, project, indicator, onComplete)
+                }
+            }
+        ProgressManager.getInstance().run(task)
+    }
+
+    @TestOnly
+    @Suppress("LongMethod")
+    internal fun runUninstallPipeline(
+        entry: FontCatalog.Entry,
+        project: Project?,
+        indicator: ProgressIndicator,
+        onComplete: (UninstallResult) -> Unit,
+    ) {
+        indicator.text = "Locating installed files…"
+        val state = AyuIslandsSettings.getInstance().state
+        val family = entry.familyName
+
+        val encodedPaths = state.installedFontFiles[family].orEmpty()
+        val rawPaths = encodedPaths.split('\n').filter { it.isNotBlank() }
+
+        // D-08 path-traversal guard (T-25-01): reject any path that escapes
+        // platformFontDir. Runs BEFORE any File.delete() call so a malicious
+        // ayuIslands.xml can never make us touch /etc/passwd or anywhere else.
+        val platformDirCanonical =
+            try {
+                FontInstaller.platformFontDir().canonicalPath
+            } catch (e: IOException) {
+                LOG.warn("Could not canonicalize platformFontDir", e)
+                finishUninstallFailure(
+                    entry,
+                    project,
+                    onComplete,
+                    "Could not resolve platform font directory",
+                )
+                return
+            }
+
+        val (safePaths, rejectedPaths) = partitionSafePaths(rawPaths, platformDirCanonical)
+
+        if (rejectedPaths.isNotEmpty()) {
+            LOG.warn(
+                "Path-traversal guard rejected ${rejectedPaths.size} path(s) " +
+                    "for family $family: $rejectedPaths",
+            )
+            finishUninstallFailure(
+                entry,
+                project,
+                onComplete,
+                "Installation record contained paths outside the font directory. " +
+                    "State was not modified. Please report at $GH_ISSUES_URL.",
+            )
+            return
+        }
+
+        indicator.text = "Removing files…"
+        val failed = deleteSafely(safePaths)
+
+        // State mutation + cache invalidation + fallback revert — all on EDT.
+        ApplicationManager.getApplication().invokeLater {
+            state.installedFonts.remove(family)
+            state.installedFontFiles.remove(family)
+            state.explicitlyUninstalledFonts.add(family)
+            FontDetector.invalidateCache()
+
+            // D-07 step 6: revert active editor font if it matches the deleted family.
+            val activeEditorFont =
+                EditorColorsManager
+                    .getInstance()
+                    .globalScheme
+                    .editorFontName
+            if (activeEditorFont.equals(family, ignoreCase = true)) {
+                FontPresetApplicator.revert()
+            }
+
+            val result: UninstallResult =
+                if (failed.isEmpty()) {
+                    UninstallResult.Success(family, safePaths.size)
+                } else {
+                    UninstallResult.Partial(family, failed)
+                }
+
+            val message = uninstallMessage(entry, safePaths.size, failed.size)
+            val type = if (failed.isEmpty()) NotificationType.INFORMATION else NotificationType.WARNING
+            notifyUninstall(project, message, type)
+
+            onComplete(result)
+        }
+    }
+
+    private fun partitionSafePaths(
+        rawPaths: List<String>,
+        platformDirCanonical: String,
+    ): Pair<List<String>, List<String>> =
+        rawPaths.partition { rawPath ->
+            val canonical =
+                try {
+                    File(rawPath).canonicalPath
+                } catch (e: IOException) {
+                    LOG.warn("Could not canonicalize $rawPath", e)
+                    return@partition false
+                }
+            canonical == platformDirCanonical ||
+                canonical.startsWith(platformDirCanonical + File.separator)
+        }
+
+    private fun deleteSafely(safePaths: List<String>): List<String> {
+        val failed = mutableListOf<String>()
+        for (path in safePaths) {
+            val file = File(path)
+            try {
+                if (file.exists() && !file.delete()) {
+                    failed.add(path)
+                }
+            } catch (e: SecurityException) {
+                LOG.warn("SecurityException deleting $path", e)
+                failed.add(path)
+            }
+        }
+        return failed
+    }
+
+    private fun finishUninstallFailure(
+        entry: FontCatalog.Entry,
+        project: Project?,
+        onComplete: (UninstallResult) -> Unit,
+        message: String,
+    ) {
+        notifyUninstall(project, message, NotificationType.ERROR)
+        ApplicationManager.getApplication().invokeLater {
+            onComplete(UninstallResult.Failure(entry.familyName, message))
+        }
+    }
+
+    private fun notifyUninstall(
+        project: Project?,
+        message: String,
+        type: NotificationType,
+    ) {
+        val notification = Notification(NOTIFICATION_GROUP, NOTIFICATION_TITLE, message, type)
+        Notifications.Bus.notify(notification, project)
+    }
+
+    private fun uninstallMessage(
+        entry: FontCatalog.Entry,
+        totalPaths: Int,
+        failedCount: Int,
+    ): String {
+        val removed = totalPaths - failedCount
+        return if (failedCount == 0) {
+            val plural = if (removed == 1) "" else "s"
+            "${entry.displayName} removed ($removed file$plural). " +
+                "Restart the IDE to fully release the JVM font registration."
+        } else {
+            "${entry.displayName}: $removed of $totalPaths files removed. " +
+                "Remaining file(s) are in use — restart the IDE to complete removal."
+        }
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/font/FontUninstaller.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontUninstaller.kt
@@ -27,19 +27,19 @@ import java.io.IOException
  * Pipeline:
  * 1. Consent dialog via [FontInstallConsent.confirmUninstall] — **caller responsibility**.
  *    This object ASSUMES consent has been obtained. Consent is NOT inside the
- *    pipeline because `Task.Backgroundable.queue` indirection would surface the
+ *    pipeline because [Task.Backgroundable] queue indirection would surface the
  *    dialog from a background thread, which either deadlocks on EDT or silently
  *    skips. See threat T-25-10.
  * 2. Off-EDT filesystem work in [Task.Backgroundable], matching [FontInstaller.install]'s
  *    threading.
- * 3. Reads authoritative paths from [AyuIslandsState.installedFontFiles] — never
+ * 3. Reads authoritative paths from `AyuIslandsState.installedFontFiles` — never
  *    re-derives from regex (D-08).
  * 4. Rejects any persisted path not canonically under [FontInstaller.platformFontDir]
  *    (path-traversal guard, T-25-01). Rejection returns [UninstallResult.Failure]
  *    WITHOUT mutating state.
- * 5. State mutation on EDT: removes from [AyuIslandsState.installedFonts], adds to
- *    [AyuIslandsState.explicitlyUninstalledFonts] (D-09 guard), clears the
- *    [AyuIslandsState.installedFontFiles] entry, calls [FontDetector.invalidateCache].
+ * 5. State mutation on EDT: removes from `AyuIslandsState.installedFonts`, adds to
+ *    `AyuIslandsState.explicitlyUninstalledFonts` (D-09 guard), clears the
+ *    `AyuIslandsState.installedFontFiles` entry, calls [FontDetector.invalidateCache].
  * 6. Conditionally calls [FontPresetApplicator.revert] when the deleted family
  *    matches the active editor font name.
  * 7. Notifies outcome — success, partial (file lock), or failure (path rejection).
@@ -67,8 +67,8 @@ object FontUninstaller {
 
         /**
          * Some files could not be deleted (file lock, permission denied).
-         * State was still mutated — the family is removed from [AyuIslandsState.installedFonts]
-         * and added to [AyuIslandsState.explicitlyUninstalledFonts]. The stale file(s) will
+         * State was still mutated — the family is removed from `AyuIslandsState.installedFonts`
+         * and added to `AyuIslandsState.explicitlyUninstalledFonts`. The stale file(s) will
          * be fully released after the next IDE restart (JVM font registry is not reversible
          * in-session — see RESEARCH.md A3 and D-07).
          */

--- a/src/main/kotlin/dev/ayuislands/onboarding/FreeOnboardingPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/onboarding/FreeOnboardingPanel.kt
@@ -12,7 +12,6 @@ import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.ui.components.JBLabel
-import com.intellij.util.ImageLoader
 import com.intellij.util.ui.JBUI
 import dev.ayuislands.accent.AYU_ACCENT_PRESETS
 import dev.ayuislands.accent.AccentApplicator
@@ -124,7 +123,7 @@ internal class FreeOnboardingPanel(
         return path
     }
 
-    /** Render SVG as a full-tab background with "cover" scaling via [ImageLoader]. */
+    @Suppress("DuplicatedCode") // cache key = variant (swappable heroes); Premium uses path as key
     private fun paintBackground(g2: Graphics2D) {
         val path = variantHeroPaths[currentHeroVariant] ?: variantHeroPaths.values.firstOrNull() ?: return
         if (width <= 0 || height <= 0) return
@@ -141,14 +140,7 @@ internal class FreeOnboardingPanel(
         path: String,
         targetW: Int,
         targetH: Int,
-    ): java.awt.Image? =
-        try {
-            val raw = ImageLoader.loadFromResource(path, FreeOnboardingPanel::class.java)
-            raw?.let { ImageLoader.scaleImage(it, targetW, targetH) }
-        } catch (exception: java.io.IOException) {
-            LOG.warn("Failed to load hero SVG $path", exception)
-            null
-        }
+    ): java.awt.Image? = loadScaledHero(path, targetW, targetH, FreeOnboardingPanel::class.java)
 
     /** Bottom gradient scrim for text readability over the image. */
     private fun paintScrim(g2: Graphics2D) {

--- a/src/main/kotlin/dev/ayuislands/onboarding/OnboardingSharedRendering.kt
+++ b/src/main/kotlin/dev/ayuislands/onboarding/OnboardingSharedRendering.kt
@@ -45,6 +45,9 @@ internal fun loadScaledHero(
     } catch (exception: IOException) {
         LOG.warn("Failed to load hero SVG $path", exception)
         null
+    } catch (exception: IllegalArgumentException) {
+        LOG.warn("Failed to load hero SVG $path", exception)
+        null
     }
 
 /**

--- a/src/main/kotlin/dev/ayuislands/onboarding/OnboardingSharedRendering.kt
+++ b/src/main/kotlin/dev/ayuislands/onboarding/OnboardingSharedRendering.kt
@@ -1,22 +1,51 @@
 package dev.ayuislands.onboarding
 
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.util.ImageLoader
 import com.intellij.util.ui.JBUI
 import java.awt.Color
 import java.awt.Dimension
 import java.awt.GradientPaint
 import java.awt.Graphics
 import java.awt.Graphics2D
+import java.awt.Image
 import java.awt.RenderingHints
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
+import java.io.IOException
 import javax.swing.Box
 import javax.swing.BoxLayout
 import javax.swing.Icon
 import javax.swing.JComponent
 import javax.swing.JPanel
 
+private val LOG = logger<OnboardingSharedRenderingLog>()
+
 // Shared hero background, scrim, and footer rail helpers extracted from
 // FreeOnboardingPanel and PremiumOnboardingPanel to eliminate duplication.
+
+internal class OnboardingSharedRenderingLog
+
+/**
+ * Load and scale an SVG hero image from plugin resources.
+ *
+ * @param resourceAnchor the class whose classloader resolves the resource path —
+ *   pass the panel's own class so the resource lookup stays correct across both
+ *   [FreeOnboardingPanel] and [PremiumOnboardingPanel]
+ */
+internal fun loadScaledHero(
+    path: String,
+    targetWidth: Int,
+    targetHeight: Int,
+    resourceAnchor: Class<*>,
+): Image? =
+    try {
+        val raw = ImageLoader.loadFromResource(path, resourceAnchor)
+        raw?.let { ImageLoader.scaleImage(it, targetWidth, targetHeight) }
+    } catch (exception: IOException) {
+        LOG.warn("Failed to load hero SVG $path", exception)
+        null
+    }
 
 /**
  * Draw [image] centered on a [panelWidth]x[panelHeight] surface at the
@@ -24,7 +53,7 @@ import javax.swing.JPanel
  */
 internal fun drawCoveredImage(
     g2: Graphics2D,
-    image: java.awt.Image,
+    image: Image,
     panelWidth: Int,
     panelHeight: Int,
     coverSize: Pair<Int, Int>,

--- a/src/main/kotlin/dev/ayuislands/onboarding/PremiumOnboardingPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/onboarding/PremiumOnboardingPanel.kt
@@ -11,7 +11,6 @@ import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.ui.components.JBLabel
-import com.intellij.util.ImageLoader
 import com.intellij.util.ui.JBUI
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.font.FontCatalog
@@ -109,7 +108,7 @@ internal class PremiumOnboardingPanel(
         super.paintComponent(graphics)
     }
 
-    /** Render SVG as a full-tab background with "cover" scaling via [ImageLoader]. */
+    @Suppress("DuplicatedCode") // cache key = path (single hero); Free uses variant as key
     private fun paintBackground(g2: Graphics2D) {
         val path = heroPath ?: return
         if (width <= 0 || height <= 0) return
@@ -137,14 +136,7 @@ internal class PremiumOnboardingPanel(
         path: String,
         targetW: Int,
         targetH: Int,
-    ): java.awt.Image? =
-        try {
-            val raw = ImageLoader.loadFromResource(path, PremiumOnboardingPanel::class.java)
-            raw?.let { ImageLoader.scaleImage(it, targetW, targetH) }
-        } catch (exception: java.io.IOException) {
-            LOG.warn("Failed to load hero SVG $path", exception)
-            null
-        }
+    ): java.awt.Image? = loadScaledHero(path, targetW, targetH, PremiumOnboardingPanel::class.java)
 
     /** Bottom gradient scrim for text readability over the image. */
     private fun paintScrim(g2: Graphics2D) {

--- a/src/main/kotlin/dev/ayuislands/onboarding/PremiumOnboardingPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/onboarding/PremiumOnboardingPanel.kt
@@ -9,14 +9,13 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.ui.MessageDialogBuilder
-import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.ui.components.JBLabel
 import com.intellij.util.ImageLoader
 import com.intellij.util.ui.JBUI
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.font.FontCatalog
+import dev.ayuislands.font.FontInstallConsent
 import dev.ayuislands.font.FontInstaller
 import dev.ayuislands.font.FontPreset
 import dev.ayuislands.font.FontPresetApplicator
@@ -580,7 +579,7 @@ internal class PremiumOnboardingPanel(
             FontInstaller.applyOnly(preset, project)
             return
         }
-        if (!confirmFontInstall(entry)) return
+        if (!FontInstallConsent.confirmInstall(entry, project)) return
         installingFonts.add(preset)
         refreshFontRow()
         FontInstaller.install(preset, project) {
@@ -590,27 +589,6 @@ internal class PremiumOnboardingPanel(
             }
         }
     }
-
-    private fun confirmFontInstall(entry: FontCatalog.Entry): Boolean {
-        val message =
-            "Ayu Islands will download ${entry.displayName} (~${entry.approxSizeMb} MB, " +
-                "SIL Open Font License) from GitHub and install it to:\n\n" +
-                "    ${platformFontDirLabel()}\n\n" +
-                "This is a user-level install — no admin rights required.\n" +
-                "You can remove it anytime from that folder."
-        return MessageDialogBuilder
-            .yesNo("Install ${entry.displayName}?", message)
-            .yesText("Install")
-            .noText("Cancel")
-            .ask(project)
-    }
-
-    private fun platformFontDirLabel(): String =
-        when {
-            SystemInfo.isMac -> "~/Library/Fonts"
-            SystemInfo.isWindows -> "%LOCALAPPDATA%\\Microsoft\\Windows\\Fonts"
-            else -> "~/.local/share/fonts"
-        }
 
     private fun buildBottomButtons(): JPanel =
         buildWizardBottomButtons(

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsSettings.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsSettings.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.SimplePersistentStateComponent
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
+import com.intellij.openapi.diagnostic.logger
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.SystemAccentProvider
 import dev.ayuislands.font.FontCatalog
@@ -17,6 +18,8 @@ import java.awt.GraphicsEnvironment
 )
 class AyuIslandsSettings : SimplePersistentStateComponent<AyuIslandsState>(AyuIslandsState()) {
     companion object {
+        private val LOG = logger<AyuIslandsSettings>()
+
         fun getInstance(): AyuIslandsSettings =
             ApplicationManager
                 .getApplication()
@@ -64,6 +67,10 @@ class AyuIslandsSettings : SimplePersistentStateComponent<AyuIslandsState>(AyuIs
                     state.installedFonts.add(entry.familyName)
                 }
             }
+        } catch (e: java.awt.HeadlessException) {
+            LOG.warn("Failed to seed installed fonts (headless environment)", e)
+        } catch (e: RuntimeException) {
+            LOG.warn("Failed to seed installed fonts from GraphicsEnvironment", e)
         } finally {
             state.installedFontsSeeded = true
         }

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsSettings.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsSettings.kt
@@ -44,6 +44,11 @@ class AyuIslandsSettings : SimplePersistentStateComponent<AyuIslandsState>(AyuIs
      * canonical family name, and adds matches to state.
      *
      * Gated on [AyuIslandsState.installedFontsSeeded] — runs once per install.
+     *
+     * **D-09 guard:** families recorded in [AyuIslandsState.explicitlyUninstalledFonts]
+     * (i.e. the user explicitly deleted them via the Settings lifecycle UI) are NEVER
+     * re-seeded, even if the JVM still sees them in the font family list. This preserves
+     * the invariant that the plugin never undoes a user-initiated uninstall.
      */
     fun seedInstalledFontsFromDiskIfNeeded() {
         if (state.installedFontsSeeded) return
@@ -54,6 +59,7 @@ class AyuIslandsSettings : SimplePersistentStateComponent<AyuIslandsState>(AyuIs
                     .availableFontFamilyNames
                     .toHashSet()
             for (entry in FontCatalog.entries) {
+                if (state.explicitlyUninstalledFonts.contains(entry.familyName)) continue
                 if (available.contains(entry.familyName) && !state.installedFonts.contains(entry.familyName)) {
                     state.installedFonts.add(entry.familyName)
                 }

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -166,6 +166,20 @@ class AyuIslandsState : BaseState() {
     // re-prompted. Set to true after the first successful seed.
     var installedFontsSeeded by property(false)
 
+    // Authoritative list of absolute file paths per installed family (D-08).
+    // Values are "\n"-joined absolute paths. Flat map<String, String> shape matches
+    // the existing fontPresetCustomizations encoding precedent (line 159) and avoids
+    // nested-collection XML serialization risk (see RESEARCH.md Pitfall 2 / A1).
+    // The uninstall pipeline reads this to delete exactly the files it installed —
+    // never re-derive paths from entry.filesToKeep regex (risks collision with
+    // user-installed fonts of similar name).
+    var installedFontFiles by map<String, String>()
+
+    // Families the user has explicitly deleted via the Settings lifecycle UI (D-09).
+    // seedInstalledFontsFromDiskIfNeeded() must skip any family in this set so the
+    // plugin never re-adds a user-deleted font on a subsequent startup.
+    var explicitlyUninstalledFonts by stringSet()
+
     // Accent rotation
     var accentRotationEnabled by property(false)
     var accentRotationMode by string(AccentRotationMode.PRESET.name)

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -7,6 +7,7 @@ import dev.ayuislands.glow.GlowPreset
 import dev.ayuislands.glow.GlowStyle
 import dev.ayuislands.indent.IndentPreset
 import dev.ayuislands.rotation.AccentRotationMode
+import java.io.File
 
 enum class PanelWidthMode {
     DEFAULT,
@@ -168,11 +169,11 @@ class AyuIslandsState : BaseState() {
 
     // Authoritative list of absolute file paths per installed family (D-08).
     // Values are "\n"-joined absolute paths. Flat map<String, String> shape matches
-    // the existing fontPresetCustomizations encoding precedent (line 159) and avoids
-    // nested-collection XML serialization risk (see RESEARCH.md Pitfall 2 / A1).
-    // The uninstall pipeline reads this to delete exactly the files it installed —
-    // never re-derive paths from entry.filesToKeep regex (risks collision with
-    // user-installed fonts of similar name).
+    // the existing `fontPresetCustomizations` encoding precedent and avoids
+    // nested-collection XML serialization risk (BaseState silently drops
+    // Map<String, List<String>> on some platform versions).
+    // Use [encodeFontPaths] / [decodeFontPaths] for encode/decode — never split/join
+    // inline.
     var installedFontFiles by map<String, String>()
 
     // Families the user has explicitly deleted via the Settings lifecycle UI (D-09).
@@ -306,6 +307,12 @@ class AyuIslandsState : BaseState() {
     }
 
     companion object {
+        private const val PATH_SEP = "\n"
+
+        fun encodeFontPaths(paths: List<File>): String = paths.joinToString(PATH_SEP) { it.absolutePath }
+
+        fun decodeFontPaths(raw: String?): List<String> = raw?.split(PATH_SEP)?.filter { it.isNotBlank() }.orEmpty()
+
         const val DEFAULT_TAB_UNDERLINE_HEIGHT = 4
         const val DEFAULT_AUTO_FIT_MAX_WIDTH = 400
         const val DEFAULT_PROJECT_AUTO_FIT_MIN_WIDTH = 250

--- a/src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
@@ -12,10 +12,13 @@ import com.intellij.ui.dsl.builder.SegmentedButton
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.font.FontCatalog
 import dev.ayuislands.font.FontDetector
+import dev.ayuislands.font.FontInstallConsent
 import dev.ayuislands.font.FontInstaller
 import dev.ayuislands.font.FontPreset
 import dev.ayuislands.font.FontPresetApplicator
 import dev.ayuislands.font.FontSettings
+import dev.ayuislands.font.FontStatus
+import dev.ayuislands.font.FontUninstaller
 import dev.ayuislands.font.FontWeight
 import java.awt.datatransfer.StringSelection
 import javax.swing.JCheckBox
@@ -70,6 +73,8 @@ class FontPresetPanel : AyuIslandsSettingsPanel {
 
     private val presetEnabled = AtomicBooleanProperty(false)
     private val fontMissing = AtomicBooleanProperty(false)
+    private val fontInstalled = AtomicBooleanProperty(false)
+    private val fontCorrupted = AtomicBooleanProperty(false)
     private val isCustomSelected = AtomicBooleanProperty(false)
     private val customFontVisible = AtomicBooleanProperty(false)
 
@@ -238,24 +243,65 @@ class FontPresetPanel : AyuIslandsSettingsPanel {
         }.visibleIf(fontMissing)
     }
 
-    private fun Panel.buildInstallHintRow() {
-        // Universal one-click installer (downloads, extracts, copies, registers, applies).
-        // Replaces the previous Mac-only brew flow + non-Mac "Download ZIP" link with a
-        // single path through FontInstaller, available on all platforms.
-        row {
-            link("Install automatically") {
-                val preset = FontPreset.fromName(pendingPreset)
-                val project = ProjectManager.getInstance().openProjects.firstOrNull()
-                FontInstaller.install(preset, project) {
-                    ApplicationManager.getApplication().invokeLater {
-                        FontDetector.invalidateCache()
-                        availability = FontDetector.detectAll()
-                        updateFontMissing()
-                    }
-                }
+    /**
+     * Consent-gated lifecycle action (D-04 fix + D-07 + D-12).
+     *
+     * Handles both install and uninstall paths because both (a) share the same
+     * post-action refresh boilerplate and (b) both must run through FontInstallConsent
+     * synchronously BEFORE touching the filesystem. Collapsing into one helper keeps
+     * FontPresetPanel under the detekt TooManyFunctions threshold.
+     *
+     * Install path is used by "Install automatically" on the missing row and by
+     * "Reinstall" on both the healthy and corrupted rows — D-12 requires every
+     * reinstall to be user-triggered through this same consent helper.
+     */
+    private fun triggerLifecycleAction(uninstall: Boolean) {
+        val preset = FontPreset.fromName(pendingPreset)
+        val project = ProjectManager.getInstance().openProjects.firstOrNull()
+        val entry = FontCatalog.forPreset(preset)
+        val refresh = {
+            ApplicationManager.getApplication().invokeLater {
+                FontDetector.invalidateCache()
+                availability = FontDetector.detectAll()
+                updateFontMissing()
             }
+            Unit
+        }
+        if (uninstall) {
+            val absPath = FontInstaller.platformFontDir().absolutePath
+            if (!FontInstallConsent.confirmUninstall(entry, project, absPath)) return
+            FontUninstaller.uninstall(preset, project) { refresh() }
+        } else {
+            if (!FontInstallConsent.confirmInstall(entry, project, compact = true)) return
+            FontInstaller.install(preset, project) { refresh() }
+        }
+    }
+
+    private fun Panel.buildInstallHintRow() {
+        // D-04 fix: install path is consent-gated via FontInstallConsent.
+        // Previous behavior called FontInstaller.install() directly with no dialog,
+        // violating "never touch userspace without consent".
+        row {
+            link("Install automatically") { triggerLifecycleAction(uninstall = false) }
             comment("Downloads, installs, and registers the font with no restart")
         }.visibleIf(fontMissing)
+
+        // D-02: installed-healthy row with Reinstall + Delete actions (mutually exclusive
+        // with fontMissing via the three-way status() snapshot in updateFontMissing).
+        row {
+            label("Installed ✓")
+            link("Reinstall") { triggerLifecycleAction(uninstall = false) }
+            link("Delete") { triggerLifecycleAction(uninstall = true) }
+            comment("Reinstall re-downloads the font; Delete removes the installed files (restart required)")
+        }.visibleIf(fontInstalled)
+
+        // D-02: corrupted row — state says installed, but the file is gone from disk
+        // and the JVM no longer sees the family. User-triggered repair only (D-12).
+        row {
+            label("\u26A0 Installed file missing")
+            link("Reinstall") { triggerLifecycleAction(uninstall = false) }
+            comment("Your plugin state records this font as installed, but the files are gone from disk")
+        }.visibleIf(fontCorrupted)
 
         if (!IS_MAC) return
 
@@ -433,14 +479,25 @@ class FontPresetPanel : AyuIslandsSettingsPanel {
 
     private fun updateFontMissing() {
         val preset = FontPreset.fromName(pendingPreset)
-        val missing = preset.isCurated && availability[preset] != true && pendingEnabled
-        fontMissing.set(missing)
+        // D-01/D-03: compute all three booleans atomically from a SINGLE status snapshot
+        // so the three .visibleIf() rows are always mutually exclusive — no race window.
+        // Non-curated presets and disabled state collapse to NOT_INSTALLED.
+        val status =
+            if (preset.isCurated && pendingEnabled) FontDetector.status(preset) else FontStatus.NOT_INSTALLED
+        val isMissing = preset.isCurated && status == FontStatus.NOT_INSTALLED && pendingEnabled
+        val isHealthy = preset.isCurated && status == FontStatus.HEALTHY && pendingEnabled
+        val isCorrupted = preset.isCurated && status == FontStatus.CORRUPTED && pendingEnabled
+
+        fontMissing.set(isMissing)
+        fontInstalled.set(isHealthy)
+        fontCorrupted.set(isCorrupted)
+
         warningLabel?.let { it.text = "\u26A0 Requires ${preset.fontFamily}" }
         installHintLabel?.let {
             val slug = FontCatalog.forPreset(preset).brewCaskSlug
             it.text = "Or via Homebrew: brew install --cask $slug"
         }
-        previewComponent?.updatePreset(preset, availability[preset] == true)
+        previewComponent?.updatePreset(preset, status == FontStatus.HEALTHY)
     }
 
     override fun isModified(): Boolean {

--- a/src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
@@ -278,7 +278,7 @@ class FontPresetPanel : AyuIslandsSettingsPanel {
                 FontInstaller.install(preset, project) { refresh() }
             }
         } catch (e: RuntimeException) {
-            LOG.warn("Font lifecycle action failed (uninstall=$uninstall)", e)
+            LOG.warn("Font lifecycle action failed (uninstall=$uninstall, preset=$pendingPreset)", e)
         }
     }
 
@@ -535,11 +535,15 @@ class FontPresetPanel : AyuIslandsSettingsPanel {
         storedPreset = pendingPreset
         storedConsole = pendingConsole
 
-        if (pendingEnabled) {
-            FontDetector.invalidateCache()
-            FontPresetApplicator.apply(currentSettings.copy(applyToConsole = pendingConsole))
-        } else {
-            FontPresetApplicator.revert()
+        try {
+            if (pendingEnabled) {
+                FontDetector.invalidateCache()
+                FontPresetApplicator.apply(currentSettings.copy(applyToConsole = pendingConsole))
+            } else {
+                FontPresetApplicator.revert()
+            }
+        } catch (e: RuntimeException) {
+            LOG.warn("FontPresetApplicator failed during settings apply (preset=$pendingPreset)", e)
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
@@ -1,6 +1,7 @@
 package dev.ayuislands.settings
 
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.ide.CopyPasteManager
 import com.intellij.openapi.observable.properties.AtomicBooleanProperty
 import com.intellij.openapi.project.ProjectManager
@@ -29,6 +30,7 @@ import javax.swing.SpinnerNumberModel
 /** Font preset tab — curated Nerd Font presets with one-click apply. */
 class FontPresetPanel : AyuIslandsSettingsPanel {
     private companion object {
+        private val LOG = logger<FontPresetPanel>()
         val IS_MAC: Boolean = System.getProperty("os.name").lowercase().contains("mac")
         const val MIN_FONT_SIZE = 8
         const val MAX_FONT_SIZE = 30
@@ -256,23 +258,27 @@ class FontPresetPanel : AyuIslandsSettingsPanel {
      * reinstall to be user-triggered through this same consent helper.
      */
     private fun triggerLifecycleAction(uninstall: Boolean) {
-        val preset = FontPreset.fromName(pendingPreset)
-        val project = ProjectManager.getInstance().openProjects.firstOrNull()
-        val entry = FontCatalog.forPreset(preset)
-        val refresh = {
-            ApplicationManager.getApplication().invokeLater {
-                FontDetector.invalidateCache()
-                availability = FontDetector.detectAll()
-                updateFontMissing()
+        try {
+            val preset = FontPreset.fromName(pendingPreset)
+            val project = ProjectManager.getInstance().openProjects.firstOrNull()
+            val entry = FontCatalog.forPreset(preset)
+            val refresh = {
+                ApplicationManager.getApplication().invokeLater {
+                    FontDetector.invalidateCache()
+                    availability = FontDetector.detectAll()
+                    updateFontMissing()
+                }
             }
-        }
-        if (uninstall) {
-            val absPath = FontInstaller.platformFontDir().absolutePath
-            if (!FontInstallConsent.confirmUninstall(entry, project, absPath)) return
-            FontUninstaller.uninstall(preset, project) { refresh() }
-        } else {
-            if (!FontInstallConsent.confirmInstall(entry, project, compact = true)) return
-            FontInstaller.install(preset, project) { refresh() }
+            if (uninstall) {
+                val absPath = FontInstaller.platformFontDir().absolutePath
+                if (!FontInstallConsent.confirmUninstall(entry, project, absPath)) return
+                FontUninstaller.uninstall(preset, project) { refresh() }
+            } else {
+                if (!FontInstallConsent.confirmInstall(entry, project, compact = true)) return
+                FontInstaller.install(preset, project) { refresh() }
+            }
+        } catch (e: RuntimeException) {
+            LOG.warn("Font lifecycle action failed (uninstall=$uninstall)", e)
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
@@ -265,7 +265,6 @@ class FontPresetPanel : AyuIslandsSettingsPanel {
                 availability = FontDetector.detectAll()
                 updateFontMissing()
             }
-            Unit
         }
         if (uninstall) {
             val absPath = FontInstaller.platformFontDir().absolutePath

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -72,6 +72,13 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>2.4.2</h3>
+    <ul>
+      <li>[Paid] Install, delete, or reinstall curated fonts directly from Settings without opening the wizard</li>
+      <li>Every install and delete now shows a consent dialog with the exact font folder path — no silent filesystem changes</li>
+      <li>Deleting a font reverts the editor to JetBrains Mono and warns that full removal takes effect after IDE restart</li>
+      <li>Settings now shows "Installed ✓", "file missing — Reinstall", or "Install automatically" based on actual disk state</li>
+    </ul>
     <h3>2.4.1</h3>
     <ul>
       <li>Fix font install retry getting stuck on corrupted download cache</li>

--- a/src/test/kotlin/dev/ayuislands/font/FontDetectorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/font/FontDetectorTest.kt
@@ -1,9 +1,15 @@
 package dev.ayuislands.font
 
 import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
 import io.mockk.every
 import io.mockk.mockkObject
+import io.mockk.mockkStatic
 import io.mockk.unmockkAll
+import io.mockk.verify
+import java.awt.GraphicsEnvironment
+import java.io.File
+import kotlin.io.path.createTempDirectory
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -192,5 +198,108 @@ class FontDetectorTest {
                 }
             }
         }
+    }
+
+    // ---- status (three-tier health check, D-10) ----
+
+    private fun stubSettingsAndGraphicsEnv(
+        state: AyuIslandsState,
+        availableFonts: Array<String>,
+    ) {
+        mockkObject(AyuIslandsSettings.Companion)
+        val settings = AyuIslandsSettings().apply { loadState(state) }
+        every { AyuIslandsSettings.getInstance() } returns settings
+
+        mockkStatic(GraphicsEnvironment::class)
+        val ge = io.mockk.mockk<GraphicsEnvironment>()
+        every { GraphicsEnvironment.getLocalGraphicsEnvironment() } returns ge
+        every { ge.availableFontFamilyNames } returns availableFonts
+        FontDetector.invalidateCache()
+    }
+
+    @Test
+    fun `status returnsNotInstalled when no record and no system font`() {
+        stubSettingsAndGraphicsEnv(AyuIslandsState(), arrayOf("JetBrains Mono", "Helvetica"))
+        assertEquals(FontStatus.NOT_INSTALLED, FontDetector.status(FontPreset.AMBIENT))
+    }
+
+    @Test
+    fun `status returnsHealthy when installedFonts has family but no file paths recorded`() {
+        val state = AyuIslandsState().apply { installedFonts.add("Maple Mono") }
+        stubSettingsAndGraphicsEnv(state, arrayOf("JetBrains Mono", "Helvetica"))
+        assertEquals(FontStatus.HEALTHY, FontDetector.status(FontPreset.AMBIENT))
+    }
+
+    @Test
+    fun `status returnsHealthy when all recorded files exist`() {
+        val tmpDir = createTempDirectory("fontdet-ok").toFile()
+        try {
+            val realFile = File(tmpDir, "MapleMono-Regular.ttf").apply { writeText("") }
+            val state =
+                AyuIslandsState().apply {
+                    installedFonts.add("Maple Mono")
+                    installedFontFiles["Maple Mono"] = realFile.absolutePath
+                }
+            stubSettingsAndGraphicsEnv(state, arrayOf("JetBrains Mono", "Helvetica"))
+            assertEquals(FontStatus.HEALTHY, FontDetector.status(FontPreset.AMBIENT))
+        } finally {
+            tmpDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `status returnsCorrupted when file missing and JVM does not see family`() {
+        val tmpDir = createTempDirectory("fontdet-corrupt").toFile()
+        try {
+            val missing = File(tmpDir, "does-not-exist.ttf")
+            val state =
+                AyuIslandsState().apply {
+                    installedFonts.add("Maple Mono")
+                    installedFontFiles["Maple Mono"] = missing.absolutePath
+                }
+            stubSettingsAndGraphicsEnv(state, arrayOf("JetBrains Mono", "Helvetica"))
+            assertEquals(FontStatus.CORRUPTED, FontDetector.status(FontPreset.AMBIENT))
+        } finally {
+            tmpDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `status returnsHealthy when file missing but JVM still sees family`() {
+        val tmpDir = createTempDirectory("fontdet-jvm-cached").toFile()
+        try {
+            val missing = File(tmpDir, "gone.ttf")
+            val state =
+                AyuIslandsState().apply {
+                    installedFonts.add("Maple Mono")
+                    installedFontFiles["Maple Mono"] = missing.absolutePath
+                }
+            stubSettingsAndGraphicsEnv(state, arrayOf("Maple Mono", "JetBrains Mono"))
+            assertEquals(FontStatus.HEALTHY, FontDetector.status(FontPreset.AMBIENT))
+        } finally {
+            tmpDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `isInstalled backwardsCompat returnsTrue when status is HEALTHY`() {
+        val state = AyuIslandsState().apply { installedFonts.add("Maple Mono") }
+        stubSettingsAndGraphicsEnv(state, arrayOf("JetBrains Mono", "Helvetica"))
+        assertEquals(FontStatus.HEALTHY, FontDetector.status(FontPreset.AMBIENT))
+        assertTrue(FontDetector.isInstalled(FontPreset.AMBIENT))
+    }
+
+    @Test
+    fun `status cachesResults until invalidate`() {
+        val state = AyuIslandsState().apply { installedFonts.add("Maple Mono") }
+        stubSettingsAndGraphicsEnv(state, arrayOf("JetBrains Mono", "Helvetica"))
+        FontDetector.status(FontPreset.AMBIENT)
+        FontDetector.status(FontPreset.AMBIENT)
+        FontDetector.status(FontPreset.AMBIENT)
+        // GraphicsEnvironment.getLocalGraphicsEnvironment() is called at most
+        // twice per epoch: once to build the installedFonts() cache and at most
+        // once more for status() edge cases. Critically, it is NOT called 3
+        // times even though status() was invoked 3 times.
+        verify(atMost = 2) { GraphicsEnvironment.getLocalGraphicsEnvironment() }
     }
 }

--- a/src/test/kotlin/dev/ayuislands/font/FontDetectorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/font/FontDetectorTest.kt
@@ -302,4 +302,44 @@ class FontDetectorTest {
         // times even though status() was invoked 3 times.
         verify(atMost = 2) { GraphicsEnvironment.getLocalGraphicsEnvironment() }
     }
+
+    // ---- user-related edge cases ----
+
+    @Test
+    fun `status returnsCorrupted when some files missing and JVM blind (partial file loss)`() {
+        val tmpDir = createTempDirectory("fontdet-partial").toFile()
+        try {
+            val existing = File(tmpDir, "MapleMono-Regular.ttf").apply { writeText("") }
+            val gone = File(tmpDir, "MapleMono-Italic.ttf")
+            val state =
+                AyuIslandsState().apply {
+                    installedFonts.add("Maple Mono")
+                    installedFontFiles["Maple Mono"] =
+                        "${existing.absolutePath}\n${gone.absolutePath}"
+                }
+            stubSettingsAndGraphicsEnv(state, arrayOf("JetBrains Mono"))
+            assertEquals(FontStatus.CORRUPTED, FontDetector.status(FontPreset.AMBIENT))
+        } finally {
+            tmpDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `status returnsNotInstalled when settings throws IllegalStateException`() {
+        val state = AyuIslandsState().apply { installedFonts.add("Maple Mono") }
+        stubSettingsAndGraphicsEnv(state, arrayOf("Maple Mono"))
+        // Now override getInstance to throw AFTER isInstalled() succeeds
+        every { AyuIslandsSettings.getInstance() } throws IllegalStateException("disposed")
+
+        assertEquals(FontStatus.NOT_INSTALLED, FontDetector.status(FontPreset.AMBIENT))
+    }
+
+    @Test
+    fun `status returnsNotInstalled when settings throws NullPointerException`() {
+        val state = AyuIslandsState().apply { installedFonts.add("Maple Mono") }
+        stubSettingsAndGraphicsEnv(state, arrayOf("Maple Mono"))
+        every { AyuIslandsSettings.getInstance() } throws NullPointerException("no app")
+
+        assertEquals(FontStatus.NOT_INSTALLED, FontDetector.status(FontPreset.AMBIENT))
+    }
 }

--- a/src/test/kotlin/dev/ayuislands/font/FontInstallConsentTest.kt
+++ b/src/test/kotlin/dev/ayuislands/font/FontInstallConsentTest.kt
@@ -1,0 +1,59 @@
+package dev.ayuislands.font
+
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class FontInstallConsentTest {
+    private val mapleEntry = FontCatalog.forPreset(FontPreset.AMBIENT)
+
+    @BeforeTest
+    fun setup() {
+        mockkObject(FontInstallConsent)
+        every { FontInstallConsent.platformFontDirLabel() } returns "~/Library/Fonts"
+    }
+
+    @AfterTest
+    fun teardown() {
+        unmockkObject(FontInstallConsent)
+    }
+
+    @Test
+    fun `confirmInstall_compactFalse includes full copy`() {
+        val message = FontInstallConsent.buildInstallMessage(mapleEntry, compact = false)
+        assertTrue(message.contains("SIL Open Font License"), "Missing license blurb")
+        assertTrue(message.contains("no admin rights required"), "Missing admin reassurance")
+        assertTrue(message.contains("${mapleEntry.approxSizeMb} MB"), "Missing size")
+        assertTrue(message.contains("~/Library/Fonts"), "Missing path label")
+        assertTrue(message.contains(mapleEntry.displayName), "Missing display name")
+    }
+
+    @Test
+    fun `confirmInstall_compactTrue omits license blurb`() {
+        val message = FontInstallConsent.buildInstallMessage(mapleEntry, compact = true)
+        assertFalse(message.contains("SIL Open Font License"), "Compact form must omit license blurb")
+        assertFalse(message.contains("no admin rights required"), "Compact form must omit admin reassurance")
+        assertTrue(message.contains("${mapleEntry.approxSizeMb} MB"), "Compact form must keep size")
+        assertTrue(message.contains(mapleEntry.displayName), "Compact form must keep display name")
+        assertTrue(message.contains("~/Library/Fonts"), "Compact form must keep path label")
+    }
+
+    @Test
+    fun `confirmUninstall includes absolute path verbatim`() {
+        val absPath = "/Users/tester/Library/Fonts"
+        val message = FontInstallConsent.buildUninstallMessage(mapleEntry, absPath)
+        assertTrue(message.contains(absPath), "Absolute path must appear verbatim")
+        assertTrue(message.contains(mapleEntry.displayName), "Display name must appear")
+    }
+
+    @Test
+    fun `confirmUninstall includesRestartWarning`() {
+        val message = FontInstallConsent.buildUninstallMessage(mapleEntry, "/tmp/fonts")
+        assertTrue(message.contains("IDE restart"), "Restart-effective warning is mandatory (RESEARCH A3, D-07)")
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/font/FontInstallConsentTest.kt
+++ b/src/test/kotlin/dev/ayuislands/font/FontInstallConsentTest.kt
@@ -2,7 +2,7 @@ package dev.ayuislands.font
 
 import io.mockk.every
 import io.mockk.mockkObject
-import io.mockk.unmockkObject
+import io.mockk.unmockkAll
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -20,40 +20,52 @@ class FontInstallConsentTest {
 
     @AfterTest
     fun teardown() {
-        unmockkObject(FontInstallConsent)
+        unmockkAll()
     }
 
     @Test
-    fun `confirmInstall_compactFalse includes full copy`() {
+    fun `install message full copy includes license and path`() {
         val message = FontInstallConsent.buildInstallMessage(mapleEntry, compact = false)
-        assertTrue(message.contains("SIL Open Font License"), "Missing license blurb")
-        assertTrue(message.contains("no admin rights required"), "Missing admin reassurance")
-        assertTrue(message.contains("${mapleEntry.approxSizeMb} MB"), "Missing size")
-        assertTrue(message.contains("~/Library/Fonts"), "Missing path label")
-        assertTrue(message.contains(mapleEntry.displayName), "Missing display name")
+        assertTrue(message.contains("SIL Open Font License"))
+        assertTrue(message.contains("no admin rights required"))
+        assertTrue(message.contains("${mapleEntry.approxSizeMb} MB"))
+        assertTrue(message.contains("~/Library/Fonts"))
+        assertTrue(message.contains(mapleEntry.displayName))
     }
 
     @Test
-    fun `confirmInstall_compactTrue omits license blurb`() {
+    fun `install message compact omits license keeps essentials`() {
         val message = FontInstallConsent.buildInstallMessage(mapleEntry, compact = true)
-        assertFalse(message.contains("SIL Open Font License"), "Compact form must omit license blurb")
-        assertFalse(message.contains("no admin rights required"), "Compact form must omit admin reassurance")
-        assertTrue(message.contains("${mapleEntry.approxSizeMb} MB"), "Compact form must keep size")
-        assertTrue(message.contains(mapleEntry.displayName), "Compact form must keep display name")
-        assertTrue(message.contains("~/Library/Fonts"), "Compact form must keep path label")
+        assertFalse(message.contains("SIL Open Font License"))
+        assertFalse(message.contains("no admin rights required"))
+        assertTrue(message.contains("${mapleEntry.approxSizeMb} MB"))
+        assertTrue(message.contains(mapleEntry.displayName))
+        assertTrue(message.contains("~/Library/Fonts"))
     }
 
     @Test
-    fun `confirmUninstall includes absolute path verbatim`() {
+    fun `uninstall message includes absolute path verbatim`() {
         val absPath = "/Users/tester/Library/Fonts"
         val message = FontInstallConsent.buildUninstallMessage(mapleEntry, absPath)
-        assertTrue(message.contains(absPath), "Absolute path must appear verbatim")
-        assertTrue(message.contains(mapleEntry.displayName), "Display name must appear")
+        assertTrue(message.contains(absPath))
+        assertTrue(message.contains(mapleEntry.displayName))
     }
 
     @Test
-    fun `confirmUninstall includesRestartWarning`() {
+    fun `uninstall message includes restart warning`() {
         val message = FontInstallConsent.buildUninstallMessage(mapleEntry, "/tmp/fonts")
-        assertTrue(message.contains("IDE restart"), "Restart-effective warning is mandatory (RESEARCH A3, D-07)")
+        assertTrue(message.contains("IDE restart"))
+    }
+
+    @Test
+    fun `platformFontDirLabel returns recognizable OS-specific path`() {
+        unmockkAll()
+        val label = FontInstallConsent.platformFontDirLabel()
+        assertTrue(
+            label.contains("Library/Fonts") ||
+                label.contains("LOCALAPPDATA") ||
+                label.contains(".local/share/fonts"),
+            "Label must be a recognizable platform font dir: $label",
+        )
     }
 }

--- a/src/test/kotlin/dev/ayuislands/font/FontInstallerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/font/FontInstallerTest.kt
@@ -6,6 +6,8 @@ import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.util.SystemInfo
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -296,5 +298,70 @@ class FontInstallerTest {
                 null,
             )
         }
+    }
+
+    // ---- persistFontState (Plan 25-03 Task 1) ----
+
+    private fun stubPersistFontStateSettings(state: AyuIslandsState = AyuIslandsState()): AyuIslandsState {
+        mockkObject(AyuIslandsSettings.Companion)
+        val settings = AyuIslandsSettings().apply { loadState(state) }
+        every { AyuIslandsSettings.getInstance() } returns settings
+        return state
+    }
+
+    @Test
+    fun `persistFontState recordsWrittenPaths`() {
+        val state = stubPersistFontStateSettings()
+        val files =
+            listOf(
+                File("/tmp/fonts/MapleMono-Regular.ttf"),
+                File("/tmp/fonts/MapleMono-Italic.ttf"),
+            )
+
+        FontInstaller.persistFontState("Maple Mono", files)
+
+        assertEquals(
+            "/tmp/fonts/MapleMono-Regular.ttf\n/tmp/fonts/MapleMono-Italic.ttf",
+            state.installedFontFiles["Maple Mono"],
+        )
+    }
+
+    @Test
+    fun `persistFontState stillWritesInstalledFonts (D-14 invariant)`() {
+        val state = stubPersistFontStateSettings()
+
+        FontInstaller.persistFontState("Victor Mono", listOf(File("/tmp/victor.ttf")))
+
+        assertTrue(state.installedFonts.contains("Victor Mono"))
+    }
+
+    @Test
+    fun `persistFontState overwritesStaleFilePaths`() {
+        val state = stubPersistFontStateSettings()
+        state.installedFontFiles["Maple Mono"] = "/old/stale/path.ttf"
+
+        FontInstaller.persistFontState("Maple Mono", listOf(File("/new/MapleMono.ttf")))
+
+        assertEquals("/new/MapleMono.ttf", state.installedFontFiles["Maple Mono"])
+        assertFalse(state.installedFontFiles["Maple Mono"]!!.contains("old/stale"))
+    }
+
+    @Test
+    fun `persistFontState emptyFilesList clearsPathEntry`() {
+        val state = stubPersistFontStateSettings()
+
+        FontInstaller.persistFontState("Maple Mono", emptyList())
+
+        assertEquals("", state.installedFontFiles["Maple Mono"])
+    }
+
+    @Test
+    fun `persistFontState removesFromExplicitlyUninstalledFonts`() {
+        val state = stubPersistFontStateSettings()
+        state.explicitlyUninstalledFonts.add("Maple Mono")
+
+        FontInstaller.persistFontState("Maple Mono", listOf(File("/tmp/MapleMono.ttf")))
+
+        assertFalse(state.explicitlyUninstalledFonts.contains("Maple Mono"))
     }
 }

--- a/src/test/kotlin/dev/ayuislands/font/FontLifecycleIntegrationTest.kt
+++ b/src/test/kotlin/dev/ayuislands/font/FontLifecycleIntegrationTest.kt
@@ -1,0 +1,286 @@
+package dev.ayuislands.font
+
+import com.intellij.notification.Notification
+import com.intellij.notification.Notifications
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.editor.colors.EditorColorsManager
+import com.intellij.openapi.editor.colors.EditorColorsScheme
+import com.intellij.openapi.progress.ProgressIndicator
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import java.awt.GraphicsEnvironment
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Integration tests that exercise the full font lifecycle as a user would
+ * experience it. Each test simulates a complete user scenario end-to-end
+ * rather than testing individual methods in isolation.
+ */
+class FontLifecycleIntegrationTest {
+    @AfterTest
+    fun cleanup() {
+        unmockkAll()
+        FontDetector.invalidateCache()
+    }
+
+    private fun stubPlatform(
+        state: AyuIslandsState,
+        platformDir: File,
+        activeEditorFont: String = "JetBrains Mono",
+        jvmFonts: Array<String> = arrayOf("JetBrains Mono"),
+    ) {
+        mockkObject(FontInstaller)
+        every { FontInstaller.platformFontDir() } returns platformDir
+
+        mockkObject(AyuIslandsSettings.Companion)
+        val settings = AyuIslandsSettings().apply { loadState(state) }
+        every { AyuIslandsSettings.getInstance() } returns settings
+
+        mockkObject(FontPresetApplicator)
+        every { FontPresetApplicator.revert() } just Runs
+
+        mockkStatic(EditorColorsManager::class)
+        val ecm = mockk<EditorColorsManager>()
+        val scheme = mockk<EditorColorsScheme>()
+        every { EditorColorsManager.getInstance() } returns ecm
+        every { ecm.globalScheme } returns scheme
+        every { scheme.editorFontName } returns activeEditorFont
+
+        mockkStatic(ApplicationManager::class)
+        val app = mockk<Application>()
+        every { ApplicationManager.getApplication() } returns app
+        every { app.invokeLater(any<Runnable>()) } answers { firstArg<Runnable>().run() }
+
+        mockkStatic(Notifications.Bus::class)
+        every { Notifications.Bus.notify(any<Notification>(), null) } answers { }
+
+        mockkStatic(GraphicsEnvironment::class)
+        val ge = mockk<GraphicsEnvironment>()
+        every { GraphicsEnvironment.getLocalGraphicsEnvironment() } returns ge
+        every { ge.availableFontFamilyNames } returns jvmFonts
+
+        FontDetector.invalidateCache()
+    }
+
+    /**
+     * User installs Maple Mono from Settings → verifies it shows as installed →
+     * deletes it → verifies it's gone → reinstalls → verifies it's back.
+     * This is the golden path: install → delete → reinstall round-trip.
+     */
+    @Test
+    fun `full install-delete-reinstall lifecycle round-trip`() {
+        val platformDir = createTempDirectory("lifecycle-roundtrip").toFile()
+        try {
+            val state = AyuIslandsState()
+            stubPlatform(state, platformDir)
+
+            // Step 1: Simulate install — user clicked Install, font downloaded + copied.
+            val fontFile = File(platformDir, "MapleMono-Regular.ttf").apply { writeText("font data") }
+            FontInstaller.persistFontState("Maple Mono", listOf(fontFile))
+
+            assertTrue(state.installedFonts.contains("Maple Mono"), "Font must be in installedFonts after install")
+            assertEquals(fontFile.absolutePath, state.installedFontFiles["Maple Mono"], "File path must be tracked")
+
+            // Step 2: Simulate delete via Settings panel.
+            val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+            val indicator = mockk<ProgressIndicator>(relaxed = true)
+            var result: FontUninstaller.UninstallResult? = null
+            FontUninstaller.runUninstallPipeline(entry, null, indicator) { result = it }
+
+            assertTrue(result is FontUninstaller.UninstallResult.Success, "Uninstall must succeed")
+            assertFalse(fontFile.exists(), "Font file must be deleted from disk")
+            assertFalse(state.installedFonts.contains("Maple Mono"), "Family must be removed from installedFonts")
+            assertTrue(state.explicitlyUninstalledFonts.contains("Maple Mono"), "Family must be in uninstall guard")
+
+            // Step 3: Reinstall — user clicked Install again.
+            val newFile = File(platformDir, "MapleMono-Regular.ttf").apply { writeText("reinstalled") }
+            FontInstaller.persistFontState("Maple Mono", listOf(newFile))
+
+            assertTrue(state.installedFonts.contains("Maple Mono"), "Font must be back in installedFonts")
+            assertFalse(
+                state.explicitlyUninstalledFonts.contains("Maple Mono"),
+                "Reinstall must clear the D-09 uninstall guard",
+            )
+        } finally {
+            platformDir.deleteRecursively()
+        }
+    }
+
+    /**
+     * User has two fonts installed (Maple Mono + Victor Mono). They delete
+     * Maple Mono. Victor Mono must remain completely unaffected — its
+     * installedFonts entry, file paths, and files on disk must survive.
+     */
+    @Test
+    fun `deleting one font does not affect another installed font`() {
+        val platformDir = createTempDirectory("lifecycle-multi").toFile()
+        try {
+            val state = AyuIslandsState()
+            stubPlatform(state, platformDir)
+
+            // Install both fonts.
+            val mapleFile = File(platformDir, "MapleMono-Regular.ttf").apply { writeText("maple") }
+            val victorFile = File(platformDir, "VictorMono-Light.ttf").apply { writeText("victor") }
+            FontInstaller.persistFontState("Maple Mono", listOf(mapleFile))
+            FontInstaller.persistFontState("Victor Mono", listOf(victorFile))
+
+            assertTrue(state.installedFonts.contains("Maple Mono"))
+            assertTrue(state.installedFonts.contains("Victor Mono"))
+
+            // Delete Maple Mono only.
+            val entry = FontCatalog.forPreset(FontPreset.AMBIENT) // Maple Mono
+            val indicator = mockk<ProgressIndicator>(relaxed = true)
+            FontUninstaller.runUninstallPipeline(entry, null, indicator) { }
+
+            // Maple Mono gone.
+            assertFalse(state.installedFonts.contains("Maple Mono"))
+            assertFalse(mapleFile.exists())
+
+            // Victor Mono untouched.
+            assertTrue(state.installedFonts.contains("Victor Mono"), "Victor Mono must remain installed")
+            assertTrue(victorFile.exists(), "Victor Mono file must survive")
+            assertEquals(
+                victorFile.absolutePath,
+                state.installedFontFiles["Victor Mono"],
+                "Victor Mono file paths must be intact",
+            )
+        } finally {
+            platformDir.deleteRecursively()
+        }
+    }
+
+    /**
+     * User installs a font, then externally deletes the font file via Finder
+     * or Terminal (not through the plugin). On next Settings open,
+     * FontDetector.status() should detect the discrepancy.
+     */
+    @Test
+    fun `external file deletion detected as corrupted when JVM forgets the family`() {
+        val platformDir = createTempDirectory("lifecycle-external-del").toFile()
+        try {
+            val state = AyuIslandsState()
+            stubPlatform(state, platformDir, jvmFonts = arrayOf("JetBrains Mono"))
+
+            // Install via plugin.
+            val fontFile = File(platformDir, "MapleMono-Regular.ttf").apply { writeText("font") }
+            FontInstaller.persistFontState("Maple Mono", listOf(fontFile))
+
+            // User deletes file externally.
+            fontFile.delete()
+
+            // Settings panel opens and calls FontDetector.status().
+            FontDetector.invalidateCache()
+            val status = FontDetector.status(FontPreset.AMBIENT)
+
+            assertEquals(
+                FontStatus.CORRUPTED,
+                status,
+                "Status must be CORRUPTED when file is gone and JVM does not see the family",
+            )
+        } finally {
+            platformDir.deleteRecursively()
+        }
+    }
+
+    /**
+     * User deletes a font, then restarts the IDE. The seeder runs on startup.
+     * Even if the JVM still sees the font (cached registration), the seeder
+     * must NOT re-add it because of the D-09 explicit-uninstall guard.
+     */
+    @Test
+    fun `deleted font survives IDE restart seeder`() {
+        val platformDir = createTempDirectory("lifecycle-restart").toFile()
+        try {
+            val state = AyuIslandsState()
+            stubPlatform(
+                state,
+                platformDir,
+                jvmFonts = arrayOf("Maple Mono", "JetBrains Mono"),
+            )
+
+            // Install + delete via plugin.
+            val fontFile = File(platformDir, "MapleMono-Regular.ttf").apply { writeText("font") }
+            FontInstaller.persistFontState("Maple Mono", listOf(fontFile))
+            val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+            val indicator = mockk<ProgressIndicator>(relaxed = true)
+            FontUninstaller.runUninstallPipeline(entry, null, indicator) { }
+
+            // Simulate IDE restart: seeder runs with JVM still seeing "Maple Mono".
+            state.installedFontsSeeded = false
+            val settings = AyuIslandsSettings().apply { loadState(state) }
+            every { AyuIslandsSettings.getInstance() } returns settings
+            settings.seedInstalledFontsFromDiskIfNeeded()
+
+            assertFalse(
+                state.installedFonts.contains("Maple Mono"),
+                "Seeder must NOT re-add a font the user explicitly deleted (D-09)",
+            )
+            assertTrue(state.installedFontsSeeded, "Seeded flag must be set regardless")
+        } finally {
+            platformDir.deleteRecursively()
+        }
+    }
+
+    /**
+     * User deletes the currently active editor font. The editor must
+     * automatically revert to JetBrains Mono so the user doesn't end up
+     * with invisible/broken text.
+     */
+    @Test
+    fun `deleting active editor font triggers automatic revert`() {
+        val platformDir = createTempDirectory("lifecycle-revert").toFile()
+        try {
+            val state = AyuIslandsState()
+            stubPlatform(state, platformDir, activeEditorFont = "Maple Mono")
+
+            val fontFile = File(platformDir, "MapleMono-Regular.ttf").apply { writeText("font") }
+            FontInstaller.persistFontState("Maple Mono", listOf(fontFile))
+
+            val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+            val indicator = mockk<ProgressIndicator>(relaxed = true)
+            FontUninstaller.runUninstallPipeline(entry, null, indicator) { }
+
+            io.mockk.verify(exactly = 1) { FontPresetApplicator.revert() }
+        } finally {
+            platformDir.deleteRecursively()
+        }
+    }
+
+    /**
+     * User deletes a font they are NOT currently using in the editor.
+     * The editor font must NOT change — revert should not fire.
+     */
+    @Test
+    fun `deleting non-active font does not touch editor settings`() {
+        val platformDir = createTempDirectory("lifecycle-no-revert").toFile()
+        try {
+            val state = AyuIslandsState()
+            stubPlatform(state, platformDir, activeEditorFont = "JetBrains Mono")
+
+            val fontFile = File(platformDir, "MapleMono-Regular.ttf").apply { writeText("font") }
+            FontInstaller.persistFontState("Maple Mono", listOf(fontFile))
+
+            val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+            val indicator = mockk<ProgressIndicator>(relaxed = true)
+            FontUninstaller.runUninstallPipeline(entry, null, indicator) { }
+
+            io.mockk.verify(exactly = 0) { FontPresetApplicator.revert() }
+        } finally {
+            platformDir.deleteRecursively()
+        }
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/font/FontUninstallerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/font/FontUninstallerTest.kt
@@ -181,8 +181,10 @@ class FontUninstallerTest {
     @Test
     fun `uninstall_rejectsPathOutsidePlatformDir`() {
         val platformDir = createTempDirectory("uninst-traversal").toFile()
+        val outsideDir = createTempDirectory("uninst-outside").toFile()
         try {
-            val escapePath = "${platformDir.absolutePath}/../../../../etc/passwd"
+            val outsideFile = File(outsideDir, "should-survive.ttf").apply { writeText("safe") }
+            val escapePath = outsideFile.absolutePath
             val state =
                 AyuIslandsState().apply {
                     installedFonts.add("Maple Mono")
@@ -199,9 +201,7 @@ class FontUninstallerTest {
                 result is FontUninstaller.UninstallResult.Failure,
                 "Expected Failure, got $result",
             )
-            // /etc/passwd must still exist (the guard did NOT delete it).
-            assertTrue(File("/etc/passwd").exists(), "Critical: /etc/passwd was touched")
-            // State must NOT be mutated on rejection (T-25-01 invariant).
+            assertTrue(outsideFile.exists(), "File outside platformDir must not be deleted")
             assertTrue(
                 state.installedFonts.contains("Maple Mono"),
                 "State must not mutate on guard rejection",
@@ -212,6 +212,7 @@ class FontUninstallerTest {
             )
         } finally {
             platformDir.deleteRecursively()
+            outsideDir.deleteRecursively()
         }
     }
 

--- a/src/test/kotlin/dev/ayuislands/font/FontUninstallerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/font/FontUninstallerTest.kt
@@ -25,6 +25,7 @@ import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 /**
@@ -290,5 +291,95 @@ class FontUninstallerTest {
         FontUninstaller.uninstall(FontPreset.AMBIENT, null) { }
 
         verify(exactly = 1) { progressMgr.run(any<Task.Backgroundable>()) }
+    }
+
+    // ---- user-related edge cases ----
+
+    @Test
+    fun `uninstall_onCompleteFiresEvenWhenRevertThrows`() {
+        val platformDir = createTempDirectory("uninst-revert-crash").toFile()
+        try {
+            val trackedFile = File(platformDir, "MapleMono.ttf").apply { writeText("x") }
+            val state =
+                AyuIslandsState().apply {
+                    installedFonts.add("Maple Mono")
+                    installedFontFiles["Maple Mono"] = trackedFile.absolutePath
+                }
+            stubUninstallPipeline(state, platformDir, activeEditorFont = "Maple Mono")
+            every { FontPresetApplicator.revert() } throws RuntimeException("EDT crash")
+
+            val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+            val indicator = mockk<ProgressIndicator>(relaxed = true)
+            var result: FontUninstaller.UninstallResult? = null
+            FontUninstaller.runUninstallPipeline(entry, null, indicator) { result = it }
+
+            assertNotNull(result, "onComplete must fire even when revert() throws")
+            assertTrue(result is FontUninstaller.UninstallResult.Success)
+            assertFalse(state.installedFonts.contains("Maple Mono"))
+        } finally {
+            platformDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `uninstall_absolutePathOutsidePlatformDir_noTraversal`() {
+        val platformDir = createTempDirectory("uninst-abs").toFile()
+        val outsideDir = createTempDirectory("uninst-outside-abs").toFile()
+        try {
+            val outsideFile = File(outsideDir, "font.ttf").apply { writeText("safe") }
+            val state =
+                AyuIslandsState().apply {
+                    installedFonts.add("Maple Mono")
+                    installedFontFiles["Maple Mono"] = outsideFile.absolutePath
+                }
+            stubUninstallPipeline(state, platformDir, activeEditorFont = "JetBrains Mono")
+
+            val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+            val indicator = mockk<ProgressIndicator>(relaxed = true)
+            var result: FontUninstaller.UninstallResult? = null
+            FontUninstaller.runUninstallPipeline(entry, null, indicator) { result = it }
+
+            assertTrue(result is FontUninstaller.UninstallResult.Failure)
+            assertTrue(outsideFile.exists(), "File outside platformDir must survive")
+            assertTrue(state.installedFonts.contains("Maple Mono"), "State unchanged on rejection")
+        } finally {
+            platformDir.deleteRecursively()
+            outsideDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `uninstall_platformDirCanonicalizationFailure_returnsFailure`() {
+        val nonexistent = File("/nonexistent/path/that/cannot/canonicalize")
+        val state =
+            AyuIslandsState().apply {
+                installedFonts.add("Maple Mono")
+                installedFontFiles["Maple Mono"] = "/some/path.ttf"
+            }
+        mockkObject(FontInstaller)
+        every { FontInstaller.platformFontDir() } returns nonexistent
+
+        mockkObject(AyuIslandsSettings.Companion)
+        val settings = AyuIslandsSettings().apply { loadState(state) }
+        every { AyuIslandsSettings.getInstance() } returns settings
+
+        mockkStatic(ApplicationManager::class)
+        val app = mockk<Application>()
+        every { ApplicationManager.getApplication() } returns app
+        every { app.invokeLater(any<Runnable>()) } answers { firstArg<Runnable>().run() }
+
+        mockkStatic(Notifications.Bus::class)
+        every { Notifications.Bus.notify(any<Notification>(), null) } answers { }
+
+        val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+        val indicator = mockk<ProgressIndicator>(relaxed = true)
+        var result: FontUninstaller.UninstallResult? = null
+        FontUninstaller.runUninstallPipeline(entry, null, indicator) { result = it }
+
+        assertTrue(
+            result is FontUninstaller.UninstallResult.Failure ||
+                result is FontUninstaller.UninstallResult.Success,
+            "Pipeline must complete without throwing",
+        )
     }
 }

--- a/src/test/kotlin/dev/ayuislands/font/FontUninstallerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/font/FontUninstallerTest.kt
@@ -1,0 +1,293 @@
+package dev.ayuislands.font
+
+import com.intellij.notification.Notification
+import com.intellij.notification.Notifications
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.editor.colors.EditorColorsManager
+import com.intellij.openapi.editor.colors.EditorColorsScheme
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.Task
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [FontUninstaller.runUninstallPipeline] and the public
+ * [FontUninstaller.uninstall] dispatcher. Covers D-07 uninstall pipeline,
+ * D-08 path-traversal guard (T-25-01), D-09 explicit-uninstall guard.
+ */
+class FontUninstallerTest {
+    @AfterTest
+    fun cleanup() {
+        unmockkAll()
+    }
+
+    /**
+     * Stub the heavy dependencies of [FontUninstaller.runUninstallPipeline]:
+     * [AyuIslandsSettings], [FontPresetApplicator], [EditorColorsManager],
+     * [ApplicationManager.invokeLater] (runs synchronously so test assertions
+     * can inspect post-state), and [FontInstaller.platformFontDir] pinned to
+     * a controlled temp directory.
+     */
+    private fun stubUninstallPipeline(
+        state: AyuIslandsState,
+        platformDir: File,
+        activeEditorFont: String,
+    ) {
+        mockkObject(FontInstaller)
+        every { FontInstaller.platformFontDir() } returns platformDir
+
+        mockkObject(AyuIslandsSettings.Companion)
+        val settings = AyuIslandsSettings().apply { loadState(state) }
+        every { AyuIslandsSettings.getInstance() } returns settings
+
+        mockkObject(FontPresetApplicator)
+        every { FontPresetApplicator.revert() } just Runs
+
+        mockkStatic(EditorColorsManager::class)
+        val ecm = mockk<EditorColorsManager>()
+        val scheme = mockk<EditorColorsScheme>()
+        every { EditorColorsManager.getInstance() } returns ecm
+        every { ecm.globalScheme } returns scheme
+        every { scheme.editorFontName } returns activeEditorFont
+
+        mockkStatic(ApplicationManager::class)
+        val app = mockk<Application>()
+        every { ApplicationManager.getApplication() } returns app
+        every { app.invokeLater(any<Runnable>()) } answers { firstArg<Runnable>().run() }
+
+        mockkStatic(Notifications.Bus::class)
+        every { Notifications.Bus.notify(any<Notification>(), null) } answers { }
+    }
+
+    @Test
+    fun `uninstall_deletesOnlyTrackedFiles`() {
+        val platformDir = createTempDirectory("uninst-only-tracked").toFile()
+        try {
+            val tracked1 = File(platformDir, "MapleMono-Regular.ttf").apply { writeText("t1") }
+            val tracked2 = File(platformDir, "MapleMono-Italic.ttf").apply { writeText("t2") }
+            val bystander = File(platformDir, "UnrelatedFont.ttf").apply { writeText("leave me") }
+
+            val state =
+                AyuIslandsState().apply {
+                    installedFonts.add("Maple Mono")
+                    installedFontFiles["Maple Mono"] =
+                        "${tracked1.absolutePath}\n${tracked2.absolutePath}"
+                }
+            stubUninstallPipeline(state, platformDir, activeEditorFont = "JetBrains Mono")
+
+            val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+            val indicator = mockk<ProgressIndicator>(relaxed = true)
+            var result: FontUninstaller.UninstallResult? = null
+            FontUninstaller.runUninstallPipeline(entry, null, indicator) { result = it }
+
+            assertFalse(tracked1.exists(), "tracked1 should be deleted")
+            assertFalse(tracked2.exists(), "tracked2 should be deleted")
+            assertTrue(bystander.exists(), "unrelated file must remain")
+            assertTrue(result is FontUninstaller.UninstallResult.Success)
+            assertEquals(2, (result as FontUninstaller.UninstallResult.Success).filesRemoved)
+        } finally {
+            platformDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `uninstall_mutatesStateCorrectly`() {
+        val platformDir = createTempDirectory("uninst-state").toFile()
+        try {
+            val trackedFile = File(platformDir, "MapleMono.ttf").apply { writeText("x") }
+            val state =
+                AyuIslandsState().apply {
+                    installedFonts.add("Maple Mono")
+                    installedFontFiles["Maple Mono"] = trackedFile.absolutePath
+                }
+            stubUninstallPipeline(state, platformDir, activeEditorFont = "JetBrains Mono")
+
+            val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+            val indicator = mockk<ProgressIndicator>(relaxed = true)
+            FontUninstaller.runUninstallPipeline(entry, null, indicator) { }
+
+            assertFalse(state.installedFonts.contains("Maple Mono"), "family must be removed")
+            assertFalse(state.installedFontFiles.containsKey("Maple Mono"), "path entry must be cleared")
+            assertTrue(
+                state.explicitlyUninstalledFonts.contains("Maple Mono"),
+                "family must be added to D-09 guard",
+            )
+        } finally {
+            platformDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `uninstall_revertsActiveFont`() {
+        val platformDir = createTempDirectory("uninst-revert").toFile()
+        try {
+            val trackedFile = File(platformDir, "MapleMono.ttf").apply { writeText("x") }
+            val state =
+                AyuIslandsState().apply {
+                    installedFonts.add("Maple Mono")
+                    installedFontFiles["Maple Mono"] = trackedFile.absolutePath
+                }
+            stubUninstallPipeline(state, platformDir, activeEditorFont = "Maple Mono")
+
+            val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+            val indicator = mockk<ProgressIndicator>(relaxed = true)
+            FontUninstaller.runUninstallPipeline(entry, null, indicator) { }
+
+            verify(exactly = 1) { FontPresetApplicator.revert() }
+        } finally {
+            platformDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `uninstall_leavesInactiveFontAlone`() {
+        val platformDir = createTempDirectory("uninst-leave-alone").toFile()
+        try {
+            val trackedFile = File(platformDir, "MapleMono.ttf").apply { writeText("x") }
+            val state =
+                AyuIslandsState().apply {
+                    installedFonts.add("Maple Mono")
+                    installedFontFiles["Maple Mono"] = trackedFile.absolutePath
+                }
+            stubUninstallPipeline(state, platformDir, activeEditorFont = "JetBrains Mono")
+
+            val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+            val indicator = mockk<ProgressIndicator>(relaxed = true)
+            FontUninstaller.runUninstallPipeline(entry, null, indicator) { }
+
+            verify(exactly = 0) { FontPresetApplicator.revert() }
+        } finally {
+            platformDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `uninstall_rejectsPathOutsidePlatformDir`() {
+        val platformDir = createTempDirectory("uninst-traversal").toFile()
+        try {
+            val escapePath = "${platformDir.absolutePath}/../../../../etc/passwd"
+            val state =
+                AyuIslandsState().apply {
+                    installedFonts.add("Maple Mono")
+                    installedFontFiles["Maple Mono"] = escapePath
+                }
+            stubUninstallPipeline(state, platformDir, activeEditorFont = "JetBrains Mono")
+
+            val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+            val indicator = mockk<ProgressIndicator>(relaxed = true)
+            var result: FontUninstaller.UninstallResult? = null
+            FontUninstaller.runUninstallPipeline(entry, null, indicator) { result = it }
+
+            assertTrue(
+                result is FontUninstaller.UninstallResult.Failure,
+                "Expected Failure, got $result",
+            )
+            // /etc/passwd must still exist (the guard did NOT delete it).
+            assertTrue(File("/etc/passwd").exists(), "Critical: /etc/passwd was touched")
+            // State must NOT be mutated on rejection (T-25-01 invariant).
+            assertTrue(
+                state.installedFonts.contains("Maple Mono"),
+                "State must not mutate on guard rejection",
+            )
+            assertFalse(
+                state.explicitlyUninstalledFonts.contains("Maple Mono"),
+                "Guard must only be set on successful/partial uninstall, never rejection",
+            )
+        } finally {
+            platformDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `uninstall_handlesPermissionDenied`() {
+        val platformDir = createTempDirectory("uninst-permission").toFile()
+        try {
+            val stubbornDir = File(platformDir, "locked").apply { mkdirs() }
+            val stubbornFile = File(stubbornDir, "Maple-Locked.ttf").apply { writeText("x") }
+            stubbornDir.setWritable(false)
+
+            val state =
+                AyuIslandsState().apply {
+                    installedFonts.add("Maple Mono")
+                    installedFontFiles["Maple Mono"] = stubbornFile.absolutePath
+                }
+            stubUninstallPipeline(state, platformDir, activeEditorFont = "JetBrains Mono")
+
+            val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+            val indicator = mockk<ProgressIndicator>(relaxed = true)
+            var result: FontUninstaller.UninstallResult? = null
+            try {
+                FontUninstaller.runUninstallPipeline(entry, null, indicator) { result = it }
+            } finally {
+                stubbornDir.setWritable(true)
+            }
+
+            // State MUST still mutate even on partial failure — user is not stuck.
+            assertFalse(state.installedFonts.contains("Maple Mono"))
+            assertTrue(state.explicitlyUninstalledFonts.contains("Maple Mono"))
+            assertTrue(
+                result is FontUninstaller.UninstallResult.Partial ||
+                    result is FontUninstaller.UninstallResult.Success,
+                "Expected Partial or Success, got $result",
+            )
+        } finally {
+            platformDir.setWritable(true)
+            platformDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `uninstall_emptyFileList_stillMutatesState`() {
+        val platformDir = createTempDirectory("uninst-legacy").toFile()
+        try {
+            val state =
+                AyuIslandsState().apply {
+                    installedFonts.add("Maple Mono")
+                }
+            stubUninstallPipeline(state, platformDir, activeEditorFont = "JetBrains Mono")
+
+            val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+            val indicator = mockk<ProgressIndicator>(relaxed = true)
+            var result: FontUninstaller.UninstallResult? = null
+            FontUninstaller.runUninstallPipeline(entry, null, indicator) { result = it }
+
+            assertFalse(state.installedFonts.contains("Maple Mono"))
+            assertTrue(state.explicitlyUninstalledFonts.contains("Maple Mono"))
+            assertTrue(result is FontUninstaller.UninstallResult.Success)
+            assertEquals(0, (result as FontUninstaller.UninstallResult.Success).filesRemoved)
+        } finally {
+            platformDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `uninstall_publicEntryPoint_queuesTaskBackgroundable`() {
+        mockkObject(FontInstaller)
+        every { FontInstaller.platformFontDir() } returns createTempDirectory("uninst-public").toFile()
+
+        mockkStatic(ProgressManager::class)
+        val progressMgr = mockk<ProgressManager>(relaxed = true)
+        every { ProgressManager.getInstance() } returns progressMgr
+
+        FontUninstaller.uninstall(FontPreset.AMBIENT, null) { }
+
+        verify(exactly = 1) { progressMgr.run(any<Task.Backgroundable>()) }
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsSettingsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsSettingsTest.kt
@@ -4,11 +4,16 @@ import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.SystemAccentProvider
 import dev.ayuislands.font.FontPreset
 import io.mockk.every
+import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.mockkStatic
 import io.mockk.unmockkAll
+import io.mockk.unmockkStatic
+import java.awt.GraphicsEnvironment
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class AyuIslandsSettingsTest {
@@ -137,5 +142,65 @@ class AyuIslandsSettingsTest {
 
         // Recorded font should only appear once, not duplicated
         assertEquals(1, state.installedFonts.count { it == fontFamily })
+    }
+
+    @Test
+    fun `seeder respectsExplicitUninstallGuard`() {
+        mockkStatic(GraphicsEnvironment::class)
+        val ge = mockk<GraphicsEnvironment>()
+        every { GraphicsEnvironment.getLocalGraphicsEnvironment() } returns ge
+        every { ge.availableFontFamilyNames } returns arrayOf("Maple Mono", "Victor Mono")
+
+        val settings = AyuIslandsSettings()
+        settings.state.explicitlyUninstalledFonts.add("Maple Mono")
+        settings.state.installedFontsSeeded = false
+
+        settings.seedInstalledFontsFromDiskIfNeeded()
+
+        assertFalse(settings.state.installedFonts.contains("Maple Mono"))
+        assertTrue(settings.state.installedFontsSeeded)
+
+        unmockkStatic(GraphicsEnvironment::class)
+    }
+
+    @Test
+    fun `seeder addsNonGuardedFamilies`() {
+        mockkStatic(GraphicsEnvironment::class)
+        val ge = mockk<GraphicsEnvironment>()
+        every { GraphicsEnvironment.getLocalGraphicsEnvironment() } returns ge
+        every { ge.availableFontFamilyNames } returns arrayOf("Maple Mono", "Victor Mono")
+
+        val settings = AyuIslandsSettings()
+        settings.state.explicitlyUninstalledFonts.add("Maple Mono")
+        settings.state.installedFontsSeeded = false
+
+        settings.seedInstalledFontsFromDiskIfNeeded()
+
+        assertTrue(settings.state.installedFonts.contains("Victor Mono"))
+        assertFalse(settings.state.installedFonts.contains("Maple Mono"))
+
+        unmockkStatic(GraphicsEnvironment::class)
+    }
+
+    @Test
+    fun `seeder marksSeededFlagEvenWhenGuardBlocksAll`() {
+        mockkStatic(GraphicsEnvironment::class)
+        val ge = mockk<GraphicsEnvironment>()
+        every { GraphicsEnvironment.getLocalGraphicsEnvironment() } returns ge
+        every { ge.availableFontFamilyNames } returns arrayOf("Maple Mono", "Victor Mono")
+
+        val settings = AyuIslandsSettings()
+        settings.state.explicitlyUninstalledFonts.add("Maple Mono")
+        settings.state.explicitlyUninstalledFonts.add("Victor Mono")
+        settings.state.explicitlyUninstalledFonts.add("Monaspace Neon")
+        settings.state.explicitlyUninstalledFonts.add("Monaspace Xenon")
+        settings.state.installedFontsSeeded = false
+
+        settings.seedInstalledFontsFromDiskIfNeeded()
+
+        assertTrue(settings.state.installedFonts.isEmpty())
+        assertTrue(settings.state.installedFontsSeeded)
+
+        unmockkStatic(GraphicsEnvironment::class)
     }
 }

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStatePersistenceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStatePersistenceTest.kt
@@ -154,6 +154,66 @@ class AyuIslandsStatePersistenceTest {
         assertEquals(EXPECTED_LICENSED_MS, reloaded.state.lastKnownLicensedMs)
     }
 
+    @Test
+    fun `installedFontFiles defaults to empty map`() {
+        val settings = AyuIslandsSettings()
+        assertTrue(settings.state.installedFontFiles.isEmpty())
+    }
+
+    @Test
+    fun `installedFontFiles survives save reload cycle`() {
+        val reloaded =
+            roundTrip { state ->
+                state.installedFontFiles["Maple Mono"] =
+                    "/Users/test/Library/Fonts/MapleMono-Regular.ttf\n" +
+                    "/Users/test/Library/Fonts/MapleMono-Italic.ttf"
+                state.installedFontFiles["Victor Mono"] =
+                    "/Users/test/Library/Fonts/VictorMono-Light.ttf"
+            }
+
+        assertEquals(
+            "/Users/test/Library/Fonts/MapleMono-Regular.ttf\n" +
+                "/Users/test/Library/Fonts/MapleMono-Italic.ttf",
+            reloaded.state.installedFontFiles["Maple Mono"],
+        )
+        assertEquals(
+            "/Users/test/Library/Fonts/VictorMono-Light.ttf",
+            reloaded.state.installedFontFiles["Victor Mono"],
+        )
+    }
+
+    @Test
+    fun `installedFontFiles entries can be removed across reload`() {
+        val reloaded =
+            roundTrip { state ->
+                state.installedFontFiles["Maple Mono"] = "/a/MapleMono-Regular.ttf"
+                state.installedFontFiles["Victor Mono"] = "/b/VictorMono-Light.ttf"
+                state.installedFontFiles.remove("Victor Mono")
+            }
+
+        assertEquals("/a/MapleMono-Regular.ttf", reloaded.state.installedFontFiles["Maple Mono"])
+        assertFalse(reloaded.state.installedFontFiles.containsKey("Victor Mono"))
+    }
+
+    @Test
+    fun `explicitlyUninstalledFonts defaults to empty set`() {
+        val settings = AyuIslandsSettings()
+        assertTrue(settings.state.explicitlyUninstalledFonts.isEmpty())
+    }
+
+    @Test
+    fun `explicitlyUninstalledFonts survives save reload cycle`() {
+        val reloaded =
+            roundTrip { state ->
+                state.explicitlyUninstalledFonts.add("Monaspace Neon")
+                state.explicitlyUninstalledFonts.add("Victor Mono")
+            }
+
+        assertTrue(reloaded.state.explicitlyUninstalledFonts.contains("Monaspace Neon"))
+        assertTrue(reloaded.state.explicitlyUninstalledFonts.contains("Victor Mono"))
+        assertEquals(2, reloaded.state.explicitlyUninstalledFonts.size)
+    }
+
     companion object {
         private const val EXPECTED_SHARP_NEON_INTENSITY = 80
         private const val EXPECTED_SHARP_NEON_WIDTH = 6

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStatePersistenceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStatePersistenceTest.kt
@@ -3,6 +3,7 @@ package dev.ayuislands.settings
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.glow.GlowAnimation
 import dev.ayuislands.glow.GlowStyle
+import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -212,6 +213,44 @@ class AyuIslandsStatePersistenceTest {
         assertTrue(reloaded.state.explicitlyUninstalledFonts.contains("Monaspace Neon"))
         assertTrue(reloaded.state.explicitlyUninstalledFonts.contains("Victor Mono"))
         assertEquals(2, reloaded.state.explicitlyUninstalledFonts.size)
+    }
+
+    // ---- encodeFontPaths / decodeFontPaths helpers ----
+
+    @Test
+    fun `encodeFontPaths joins absolute paths with newline`() {
+        val files = listOf(File("/a/Regular.ttf"), File("/b/Italic.ttf"))
+        assertEquals("/a/Regular.ttf\n/b/Italic.ttf", AyuIslandsState.encodeFontPaths(files))
+    }
+
+    @Test
+    fun `encodeFontPaths returns empty string for empty list`() {
+        assertEquals("", AyuIslandsState.encodeFontPaths(emptyList()))
+    }
+
+    @Test
+    fun `decodeFontPaths returns empty list for null`() {
+        assertTrue(AyuIslandsState.decodeFontPaths(null).isEmpty())
+    }
+
+    @Test
+    fun `decodeFontPaths returns empty list for blank string`() {
+        assertTrue(AyuIslandsState.decodeFontPaths("").isEmpty())
+        assertTrue(AyuIslandsState.decodeFontPaths("  ").isEmpty())
+    }
+
+    @Test
+    fun `decodeFontPaths skips blank lines in middle`() {
+        val result = AyuIslandsState.decodeFontPaths("/a/Regular.ttf\n\n/b/Italic.ttf")
+        assertEquals(listOf("/a/Regular.ttf", "/b/Italic.ttf"), result)
+    }
+
+    @Test
+    fun `encodeFontPaths and decodeFontPaths round-trip`() {
+        val files = listOf(File("/Users/test/Library/Fonts/Mono.ttf"), File("/tmp/Bold.ttf"))
+        val encoded = AyuIslandsState.encodeFontPaths(files)
+        val decoded = AyuIslandsState.decodeFontPaths(encoded)
+        assertEquals(files.map { it.absolutePath }, decoded)
     }
 
     companion object {


### PR DESCRIPTION
## Summary

- Add install / delete / reinstall lifecycle actions for curated font presets (Victor Mono, Maple Mono, Monaspace Neon, Monaspace Xenon) directly from Settings → Ayu Islands → Font, without opening the premium wizard
- Fix a pre-existing UX-rule violation where the Settings install link called `FontInstaller.install()` with no consent dialog — every filesystem touch is now consent-gated with the exact platform font directory path shown
- Deleting a font reverts the editor to JetBrains Mono and warns that full removal takes effect after IDE restart (JVM has no font unregister API)
- Three-state detection: "Install automatically" / "Installed ✓ · Reinstall · Delete" / "⚠ Installed file missing — Reinstall" based on actual disk state via new `FontDetector.status()` tri-state API
- Path-traversal guard on the uninstall pipeline rejects any persisted path not canonically under the platform font directory — prevents a malicious `ayuIslands.xml` from making the plugin delete files outside `~/Library/Fonts`
- Explicit-uninstall guard ensures the seeder never re-adds a user-deleted font on subsequent IDE startups

## Key files

| Area | Files |
|------|-------|
| State foundation | `AyuIslandsState.kt`, `AyuIslandsSettings.kt` |
| Consent helper | `FontInstallConsent.kt` (new) |
| Tri-state detection | `FontDetector.kt` |
| Uninstall pipeline | `FontUninstaller.kt` (new) |
| Install path extension | `FontInstaller.kt` |
| Settings UI | `FontPresetPanel.kt` |
| Wizard rewire | `PremiumOnboardingPanel.kt` |
| Shared rendering | `OnboardingSharedRendering.kt` |

## Test plan

- [x] 31 new unit tests across 5 test classes — state persistence round-trip, seeder guard, consent message shape, FontDetector status tiers, uninstall pipeline (delete-only-tracked, state mutation, revert-on-active, no-revert-on-inactive, path-traversal rejection, permission-denied partial, legacy empty-list, Task.Backgroundable dispatch)
- [x] `./gradlew clean test detekt ktlintCheck verifyPlugin` passes on all 12 IDE targets
- [x] Bytecode verification via `javap -c -p` confirms new classes in the distribution JAR
- [x] Runtime smoke test on macOS: install → delete → reinstall flow with consent dialogs, editor revert, and seeder guard across IDE restart
- [ ] Windows file-lock edge case not runtime-tested (documented known gap)
- [ ] Linux `~/.local/share/fonts` not runtime-tested (documented known gap)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add consent-gated font install/uninstall lifecycle management, tri-state font health detection, and uninstall safety guards, and wire these into the Settings and onboarding flows.

New Features:
- Expose install, delete, and reinstall actions for curated fonts directly in the Settings font panel with state-aware UI tiers.
- Introduce a reusable consent helper for font install and uninstall flows shared between Settings and the premium onboarding wizard.
- Add a dedicated font uninstall pipeline that runs off the EDT and integrates with editor font fallback and user notifications.

Bug Fixes:
- Ensure all font install and delete actions are gated by explicit user consent instead of performing silent filesystem operations.

Enhancements:
- Track installed font file paths and explicit uninstall decisions in persistent state to support safe removal and prevent re-seeding deleted fonts.
- Extend font detection with a cached tri-state health status API used by the Settings UI to distinguish not installed, healthy, and corrupted fonts.
- Refactor shared onboarding hero image loading into a common helper to eliminate duplication across free and premium panels.

Documentation:
- Update plugin change notes to describe the new font lifecycle management behavior and UX.

Tests:
- Add comprehensive unit coverage for font health status detection, font state persistence, install consent copy, uninstall pipeline behavior, and seeding guards for explicitly uninstalled fonts.