### PR TITLE
chore: bump version to 2.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2.4.2] - 2026-04-12
+
+### Added
+- [Paid] Install, delete, or reinstall curated fonts directly from Settings without opening the wizard
+- Every install and delete now shows a consent dialog with the exact platform font folder path
+- Deleting a font reverts the editor to JetBrains Mono and warns that full removal takes effect after IDE restart
+- Settings now shows "Installed", "file missing — Reinstall", or "Install automatically" based on actual disk state
+
+### Fixed
+- Fix Settings install link silently writing to ~/Library/Fonts with no consent dialog
+
 ## [2.4.1] - 2026-04-11
 
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.4.1
+pluginVersion=2.4.2
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
@@ -41,6 +41,12 @@ internal object UpdateNotifier {
 
     private val RELEASE_NOTES =
         mapOf(
+            "2.4.2" to
+                "<ul>" +
+                "<li>Install, delete, or reinstall fonts from Settings</li>" +
+                "<li>Consent dialog before any font file changes</li>" +
+                "<li>Three-state font status detection</li>" +
+                "</ul>",
             "2.4.1" to
                 "<ul>" +
                 "<li>Fix font install retry on corrupted cache</li>" +


### PR DESCRIPTION
## Summary

Version bump for v2.4.2 release — font lifecycle management in Settings panel.

- `gradle.properties`: 2.4.1 → 2.4.2
- `CHANGELOG.md`: v2.4.2 entry with 5 bullets
- `UpdateNotifier.kt`: v2.4.2 release notes for in-IDE notification

No code changes — version/changelog only. Feature code shipped in #115.

## Summary by Sourcery

Bump the plugin version to 2.4.2 and document the new Settings-based font lifecycle management features and fixes.

New Features:
- Document Settings-based install, delete, and reinstall flows for curated fonts, including three-state disk-backed status display.

Bug Fixes:
- Document the fix for the Settings install link that previously modified ~/Library/Fonts without a consent dialog.

Enhancements:
- Add in-IDE release notes entry for version 2.4.2 covering font management and consent dialog improvements.

Build:
- Update pluginVersion in gradle.properties from 2.4.1 to 2.4.2.