### PR TITLE
Adding Semgrep as a second security scanner

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,49 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# This workflow file requires a free account on Semgrep.dev to
+# manage rules, file ignores, notifications, and more.
+#
+# See https://semgrep.dev/docs
+
+name: Semgrep
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main" ]
+  schedule:
+    - cron: '33 0 * * 6'
+
+permissions:
+  contents: read
+
+jobs:
+  semgrep:
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    name: Scan
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout project source
+      - uses: actions/checkout@v4
+
+      # Scan code using the project's configuration on https://semgrep.dev/manage
+      - uses: returntocorp/semgrep-action@fcd5ab7459e8d91cb1777481980d1b18b4fc6735
+        with:
+          publishToken: ${{ secrets.SEMGREP_APP_TOKEN }}
+          publishDeployment: ${{ secrets.SEMGREP_DEPLOYMENT_ID }}
+          generateSarif: "1"
+
+      # Upload SARIF file generated in the previous step
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: semgrep.sarif
+        if: always()


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->

## Changes

-

## Test Plan

- [ ] `./gradlew buildPlugin` succeeds
- [ ] `./gradlew verifyPlugin` passes all IDE targets
- [ ] Manual verification in `runIde` sandbox

## Related Issues

<!-- Link to related issues: Fixes #123, Closes #456 -->

## Checklist

- [ ] Changes applied to BOTH `.theme.json` files per variant (if theme change)
- [ ] Commit messages follow conventional commits format
- [ ] No unused imports or dead code introduced

## Summary by Sourcery

CI:
- Introduce a Semgrep GitHub Actions workflow to run on main branch pushes, pull requests, and a weekly schedule, publishing SARIF results to GitHub.