### PR TITLE
chore(deps): pin intellij.platform Gradle plugin below 2.14.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,11 @@ updates:
       # Remove this rule once github/codeql#21484 is resolved.
       - dependency-name: "org.jetbrains.kotlin.jvm"
         versions: [">= 2.3.20"]
+
+      # IntelliJ Platform Gradle Plugin 2.14.0 regressed TestFrameworkType.Platform
+      # — com.intellij.testFramework.LoggedErrorProcessor disappears from test classpath,
+      # breaking LicenseTransitionListenerTest + AccentRotationServiceTest (see PR #123).
+      # Lift when 2.14.x fixes resolution or after verifying an alternative
+      # TestFrameworkType variant exposes the class.
+      - dependency-name: "org.jetbrains.intellij.platform"
+        versions: [">= 2.14.0"]


### PR DESCRIPTION
## Why

Dependabot PR #123 bumped `org.jetbrains.intellij.platform` 2.13.1 → 2.14.0 and broke CI on `Test` + `CodeQL (java-kotlin)`. Both fail at `:compileTestKotlin` with the same error — `com.intellij.testFramework.LoggedErrorProcessor` disappears from the test classpath after the bump. Production `:compileKotlin` still passes, so this is a `TestFrameworkType.Platform` composition regression on the plugin side, not our code.

Used by:
- `src/test/kotlin/dev/ayuislands/licensing/LicenseTransitionListenerTest.kt`
- `src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt`

Both tests rely on `LoggedErrorProcessor.executeWith(...)` to swallow expected `Logger.error(...)` during state transitions — removing it would lose meaningful coverage.

## What

- Add a Dependabot ignore rule for `org.jetbrains.intellij.platform >= 2.14.0` in `.github/dependabot.yml`, mirroring the existing Kotlin-for-CodeQL pin pattern.
- Closed PR #123 with the diagnosis.

## When to lift

Either a 2.14.x patch restores `TestFrameworkType.Platform` composition, or we verify an alternative variant (`Bundled` / `Common`) exposes `LoggedErrorProcessor` without breaking other tests. Quick local check: `rm -rf build .gradle && ./gradlew compileTestKotlin`.

## Summary by Sourcery

Build:
- Add a Dependabot ignore rule to prevent upgrades of org.jetbrains.intellij.platform to versions 2.14.0 and above.