### PR TITLE
ci(semgrep): pin checkout SHA and disable credential persistence

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -32,7 +32,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checkout project source
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       # Scan code using the project's configuration on https://semgrep.dev/manage
       - uses: returntocorp/semgrep-action@fcd5ab7459e8d91cb1777481980d1b18b4fc6735


### PR DESCRIPTION
## Summary

- Fix zizmor `artipacked` finding by adding `persist-credentials: false` to the checkout step in semgrep.yml
- Pin `actions/checkout` to SHA (`de0fac2...` / v6) to match the convention used in build.yml

## Test plan

- [ ] CI passes — zizmor job goes green
- [ ] Gate job succeeds

## Summary by Sourcery

Pin the Semgrep workflow checkout action to a specific SHA and disable credential persistence in the checkout step.

CI:
- Update the Semgrep GitHub Actions workflow to use actions/checkout pinned to a specific commit SHA instead of a floating version.
- Configure the Semgrep workflow checkout step to disable credential persistence to satisfy security scanning requirements.