### PR TITLE
feat: per-project and per-language accent overrides

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,11 @@ updates:
       # Remove this rule once github/codeql#21484 is resolved.
       - dependency-name: "org.jetbrains.kotlin.jvm"
         versions: [">= 2.3.20"]
+
+      # IntelliJ Platform Gradle Plugin 2.14.0 regressed TestFrameworkType.Platform
+      # — com.intellij.testFramework.LoggedErrorProcessor disappears from test classpath,
+      # breaking LicenseTransitionListenerTest + AccentRotationServiceTest (see PR #123).
+      # Lift when 2.14.x fixes resolution or after verifying an alternative
+      # TestFrameworkType variant exposes the class.
+      - dependency-name: "org.jetbrains.intellij.platform"
+        versions: [">= 2.14.0"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -204,6 +204,7 @@ kover {
                     "dev.ayuislands.settings.mappings.OverridesGroupBuilder*",
                     "dev.ayuislands.settings.mappings.AddProjectMappingDialog*",
                     "dev.ayuislands.settings.mappings.AddLanguageMappingDialog*",
+                    "dev.ayuislands.settings.mappings.EditAccentColorDialog*",
                     "dev.ayuislands.settings.mappings.AccentSwatchPickerRow*",
                     "dev.ayuislands.settings.mappings.RoundedSwatchRenderer*",
                 )

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -206,10 +206,6 @@ kover {
                     "dev.ayuislands.settings.mappings.AddLanguageMappingDialog*",
                     "dev.ayuislands.settings.mappings.AccentSwatchPickerRow*",
                     "dev.ayuislands.settings.mappings.RoundedSwatchRenderer*",
-                    // IDE glue: SDK + ModuleManager probes
-                    "dev.ayuislands.accent.ProjectLanguageDetector*",
-                    // IDE glue: AWTEventListener + WindowManager focus-swap
-                    "dev.ayuislands.settings.mappings.ProjectAccentSwapService*",
                 )
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -200,6 +200,16 @@ kover {
                     "dev.ayuislands.accent.elements.BracketScopeRenderer*",
                     // Swing Border + Component lifecycle (editor focus management)
                     "dev.ayuislands.glow.FocusRingManager*",
+                    // Accent mappings UI: DialogWrapper, JBTable wiring, paintComponent renderers
+                    "dev.ayuislands.settings.mappings.OverridesGroupBuilder*",
+                    "dev.ayuislands.settings.mappings.AddProjectMappingDialog*",
+                    "dev.ayuislands.settings.mappings.AddLanguageMappingDialog*",
+                    "dev.ayuislands.settings.mappings.AccentSwatchPickerRow*",
+                    "dev.ayuislands.settings.mappings.RoundedSwatchRenderer*",
+                    // IDE glue: SDK + ModuleManager probes
+                    "dev.ayuislands.accent.ProjectLanguageDetector*",
+                    // IDE glue: AWTEventListener + WindowManager focus-swap
+                    "dev.ayuislands.settings.mappings.ProjectAccentSwapService*",
                 )
             }
         }

--- a/codecov.yml
+++ b/codecov.yml
@@ -18,6 +18,15 @@ ignore:
   - "src/main/kotlin/dev/ayuislands/font/FontPresetApplicator.kt"
   - "src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt"
   - "src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt"
+  # Pure DialogWrapper UI glue: ColorPicker/ComboBox/FileChooser wiring with no extractable
+  # logic. Same files are already excluded from Kover; aligning codecov so the patch report
+  # doesn't double-flag what Kover correctly ignores.
+  - "src/main/kotlin/dev/ayuislands/settings/mappings/EditAccentColorDialog.kt"
+  - "src/main/kotlin/dev/ayuislands/settings/mappings/AddProjectMappingDialog.kt"
+  - "src/main/kotlin/dev/ayuislands/settings/mappings/AddLanguageMappingDialog.kt"
+  - "src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt"
+  - "src/main/kotlin/dev/ayuislands/settings/mappings/AccentSwatchPickerRow.kt"
+  - "src/main/kotlin/dev/ayuislands/settings/mappings/RoundedSwatchRenderer.kt"
 
 comment:
   layout: "condensed_header, condensed_files, condensed_footer"

--- a/proguard-rules.pro
+++ b/proguard-rules.pro
@@ -20,6 +20,16 @@
 # State class — XML serialized, all property names must be preserved
 -keep class dev.ayuislands.settings.AyuIslandsState { *; }
 
+# plugin.xml: applicationService (per-project + per-language accent overrides)
+-keep class dev.ayuislands.settings.mappings.AccentMappingsSettings { *; }
+# State class — XML serialized, preserve property names for map delegates
+-keep class dev.ayuislands.settings.mappings.AccentMappingsState { *; }
+# Resolver + detector singletons called from kept classes
+-keep class dev.ayuislands.accent.AccentResolver { *; }
+-keep class dev.ayuislands.accent.ProjectLanguageDetector { *; }
+# plugin.xml: applicationService (focus-swap listener)
+-keep class dev.ayuislands.settings.mappings.ProjectAccentSwapService { *; }
+
 # Enums — serialized by name
 -keep enum dev.ayuislands.accent.AyuVariant { *; }
 -keep enum dev.ayuislands.accent.AccentElementId { *; }

--- a/proguard-rules.pro
+++ b/proguard-rules.pro
@@ -30,6 +30,13 @@
 # plugin.xml: applicationService (focus-swap listener)
 -keep class dev.ayuislands.settings.mappings.ProjectAccentSwapService { *; }
 
+# MessageBus pub/sub for component-tree refresh. Topic is accessed reflectively by the
+# platform's message-bus machinery to deserialize listeners; the fun interface is the
+# listener type registered via project.messageBus.connect(this).subscribe(TOPIC, ...).
+-keep class dev.ayuislands.ui.ComponentTreeRefresher { *; }
+-keep class dev.ayuislands.ui.ComponentTreeRefreshedTopic { *; }
+-keep class dev.ayuislands.ui.ComponentTreeRefreshedListener { *; }
+
 # Enums — serialized by name
 -keep enum dev.ayuislands.accent.AyuVariant { *; }
 -keep enum dev.ayuislands.accent.AccentElementId { *; }

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsAppListener.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsAppListener.kt
@@ -3,15 +3,17 @@ package dev.ayuislands
 import com.intellij.ide.AppLifecycleListener
 import com.intellij.openapi.diagnostic.logger
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
-import dev.ayuislands.settings.AyuIslandsSettings
 
 internal class AyuIslandsAppListener : AppLifecycleListener {
     override fun appFrameCreated(commandLineArgs: MutableList<String>) {
         val themeName = AyuVariant.currentThemeName()
         val variant = AyuVariant.fromThemeName(themeName) ?: return
 
-        val accentHex = AyuIslandsSettings.getInstance().getAccentForVariant(variant)
+        // No project context yet; resolver falls through to the global accent
+        // (or language override if one is configured and we later re-apply in StartupActivity).
+        val accentHex = AccentResolver.resolve(null, variant)
         AccentApplicator.apply(accentHex)
         LOG.info("Ayu Islands accent pre-applied in appFrameCreated: $accentHex for ${variant.name}")
     }

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsLafListener.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsLafListener.kt
@@ -42,6 +42,11 @@ class AyuIslandsLafListener : LafManagerListener {
         // Platform already walked the component tree during the LAF change, resetting component-level
         // overrides (scrollbar preferredSize, horizontal policy, rendering wrappers). Publish the
         // refresh event per open project so subscribed managers reapply. No tree walk needed here.
+        //
+        // Load-bearing platform-behavior assumption — verified against IntelliJ Platform 2025.1
+        // (`LafManagerImpl.updateLafNoSave` walks frames before firing `lookAndFeelChanged`).
+        // If a future platform bump changes the order, scrollbar hides will regress after theme
+        // switches and we'll need to switch this back to `ComponentTreeRefresher.walkAndNotify`.
         for (openProject in ProjectManager.getInstance().openProjects) {
             if (openProject.isDefault || openProject.isDisposed) continue
             ComponentTreeRefresher.notifyOnly(openProject)

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsLafListener.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsLafListener.kt
@@ -5,7 +5,6 @@ import com.intellij.ide.ui.LafManagerListener
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.ProjectManager
 import dev.ayuislands.accent.AccentApplicator
-import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.font.FontPresetApplicator
 import dev.ayuislands.glow.GlowOverlayManager
@@ -26,9 +25,7 @@ class AyuIslandsLafListener : LafManagerListener {
         }
 
         val settings = AyuIslandsSettings.getInstance()
-        val focusedProject = ProjectManager.getInstance().openProjects.firstOrNull { !it.isDefault && !it.isDisposed }
-        val accentHex = AccentResolver.resolve(focusedProject, variant)
-        AccentApplicator.apply(accentHex)
+        val accentHex = AccentApplicator.applyForFocusedProject(variant)
         LOG.info("Ayu Islands accent re-applied on theme change: $accentHex")
 
         // Re-apply font preset if enabled

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsLafListener.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsLafListener.kt
@@ -9,8 +9,8 @@ import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.font.FontPresetApplicator
 import dev.ayuislands.glow.GlowOverlayManager
-import dev.ayuislands.projectview.ProjectViewScrollbarManager
 import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.ui.ComponentTreeRefresher
 
 /** Re-applies accent, font, glow, and scrollbar settings on theme change. */
 class AyuIslandsLafListener : LafManagerListener {
@@ -42,22 +42,16 @@ class AyuIslandsLafListener : LafManagerListener {
         }
         syncService.clearProgrammaticSwitch()
 
-        // Re-apply Project View scrollbar setting
-        reapplyProjectViewScrollbar()
+        // Platform already walked the component tree during the LAF change, resetting component-level
+        // overrides (scrollbar preferredSize, horizontal policy, rendering wrappers). Publish the
+        // refresh event per open project so subscribed managers reapply. No tree walk needed here.
+        for (openProject in ProjectManager.getInstance().openProjects) {
+            if (openProject.isDefault || openProject.isDisposed) continue
+            ComponentTreeRefresher.notifyOnly(openProject)
+        }
 
         // Update glow overlays with new accent color
         GlowOverlayManager.syncGlowForAllProjects()
-    }
-
-    private fun reapplyProjectViewScrollbar() {
-        if (!AyuIslandsSettings.getInstance().state.hideProjectViewHScrollbar) return
-        for (openProject in ProjectManager.getInstance().openProjects) {
-            try {
-                ProjectViewScrollbarManager.getInstance(openProject).apply()
-            } catch (exception: RuntimeException) {
-                LOG.warn("Failed to re-apply scrollbar for project ${openProject.name}: ${exception.message}")
-            }
-        }
     }
 
     companion object {

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsLafListener.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsLafListener.kt
@@ -5,6 +5,7 @@ import com.intellij.ide.ui.LafManagerListener
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.ProjectManager
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.font.FontPresetApplicator
 import dev.ayuislands.glow.GlowOverlayManager
@@ -25,7 +26,8 @@ class AyuIslandsLafListener : LafManagerListener {
         }
 
         val settings = AyuIslandsSettings.getInstance()
-        val accentHex = settings.getAccentForVariant(variant)
+        val focusedProject = ProjectManager.getInstance().openProjects.firstOrNull { !it.isDefault && !it.isDisposed }
+        val accentHex = AccentResolver.resolve(focusedProject, variant)
         AccentApplicator.apply(accentHex)
         LOG.info("Ayu Islands accent re-applied on theme change: $accentHex")
 

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -205,6 +205,17 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
         }
     }
 
+    /**
+     * Test-only hook around [runStep]. Inline private functions can't be called from a
+     * test classpath; this thin wrapper exposes the catch semantics without leaking the
+     * helper itself.
+     */
+    @org.jetbrains.annotations.TestOnly
+    internal fun runStepForTest(
+        name: String,
+        block: () -> Unit,
+    ) = runStep(name, block)
+
     companion object {
         private val LOG = logger<AyuIslandsStartupActivity>()
         private const val MS_PER_HOUR = 3_600_000L

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -141,37 +141,51 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
         // Compute adaptive delay on background thread (execute() coroutine)
         val adaptiveDelayMs = StartupLicenseHandler.computeAdaptiveDelay()
 
+        // Each step runs under its own named try/catch so an exception in one stage doesn't
+        // mask the others and the log line identifies which step actually broke. A single
+        // catch used to produce a generic "License defaults failed" with no way to tell
+        // whether migration, orchestrator routing, defaults, workspace init, wizard
+        // scheduling, or trial warning blew up.
         SwingUtilities.invokeLater {
             if (project.isDisposed) return@invokeLater
-            try {
-                // Run migration and orchestrator before license defaults
-                StartupLicenseHandler.runOnboardingMigration(settings)
-                val wizardAction =
-                    StartupLicenseHandler.resolveOnboarding(
-                        isLicensed,
-                        settings,
-                        isReturningUser,
-                    )
+            var wizardAction: dev.ayuislands.onboarding.WizardAction? = null
 
-                if (isLicensed) {
-                    StartupLicenseHandler.applyLicensedDefaults(settings)
-                } else {
+            runStep("onboarding-migration") { StartupLicenseHandler.runOnboardingMigration(settings) }
+            runStep("resolve-onboarding") {
+                wizardAction = StartupLicenseHandler.resolveOnboarding(isLicensed, settings, isReturningUser)
+            }
+            if (isLicensed) {
+                runStep("apply-licensed-defaults") { StartupLicenseHandler.applyLicensedDefaults(settings) }
+            } else {
+                runStep("apply-unlicensed-defaults") {
                     StartupLicenseHandler.applyUnlicensedDefaults(project, variant, settings)
                 }
-
-                settings.state.migrateWidthModes()
-                StartupLicenseHandler.initWorkspaceServices(project, settings)
-
-                // Schedule wizard based on orchestrator decision
-                StartupLicenseHandler.handleWizardAction(wizardAction, project, adaptiveDelayMs, settings)
-
-                // Check trial expiry warning (only runs for trial users)
-                if (isLicensed) {
-                    LicenseChecker.checkTrialExpiryWarning(project)
-                }
-            } catch (e: RuntimeException) {
-                LOG.error("License defaults failed", e)
             }
+            runStep("migrate-width-modes") { settings.state.migrateWidthModes() }
+            runStep("init-workspace-services") { StartupLicenseHandler.initWorkspaceServices(project, settings) }
+            runStep("handle-wizard-action") {
+                wizardAction?.let {
+                    StartupLicenseHandler.handleWizardAction(it, project, adaptiveDelayMs, settings)
+                }
+            }
+            if (isLicensed) {
+                runStep("check-trial-expiry") { LicenseChecker.checkTrialExpiryWarning(project) }
+            }
+        }
+    }
+
+    /**
+     * Invokes [block]; on [RuntimeException] logs with the step name so post-mortems don't
+     * need to cross-reference line numbers against a generic "License defaults failed".
+     */
+    private inline fun runStep(
+        name: String,
+        block: () -> Unit,
+    ) {
+        try {
+            block()
+        } catch (exception: RuntimeException) {
+            LOG.error("License startup step '$name' failed", exception)
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -177,7 +177,14 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
     /**
      * Invokes [block]; on [RuntimeException] logs with the step name so post-mortems don't
      * need to cross-reference line numbers against a generic "License defaults failed".
+     *
+     * `Error` subtypes (ExceptionInInitializerError from lazy class init,
+     * NoClassDefFoundError from optional plugin dependencies, OOM) are caught so the step
+     * name still reaches the log — but rethrown so the JVM's normal error-escalation path
+     * remains intact. Without that rethrow, an OOM in step N would silently skip steps
+     * N+1..end and the user would see a half-initialized plugin.
      */
+    @Suppress("TooGenericExceptionCaught") // Error catch is intentional — we log then rethrow
     private inline fun runStep(
         name: String,
         block: () -> Unit,
@@ -186,6 +193,9 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
             block()
         } catch (exception: RuntimeException) {
             LOG.error("License startup step '$name' failed", exception)
+        } catch (error: Error) {
+            LOG.error("License startup step '$name' failed with Error", error)
+            throw error
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -5,18 +5,20 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
 import com.intellij.openapi.wm.WindowManager
-import com.intellij.util.IJSwingUtilities
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.conflict.ConflictRegistry
+import dev.ayuislands.editor.EditorScrollbarManager
 import dev.ayuislands.font.FontPreset
 import dev.ayuislands.font.FontPresetApplicator
 import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.projectview.ProjectViewScrollbarManager
 import dev.ayuislands.rotation.AccentRotationService
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
+import dev.ayuislands.ui.ComponentTreeRefresher
 import javax.swing.SwingUtilities
 
 internal class AyuIslandsStartupActivity : ProjectActivity {
@@ -39,19 +41,24 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
         swapService.install()
         swapService.notifyExternalApply(accentHex)
 
+        // Eager-instantiate per-project scrollbar managers BEFORE firing the first refresh event.
+        // Their init{} blocks subscribe to ComponentTreeRefreshedTopic; without this, the
+        // walkAndNotify below publishes into an empty subscriber list and the managers — lazily
+        // created later by StartupLicenseHandler.initWorkspaceServices on a subsequent EDT turn —
+        // miss the initial refresh (plus any editors already opened before they subscribed to
+        // EditorFactoryListener). Services are no-op when their toggles are off and are cheap to
+        // instantiate, so gating on settings would only add complexity.
+        EditorScrollbarManager.getInstance(project)
+        ProjectViewScrollbarManager.getInstance(project)
+
         // Force a component-tree LAF refresh on the project frame so already-rendered toolbar,
         // tab underlines, scrollbar chrome, and focus rings pick up the resolved accent.
         // AccentApplicator only updates UIManager + editor scheme; cached JBColor instances on
         // already-painted components otherwise keep the global-accent values they captured when
         // the frame first rendered.
         SwingUtilities.invokeLater {
-            if (project.isDisposed) return@invokeLater
             val frame = WindowManager.getInstance().getFrame(project) ?: return@invokeLater
-            try {
-                IJSwingUtilities.updateComponentTreeUI(frame)
-            } catch (exception: RuntimeException) {
-                LOG.warn("Startup UI refresh failed for ${project.name}: ${exception.message}")
-            }
+            ComponentTreeRefresher.walkAndNotify(project, frame)
         }
 
         // Apply persisted font preset (FontPresetApplicator ensures EDT internally)

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -4,7 +4,10 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
+import com.intellij.openapi.wm.WindowManager
+import com.intellij.util.IJSwingUtilities
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.conflict.ConflictRegistry
 import dev.ayuislands.font.FontPreset
@@ -13,6 +16,7 @@ import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.rotation.AccentRotationService
 import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 import javax.swing.SwingUtilities
 
 internal class AyuIslandsStartupActivity : ProjectActivity {
@@ -26,8 +30,29 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
         // Belt-and-suspenders: accent is pre-applied in appFrameCreated() (no gold flash),
         // but project-dependent features (BracketFadeManager, editor TextAttributesKey overrides)
         // need this second idempotent call once a project context exists.
-        val accentHex = settings.getAccentForVariant(variant)
+        // Project/language overrides win over the global accent; AccentResolver centralizes the chain.
+        val accentHex = AccentResolver.resolve(project, variant)
         AccentApplicator.apply(accentHex)
+        // Install the focus-swap listener once per IDE lifetime; subsequent calls are no-ops.
+        // Also sync the cache so the listener doesn't skip the first real WINDOW_ACTIVATED event.
+        val swapService = ProjectAccentSwapService.getInstance()
+        swapService.install()
+        swapService.notifyExternalApply(accentHex)
+
+        // Force a component-tree LAF refresh on the project frame so already-rendered toolbar,
+        // tab underlines, scrollbar chrome, and focus rings pick up the resolved accent.
+        // AccentApplicator only updates UIManager + editor scheme; cached JBColor instances on
+        // already-painted components otherwise keep the global-accent values they captured when
+        // the frame first rendered.
+        SwingUtilities.invokeLater {
+            if (project.isDisposed) return@invokeLater
+            val frame = WindowManager.getInstance().getFrame(project) ?: return@invokeLater
+            try {
+                IJSwingUtilities.updateComponentTreeUI(frame)
+            } catch (exception: RuntimeException) {
+                LOG.warn("Startup UI refresh failed for ${project.name}: ${exception.message}")
+            }
+        }
 
         // Apply persisted font preset (FontPresetApplicator ensures EDT internally)
         // Migrate legacy preset names (GLOW_WRITER→WHISPER, CLEAN→AMBIENT, etc.)

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -175,16 +175,20 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
     }
 
     /**
-     * Invokes [block]; on [RuntimeException] logs with the step name so post-mortems don't
-     * need to cross-reference line numbers against a generic "License defaults failed".
+     * Invokes [block] with fine-grained error handling so each startup step gets its own
+     * log line, and the JVM's error-escalation path stays intact for genuinely fatal errors:
      *
-     * `Error` subtypes (ExceptionInInitializerError from lazy class init,
-     * NoClassDefFoundError from optional plugin dependencies, OOM) are caught so the step
-     * name still reaches the log — but rethrown so the JVM's normal error-escalation path
-     * remains intact. Without that rethrow, an OOM in step N would silently skip steps
-     * N+1..end and the user would see a half-initialized plugin.
+     *  - [RuntimeException] — logged, swallowed; the next step runs.
+     *  - [VirtualMachineError] (OutOfMemoryError, StackOverflowError, InternalError,
+     *    UnknownError) — logged and rethrown. These mean the JVM is in an unrecoverable
+     *    state; continuing risks cascading corruption, and IntelliJ's crash reporter keys
+     *    off uncaught VM errors.
+     *  - Other [Error] (LinkageError, NoClassDefFoundError, ExceptionInInitializerError,
+     *    AssertionError) — logged, swallowed; the next step runs. These usually mean an
+     *    optional plugin dependency didn't load or a plugin extension point initializer
+     *    threw — the plugin's own startup should continue, not abort.
      */
-    @Suppress("TooGenericExceptionCaught") // Error catch is intentional — we log then rethrow
+    @Suppress("TooGenericExceptionCaught") // VM error rethrown; generic Error logged-and-continue
     private inline fun runStep(
         name: String,
         block: () -> Unit,
@@ -193,9 +197,11 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
             block()
         } catch (exception: RuntimeException) {
             LOG.error("License startup step '$name' failed", exception)
+        } catch (error: VirtualMachineError) {
+            LOG.error("License startup step '$name' failed with VM error", error)
+            throw error
         } catch (error: Error) {
             LOG.error("License startup step '$name' failed with Error", error)
-            throw error
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -181,13 +181,17 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
      *  - [RuntimeException] — logged, swallowed; the next step runs.
      *  - [VirtualMachineError] (OutOfMemoryError, StackOverflowError, InternalError,
      *    UnknownError) — logged and rethrown. These indicate the JVM is in an
-     *    unrecoverable state; any further work is undefined behavior. Rethrowing hands
-     *    control to the platform's uncaught-exception handler, which escalates normally.
-     *  - Other [Error] (LinkageError, ExceptionInInitializerError, AssertionError) —
-     *    logged, swallowed; the next step runs. These usually indicate a class-loading
-     *    or static-initializer issue in an individual step's transitive closure (e.g.
-     *    a Kotlin stdlib / compiler version mismatch surfacing from a lazily-loaded
-     *    service); the plugin's other startup steps should continue independently.
+     *    unrecoverable state; any further work is undefined behavior. Rethrowing surfaces
+     *    the error back to whoever dispatched this Runnable — on EDT that's
+     *    `IdeEventQueue.dispatchException`, which logs at ERROR and may surface a
+     *    fatal-error dialog; on background dispatchers the default uncaught-exception
+     *    handler takes over. Either way we don't swallow a VM-level failure.
+     *  - Other [Error] (NoClassDefFoundError, LinkageError, ExceptionInInitializerError,
+     *    AssertionError) — logged, swallowed; the next step runs. These usually indicate
+     *    a class-loading or static-initializer problem in an individual step's transitive
+     *    closure (e.g. a lazily-loaded service whose class body references a renamed
+     *    platform API, surfacing as `NoClassDefFoundError` only once that service is
+     *    first touched); the plugin's other startup steps should continue independently.
      */
     @Suppress("TooGenericExceptionCaught") // VM error rethrown; generic Error logged-and-continue
     private inline fun runStep(

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -176,22 +176,23 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
 
     /**
      * Invokes [block] with fine-grained error handling so each startup step gets its own
-     * log line, and the JVM's error-escalation path stays intact for genuinely fatal errors:
+     * log line, and the JVM's error-escalation path stays intact for genuinely fatal errors.
+     *
+     * All production call sites run inside `SwingUtilities.invokeLater { ... }` (see
+     * [checkLicenseState]), so the surrounding Runnable is dispatched by `IdeEventQueue`:
      *
      *  - [RuntimeException] — logged, swallowed; the next step runs.
      *  - [VirtualMachineError] (OutOfMemoryError, StackOverflowError, InternalError,
-     *    UnknownError) — logged and rethrown. These indicate the JVM is in an
-     *    unrecoverable state; any further work is undefined behavior. Rethrowing surfaces
-     *    the error back to whoever dispatched this Runnable — on EDT that's
-     *    `IdeEventQueue.dispatchException`, which logs at ERROR and may surface a
-     *    fatal-error dialog; on background dispatchers the default uncaught-exception
-     *    handler takes over. Either way we don't swallow a VM-level failure.
+     *    UnknownError) — logged and rethrown. These indicate the JVM is in an unrecoverable
+     *    state; any further work is undefined behavior. Rethrowing surfaces the error back
+     *    to `IdeEventQueue.dispatchException`, which logs at ERROR and may surface a
+     *    fatal-error dialog — the one place a VM-level failure should still be visible.
      *  - Other [Error] (NoClassDefFoundError, LinkageError, ExceptionInInitializerError,
      *    AssertionError) — logged, swallowed; the next step runs. These usually indicate
      *    a class-loading or static-initializer problem in an individual step's transitive
      *    closure (e.g. a lazily-loaded service whose class body references a renamed
-     *    platform API, surfacing as `NoClassDefFoundError` only once that service is
-     *    first touched); the plugin's other startup steps should continue independently.
+     *    platform API, surfacing as `NoClassDefFoundError` only once that service is first
+     *    touched); the plugin's other startup steps should continue independently.
      */
     @Suppress("TooGenericExceptionCaught") // VM error rethrown; generic Error logged-and-continue
     private inline fun runStep(

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -180,13 +180,14 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
      *
      *  - [RuntimeException] — logged, swallowed; the next step runs.
      *  - [VirtualMachineError] (OutOfMemoryError, StackOverflowError, InternalError,
-     *    UnknownError) — logged and rethrown. These mean the JVM is in an unrecoverable
-     *    state; continuing risks cascading corruption, and IntelliJ's crash reporter keys
-     *    off uncaught VM errors.
-     *  - Other [Error] (LinkageError, NoClassDefFoundError, ExceptionInInitializerError,
-     *    AssertionError) — logged, swallowed; the next step runs. These usually mean an
-     *    optional plugin dependency didn't load or a plugin extension point initializer
-     *    threw — the plugin's own startup should continue, not abort.
+     *    UnknownError) — logged and rethrown. These indicate the JVM is in an
+     *    unrecoverable state; any further work is undefined behavior. Rethrowing hands
+     *    control to the platform's uncaught-exception handler, which escalates normally.
+     *  - Other [Error] (LinkageError, ExceptionInInitializerError, AssertionError) —
+     *    logged, swallowed; the next step runs. These usually indicate a class-loading
+     *    or static-initializer issue in an individual step's transitive closure (e.g.
+     *    a Kotlin stdlib / compiler version mismatch surfacing from a lazily-loaded
+     *    service); the plugin's other startup steps should continue independently.
      */
     @Suppress("TooGenericExceptionCaught") // VM error rethrown; generic Error logged-and-continue
     private inline fun runStep(
@@ -206,9 +207,9 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
     }
 
     /**
-     * Test-only hook around [runStep]. Inline private functions can't be called from a
-     * test classpath; this thin wrapper exposes the catch semantics without leaking the
-     * helper itself.
+     * Test-only hook around [runStep]. Private functions are unreachable from test classes
+     * in other packages; this thin wrapper exposes the catch semantics without widening
+     * [runStep] itself.
      */
     @org.jetbrains.annotations.TestOnly
     internal fun runStepForTest(

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.extensions.PluginId
+import com.intellij.openapi.project.ProjectManager
 import com.intellij.ui.ColorUtil
 import dev.ayuislands.accent.conflict.ConflictRegistry
 import dev.ayuislands.glow.GlowStyle
@@ -18,6 +19,7 @@ import dev.ayuislands.glow.GlowTabMode
 import dev.ayuislands.indent.IndentRainbowSync
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
+import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 import java.awt.Color
 import java.awt.Window
 import java.lang.reflect.Method
@@ -134,6 +136,35 @@ object AccentApplicator {
         } else {
             invokeLaterSafe(work)
         }
+    }
+
+    /**
+     * Convenience wrapper around [AccentResolver.resolve] + [apply] for the "currently
+     * focused project" use case — callers (settings panels, LAF listener, rotation tick)
+     * previously hand-wired the same pattern:
+     *
+     * ```
+     * val focused = ProjectManager.getInstance().openProjects
+     *     .firstOrNull { !it.isDefault && !it.isDisposed }
+     * val hex = AccentResolver.resolve(focused, variant)
+     * AccentApplicator.apply(hex)
+     * ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
+     * ```
+     *
+     * Centralizing the sequence keeps focused-project selection, override-priority
+     * resolution, and swap-cache synchronization consistent across callers. Returns
+     * the applied hex so callers can log or display it.
+     */
+    fun applyForFocusedProject(variant: AyuVariant): String {
+        val focusedProject =
+            ProjectManager
+                .getInstance()
+                .openProjects
+                .firstOrNull { !it.isDefault && !it.isDisposed }
+        val hex = AccentResolver.resolve(focusedProject, variant)
+        apply(hex)
+        ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
+        return hex
     }
 
     fun revertAll() {

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -140,21 +140,16 @@ object AccentApplicator {
     }
 
     /**
-     * Convenience wrapper around [AccentResolver.resolve] + [apply] for the "currently
-     * focused project" use case — callers (settings panels, LAF listener, rotation tick)
-     * previously hand-wired the same pattern:
+     * Convenience wrapper around [AccentResolver.resolve] + [apply] for the "currently focused
+     * project" use case. Before this helper existed, four callers (settings panels, LAF
+     * listener, rotation tick, startup) hand-wired variants of the same sequence — and they
+     * were *inconsistent*: only the rotation path and the overrides-panel re-apply called
+     * [ProjectAccentSwapService.notifyExternalApply]; the panels and LAF listener skipped it,
+     * leaving the swap-cache stale and causing one redundant apply on the next WINDOW_ACTIVATED.
      *
-     * ```
-     * val focused = ProjectManager.getInstance().openProjects
-     *     .firstOrNull { !it.isDefault && !it.isDisposed }
-     * val hex = AccentResolver.resolve(focused, variant)
-     * AccentApplicator.apply(hex)
-     * ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
-     * ```
-     *
-     * Centralizing the sequence keeps focused-project selection, override-priority
-     * resolution, and swap-cache synchronization consistent across callers. Returns
-     * the applied hex so callers can log or display it.
+     * Centralizing the sequence makes focused-project selection, override-priority resolution,
+     * and swap-cache synchronization uniformly correct across callers. Returns the applied
+     * hex so callers can log or display it.
      */
     fun applyForFocusedProject(variant: AyuVariant): String {
         val focusedProject = resolveFocusedProject()

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -121,7 +121,7 @@ object AccentApplicator {
                 applyElements(state, accent, variant)
                 syncCodeGlanceProViewport(accentHex)
                 if (variant != null) {
-                    IndentRainbowSync.apply(variant)
+                    IndentRainbowSync.apply(variant, accentHex)
                 }
                 applyAlwaysOnEditorKeys(accent)
                 overrideTabUnderlineForOffMode(state, variant)

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -141,10 +141,9 @@ object AccentApplicator {
 
     /**
      * Convenience wrapper around [AccentResolver.resolve] + [apply] for the "currently focused
-     * project" use case. Five production sites call it today: the three settings panels
-     * (Accent / Elements / Plugins), [dev.ayuislands.AyuIslandsLafListener], and the
-     * [dev.ayuislands.rotation.AccentRotationService] tick. Pre-helper, those sites hand-wired
-     * variants of the same sequence and were *inconsistent*: only the rotation path called
+     * project" use case. Called from the settings panels (Accent / Elements / Plugins), the
+     * LAF listener, and the rotation tick. Pre-helper, those sites hand-wired variants of
+     * the same sequence and were *inconsistent*: only the rotation path called
      * [ProjectAccentSwapService.notifyExternalApply]; the panels and LAF listener skipped it,
      * leaving the swap-cache stale and causing one redundant apply on the next WINDOW_ACTIVATED.
      *

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -141,15 +141,20 @@ object AccentApplicator {
 
     /**
      * Convenience wrapper around [AccentResolver.resolve] + [apply] for the "currently focused
-     * project" use case. Before this helper existed, four callers (settings panels, LAF
-     * listener, rotation tick, startup) hand-wired variants of the same sequence — and they
-     * were *inconsistent*: only the rotation path and the overrides-panel re-apply called
+     * project" use case. Five production sites call it today: the three settings panels
+     * (Accent / Elements / Plugins), [dev.ayuislands.AyuIslandsLafListener], and the
+     * [dev.ayuislands.rotation.AccentRotationService] tick. Pre-helper, those sites hand-wired
+     * variants of the same sequence and were *inconsistent*: only the rotation path called
      * [ProjectAccentSwapService.notifyExternalApply]; the panels and LAF listener skipped it,
      * leaving the swap-cache stale and causing one redundant apply on the next WINDOW_ACTIVATED.
      *
      * Centralizing the sequence makes focused-project selection, override-priority resolution,
      * and swap-cache synchronization uniformly correct across callers. Returns the applied
      * hex so callers can log or display it.
+     *
+     * Note: [dev.ayuislands.AyuIslandsStartupActivity] is NOT a caller — it operates on the
+     * specific project the platform hands it, not the focused one, so it bypasses this helper
+     * and calls [AccentResolver.resolve] + [apply] directly with that project.
      */
     fun applyForFocusedProject(variant: AyuVariant): String {
         val focusedProject = resolveFocusedProject()
@@ -171,16 +176,18 @@ object AccentApplicator {
      *     shutdown edge cases where the focus manager is torn down
      *  3. `null` — no project open; resolver will return the global accent
      */
-    private fun resolveFocusedProject() =
+    private fun resolveFocusedProject(): com.intellij.openapi.project.Project? =
         IdeFocusManager
             .getGlobalInstance()
             .lastFocusedFrame
             ?.project
-            ?.takeIf { !it.isDefault && !it.isDisposed }
+            ?.takeIf { it.isUsable() }
             ?: ProjectManager
                 .getInstance()
                 .openProjects
-                .firstOrNull { !it.isDefault && !it.isDisposed }
+                .firstOrNull { it.isUsable() }
+
+    private fun com.intellij.openapi.project.Project.isUsable(): Boolean = !isDefault && !isDisposed
 
     fun revertAll() {
         // All revert work batched into a single EDT dispatch

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.wm.IdeFocusManager
 import com.intellij.ui.ColorUtil
 import dev.ayuislands.accent.conflict.ConflictRegistry
 import dev.ayuislands.glow.GlowStyle
@@ -156,16 +157,35 @@ object AccentApplicator {
      * the applied hex so callers can log or display it.
      */
     fun applyForFocusedProject(variant: AyuVariant): String {
-        val focusedProject =
-            ProjectManager
-                .getInstance()
-                .openProjects
-                .firstOrNull { !it.isDefault && !it.isDisposed }
+        val focusedProject = resolveFocusedProject()
         val hex = AccentResolver.resolve(focusedProject, variant)
         apply(hex)
         ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
         return hex
     }
+
+    /**
+     * Resolves the *actually* focused project — the one whose window has OS-level focus,
+     * not just "the first open project in enumeration order". With two or more project
+     * windows open, a naive `ProjectManager.openProjects.firstOrNull` would silently apply
+     * the wrong project's override (rotation tick, settings Apply, LAF change would flow
+     * through it for the wrong window). Fallback chain:
+     *
+     *  1. [IdeFocusManager.lastFocusedFrame]'s project — real focus state
+     *  2. First non-default non-disposed open project — pre-focus-manager startup, or
+     *     shutdown edge cases where the focus manager is torn down
+     *  3. `null` — no project open; resolver will return the global accent
+     */
+    private fun resolveFocusedProject() =
+        IdeFocusManager
+            .getGlobalInstance()
+            .lastFocusedFrame
+            ?.project
+            ?.takeIf { !it.isDefault && !it.isDisposed }
+            ?: ProjectManager
+                .getInstance()
+                .openProjects
+                .firstOrNull { !it.isDefault && !it.isDisposed }
 
     fun revertAll() {
         // All revert work batched into a single EDT dispatch

--- a/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
@@ -7,12 +7,13 @@ import dev.ayuislands.settings.mappings.AccentMappingsSettings
 import java.io.File
 
 /**
- * Resolves the effective accent hex for a given [project] and [variant] in priority order:
+ * Resolves the effective accent hex for a project + variant pair in priority order:
  *
- *  1. **Project override** — `AccentMappingsState.projectAccents[canonicalPath]`
- *  2. **Language override** — dominant language of the project via [ProjectLanguageDetector]
+ *  1. **Project override** — `AccentMappingsState.projectAccents` keyed by the project's
+ *     canonical base path.
+ *  2. **Language override** — dominant language of the project via [ProjectLanguageDetector].
  *  3. **Global** — [AyuIslandsSettings.getAccentForVariant] (which itself honors
- *     follow-system-accent and per-variant stored hex)
+ *     follow-system-accent and per-variant stored hex).
  *
  * Per-project and per-language overrides are premium features: when the license check
  * fails, the resolver short-circuits to the global accent regardless of stored mappings.

--- a/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
@@ -1,6 +1,7 @@
 package dev.ayuislands.accent
 
 import com.intellij.openapi.project.Project
+import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.mappings.AccentMappingsSettings
 import java.io.File
@@ -13,6 +14,11 @@ import java.io.File
  *  3. **Global** — [AyuIslandsSettings.getAccentForVariant] (which itself honors
  *     follow-system-accent and per-variant stored hex)
  *
+ * Per-project and per-language overrides are premium features: when the license check
+ * fails, the resolver short-circuits to the global accent regardless of stored mappings.
+ * The UI disables override add/edit for unlicensed users, but this guard protects against
+ * trial expiry with previously-stored mappings and against manually imported settings XML.
+ *
  * Zero-cost path: if both override maps are empty, the resolver does not touch
  * [ProjectLanguageDetector] and short-circuits to the global accent. See [Source]
  * for UI marker ordering.
@@ -24,6 +30,8 @@ object AccentResolver {
         project: Project?,
         variant: AyuVariant,
     ): String {
+        val globalAccent = AyuIslandsSettings.getInstance().getAccentForVariant(variant)
+        if (!LicenseChecker.isLicensedOrGrace()) return globalAccent
         val mappings = AccentMappingsSettings.getInstance().state
         if (project != null && !project.isDefault && !project.isDisposed) {
             projectKey(project)?.let { mappings.projectAccents[it] }?.let { return it }
@@ -33,17 +41,22 @@ object AccentResolver {
                 }
             }
         }
-        return AyuIslandsSettings.getInstance().getAccentForVariant(variant)
+        return globalAccent
     }
 
     /**
      * Returns which layer of the resolution chain produced the accent for [project].
      * Used by the settings UI to surface "Currently active: ... (project override)" context.
+     *
+     * Mirrors the license gate in [resolve]: unlicensed callers always see [Source.GLOBAL],
+     * so the UI label does not claim a project/language override is "active" when the
+     * resolver is actually returning the global accent.
      */
     fun source(
         project: Project?,
         @Suppress("UNUSED_PARAMETER") variant: AyuVariant,
     ): Source {
+        if (!LicenseChecker.isLicensedOrGrace()) return Source.GLOBAL
         val mappings = AccentMappingsSettings.getInstance().state
         if (project != null && !project.isDefault && !project.isDisposed) {
             projectKey(project)?.let { mappings.projectAccents[it] }?.let { return Source.PROJECT_OVERRIDE }

--- a/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
@@ -89,19 +89,27 @@ object AccentResolver {
 
     /**
      * Stable key for a [project]: the canonicalized absolute path of `basePath`.
-     * Returns `null` when the project has no base path or canonicalization throws
-     * (permission error, symlink loop, missing directory, network-share unreachable).
+     * Returns `null` when:
+     *  - the project has no base path
+     *  - the project is being disposed concurrently (basePath / name access throws
+     *    `AlreadyDisposedException` — possible when focus swap / rotation races with
+     *    a project-close event)
+     *  - canonicalization throws (permission error, symlink loop, missing directory,
+     *    network-share unreachable)
      *
      * Canonicalization failures are logged once per project — this runs on hot paths
      * (focus swap, rotation tick) so we guard against log spam via [loggedCanonicalFailures].
+     * basePath / name access are each in their own `runCatching` so a race mid-dispose
+     * degrades to "return null" silently instead of escalating through the resolver.
      */
     fun projectKey(project: Project): String? {
-        val raw = project.basePath ?: return null
+        val raw = runCatching { project.basePath }.getOrNull() ?: return null
         return runCatching { File(raw).canonicalPath }
             .onFailure { exception ->
                 if (loggedCanonicalFailures.add(project)) {
+                    val name = runCatching { project.name }.getOrDefault("<disposed>")
                     LOG.warn(
-                        "Failed to canonicalize basePath for '${project.name}' ($raw); " +
+                        "Failed to canonicalize basePath for '$name' ($raw); " +
                             "project-override resolution will fall back to global accent",
                         exception,
                     )

--- a/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
@@ -106,7 +106,7 @@ object AccentResolver {
      * resolver — while still letting [kotlin.coroutines.cancellation.CancellationException]
      * propagate, since the resolver is reachable from coroutine contexts
      * (`AyuIslandsStartupActivity.execute`) where swallowing cancellation would keep
-     * a cancelled coroutine alive past its structural concurrency boundary.
+     * a cancelled coroutine alive past its structured-concurrency boundary.
      */
     fun projectKey(project: Project): String? {
         val raw =
@@ -141,22 +141,6 @@ object AccentResolver {
                     )
                 }
             }.getOrNull()
-    }
-
-    /**
-     * [kotlin.runCatching] variant that rethrows
-     * [kotlin.coroutines.cancellation.CancellationException] instead of capturing it in
-     * the returned [Result]. This resolver is called from `AyuIslandsStartupActivity`'s
-     * coroutine body; swallowing cancellation there would let the coroutine continue
-     * past its scope's cancellation, breaking structured concurrency. Other Throwables
-     * (including [Error] subtypes like `NoClassDefFoundError` from a mid-dispose race
-     * on a lazily-loaded service accessor) keep the existing fall-back-to-null behavior.
-     */
-    private inline fun <T> runCatchingPreservingCancellation(block: () -> T): Result<T> {
-        val result = runCatching(block)
-        val cause = result.exceptionOrNull()
-        if (cause is kotlin.coroutines.cancellation.CancellationException) throw cause
-        return result
     }
 
     /**

--- a/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
@@ -1,0 +1,67 @@
+package dev.ayuislands.accent
+
+import com.intellij.openapi.project.Project
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.mappings.AccentMappingsSettings
+import java.io.File
+
+/**
+ * Resolves the effective accent hex for a given [project] and [variant] in priority order:
+ *
+ *  1. **Project override** — `AccentMappingsState.projectAccents[canonicalPath]`
+ *  2. **Language override** — dominant language of the project via [ProjectLanguageDetector]
+ *  3. **Global** — [AyuIslandsSettings.getAccentForVariant] (which itself honors
+ *     follow-system-accent and per-variant stored hex)
+ *
+ * Zero-cost path: if both override maps are empty, the resolver does not touch
+ * [ProjectLanguageDetector] and short-circuits to the global accent. See [Source]
+ * for UI marker ordering.
+ */
+object AccentResolver {
+    enum class Source { PROJECT_OVERRIDE, LANGUAGE_OVERRIDE, GLOBAL }
+
+    fun resolve(
+        project: Project?,
+        variant: AyuVariant,
+    ): String {
+        val mappings = AccentMappingsSettings.getInstance().state
+        if (project != null && !project.isDefault && !project.isDisposed) {
+            projectKey(project)?.let { mappings.projectAccents[it] }?.let { return it }
+            if (mappings.languageAccents.isNotEmpty()) {
+                ProjectLanguageDetector.dominant(project)?.let { languageId ->
+                    mappings.languageAccents[languageId]?.let { return it }
+                }
+            }
+        }
+        return AyuIslandsSettings.getInstance().getAccentForVariant(variant)
+    }
+
+    /**
+     * Returns which layer of the resolution chain produced the accent for [project].
+     * Used by the settings UI to surface "Currently active: ... (project override)" context.
+     */
+    fun source(
+        project: Project?,
+        @Suppress("UNUSED_PARAMETER") variant: AyuVariant,
+    ): Source {
+        val mappings = AccentMappingsSettings.getInstance().state
+        if (project != null && !project.isDefault && !project.isDisposed) {
+            projectKey(project)?.let { mappings.projectAccents[it] }?.let { return Source.PROJECT_OVERRIDE }
+            if (mappings.languageAccents.isNotEmpty()) {
+                ProjectLanguageDetector.dominant(project)?.let { languageId ->
+                    if (mappings.languageAccents[languageId] != null) return Source.LANGUAGE_OVERRIDE
+                }
+            }
+        }
+        return Source.GLOBAL
+    }
+
+    /**
+     * Stable key for a [project]: the canonicalized absolute path of `basePath`.
+     * Returns `null` when the project has no base path or canonicalization throws.
+     */
+    fun projectKey(project: Project): String? =
+        project.basePath?.let { raw ->
+            runCatching { File(raw).canonicalPath }.getOrNull()
+        }
+}

--- a/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
@@ -99,10 +99,13 @@ object AccentResolver {
      *    network-share unreachable)
      *
      * Failures are logged once per project per failure mode — this runs on hot paths
-     * (focus swap, rotation tick) so we guard against log spam via [loggedBasePathFailures]
-     * and [loggedCanonicalFailures]. basePath / name access are each in their own
-     * `runCatching` so a race mid-dispose degrades to "return null" silently instead of
-     * escalating through the resolver.
+     * (focus swap, rotation tick) so we guard against log spam via per-mode
+     * [OneShotProjectGate]s ([basePathWarnGate] and [canonicalWarnGate]). `basePath` /
+     * `name` access are each in their own `runCatching` so a race mid-dispose degrades
+     * to "return null" silently instead of escalating through the resolver — the
+     * `name` probe uses `runCatching` with a `"<disposed>"` default so a VM-level
+     * error during the label read still lets the warn fire with the real basePath
+     * exception as its cause.
      */
     fun projectKey(project: Project): String? {
         val raw =

--- a/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.project.Project
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.mappings.AccentMappingsSettings
+import org.jetbrains.annotations.TestOnly
 import java.io.File
 import java.util.Collections
 import java.util.WeakHashMap
@@ -32,18 +33,13 @@ object AccentResolver {
     private val LOG = logger<AccentResolver>()
 
     /**
-     * Per-failure-mode gates for [projectKey] warnings — see the [projectKey] KDoc for why.
-     * Split across two sets so a project that previously hit one failure mode can still log
+     * Per-failure-mode warn gates for [projectKey] — see the [projectKey] KDoc for why.
+     * Split across two gates so a project that previously hit one failure mode can still log
      * the other: a project whose `basePath` throws once, then later hands back a path whose
      * canonicalization fails, must not have the second warn silently dropped by a shared gate.
-     * Backed by synchronized WeakHashMaps because the resolver is called from multiple
-     * threads (EDT from the AWT listener, coroutine from [dev.ayuislands.AyuIslandsStartupActivity],
-     * background from rotation). Weak references let entries age out with project disposal.
      */
-    private val loggedBasePathFailures: MutableSet<Project> =
-        Collections.synchronizedSet(Collections.newSetFromMap(WeakHashMap()))
-    private val loggedCanonicalFailures: MutableSet<Project> =
-        Collections.synchronizedSet(Collections.newSetFromMap(WeakHashMap()))
+    private val basePathWarnGate = OneShotProjectGate()
+    private val canonicalWarnGate = OneShotProjectGate()
 
     /**
      * Resolves the effective accent hex. Delegates to the shared override-traversal helper,
@@ -115,17 +111,20 @@ object AccentResolver {
                     // Symmetric with the canonicalization branch below: a platform regression
                     // making `project.basePath` throw for any project type would silently
                     // demote every project to global accent without a breadcrumb unless we
-                    // log here too.
-                    if (loggedBasePathFailures.add(project)) {
+                    // log here too. `project.name` is read defensively inside runCatching for
+                    // the same reason — when basePath throws, name access is likely to throw
+                    // from the same mid-dispose race, and we'd rather log a marker than a NPE.
+                    if (basePathWarnGate.tryAcquire(project)) {
+                        val name = runCatching { project.name }.getOrDefault("<disposed>")
                         LOG.warn(
-                            "Failed to read basePath for project; falling back to global accent",
+                            "Failed to read basePath for project '$name'; falling back to global accent",
                             exception,
                         )
                     }
                 }.getOrNull() ?: return null
         return runCatching { File(raw).canonicalPath }
             .onFailure { exception ->
-                if (loggedCanonicalFailures.add(project)) {
+                if (canonicalWarnGate.tryAcquire(project)) {
                     val name = runCatching { project.name }.getOrDefault("<disposed>")
                     LOG.warn(
                         "Failed to canonicalize basePath for '$name' ($raw); " +
@@ -134,5 +133,42 @@ object AccentResolver {
                     )
                 }
             }.getOrNull()
+    }
+
+    /**
+     * Test-only seam: clear both warn gates so each test gets a fresh budget. Without this,
+     * `object`-scoped state leaks across test methods when a Project mock happens to be
+     * reused, silently dropping dedup-assertable warns under test-ordering variance.
+     */
+    @TestOnly
+    internal fun resetWarnGatesForTest() {
+        basePathWarnGate.clear()
+        canonicalWarnGate.clear()
+    }
+
+    /**
+     * One-shot per-project warn gate. [tryAcquire] returns `true` the first time a given
+     * project is seen and `false` on every subsequent call — so hot-path callers can emit
+     * a warn at first failure without spamming idea.log every focus swap / rotation tick.
+     *
+     * Backed by a synchronized WeakHashMap because the resolver is called from multiple
+     * threads (EDT from the AWT listener, coroutine from
+     * [dev.ayuislands.AyuIslandsStartupActivity], background from rotation). Weak references
+     * let entries age out with project disposal, so long-running IDE sessions don't
+     * accumulate unbounded gate state as projects open and close.
+     *
+     * Encapsulated as its own type so the invariant ("membership = warn-has-fired; only
+     * `add()`'s return value is load-bearing") lives in the type instead of comments, and
+     * the `Set.clear / contains / remove / iterate` surface is hidden from callers.
+     */
+    private class OneShotProjectGate {
+        private val seen: MutableSet<Project> =
+            Collections.synchronizedSet(Collections.newSetFromMap(WeakHashMap()))
+
+        fun tryAcquire(project: Project): Boolean = seen.add(project)
+
+        fun clear() {
+            seen.clear()
+        }
     }
 }

--- a/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
@@ -103,7 +103,20 @@ object AccentResolver {
      * degrades to "return null" silently instead of escalating through the resolver.
      */
     fun projectKey(project: Project): String? {
-        val raw = runCatching { project.basePath }.getOrNull() ?: return null
+        val raw =
+            runCatching { project.basePath }
+                .onFailure { exception ->
+                    // Symmetric with the canonicalization branch below: a platform regression
+                    // making `project.basePath` throw for any project type would silently
+                    // demote every project to global accent without a breadcrumb unless we
+                    // log here too. Dedup via the same gate to avoid log spam on hot paths.
+                    if (loggedCanonicalFailures.add(project)) {
+                        LOG.warn(
+                            "Failed to read basePath for project; falling back to global accent",
+                            exception,
+                        )
+                    }
+                }.getOrNull() ?: return null
         return runCatching { File(raw).canonicalPath }
             .onFailure { exception ->
                 if (loggedCanonicalFailures.add(project)) {

--- a/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
@@ -32,11 +32,16 @@ object AccentResolver {
     private val LOG = logger<AccentResolver>()
 
     /**
-     * First-failure-only gate for [projectKey] warnings — see the [projectKey] KDoc for why.
-     * Backed by a synchronized WeakHashMap because the resolver is called from multiple
+     * Per-failure-mode gates for [projectKey] warnings — see the [projectKey] KDoc for why.
+     * Split across two sets so a project that previously hit one failure mode can still log
+     * the other: a project whose `basePath` throws once, then later hands back a path whose
+     * canonicalization fails, must not have the second warn silently dropped by a shared gate.
+     * Backed by synchronized WeakHashMaps because the resolver is called from multiple
      * threads (EDT from the AWT listener, coroutine from [dev.ayuislands.AyuIslandsStartupActivity],
      * background from rotation). Weak references let entries age out with project disposal.
      */
+    private val loggedBasePathFailures: MutableSet<Project> =
+        Collections.synchronizedSet(Collections.newSetFromMap(WeakHashMap()))
     private val loggedCanonicalFailures: MutableSet<Project> =
         Collections.synchronizedSet(Collections.newSetFromMap(WeakHashMap()))
 
@@ -97,10 +102,11 @@ object AccentResolver {
      *  - canonicalization throws (permission error, symlink loop, missing directory,
      *    network-share unreachable)
      *
-     * Canonicalization failures are logged once per project — this runs on hot paths
-     * (focus swap, rotation tick) so we guard against log spam via [loggedCanonicalFailures].
-     * basePath / name access are each in their own `runCatching` so a race mid-dispose
-     * degrades to "return null" silently instead of escalating through the resolver.
+     * Failures are logged once per project per failure mode — this runs on hot paths
+     * (focus swap, rotation tick) so we guard against log spam via [loggedBasePathFailures]
+     * and [loggedCanonicalFailures]. basePath / name access are each in their own
+     * `runCatching` so a race mid-dispose degrades to "return null" silently instead of
+     * escalating through the resolver.
      */
     fun projectKey(project: Project): String? {
         val raw =
@@ -109,8 +115,8 @@ object AccentResolver {
                     // Symmetric with the canonicalization branch below: a platform regression
                     // making `project.basePath` throw for any project type would silently
                     // demote every project to global accent without a breadcrumb unless we
-                    // log here too. Dedup via the same gate to avoid log spam on hot paths.
-                    if (loggedCanonicalFailures.add(project)) {
+                    // log here too.
+                    if (loggedBasePathFailures.add(project)) {
                         LOG.warn(
                             "Failed to read basePath for project; falling back to global accent",
                             exception,

--- a/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
@@ -101,34 +101,39 @@ object AccentResolver {
      * Failures are logged once per project per failure mode — this runs on hot paths
      * (focus swap, rotation tick) so we guard against log spam via per-mode
      * [OneShotProjectGate]s ([basePathWarnGate] and [canonicalWarnGate]). `basePath` /
-     * `name` access are each in their own `runCatching` so a race mid-dispose degrades
-     * to "return null" silently instead of escalating through the resolver — the
-     * `name` probe uses `runCatching` with a `"<disposed>"` default so a VM-level
-     * error during the label read still lets the warn fire with the real basePath
-     * exception as its cause.
+     * `name` access are each wrapped in [runCatchingPreservingCancellation] so a race
+     * mid-dispose degrades to "return null" silently instead of escalating through the
+     * resolver — while still letting [kotlin.coroutines.cancellation.CancellationException]
+     * propagate, since the resolver is reachable from coroutine contexts
+     * (`AyuIslandsStartupActivity.execute`) where swallowing cancellation would keep
+     * a cancelled coroutine alive past its structural concurrency boundary.
      */
     fun projectKey(project: Project): String? {
         val raw =
-            runCatching { project.basePath }
+            runCatchingPreservingCancellation { project.basePath }
                 .onFailure { exception ->
                     // Symmetric with the canonicalization branch below: a platform regression
                     // making `project.basePath` throw for any project type would silently
                     // demote every project to global accent without a breadcrumb unless we
-                    // log here too. `project.name` is read defensively inside runCatching for
-                    // the same reason — when basePath throws, name access is likely to throw
-                    // from the same mid-dispose race, and we'd rather log a marker than a NPE.
+                    // log here too. `project.name` is read defensively for the same reason —
+                    // when basePath throws, name access is likely to throw from the same
+                    // mid-dispose race, and we'd rather log a marker than a NPE.
                     if (basePathWarnGate.tryAcquire(project)) {
-                        val name = runCatching { project.name }.getOrDefault("<disposed>")
+                        val name =
+                            runCatchingPreservingCancellation { project.name }
+                                .getOrDefault("<disposed>")
                         LOG.warn(
                             "Failed to read basePath for project '$name'; falling back to global accent",
                             exception,
                         )
                     }
                 }.getOrNull() ?: return null
-        return runCatching { File(raw).canonicalPath }
+        return runCatchingPreservingCancellation { File(raw).canonicalPath }
             .onFailure { exception ->
                 if (canonicalWarnGate.tryAcquire(project)) {
-                    val name = runCatching { project.name }.getOrDefault("<disposed>")
+                    val name =
+                        runCatchingPreservingCancellation { project.name }
+                            .getOrDefault("<disposed>")
                     LOG.warn(
                         "Failed to canonicalize basePath for '$name' ($raw); " +
                             "project-override resolution will fall back to global accent",
@@ -136,6 +141,22 @@ object AccentResolver {
                     )
                 }
             }.getOrNull()
+    }
+
+    /**
+     * [kotlin.runCatching] variant that rethrows
+     * [kotlin.coroutines.cancellation.CancellationException] instead of capturing it in
+     * the returned [Result]. This resolver is called from `AyuIslandsStartupActivity`'s
+     * coroutine body; swallowing cancellation there would let the coroutine continue
+     * past its scope's cancellation, breaking structured concurrency. Other Throwables
+     * (including [Error] subtypes like `NoClassDefFoundError` from a mid-dispose race
+     * on a lazily-loaded service accessor) keep the existing fall-back-to-null behavior.
+     */
+    private inline fun <T> runCatchingPreservingCancellation(block: () -> T): Result<T> {
+        val result = runCatching(block)
+        val cause = result.exceptionOrNull()
+        if (cause is kotlin.coroutines.cancellation.CancellationException) throw cause
+        return result
     }
 
     /**

--- a/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
@@ -1,10 +1,13 @@
 package dev.ayuislands.accent
 
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.mappings.AccentMappingsSettings
 import java.io.File
+import java.util.Collections
+import java.util.WeakHashMap
 
 /**
  * Resolves the effective accent hex for a project + variant pair in priority order:
@@ -20,29 +23,33 @@ import java.io.File
  * The UI disables override add/edit for unlicensed users, but this guard protects against
  * trial expiry with previously-stored mappings and against manually imported settings XML.
  *
- * Zero-cost path: if both override maps are empty, the resolver does not touch
- * [ProjectLanguageDetector] and short-circuits to the global accent. See [Source]
- * for UI marker ordering.
+ * Zero-cost path: when `languageAccents` is empty the detector is never consulted,
+ * so projects without any language overrides take a pure map-lookup path.
  */
 object AccentResolver {
     enum class Source { PROJECT_OVERRIDE, LANGUAGE_OVERRIDE, GLOBAL }
 
+    private val LOG = logger<AccentResolver>()
+
+    /**
+     * Dedup set for canonicalPath warnings — a failing project base path is hot-path on focus
+     * swap / rotation ticks, so we log the first failure and suppress subsequent ones for the
+     * same project to avoid flooding idea.log. WeakHashMap keyed by Project so entries age out
+     * with the project's disposal.
+     */
+    private val loggedCanonicalFailures: MutableSet<Project> =
+        Collections.newSetFromMap(WeakHashMap())
+
+    /**
+     * Resolves the effective accent hex. Delegates to the shared override-traversal helper,
+     * falling back to the global per-variant accent when no override applies.
+     */
     fun resolve(
         project: Project?,
         variant: AyuVariant,
     ): String {
         val globalAccent = AyuIslandsSettings.getInstance().getAccentForVariant(variant)
-        if (!LicenseChecker.isLicensedOrGrace()) return globalAccent
-        val mappings = AccentMappingsSettings.getInstance().state
-        if (project != null && !project.isDefault && !project.isDisposed) {
-            projectKey(project)?.let { mappings.projectAccents[it] }?.let { return it }
-            if (mappings.languageAccents.isNotEmpty()) {
-                ProjectLanguageDetector.dominant(project)?.let { languageId ->
-                    mappings.languageAccents[languageId]?.let { return it }
-                }
-            }
-        }
-        return globalAccent
+        return findOverride(project)?.second ?: globalAccent
     }
 
     /**
@@ -53,29 +60,52 @@ object AccentResolver {
      * so the UI label does not claim a project/language override is "active" when the
      * resolver is actually returning the global accent.
      */
-    fun source(
-        project: Project?,
-        @Suppress("UNUSED_PARAMETER") variant: AyuVariant,
-    ): Source {
-        if (!LicenseChecker.isLicensedOrGrace()) return Source.GLOBAL
+    fun source(project: Project?): Source = findOverride(project)?.first ?: Source.GLOBAL
+
+    /**
+     * Single traversal of the override priority chain shared by [resolve] and [source].
+     * Returns `null` when no override applies (global wins) — either because the license
+     * check fails, the project is null/default/disposed, or no mapping matches.
+     *
+     * Centralizing the traversal means adding a new override tier (e.g. folder override)
+     * touches only this function, and [resolve]/[source] cannot drift out of sync.
+     */
+    private fun findOverride(project: Project?): Pair<Source, String>? {
+        if (!LicenseChecker.isLicensedOrGrace()) return null
+        if (project == null || project.isDefault || project.isDisposed) return null
+
         val mappings = AccentMappingsSettings.getInstance().state
-        if (project != null && !project.isDefault && !project.isDisposed) {
-            projectKey(project)?.let { mappings.projectAccents[it] }?.let { return Source.PROJECT_OVERRIDE }
-            if (mappings.languageAccents.isNotEmpty()) {
-                ProjectLanguageDetector.dominant(project)?.let { languageId ->
-                    if (mappings.languageAccents[languageId] != null) return Source.LANGUAGE_OVERRIDE
-                }
+        projectKey(project)
+            ?.let { mappings.projectAccents[it] }
+            ?.let { return Source.PROJECT_OVERRIDE to it }
+
+        if (mappings.languageAccents.isNotEmpty()) {
+            ProjectLanguageDetector.dominant(project)?.let { languageId ->
+                mappings.languageAccents[languageId]?.let { return Source.LANGUAGE_OVERRIDE to it }
             }
         }
-        return Source.GLOBAL
+        return null
     }
 
     /**
      * Stable key for a [project]: the canonicalized absolute path of `basePath`.
-     * Returns `null` when the project has no base path or canonicalization throws.
+     * Returns `null` when the project has no base path or canonicalization throws
+     * (permission error, symlink loop, missing directory, network-share unreachable).
+     *
+     * Canonicalization failures are logged once per project — this runs on hot paths
+     * (focus swap, rotation tick) so we guard against log spam via [loggedCanonicalFailures].
      */
-    fun projectKey(project: Project): String? =
-        project.basePath?.let { raw ->
-            runCatching { File(raw).canonicalPath }.getOrNull()
-        }
+    fun projectKey(project: Project): String? {
+        val raw = project.basePath ?: return null
+        return runCatching { File(raw).canonicalPath }
+            .onFailure { exception ->
+                if (loggedCanonicalFailures.add(project)) {
+                    LOG.warn(
+                        "Failed to canonicalize basePath for '${project.name}' ($raw); " +
+                            "project-override resolution will fall back to global accent",
+                        exception,
+                    )
+                }
+            }.getOrNull()
+    }
 }

--- a/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
@@ -32,13 +32,13 @@ object AccentResolver {
     private val LOG = logger<AccentResolver>()
 
     /**
-     * Dedup set for canonicalPath warnings — a failing project base path is hot-path on focus
-     * swap / rotation ticks, so we log the first failure and suppress subsequent ones for the
-     * same project to avoid flooding idea.log. WeakHashMap keyed by Project so entries age out
-     * with the project's disposal.
+     * First-failure-only gate for [projectKey] warnings — see the [projectKey] KDoc for why.
+     * Backed by a synchronized WeakHashMap because the resolver is called from multiple
+     * threads (EDT from the AWT listener, coroutine from [dev.ayuislands.AyuIslandsStartupActivity],
+     * background from rotation). Weak references let entries age out with project disposal.
      */
     private val loggedCanonicalFailures: MutableSet<Project> =
-        Collections.newSetFromMap(WeakHashMap())
+        Collections.synchronizedSet(Collections.newSetFromMap(WeakHashMap()))
 
     /**
      * Resolves the effective accent hex. Delegates to the shared override-traversal helper,

--- a/src/main/kotlin/dev/ayuislands/accent/CancellationSafeRunCatching.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/CancellationSafeRunCatching.kt
@@ -1,0 +1,23 @@
+package dev.ayuislands.accent
+
+/**
+ * [kotlin.runCatching] variant that rethrows
+ * [kotlin.coroutines.cancellation.CancellationException] instead of capturing it in the
+ * returned [Result].
+ *
+ * The resolver chain ([AccentResolver.projectKey], [ProjectLanguageDetector.dominant]) is
+ * reachable from `AyuIslandsStartupActivity.execute`'s coroutine body; swallowing
+ * cancellation there would let the coroutine continue past its scope's cancellation,
+ * breaking structured concurrency. Other `Throwable`s (including `Error` subtypes like
+ * `NoClassDefFoundError` from a mid-dispose race on a lazily-loaded service accessor) keep
+ * the existing fall-back-to-failure-result behavior.
+ *
+ * Package-internal because every caller today sits in `dev.ayuislands.accent`; lift
+ * further if a caller from another package ever needs the same contract.
+ */
+internal inline fun <T> runCatchingPreservingCancellation(block: () -> T): Result<T> {
+    val result = runCatching(block)
+    val cause = result.exceptionOrNull()
+    if (cause is kotlin.coroutines.cancellation.CancellationException) throw cause
+    return result
+}

--- a/src/main/kotlin/dev/ayuislands/accent/CancellationSafeRunCatching.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/CancellationSafeRunCatching.kt
@@ -12,6 +12,12 @@ package dev.ayuislands.accent
  * `NoClassDefFoundError` from a mid-dispose race on a lazily-loaded service accessor) keep
  * the existing fall-back-to-failure-result behavior.
  *
+ * Only the top-level exception is inspected. If an IntelliJ platform API catches a
+ * `CancellationException` and rewraps it (e.g. `throw IllegalStateException("disposed",
+ * cancellationException)`), the wrapper is NOT itself a `CancellationException` and the
+ * cancellation signal is lost. No current caller sits behind such a rewrap, but if a
+ * future call site does, walk the `cause` chain before returning the Result.
+ *
  * Package-internal because every caller today sits in `dev.ayuislands.accent`; lift
  * further if a caller from another package ever needs the same contract.
  */

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
@@ -1,5 +1,6 @@
 package dev.ayuislands.accent
 
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
@@ -11,23 +12,36 @@ import java.util.concurrent.ConcurrentHashMap
  *
  * Detection strategy:
  *  1. **Project SDK type name** — covers JVM, Python, Go, Rust, Node, etc.
- *  2. **Module names** — fallback for Kotlin / Gradle / Android projects whose SDK
- *     is JVM but the module name hints at the real language.
+ *  2. **Module names** — fallback when the SDK is JVM but the module name hints at the real
+ *     language. Actual module keywords matched: `kotlin`, `python`, `scala`,
+ *     `android` (→ kotlin), `flutter` / `dart` (→ dart).
  *
  * Empty / polyglot / no-SDK projects return `null` and fall through to the global accent.
+ *
+ * Cache correctness: a detection that threw (project mid-dispose, SDK list mutation race,
+ * ModuleManager teardown) is **not** cached — the next call retries. Without that guard,
+ * a single transient failure would permanently poison the cache for that project.
  */
 object ProjectLanguageDetector {
+    private val LOG = logger<ProjectLanguageDetector>()
+
     // ConcurrentHashMap rejects null values, so we store an empty-string sentinel
-    // whenever detection returns null. AYU language ids are always non-empty
-    // ("kotlin", "python", ...) so the sentinel cannot collide with a real id.
+    // whenever detection definitively returns null (SDK absent AND no matching module).
+    // AYU language ids are always non-empty ("kotlin", "python", ...) so the sentinel
+    // cannot collide with a real id.
     private const val NULL_SENTINEL = ""
     private val cache = ConcurrentHashMap<String, String>()
 
     /** Dominant language id for [project], cached per canonical path. */
     fun dominant(project: Project): String? {
         val key = AccentResolver.projectKey(project) ?: return null
-        val cached = cache.getOrPut(key) { detectInternal(project) ?: NULL_SENTINEL }
-        return cached.takeIf { it.isNotEmpty() }
+        cache[key]?.let { return it.takeIf { hit -> hit.isNotEmpty() } }
+
+        val detection = detectInternal(project)
+        if (detection.cacheable) {
+            cache[key] = detection.languageId ?: NULL_SENTINEL
+        }
+        return detection.languageId
     }
 
     /**
@@ -43,22 +57,52 @@ object ProjectLanguageDetector {
         cache.clear()
     }
 
-    private fun detectInternal(project: Project): String? {
-        val sdkName =
+    /**
+     * Result of a single detection attempt. `cacheable = false` signals a transient failure
+     * (the underlying IntelliJ API threw) — the caller must NOT persist this result, so the
+     * next invocation retries instead of serving a poisoned cache entry.
+     */
+    private data class DetectionResult(
+        val languageId: String?,
+        val cacheable: Boolean,
+    )
+
+    private fun detectInternal(project: Project): DetectionResult {
+        val sdkResult =
             runCatching {
                 ProjectRootManager
                     .getInstance(project)
                     .projectSdk
                     ?.sdkType
                     ?.name
-            }.getOrNull()
-        sdkTypeToLanguageId(sdkName)?.let { return it }
-
-        val moduleManager = runCatching { ModuleManager.getInstance(project) }.getOrNull() ?: return null
-        for (module in moduleManager.modules) {
-            moduleNameToLanguageId(module.name.lowercase())?.let { return it }
+            }
+        if (sdkResult.isFailure) {
+            LOG.warn(
+                "SDK lookup failed during language detection; will retry on next call instead of caching null",
+                sdkResult.exceptionOrNull(),
+            )
+            return DetectionResult(languageId = null, cacheable = false)
         }
-        return null
+        sdkTypeToLanguageId(sdkResult.getOrNull())?.let {
+            return DetectionResult(languageId = it, cacheable = true)
+        }
+
+        val moduleResult = runCatching { ModuleManager.getInstance(project).modules.map { it.name } }
+        if (moduleResult.isFailure) {
+            LOG.warn(
+                "Module lookup failed during language detection; will retry on next call instead of caching null",
+                moduleResult.exceptionOrNull(),
+            )
+            return DetectionResult(languageId = null, cacheable = false)
+        }
+        val moduleNames = moduleResult.getOrDefault(emptyList())
+        for (moduleName in moduleNames) {
+            moduleNameToLanguageId(moduleName.lowercase())?.let {
+                return DetectionResult(languageId = it, cacheable = true)
+            }
+        }
+        // Definitive null — no SDK match, no module match. Safe to cache.
+        return DetectionResult(languageId = null, cacheable = true)
     }
 
     private fun sdkTypeToLanguageId(sdkTypeName: String?): String? {

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
@@ -68,8 +68,12 @@ object ProjectLanguageDetector {
     )
 
     private fun detectInternal(project: Project): DetectionResult {
+        // Both platform lookups wrap via runCatchingPreservingCancellation — `dominant`
+        // is reachable from AyuIslandsStartupActivity.execute's coroutine body via
+        // AccentResolver.findOverride, and plain `runCatching` would swallow
+        // CancellationException and keep a cancelled coroutine alive.
         val sdkResult =
-            runCatching {
+            runCatchingPreservingCancellation {
                 ProjectRootManager
                     .getInstance(project)
                     .projectSdk
@@ -87,7 +91,10 @@ object ProjectLanguageDetector {
             return DetectionResult(languageId = it, cacheable = true)
         }
 
-        val moduleResult = runCatching { ModuleManager.getInstance(project).modules.map { it.name } }
+        val moduleResult =
+            runCatchingPreservingCancellation {
+                ModuleManager.getInstance(project).modules.map { it.name }
+            }
         if (moduleResult.isFailure) {
             LOG.warn(
                 "Module lookup failed during language detection; will retry on next call instead of caching null",

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
@@ -17,12 +17,17 @@ import java.util.concurrent.ConcurrentHashMap
  * Empty / polyglot / no-SDK projects return `null` and fall through to the global accent.
  */
 object ProjectLanguageDetector {
-    private val cache = ConcurrentHashMap<String, String?>()
+    // ConcurrentHashMap rejects null values, so we store an empty-string sentinel
+    // whenever detection returns null. AYU language ids are always non-empty
+    // ("kotlin", "python", ...) so the sentinel cannot collide with a real id.
+    private const val NULL_SENTINEL = ""
+    private val cache = ConcurrentHashMap<String, String>()
 
     /** Dominant language id for [project], cached per canonical path. */
     fun dominant(project: Project): String? {
         val key = AccentResolver.projectKey(project) ?: return null
-        return cache.getOrPut(key) { detectInternal(project) }
+        val cached = cache.getOrPut(key) { detectInternal(project) ?: NULL_SENTINEL }
+        return cached.takeIf { it.isNotEmpty() }
     }
 
     /**

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
@@ -1,0 +1,95 @@
+package dev.ayuislands.accent
+
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ProjectRootManager
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Heuristic detector for the dominant language of a project, used only when
+ * the language-accent override map is non-empty (the [AccentResolver] gates this).
+ *
+ * Detection strategy:
+ *  1. **Project SDK type name** — covers JVM, Python, Go, Rust, Node, etc.
+ *  2. **Module names** — fallback for Kotlin / Gradle / Android projects whose SDK
+ *     is JVM but the module name hints at the real language.
+ *
+ * Empty / polyglot / no-SDK projects return `null` and fall through to the global accent.
+ */
+object ProjectLanguageDetector {
+    private val cache = ConcurrentHashMap<String, String?>()
+
+    /** Dominant language id for [project], cached per canonical path. */
+    fun dominant(project: Project): String? {
+        val key = AccentResolver.projectKey(project) ?: return null
+        return cache.getOrPut(key) { detectInternal(project) }
+    }
+
+    /**
+     * Clear the cached detection for [project]; call from project-close hooks
+     * so a re-opened project can be re-analyzed.
+     */
+    fun invalidate(project: Project) {
+        AccentResolver.projectKey(project)?.let { cache.remove(it) }
+    }
+
+    /** Drop the entire cache — useful for test isolation. */
+    fun clear() {
+        cache.clear()
+    }
+
+    private fun detectInternal(project: Project): String? {
+        val sdkName =
+            runCatching {
+                ProjectRootManager
+                    .getInstance(project)
+                    .projectSdk
+                    ?.sdkType
+                    ?.name
+            }.getOrNull()
+        sdkTypeToLanguageId(sdkName)?.let { return it }
+
+        val moduleManager = runCatching { ModuleManager.getInstance(project) }.getOrNull() ?: return null
+        for (module in moduleManager.modules) {
+            moduleNameToLanguageId(module.name.lowercase())?.let { return it }
+        }
+        return null
+    }
+
+    private fun sdkTypeToLanguageId(sdkTypeName: String?): String? {
+        if (sdkTypeName == null) return null
+        val lowered = sdkTypeName.lowercase()
+        return sdkNameLookupPrimary(lowered) ?: sdkNameLookupSecondary(lowered)
+    }
+
+    private fun sdkNameLookupPrimary(lowered: String): String? =
+        when {
+            lowered.contains("kotlin") -> "kotlin"
+            lowered.contains("python") -> "python"
+            lowered.contains("node") -> "javascript"
+            lowered.contains("typescript") -> "typescript"
+            lowered.contains("rust") -> "rust"
+            lowered.contains("go") && !lowered.contains("google") -> "go"
+            else -> null
+        }
+
+    private fun sdkNameLookupSecondary(lowered: String): String? =
+        when {
+            lowered.contains("ruby") -> "ruby"
+            lowered.contains("php") -> "php"
+            lowered.contains("dart") -> "dart"
+            lowered.contains("scala") -> "scala"
+            lowered.contains("javasdk") || lowered.contains("jdk") -> "java"
+            else -> null
+        }
+
+    private fun moduleNameToLanguageId(lowered: String): String? =
+        when {
+            lowered.contains("kotlin") -> "kotlin"
+            lowered.contains("python") -> "python"
+            lowered.contains("scala") -> "scala"
+            lowered.contains("android") -> "kotlin"
+            lowered.contains("flutter") || lowered.contains("dart") -> "dart"
+            else -> null
+        }
+}

--- a/src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
+++ b/src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
@@ -2,6 +2,7 @@ package dev.ayuislands.editor
 
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.editor.event.EditorFactoryEvent
 import com.intellij.openapi.editor.event.EditorFactoryListener
@@ -68,11 +69,22 @@ class EditorScrollbarManager(
      * Clear `ORIGINAL_PREFERRED_SIZE_KEY` on every currently-patched scrollbar so the next
      * [hideScrollBar] call captures the post-refresh default instead of serving a stale
      * pre-LAF-change dimension.
+     *
+     * Iterates a snapshot of the keys, not the live view, because [patchedScrollPanes] is a
+     * [WeakHashMap] that expunges stale entries on any access — including during iteration —
+     * which can race with a concurrent `editorCreated` listener mutation elsewhere on the
+     * EDT. The snapshot plus try/catch keep the listener alive even if Swing throws from
+     * a downstream `putClientProperty`.
      */
     private fun resetOriginalSizeCache() {
-        for (scrollPane in patchedScrollPanes.keys) {
-            scrollPane.verticalScrollBar?.putClientProperty(ORIGINAL_PREFERRED_SIZE_KEY, null)
-            scrollPane.horizontalScrollBar?.putClientProperty(ORIGINAL_PREFERRED_SIZE_KEY, null)
+        val panes = patchedScrollPanes.keys.toList()
+        for (scrollPane in panes) {
+            try {
+                scrollPane.verticalScrollBar?.putClientProperty(ORIGINAL_PREFERRED_SIZE_KEY, null)
+                scrollPane.horizontalScrollBar?.putClientProperty(ORIGINAL_PREFERRED_SIZE_KEY, null)
+            } catch (exception: RuntimeException) {
+                LOG.warn("Failed to clear scrollbar original-size cache on refresh", exception)
+            }
         }
     }
 
@@ -177,6 +189,7 @@ class EditorScrollbarManager(
     )
 
     companion object {
+        private val LOG = logger<EditorScrollbarManager>()
         private const val ORIGINAL_PREFERRED_SIZE_KEY = "ayuIslands.originalPreferredSize"
         private val ZERO_SIZE = Dimension(0, 0)
 

--- a/src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
+++ b/src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
@@ -70,11 +70,12 @@ class EditorScrollbarManager(
      * [hideScrollBar] call captures the post-refresh default instead of serving a stale
      * pre-LAF-change dimension.
      *
-     * Iterates a snapshot of the keys, not the live view, because [patchedScrollPanes] is a
-     * [WeakHashMap] that expunges stale entries on any access — including during iteration —
-     * which can race with a concurrent `editorCreated` listener mutation elsewhere on the
-     * EDT. The snapshot plus try/catch keep the listener alive even if Swing throws from
-     * a downstream `putClientProperty`.
+     * Iterates a snapshot of the keys, not the live view: [WeakHashMap]'s iterator can throw
+     * [ConcurrentModificationException] when GC-driven expunge mutates the map's modCount
+     * mid-iteration (the expunge runs during `keys.iterator().hasNext()` / `next()` calls,
+     * independent of any other mutator thread — relevant even with strict EDT serialization).
+     * The snapshot freezes the set we walk, and the per-pane try/catch keeps the listener
+     * alive if Swing throws from a downstream `putClientProperty`.
      */
     private fun resetOriginalSizeCache() {
         val panes = patchedScrollPanes.keys.toList()

--- a/src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
+++ b/src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
@@ -47,12 +47,33 @@ class EditorScrollbarManager(
         // Self-heal after IJSwingUtilities.updateComponentTreeUI (startup, focus swap,
         // LAF change) — that walk calls updateUI() on every JScrollBar descendant and
         // resets the preferredSize=0 trick this manager uses to hide scrollbars.
+        //
+        // Drop the cached "original preferred size" client property before reapplying so the
+        // next hideScrollBar call captures the freshly-installed default. Without this, the
+        // first apply's original-size snapshot (captured under the previous LAF) would be what
+        // restore returns after a theme switch, silently drifting the restored scrollbar
+        // dimensions away from the new theme's default.
         project.messageBus
             .connect(this)
             .subscribe(
                 ComponentTreeRefreshedTopic.TOPIC,
-                ComponentTreeRefreshedListener { apply() },
+                ComponentTreeRefreshedListener {
+                    resetOriginalSizeCache()
+                    apply()
+                },
             )
+    }
+
+    /**
+     * Clear `ORIGINAL_PREFERRED_SIZE_KEY` on every currently-patched scrollbar so the next
+     * [hideScrollBar] call captures the post-refresh default instead of serving a stale
+     * pre-LAF-change dimension.
+     */
+    private fun resetOriginalSizeCache() {
+        for (scrollPane in patchedScrollPanes.keys) {
+            scrollPane.verticalScrollBar?.putClientProperty(ORIGINAL_PREFERRED_SIZE_KEY, null)
+            scrollPane.horizontalScrollBar?.putClientProperty(ORIGINAL_PREFERRED_SIZE_KEY, null)
+        }
     }
 
     fun apply() {

--- a/src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
+++ b/src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
@@ -9,6 +9,8 @@ import com.intellij.openapi.editor.ex.EditorEx
 import com.intellij.openapi.project.Project
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.ui.ComponentTreeRefreshedListener
+import dev.ayuislands.ui.ComponentTreeRefreshedTopic
 import java.awt.Dimension
 import java.util.WeakHashMap
 import javax.swing.JScrollBar
@@ -41,6 +43,16 @@ class EditorScrollbarManager(
             },
             this,
         )
+
+        // Self-heal after IJSwingUtilities.updateComponentTreeUI (startup, focus swap,
+        // LAF change) — that walk calls updateUI() on every JScrollBar descendant and
+        // resets the preferredSize=0 trick this manager uses to hide scrollbars.
+        project.messageBus
+            .connect(this)
+            .subscribe(
+                ComponentTreeRefreshedTopic.TOPIC,
+                ComponentTreeRefreshedListener { apply() },
+            )
     }
 
     fun apply() {
@@ -63,31 +75,43 @@ class EditorScrollbarManager(
         val hideVertical = state.hideEditorVScrollbar
         val hideHorizontal = state.hideEditorHScrollbar
 
-        if (hideVertical || hideHorizontal) {
-            val patched = patchedScrollPanes.getOrPut(scrollPane) { PatchedState() }
-            if (hideVertical && !patched.verticalHidden) {
-                hideScrollBar(scrollPane.verticalScrollBar)
-                patched.verticalHidden = true
-            } else if (!hideVertical && patched.verticalHidden) {
-                restoreScrollBar(scrollPane.verticalScrollBar)
-                patched.verticalHidden = false
-            }
-            if (hideHorizontal && !patched.horizontalHidden) {
-                hideScrollBar(scrollPane.horizontalScrollBar)
-                patched.horizontalHidden = true
-            } else if (!hideHorizontal && patched.horizontalHidden) {
-                restoreScrollBar(scrollPane.horizontalScrollBar)
-                patched.horizontalHidden = false
-            }
-        } else {
+        if (!hideVertical && !hideHorizontal) {
             restoreEditor(scrollPane)
+            return
         }
+
+        // Apply is idempotent: we re-apply `hideScrollBar` every call without consulting
+        // `patched.verticalHidden` because the platform can silently restore the default
+        // preferred size during LAF changes and component-tree refreshes. The cached flag
+        // would still read "true" while the scrollbar is visible again, so a flag-gated
+        // call path would skip re-hiding. `hideScrollBar` preserves the original size only
+        // on the first call (client property is never overwritten), so repeated invocations
+        // are safe.
+        val patched = patchedScrollPanes.getOrPut(scrollPane) { PatchedState() }
+        if (hideVertical) {
+            hideScrollBar(scrollPane.verticalScrollBar)
+            patched.verticalHidden = true
+        } else if (patched.verticalHidden) {
+            restoreScrollBar(scrollPane.verticalScrollBar)
+            patched.verticalHidden = false
+        }
+        if (hideHorizontal) {
+            hideScrollBar(scrollPane.horizontalScrollBar)
+            patched.horizontalHidden = true
+        } else if (patched.horizontalHidden) {
+            restoreScrollBar(scrollPane.horizontalScrollBar)
+            patched.horizontalHidden = false
+        }
+        scrollPane.revalidate()
     }
 
     private fun hideScrollBar(scrollBar: JScrollBar) {
-        val originalSize = scrollBar.preferredSize?.let { Dimension(it) }
-        scrollBar.putClientProperty(ORIGINAL_PREFERRED_SIZE_KEY, originalSize)
+        if (scrollBar.getClientProperty(ORIGINAL_PREFERRED_SIZE_KEY) == null) {
+            val originalSize = scrollBar.preferredSize?.let { Dimension(it) }
+            scrollBar.putClientProperty(ORIGINAL_PREFERRED_SIZE_KEY, originalSize)
+        }
         scrollBar.preferredSize = ZERO_SIZE
+        scrollBar.revalidate()
     }
 
     private fun restoreScrollBar(scrollBar: JScrollBar) {

--- a/src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
+++ b/src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
@@ -165,7 +165,13 @@ class EditorScrollbarManager(
         patchedScrollPanes.clear()
     }
 
-    private data class PatchedState(
+    /**
+     * Mutable per-scrollPane patch state. Not a `data class` — we mutate flags in place on hot
+     * paths (every apply call), and the auto-generated equals/hashCode from `data class` would
+     * be a foot-gun if anything ever used PatchedState as a map key (we use it as a WeakHashMap
+     * *value*, not key). Plain class with `var` matches the imperative usage.
+     */
+    private class PatchedState(
         var verticalHidden: Boolean = false,
         var horizontalHidden: Boolean = false,
     )

--- a/src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
+++ b/src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
@@ -66,6 +66,14 @@ class EditorScrollbarManager(
     }
 
     /**
+     * Test-only entry point for [resetOriginalSizeCache]. The listener path that calls it
+     * goes through `project.messageBus.syncPublisher(...)` which is impractical to wire
+     * without a real Project; this seam lets unit tests verify the catch path directly.
+     */
+    @org.jetbrains.annotations.TestOnly
+    internal fun resetOriginalSizeCacheForTest() = resetOriginalSizeCache()
+
+    /**
      * Clear `ORIGINAL_PREFERRED_SIZE_KEY` on every currently-patched scrollbar so the next
      * [hideScrollBar] call captures the post-refresh default instead of serving a stale
      * pre-LAF-change dimension.

--- a/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
@@ -215,8 +216,7 @@ class GlowOverlayManager(
         if (!state.glowFocusRing) return
 
         val variant = AyuVariant.detect()
-        val settings = AyuIslandsSettings.getInstance()
-        val accentHex = if (variant != null) settings.getAccentForVariant(variant) else DEFAULT_ACCENT_HEX
+        val accentHex = if (variant != null) AccentResolver.resolve(project, variant) else DEFAULT_ACCENT_HEX
         val style = GlowStyle.fromName(state.glowStyle ?: GlowStyle.SOFT.name)
         val accent = safeDecodeColor(accentHex)
         val intensity = state.getIntensityForStyle(style)
@@ -255,9 +255,8 @@ class GlowOverlayManager(
         val layeredPane = rootPane.layeredPane
 
         val state = AyuIslandsSettings.getInstance().state
-        val settings = AyuIslandsSettings.getInstance()
         val variant = AyuVariant.detect()
-        val accentHex = if (variant != null) settings.getAccentForVariant(variant) else DEFAULT_ACCENT_HEX
+        val accentHex = if (variant != null) AccentResolver.resolve(project, variant) else DEFAULT_ACCENT_HEX
         val style = GlowStyle.fromName(state.glowStyle ?: GlowStyle.SOFT.name)
 
         val glassPane =
@@ -404,7 +403,7 @@ class GlowOverlayManager(
         }
 
         val variant = AyuVariant.detect()
-        val accentHex = if (variant != null) settings.getAccentForVariant(variant) else DEFAULT_ACCENT_HEX
+        val accentHex = if (variant != null) AccentResolver.resolve(project, variant) else DEFAULT_ACCENT_HEX
         val accent = safeDecodeColor(accentHex)
         val style = GlowStyle.fromName(state.glowStyle ?: GlowStyle.SOFT.name)
 

--- a/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
@@ -11,7 +11,6 @@ import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener
-import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.licensing.LicenseChecker
@@ -28,7 +27,6 @@ import java.beans.PropertyChangeListener
 import javax.swing.JComponent
 import javax.swing.JLayeredPane
 import javax.swing.SwingUtilities
-import javax.swing.UIManager
 
 /** Manages glow overlays for tool windows, editor, tabs, and focus rings. */
 class GlowOverlayManager(
@@ -52,9 +50,6 @@ class GlowOverlayManager(
     companion object {
         private const val EDITOR_ID = "Editor"
         private const val DEFAULT_ACCENT_HEX = "#FFCC66"
-        private const val TAB_ACCENT_BG_ALPHA = 50
-        private const val KEY_TAB_UNDERLINE = "EditorTabs.underlinedBorderColor"
-        private const val KEY_TAB_BACKGROUND = "EditorTabs.underlinedTabBackground"
 
         fun getInstance(project: Project): GlowOverlayManager = project.getService(GlowOverlayManager::class.java)
 
@@ -408,7 +403,7 @@ class GlowOverlayManager(
         val style = GlowStyle.fromName(state.glowStyle ?: GlowStyle.SOFT.name)
 
         updateOverlayStyles(state, accent, style)
-        updateTabGlow(state, accent)
+        repaintTabs()
 
         val intensity = state.getIntensityForStyle(style)
         focusRingManager.updateFocusRingGlow(accent, style, intensity, state.glowFocusRing)
@@ -436,35 +431,23 @@ class GlowOverlayManager(
         }
     }
 
-    private fun updateTabGlow(
-        state: AyuIslandsState,
-        accent: Color,
-    ) {
-        val tabMode = GlowTabMode.fromName(state.glowTabMode ?: "MINIMAL")
-
-        when (tabMode) {
-            GlowTabMode.MINIMAL -> {
-                UIManager.put(KEY_TAB_UNDERLINE, accent)
-                UIManager.put(KEY_TAB_BACKGROUND, Color(0, 0, 0, 0))
-            }
-            GlowTabMode.FULL -> {
-                UIManager.put(KEY_TAB_UNDERLINE, accent)
-                UIManager.put(
-                    KEY_TAB_BACKGROUND,
-                    Color(accent.red, accent.green, accent.blue, TAB_ACCENT_BG_ALPHA),
-                )
-            }
-            GlowTabMode.OFF -> {
-                val variant = AyuVariant.detect()
-                if (variant != null) {
-                    UIManager.put(KEY_TAB_UNDERLINE, Color.decode(variant.neutralGray))
-                }
-                UIManager.put(KEY_TAB_BACKGROUND, Color(0, 0, 0, 0))
-            }
-        }
-
-        UIManager.put("EditorTabs.underlineHeight", AccentApplicator.resolveUnderlineHeight(state))
-
+    /**
+     * Repaints editor tabs for THIS project only.
+     *
+     * Previously this also wrote `EditorTabs.underlinedBorderColor`, `KEY_TAB_BACKGROUND`,
+     * and `EditorTabs.underlineHeight` to `UIManager`. That was a subtle race: `UIManager`
+     * is a single JVM-wide table, and `syncGlowForAllProjects` iterates every open project,
+     * so the last project's accent ended up in `UIManager` regardless of which window the
+     * user was actually looking at — clearly wrong when one project has a per-project
+     * override and another doesn't (tabs show the loser's color while glow, scoped to each
+     * project's overlay, correctly shows the right one).
+     *
+     * AccentApplicator.apply writes those UIManager keys exactly once, for the focused
+     * project's resolved accent, and the focus-swap service re-applies on WINDOW_ACTIVATED.
+     * Tab appearance now follows the resolved accent consistently; this method only nudges
+     * Swing to repaint the tabs so the glow-overlay bounds recalculate for this project.
+     */
+    private fun repaintTabs() {
         EditorTabGeometry.repaintEditorTabs(project)
     }
 

--- a/src/main/kotlin/dev/ayuislands/indent/IndentRainbowSync.kt
+++ b/src/main/kotlin/dev/ayuislands/indent/IndentRainbowSync.kt
@@ -42,7 +42,18 @@ object IndentRainbowSync {
 
     @Volatile private var methodsResolved = false
 
-    fun apply(variant: AyuVariant) {
+    /**
+     * Syncs Indent Rainbow's custom palette to [accentHex] for the given [variant].
+     * The caller (typically [dev.ayuislands.accent.AccentApplicator.apply]) passes the
+     * resolved accent — the one that just went through per-project / per-language
+     * override resolution — so IR reflects the SAME color the rest of the plugin just
+     * applied, not the global accent stored in settings (which rotation mutates to a
+     * different value from what the focused project actually shows).
+     */
+    fun apply(
+        variant: AyuVariant,
+        accentHex: String,
+    ) {
         val state = AyuIslandsSettings.getInstance().state
         if (!state.irIntegrationEnabled) {
             revert()
@@ -55,7 +66,6 @@ object IndentRainbowSync {
         val enumValue = customEnumValue ?: return
 
         try {
-            val accentHex = AyuIslandsSettings.getInstance().getAccentForVariant(variant)
             val palette = IndentPalette.forAccent(accentHex, variant)
             val preset =
                 IndentPreset.fromName(

--- a/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
+++ b/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
@@ -15,6 +15,8 @@ import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.PanelWidthMode
 import dev.ayuislands.toolwindow.AutoFitCalculator
 import dev.ayuislands.toolwindow.ToolWindowAutoFitter
+import dev.ayuislands.ui.ComponentTreeRefreshedListener
+import dev.ayuislands.ui.ComponentTreeRefreshedTopic
 import java.awt.Component
 import java.beans.PropertyChangeListener
 import java.util.MissingResourceException
@@ -73,6 +75,16 @@ class ProjectViewScrollbarManager(
         SwingUtilities.invokeLater {
             if (!project.isDisposed) apply()
         }
+
+        // Self-heal after IJSwingUtilities.updateComponentTreeUI (startup, focus swap,
+        // LAF change) — the walk resets the ScrollPane's horizontal scrollbar policy
+        // and any rendering overrides we patch from apply().
+        project.messageBus
+            .connect(this)
+            .subscribe(
+                ComponentTreeRefreshedTopic.TOPIC,
+                ComponentTreeRefreshedListener { apply() },
+            )
     }
 
     fun apply() {

--- a/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
+++ b/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
@@ -5,7 +5,6 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.logger
-import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.util.CheckedDisposable
 import com.intellij.openapi.util.Condition
 import com.intellij.openapi.util.Disposer
@@ -13,12 +12,10 @@ import com.intellij.util.concurrency.AppExecutorUtil
 import dev.ayuislands.accent.AYU_ACCENT_PRESETS
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentColor
-import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
-import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 import org.jetbrains.annotations.TestOnly
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
@@ -183,15 +180,9 @@ class AccentRotationService : Disposable {
                         System.currentTimeMillis()
                     // Rotation updates the GLOBAL accent layer only. For the currently focused
                     // project we must apply the RESOLVED color so per-project and per-language
-                    // overrides keep winning during rotation ticks.
-                    val focusedProject =
-                        ProjectManager
-                            .getInstance()
-                            .openProjects
-                            .firstOrNull { !it.isDefault && !it.isDisposed }
-                    val resolvedHex = AccentResolver.resolve(focusedProject, variant)
-                    AccentApplicator.apply(resolvedHex)
-                    ProjectAccentSwapService.getInstance().notifyExternalApply(resolvedHex)
+                    // overrides keep winning during rotation ticks. applyForFocusedProject
+                    // centralizes focus selection + resolver + apply + swap-cache sync.
+                    val resolvedHex = AccentApplicator.applyForFocusedProject(variant)
                     LOG.info(
                         "Accent rotated: mode=$mode, global=${newHex.second}, applied=$resolvedHex",
                     )

--- a/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
+++ b/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
@@ -115,13 +115,18 @@ class AccentRotationService : Disposable {
     }
 
     fun stopRotation() {
-        scheduledFuture?.cancel(false)
-        scheduledFuture = null
-        // Reset the circuit-breaker budget whenever rotation is torn down — otherwise a user
-        // who saw one failure, toggled rotation off, then re-enabled it, would find the
-        // breaker tripping after a single failure instead of the documented MAX_CONSECUTIVE
-        // _FAILURES. Re-enables should start clean.
+        // Reset the circuit-breaker budget BEFORE cancelling the future so a throw from
+        // cancel (CancellationException on double-cancel, RejectedExecutionException during
+        // executor shutdown) cannot leave the counter stuck. Every teardown — user toggle,
+        // breaker trip, service dispose — must start re-enables with a full failure budget.
         consecutiveFailures = 0
+        val future = scheduledFuture
+        scheduledFuture = null
+        try {
+            future?.cancel(false)
+        } catch (exception: RuntimeException) {
+            LOG.warn("Failed to cancel scheduled rotation future", exception)
+        }
     }
 
     @TestOnly
@@ -252,8 +257,8 @@ class AccentRotationService : Disposable {
     private fun onRotationFailure(failure: RotationFailure) {
         val count = ++consecutiveFailures
         if (count < MAX_CONSECUTIVE_FAILURES) return
+        // stopRotation resets consecutiveFailures as part of teardown — no redundant assignment.
         stopRotation()
-        consecutiveFailures = 0
         val notification =
             NotificationGroupManager
                 .getInstance()

--- a/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
+++ b/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
@@ -116,10 +116,13 @@ class AccentRotationService : Disposable {
     }
 
     fun stopRotation() {
-        // Reset the circuit-breaker budget BEFORE cancelling the future so a throw from
-        // cancel (CancellationException on double-cancel, RejectedExecutionException during
-        // executor shutdown) cannot leave the counter stuck. Every teardown — user toggle,
-        // breaker trip, service dispose — must start re-enables with a full failure budget.
+        // Reset the circuit-breaker budget BEFORE cancelling the future. cancel() on a
+        // standard ScheduledFuture returns a boolean rather than throwing, but we wrap
+        // defensively in case a custom executor wrapper (e.g. AppExecutorUtil composition)
+        // ever adds throwing behavior. Reset-first ordering ensures the counter stays in
+        // sync even if a future JDK / platform change makes cancel() propagate — every
+        // teardown (user toggle, breaker trip, service dispose) must start re-enables
+        // with a full failure budget.
         consecutiveFailures = 0
         val future = scheduledFuture
         scheduledFuture = null
@@ -274,8 +277,7 @@ class AccentRotationService : Disposable {
     private fun onRotationFailure(failure: RotationFailure) {
         val count = ++consecutiveFailures
         if (count < MAX_CONSECUTIVE_FAILURES) return
-        // stopRotation resets consecutiveFailures as part of teardown — no redundant assignment.
-        stopRotation()
+        stopRotation() // resets consecutiveFailures as part of teardown
         val notification =
             NotificationGroupManager
                 .getInstance()

--- a/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
+++ b/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
@@ -116,13 +116,15 @@ class AccentRotationService : Disposable {
     }
 
     fun stopRotation() {
-        // Reset the circuit-breaker budget BEFORE cancelling the future. cancel() on a
-        // standard ScheduledFuture returns a boolean rather than throwing, but we wrap
-        // defensively: a custom executor wrapper (e.g. AppExecutorUtil composition) could
-        // surface CancellationException on double-cancel, or RejectedExecutionException if
-        // the underlying pool is mid-shutdown. Reset-first ordering ensures the counter
-        // stays in sync even if cancel() ends up propagating — every teardown (user toggle,
-        // breaker trip, service dispose) must start re-enables with a full failure budget.
+        // Reset the circuit-breaker budget BEFORE cancelling the future. The JDK's
+        // `ScheduledFuture.cancel(boolean)` contract returns a boolean rather than throwing,
+        // but we wrap the call in catch-RuntimeException defensively: `scheduledFuture` is
+        // obtained via `AppExecutorUtil.getAppScheduledExecutorService()`, a platform-wrapped
+        // composite executor. If a future platform change installs a lifecycle-tracking
+        // wrapper that throws (e.g. `IllegalStateException` from a disposed pool accessor),
+        // the reset-first ordering guarantees that the counter stays in sync — every teardown
+        // (user toggle, breaker trip, service dispose) must start re-enables with a full
+        // failure budget.
         consecutiveFailures = 0
         val future = scheduledFuture
         scheduledFuture = null

--- a/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
+++ b/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
@@ -118,11 +118,11 @@ class AccentRotationService : Disposable {
     fun stopRotation() {
         // Reset the circuit-breaker budget BEFORE cancelling the future. cancel() on a
         // standard ScheduledFuture returns a boolean rather than throwing, but we wrap
-        // defensively in case a custom executor wrapper (e.g. AppExecutorUtil composition)
-        // ever adds throwing behavior. Reset-first ordering ensures the counter stays in
-        // sync even if a future JDK / platform change makes cancel() propagate — every
-        // teardown (user toggle, breaker trip, service dispose) must start re-enables
-        // with a full failure budget.
+        // defensively: a custom executor wrapper (e.g. AppExecutorUtil composition) could
+        // surface CancellationException on double-cancel, or RejectedExecutionException if
+        // the underlying pool is mid-shutdown. Reset-first ordering ensures the counter
+        // stays in sync even if cancel() ends up propagating — every teardown (user toggle,
+        // breaker trip, service dispose) must start re-enables with a full failure budget.
         consecutiveFailures = 0
         val future = scheduledFuture
         scheduledFuture = null

--- a/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
+++ b/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.util.CheckedDisposable
 import com.intellij.openapi.util.Condition
 import com.intellij.openapi.util.Disposer
@@ -12,10 +13,12 @@ import com.intellij.util.concurrency.AppExecutorUtil
 import dev.ayuislands.accent.AYU_ACCENT_PRESETS
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentColor
+import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 import org.jetbrains.annotations.TestOnly
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
@@ -178,10 +181,19 @@ class AccentRotationService : Disposable {
                     )
                     state.accentRotationLastSwitchMs =
                         System.currentTimeMillis()
-                    AccentApplicator.apply(newHex.second)
+                    // Rotation updates the GLOBAL accent layer only. For the currently focused
+                    // project we must apply the RESOLVED color so per-project and per-language
+                    // overrides keep winning during rotation ticks.
+                    val focusedProject =
+                        ProjectManager
+                            .getInstance()
+                            .openProjects
+                            .firstOrNull { !it.isDefault && !it.isDisposed }
+                    val resolvedHex = AccentResolver.resolve(focusedProject, variant)
+                    AccentApplicator.apply(resolvedHex)
+                    ProjectAccentSwapService.getInstance().notifyExternalApply(resolvedHex)
                     LOG.info(
-                        "Accent rotated: " +
-                            "mode=$mode, color=${newHex.second}",
+                        "Accent rotated: mode=$mode, global=${newHex.second}, applied=$resolvedHex",
                     )
                 } catch (exception: RuntimeException) {
                     LOG.error(

--- a/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
+++ b/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.util.CheckedDisposable
 import com.intellij.openapi.util.Condition
 import com.intellij.openapi.util.Disposer
@@ -228,13 +229,26 @@ class AccentRotationService : Disposable {
             LOG.info("Accent rotated: mode=$mode, global=${newHex.second}, applied=$resolvedHex")
             null
         } catch (exception: RuntimeException) {
+            // Include focused-project identity so post-mortems can tell which project's
+            // override (if any) the apply stage was wrestling with when it failed.
+            val focusedName =
+                runCatching { focusedProjectName() }.getOrDefault("<unknown>")
             LOG.error(
-                "Accent rotation stage=$stage failed (mode=$mode, color=${newHex.second})",
+                "Accent rotation stage=$stage failed (mode=$mode, color=${newHex.second}, " +
+                    "focusedProject=$focusedName)",
                 exception,
             )
             RotationFailure(stage = stage, exception = exception)
         }
     }
+
+    private fun focusedProjectName(): String =
+        ProjectManager
+            .getInstance()
+            .openProjects
+            .firstOrNull { !it.isDefault && !it.isDisposed }
+            ?.name
+            ?: "<none>"
 
     /**
      * Sync glow overlays with the new accent. Returns a [RotationFailure] so the circuit

--- a/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
+++ b/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
@@ -118,20 +118,25 @@ class AccentRotationService : Disposable {
     fun stopRotation() {
         // Reset the circuit-breaker budget BEFORE cancelling the future. The JDK's
         // `ScheduledFuture.cancel(boolean)` contract returns a boolean rather than throwing,
-        // but we wrap the call in catch-RuntimeException defensively: `scheduledFuture` is
-        // obtained via `AppExecutorUtil.getAppScheduledExecutorService()`, a platform-wrapped
-        // composite executor. If a future platform change installs a lifecycle-tracking
-        // wrapper that throws (e.g. `IllegalStateException` from a disposed pool accessor),
-        // the reset-first ordering guarantees that the counter stays in sync — every teardown
-        // (user toggle, breaker trip, service dispose) must start re-enables with a full
-        // failure budget.
+        // and `AppExecutorUtil.getAppScheduledExecutorService()` as of platformVersion 2025.1
+        // composes an executor whose wrapper does not throw either — so the catch below is
+        // cheap defensive insurance rather than a known failure path. Reset-first ordering
+        // guarantees that if the JDK / platform contract ever tightens (disposed-pool lookup
+        // throws, lifecycle-checking wrapper added), the counter stays in sync and every
+        // teardown (user toggle, breaker trip, service dispose) starts re-enables with a
+        // full failure budget. The warn message below names the JDK contract so triage sees
+        // signal value: if it ever fires, it's a regression worth investigating.
         consecutiveFailures = 0
         val future = scheduledFuture
         scheduledFuture = null
         try {
             future?.cancel(false)
         } catch (exception: RuntimeException) {
-            LOG.warn("Failed to cancel scheduled rotation future", exception)
+            LOG.warn(
+                "Failed to cancel scheduled rotation future " +
+                    "(unexpected — JDK's Future.cancel contract returns a boolean without throwing)",
+                exception,
+            )
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
+++ b/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
@@ -1,5 +1,7 @@
 package dev.ayuislands.rotation
 
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
@@ -46,6 +48,16 @@ class AccentRotationService : Disposable {
 
     @Volatile
     private var scheduledFuture: ScheduledFuture<*>? = null
+
+    /**
+     * Circuit-breaker counter. When a rotation tick fails, this increments; on
+     * [MAX_CONSECUTIVE_FAILURES] consecutive failures we stop the scheduler and notify the user.
+     * Reset to zero on every successful tick. This stops a broken rotation from hammering
+     * idea.log every hour indefinitely when the root cause is persistent (corrupted state,
+     * stuck UIManager, missing variant).
+     */
+    @Volatile
+    private var consecutiveFailures: Int = 0
 
     fun startRotation() {
         stopRotation()
@@ -167,40 +179,13 @@ class AccentRotationService : Disposable {
                 }
         app.invokeLater(
             {
-                try {
-                    if (mode == AccentRotationMode.PRESET) {
-                        state.accentRotationPresetIndex =
-                            newHex.first
-                    }
-                    settings.setAccentForVariant(
-                        variant,
-                        newHex.second,
-                    )
-                    state.accentRotationLastSwitchMs =
-                        System.currentTimeMillis()
-                    // Rotation updates the GLOBAL accent layer only. For the currently focused
-                    // project we must apply the RESOLVED color so per-project and per-language
-                    // overrides keep winning during rotation ticks. applyForFocusedProject
-                    // centralizes focus selection + resolver + apply + swap-cache sync.
-                    val resolvedHex = AccentApplicator.applyForFocusedProject(variant)
-                    LOG.info(
-                        "Accent rotated: mode=$mode, global=${newHex.second}, applied=$resolvedHex",
-                    )
-                } catch (exception: RuntimeException) {
-                    LOG.error(
-                        "Accent rotation failed: " +
-                            "mode=$mode, color=${newHex.second}",
-                        exception,
-                    )
-                }
+                val applyFailure = runApplyStage(mode, newHex, variant, state, settings)
+                val glowFailure = runGlowStage()
 
-                try {
-                    GlowOverlayManager.syncGlowForAllProjects()
-                } catch (exception: RuntimeException) {
-                    LOG.warn(
-                        "Glow sync after accent rotation failed",
-                        exception,
-                    )
+                if (applyFailure != null || glowFailure != null) {
+                    onRotationFailure(applyFailure ?: glowFailure!!)
+                } else {
+                    consecutiveFailures = 0
                 }
             },
             ModalityState.nonModal(),
@@ -208,12 +193,91 @@ class AccentRotationService : Disposable {
         )
     }
 
+    /**
+     * Commit the new preset index + global accent hex, then re-apply the resolver output for
+     * the focused project so overrides stay sticky. Returns a failure descriptor on exception.
+     */
+    private fun runApplyStage(
+        mode: AccentRotationMode,
+        newHex: Pair<Int, String>,
+        variant: AyuVariant,
+        state: dev.ayuislands.settings.AyuIslandsState,
+        settings: AyuIslandsSettings,
+    ): RotationFailure? =
+        try {
+            if (mode == AccentRotationMode.PRESET) {
+                state.accentRotationPresetIndex = newHex.first
+            }
+            settings.setAccentForVariant(variant, newHex.second)
+            state.accentRotationLastSwitchMs = System.currentTimeMillis()
+            // Rotation updates the GLOBAL accent layer only. For the currently focused project we
+            // must apply the RESOLVED color so per-project and per-language overrides keep winning
+            // during rotation ticks.
+            val resolvedHex = AccentApplicator.applyForFocusedProject(variant)
+            LOG.info("Accent rotated: mode=$mode, global=${newHex.second}, applied=$resolvedHex")
+            null
+        } catch (exception: RuntimeException) {
+            LOG.error(
+                "Accent rotation stage=apply failed (mode=$mode, color=${newHex.second})",
+                exception,
+            )
+            RotationFailure(stage = "apply", exception = exception)
+        }
+
+    /** Sync glow overlays with the new accent. Separate stage so apply failures don't mask it. */
+    private fun runGlowStage(): RotationFailure? =
+        try {
+            GlowOverlayManager.syncGlowForAllProjects()
+            null
+        } catch (exception: RuntimeException) {
+            LOG.error("Accent rotation stage=glow-sync failed", exception)
+            RotationFailure(stage = "glow-sync", exception = exception)
+        }
+
+    /**
+     * Track the failure. Once [MAX_CONSECUTIVE_FAILURES] is reached, stop the scheduler and
+     * surface a notification so the user discovers the problem instead of silently losing the
+     * rotation feature. The user can re-enable it from Settings > Accent > Rotation after
+     * investigating.
+     */
+    private fun onRotationFailure(failure: RotationFailure) {
+        val count = ++consecutiveFailures
+        if (count < MAX_CONSECUTIVE_FAILURES) return
+        stopRotation()
+        consecutiveFailures = 0
+        val notification =
+            NotificationGroupManager
+                .getInstance()
+                .getNotificationGroup(NOTIFICATION_GROUP_ID)
+                .createNotification(
+                    "Ayu Islands: accent rotation stopped",
+                    "Rotation failed $MAX_CONSECUTIVE_FAILURES times in a row (last stage: " +
+                        "${failure.stage}). Re-enable it from Settings > Accent > Rotation after " +
+                        "checking the logs.",
+                    NotificationType.WARNING,
+                )
+        notification.notify(null)
+    }
+
+    private data class RotationFailure(
+        val stage: String,
+        val exception: Throwable,
+    )
+
     override fun dispose() {
         stopRotation()
     }
 
     companion object {
         private val LOG = logger<AccentRotationService>()
+        private const val NOTIFICATION_GROUP_ID = "Ayu Islands"
+
+        /**
+         * Trip the circuit breaker and notify the user after three consecutive rotation
+         * failures. Lower threshold risks spurious notifications on transient hiccups;
+         * higher threshold means three+ hours of silent log spam before the user finds out.
+         */
+        private const val MAX_CONSECUTIVE_FAILURES = 3
 
         fun getInstance(): AccentRotationService =
             ApplicationManager

--- a/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
+++ b/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
@@ -117,6 +117,11 @@ class AccentRotationService : Disposable {
     fun stopRotation() {
         scheduledFuture?.cancel(false)
         scheduledFuture = null
+        // Reset the circuit-breaker budget whenever rotation is torn down — otherwise a user
+        // who saw one failure, toggled rotation off, then re-enabled it, would find the
+        // breaker tripping after a single failure instead of the documented MAX_CONSECUTIVE
+        // _FAILURES. Re-enables should start clean.
+        consecutiveFailures = 0
     }
 
     @TestOnly

--- a/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
+++ b/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
@@ -226,17 +226,21 @@ class AccentRotationService : Disposable {
                 "Accent rotation stage=apply failed (mode=$mode, color=${newHex.second})",
                 exception,
             )
-            RotationFailure(stage = "apply", exception = exception)
+            RotationFailure(stage = Stage.APPLY, exception = exception)
         }
 
-    /** Sync glow overlays with the new accent. Separate stage so apply failures don't mask it. */
+    /**
+     * Sync glow overlays with the new accent. Already ran in its own try/catch pre-refactor;
+     * what this commit series adds is feeding a shared circuit-breaker counter through the
+     * returned [RotationFailure].
+     */
     private fun runGlowStage(): RotationFailure? =
         try {
             GlowOverlayManager.syncGlowForAllProjects()
             null
         } catch (exception: RuntimeException) {
             LOG.error("Accent rotation stage=glow-sync failed", exception)
-            RotationFailure(stage = "glow-sync", exception = exception)
+            RotationFailure(stage = Stage.GLOW_SYNC, exception = exception)
         }
 
     /**
@@ -257,15 +261,27 @@ class AccentRotationService : Disposable {
                 .createNotification(
                     "Ayu Islands: accent rotation stopped",
                     "Rotation failed $MAX_CONSECUTIVE_FAILURES times in a row (last stage: " +
-                        "${failure.stage}). Re-enable it from Settings > Accent > Rotation after " +
-                        "checking the logs.",
+                        "${failure.stage.logLabel}). Re-enable it from Settings > Accent > " +
+                        "Rotation after checking the logs.",
                     NotificationType.WARNING,
                 )
         notification.notify(null)
     }
 
+    /**
+     * Pipeline stages the circuit breaker tracks. Previously stringly-typed (`"apply"` /
+     * `"glow-sync"`), which let a typo-prone caller silently write the wrong label into logs
+     * and notifications. Closed enum so the compiler catches label drift.
+     */
+    private enum class Stage(
+        val logLabel: String,
+    ) {
+        APPLY("apply"),
+        GLOW_SYNC("glow-sync"),
+    }
+
     private data class RotationFailure(
-        val stage: String,
+        val stage: Stage,
         val exception: Throwable,
     )
 
@@ -278,9 +294,10 @@ class AccentRotationService : Disposable {
         private const val NOTIFICATION_GROUP_ID = "Ayu Islands"
 
         /**
-         * Trip the circuit breaker and notify the user after three consecutive rotation
-         * failures. Lower threshold risks spurious notifications on transient hiccups;
-         * higher threshold means three+ hours of silent log spam before the user finds out.
+         * Trip the circuit breaker and notify the user after this many consecutive rotation
+         * failures. Lower threshold risks spurious notifications on transient hiccups; higher
+         * threshold lets the log spam accumulate across more rotation cycles before the user
+         * discovers rotation has been silently broken.
          */
         private const val MAX_CONSECUTIVE_FAILURES = 3
 

--- a/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
+++ b/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
@@ -213,8 +213,9 @@ class AccentRotationService : Disposable {
         variant: AyuVariant,
         state: dev.ayuislands.settings.AyuIslandsState,
         settings: AyuIslandsSettings,
-    ): RotationFailure? =
-        try {
+    ): RotationFailure? {
+        val stage = Stage.APPLY
+        return try {
             if (mode == AccentRotationMode.PRESET) {
                 state.accentRotationPresetIndex = newHex.first
             }
@@ -228,25 +229,27 @@ class AccentRotationService : Disposable {
             null
         } catch (exception: RuntimeException) {
             LOG.error(
-                "Accent rotation stage=apply failed (mode=$mode, color=${newHex.second})",
+                "Accent rotation stage=$stage failed (mode=$mode, color=${newHex.second})",
                 exception,
             )
-            RotationFailure(stage = Stage.APPLY, exception = exception)
+            RotationFailure(stage = stage, exception = exception)
         }
+    }
 
     /**
-     * Sync glow overlays with the new accent. Already ran in its own try/catch pre-refactor;
-     * what this commit series adds is feeding a shared circuit-breaker counter through the
-     * returned [RotationFailure].
+     * Sync glow overlays with the new accent. Returns a [RotationFailure] so the circuit
+     * breaker upstream can count glow-sync failures alongside apply failures.
      */
-    private fun runGlowStage(): RotationFailure? =
-        try {
+    private fun runGlowStage(): RotationFailure? {
+        val stage = Stage.GLOW_SYNC
+        return try {
             GlowOverlayManager.syncGlowForAllProjects()
             null
         } catch (exception: RuntimeException) {
-            LOG.error("Accent rotation stage=glow-sync failed", exception)
-            RotationFailure(stage = Stage.GLOW_SYNC, exception = exception)
+            LOG.error("Accent rotation stage=$stage failed", exception)
+            RotationFailure(stage = stage, exception = exception)
         }
+    }
 
     /**
      * Track the failure. Once [MAX_CONSECUTIVE_FAILURES] is reached, stop the scheduler and
@@ -266,8 +269,8 @@ class AccentRotationService : Disposable {
                 .createNotification(
                     "Ayu Islands: accent rotation stopped",
                     "Rotation failed $MAX_CONSECUTIVE_FAILURES times in a row (last stage: " +
-                        "${failure.stage.logLabel}). Re-enable it from Settings > Accent > " +
-                        "Rotation after checking the logs.",
+                        "${failure.stage}). Re-enable it from Settings > Accent > Rotation " +
+                        "after checking the logs.",
                     NotificationType.WARNING,
                 )
         notification.notify(null)
@@ -276,13 +279,19 @@ class AccentRotationService : Disposable {
     /**
      * Pipeline stages the circuit breaker tracks. Previously stringly-typed (`"apply"` /
      * `"glow-sync"`), which let a typo-prone caller silently write the wrong label into logs
-     * and notifications. Closed enum so the compiler catches label drift.
+     * and notifications. Closed enum so the compiler catches label drift; [toString] returns
+     * the wire-compatible label so both `idea.log` messages and user notifications reference
+     * the single authoritative source (`"$stage"`), eliminating the hardcoded-vs-enum drift
+     * risk between the two sites.
      */
     private enum class Stage(
-        val logLabel: String,
+        private val label: String,
     ) {
         APPLY("apply"),
         GLOW_SYNC("glow-sync"),
+        ;
+
+        override fun toString(): String = label
     }
 
     private data class RotationFailure(

--- a/src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
@@ -173,7 +173,11 @@ class AccentColorPanel(
         private val accent: AccentColor,
     ) : JComponent() {
         init {
-            preferredSize = Dimension(0, PANEL_HEIGHT)
+            // Explicit non-zero width: the outer cell uses AlignX.LEFT (not Align.FILL) so
+            // the panel stays at its natural preferred width regardless of Settings dialog
+            // expansion (e.g. when Overrides opens and its AutoSizingTable requests a wider
+            // viewport for full project paths). Width=0 would collapse the GridLayout.
+            preferredSize = Dimension(NATURAL_SWATCH_WIDTH, PANEL_HEIGHT)
             toolTipText = accent.name
             cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
             addMouseListener(
@@ -566,6 +570,14 @@ class AccentColorPanel(
 
     companion object {
         private const val PANEL_HEIGHT = 26
+
+        // Per-swatch preferred width. 110 gives each preset enough horizontal mass to read
+        // as a distinct color block (not a cramped pill) while keeping the panel's natural
+        // width under the "Overrides open → dialog widens" scenario — AlignX.LEFT on the
+        // outer cell pins total panel width to 120 (left col) + 6 (gap) + 4*110 + 3*2 = 572px
+        // regardless of Settings dialog size, so opening Overrides cannot stretch or compress
+        // the swatches.
+        private const val NATURAL_SWATCH_WIDTH = 110
         private const val PANEL_ARC = 8f
         private const val GRID_GAP = 2
         private const val LEFT_COLUMN_GAP = 4

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -1,5 +1,7 @@
 package dev.ayuislands.settings
 
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.ui.ColorPicker
 import com.intellij.ui.components.JBCheckBox
@@ -9,13 +11,17 @@ import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.dsl.builder.selected
 import dev.ayuislands.accent.AYU_ACCENT_PRESETS
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.accent.ProjectLanguageDetector
 import dev.ayuislands.accent.SystemAccentProvider
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.rotation.AccentRotationMode
 import dev.ayuislands.rotation.AccentRotationService
 import dev.ayuislands.rotation.ContrastAwareColorGenerator
+import dev.ayuislands.settings.mappings.OverridesGroupBuilder
 import java.awt.Color
+import javax.swing.JEditorPane
 
 /** Accent color section for the Ayu Islands settings panel. */
 class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
@@ -38,17 +44,36 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
     private var storedRotationInterval: Int = AyuIslandsState.DEFAULT_ROTATION_INTERVAL_HOURS
     private var rotationEnabledCheckbox: JBCheckBox? = null
 
+    private val overrides = OverridesGroupBuilder()
+    private var contextProject: Project? = null
+    private var currentlyActiveLabel: JEditorPane? = null
+
     override fun buildPanel(
         panel: Panel,
         variant: AyuVariant,
     ) {
         initializeState(variant)
+        contextProject =
+            ProjectManager
+                .getInstance()
+                .openProjects
+                .firstOrNull { !it.isDefault && !it.isDisposed }
         val colorPanel = createAccentColorPanel()
         applyInitialSelection(colorPanel, storedAccent)
         updateHeroGlow()
         panel.buildAccentColorGroup(colorPanel)
+        overrides.buildGroup(panel, contextProject)
         panel.buildAccentRotationGroup()
+
+        val externalAccentListener = onAccentChanged
+        onAccentChanged = { hex ->
+            externalAccentListener?.invoke(hex)
+            updateCurrentlyActiveLabel()
+        }
+        overrides.addPendingChangeListener { updateCurrentlyActiveLabel() }
+
         updatePanelEnabled()
+        updateCurrentlyActiveLabel()
     }
 
     private fun initializeState(variant: AyuVariant) {
@@ -169,8 +194,51 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
                 }
             }
             row { cell(colorPanel).resizableColumn().align(Align.FILL) }
+            row {
+                currentlyActiveLabel = comment("").component
+            }
         }
     }
+
+    private fun updateCurrentlyActiveLabel() {
+        val label = currentlyActiveLabel ?: return
+        val currentVariant = variant ?: return
+        val globalHex = resolvePendingGlobalHex(currentVariant)
+        val effectiveHex = overrides.resolvePending(contextProject, globalHex)
+        val displayHex = effectiveHex.ifBlank { globalHex }
+        val presetName =
+            AYU_ACCENT_PRESETS
+                .firstOrNull { it.hex.equals(displayHex, ignoreCase = true) }
+                ?.name
+                ?: "Custom"
+        val sourceText = describeActiveSource(overrides.sourcePending(contextProject))
+        label.text = "Currently active: $presetName ($sourceText)"
+    }
+
+    private fun resolvePendingGlobalHex(currentVariant: AyuVariant): String {
+        val settings = AyuIslandsSettings.getInstance()
+        if (pendingFollowSystem) {
+            val systemHex = SystemAccentProvider.resolve()
+            if (systemHex != null) return systemHex
+        }
+        if (pendingAccent.isNotEmpty()) return pendingAccent
+        return settings.getAccentForVariant(currentVariant)
+    }
+
+    private fun describeActiveSource(source: AccentResolver.Source): String =
+        when (source) {
+            AccentResolver.Source.PROJECT_OVERRIDE ->
+                "project override for \"${contextProject?.name ?: "?"}\""
+            AccentResolver.Source.LANGUAGE_OVERRIDE -> {
+                val dominant =
+                    contextProject
+                        ?.let { ProjectLanguageDetector.dominant(it) }
+                        ?.replaceFirstChar { it.uppercase() }
+                        ?: "?"
+                "language override: $dominant"
+            }
+            AccentResolver.Source.GLOBAL -> "global"
+        }
 
     private fun Panel.buildAccentRotationGroup() {
         group("Accent Rotation") {
@@ -353,6 +421,7 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
         if (pendingRotationEnabled != storedRotationEnabled) return true
         if (pendingRotationMode != storedRotationMode) return true
         if (pendingRotationInterval != storedRotationInterval) return true
+        if (overrides.isModified()) return true
         if (pendingFollowSystem) return false
         return pendingAccent != storedAccent
     }
@@ -361,6 +430,7 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
         val currentVariant = variant ?: return
         if (!isModified()) return
         val settings = AyuIslandsSettings.getInstance()
+        val overridesDirty = overrides.isModified()
 
         if (pendingFollowSystem != storedFollowSystem) {
             settings.state.followSystemAccent = pendingFollowSystem
@@ -442,6 +512,11 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
                 service.stopRotation()
             }
         }
+
+        if (overridesDirty) {
+            overrides.apply()
+        }
+        updateCurrentlyActiveLabel()
     }
 
     override fun reset() {
@@ -453,8 +528,10 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
         pendingRotationInterval = storedRotationInterval
         rotationEnabledCheckbox?.isSelected = storedRotationEnabled
         accentPanel?.let { applyInitialSelection(it, storedAccent) }
+        overrides.reset()
         updateHeroGlow()
         updatePanelEnabled()
+        updateCurrentlyActiveLabel()
     }
 
     private fun updateHeroGlow() {

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -602,20 +602,22 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
      * Route accent apply through [AccentApplicator.applyForFocusedProject] so a stored
      * per-project/per-language override wins over the freshly-stored global accent.
      *
-     * Three independent failure modes, each with its own recovery path:
+     * Each stage has its own recovery path so the Settings panel never escalates a
+     * corrupted hex into a generic "Can't save" dialog:
      *
-     *  1. `applyForFocusedProject` throws — typically a corrupted stored override hex
-     *     (hand-edited XML, legacy writer) blowing up `Color.decode` inside UIManager fill.
-     *     Fall back to applying [effectiveAccent] (the unresolved global) directly AND sync
-     *     the swap-cache so the next WINDOW_ACTIVATED doesn't redundantly re-apply — this
-     *     is the same invariant `applyForFocusedProject` itself maintains.
-     *  2. The global-fallback `apply` also throws — the global hex itself is malformed.
-     *     Log the secondary failure and leave the visible accent unchanged; the Settings
-     *     panel stays operational instead of escalating into a generic "Can't save" dialog.
-     *  3. The global-fallback `apply` succeeded but `notifyExternalApply` throws — the
-     *     visible accent DID change, only the focus-swap cache is stale. Log at WARN (not
-     *     ERROR) to distinguish from the harder "apply also failed" path, and return;
-     *     the next WINDOW_ACTIVATED will redundantly re-apply without user-visible impact.
+     *  - Preferred path: `applyForFocusedProject` resolves the override chain and applies
+     *    the winning color. Typical failure mode is a corrupted stored override hex
+     *    (hand-edited XML, legacy writer) blowing up `Color.decode` inside UIManager fill.
+     *    On throw, we log at ERROR and fall through to the global-fallback block below.
+     *  - Global-fallback `apply`: re-applies [effectiveAccent] (the unresolved global hex)
+     *    directly. On throw, the global hex itself is malformed — log at ERROR and return;
+     *    the visible accent stays unchanged and the Settings panel remains operational.
+     *  - Global-fallback `notifyExternalApply`: syncs the focus-swap cache so the next
+     *    WINDOW_ACTIVATED doesn't redundantly re-apply — the same invariant
+     *    `applyForFocusedProject` itself maintains internally. On throw after the global
+     *    apply succeeded, the visible accent DID change and only the cache is stale; log
+     *    at WARN (not ERROR) to distinguish from the "apply also failed" path. The next
+     *    WINDOW_ACTIVATED will redundantly re-apply without user-visible impact.
      *
      * Visibility: `internal` (instead of `private`) so unit tests can exercise the
      * failure-recovery contract directly, without going through the BoundConfigurable
@@ -638,11 +640,11 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
             )
         }
 
-        // Two discrete failure modes; keep the logs honest:
-        //  - apply() throws → visible accent unchanged, log "also failed"
-        //  - notifyExternalApply() throws after apply() succeeded → visible accent DID
-        //    change, only the swap cache is stale; log that specifically so triage
-        //    doesn't get "also failed" on a path where apply actually worked.
+        // Keep the logs honest across the two remaining stages: a thrown `apply` leaves the
+        // visible accent unchanged (logged as "also failed"), whereas a thrown
+        // `notifyExternalApply` after a successful `apply` means the accent DID change and
+        // only the swap cache is stale. Log them separately so triage doesn't get an "also
+        // failed" breadcrumb on a path where apply actually worked.
         try {
             AccentApplicator.apply(effectiveAccent)
         } catch (exception: RuntimeException) {

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -49,6 +49,14 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
     private var contextProject: Project? = null
     private var currentlyActiveLabel: JEditorPane? = null
 
+    /**
+     * Hook called between the Accent Color group and the Overrides group during [buildPanel].
+     * The configurable uses it to inject [AyuIslandsAppearancePanel]'s "System" collapsible
+     * group so the visual order is Accent Color → System → Overrides → Rotation while each
+     * panel keeps ownership of its own state.
+     */
+    var beforeOverridesInjection: ((Panel) -> Unit)? = null
+
     override fun buildPanel(
         panel: Panel,
         variant: AyuVariant,
@@ -63,6 +71,7 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
         applyInitialSelection(colorPanel, storedAccent)
         updateHeroGlow()
         panel.buildAccentColorGroup(colorPanel)
+        beforeOverridesInjection?.invoke(panel)
         overrides.buildGroup(panel, contextProject)
         panel.buildAccentRotationGroup()
 
@@ -157,47 +166,55 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
             row {
                 comment("Choose your accent color. Swatches are shared across all variants.")
             }
-            if (SystemInfo.isMac) {
-                row {
-                    val checkbox =
-                        checkBox("Follow system accent color")
-                            .component
-                    checkbox.isSelected = pendingFollowSystem
-                    checkbox.addActionListener {
-                        pendingFollowSystem = checkbox.isSelected
-                        updatePanelEnabled()
-                        if (pendingFollowSystem && pendingRotationEnabled) {
-                            pendingRotationEnabled = false
-                            rotationEnabledCheckbox?.isSelected = false
-                        }
-                        if (pendingFollowSystem) {
-                            SystemAccentProvider.resolve()?.let { hex ->
-                                applyInitialSelection(colorPanel, hex)
-                                onAccentChanged?.invoke(hex)
-                            }
-                        } else {
-                            val settings =
-                                AyuIslandsSettings.getInstance()
-                            val manualAccent =
-                                getManualAccent(
-                                    variant ?: return@addActionListener,
-                                    settings,
-                                )
-                            pendingAccent = manualAccent
-                            applyInitialSelection(
-                                colorPanel,
-                                manualAccent,
-                            )
-                            onAccentChanged?.invoke(manualAccent)
-                        }
-                    }
-                    followSystemCheckbox = checkbox
-                }
-            }
             row { cell(colorPanel).resizableColumn().align(Align.FILL) }
             row {
                 currentlyActiveLabel = comment("").component
             }
+        }
+    }
+
+    /**
+     * Renders the `Follow system accent color` checkbox and binds its state +
+     * side-effects. Called by [AyuIslandsAppearancePanel] from inside the macOS
+     * "System" collapsible group so both system-integration toggles sit together.
+     * The state and enable/disable swatch-panel logic remain here because they
+     * couple tightly with [pendingFollowSystem], the active color panel, and the
+     * rotation-exclusion invariant.
+     *
+     * Must only be invoked AFTER [buildPanel] has called [createAccentColorPanel]
+     * so [accentPanel] is non-null.
+     */
+    fun installSystemAccentCheckbox(panel: Panel) {
+        if (!SystemInfo.isMac) return
+        panel.row {
+            val checkbox = checkBox("Follow system accent color").component
+            checkbox.isSelected = pendingFollowSystem
+            checkbox.addActionListener {
+                pendingFollowSystem = checkbox.isSelected
+                updatePanelEnabled()
+                if (pendingFollowSystem && pendingRotationEnabled) {
+                    pendingRotationEnabled = false
+                    rotationEnabledCheckbox?.isSelected = false
+                }
+                val colorPanel = accentPanel ?: return@addActionListener
+                if (pendingFollowSystem) {
+                    SystemAccentProvider.resolve()?.let { hex ->
+                        applyInitialSelection(colorPanel, hex)
+                        onAccentChanged?.invoke(hex)
+                    }
+                } else {
+                    val settings = AyuIslandsSettings.getInstance()
+                    val manualAccent =
+                        getManualAccent(
+                            variant ?: return@addActionListener,
+                            settings,
+                        )
+                    pendingAccent = manualAccent
+                    applyInitialSelection(colorPanel, manualAccent)
+                    onAccentChanged?.invoke(manualAccent)
+                }
+            }
+            followSystemCheckbox = checkbox
         }
     }
 
@@ -259,15 +276,21 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
         }
 
     private fun Panel.buildAccentRotationGroup() {
-        group("Accent Rotation") {
-            row {
-                comment(
-                    "Automatically change your accent color on a schedule.",
-                )
+        val settings = AyuIslandsSettings.getInstance()
+        val collapsible =
+            collapsibleGroup("Accent Rotation") {
+                row {
+                    comment(
+                        "Automatically change your accent color on a schedule.",
+                    )
+                }
+                val rotationCheckboxCell = buildRotationEnableRow()
+                buildRotationModeRow(rotationCheckboxCell)
+                buildRotationIntervalRow(rotationCheckboxCell)
             }
-            val rotationCheckboxCell = buildRotationEnableRow()
-            buildRotationModeRow(rotationCheckboxCell)
-            buildRotationIntervalRow(rotationCheckboxCell)
+        collapsible.expanded = settings.state.accentRotationGroupExpanded
+        collapsible.addExpandedListener { expanded ->
+            settings.state.accentRotationGroupExpanded = expanded
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -5,7 +5,7 @@ import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.ui.ColorPicker
 import com.intellij.ui.components.JBCheckBox
-import com.intellij.ui.dsl.builder.Align
+import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.Cell
 import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.dsl.builder.selected
@@ -166,7 +166,11 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
             row {
                 comment("Choose your accent color. Swatches are shared across all variants.")
             }
-            row { cell(colorPanel).resizableColumn().align(Align.FILL) }
+            // AlignX.LEFT (not Align.FILL) so the panel uses its natural preferred width.
+            // PresetComponent.preferredSize gives each swatch a fixed width (~80px); without
+            // FILL, expanding the Settings dialog (e.g. opening Overrides with its wide
+            // AutoSizingTable viewport) cannot stretch the swatches horizontally.
+            row { cell(colorPanel).align(AlignX.LEFT) }
             row {
                 currentlyActiveLabel = comment("").component
             }

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -612,8 +612,13 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
      *  2. The global-fallback apply also throws — the global hex itself is malformed. Log
      *     the secondary failure and leave the visible accent unchanged; the Settings panel
      *     stays operational instead of escalating into a generic "Can't save" dialog.
+     *
+     * Visibility: `internal` (instead of `private`) so unit tests can verify the
+     * failure-recovery contract directly without instantiating the Swing-heavy panel
+     * scaffolding. `@TestOnly` keeps the seam visible only to test consumers.
      */
-    private fun applyWithFallback(
+    @org.jetbrains.annotations.TestOnly
+    internal fun applyWithFallback(
         currentVariant: AyuVariant,
         effectiveAccent: String,
     ) {

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -600,10 +600,18 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
 
     /**
      * Route accent apply through [AccentApplicator.applyForFocusedProject] so a stored
-     * per-project/per-language override wins over the freshly-stored global accent. A
-     * corrupted stored override hex (hand-edited XML, legacy writer) would otherwise surface
-     * as a Settings "Can't save" dialog with no diagnostic — the catch logs the cause and
-     * falls back to the global [effectiveAccent] so the panel stays usable.
+     * per-project/per-language override wins over the freshly-stored global accent.
+     *
+     * Two independent failure modes, each with its own fallback:
+     *
+     *  1. `applyForFocusedProject` throws — typically a corrupted stored override hex
+     *     (hand-edited XML, legacy writer) blowing up `Color.decode` inside UIManager fill.
+     *     Fall back to applying [effectiveAccent] (the unresolved global) directly AND sync
+     *     the swap-cache so the next WINDOW_ACTIVATED doesn't redundantly re-apply — this
+     *     is the same invariant `applyForFocusedProject` itself maintains.
+     *  2. The global-fallback apply also throws — the global hex itself is malformed. Log
+     *     the secondary failure and leave the visible accent unchanged; the Settings panel
+     *     stays operational instead of escalating into a generic "Can't save" dialog.
      */
     private fun applyWithFallback(
         currentVariant: AyuVariant,
@@ -611,12 +619,24 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
     ) {
         try {
             AccentApplicator.applyForFocusedProject(currentVariant)
+            return
         } catch (exception: RuntimeException) {
             LOG.error(
-                "Failed to apply resolved accent for focused project; falling back to global",
+                "Failed to apply resolved accent for focused project " +
+                    "(variant=$currentVariant, fallbackHex=$effectiveAccent); falling back to global",
                 exception,
             )
+        }
+
+        try {
             AccentApplicator.apply(effectiveAccent)
+            ProjectAccentSwapService.getInstance().notifyExternalApply(effectiveAccent)
+        } catch (exception: RuntimeException) {
+            LOG.error(
+                "Global accent fallback also failed (variant=$currentVariant, hex=$effectiveAccent); " +
+                    "Settings panel leaving visible accent unchanged",
+                exception,
+            )
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -613,9 +613,10 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
      *     the secondary failure and leave the visible accent unchanged; the Settings panel
      *     stays operational instead of escalating into a generic "Can't save" dialog.
      *
-     * Visibility: `internal` (instead of `private`) so unit tests can verify the
-     * failure-recovery contract directly without instantiating the Swing-heavy panel
-     * scaffolding. `@TestOnly` keeps the seam visible only to test consumers.
+     * Visibility: `internal` (instead of `private`) so unit tests can exercise the
+     * failure-recovery contract directly, without going through the BoundConfigurable
+     * lifecycle (createPanel() → apply() → platform dispatch). `@TestOnly` keeps the
+     * seam visible only to test consumers via the IDE inspection.
      */
     @org.jetbrains.annotations.TestOnly
     internal fun applyWithFallback(
@@ -633,13 +634,28 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
             )
         }
 
+        // Two discrete failure modes; keep the logs honest:
+        //  - apply() throws → visible accent unchanged, log "also failed"
+        //  - notifyExternalApply() throws after apply() succeeded → visible accent DID
+        //    change, only the swap cache is stale; log that specifically so triage
+        //    doesn't get "also failed" on a path where apply actually worked.
         try {
             AccentApplicator.apply(effectiveAccent)
-            ProjectAccentSwapService.getInstance().notifyExternalApply(effectiveAccent)
         } catch (exception: RuntimeException) {
             LOG.error(
                 "Global accent fallback also failed (variant=$currentVariant, hex=$effectiveAccent); " +
                     "Settings panel leaving visible accent unchanged",
+                exception,
+            )
+            return
+        }
+        try {
+            ProjectAccentSwapService.getInstance().notifyExternalApply(effectiveAccent)
+        } catch (exception: RuntimeException) {
+            LOG.warn(
+                "Global accent applied but swap-cache sync failed " +
+                    "(variant=$currentVariant, hex=$effectiveAccent); " +
+                    "next WINDOW_ACTIVATED will redundantly re-apply",
                 exception,
             )
         }

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -494,7 +494,11 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
             settings.setAccentForVariant(currentVariant, "")
             AccentApplicator.revertAll()
         } else {
-            AccentApplicator.apply(effectiveAccent)
+            // Route through applyForFocusedProject so a per-project/per-language override on the
+            // currently focused project wins over the freshly-stored global accent. Applying
+            // effectiveAccent directly would overwrite the override until the next focus swap or
+            // LAF change — breaking the "per-project override is sticky" invariant.
+            AccentApplicator.applyForFocusedProject(currentVariant)
         }
         storedAccent = effectiveAccent
 

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -602,16 +602,20 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
      * Route accent apply through [AccentApplicator.applyForFocusedProject] so a stored
      * per-project/per-language override wins over the freshly-stored global accent.
      *
-     * Two independent failure modes, each with its own fallback:
+     * Three independent failure modes, each with its own recovery path:
      *
      *  1. `applyForFocusedProject` throws — typically a corrupted stored override hex
      *     (hand-edited XML, legacy writer) blowing up `Color.decode` inside UIManager fill.
      *     Fall back to applying [effectiveAccent] (the unresolved global) directly AND sync
      *     the swap-cache so the next WINDOW_ACTIVATED doesn't redundantly re-apply — this
      *     is the same invariant `applyForFocusedProject` itself maintains.
-     *  2. The global-fallback apply also throws — the global hex itself is malformed. Log
-     *     the secondary failure and leave the visible accent unchanged; the Settings panel
-     *     stays operational instead of escalating into a generic "Can't save" dialog.
+     *  2. The global-fallback `apply` also throws — the global hex itself is malformed.
+     *     Log the secondary failure and leave the visible accent unchanged; the Settings
+     *     panel stays operational instead of escalating into a generic "Can't save" dialog.
+     *  3. The global-fallback `apply` succeeded but `notifyExternalApply` throws — the
+     *     visible accent DID change, only the focus-swap cache is stale. Log at WARN (not
+     *     ERROR) to distinguish from the harder "apply also failed" path, and return;
+     *     the next WINDOW_ACTIVATED will redundantly re-apply without user-visible impact.
      *
      * Visibility: `internal` (instead of `private`) so unit tests can exercise the
      * failure-recovery contract directly, without going through the BoundConfigurable

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -20,6 +20,7 @@ import dev.ayuislands.rotation.AccentRotationMode
 import dev.ayuislands.rotation.AccentRotationService
 import dev.ayuislands.rotation.ContrastAwareColorGenerator
 import dev.ayuislands.settings.mappings.OverridesGroupBuilder
+import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 import java.awt.Color
 import javax.swing.JEditorPane
 
@@ -213,6 +214,23 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
                 ?: "Custom"
         val sourceText = describeActiveSource(overrides.sourcePending(contextProject))
         label.text = "Currently active: $presetName ($sourceText)"
+    }
+
+    /**
+     * Rotation paths persist the new global accent, then must apply the **resolved** color
+     * so per-project and per-language overrides keep winning during the rotation tick.
+     * Also syncs the focus-swap service cache so the next WINDOW_ACTIVATED comparison
+     * lines up with what's actually on screen.
+     */
+    private fun applyRotationRespectingOverrides(currentVariant: AyuVariant) {
+        val focusedProject =
+            ProjectManager
+                .getInstance()
+                .openProjects
+                .firstOrNull { !it.isDefault && !it.isDisposed }
+        val resolvedHex = AccentResolver.resolve(focusedProject, currentVariant)
+        AccentApplicator.apply(resolvedHex)
+        ProjectAccentSwapService.getInstance().notifyExternalApply(resolvedHex)
     }
 
     private fun resolvePendingGlobalHex(currentVariant: AyuVariant): String {
@@ -477,7 +495,7 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
                             )
                         settings.setAccentForVariant(currentVariant, rotationHex)
                         settings.state.accentRotationLastSwitchMs = System.currentTimeMillis()
-                        AccentApplicator.apply(rotationHex)
+                        applyRotationRespectingOverrides(currentVariant)
                         storedAccent = rotationHex
                         pendingAccent = rotationHex
                         accentPanel?.selectedPreset = null
@@ -495,7 +513,7 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
                         val presetHex = AYU_ACCENT_PRESETS[nextIndex].hex
                         settings.setAccentForVariant(currentVariant, presetHex)
                         settings.state.accentRotationLastSwitchMs = System.currentTimeMillis()
-                        AccentApplicator.apply(presetHex)
+                        applyRotationRespectingOverrides(currentVariant)
                         storedAccent = presetHex
                         pendingAccent = presetHex
                         pendingCustomColor = null

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -1,5 +1,6 @@
 package dev.ayuislands.settings
 
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.util.SystemInfo
@@ -494,11 +495,7 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
             settings.setAccentForVariant(currentVariant, "")
             AccentApplicator.revertAll()
         } else {
-            // Route through applyForFocusedProject so a per-project/per-language override on the
-            // currently focused project wins over the freshly-stored global accent. Applying
-            // effectiveAccent directly would overwrite the override until the next focus swap or
-            // LAF change — breaking the "per-project override is sticky" invariant.
-            AccentApplicator.applyForFocusedProject(currentVariant)
+            applyWithFallback(currentVariant, effectiveAccent)
         }
         storedAccent = effectiveAccent
 
@@ -601,7 +598,30 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
         }
     }
 
+    /**
+     * Route accent apply through [AccentApplicator.applyForFocusedProject] so a stored
+     * per-project/per-language override wins over the freshly-stored global accent. A
+     * corrupted stored override hex (hand-edited XML, legacy writer) would otherwise surface
+     * as a Settings "Can't save" dialog with no diagnostic — the catch logs the cause and
+     * falls back to the global [effectiveAccent] so the panel stays usable.
+     */
+    private fun applyWithFallback(
+        currentVariant: AyuVariant,
+        effectiveAccent: String,
+    ) {
+        try {
+            AccentApplicator.applyForFocusedProject(currentVariant)
+        } catch (exception: RuntimeException) {
+            LOG.error(
+                "Failed to apply resolved accent for focused project; falling back to global",
+                exception,
+            )
+            AccentApplicator.apply(effectiveAccent)
+        }
+    }
+
     companion object {
+        private val LOG = logger<AyuIslandsAccentPanel>()
         private const val INTERVAL_1H = 1
         private const val INTERVAL_3H = 3
         private const val INTERVAL_6H = 6

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAppearancePanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAppearancePanel.kt
@@ -9,7 +9,20 @@ import dev.ayuislands.AppearanceSyncService
 import dev.ayuislands.accent.AyuVariant
 import javax.swing.JComboBox
 
-/** System appearance section — visible on macOS only. */
+/**
+ * Typealias for injecting a row (e.g. the `Follow system accent color` checkbox owned
+ * by [AyuIslandsAccentPanel]) into the shared `System` collapsible group rendered by
+ * this panel. The configurable sets the bridge before `buildPanel` runs.
+ */
+typealias SystemAccentRowInstaller = (Panel) -> Unit
+
+/**
+ * Hosts the shared macOS "System" collapsible group — appearance (Light/Dark) and
+ * accent-color system integration. The accent-color checkbox is owned by
+ * [AyuIslandsAccentPanel]; [systemAccentRowInstaller] is wired by the configurable
+ * so the checkbox renders inside this group while its state and side-effects stay
+ * with the accent panel.
+ */
 class AyuIslandsAppearancePanel : AyuIslandsSettingsPanel {
     private var pendingFollowAppearance: Boolean = false
     private var storedFollowAppearance: Boolean = false
@@ -18,6 +31,8 @@ class AyuIslandsAppearancePanel : AyuIslandsSettingsPanel {
     private var pendingNightTheme: String = "Mirage"
     private var storedNightTheme: String = "Mirage"
     private var nightThemeCombo: JComboBox<String>? = null
+
+    var systemAccentRowInstaller: SystemAccentRowInstaller? = null
 
     override fun buildPanel(
         panel: Panel,
@@ -34,29 +49,39 @@ class AyuIslandsAppearancePanel : AyuIslandsSettingsPanel {
 
         if (!SystemInfo.isMac) return
 
-        panel.group("System") {
-            row { comment("Automatically switch between Light and Dark variants.") }
-            lateinit var checkboxCell: Cell<JBCheckBox>
-            row {
-                checkboxCell =
-                    checkBox("Follow system appearance (Light / Dark)")
-                val checkbox = checkboxCell.component
-                checkbox.isSelected = pendingFollowAppearance
-                checkbox.addActionListener {
-                    pendingFollowAppearance = checkbox.isSelected
+        val collapsible =
+            panel.collapsibleGroup("System") {
+                row { comment("Inherit appearance and accent color from macOS.") }
+                lateinit var checkboxCell: Cell<JBCheckBox>
+                row {
+                    checkboxCell =
+                        checkBox("Follow system appearance (Light / Dark)")
+                    val checkbox = checkboxCell.component
+                    checkbox.isSelected = pendingFollowAppearance
+                    checkbox.addActionListener {
+                        pendingFollowAppearance = checkbox.isSelected
+                    }
+                    followAppearanceCheckbox = checkbox
                 }
-                followAppearanceCheckbox = checkbox
+                row {
+                    label("Night theme:")
+                    val nightOptions = listOf("Mirage", "Dark")
+                    val combo = comboBox(nightOptions).component
+                    combo.selectedItem = currentNight
+                    combo.addActionListener {
+                        pendingNightTheme = combo.selectedItem as? String ?: "Mirage"
+                    }
+                    nightThemeCombo = combo
+                }.visibleIf(checkboxCell.selected)
+
+                // Accent-color system checkbox lives in AyuIslandsAccentPanel (owns the
+                // pendingFollowSystem state and swatch-panel disable logic). We inject
+                // its row here so the UI groups both macOS integrations together.
+                systemAccentRowInstaller?.invoke(this)
             }
-            row {
-                label("Night theme:")
-                val nightOptions = listOf("Mirage", "Dark")
-                val combo = comboBox(nightOptions).component
-                combo.selectedItem = currentNight
-                combo.addActionListener {
-                    pendingNightTheme = combo.selectedItem as? String ?: "Mirage"
-                }
-                nightThemeCombo = combo
-            }.visibleIf(checkboxCell.selected)
+        collapsible.expanded = settings.state.systemGroupExpanded
+        collapsible.addExpandedListener { expanded ->
+            settings.state.systemGroupExpanded = expanded
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt
@@ -80,10 +80,21 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
         // Wire accent color changes to the element preview
         accentPanel.onAccentChanged = { hex -> elementsPanel.updatePreviewAccent(hex) }
 
+        // Visual order: Accent Color → System → Overrides → Rotation → Elements.
+        // AccentPanel renders Accent Color → (inject) → Overrides → Rotation; the
+        // injection point hosts AppearancePanel's "System" collapsibleGroup so both
+        // macOS integrations (appearance + accent color) sit together between
+        // Accent Color and the Pro override sections.
+        accentPanel.beforeOverridesInjection = { injectionPanel ->
+            appearancePanel.buildPanel(injectionPanel, variant)
+        }
+        appearancePanel.systemAccentRowInstaller = { rowHostPanel ->
+            accentPanel.installSystemAccentCheckbox(rowHostPanel)
+        }
+
         // Build tab content panels eagerly via DSL
         val accentTab =
             panel {
-                appearancePanel.buildPanel(this@panel, variant)
                 accentPanel.buildPanel(this@panel, variant)
                 elementsPanel.buildPanel(this@panel, variant)
 

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsElementsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsElementsPanel.kt
@@ -1,6 +1,5 @@
 package dev.ayuislands.settings
 
-import com.intellij.openapi.project.ProjectManager
 import com.intellij.ui.dsl.builder.AlignY
 import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.dsl.builder.Row
@@ -8,7 +7,6 @@ import com.intellij.ui.dsl.builder.SegmentedButton
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.AccentGroup
-import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.conflict.ConflictRegistry
 import dev.ayuislands.accent.conflict.ConflictType
@@ -336,16 +334,11 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
         storedTabUnderlineGlowSync = pendingTabUnderlineGlowSync
         storedBracketScope = pendingBracketScope
 
-        // Re-apply accent with new toggle states — respect per-project/per-language overrides
-        // so this pass doesn't stomp the accent applied by AyuIslandsAccentPanel earlier in the cycle.
+        // Re-apply accent with new toggle states via applyForFocusedProject so per-project/
+        // per-language overrides aren't stomped by the accent applied by AyuIslandsAccentPanel
+        // earlier in the Configurable.apply cycle.
         val currentVariant = variant ?: return
-        val focusedProject =
-            ProjectManager
-                .getInstance()
-                .openProjects
-                .firstOrNull { !it.isDefault && !it.isDisposed }
-        val accentHex = AccentResolver.resolve(focusedProject, currentVariant)
-        AccentApplicator.apply(accentHex)
+        AccentApplicator.applyForFocusedProject(currentVariant)
     }
 
     override fun reset() {

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsElementsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsElementsPanel.kt
@@ -98,141 +98,146 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
         val previewComponent = preview.createComponent()
         elementPreview = preview
 
-        panel.group("Accent Elements") {
-            if (!licensed) {
-                row { comment("Per-element toggles require a Pro license.") }
-            }
-
-            row {
-                // Left: checkbox columns + enable/disable
-                panel {
-                    twoColumnsRow(
-                        // Visual group
-                        {
-                            panel {
-                                row { label("Visual").bold() }
-                                for (id in AccentElementId.entries.filter { it.group == AccentGroup.VISUAL }) {
-                                    buildToggleRow(this, id, licensed)
-                                }
-                            }
-                        },
-                        // Interactive group
-                        {
-                            panel {
-                                row { label("Interactive").bold() }
-                                for (
-                                id in
-                                AccentElementId.entries.filter { it.group == AccentGroup.INTERACTIVE }
-                                ) {
-                                    buildToggleRow(this, id, licensed)
-                                }
-                            }
-                        },
-                    )
-
-                    // Enable all / Disable all links
-                    row {
-                        link("Enable all") {
-                            AccentElementId.entries.forEach { pendingToggles[it] = true }
-                            refreshCheckboxes()
-                            syncPreviewToggles()
-                            onToggleChanged?.invoke()
-                        }.enabled(licensed)
-                        link("Disable all") {
-                            AccentElementId.entries.forEach { pendingToggles[it] = false }
-                            refreshCheckboxes()
-                            syncPreviewToggles()
-                            onToggleChanged?.invoke()
-                        }.enabled(licensed)
-                    }
+        val settings = AyuIslandsSettings.getInstance()
+        val collapsible =
+            panel.collapsibleGroup("Accent Elements") {
+                // ---- Subsection 1: Per-element toggles ----
+                row { label("Per-element toggles").bold() }
+                if (!licensed) {
+                    row { comment("Per-element toggles require a Pro license.") }
                 }
-
-                // Right: hover preview mockup
-                cell(previewComponent).align(AlignY.CENTER)
-            }
-        }
-
-        panel.group("Bracket Scope") {
-            row {
-                val scopeCb =
-                    checkBox("Highlight bracket scope on gutter")
-                        .comment("Show accent-colored scope stripe when caret is on a bracket")
-                scopeCb.component.isSelected = pendingBracketScope
-                scopeCb.component.isEnabled = licensed
-                scopeCb.component.addActionListener {
-                    pendingBracketScope = scopeCb.component.isSelected
-                }
-                bracketScopeCheckbox = scopeCb.component
-            }
-        }
-
-        buildActiveTabRow(panel)
-    }
-
-    private fun buildActiveTabRow(panel: Panel) {
-        val state = AyuIslandsSettings.getInstance().state
-        val glowEnabled = state.glowEnabled
-
-        val islandsUi = AyuVariant.isIslandsUi()
-
-        panel.group("Active Tab") {
-            // Tab accent style (Islands UI only)
-            tabModeCommentRow =
                 row {
-                    comment(
-                        "Minimal = underline only, Full = underline + tinted background, Off = neutral",
-                    )
-                }.visible(islandsUi)
-            tabModeRow =
-                row {
-                    label("Tab accent style")
-                    val segmented =
-                        segmentedButton(GlowTabMode.entries) { mode -> text = mode.displayName }
-                    segmented.selectedItem = GlowTabMode.fromName(pendingTabMode)
-                    segmented.enabled(licensed)
-                    @Suppress("UnstableApiUsage")
-                    segmented.whenItemSelected { mode ->
-                        pendingTabMode = mode.name
-                        updateThicknessRowVisibility()
-                    }
-                    tabModeSegmented = segmented
-                }.visible(islandsUi)
-
-            // Underline thickness presets (non-Islands only)
-            val tabModeIsOff = GlowTabMode.fromName(pendingTabMode) == GlowTabMode.OFF
-            thicknessRow =
-                row {
-                    label("Underline thickness")
-                    val thickSegmented =
-                        segmentedButton(UNDERLINE_THICKNESS_PRESETS) { value -> text = "${value}px" }
-                    thickSegmented.selectedItem = pendingTabUnderlineHeight
-                    thickSegmented.enabled(licensed && !pendingTabUnderlineGlowSync)
-                    @Suppress("UnstableApiUsage")
-                    thickSegmented.whenItemSelected { value -> pendingTabUnderlineHeight = value }
-                    thicknessSegmented = thickSegmented
-                }.visible(!tabModeIsOff && !islandsUi)
-
-            // Sync with the glow width checkbox (hidden on Islands UI)
-            syncRow =
-                row {
-                    val cb = checkBox("Sync with glow width")
-                    cb.component.isSelected = pendingTabUnderlineGlowSync
-                    cb.component.isEnabled = licensed && glowEnabled
-                    if (!glowEnabled) {
-                        cb.component.toolTipText = "Enable glow to sync"
-                    }
-                    cb.component.addActionListener {
-                        pendingTabUnderlineGlowSync = cb.component.isSelected
-                        updateThicknessEnabledState()
-                        if (pendingTabUnderlineGlowSync && glowEnabled) {
-                            val style = GlowStyle.fromName(state.glowStyle ?: GlowStyle.SOFT.name)
-                            val syncedWidth = state.getWidthForStyle(style)
-                            thicknessSegmented?.selectedItem = syncedWidth
+                    // Left: checkbox columns + enable/disable
+                    panel {
+                        twoColumnsRow(
+                            {
+                                panel {
+                                    row { label("Visual").bold() }
+                                    for (id in AccentElementId.entries.filter { it.group == AccentGroup.VISUAL }) {
+                                        buildToggleRow(this, id, licensed)
+                                    }
+                                }
+                            },
+                            {
+                                panel {
+                                    row { label("Interactive").bold() }
+                                    for (id in AccentElementId.entries.filter { it.group == AccentGroup.INTERACTIVE }) {
+                                        buildToggleRow(this, id, licensed)
+                                    }
+                                }
+                            },
+                        )
+                        row {
+                            link("Enable all") {
+                                AccentElementId.entries.forEach { pendingToggles[it] = true }
+                                refreshCheckboxes()
+                                syncPreviewToggles()
+                                onToggleChanged?.invoke()
+                            }.enabled(licensed)
+                            link("Disable all") {
+                                AccentElementId.entries.forEach { pendingToggles[it] = false }
+                                refreshCheckboxes()
+                                syncPreviewToggles()
+                                onToggleChanged?.invoke()
+                            }.enabled(licensed)
                         }
                     }
-                    syncCheckbox = cb.component
-                }.visible(!tabModeIsOff && !islandsUi)
+                    // Right: hover preview mockup
+                    cell(previewComponent).align(AlignY.CENTER)
+                }
+
+                // ---- Subsection 2: Tab underline ----
+                separator()
+                row { label("Tab underline").bold() }
+                buildActiveTabContent()
+
+                // ---- Subsection 3: Bracket scope ----
+                separator()
+                row { label("Bracket scope").bold() }
+                row {
+                    val scopeCb =
+                        checkBox("Highlight bracket scope on gutter")
+                            .comment("Show accent-colored scope stripe when caret is on a bracket")
+                    scopeCb.component.isSelected = pendingBracketScope
+                    scopeCb.component.isEnabled = licensed
+                    scopeCb.component.addActionListener {
+                        pendingBracketScope = scopeCb.component.isSelected
+                    }
+                    bracketScopeCheckbox = scopeCb.component
+                }
+            }
+        collapsible.expanded = settings.state.accentElementsGroupExpanded
+        collapsible.addExpandedListener { expanded ->
+            settings.state.accentElementsGroupExpanded = expanded
         }
+    }
+
+    /**
+     * Renders Tab-underline rows directly onto the receiver [Panel] — no group wrapper.
+     * Called from inside the parent `Accent Elements` collapsibleGroup where this content
+     * sits under the `Tab underline` subsection header.
+     */
+    private fun Panel.buildActiveTabContent() {
+        val state = AyuIslandsSettings.getInstance().state
+        val glowEnabled = state.glowEnabled
+        val islandsUi = AyuVariant.isIslandsUi()
+
+        // Tab accent style (Islands UI only)
+        tabModeCommentRow =
+            row {
+                comment(
+                    "Minimal = underline only, Full = underline + tinted background, Off = neutral",
+                )
+            }.visible(islandsUi)
+        tabModeRow =
+            row {
+                label("Tab accent style")
+                val segmented =
+                    segmentedButton(GlowTabMode.entries) { mode -> text = mode.displayName }
+                segmented.selectedItem = GlowTabMode.fromName(pendingTabMode)
+                segmented.enabled(licensed)
+                @Suppress("UnstableApiUsage")
+                segmented.whenItemSelected { mode ->
+                    pendingTabMode = mode.name
+                    updateThicknessRowVisibility()
+                }
+                tabModeSegmented = segmented
+            }.visible(islandsUi)
+
+        // Underline thickness presets (non-Islands only)
+        val tabModeIsOff = GlowTabMode.fromName(pendingTabMode) == GlowTabMode.OFF
+        thicknessRow =
+            row {
+                label("Underline thickness")
+                val thickSegmented =
+                    segmentedButton(UNDERLINE_THICKNESS_PRESETS) { value -> text = "${value}px" }
+                thickSegmented.selectedItem = pendingTabUnderlineHeight
+                thickSegmented.enabled(licensed && !pendingTabUnderlineGlowSync)
+                @Suppress("UnstableApiUsage")
+                thickSegmented.whenItemSelected { value -> pendingTabUnderlineHeight = value }
+                thicknessSegmented = thickSegmented
+            }.visible(!tabModeIsOff && !islandsUi)
+
+        // Sync with the glow width checkbox (hidden on Islands UI)
+        syncRow =
+            row {
+                val cb = checkBox("Sync with glow width")
+                cb.component.isSelected = pendingTabUnderlineGlowSync
+                cb.component.isEnabled = licensed && glowEnabled
+                if (!glowEnabled) {
+                    cb.component.toolTipText = "Enable glow to sync"
+                }
+                cb.component.addActionListener {
+                    pendingTabUnderlineGlowSync = cb.component.isSelected
+                    updateThicknessEnabledState()
+                    if (pendingTabUnderlineGlowSync && glowEnabled) {
+                        val style = GlowStyle.fromName(state.glowStyle ?: GlowStyle.SOFT.name)
+                        val syncedWidth = state.getWidthForStyle(style)
+                        thicknessSegmented?.selectedItem = syncedWidth
+                    }
+                }
+                syncCheckbox = cb.component
+            }.visible(!tabModeIsOff && !islandsUi)
     }
 
     private fun updateThicknessRowVisibility() {

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsElementsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsElementsPanel.kt
@@ -99,7 +99,7 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
         val settings = AyuIslandsSettings.getInstance()
         val collapsible =
             panel.collapsibleGroup("Accent Elements") {
-                // ---- Subsection 1: Per-element toggles ----
+                // Subsection 1: Per-element toggles
                 row { label("Per-element toggles").bold() }
                 if (!licensed) {
                     row { comment("Per-element toggles require a Pro license.") }
@@ -144,12 +144,12 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
                     cell(previewComponent).align(AlignY.CENTER)
                 }
 
-                // ---- Subsection 2: Tab underline ----
+                // Subsection 2: Tab underline
                 separator()
                 row { label("Tab underline").bold() }
                 buildActiveTabContent()
 
-                // ---- Subsection 3: Bracket scope ----
+                // Subsection 3: Bracket scope
                 separator()
                 row { label("Bracket scope").bold() }
                 row {

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsElementsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsElementsPanel.kt
@@ -1,5 +1,6 @@
 package dev.ayuislands.settings
 
+import com.intellij.openapi.project.ProjectManager
 import com.intellij.ui.dsl.builder.AlignY
 import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.dsl.builder.Row
@@ -7,6 +8,7 @@ import com.intellij.ui.dsl.builder.SegmentedButton
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.AccentGroup
+import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.conflict.ConflictRegistry
 import dev.ayuislands.accent.conflict.ConflictType
@@ -329,9 +331,15 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
         storedTabUnderlineGlowSync = pendingTabUnderlineGlowSync
         storedBracketScope = pendingBracketScope
 
-        // Re-apply accent with new toggle states
+        // Re-apply accent with new toggle states — respect per-project/per-language overrides
+        // so this pass doesn't stomp the accent applied by AyuIslandsAccentPanel earlier in the cycle.
         val currentVariant = variant ?: return
-        val accentHex = AyuIslandsSettings.getInstance().getAccentForVariant(currentVariant)
+        val focusedProject =
+            ProjectManager
+                .getInstance()
+                .openProjects
+                .firstOrNull { !it.isDefault && !it.isDisposed }
+        val accentHex = AccentResolver.resolve(focusedProject, currentVariant)
         AccentApplicator.apply(accentHex)
     }
 

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -203,6 +203,12 @@ class AyuIslandsState : BaseState() {
     var workspaceEditorExpanded by property(false)
     var workspaceGitPanelExpanded by property(false)
 
+    // Accent tab: collapsible group expanded states (persisted across settings opens)
+    var systemGroupExpanded by property(false)
+    var overridesGroupExpanded by property(false)
+    var accentRotationGroupExpanded by property(true)
+    var accentElementsGroupExpanded by property(false)
+
     // Force overrides for conflicting elements (element ID names)
     var forceOverrides by stringSet()
 

--- a/src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
@@ -1,10 +1,12 @@
 package dev.ayuislands.settings
 
 import com.intellij.openapi.observable.properties.AtomicBooleanProperty
+import com.intellij.openapi.project.ProjectManager
 import com.intellij.ui.dsl.builder.Align
 import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.dsl.builder.SegmentedButton
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.conflict.ConflictRegistry
 import dev.ayuislands.indent.IndentPreset
@@ -191,8 +193,15 @@ class PluginsPanel : AyuIslandsSettingsPanel {
         storedCgpIntegration = pendingCgpIntegration
         storedErrorHighlight = pendingErrorHighlight
 
+        // Route through AccentResolver so per-project/per-language overrides are preserved
+        // during the settings apply cycle (PluginsPanel runs after AccentPanel in Configurable.apply).
         val currentVariant = variant ?: return
-        val accentHex = AyuIslandsSettings.getInstance().getAccentForVariant(currentVariant)
+        val focusedProject =
+            ProjectManager
+                .getInstance()
+                .openProjects
+                .firstOrNull { !it.isDefault && !it.isDisposed }
+        val accentHex = AccentResolver.resolve(focusedProject, currentVariant)
         AccentApplicator.apply(accentHex)
     }
 

--- a/src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
@@ -1,12 +1,10 @@
 package dev.ayuislands.settings
 
 import com.intellij.openapi.observable.properties.AtomicBooleanProperty
-import com.intellij.openapi.project.ProjectManager
 import com.intellij.ui.dsl.builder.Align
 import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.dsl.builder.SegmentedButton
 import dev.ayuislands.accent.AccentApplicator
-import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.conflict.ConflictRegistry
 import dev.ayuislands.indent.IndentPreset
@@ -193,16 +191,11 @@ class PluginsPanel : AyuIslandsSettingsPanel {
         storedCgpIntegration = pendingCgpIntegration
         storedErrorHighlight = pendingErrorHighlight
 
-        // Route through AccentResolver so per-project/per-language overrides are preserved
-        // during the settings apply cycle (PluginsPanel runs after AccentPanel in Configurable.apply).
+        // Route through AccentApplicator.applyForFocusedProject so per-project/per-language
+        // overrides are preserved during the settings apply cycle (PluginsPanel runs after
+        // AccentPanel in Configurable.apply).
         val currentVariant = variant ?: return
-        val focusedProject =
-            ProjectManager
-                .getInstance()
-                .openProjects
-                .firstOrNull { !it.isDefault && !it.isDisposed }
-        val accentHex = AccentResolver.resolve(focusedProject, currentVariant)
-        AccentApplicator.apply(accentHex)
+        AccentApplicator.applyForFocusedProject(currentVariant)
     }
 
     override fun reset() {

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettings.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettings.kt
@@ -31,18 +31,25 @@ import com.intellij.openapi.diagnostic.logger
 class AccentMappingsSettings : SimplePersistentStateComponent<AccentMappingsState>(AccentMappingsState()) {
     override fun loadState(state: AccentMappingsState) {
         super.loadState(state)
-        migrateUserHomeMacro(state)
+        migrateUserHomeMacro(state.projectAccents, state.projectDisplayNames)
     }
 
     /**
      * Back-fill migration: earlier builds persisted paths under `$USER_HOME$/...` because
      * path-macro substitution defaulted to on. Rewrite any such keys in-place on load so
      * existing users keep their mappings after this fix ships.
+     *
+     * Takes maps as parameters (rather than an [AccentMappingsState]) so tests can substitute
+     * throwing maps to exercise the `runCatching` branches — `BaseState`-delegated map
+     * accessors are private and cannot be swapped on a real state instance.
      */
-    private fun migrateUserHomeMacro(state: AccentMappingsState) {
+    internal fun migrateUserHomeMacro(
+        projectAccents: MutableMap<String, String>,
+        projectDisplayNames: MutableMap<String, String>,
+    ) {
         val userHome = System.getProperty("user.home")?.takeIf { it.isNotBlank() }
         if (userHome == null) {
-            logBlankUserHomeIfLegacyKeysPresent(state)
+            logBlankUserHomeIfLegacyKeysPresent(projectAccents, projectDisplayNames)
             return
         }
 
@@ -58,33 +65,46 @@ class AccentMappingsSettings : SimplePersistentStateComponent<AccentMappingsStat
         // succeed do we swap them into place. rewriteKeys may legitimately return null when
         // a map has no macro-prefixed keys — that's different from exceptional failure, so
         // we distinguish Result.isFailure explicitly rather than collapsing via getOrNull.
-        val accentsResult = runCatching { rewriteKeys(state.projectAccents, userHome) }
-        val namesResult = runCatching { rewriteKeys(state.projectDisplayNames, userHome) }
+        val accentsResult = runCatching { rewriteKeys(projectAccents, userHome) }
+        val namesResult = runCatching { rewriteKeys(projectDisplayNames, userHome) }
         if (accentsResult.isFailure || namesResult.isFailure) {
-            // If both rewrites failed, link the second cause via addSuppressed so triage
-            // doesn't lose visibility on the second failure mode.
-            val primary = accentsResult.exceptionOrNull() ?: namesResult.exceptionOrNull()!!
-            if (accentsResult.isFailure && namesResult.isFailure) {
-                namesResult.exceptionOrNull()?.let { primary.addSuppressed(it) }
-            }
-            LOG.warn(
-                "Failed to migrate \$USER_HOME\$-prefixed accent-mapping keys; " +
-                    "will retry on next IDE restart",
-                primary,
-            )
+            warnMigrationFailed(accentsResult, namesResult)
             return
         }
 
         val rewrittenAccents = accentsResult.getOrNull()
         val rewrittenNames = namesResult.getOrNull()
         if (rewrittenAccents != null) {
-            state.projectAccents.clear()
-            state.projectAccents.putAll(rewrittenAccents)
+            projectAccents.clear()
+            projectAccents.putAll(rewrittenAccents)
         }
         if (rewrittenNames != null) {
-            state.projectDisplayNames.clear()
-            state.projectDisplayNames.putAll(rewrittenNames)
+            projectDisplayNames.clear()
+            projectDisplayNames.putAll(rewrittenNames)
         }
+    }
+
+    /**
+     * Emits a single WARN for a rewrite failure. When BOTH rewrites throw, the second cause
+     * is linked to the primary via [Throwable.addSuppressed] so triage sees both failure
+     * modes instead of losing the secondary to the `?:` collapse. Caller guarantees at least
+     * one of the two results has failed.
+     */
+    private fun warnMigrationFailed(
+        accentsResult: Result<Map<String, String>?>,
+        namesResult: Result<Map<String, String>?>,
+    ) {
+        val accentsCause = accentsResult.exceptionOrNull()
+        val namesCause = namesResult.exceptionOrNull()
+        val primary = accentsCause ?: namesCause!!
+        if (accentsCause != null && namesCause != null) {
+            primary.addSuppressed(namesCause)
+        }
+        LOG.warn(
+            "Failed to migrate \$USER_HOME\$-prefixed accent-mapping keys; " +
+                "will retry on next IDE restart",
+            primary,
+        )
     }
 
     /**
@@ -95,11 +115,14 @@ class AccentMappingsSettings : SimplePersistentStateComponent<AccentMappingsStat
      * The probe itself is in runCatching because a CME reading `.keys` during startup
      * deserialization must not propagate out of `loadState` and fail settings loading.
      */
-    private fun logBlankUserHomeIfLegacyKeysPresent(state: AccentMappingsState) {
+    private fun logBlankUserHomeIfLegacyKeysPresent(
+        projectAccents: Map<String, String>,
+        projectDisplayNames: Map<String, String>,
+    ) {
         val hasLegacyKeys =
             runCatching {
-                state.projectAccents.keys.any { it.startsWith(USER_HOME_MACRO) } ||
-                    state.projectDisplayNames.keys.any { it.startsWith(USER_HOME_MACRO) }
+                projectAccents.keys.any { it.startsWith(USER_HOME_MACRO) } ||
+                    projectDisplayNames.keys.any { it.startsWith(USER_HOME_MACRO) }
             }.getOrDefault(false)
         if (hasLegacyKeys) {
             LOG.warn(

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettings.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettings.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.components.SimplePersistentStateComponent
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import com.intellij.openapi.diagnostic.logger
+import org.jetbrains.annotations.TestOnly
 
 /**
  * Application-level persistent store for per-project and per-language accent overrides.
@@ -40,9 +41,18 @@ class AccentMappingsSettings : SimplePersistentStateComponent<AccentMappingsStat
      * existing users keep their mappings after this fix ships.
      *
      * Takes maps as parameters (rather than an [AccentMappingsState]) so tests can substitute
-     * throwing maps to exercise the `runCatching` branches — `BaseState`-delegated map
-     * accessors are private and cannot be swapped on a real state instance.
+     * throwing maps to exercise the `runCatching` branches. `BaseState`'s `map()` delegate
+     * does not expose backing-map substitution — `setValue` copies entries rather than
+     * swapping the reference — so there's no way to install a custom `MutableMap` subclass
+     * on a real state instance via its public property; the only alternative to a map-typed
+     * helper is reflection or a test-only subclass, both uglier.
+     *
+     * `@TestOnly` flags the test-seam intent in IDE inspections. The sole production caller
+     * is [loadState] above, which holds the keys-in-lockstep invariant between
+     * `projectAccents` / `projectDisplayNames`; future non-test callers should go through
+     * [loadState] instead of invoking this directly.
      */
+    @TestOnly
     internal fun migrateUserHomeMacro(
         projectAccents: MutableMap<String, String>,
         projectDisplayNames: MutableMap<String, String>,
@@ -68,7 +78,7 @@ class AccentMappingsSettings : SimplePersistentStateComponent<AccentMappingsStat
         val accentsResult = runCatching { rewriteKeys(projectAccents, userHome) }
         val namesResult = runCatching { rewriteKeys(projectDisplayNames, userHome) }
         if (accentsResult.isFailure || namesResult.isFailure) {
-            warnMigrationFailed(accentsResult, namesResult)
+            warnMigrationFailed(accentsResult.exceptionOrNull(), namesResult.exceptionOrNull())
             return
         }
 
@@ -85,18 +95,27 @@ class AccentMappingsSettings : SimplePersistentStateComponent<AccentMappingsStat
     }
 
     /**
-     * Emits a single WARN for a rewrite failure. When BOTH rewrites throw, the second cause
+     * Emits a single WARN for a rewrite failure. When BOTH rewrites threw, the second cause
      * is linked to the primary via [Throwable.addSuppressed] so triage sees both failure
-     * modes instead of losing the secondary to the `?:` collapse. Caller guarantees at least
-     * one of the two results has failed.
+     * modes instead of losing the secondary to the `?:` collapse. When neither cause is
+     * present (defensive — the call site's `isFailure` gate should prevent this) the helper
+     * logs a self-describing marker WARN instead of throwing, so a regression in the caller
+     * doesn't become an NPE inside the log path.
      */
     private fun warnMigrationFailed(
-        accentsResult: Result<Map<String, String>?>,
-        namesResult: Result<Map<String, String>?>,
+        accentsCause: Throwable?,
+        namesCause: Throwable?,
     ) {
-        val accentsCause = accentsResult.exceptionOrNull()
-        val namesCause = namesResult.exceptionOrNull()
-        val primary = accentsCause ?: namesCause!!
+        val primary =
+            accentsCause
+                ?: namesCause
+                ?: run {
+                    LOG.warn(
+                        "warnMigrationFailed invoked with two successful results; " +
+                            "call-site gate regressed — no cause to report",
+                    )
+                    return
+                }
         if (accentsCause != null && namesCause != null) {
             primary.addSuppressed(namesCause)
         }

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettings.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettings.kt
@@ -45,9 +45,16 @@ class AccentMappingsSettings : SimplePersistentStateComponent<AccentMappingsStat
             // Surface the failure so affected users can find a breadcrumb in idea.log. Silent no-op
             // means stored `$USER_HOME$/...` keys never match the absolute canonical path
             // AccentResolver hands to the map lookup — overrides become invisible with no trace.
+            //
+            // The key-existence probe is wrapped in runCatching because BaseState-backed maps are
+            // shared mutable and theoretically racy with concurrent writers during startup
+            // deserialization — a ConcurrentModificationException here would propagate out of
+            // loadState and fail settings loading entirely.
             val hasLegacyKeys =
-                state.projectAccents.keys.any { it.startsWith(USER_HOME_MACRO) } ||
-                    state.projectDisplayNames.keys.any { it.startsWith(USER_HOME_MACRO) }
+                runCatching {
+                    state.projectAccents.keys.any { it.startsWith(USER_HOME_MACRO) } ||
+                        state.projectDisplayNames.keys.any { it.startsWith(USER_HOME_MACRO) }
+                }.getOrDefault(false)
             if (hasLegacyKeys) {
                 LOG.warn(
                     "Cannot migrate legacy $USER_HOME_MACRO-prefixed accent-mapping keys: " +

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettings.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettings.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.SimplePersistentStateComponent
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
+import com.intellij.openapi.diagnostic.logger
 
 /**
  * Application-level persistent store for per-project and per-language accent overrides.
@@ -35,7 +36,24 @@ class AccentMappingsSettings : SimplePersistentStateComponent<AccentMappingsStat
      * existing users keep their mappings after this fix ships.
      */
     private fun migrateUserHomeMacro(state: AccentMappingsState) {
-        val userHome = System.getProperty("user.home")?.takeIf { it.isNotBlank() } ?: return
+        val userHome = System.getProperty("user.home")?.takeIf { it.isNotBlank() }
+        if (userHome == null) {
+            // Surface the failure so affected users can find a breadcrumb in idea.log. Silent no-op
+            // means stored `$USER_HOME$/...` keys never match the absolute canonical path
+            // AccentResolver hands to the map lookup — overrides become invisible with no trace.
+            val hasLegacyKeys =
+                state.projectAccents.keys.any { it.startsWith(USER_HOME_MACRO) } ||
+                    state.projectDisplayNames.keys.any { it.startsWith(USER_HOME_MACRO) }
+            if (hasLegacyKeys) {
+                LOG.warn(
+                    "Cannot migrate legacy \$USER_HOME\$-prefixed accent-mapping keys: " +
+                        "System.getProperty(\"user.home\") is unavailable. " +
+                        "Affected per-project overrides won't resolve until re-added under " +
+                        "Settings > Ayu Islands > Accent > Overrides.",
+                )
+            }
+            return
+        }
 
         val rewrittenAccents = rewriteKeys(state.projectAccents, userHome)
         if (rewrittenAccents != null) {
@@ -61,6 +79,7 @@ class AccentMappingsSettings : SimplePersistentStateComponent<AccentMappingsStat
     }
 
     companion object {
+        private val LOG = logger<AccentMappingsSettings>()
         private const val USER_HOME_MACRO = "\$USER_HOME\$"
 
         fun getInstance(): AccentMappingsSettings =

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettings.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettings.kt
@@ -1,0 +1,71 @@
+package dev.ayuislands.settings.mappings
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.SimplePersistentStateComponent
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+
+/**
+ * Application-level persistent store for per-project and per-language accent overrides.
+ *
+ * Lives in its own XML file (not [AyuIslandsState][dev.ayuislands.settings.AyuIslandsState])
+ * to keep the existing state file focused and to reduce blast radius if nested-map
+ * XML serialization surprises us.
+ *
+ * `usePathMacroManager = false`: project paths are stored verbatim (absolute canonical paths),
+ * not auto-substituted with `$USER_HOME$` macros. The platform expands macros for known path
+ * fields but NOT for arbitrary map keys, which would silently break [AccentResolver] lookups
+ * — an absolute `projectKey` would never match a macro-prefixed stored key.
+ */
+@Service
+@State(
+    name = "AyuIslandsAccentMappings",
+    storages = [Storage(value = "ayuIslandsAccentMappings.xml", usePathMacroManager = false)],
+)
+class AccentMappingsSettings : SimplePersistentStateComponent<AccentMappingsState>(AccentMappingsState()) {
+    override fun loadState(state: AccentMappingsState) {
+        super.loadState(state)
+        migrateUserHomeMacro(state)
+    }
+
+    /**
+     * Back-fill migration: earlier builds persisted paths under `$USER_HOME$/...` because
+     * path-macro substitution defaulted to on. Rewrite any such keys in-place on load so
+     * existing users keep their mappings after this fix ships.
+     */
+    private fun migrateUserHomeMacro(state: AccentMappingsState) {
+        val userHome = System.getProperty("user.home")?.takeIf { it.isNotBlank() } ?: return
+
+        val rewrittenAccents = rewriteKeys(state.projectAccents, userHome)
+        if (rewrittenAccents != null) {
+            state.projectAccents.clear()
+            state.projectAccents.putAll(rewrittenAccents)
+        }
+
+        val rewrittenNames = rewriteKeys(state.projectDisplayNames, userHome)
+        if (rewrittenNames != null) {
+            state.projectDisplayNames.clear()
+            state.projectDisplayNames.putAll(rewrittenNames)
+        }
+    }
+
+    private fun rewriteKeys(
+        source: Map<String, String>,
+        userHome: String,
+    ): Map<String, String>? {
+        if (source.none { it.key.startsWith(USER_HOME_MACRO) }) return null
+        return source.mapKeys { (key, _) ->
+            if (key.startsWith(USER_HOME_MACRO)) userHome + key.removePrefix(USER_HOME_MACRO) else key
+        }
+    }
+
+    companion object {
+        private const val USER_HOME_MACRO = "\$USER_HOME\$"
+
+        fun getInstance(): AccentMappingsSettings =
+            ApplicationManager
+                .getApplication()
+                .getService(AccentMappingsSettings::class.java)
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettings.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettings.kt
@@ -61,8 +61,16 @@ class AccentMappingsSettings : SimplePersistentStateComponent<AccentMappingsStat
         val accentsResult = runCatching { rewriteKeys(state.projectAccents, userHome) }
         val namesResult = runCatching { rewriteKeys(state.projectDisplayNames, userHome) }
         if (accentsResult.isFailure || namesResult.isFailure) {
-            warnMigrationFailed(
-                accentsResult.exceptionOrNull() ?: namesResult.exceptionOrNull()!!,
+            // If both rewrites failed, link the second cause via addSuppressed so triage
+            // doesn't lose visibility on the second failure mode.
+            val primary = accentsResult.exceptionOrNull() ?: namesResult.exceptionOrNull()!!
+            if (accentsResult.isFailure && namesResult.isFailure) {
+                namesResult.exceptionOrNull()?.let { primary.addSuppressed(it) }
+            }
+            LOG.warn(
+                "Failed to migrate \$USER_HOME\$-prefixed accent-mapping keys; " +
+                    "will retry on next IDE restart",
+                primary,
             )
             return
         }
@@ -77,14 +85,6 @@ class AccentMappingsSettings : SimplePersistentStateComponent<AccentMappingsStat
             state.projectDisplayNames.clear()
             state.projectDisplayNames.putAll(rewrittenNames)
         }
-    }
-
-    private fun warnMigrationFailed(exception: Throwable) {
-        LOG.warn(
-            "Failed to migrate \$USER_HOME\$-prefixed accent-mapping keys; " +
-                "will retry on next IDE restart",
-            exception,
-        )
     }
 
     /**

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettings.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettings.kt
@@ -6,7 +6,6 @@ import com.intellij.openapi.components.SimplePersistentStateComponent
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import com.intellij.openapi.diagnostic.logger
-import org.jetbrains.annotations.TestOnly
 
 /**
  * Application-level persistent store for per-project and per-language accent overrides.
@@ -47,12 +46,12 @@ class AccentMappingsSettings : SimplePersistentStateComponent<AccentMappingsStat
      * on a real state instance via its public property; the only alternative to a map-typed
      * helper is reflection or a test-only subclass, both uglier.
      *
-     * `@TestOnly` flags the test-seam intent in IDE inspections. The sole production caller
-     * is [loadState] above, which holds the keys-in-lockstep invariant between
+     * Not annotated `@TestOnly` — the production [loadState] calls this directly, which
+     * the inspection would flag. The KDoc test-seam intent stands, but the sole production
+     * caller is [loadState] above, which holds the keys-in-lockstep invariant between
      * `projectAccents` / `projectDisplayNames`; future non-test callers should go through
      * [loadState] instead of invoking this directly.
      */
-    @TestOnly
     internal fun migrateUserHomeMacro(
         projectAccents: MutableMap<String, String>,
         projectDisplayNames: MutableMap<String, String>,

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettings.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettings.kt
@@ -42,41 +42,58 @@ class AccentMappingsSettings : SimplePersistentStateComponent<AccentMappingsStat
     private fun migrateUserHomeMacro(state: AccentMappingsState) {
         val userHome = System.getProperty("user.home")?.takeIf { it.isNotBlank() }
         if (userHome == null) {
-            // Surface the failure so affected users can find a breadcrumb in idea.log. Silent no-op
-            // means stored `$USER_HOME$/...` keys never match the absolute canonical path
-            // AccentResolver hands to the map lookup — overrides become invisible with no trace.
-            //
-            // The key-existence probe is wrapped in runCatching because BaseState-backed maps are
-            // shared mutable and theoretically racy with concurrent writers during startup
-            // deserialization — a ConcurrentModificationException here would propagate out of
-            // loadState and fail settings loading entirely.
-            val hasLegacyKeys =
-                runCatching {
-                    state.projectAccents.keys.any { it.startsWith(USER_HOME_MACRO) } ||
-                        state.projectDisplayNames.keys.any { it.startsWith(USER_HOME_MACRO) }
-                }.getOrDefault(false)
-            if (hasLegacyKeys) {
-                LOG.warn(
-                    "Cannot migrate legacy $USER_HOME_MACRO-prefixed accent-mapping keys: " +
-                        "System.getProperty(\"user.home\") is unavailable. " +
-                        "Affected per-project overrides won't resolve until re-added under " +
-                        "Settings > Ayu Islands > Accent > Overrides.",
-                )
-            }
+            logBlankUserHomeIfLegacyKeysPresent(state)
             return
         }
 
-        val rewrittenAccents = rewriteKeys(state.projectAccents, userHome)
-        if (rewrittenAccents != null) {
-            state.projectAccents.clear()
-            state.projectAccents.putAll(rewrittenAccents)
+        // Wrap the productive rewrite path too. BaseState-backed maps are platform-shared and
+        // mutable; a theoretical concurrent write during startup deserialization would throw
+        // ConcurrentModificationException out of the iteration inside rewriteKeys, which
+        // would propagate out of loadState and fail settings loading entirely. Log-and-skip
+        // the migration — affected users re-attempt on next IDE restart.
+        runCatching {
+            rewriteMacroKeysInPlace(state.projectAccents, userHome)
+            rewriteMacroKeysInPlace(state.projectDisplayNames, userHome)
+        }.onFailure { exception ->
+            LOG.warn(
+                "Failed to migrate \$USER_HOME\$-prefixed accent-mapping keys; " +
+                    "will retry on next IDE restart",
+                exception,
+            )
         }
+    }
 
-        val rewrittenNames = rewriteKeys(state.projectDisplayNames, userHome)
-        if (rewrittenNames != null) {
-            state.projectDisplayNames.clear()
-            state.projectDisplayNames.putAll(rewrittenNames)
+    /**
+     * Surface blank-user.home to users so they can find a breadcrumb in idea.log. Silent no-op
+     * means stored `$USER_HOME$/...` keys never match the absolute canonical path
+     * AccentResolver hands to the map lookup — overrides become invisible with no trace.
+     *
+     * The probe itself is in runCatching because a CME reading `.keys` during startup
+     * deserialization must not propagate out of `loadState` and fail settings loading.
+     */
+    private fun logBlankUserHomeIfLegacyKeysPresent(state: AccentMappingsState) {
+        val hasLegacyKeys =
+            runCatching {
+                state.projectAccents.keys.any { it.startsWith(USER_HOME_MACRO) } ||
+                    state.projectDisplayNames.keys.any { it.startsWith(USER_HOME_MACRO) }
+            }.getOrDefault(false)
+        if (hasLegacyKeys) {
+            LOG.warn(
+                "Cannot migrate legacy $USER_HOME_MACRO-prefixed accent-mapping keys: " +
+                    "System.getProperty(\"user.home\") is unavailable. " +
+                    "Affected per-project overrides won't resolve until re-added under " +
+                    "Settings > Ayu Islands > Accent > Overrides.",
+            )
         }
+    }
+
+    private fun rewriteMacroKeysInPlace(
+        map: MutableMap<String, String>,
+        userHome: String,
+    ) {
+        val rewritten = rewriteKeys(map, userHome) ?: return
+        map.clear()
+        map.putAll(rewritten)
     }
 
     private fun rewriteKeys(

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettings.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettings.kt
@@ -49,18 +49,42 @@ class AccentMappingsSettings : SimplePersistentStateComponent<AccentMappingsStat
         // Wrap the productive rewrite path too. BaseState-backed maps are platform-shared and
         // mutable; a theoretical concurrent write during startup deserialization would throw
         // ConcurrentModificationException out of the iteration inside rewriteKeys, which
-        // would propagate out of loadState and fail settings loading entirely. Log-and-skip
-        // the migration — affected users re-attempt on next IDE restart.
-        runCatching {
-            rewriteMacroKeysInPlace(state.projectAccents, userHome)
-            rewriteMacroKeysInPlace(state.projectDisplayNames, userHome)
-        }.onFailure { exception ->
-            LOG.warn(
-                "Failed to migrate \$USER_HOME\$-prefixed accent-mapping keys; " +
-                    "will retry on next IDE restart",
-                exception,
+        // would propagate out of loadState and fail settings loading entirely.
+        //
+        // Compute BOTH rewrites before mutating EITHER map. rewriteKeys builds a new map and
+        // returns it without touching the source — so if the second computation throws, the
+        // first map is untouched and the state stays consistent (keys-in-lockstep invariant
+        // between projectAccents / projectDisplayNames preserved). Only after both rewrites
+        // succeed do we swap them into place. rewriteKeys may legitimately return null when
+        // a map has no macro-prefixed keys — that's different from exceptional failure, so
+        // we distinguish Result.isFailure explicitly rather than collapsing via getOrNull.
+        val accentsResult = runCatching { rewriteKeys(state.projectAccents, userHome) }
+        val namesResult = runCatching { rewriteKeys(state.projectDisplayNames, userHome) }
+        if (accentsResult.isFailure || namesResult.isFailure) {
+            warnMigrationFailed(
+                accentsResult.exceptionOrNull() ?: namesResult.exceptionOrNull()!!,
             )
+            return
         }
+
+        val rewrittenAccents = accentsResult.getOrNull()
+        val rewrittenNames = namesResult.getOrNull()
+        if (rewrittenAccents != null) {
+            state.projectAccents.clear()
+            state.projectAccents.putAll(rewrittenAccents)
+        }
+        if (rewrittenNames != null) {
+            state.projectDisplayNames.clear()
+            state.projectDisplayNames.putAll(rewrittenNames)
+        }
+    }
+
+    private fun warnMigrationFailed(exception: Throwable) {
+        LOG.warn(
+            "Failed to migrate \$USER_HOME\$-prefixed accent-mapping keys; " +
+                "will retry on next IDE restart",
+            exception,
+        )
     }
 
     /**
@@ -85,15 +109,6 @@ class AccentMappingsSettings : SimplePersistentStateComponent<AccentMappingsStat
                     "Settings > Ayu Islands > Accent > Overrides.",
             )
         }
-    }
-
-    private fun rewriteMacroKeysInPlace(
-        map: MutableMap<String, String>,
-        userHome: String,
-    ) {
-        val rewritten = rewriteKeys(map, userHome) ?: return
-        map.clear()
-        map.putAll(rewritten)
     }
 
     private fun rewriteKeys(

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettings.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettings.kt
@@ -101,7 +101,7 @@ class AccentMappingsSettings : SimplePersistentStateComponent<AccentMappingsStat
      * logs a self-describing marker WARN instead of throwing, so a regression in the caller
      * doesn't become an NPE inside the log path.
      */
-    private fun warnMigrationFailed(
+    internal fun warnMigrationFailed(
         accentsCause: Throwable?,
         namesCause: Throwable?,
     ) {

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettings.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettings.kt
@@ -46,11 +46,11 @@ class AccentMappingsSettings : SimplePersistentStateComponent<AccentMappingsStat
      * on a real state instance via its public property; the only alternative to a map-typed
      * helper is reflection or a test-only subclass, both uglier.
      *
-     * Not annotated `@TestOnly` — the production [loadState] calls this directly, which
-     * the inspection would flag. The KDoc test-seam intent stands, but the sole production
-     * caller is [loadState] above, which holds the keys-in-lockstep invariant between
-     * `projectAccents` / `projectDisplayNames`; future non-test callers should go through
-     * [loadState] instead of invoking this directly.
+     * Visibility is `internal` rather than `@TestOnly` because [loadState] is a production
+     * caller; `@TestOnly` would fire an inspection warning on the real call site. The sole
+     * production call site is [loadState] above, which holds the keys-in-lockstep invariant
+     * between `projectAccents` / `projectDisplayNames`. Future non-test callers should route
+     * through [loadState] to preserve that invariant rather than invoking this directly.
      */
     internal fun migrateUserHomeMacro(
         projectAccents: MutableMap<String, String>,

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettings.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettings.kt
@@ -16,9 +16,13 @@ import com.intellij.openapi.diagnostic.logger
  *
  * `usePathMacroManager = false`: project paths are stored verbatim (absolute canonical paths),
  * not auto-substituted with `$USER_HOME$` macros. The platform expands macros for known path
- * fields but NOT for arbitrary map keys, which would silently break [AccentResolver] lookups
- * — an absolute `projectKey` would never match a macro-prefixed stored key.
+ * fields but NOT for arbitrary map keys, which would silently break
+ * [dev.ayuislands.accent.AccentResolver] lookups — an absolute `projectKey` would never match
+ * a macro-prefixed stored key. The `usePathMacroManager` flag is `@ApiStatus.Internal` on
+ * [Storage], but it is the only documented way to opt out of macro substitution for arbitrary
+ * map keys — hence the `@Suppress("UnstableApiUsage")`.
  */
+@Suppress("UnstableApiUsage")
 @Service
 @State(
     name = "AyuIslandsAccentMappings",
@@ -46,7 +50,7 @@ class AccentMappingsSettings : SimplePersistentStateComponent<AccentMappingsStat
                     state.projectDisplayNames.keys.any { it.startsWith(USER_HOME_MACRO) }
             if (hasLegacyKeys) {
                 LOG.warn(
-                    "Cannot migrate legacy \$USER_HOME\$-prefixed accent-mapping keys: " +
+                    "Cannot migrate legacy $USER_HOME_MACRO-prefixed accent-mapping keys: " +
                         "System.getProperty(\"user.home\") is unavailable. " +
                         "Affected per-project overrides won't resolve until re-added under " +
                         "Settings > Ayu Islands > Accent > Overrides.",
@@ -80,7 +84,7 @@ class AccentMappingsSettings : SimplePersistentStateComponent<AccentMappingsStat
 
     companion object {
         private val LOG = logger<AccentMappingsSettings>()
-        private const val USER_HOME_MACRO = "\$USER_HOME\$"
+        private const val USER_HOME_MACRO = $$"$USER_HOME$"
 
         fun getInstance(): AccentMappingsSettings =
             ApplicationManager

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/AccentMappingsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/AccentMappingsState.kt
@@ -1,0 +1,16 @@
+package dev.ayuislands.settings.mappings
+
+import com.intellij.openapi.components.BaseState
+
+/**
+ * Persisted application-level accent overrides resolved in priority order:
+ * project (by canonical path) > language (by lowercase Language.id) > global.
+ *
+ * Display names are kept alongside project paths so orphaned rows (path no longer
+ * exists on disk) can still render meaningfully in the settings table.
+ */
+class AccentMappingsState : BaseState() {
+    var projectAccents by map<String, String>()
+    var languageAccents by map<String, String>()
+    var projectDisplayNames by map<String, String>()
+}

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/AccentSwatchPickerRow.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/AccentSwatchPickerRow.kt
@@ -1,0 +1,138 @@
+package dev.ayuislands.settings.mappings
+
+import com.intellij.ui.ColorPicker
+import com.intellij.ui.components.ActionLink
+import com.intellij.util.ui.JBUI
+import dev.ayuislands.accent.AYU_ACCENT_PRESETS
+import dev.ayuislands.accent.AccentColor
+import java.awt.Color
+import java.awt.Cursor
+import java.awt.Dimension
+import java.awt.FlowLayout
+import java.awt.Graphics
+import java.awt.Graphics2D
+import java.awt.RenderingHints
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import java.awt.geom.RoundRectangle2D
+import javax.swing.JComponent
+import javax.swing.JPanel
+import javax.swing.UIManager
+
+/**
+ * Compact horizontal strip of preset swatches + "Custom…" link, used inside
+ * the Add/Edit mapping dialogs. A heavier alternative to the full grid+shuffle
+ * [AccentColorPanel][dev.ayuislands.settings.AccentColorPanel] when the context
+ * is modal and there's no reason to offer shuffle or hero animations.
+ *
+ * [selectedHex] reflects the current selection (`null` when nothing chosen).
+ * Changing it from outside will repaint; user clicks mutate it and fire [onSelected].
+ */
+class AccentSwatchPickerRow(
+    private val onSelected: (String) -> Unit,
+) : JPanel(FlowLayout(FlowLayout.LEADING, GAP, 0)) {
+    var selectedHex: String? = null
+        set(value) {
+            field = value
+            repaint()
+        }
+
+    init {
+        isOpaque = false
+        for (preset in AYU_ACCENT_PRESETS) {
+            add(SwatchButton(preset))
+        }
+        val customLink =
+            ActionLink("Custom…") {
+                val chosen =
+                    ColorPicker.showDialog(
+                        topLevelAncestor ?: this,
+                        "Choose Accent Color",
+                        selectedHex?.let { RoundedSwatchRenderer.safeDecodeColor(it) },
+                        true,
+                        emptyList(),
+                        false,
+                    )
+                if (chosen != null) {
+                    val hex = "#%02X%02X%02X".format(chosen.red, chosen.green, chosen.blue)
+                    selectedHex = hex
+                    onSelected(hex)
+                }
+            }
+        customLink.border = JBUI.Borders.emptyLeft(GAP)
+        add(customLink)
+    }
+
+    private inner class SwatchButton(
+        private val preset: AccentColor,
+    ) : JComponent() {
+        init {
+            preferredSize = Dimension(SWATCH_SIZE + SELECTION_OUTLINE * 2, SWATCH_SIZE + SELECTION_OUTLINE * 2)
+            cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+            toolTipText = "${preset.name} (${preset.hex})"
+            addMouseListener(
+                object : MouseAdapter() {
+                    override fun mouseClicked(e: MouseEvent) {
+                        selectedHex = preset.hex
+                        onSelected(preset.hex)
+                    }
+                },
+            )
+        }
+
+        override fun paintComponent(g: Graphics) {
+            val graphics = g.create() as Graphics2D
+            try {
+                graphics.setRenderingHint(
+                    RenderingHints.KEY_ANTIALIASING,
+                    RenderingHints.VALUE_ANTIALIAS_ON,
+                )
+                val swatchX = SELECTION_OUTLINE.toFloat()
+                val swatchY = SELECTION_OUTLINE.toFloat()
+                val fill = RoundedSwatchRenderer.safeDecodeColor(preset.hex) ?: return
+                val shape =
+                    RoundRectangle2D.Float(
+                        swatchX,
+                        swatchY,
+                        SWATCH_SIZE.toFloat(),
+                        SWATCH_SIZE.toFloat(),
+                        SWATCH_ARC,
+                        SWATCH_ARC,
+                    )
+                graphics.color = fill
+                graphics.fill(shape)
+                val borderColor = UIManager.getColor("Separator.separatorColor") ?: Color(BORDER_RGB)
+                graphics.color = borderColor
+                graphics.draw(shape)
+
+                if (selectedHex?.equals(preset.hex, ignoreCase = true) == true) {
+                    graphics.color = UIManager.getColor("Focus.borderColor") ?: fill
+                    graphics.stroke = java.awt.BasicStroke(SELECTION_STROKE)
+                    graphics.draw(
+                        RoundRectangle2D.Float(
+                            SELECTION_BORDER_OFFSET,
+                            SELECTION_BORDER_OFFSET,
+                            (SWATCH_SIZE + SELECTION_OUTLINE * 2 - 1).toFloat(),
+                            (SWATCH_SIZE + SELECTION_OUTLINE * 2 - 1).toFloat(),
+                            SWATCH_ARC + SELECTION_ARC_EXTRA,
+                            SWATCH_ARC + SELECTION_ARC_EXTRA,
+                        ),
+                    )
+                }
+            } finally {
+                graphics.dispose()
+            }
+        }
+    }
+
+    companion object {
+        private const val SWATCH_SIZE = 18
+        private const val SWATCH_ARC = 5f
+        private const val SELECTION_OUTLINE = 3
+        private const val SELECTION_STROKE = 1.5f
+        private const val SELECTION_BORDER_OFFSET = 0.5f
+        private const val SELECTION_ARC_EXTRA = 2f
+        private const val GAP = 4
+        private const val BORDER_RGB = 0x4E5A6E
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/AddLanguageMappingDialog.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/AddLanguageMappingDialog.kt
@@ -1,0 +1,119 @@
+package dev.ayuislands.settings.mappings
+
+import com.intellij.lang.Language
+import com.intellij.openapi.fileTypes.FileTypeManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.ComboBox
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.openapi.ui.ValidationInfo
+import com.intellij.ui.dsl.builder.AlignX
+import com.intellij.ui.dsl.builder.TopGap
+import com.intellij.ui.dsl.builder.panel
+import java.awt.Component
+import javax.swing.DefaultComboBoxModel
+import javax.swing.DefaultListCellRenderer
+import javax.swing.JComponent
+import javax.swing.JList
+
+/** Option shown in the language combo box: a stable id plus its human-readable name. */
+internal data class LanguageOption(
+    val id: String,
+    val displayName: String,
+)
+
+/**
+ * Dialog for adding a language → accent mapping. The combo box lists every
+ * registered [Language] that has a [com.intellij.openapi.fileTypes.LanguageFileType]
+ * association, filtered to exclude Language.ANY and already-mapped ids.
+ */
+class AddLanguageMappingDialog(
+    parent: Project?,
+    excludedLanguageIds: Set<String>,
+    initialHex: String? = null,
+) : DialogWrapper(parent, true) {
+    private val comboBox: ComboBox<LanguageOption>
+    private val swatchPicker = AccentSwatchPickerRow { selected -> resultHex = selected }
+
+    var resultLanguageId: String? = null
+        private set
+    var resultDisplayName: String? = null
+        private set
+    var resultHex: String? = initialHex
+        private set
+
+    init {
+        title = "Add Language Override"
+        swatchPicker.selectedHex = initialHex
+
+        val options = loadLanguages(excludedLanguageIds)
+        comboBox =
+            ComboBox(DefaultComboBoxModel(options.toTypedArray())).apply {
+                renderer = LanguageRenderer()
+                isSwingPopup = false
+                if (options.isNotEmpty()) selectedIndex = 0
+            }
+
+        init()
+    }
+
+    override fun createCenterPanel(): JComponent =
+        panel {
+            row("Language:") {
+                cell(comboBox)
+                    .resizableColumn()
+                    .align(AlignX.FILL)
+            }
+            row("Color:") {
+                cell(swatchPicker)
+            }.topGap(TopGap.MEDIUM)
+            row {
+                comment("Applied when a project's dominant language matches and no project override exists.")
+            }
+        }
+
+    override fun doValidate(): ValidationInfo? {
+        if (comboBox.itemCount == 0) return ValidationInfo("No languages available to add.", comboBox)
+        if (comboBox.selectedItem !is LanguageOption) return ValidationInfo("Choose a language.", comboBox)
+        if (swatchPicker.selectedHex.isNullOrBlank()) return ValidationInfo("Choose an accent color.", swatchPicker)
+        return null
+    }
+
+    override fun doOKAction() {
+        val option = comboBox.selectedItem as? LanguageOption ?: return
+        resultLanguageId = option.id
+        resultDisplayName = option.displayName
+        resultHex = swatchPicker.selectedHex
+        super.doOKAction()
+    }
+
+    private fun loadLanguages(excluded: Set<String>): List<LanguageOption> {
+        val fileTypes = FileTypeManager.getInstance()
+        return Language
+            .getRegisteredLanguages()
+            .asSequence()
+            .filter { it !== Language.ANY }
+            .filter { it.displayName.isNotBlank() }
+            .filter { runCatching { fileTypes.findFileTypeByLanguage(it) }.getOrNull() != null }
+            .map { LanguageOption(it.id.lowercase(), it.displayName) }
+            .distinctBy { it.id }
+            .filter { option -> excluded.none { it.equals(option.id, ignoreCase = true) } }
+            .sortedBy { it.displayName.lowercase() }
+            .toList()
+    }
+
+    private class LanguageRenderer : DefaultListCellRenderer() {
+        override fun getListCellRendererComponent(
+            list: JList<*>?,
+            value: Any?,
+            index: Int,
+            isSelected: Boolean,
+            cellHasFocus: Boolean,
+        ): Component {
+            super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus)
+            if (value is LanguageOption) {
+                text = value.displayName
+            }
+            return this
+        }
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/AddProjectMappingDialog.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/AddProjectMappingDialog.kt
@@ -118,7 +118,15 @@ class AddProjectMappingDialog(
 
     override fun doOKAction() {
         val rawPath = pathField.text.trim()
-        val canonical = runCatching { File(rawPath).canonicalPath }.getOrNull() ?: return
+        // doValidate() already checks canonicalPath before the OK button enables, but a race
+        // (directory deleted between validate and click) would otherwise cause a silent early
+        // return — dialog appears frozen, user has no idea why OK stopped working. setErrorText
+        // surfaces the condition and keeps the dialog open so the user can retry or cancel.
+        val canonical =
+            runCatching { File(rawPath).canonicalPath }.getOrNull() ?: run {
+                setErrorText("Could not resolve path (directory may have been removed).", pathField)
+                return
+            }
         resultCanonicalPath = canonical
         resultDisplayName =
             recentList.selectedValue

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/AddProjectMappingDialog.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/AddProjectMappingDialog.kt
@@ -131,7 +131,10 @@ class AddProjectMappingDialog(
 
     private fun loadRecentProjects(excluded: Set<String>): List<RecentProjectRow> =
         runCatching {
-            val actions = RecentProjectListActionProvider.getInstance().getActions(false, false)
+            val actions =
+                RecentProjectListActionProvider
+                    .getInstance()
+                    .getActions(addClearListItem = false, useGroups = false)
             actions
                 .filterIsInstance<ReopenProjectAction>()
                 .mapNotNull { action ->

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/AddProjectMappingDialog.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/AddProjectMappingDialog.kt
@@ -1,0 +1,168 @@
+package dev.ayuislands.settings.mappings
+
+import com.intellij.ide.RecentProjectListActionProvider
+import com.intellij.ide.ReopenProjectAction
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.openapi.ui.TextFieldWithBrowseButton
+import com.intellij.openapi.ui.ValidationInfo
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBList
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.dsl.builder.AlignX
+import com.intellij.ui.dsl.builder.TopGap
+import com.intellij.ui.dsl.builder.panel
+import com.intellij.util.ui.JBUI
+import java.awt.Component
+import java.io.File
+import javax.swing.DefaultListCellRenderer
+import javax.swing.DefaultListModel
+import javax.swing.JComponent
+import javax.swing.JList
+import javax.swing.ListSelectionModel
+
+/** Row model used by the recent-projects list inside [AddProjectMappingDialog]. */
+internal data class RecentProjectRow(
+    val canonicalPath: String,
+    val displayName: String,
+)
+
+/**
+ * Dialog for adding a project → accent mapping. Offers a path field with a folder
+ * browser and (when available) a list of recent projects pre-filtered to paths
+ * not already mapped. A compact [AccentSwatchPickerRow] lets the user pick the color.
+ */
+class AddProjectMappingDialog(
+    parent: Project?,
+    private val excludedPaths: Set<String>,
+    initialHex: String? = null,
+) : DialogWrapper(parent, true) {
+    private val pathField = TextFieldWithBrowseButton()
+    private val recentList = JBList<RecentProjectRow>()
+    private val swatchPicker = AccentSwatchPickerRow { selected -> resultHex = selected }
+
+    var resultCanonicalPath: String? = null
+        private set
+    var resultDisplayName: String? = null
+        private set
+    var resultHex: String? = initialHex
+        private set
+
+    init {
+        title = "Add Project Override"
+        swatchPicker.selectedHex = initialHex
+
+        pathField.addBrowseFolderListener(
+            parent,
+            FileChooserDescriptorFactory.createSingleFolderDescriptor().withTitle("Select Project Folder"),
+        )
+
+        val recentModel = DefaultListModel<RecentProjectRow>()
+        for (row in loadRecentProjects(excludedPaths)) recentModel.addElement(row)
+        recentList.model = recentModel
+        recentList.selectionMode = ListSelectionModel.SINGLE_SELECTION
+        recentList.cellRenderer = RecentProjectRenderer()
+        recentList.addListSelectionListener { event ->
+            if (event.valueIsAdjusting) return@addListSelectionListener
+            recentList.selectedValue?.let { row -> pathField.text = row.canonicalPath }
+        }
+
+        init()
+    }
+
+    override fun createCenterPanel(): JComponent =
+        panel {
+            row("Path:") {
+                cell(pathField)
+                    .resizableColumn()
+                    .align(AlignX.FILL)
+            }
+            if (recentList.model.size > 0) {
+                row {
+                    cell(JBLabel("Or pick from recent projects:"))
+                }.topGap(TopGap.SMALL)
+                row {
+                    cell(JBScrollPane(recentList))
+                        .resizableColumn()
+                        .align(AlignX.FILL)
+                        .applyToComponent { preferredSize = JBUI.size(RECENT_LIST_WIDTH, RECENT_LIST_HEIGHT) }
+                }
+            }
+            row("Color:") {
+                cell(swatchPicker)
+            }.topGap(TopGap.MEDIUM)
+            row {
+                comment("Applied across all Ayu variants (Mirage, Dark, Light).")
+            }
+        }
+
+    override fun doValidate(): ValidationInfo? {
+        val rawPath = pathField.text.trim()
+        if (rawPath.isEmpty()) return ValidationInfo("Enter a project path.", pathField)
+        val file = File(rawPath)
+        if (!runCatching { file.isDirectory }.getOrDefault(false)) {
+            return ValidationInfo("Path is not an existing directory.", pathField)
+        }
+        val canonical =
+            runCatching { file.canonicalPath }.getOrNull()
+                ?: return ValidationInfo("Could not resolve path.", pathField)
+        if (excludedPaths.any { it.equals(canonical, ignoreCase = true) }) {
+            return ValidationInfo("This project already has an override.", pathField)
+        }
+        if (swatchPicker.selectedHex.isNullOrBlank()) {
+            return ValidationInfo("Choose an accent color.", swatchPicker)
+        }
+        return null
+    }
+
+    override fun doOKAction() {
+        val rawPath = pathField.text.trim()
+        val canonical = runCatching { File(rawPath).canonicalPath }.getOrNull() ?: return
+        resultCanonicalPath = canonical
+        resultDisplayName =
+            recentList.selectedValue
+                ?.takeIf { it.canonicalPath == canonical }
+                ?.displayName
+                ?: File(canonical).name
+        resultHex = swatchPicker.selectedHex
+        super.doOKAction()
+    }
+
+    private fun loadRecentProjects(excluded: Set<String>): List<RecentProjectRow> =
+        runCatching {
+            val actions = RecentProjectListActionProvider.getInstance().getActions(false, false)
+            actions
+                .filterIsInstance<ReopenProjectAction>()
+                .mapNotNull { action ->
+                    val canonical =
+                        runCatching { File(action.projectPath).canonicalPath }.getOrNull()
+                            ?: return@mapNotNull null
+                    if (excluded.any { it.equals(canonical, ignoreCase = true) }) return@mapNotNull null
+                    if (!runCatching { File(canonical).isDirectory }.getOrDefault(false)) return@mapNotNull null
+                    val name = action.projectName?.takeIf { it.isNotBlank() } ?: File(canonical).name
+                    RecentProjectRow(canonical, name)
+                }.distinctBy { it.canonicalPath }
+        }.getOrDefault(emptyList())
+
+    companion object {
+        private const val RECENT_LIST_WIDTH = 460
+        private const val RECENT_LIST_HEIGHT = 160
+    }
+
+    private class RecentProjectRenderer : DefaultListCellRenderer() {
+        override fun getListCellRendererComponent(
+            list: JList<*>?,
+            value: Any?,
+            index: Int,
+            isSelected: Boolean,
+            cellHasFocus: Boolean,
+        ): Component {
+            super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus)
+            if (value is RecentProjectRow) {
+                text = "${value.displayName}   —   ${value.canonicalPath}"
+            }
+            return this
+        }
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/EditAccentColorDialog.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/EditAccentColorDialog.kt
@@ -1,0 +1,124 @@
+package dev.ayuislands.settings.mappings
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.openapi.ui.ValidationInfo
+import com.intellij.ui.ColorPicker
+import com.intellij.ui.dsl.builder.Align
+import com.intellij.ui.dsl.builder.panel
+import com.intellij.util.ui.JBUI
+import dev.ayuislands.accent.AYU_ACCENT_PRESETS
+import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.rotation.ContrastAwareColorGenerator
+import dev.ayuislands.settings.AccentColorPanel
+import javax.swing.JComponent
+
+/**
+ * Modal color picker for the Overrides table "Edit color" action. Embeds the same
+ * [AccentColorPanel] used in the main Accent tab — shade-name label + Custom link +
+ * Shuffle link on the left, 4×3 preset grid + dynamic 13th swatch on the right — so
+ * users see the familiar layout and can orient immediately.
+ *
+ * Reuses [AccentColorPanel] verbatim. Shuffle is wired through [ContrastAwareColorGenerator]
+ * but scoped to this dialog — it does not pollute [AyuIslandsSettings.lastShuffleColor] the
+ * way the main panel does, because this modal edits a single override, not the global state.
+ */
+class EditAccentColorDialog(
+    parent: Project?,
+    private val initialHex: String,
+    private val mappingLabel: String,
+) : DialogWrapper(parent, true) {
+    var resultHex: String = initialHex
+        private set
+
+    private lateinit var colorPanel: AccentColorPanel
+
+    init {
+        title = "Edit Accent Color"
+        colorPanel =
+            AccentColorPanel(
+                presets = AYU_ACCENT_PRESETS,
+                onPresetSelected = { accent ->
+                    resultHex = accent.hex
+                    colorPanel.selectedPreset = accent.hex
+                    colorPanel.customColor = null
+                },
+                onCustomTrigger = { handleCustomTrigger() },
+                onReset = { /* Cancel button handles revert */ },
+                onShuffleTrigger = { handleShuffleTrigger() },
+                onThirteenthSwatchClicked = { hex ->
+                    resultHex = hex
+                    colorPanel.selectedPreset = null
+                    colorPanel.customColor = hex
+                },
+            )
+        // Without an explicit minimum the inner AccentColorPanel (BorderLayout + tiny
+        // PresetComponent naturals) collapses the grid into near-invisible dots when the
+        // modal renders. Pin a sensible floor that matches the main Settings panel's visual
+        // weight — the dialog can still grow if the user drags it, but never shrinks below.
+        colorPanel.preferredSize = JBUI.size(PANEL_MIN_WIDTH, PANEL_MIN_HEIGHT)
+        colorPanel.minimumSize = JBUI.size(PANEL_MIN_WIDTH, PANEL_MIN_HEIGHT)
+        applyInitialSelection()
+        init()
+    }
+
+    private fun applyInitialSelection() {
+        val preset = AYU_ACCENT_PRESETS.firstOrNull { it.hex.equals(initialHex, ignoreCase = true) }
+        if (preset != null) {
+            colorPanel.selectedPreset = preset.hex
+        } else {
+            colorPanel.customColor = initialHex
+            colorPanel.showThirteenthSwatchImmediate(initialHex)
+        }
+    }
+
+    private fun handleCustomTrigger() {
+        val chosen =
+            ColorPicker.showDialog(
+                colorPanel.topLevelAncestor ?: colorPanel,
+                "Choose Accent Color",
+                RoundedSwatchRenderer.safeDecodeColor(resultHex),
+                true,
+                emptyList(),
+                false,
+            ) ?: return
+        val hex = "#%02X%02X%02X".format(chosen.red, chosen.green, chosen.blue)
+        resultHex = hex
+        colorPanel.selectedPreset = null
+        colorPanel.customColor = hex
+        colorPanel.showThirteenthSwatchImmediate(hex)
+    }
+
+    private fun handleShuffleTrigger() {
+        val variant = AyuVariant.detect() ?: return
+        val randomHex = ContrastAwareColorGenerator.generate(variant)
+        resultHex = randomHex
+        colorPanel.selectedPreset = null
+        colorPanel.customColor = randomHex
+        colorPanel.showThirteenthSwatch(randomHex)
+    }
+
+    override fun createCenterPanel(): JComponent =
+        panel {
+            row {
+                comment("Editing accent for: $mappingLabel")
+            }
+            row {
+                cell(colorPanel)
+                    .resizableColumn()
+                    .align(Align.FILL)
+            }
+        }
+
+    override fun doValidate(): ValidationInfo? =
+        if (resultHex.isBlank()) {
+            ValidationInfo("Choose an accent color.")
+        } else {
+            null
+        }
+
+    companion object {
+        private const val PANEL_MIN_WIDTH = 460
+        private const val PANEL_MIN_HEIGHT = 130
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/LanguageMappingsTableModel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/LanguageMappingsTableModel.kt
@@ -9,8 +9,8 @@ import javax.swing.table.AbstractTableModel
  *
  * `languageId` is validated at construction to be non-blank and all-lowercase — the
  * KDoc convention that `AddLanguageMappingDialog` relies on now also holds at the
- * type level, so [containsLanguage] can use a plain case-sensitive `==` instead of
- * a defensive `ignoreCase = true` compensator.
+ * type level, so [LanguageMappingsTableModel.containsLanguage] can use a plain
+ * case-sensitive `==` instead of a defensive `ignoreCase = true` compensator.
  */
 data class LanguageMapping(
     val languageId: String,

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/LanguageMappingsTableModel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/LanguageMappingsTableModel.kt
@@ -1,0 +1,87 @@
+package dev.ayuislands.settings.mappings
+
+import javax.swing.table.AbstractTableModel
+
+/**
+ * Row for the Language Overrides table. [languageId] is the lowercase canonical id
+ * used as the map key (e.g. "kotlin", "python"). [displayName] is the human-readable
+ * label pulled from `Language.displayName` at add time and kept as-is in storage.
+ */
+class LanguageMapping(
+    val languageId: String,
+    var displayName: String,
+    var hex: String,
+)
+
+/**
+ * Table model for the Language Overrides section. Two columns: Color (hex),
+ * Language (display name). Matches the Project model shape for symmetric UI code.
+ */
+class LanguageMappingsTableModel : AbstractTableModel() {
+    private val rows: MutableList<LanguageMapping> = mutableListOf()
+
+    fun replaceAll(mappings: Collection<LanguageMapping>) {
+        rows.clear()
+        rows.addAll(mappings)
+        fireTableDataChanged()
+    }
+
+    fun snapshot(): List<LanguageMapping> = rows.toList()
+
+    fun add(mapping: LanguageMapping): Int {
+        rows += mapping
+        val index = rows.size - 1
+        fireTableRowsInserted(index, index)
+        return index
+    }
+
+    fun remove(row: Int) {
+        if (row !in rows.indices) return
+        rows.removeAt(row)
+        fireTableRowsDeleted(row, row)
+    }
+
+    fun updateHex(
+        row: Int,
+        hex: String,
+    ) {
+        if (row !in rows.indices) return
+        rows[row].hex = hex
+        fireTableRowsUpdated(row, row)
+    }
+
+    fun rowAt(index: Int): LanguageMapping? = rows.getOrNull(index)
+
+    fun containsLanguage(languageId: String): Boolean = rows.any { it.languageId.equals(languageId, ignoreCase = true) }
+
+    override fun getRowCount(): Int = rows.size
+
+    override fun getColumnCount(): Int = COLUMN_NAMES.size
+
+    override fun getColumnName(column: Int): String = COLUMN_NAMES.getOrElse(column) { "" }
+
+    override fun getColumnClass(columnIndex: Int): Class<*> = String::class.java
+
+    override fun isCellEditable(
+        rowIndex: Int,
+        columnIndex: Int,
+    ): Boolean = false
+
+    override fun getValueAt(
+        rowIndex: Int,
+        columnIndex: Int,
+    ): Any? {
+        val mapping = rowAt(rowIndex) ?: return null
+        return when (columnIndex) {
+            COLUMN_COLOR -> mapping.hex
+            COLUMN_LANGUAGE -> mapping.displayName
+            else -> null
+        }
+    }
+
+    companion object {
+        const val COLUMN_COLOR = 0
+        const val COLUMN_LANGUAGE = 1
+        private val COLUMN_NAMES = listOf("Color", "Language")
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/LanguageMappingsTableModel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/LanguageMappingsTableModel.kt
@@ -6,12 +6,29 @@ import javax.swing.table.AbstractTableModel
  * Row for the Language Overrides table. [languageId] is the lowercase canonical id
  * used as the map key (e.g. "kotlin", "python"). [displayName] is the human-readable
  * label pulled from `Language.displayName` at add time and kept as-is in storage.
+ *
+ * `languageId` is validated at construction to be non-blank and all-lowercase — the
+ * KDoc convention that `AddLanguageMappingDialog` relies on now also holds at the
+ * type level, so [containsLanguage] can use a plain case-sensitive `==` instead of
+ * a defensive `ignoreCase = true` compensator.
  */
-class LanguageMapping(
+data class LanguageMapping(
     val languageId: String,
-    var displayName: String,
-    var hex: String,
-)
+    val displayName: String,
+    val hex: String,
+) {
+    init {
+        require(languageId.isNotBlank()) { "languageId must not be blank" }
+        require(languageId == languageId.lowercase()) {
+            "languageId must be lowercase, got: '$languageId'"
+        }
+        require(HEX_REGEX.matches(hex)) { "hex must be #RRGGBB, got: '$hex'" }
+    }
+
+    companion object {
+        private val HEX_REGEX = Regex("^#[0-9A-Fa-f]{6}$")
+    }
+}
 
 /**
  * Table model for the Language Overrides section. Two columns: Color (hex),
@@ -46,13 +63,18 @@ class LanguageMappingsTableModel : AbstractTableModel() {
         hex: String,
     ) {
         if (row !in rows.indices) return
-        rows[row].hex = hex
+        rows[row] = rows[row].copy(hex = hex)
         fireTableRowsUpdated(row, row)
     }
 
     fun rowAt(index: Int): LanguageMapping? = rows.getOrNull(index)
 
-    fun containsLanguage(languageId: String): Boolean = rows.any { it.languageId.equals(languageId, ignoreCase = true) }
+    /**
+     * Case-sensitive match: [LanguageMapping.languageId] is guaranteed lowercase by its init
+     * block, and call sites (`AddLanguageMappingDialog.doOKAction`) lowercase the probe before
+     * calling this. No `ignoreCase = true` compensator needed.
+     */
+    fun containsLanguage(languageId: String): Boolean = rows.any { it.languageId == languageId }
 
     override fun getRowCount(): Int = rows.size
 

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -1,0 +1,500 @@
+package dev.ayuislands.settings.mappings
+
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.ui.ColorPicker
+import com.intellij.ui.ToolbarDecorator
+import com.intellij.ui.dsl.builder.Align
+import com.intellij.ui.dsl.builder.Panel
+import com.intellij.ui.table.JBTable
+import com.intellij.util.ui.JBUI
+import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentResolver
+import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.accent.ProjectLanguageDetector
+import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.settings.AyuIslandsSettings
+import java.awt.BorderLayout
+import java.awt.CardLayout
+import java.awt.Color
+import java.awt.Component
+import java.awt.FlowLayout
+import java.io.File
+import javax.swing.ButtonGroup
+import javax.swing.JComponent
+import javax.swing.JPanel
+import javax.swing.JRadioButton
+import javax.swing.ListSelectionModel
+import javax.swing.table.DefaultTableCellRenderer
+
+/**
+ * Builds the "Overrides" group inside the Accent settings tab. Hosts a segmented
+ * toggle between Projects and Languages, each backed by its own [JBTable] and
+ * [ToolbarDecorator] with add / pin-current / edit-color / remove actions.
+ *
+ * All mutations happen on an in-memory pending model; callers use [isModified],
+ * [apply], and [reset] to participate in the usual settings lifecycle. [addPendingChangeListener]
+ * lets observers (the reactive "Currently active: ..." comment) refresh on every edit.
+ */
+class OverridesGroupBuilder {
+    private val projectModel = ProjectMappingsTableModel()
+    private val languageModel = LanguageMappingsTableModel()
+    private val projectTable = JBTable(projectModel)
+    private val languageTable = JBTable(languageModel)
+
+    private var storedProjects: List<ProjectMapping> = emptyList()
+    private var storedLanguages: List<LanguageMapping> = emptyList()
+    private val listeners: MutableList<Runnable> = mutableListOf()
+
+    private val cardPanel = JPanel(CardLayout())
+    private var parentProject: Project? = null
+
+    init {
+        configureProjectTable()
+        configureLanguageTable()
+    }
+
+    fun buildGroup(
+        panel: Panel,
+        contextProject: Project?,
+    ) {
+        parentProject = contextProject
+        loadFromState()
+
+        val licensed = LicenseChecker.isLicensedOrGrace()
+
+        val segmentedBar = buildSegmentedBar()
+        cardPanel.add(decorateTable(projectTable, projectActions(licensed)), CARD_PROJECTS)
+        cardPanel.add(decorateTable(languageTable, languageActions(licensed)), CARD_LANGUAGES)
+        cardPanel.preferredSize = JBUI.size(CARD_WIDTH, CARD_HEIGHT)
+
+        panel.group("Overrides") {
+            row {
+                comment(
+                    "Pin an accent color to a specific project or a programming language. " +
+                        "Project overrides win over language overrides; both win over the global accent.",
+                )
+            }
+            row {
+                cell(segmentedBar)
+            }
+            row {
+                cell(cardPanel)
+                    .resizableColumn()
+                    .align(Align.FILL)
+            }
+            if (!licensed) {
+                row {
+                    comment("Pro feature")
+                }
+            }
+        }
+    }
+
+    // ---- Lifecycle integration ----
+
+    fun isModified(): Boolean {
+        val currentProjects = projectModel.snapshot().toFingerprint()
+        val storedProjectsFingerprint = storedProjects.toFingerprint()
+        if (currentProjects != storedProjectsFingerprint) return true
+
+        val currentLanguages = languageModel.snapshot().toLanguageFingerprint()
+        val storedLanguagesFingerprint = storedLanguages.toLanguageFingerprint()
+        return currentLanguages != storedLanguagesFingerprint
+    }
+
+    fun apply() {
+        val state = AccentMappingsSettingsAccess.stateFor()
+        state.projectAccents.clear()
+        state.projectDisplayNames.clear()
+        for (row in projectModel.snapshot()) {
+            state.projectAccents[row.canonicalPath] = row.hex
+            state.projectDisplayNames[row.canonicalPath] = row.displayName
+        }
+        state.languageAccents.clear()
+        for (row in languageModel.snapshot()) {
+            state.languageAccents[row.languageId] = row.hex
+        }
+
+        reapplyForCurrentContext()
+        snapshotStored()
+        fireChanged()
+    }
+
+    fun reset() {
+        projectModel.replaceAll(storedProjects.map { ProjectMapping(it.canonicalPath, it.displayName, it.hex) })
+        languageModel.replaceAll(storedLanguages.map { LanguageMapping(it.languageId, it.displayName, it.hex) })
+        fireChanged()
+    }
+
+    fun addPendingChangeListener(runnable: Runnable) {
+        listeners += runnable
+    }
+
+    /**
+     * Resolve the accent hex using the **pending** (not yet applied) overrides model.
+     * Falls back to [fallbackGlobalHex] when no override matches.
+     */
+    fun resolvePending(
+        project: Project?,
+        fallbackGlobalHex: String,
+    ): String {
+        if (project != null && !project.isDefault && !project.isDisposed) {
+            AccentResolver.projectKey(project)?.let { key ->
+                projectModel.snapshot().firstOrNull { it.canonicalPath == key }?.let { return it.hex }
+            }
+            val languages = languageModel.snapshot()
+            if (languages.isNotEmpty()) {
+                ProjectLanguageDetector.dominant(project)?.let { languageId ->
+                    languages.firstOrNull { it.languageId.equals(languageId, ignoreCase = true) }?.let { return it.hex }
+                }
+            }
+        }
+        return fallbackGlobalHex
+    }
+
+    /**
+     * Matching [AccentResolver.Source] for [project] under the **pending** overrides model.
+     */
+    fun sourcePending(project: Project?): AccentResolver.Source {
+        if (project != null && !project.isDefault && !project.isDisposed) {
+            val key = AccentResolver.projectKey(project)
+            if (key != null && projectModel.snapshot().any { it.canonicalPath == key }) {
+                return AccentResolver.Source.PROJECT_OVERRIDE
+            }
+            val languages = languageModel.snapshot()
+            if (languages.isNotEmpty()) {
+                val dominant = ProjectLanguageDetector.dominant(project)
+                if (dominant != null && languages.any { it.languageId.equals(dominant, ignoreCase = true) }) {
+                    return AccentResolver.Source.LANGUAGE_OVERRIDE
+                }
+            }
+        }
+        return AccentResolver.Source.GLOBAL
+    }
+
+    // ---- Internals ----
+
+    private fun loadFromState() {
+        val state = AccentMappingsSettingsAccess.stateFor()
+        val projects =
+            state.projectAccents.map { (path, hex) ->
+                ProjectMapping(
+                    canonicalPath = path,
+                    displayName = state.projectDisplayNames[path] ?: File(path).name,
+                    hex = hex,
+                )
+            }
+        val languages =
+            state.languageAccents.map { (id, hex) ->
+                val displayName =
+                    runCatching {
+                        com.intellij.lang.Language
+                            .findLanguageByID(id)
+                            ?.displayName
+                    }.getOrNull()
+                        ?.takeIf { it.isNotBlank() }
+                        ?: id
+                LanguageMapping(
+                    languageId = id,
+                    displayName = displayName,
+                    hex = hex,
+                )
+            }
+        projectModel.replaceAll(projects)
+        languageModel.replaceAll(languages)
+        snapshotStored()
+    }
+
+    private fun snapshotStored() {
+        storedProjects = projectModel.snapshot().map { ProjectMapping(it.canonicalPath, it.displayName, it.hex) }
+        storedLanguages = languageModel.snapshot().map { LanguageMapping(it.languageId, it.displayName, it.hex) }
+    }
+
+    private val fireChanged: () -> Unit = { listeners.forEach { it.run() } }
+
+    private fun buildSegmentedBar(): JComponent {
+        val projectsRadio = JRadioButton("Projects", true)
+        val languagesRadio = JRadioButton("Languages", false)
+        val group =
+            ButtonGroup().apply {
+                add(projectsRadio)
+                add(languagesRadio)
+            }
+        projectsRadio.addActionListener { (cardPanel.layout as CardLayout).show(cardPanel, CARD_PROJECTS) }
+        languagesRadio.addActionListener { (cardPanel.layout as CardLayout).show(cardPanel, CARD_LANGUAGES) }
+
+        val bar =
+            JPanel(FlowLayout(FlowLayout.LEADING, BAR_HGAP, BAR_VGAP)).apply {
+                isOpaque = false
+                add(projectsRadio)
+                add(languagesRadio)
+            }
+        // Retain strong reference so actions survive focus changes
+        bar.putClientProperty("ayu.overrides.group", group)
+        return bar
+    }
+
+    private fun configureProjectTable() {
+        projectTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION)
+        projectTable.rowHeight = TABLE_ROW_HEIGHT
+        projectTable.setShowGrid(false)
+        projectTable.getColumnModel().getColumn(ProjectMappingsTableModel.COLUMN_COLOR).apply {
+            preferredWidth = COLOR_COLUMN_WIDTH
+            cellRenderer = RoundedSwatchRenderer()
+        }
+        projectTable.getColumnModel().getColumn(ProjectMappingsTableModel.COLUMN_PROJECT).apply {
+            preferredWidth = PROJECT_COLUMN_WIDTH
+            cellRenderer = DimOrphanRenderer { row -> projectModel.isOrphan(row) }
+        }
+        projectTable.getColumnModel().getColumn(ProjectMappingsTableModel.COLUMN_PATH).apply {
+            cellRenderer = DimOrphanRenderer { row -> projectModel.isOrphan(row) }
+        }
+    }
+
+    private fun configureLanguageTable() {
+        languageTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION)
+        languageTable.rowHeight = TABLE_ROW_HEIGHT
+        languageTable.setShowGrid(false)
+        languageTable.getColumnModel().getColumn(LanguageMappingsTableModel.COLUMN_COLOR).apply {
+            preferredWidth = COLOR_COLUMN_WIDTH
+            cellRenderer = RoundedSwatchRenderer()
+        }
+    }
+
+    private fun decorateTable(
+        table: JBTable,
+        actions: TableActions,
+    ): JComponent {
+        val decorator =
+            ToolbarDecorator
+                .createDecorator(table)
+                .disableUpDownActions()
+                .setAddAction { actions.add() }
+                .setEditAction { actions.edit() }
+                .setRemoveAction { actions.remove() }
+                .setAddActionName("Add")
+                .setEditActionName("Edit color")
+                .setRemoveActionName("Remove")
+                .setAddActionUpdater { _ -> actions.addEnabled() }
+                .setEditActionUpdater { _ -> actions.editEnabled() }
+                .setRemoveActionUpdater { _ -> actions.removeEnabled() }
+
+        actions.extraActions.forEach { decorator.addExtraAction(it) }
+        val wrapper = JPanel(BorderLayout())
+        wrapper.add(decorator.createPanel(), BorderLayout.CENTER)
+        return wrapper
+    }
+
+    private fun projectActions(licensed: Boolean): TableActions {
+        val extras: List<AnAction> =
+            if (licensed) {
+                listOf(
+                    object : AnAction(
+                        "Pin Current Project",
+                        "Add the current project with the global accent",
+                        AllIcons.Actions.PinTab,
+                    ) {
+                        override fun actionPerformed(event: AnActionEvent) {
+                            pinCurrentProject()
+                        }
+
+                        override fun update(event: AnActionEvent) {
+                            event.presentation.isEnabled = canPinCurrentProject()
+                        }
+                    },
+                )
+            } else {
+                emptyList()
+            }
+
+        return TableActions(
+            add = { showAddProjectDialog() },
+            edit = { editSelectedProjectColor() },
+            remove = { removeSelectedProject() },
+            addEnabled = { licensed },
+            editEnabled = { licensed && projectTable.selectedRow >= 0 },
+            removeEnabled = { projectTable.selectedRow >= 0 },
+            extraActions = extras,
+        )
+    }
+
+    private fun languageActions(licensed: Boolean): TableActions =
+        TableActions(
+            add = { showAddLanguageDialog() },
+            edit = { editSelectedLanguageColor() },
+            remove = { removeSelectedLanguage() },
+            addEnabled = { licensed },
+            editEnabled = { licensed && languageTable.selectedRow >= 0 },
+            removeEnabled = { languageTable.selectedRow >= 0 },
+            extraActions = emptyList(),
+        )
+
+    // ---- Project actions ----
+
+    private fun showAddProjectDialog() {
+        val excluded = projectModel.snapshot().map { it.canonicalPath }.toSet()
+        val dialog = AddProjectMappingDialog(parentProject, excluded)
+        if (!dialog.showAndGet()) return
+        val path = dialog.resultCanonicalPath ?: return
+        val hex = dialog.resultHex ?: return
+        val name = dialog.resultDisplayName ?: File(path).name
+        val index = projectModel.add(ProjectMapping(path, name, hex))
+        projectTable.selectionModel.setSelectionInterval(index, index)
+        fireChanged()
+    }
+
+    private fun canPinCurrentProject(): Boolean {
+        val project = parentProject ?: return false
+        if (project.isDefault || project.isDisposed) return false
+        val key = AccentResolver.projectKey(project) ?: return false
+        return !projectModel.containsPath(key)
+    }
+
+    private fun pinCurrentProject() {
+        val project = parentProject ?: return
+        if (project.isDefault || project.isDisposed) return
+        val key = AccentResolver.projectKey(project) ?: return
+        if (projectModel.containsPath(key)) return
+        val variant = AyuVariant.detect() ?: AyuVariant.MIRAGE
+        val hex = AyuIslandsSettings.getInstance().getAccentForVariant(variant)
+        val name = project.name.takeIf { it.isNotBlank() } ?: File(key).name
+        val index = projectModel.add(ProjectMapping(key, name, hex))
+        projectTable.selectionModel.setSelectionInterval(index, index)
+        fireChanged()
+    }
+
+    private fun editSelectedProjectColor() {
+        val row = projectTable.selectedRow.takeIf { it >= 0 } ?: return
+        val mapping = projectModel.rowAt(row) ?: return
+        val chosen =
+            ColorPicker.showDialog(
+                projectTable,
+                "Choose Accent Color",
+                RoundedSwatchRenderer.safeDecodeColor(mapping.hex),
+                true,
+                emptyList(),
+                false,
+            ) ?: return
+        val hex = "#%02X%02X%02X".format(chosen.red, chosen.green, chosen.blue)
+        projectModel.updateHex(row, hex)
+        fireChanged()
+    }
+
+    private fun removeSelectedProject() {
+        val row = projectTable.selectedRow.takeIf { it >= 0 } ?: return
+        projectModel.remove(row)
+        fireChanged()
+    }
+
+    // ---- Language actions ----
+
+    private fun showAddLanguageDialog() {
+        val excluded = languageModel.snapshot().map { it.languageId }.toSet()
+        val dialog = AddLanguageMappingDialog(parentProject, excluded)
+        if (!dialog.showAndGet()) return
+        val id = dialog.resultLanguageId ?: return
+        val hex = dialog.resultHex ?: return
+        val name = dialog.resultDisplayName ?: id
+        val index = languageModel.add(LanguageMapping(id, name, hex))
+        languageTable.selectionModel.setSelectionInterval(index, index)
+        fireChanged()
+    }
+
+    private fun editSelectedLanguageColor() {
+        val row = languageTable.selectedRow.takeIf { it >= 0 } ?: return
+        val mapping = languageModel.rowAt(row) ?: return
+        val chosen =
+            ColorPicker.showDialog(
+                languageTable,
+                "Choose Accent Color",
+                RoundedSwatchRenderer.safeDecodeColor(mapping.hex),
+                true,
+                emptyList(),
+                false,
+            ) ?: return
+        val hex = "#%02X%02X%02X".format(chosen.red, chosen.green, chosen.blue)
+        languageModel.updateHex(row, hex)
+        fireChanged()
+    }
+
+    private fun removeSelectedLanguage() {
+        val row = languageTable.selectedRow.takeIf { it >= 0 } ?: return
+        languageModel.remove(row)
+        fireChanged()
+    }
+
+    // ---- Apply re-render ----
+
+    private fun reapplyForCurrentContext() {
+        val variant = AyuVariant.detect() ?: return
+        val project = parentProject ?: ProjectManager.getInstance().openProjects.firstOrNull()
+        val hex = AccentResolver.resolve(project, variant)
+        AccentApplicator.apply(hex)
+        // Keep the focus-swap cache consistent so the next WINDOW_ACTIVATED event
+        // evaluates against the color actually showing on screen right now.
+        ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
+    }
+
+    companion object {
+        private const val CARD_PROJECTS = "projects"
+        private const val CARD_LANGUAGES = "languages"
+        private const val CARD_WIDTH = 620
+        private const val CARD_HEIGHT = 200
+        private const val TABLE_ROW_HEIGHT = 24
+        private const val COLOR_COLUMN_WIDTH = 110
+        private const val PROJECT_COLUMN_WIDTH = 180
+        private const val BAR_HGAP = 4
+        private const val BAR_VGAP = 0
+    }
+
+    private class TableActions(
+        val add: () -> Unit,
+        val edit: () -> Unit,
+        val remove: () -> Unit,
+        val addEnabled: () -> Boolean,
+        val editEnabled: () -> Boolean,
+        val removeEnabled: () -> Boolean,
+        val extraActions: List<AnAction>,
+    )
+
+    private class DimOrphanRenderer(
+        private val orphanProbe: (Int) -> Boolean,
+    ) : DefaultTableCellRenderer() {
+        override fun getTableCellRendererComponent(
+            table: javax.swing.JTable,
+            value: Any?,
+            isSelected: Boolean,
+            hasFocus: Boolean,
+            row: Int,
+            column: Int,
+        ): Component {
+            super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column)
+            val orphan = orphanProbe(row)
+            if (orphan) {
+                foreground = javax.swing.UIManager.getColor("Label.disabledForeground") ?: Color.GRAY
+                toolTipText = "Path no longer exists on disk"
+            } else {
+                toolTipText = null
+            }
+            return this
+        }
+    }
+}
+
+/**
+ * Isolated state access wrapper so test code can substitute a synthetic state
+ * without pulling in the full [AccentMappingsSettings] service graph.
+ */
+private object AccentMappingsSettingsAccess {
+    fun stateFor(): AccentMappingsState = AccentMappingsSettings.getInstance().state
+}
+
+private fun List<ProjectMapping>.toFingerprint(): Set<Triple<String, String, String>> =
+    map { Triple(it.canonicalPath, it.displayName, it.hex) }.toSet()
+
+private fun List<LanguageMapping>.toLanguageFingerprint(): Set<Triple<String, String, String>> =
+    map { Triple(it.languageId, it.displayName, it.hex) }.toSet()

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -533,7 +533,7 @@ class OverridesGroupBuilder {
         }
     }
 
-    private class TableActions(
+    private data class TableActions(
         val add: () -> Unit,
         val edit: () -> Unit,
         val remove: () -> Unit,

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -189,6 +189,16 @@ class OverridesGroupBuilder {
 
     // Internals: pending-model resolver + UI wiring helpers
 
+    /**
+     * Populate the pending table models from the persisted [AccentMappingsSettings]. Public
+     * [buildGroup] calls this during UI setup; exposed to tests so `resolvePending` and
+     * `sourcePending` can be exercised without inflating the full Swing tree.
+     */
+    @org.jetbrains.annotations.TestOnly
+    internal fun loadFromStateForTest() {
+        loadFromState()
+    }
+
     private fun loadFromState() {
         val state = AccentMappingsSettingsAccess.stateFor()
         val projects =

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -3,6 +3,7 @@ package dev.ayuislands.settings.mappings
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.ui.ToolbarDecorator
@@ -201,29 +202,48 @@ class OverridesGroupBuilder {
 
     private fun loadFromState() {
         val state = AccentMappingsSettingsAccess.stateFor()
+        // Per-row resilience: ProjectMapping / LanguageMapping have require(...) invariants at
+        // construction (valid #RRGGBB hex, lowercase language id, non-blank canonical path).
+        // If the persisted XML contains even one malformed row — hand-edited, imported, legacy —
+        // a blanket map { ... } would throw during Settings panel construction and the whole
+        // Overrides UI would refuse to open. Worse, the user would have no way to fix it
+        // because the UI that shows the bad row is exactly the UI that's broken. Drop malformed
+        // rows individually with a warn log; users can re-add them from the surviving UI.
         val projects =
-            state.projectAccents.map { (path, hex) ->
-                ProjectMapping(
-                    canonicalPath = path,
-                    displayName = state.projectDisplayNames[path] ?: File(path).name,
-                    hex = hex,
-                )
+            state.projectAccents.mapNotNull { (path, hex) ->
+                runCatching {
+                    ProjectMapping(
+                        canonicalPath = path,
+                        displayName = state.projectDisplayNames[path] ?: File(path).name,
+                        hex = hex,
+                    )
+                }.onFailure { exception ->
+                    LOG.warn(
+                        "Dropping malformed project override row (path='$path', hex='$hex'): ${exception.message}",
+                    )
+                }.getOrNull()
             }
         val languages =
-            state.languageAccents.map { (id, hex) ->
-                val displayName =
-                    runCatching {
-                        com.intellij.lang.Language
-                            .findLanguageByID(id)
-                            ?.displayName
-                    }.getOrNull()
-                        ?.takeIf { it.isNotBlank() }
-                        ?: id
-                LanguageMapping(
-                    languageId = id,
-                    displayName = displayName,
-                    hex = hex,
-                )
+            state.languageAccents.mapNotNull { (id, hex) ->
+                runCatching {
+                    val displayName =
+                        runCatching {
+                            com.intellij.lang.Language
+                                .findLanguageByID(id)
+                                ?.displayName
+                        }.getOrNull()
+                            ?.takeIf { it.isNotBlank() }
+                            ?: id
+                    LanguageMapping(
+                        languageId = id,
+                        displayName = displayName,
+                        hex = hex,
+                    )
+                }.onFailure { exception ->
+                    LOG.warn(
+                        "Dropping malformed language override row (id='$id', hex='$hex'): ${exception.message}",
+                    )
+                }.getOrNull()
             }
         projectModel.replaceAll(projects)
         languageModel.replaceAll(languages)
@@ -462,6 +482,7 @@ class OverridesGroupBuilder {
     }
 
     companion object {
+        private val LOG = logger<OverridesGroupBuilder>()
         private const val CARD_PROJECTS = "projects"
         private const val CARD_LANGUAGES = "languages"
         private const val TABLE_ROW_HEIGHT = 24

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -161,7 +161,10 @@ class OverridesGroupBuilder {
             val languages = languageModel.snapshot()
             if (languages.isNotEmpty()) {
                 ProjectLanguageDetector.dominant(project)?.let { languageId ->
-                    languages.firstOrNull { it.languageId.equals(languageId, ignoreCase = true) }?.let { return it.hex }
+                    // LanguageMapping.init enforces lowercase at construction; ProjectLanguageDetector
+                    // returns lowercase ids. Case-sensitive equality is sufficient — plain `==`
+                    // stays consistent with LanguageMappingsTableModel.containsLanguage.
+                    languages.firstOrNull { it.languageId == languageId }?.let { return it.hex }
                 }
             }
         }
@@ -180,7 +183,8 @@ class OverridesGroupBuilder {
             val languages = languageModel.snapshot()
             if (languages.isNotEmpty()) {
                 val dominant = ProjectLanguageDetector.dominant(project)
-                if (dominant != null && languages.any { it.languageId.equals(dominant, ignoreCase = true) }) {
+                // See resolvePending: both sides are lowercase by invariant, no compensator needed.
+                if (dominant != null && languages.any { it.languageId == dominant }) {
                     return AccentResolver.Source.LANGUAGE_OVERRIDE
                 }
             }

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -75,26 +75,32 @@ class OverridesGroupBuilder {
         // auto-pack to their widest cell on every model change; last column absorbs
         // remaining width via AUTO_RESIZE_LAST_COLUMN.
 
-        panel.group("Overrides") {
-            row {
-                comment(
-                    "Pin an accent color to a specific project or a programming language. " +
-                        "Project overrides win over language overrides; both win over the global accent.",
-                )
-            }
-            row {
-                cell(segmentedBar)
-            }
-            row {
-                cell(cardPanel)
-                    .resizableColumn()
-                    .align(Align.FILL)
-            }
-            if (!licensed) {
+        val settings = AyuIslandsSettings.getInstance()
+        val collapsible =
+            panel.collapsibleGroup("Overrides") {
                 row {
-                    comment("Pro feature")
+                    comment(
+                        "Pin an accent color to a specific project or a programming language. " +
+                            "Project overrides win over language overrides; both win over the global accent.",
+                    )
+                }
+                row {
+                    cell(segmentedBar)
+                }
+                row {
+                    cell(cardPanel)
+                        .resizableColumn()
+                        .align(Align.FILL)
+                }
+                if (!licensed) {
+                    row {
+                        comment("Pro feature")
+                    }
                 }
             }
+        collapsible.expanded = settings.state.overridesGroupExpanded
+        collapsible.addExpandedListener { expanded ->
+            settings.state.overridesGroupExpanded = expanded
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -71,9 +71,10 @@ class OverridesGroupBuilder {
         cardPanel.add(decorateTable(projectTable, projectActions(licensed)), CARD_PROJECTS)
         cardPanel.add(decorateTable(languageTable, languageActions(licensed)), CARD_LANGUAGES)
         // No fixed preferredSize: the AutoSizingTable drives height via
-        // getPreferredScrollableViewportSize (row count × row height) and columns 0..N-2
-        // auto-pack to their widest cell on every model change; last column absorbs
-        // remaining width via AUTO_RESIZE_LAST_COLUMN.
+        // getPreferredScrollableViewportSize (row count × row height) and every column
+        // auto-packs to the wider of header/content on every model change. AUTO_RESIZE_LAST_COLUMN
+        // then lets the last column absorb any remaining width when the containing panel is wider
+        // than the sum of packed widths, or shrink (via horizontal scroll) when narrower.
 
         val settings = AyuIslandsSettings.getInstance()
         val collapsible =
@@ -104,7 +105,7 @@ class OverridesGroupBuilder {
         }
     }
 
-    // ---- Lifecycle integration ----
+    // Settings panel lifecycle (isModified / apply / reset)
 
     fun isModified(): Boolean {
         val currentProjects = projectModel.snapshot().toFingerprint()
@@ -186,7 +187,7 @@ class OverridesGroupBuilder {
         return AccentResolver.Source.GLOBAL
     }
 
-    // ---- Internals ----
+    // Internals: pending-model resolver + UI wiring helpers
 
     private fun loadFromState() {
         val state = AccentMappingsSettingsAccess.stateFor()
@@ -356,7 +357,7 @@ class OverridesGroupBuilder {
             extraActions = emptyList(),
         )
 
-    // ---- Project actions ----
+    // Project-table actions: add / edit / remove + pin-current
 
     private fun showAddProjectDialog() {
         val excluded = projectModel.snapshot().map { it.canonicalPath }.toSet()
@@ -396,7 +397,7 @@ class OverridesGroupBuilder {
         fireChanged()
     }
 
-    // ---- Language actions ----
+    // Language-table actions: add / edit / remove
 
     private fun showAddLanguageDialog() {
         val excluded = languageModel.snapshot().map { it.languageId }.toSet()
@@ -438,7 +439,7 @@ class OverridesGroupBuilder {
         fireChanged()
     }
 
-    // ---- Apply re-render ----
+    // Applies the committed mapping set via resolver → applicator → swap-cache sync
 
     private fun reapplyForCurrentContext() {
         val variant = AyuVariant.detect() ?: return
@@ -460,9 +461,10 @@ class OverridesGroupBuilder {
 
     /**
      * [JBTable] that sizes its viewport to the current row count (clamped to
-     * [MIN_VISIBLE_ROWS]..[MAX_VISIBLE_ROWS]) and auto-packs all columns except the
-     * last one to the widest header or cell content on every model change.
-     * The last column is left to absorb remaining width via [AUTO_RESIZE_LAST_COLUMN].
+     * [MIN_VISIBLE_ROWS]..[MAX_VISIBLE_ROWS]) and auto-packs every column to the wider of
+     * header / cell content on every model change. With [AUTO_RESIZE_LAST_COLUMN] Swing then
+     * lets the last column absorb any extra width when the containing panel is wider than
+     * the sum of packed widths, and shrink (horizontal scroll) when narrower.
      */
     private class AutoSizingTable(
         model: TableModel,

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -235,6 +235,11 @@ class OverridesGroupBuilder {
                             com.intellij.lang.Language
                                 .findLanguageByID(id)
                                 ?.displayName
+                        }.onFailure { exception ->
+                            // Display-name lookup fell through to the raw id fallback — log at
+                            // DEBUG because the row is still usable; surface the platform API
+                            // regression only for users who enable debug logging.
+                            LOG.debug("Language display-name lookup failed for id='$id'", exception)
                         }.getOrNull()
                             ?.takeIf { it.isNotBlank() }
                             ?: id

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -5,12 +5,10 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
-import com.intellij.ui.ColorPicker
 import com.intellij.ui.ToolbarDecorator
 import com.intellij.ui.dsl.builder.Align
 import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.table.JBTable
-import com.intellij.util.ui.JBUI
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
@@ -21,14 +19,17 @@ import java.awt.BorderLayout
 import java.awt.CardLayout
 import java.awt.Color
 import java.awt.Component
+import java.awt.Dimension
 import java.awt.FlowLayout
 import java.io.File
 import javax.swing.ButtonGroup
 import javax.swing.JComponent
 import javax.swing.JPanel
 import javax.swing.JRadioButton
+import javax.swing.JTable
 import javax.swing.ListSelectionModel
 import javax.swing.table.DefaultTableCellRenderer
+import javax.swing.table.TableModel
 
 /**
  * Builds the "Overrides" group inside the Accent settings tab. Hosts a segmented
@@ -42,8 +43,8 @@ import javax.swing.table.DefaultTableCellRenderer
 class OverridesGroupBuilder {
     private val projectModel = ProjectMappingsTableModel()
     private val languageModel = LanguageMappingsTableModel()
-    private val projectTable = JBTable(projectModel)
-    private val languageTable = JBTable(languageModel)
+    private val projectTable: JBTable = AutoSizingTable(projectModel)
+    private val languageTable: JBTable = AutoSizingTable(languageModel)
 
     private var storedProjects: List<ProjectMapping> = emptyList()
     private var storedLanguages: List<LanguageMapping> = emptyList()
@@ -69,7 +70,10 @@ class OverridesGroupBuilder {
         val segmentedBar = buildSegmentedBar()
         cardPanel.add(decorateTable(projectTable, projectActions(licensed)), CARD_PROJECTS)
         cardPanel.add(decorateTable(languageTable, languageActions(licensed)), CARD_LANGUAGES)
-        cardPanel.preferredSize = JBUI.size(CARD_WIDTH, CARD_HEIGHT)
+        // No fixed preferredSize: the AutoSizingTable drives height via
+        // getPreferredScrollableViewportSize (row count × row height) and columns 0..N-2
+        // auto-pack to their widest cell on every model change; last column absorbs
+        // remaining width via AUTO_RESIZE_LAST_COLUMN.
 
         panel.group("Overrides") {
             row {
@@ -243,11 +247,9 @@ class OverridesGroupBuilder {
         projectTable.rowHeight = TABLE_ROW_HEIGHT
         projectTable.setShowGrid(false)
         projectTable.getColumnModel().getColumn(ProjectMappingsTableModel.COLUMN_COLOR).apply {
-            preferredWidth = COLOR_COLUMN_WIDTH
             cellRenderer = RoundedSwatchRenderer()
         }
         projectTable.getColumnModel().getColumn(ProjectMappingsTableModel.COLUMN_PROJECT).apply {
-            preferredWidth = PROJECT_COLUMN_WIDTH
             cellRenderer = DimOrphanRenderer { row -> projectModel.isOrphan(row) }
         }
         projectTable.getColumnModel().getColumn(ProjectMappingsTableModel.COLUMN_PATH).apply {
@@ -260,7 +262,6 @@ class OverridesGroupBuilder {
         languageTable.rowHeight = TABLE_ROW_HEIGHT
         languageTable.setShowGrid(false)
         languageTable.getColumnModel().getColumn(LanguageMappingsTableModel.COLUMN_COLOR).apply {
-            preferredWidth = COLOR_COLUMN_WIDTH
             cellRenderer = RoundedSwatchRenderer()
         }
     }
@@ -370,17 +371,9 @@ class OverridesGroupBuilder {
     private fun editSelectedProjectColor() {
         val row = projectTable.selectedRow.takeIf { it >= 0 } ?: return
         val mapping = projectModel.rowAt(row) ?: return
-        val chosen =
-            ColorPicker.showDialog(
-                projectTable,
-                "Choose Accent Color",
-                RoundedSwatchRenderer.safeDecodeColor(mapping.hex),
-                true,
-                emptyList(),
-                false,
-            ) ?: return
-        val hex = "#%02X%02X%02X".format(chosen.red, chosen.green, chosen.blue)
-        projectModel.updateHex(row, hex)
+        val dialog = EditAccentColorDialog(parentProject, mapping.hex, mapping.displayName)
+        if (!dialog.showAndGet()) return
+        projectModel.updateHex(row, dialog.resultHex)
         fireChanged()
     }
 
@@ -407,17 +400,9 @@ class OverridesGroupBuilder {
     private fun editSelectedLanguageColor() {
         val row = languageTable.selectedRow.takeIf { it >= 0 } ?: return
         val mapping = languageModel.rowAt(row) ?: return
-        val chosen =
-            ColorPicker.showDialog(
-                languageTable,
-                "Choose Accent Color",
-                RoundedSwatchRenderer.safeDecodeColor(mapping.hex),
-                true,
-                emptyList(),
-                false,
-            ) ?: return
-        val hex = "#%02X%02X%02X".format(chosen.red, chosen.green, chosen.blue)
-        languageModel.updateHex(row, hex)
+        val dialog = EditAccentColorDialog(parentProject, mapping.hex, mapping.displayName)
+        if (!dialog.showAndGet()) return
+        languageModel.updateHex(row, dialog.resultHex)
         fireChanged()
     }
 
@@ -442,13 +427,84 @@ class OverridesGroupBuilder {
     companion object {
         private const val CARD_PROJECTS = "projects"
         private const val CARD_LANGUAGES = "languages"
-        private const val CARD_WIDTH = 620
-        private const val CARD_HEIGHT = 200
         private const val TABLE_ROW_HEIGHT = 24
-        private const val COLOR_COLUMN_WIDTH = 110
-        private const val PROJECT_COLUMN_WIDTH = 180
         private const val BAR_HGAP = 4
         private const val BAR_VGAP = 0
+    }
+
+    /**
+     * [JBTable] that sizes its viewport to the current row count (clamped to
+     * [MIN_VISIBLE_ROWS]..[MAX_VISIBLE_ROWS]) and auto-packs all columns except the
+     * last one to the widest header or cell content on every model change.
+     * The last column is left to absorb remaining width via [AUTO_RESIZE_LAST_COLUMN].
+     */
+    private class AutoSizingTable(
+        model: TableModel,
+    ) : JBTable(model) {
+        init {
+            autoResizeMode = JTable.AUTO_RESIZE_LAST_COLUMN
+            model.addTableModelListener { repack() }
+        }
+
+        override fun getPreferredScrollableViewportSize(): Dimension {
+            val visibleRows = rowCount.coerceIn(MIN_VISIBLE_ROWS, MAX_VISIBLE_ROWS)
+            val headerHeight = tableHeader?.preferredSize?.height ?: 0
+            val bodyHeight = visibleRows * rowHeight
+            // Viewport width = sum of packed column widths so the surrounding Kotlin UI DSL
+            // panel (Align.FILL) grows to show every column fully before kicking in horizontal
+            // scrolling. Floor to MIN_VIEWPORT_WIDTH so an empty table still looks reasonable
+            // on first render (before the TableModelListener has fired a pack pass).
+            val summedWidth = (0 until columnCount).sumOf { columnModel.getColumn(it).preferredWidth }
+            val width = maxOf(summedWidth, MIN_VIEWPORT_WIDTH)
+            return Dimension(width, bodyHeight + headerHeight)
+        }
+
+        /**
+         * Packs every column (including the last) to the widest of header + cell content.
+         * [AUTO_RESIZE_LAST_COLUMN] then lets the last column expand when the containing
+         * panel exceeds the sum, and lets it shrink (horizontal scroll) when the panel is
+         * narrower.
+         */
+        fun repack() {
+            for (index in 0 until columnCount) {
+                packColumn(index)
+            }
+            revalidate()
+            repaint()
+        }
+
+        private fun packColumn(columnIndex: Int) {
+            val column = columnModel.getColumn(columnIndex)
+            val headerWidth =
+                tableHeader
+                    ?.defaultRenderer
+                    ?.getTableCellRendererComponent(
+                        this,
+                        column.headerValue,
+                        false,
+                        false,
+                        -1,
+                        columnIndex,
+                    )?.preferredSize
+                    ?.width
+                    ?: COLUMN_MIN_WIDTH
+            var width = maxOf(COLUMN_MIN_WIDTH, headerWidth + PACK_PADDING)
+            for (row in 0 until rowCount) {
+                val renderer = getCellRenderer(row, columnIndex)
+                val comp = prepareRenderer(renderer, row, columnIndex)
+                width = maxOf(width, comp.preferredSize.width + PACK_PADDING)
+            }
+            column.preferredWidth = width.coerceAtMost(COLUMN_MAX_WIDTH)
+        }
+
+        companion object {
+            private const val MIN_VISIBLE_ROWS = 2
+            private const val MAX_VISIBLE_ROWS = 8
+            private const val COLUMN_MIN_WIDTH = 60
+            private const val COLUMN_MAX_WIDTH = 600
+            private const val PACK_PADDING = 16
+            private const val MIN_VIEWPORT_WIDTH = 520
+        }
     }
 
     private class TableActions(

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -238,7 +238,7 @@ class OverridesGroupBuilder {
         languagesRadio.addActionListener { (cardPanel.layout as CardLayout).show(cardPanel, CARD_LANGUAGES) }
 
         val bar =
-            JPanel(FlowLayout(FlowLayout.LEADING, BAR_HGAP, BAR_VGAP)).apply {
+            JPanel(FlowLayout(FlowLayout.LEADING, BAR_HORIZONTAL_GAP, BAR_VERTICAL_GAP)).apply {
                 isOpaque = false
                 add(projectsRadio)
                 add(languagesRadio)
@@ -284,7 +284,7 @@ class OverridesGroupBuilder {
                 .setEditAction { actions.edit() }
                 .setRemoveAction { actions.remove() }
                 .setAddActionName("Add")
-                .setEditActionName("Edit color")
+                .setEditActionName("Edit Color")
                 .setRemoveActionName("Remove")
                 .setAddActionUpdater { _ -> actions.addEnabled() }
                 .setEditActionUpdater { _ -> actions.editEnabled() }
@@ -320,7 +320,15 @@ class OverridesGroupBuilder {
 
         return TableActions(
             add = { showAddProjectDialog() },
-            edit = { editSelectedProjectColor() },
+            edit = {
+                editSelectedColor(
+                    table = projectTable,
+                    rowAt = projectModel::rowAt,
+                    hex = ProjectMapping::hex,
+                    displayName = ProjectMapping::displayName,
+                    updateHex = projectModel::updateHex,
+                )
+            },
             remove = { removeSelectedProject() },
             addEnabled = { licensed },
             editEnabled = { licensed && projectTable.selectedRow >= 0 },
@@ -332,7 +340,15 @@ class OverridesGroupBuilder {
     private fun languageActions(licensed: Boolean): TableActions =
         TableActions(
             add = { showAddLanguageDialog() },
-            edit = { editSelectedLanguageColor() },
+            edit = {
+                editSelectedColor(
+                    table = languageTable,
+                    rowAt = languageModel::rowAt,
+                    hex = LanguageMapping::hex,
+                    displayName = LanguageMapping::displayName,
+                    updateHex = languageModel::updateHex,
+                )
+            },
             remove = { removeSelectedLanguage() },
             addEnabled = { licensed },
             editEnabled = { licensed && languageTable.selectedRow >= 0 },
@@ -374,15 +390,6 @@ class OverridesGroupBuilder {
         fireChanged()
     }
 
-    private fun editSelectedProjectColor() {
-        val row = projectTable.selectedRow.takeIf { it >= 0 } ?: return
-        val mapping = projectModel.rowAt(row) ?: return
-        val dialog = EditAccentColorDialog(parentProject, mapping.hex, mapping.displayName)
-        if (!dialog.showAndGet()) return
-        projectModel.updateHex(row, dialog.resultHex)
-        fireChanged()
-    }
-
     private fun removeSelectedProject() {
         val row = projectTable.selectedRow.takeIf { it >= 0 } ?: return
         projectModel.remove(row)
@@ -403,12 +410,25 @@ class OverridesGroupBuilder {
         fireChanged()
     }
 
-    private fun editSelectedLanguageColor() {
-        val row = languageTable.selectedRow.takeIf { it >= 0 } ?: return
-        val mapping = languageModel.rowAt(row) ?: return
-        val dialog = EditAccentColorDialog(parentProject, mapping.hex, mapping.displayName)
+    /**
+     * Generic edit-color flow shared by project and language tables. Takes accessors
+     * for the model-specific lookup and update so the Project- and Language- specific
+     * callers collapse to a single call with closures capturing their model/table —
+     * sharing the JBTable selection probe, the modal dialog wiring, and the
+     * pending-change notification.
+     */
+    private inline fun <M> editSelectedColor(
+        table: JBTable,
+        rowAt: (Int) -> M?,
+        hex: (M) -> String,
+        displayName: (M) -> String,
+        updateHex: (Int, String) -> Unit,
+    ) {
+        val row = table.selectedRow.takeIf { it >= 0 } ?: return
+        val mapping = rowAt(row) ?: return
+        val dialog = EditAccentColorDialog(parentProject, hex(mapping), displayName(mapping))
         if (!dialog.showAndGet()) return
-        languageModel.updateHex(row, dialog.resultHex)
+        updateHex(row, dialog.resultHex)
         fireChanged()
     }
 
@@ -434,8 +454,8 @@ class OverridesGroupBuilder {
         private const val CARD_PROJECTS = "projects"
         private const val CARD_LANGUAGES = "languages"
         private const val TABLE_ROW_HEIGHT = 24
-        private const val BAR_HGAP = 4
-        private const val BAR_VGAP = 0
+        private const val BAR_HORIZONTAL_GAP = 4
+        private const val BAR_VERTICAL_GAP = 0
     }
 
     /**
@@ -448,7 +468,7 @@ class OverridesGroupBuilder {
         model: TableModel,
     ) : JBTable(model) {
         init {
-            autoResizeMode = JTable.AUTO_RESIZE_LAST_COLUMN
+            autoResizeMode = AUTO_RESIZE_LAST_COLUMN
             model.addTableModelListener { repack() }
         }
 
@@ -527,7 +547,7 @@ class OverridesGroupBuilder {
         private val orphanProbe: (Int) -> Boolean,
     ) : DefaultTableCellRenderer() {
         override fun getTableCellRendererComponent(
-            table: javax.swing.JTable,
+            table: JTable,
             value: Any?,
             isSelected: Boolean,
             hasFocus: Boolean,

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapService.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapService.kt
@@ -54,9 +54,10 @@ class ProjectAccentSwapService : Disposable {
     private fun onWindowActivated(event: AWTEvent) {
         // Wrap the entire handler so a single exception (e.g. Color.decode on a corrupted stored
         // hex, WindowManager state inconsistency during shutdown) does not escape to the AWT
-        // dispatcher. Without this, a transient failure would still propagate to the uncaught
-        // exception handler, land in idea.log as SEVERE, and the AWTEventListener would keep
-        // re-firing the broken path on every subsequent WINDOW_ACTIVATED.
+        // dispatcher. AWT does not remove failing listeners, so the listener would keep firing
+        // — but each failure would dump a generic uncaught-exception trace into idea.log (SEVERE
+        // in some IDE builds, which triggers a user-visible error balloon) with no project /
+        // hex context. The catch here converts that into an actionable LOG.error.
         try {
             handleWindowActivated(event)
         } catch (exception: RuntimeException) {

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapService.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapService.kt
@@ -1,0 +1,120 @@
+package dev.ayuislands.settings.mappings
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.WindowManager
+import com.intellij.util.IJSwingUtilities
+import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentResolver
+import dev.ayuislands.accent.AyuVariant
+import java.awt.AWTEvent
+import java.awt.Toolkit
+import java.awt.Window
+import java.awt.event.AWTEventListener
+import java.awt.event.WindowEvent
+import javax.swing.SwingUtilities
+
+/**
+ * Focus-swap bridge between [AccentResolver] (per-project override store) and
+ * [AccentApplicator] (global UIManager). UIManager is a single JVM-wide table,
+ * so the "current accent" is whatever was applied last. Without this service,
+ * switching between two project windows would leave the accent stuck on
+ * whichever project happened to trigger the most recent apply — meaning the
+ * per-project override feature would not visibly isolate between windows.
+ *
+ * Listens for [WindowEvent.WINDOW_ACTIVATED] via [AWTEventListener] and, when
+ * the activated window maps to a project, re-applies the resolved accent hex
+ * if it differs from the last applied value. Idempotent and safe to install
+ * from every [com.intellij.openapi.startup.ProjectActivity] call.
+ */
+class ProjectAccentSwapService : Disposable {
+    @Volatile
+    private var lastAppliedProject: Project? = null
+
+    @Volatile
+    private var lastAppliedHex: String? = null
+
+    private var listener: AWTEventListener? = null
+
+    fun install() {
+        if (listener != null) return
+        val awtListener =
+            AWTEventListener { event ->
+                if (event.id == WindowEvent.WINDOW_ACTIVATED) {
+                    SwingUtilities.invokeLater { onWindowActivated(event) }
+                }
+            }
+        Toolkit.getDefaultToolkit().addAWTEventListener(awtListener, AWTEvent.WINDOW_EVENT_MASK)
+        listener = awtListener
+        LOG.info("ProjectAccentSwapService installed")
+    }
+
+    private fun onWindowActivated(event: AWTEvent) {
+        val window = (event as? WindowEvent)?.window ?: return
+        val project = findProjectForWindow(window) ?: return
+        if (project.isDisposed || project.isDefault) return
+        if (project === lastAppliedProject) return
+
+        val variant = AyuVariant.detect() ?: return
+        val effectiveHex = AccentResolver.resolve(project, variant)
+
+        lastAppliedProject = project
+        if (effectiveHex == lastAppliedHex) return
+
+        lastAppliedHex = effectiveHex
+        AccentApplicator.apply(effectiveHex)
+
+        // AccentApplicator updates UIManager + editor scheme. Editor and CodeGlance Pro refresh via
+        // their own message-bus topics, but UIManager-only components (toolbar, tab underlines,
+        // scrollbar chrome, focus rings) hold cached JBColor resolutions at construction time and
+        // do not re-read from UIManager on plain `repaint()`. Force a component-tree LAF refresh
+        // on the focused window so the accent change propagates to every painted descendant.
+        // IJSwingUtilities skips non-UIResource components — the safe IntelliJ variant.
+        try {
+            IJSwingUtilities.updateComponentTreeUI(window)
+        } catch (exception: RuntimeException) {
+            LOG.warn("Component tree UI refresh failed for ${project.name}", exception)
+        }
+        LOG.info("Project accent swapped to $effectiveHex for ${project.name}")
+    }
+
+    /**
+     * Notify after an external apply (settings panel, rotation, startup activity) so the
+     * cache matches the current UIManager state and we don't skip the next real swap.
+     */
+    fun notifyExternalApply(hex: String) {
+        lastAppliedHex = hex
+    }
+
+    private fun findProjectForWindow(window: Window): Project? {
+        val windowManager = WindowManager.getInstance()
+        for (frame in windowManager.allProjectFrames) {
+            val frameWindow = SwingUtilities.getWindowAncestor(frame.component)
+            if (frameWindow === window) {
+                return frame.project
+            }
+        }
+        return null
+    }
+
+    override fun dispose() {
+        listener?.let {
+            Toolkit.getDefaultToolkit().removeAWTEventListener(it)
+            listener = null
+        }
+        lastAppliedProject = null
+        lastAppliedHex = null
+        LOG.info("ProjectAccentSwapService disposed")
+    }
+
+    companion object {
+        private val LOG = logger<ProjectAccentSwapService>()
+
+        fun getInstance(): ProjectAccentSwapService =
+            ApplicationManager
+                .getApplication()
+                .getService(ProjectAccentSwapService::class.java)
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapService.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapService.kt
@@ -110,7 +110,11 @@ class ProjectAccentSwapService : Disposable {
                 val frameWindow = SwingUtilities.getWindowAncestor(frame.component) ?: continue
                 if (frameWindow === window) return project
             } catch (exception: RuntimeException) {
-                LOG.debug("Skipping frame during window-to-project resolution: ${exception.message}")
+                // Warn with the exception so a platform regression that starts throwing here
+                // (e.g. WindowManager breaking invariants during shutdown) is visible in
+                // idea.log. DEBUG would hide the issue from user-submitted logs. The loop
+                // continues so one bad frame doesn't block resolution of a healthy one.
+                LOG.warn("Skipping frame during window-to-project resolution", exception)
             }
         }
         return null

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapService.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapService.kt
@@ -38,6 +38,15 @@ class ProjectAccentSwapService : Disposable {
 
     private var listener: AWTEventListener? = null
 
+    /**
+     * First-warn-only gate for `findProjectForWindow` exceptions. The listener fires on
+     * every WINDOW_ACTIVATED — one broken frame would otherwise spam idea.log on every
+     * alt-tab / dialog / popup. After the first warning, subsequent failures degrade to
+     * DEBUG so they're still captured when a user enables debug logging for a report.
+     */
+    @Volatile
+    private var frameResolutionFailureLogged: Boolean = false
+
     fun install() {
         if (listener != null) return
         val awtListener =
@@ -111,11 +120,20 @@ class ProjectAccentSwapService : Disposable {
                 val frameWindow = SwingUtilities.getWindowAncestor(frame.component) ?: continue
                 if (frameWindow === window) return project
             } catch (exception: RuntimeException) {
-                // Warn with the exception so a platform regression that starts throwing here
-                // (e.g. WindowManager breaking invariants during shutdown) is visible in
-                // idea.log. DEBUG would hide the issue from user-submitted logs. The loop
-                // continues so one bad frame doesn't block resolution of a healthy one.
-                LOG.warn("Skipping frame during window-to-project resolution", exception)
+                // Warn on the first failure so user-submitted logs surface it, then degrade to
+                // DEBUG — WINDOW_ACTIVATED fires on every alt-tab / dialog open, so one broken
+                // frame would otherwise spam idea.log. The loop continues so one bad frame
+                // doesn't block resolution of a healthy one.
+                if (!frameResolutionFailureLogged) {
+                    frameResolutionFailureLogged = true
+                    LOG.warn(
+                        "Skipping frame during window-to-project resolution " +
+                            "(further failures logged at DEBUG)",
+                        exception,
+                    )
+                } else {
+                    LOG.debug("Skipping frame during window-to-project resolution", exception)
+                }
             }
         }
         return null

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapService.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapService.kt
@@ -5,10 +5,10 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.WindowManager
-import com.intellij.util.IJSwingUtilities
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.ui.ComponentTreeRefresher
 import java.awt.AWTEvent
 import java.awt.Toolkit
 import java.awt.Window
@@ -66,17 +66,13 @@ class ProjectAccentSwapService : Disposable {
         lastAppliedHex = effectiveHex
         AccentApplicator.apply(effectiveHex)
 
-        // AccentApplicator updates UIManager + editor scheme. Editor and CodeGlance Pro refresh via
-        // their own message-bus topics, but UIManager-only components (toolbar, tab underlines,
-        // scrollbar chrome, focus rings) hold cached JBColor resolutions at construction time and
-        // do not re-read from UIManager on plain `repaint()`. Force a component-tree LAF refresh
-        // on the focused window so the accent change propagates to every painted descendant.
-        // IJSwingUtilities skips non-UIResource components — the safe IntelliJ variant.
-        try {
-            IJSwingUtilities.updateComponentTreeUI(window)
-        } catch (exception: RuntimeException) {
-            LOG.warn("Component tree UI refresh failed for ${project.name}", exception)
-        }
+        // AccentApplicator updates UIManager + editor scheme. UIManager-only components
+        // (toolbar, tab underlines, scrollbar chrome, focus rings) hold cached JBColor
+        // resolutions captured at construction time and will not re-read UIManager on a
+        // plain `repaint()`. ComponentTreeRefresher does the component-tree LAF refresh
+        // AND fires ComponentTreeRefreshedTopic so managers whose customizations got
+        // reset by the walk (scrollbar hiders etc.) reapply themselves.
+        ComponentTreeRefresher.walkAndNotify(project, window)
         LOG.info("Project accent swapped to $effectiveHex for ${project.name}")
     }
 

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapService.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapService.kt
@@ -9,6 +9,7 @@ import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.ui.ComponentTreeRefresher
+import org.jetbrains.annotations.TestOnly
 import java.awt.AWTEvent
 import java.awt.Toolkit
 import java.awt.Window
@@ -59,6 +60,15 @@ class ProjectAccentSwapService : Disposable {
         listener = awtListener
         LOG.info("ProjectAccentSwapService installed")
     }
+
+    /**
+     * Test seam exposing the `RuntimeException`-catching handler entry point. Production
+     * code reaches this via the AWTEventListener registered in [install]; tests invoke it
+     * directly without bringing up the AWT dispatch loop. Marked `@TestOnly` so the IDE
+     * inspection flags any non-test callers.
+     */
+    @TestOnly
+    internal fun onWindowActivatedForTest(event: AWTEvent) = onWindowActivated(event)
 
     private fun onWindowActivated(event: AWTEvent) {
         // Wrap the entire handler so a single exception (e.g. Color.decode on a corrupted stored

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapService.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapService.kt
@@ -52,6 +52,19 @@ class ProjectAccentSwapService : Disposable {
     }
 
     private fun onWindowActivated(event: AWTEvent) {
+        // Wrap the entire handler so a single exception (e.g. Color.decode on a corrupted stored
+        // hex, WindowManager state inconsistency during shutdown) does not escape to the AWT
+        // dispatcher. Without this, a transient failure would still propagate to the uncaught
+        // exception handler, land in idea.log as SEVERE, and the AWTEventListener would keep
+        // re-firing the broken path on every subsequent WINDOW_ACTIVATED.
+        try {
+            handleWindowActivated(event)
+        } catch (exception: RuntimeException) {
+            LOG.error("Project accent swap failed on window activation", exception)
+        }
+    }
+
+    private fun handleWindowActivated(event: AWTEvent) {
         val window = (event as? WindowEvent)?.window ?: return
         val project = findProjectForWindow(window) ?: return
         if (project.isDisposed || project.isDefault) return
@@ -85,11 +98,19 @@ class ProjectAccentSwapService : Disposable {
     }
 
     private fun findProjectForWindow(window: Window): Project? {
+        // WindowManager.allProjectFrames can contain frames mid-dispose (shutdown race, window
+        // closed between enumeration and access). Guard each frame access so one bad frame
+        // doesn't escape the listener. Skip frames whose project is already disposed — we'd
+        // short-circuit in handleWindowActivated anyway, but skipping here avoids pointless work.
         val windowManager = WindowManager.getInstance()
         for (frame in windowManager.allProjectFrames) {
-            val frameWindow = SwingUtilities.getWindowAncestor(frame.component)
-            if (frameWindow === window) {
-                return frame.project
+            try {
+                val project = frame.project ?: continue
+                if (project.isDisposed) continue
+                val frameWindow = SwingUtilities.getWindowAncestor(frame.component) ?: continue
+                if (frameWindow === window) return project
+            } catch (exception: RuntimeException) {
+                LOG.debug("Skipping frame during window-to-project resolution: ${exception.message}")
             }
         }
         return null

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectMappingsTableModel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectMappingsTableModel.kt
@@ -4,15 +4,26 @@ import java.io.File
 import javax.swing.table.AbstractTableModel
 
 /**
- * Mutable in-memory row representation for the Project Overrides table.
- * [hex] and [displayName] are `var` so `Edit color` / future display-name edits
- * can mutate the row in place without rebuilding the list.
+ * Row representation for the Project Overrides table.
+ *
+ * Immutable `val` fields enforce invariants at construction — `canonicalPath` can't be
+ * blank, and `hex` must look like `#RRGGBB`. Edits go through [copy] rather than in-place
+ * mutation, so the table model's fingerprint-based isModified detection stays reliable.
  */
-class ProjectMapping(
+data class ProjectMapping(
     val canonicalPath: String,
-    var displayName: String,
-    var hex: String,
-)
+    val displayName: String,
+    val hex: String,
+) {
+    init {
+        require(canonicalPath.isNotBlank()) { "canonicalPath must not be blank" }
+        require(HEX_REGEX.matches(hex)) { "hex must be #RRGGBB, got: '$hex'" }
+    }
+
+    companion object {
+        private val HEX_REGEX = Regex("^#[0-9A-Fa-f]{6}$")
+    }
+}
 
 /**
  * Table model for the Project Overrides section. Three columns: Color (hex),
@@ -48,7 +59,7 @@ class ProjectMappingsTableModel : AbstractTableModel() {
         hex: String,
     ) {
         if (row !in rows.indices) return
-        rows[row].hex = hex
+        rows[row] = rows[row].copy(hex = hex)
         fireTableRowsUpdated(row, row)
     }
 

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectMappingsTableModel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectMappingsTableModel.kt
@@ -1,0 +1,96 @@
+package dev.ayuislands.settings.mappings
+
+import java.io.File
+import javax.swing.table.AbstractTableModel
+
+/**
+ * Mutable in-memory row representation for the Project Overrides table.
+ * [hex] and [displayName] are `var` so `Edit color` / future display-name edits
+ * can mutate the row in place without rebuilding the list.
+ */
+class ProjectMapping(
+    val canonicalPath: String,
+    var displayName: String,
+    var hex: String,
+)
+
+/**
+ * Table model for the Project Overrides section. Three columns: Color (hex),
+ * Project (display name), Path (canonical path). Rows track orphaned paths
+ * via [isOrphan]; the table-level prepareRenderer hook styles them accordingly.
+ */
+class ProjectMappingsTableModel : AbstractTableModel() {
+    private val rows: MutableList<ProjectMapping> = mutableListOf()
+
+    fun replaceAll(mappings: Collection<ProjectMapping>) {
+        rows.clear()
+        rows.addAll(mappings)
+        fireTableDataChanged()
+    }
+
+    fun snapshot(): List<ProjectMapping> = rows.toList()
+
+    fun add(mapping: ProjectMapping): Int {
+        rows += mapping
+        val index = rows.size - 1
+        fireTableRowsInserted(index, index)
+        return index
+    }
+
+    fun remove(row: Int) {
+        if (row !in rows.indices) return
+        rows.removeAt(row)
+        fireTableRowsDeleted(row, row)
+    }
+
+    fun updateHex(
+        row: Int,
+        hex: String,
+    ) {
+        if (row !in rows.indices) return
+        rows[row].hex = hex
+        fireTableRowsUpdated(row, row)
+    }
+
+    fun rowAt(index: Int): ProjectMapping? = rows.getOrNull(index)
+
+    fun containsPath(canonicalPath: String): Boolean = rows.any { it.canonicalPath == canonicalPath }
+
+    fun isOrphan(row: Int): Boolean {
+        val mapping = rowAt(row) ?: return false
+        return !runCatching { File(mapping.canonicalPath).isDirectory }.getOrDefault(false)
+    }
+
+    override fun getRowCount(): Int = rows.size
+
+    override fun getColumnCount(): Int = COLUMN_NAMES.size
+
+    override fun getColumnName(column: Int): String = COLUMN_NAMES.getOrElse(column) { "" }
+
+    override fun getColumnClass(columnIndex: Int): Class<*> = String::class.java
+
+    override fun isCellEditable(
+        rowIndex: Int,
+        columnIndex: Int,
+    ): Boolean = false
+
+    override fun getValueAt(
+        rowIndex: Int,
+        columnIndex: Int,
+    ): Any? {
+        val mapping = rowAt(rowIndex) ?: return null
+        return when (columnIndex) {
+            COLUMN_COLOR -> mapping.hex
+            COLUMN_PROJECT -> mapping.displayName
+            COLUMN_PATH -> mapping.canonicalPath
+            else -> null
+        }
+    }
+
+    companion object {
+        const val COLUMN_COLOR = 0
+        const val COLUMN_PROJECT = 1
+        const val COLUMN_PATH = 2
+        private val COLUMN_NAMES = listOf("Color", "Project", "Path")
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/RoundedSwatchRenderer.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/RoundedSwatchRenderer.kt
@@ -1,6 +1,7 @@
 package dev.ayuislands.settings.mappings
 
 import com.intellij.util.ui.JBUI
+import dev.ayuislands.accent.AYU_ACCENT_PRESETS
 import java.awt.Color
 import java.awt.Component
 import java.awt.Graphics
@@ -31,7 +32,7 @@ class RoundedSwatchRenderer : DefaultTableCellRenderer() {
     ): Component {
         super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column)
         hexValue = value as? String
-        text = hexValue?.uppercase() ?: ""
+        text = formatLabel(hexValue)
         border =
             JBUI.Borders.empty(
                 BORDER_VERTICAL,
@@ -79,6 +80,19 @@ class RoundedSwatchRenderer : DefaultTableCellRenderer() {
         private const val BORDER_RGB = 0x4E5A6E
         private const val BORDER_VERTICAL = 2
         private const val BORDER_TEXT_RIGHT = 4
+
+        /**
+         * Label shown next to the swatch: inherits the curated preset name when [hex]
+         * matches one of [AYU_ACCENT_PRESETS] (e.g. "Amber (#F29E74)"), falls back to
+         * plain hex for custom colors. Public so other renderers / dialogs can reuse
+         * the same formatting and stay consistent.
+         */
+        fun formatLabel(hex: String?): String {
+            if (hex.isNullOrBlank()) return ""
+            val preset = AYU_ACCENT_PRESETS.firstOrNull { it.hex.equals(hex, ignoreCase = true) }
+            val upper = hex.uppercase()
+            return if (preset != null) "${preset.name} ($upper)" else upper
+        }
 
         fun safeDecodeColor(hex: String): Color? =
             try {

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/RoundedSwatchRenderer.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/RoundedSwatchRenderer.kt
@@ -1,0 +1,90 @@
+package dev.ayuislands.settings.mappings
+
+import com.intellij.util.ui.JBUI
+import java.awt.Color
+import java.awt.Component
+import java.awt.Graphics
+import java.awt.Graphics2D
+import java.awt.RenderingHints
+import java.awt.geom.RoundRectangle2D
+import javax.swing.JTable
+import javax.swing.UIManager
+import javax.swing.table.DefaultTableCellRenderer
+
+/**
+ * JBTable cell renderer that paints a rounded color swatch next to its hex code.
+ *
+ * Accepts a `String` hex value ("#RRGGBB"); invalid or empty values render as blank.
+ * The swatch sits on the left, the hex text to the right. Intended for the `Color`
+ * column of the project / language mappings tables.
+ */
+class RoundedSwatchRenderer : DefaultTableCellRenderer() {
+    private var hexValue: String? = null
+
+    override fun getTableCellRendererComponent(
+        table: JTable,
+        value: Any?,
+        isSelected: Boolean,
+        hasFocus: Boolean,
+        row: Int,
+        column: Int,
+    ): Component {
+        super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column)
+        hexValue = value as? String
+        text = hexValue?.uppercase() ?: ""
+        border =
+            JBUI.Borders.empty(
+                BORDER_VERTICAL,
+                LEFT_INSET + SWATCH_SIZE + TEXT_GAP,
+                BORDER_VERTICAL,
+                BORDER_TEXT_RIGHT,
+            )
+        return this
+    }
+
+    override fun paintComponent(g: Graphics) {
+        super.paintComponent(g)
+        val hex = hexValue ?: return
+        val color = safeDecodeColor(hex) ?: return
+        val graphics = g.create() as Graphics2D
+        try {
+            graphics.setRenderingHint(
+                RenderingHints.KEY_ANTIALIASING,
+                RenderingHints.VALUE_ANTIALIAS_ON,
+            )
+            val y = (height - SWATCH_SIZE) / 2f
+            val shape =
+                RoundRectangle2D.Float(
+                    LEFT_INSET.toFloat(),
+                    y,
+                    SWATCH_SIZE.toFloat(),
+                    SWATCH_SIZE.toFloat(),
+                    SWATCH_ARC,
+                    SWATCH_ARC,
+                )
+            graphics.color = color
+            graphics.fill(shape)
+            graphics.color = UIManager.getColor("Separator.separatorColor") ?: Color(BORDER_RGB)
+            graphics.draw(shape)
+        } finally {
+            graphics.dispose()
+        }
+    }
+
+    companion object {
+        private const val LEFT_INSET = 6
+        private const val SWATCH_SIZE = 14
+        private const val SWATCH_ARC = 4f
+        private const val TEXT_GAP = 8
+        private const val BORDER_RGB = 0x4E5A6E
+        private const val BORDER_VERTICAL = 2
+        private const val BORDER_TEXT_RIGHT = 4
+
+        fun safeDecodeColor(hex: String): Color? =
+            try {
+                Color.decode(hex)
+            } catch (_: NumberFormatException) {
+                null
+            }
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/ui/ComponentTreeRefreshedTopic.kt
+++ b/src/main/kotlin/dev/ayuislands/ui/ComponentTreeRefreshedTopic.kt
@@ -1,0 +1,27 @@
+package dev.ayuislands.ui
+
+import com.intellij.openapi.project.Project
+import com.intellij.util.messages.Topic
+
+/**
+ * Listener fired after a forced component-tree LAF refresh has walked a project's
+ * frame. Subscribe in `init {}` on any project-scoped service that installs per-component
+ * overrides (`putClientProperty`, `setPreferredSize`, `setBorder`, and similar) that
+ * `JComponent.updateUI()` resets — e.g. scrollbar-hide tricks, caret-row overlays.
+ *
+ * Each subscriber receives events published on its own `project.messageBus` only; cross-
+ * project contamination is blocked by [Topic.BroadcastDirection.NONE].
+ */
+fun interface ComponentTreeRefreshedListener {
+    fun afterRefresh(project: Project)
+}
+
+object ComponentTreeRefreshedTopic {
+    @JvmField
+    val TOPIC: Topic<ComponentTreeRefreshedListener> =
+        Topic.create(
+            "Ayu Islands component tree refreshed",
+            ComponentTreeRefreshedListener::class.java,
+            Topic.BroadcastDirection.NONE,
+        )
+}

--- a/src/main/kotlin/dev/ayuislands/ui/ComponentTreeRefresher.kt
+++ b/src/main/kotlin/dev/ayuislands/ui/ComponentTreeRefresher.kt
@@ -32,7 +32,13 @@ object ComponentTreeRefresher {
         try {
             IJSwingUtilities.updateComponentTreeUI(root)
         } catch (exception: RuntimeException) {
-            LOG.warn("Component tree refresh failed for ${project.name}: ${exception.message}")
+            // Pass the exception as the second argument so the stacktrace is preserved in
+            // idea.log — post-mortem on a failed Swing refresh is impossible without it.
+            // Include the root component class so failures on a specific tree node are traceable.
+            LOG.warn(
+                "Component tree refresh failed for ${project.name} (root=${root.javaClass.simpleName})",
+                exception,
+            )
         }
         notifyOnly(project)
     }

--- a/src/main/kotlin/dev/ayuislands/ui/ComponentTreeRefresher.kt
+++ b/src/main/kotlin/dev/ayuislands/ui/ComponentTreeRefresher.kt
@@ -1,0 +1,51 @@
+package dev.ayuislands.ui
+
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.intellij.util.IJSwingUtilities
+import java.awt.Component
+
+/**
+ * Central pipeline for "the component tree was refreshed → subscribed managers, please
+ * reapply your overrides".
+ *
+ * `IJSwingUtilities.updateComponentTreeUI` calls `updateUI()` on every descendant, which
+ * resets component-level customizations our managers install (e.g.
+ * `EditorScrollbarManager` zeroes `JScrollBar.preferredSize` to hide scrollbars —
+ * `updateUI()` restores the default size). After the walk we publish a project-scoped
+ * event on [ComponentTreeRefreshedTopic] so subscribers reapply.
+ *
+ * Callers that need stale-color refresh (e.g. startup activity, focus-swap) use
+ * [walkAndNotify]. Callers triggered by the platform's own LAF refresh (e.g.
+ * `LafManagerListener.lookAndFeelChanged`) use [notifyOnly] — the tree walk is redundant
+ * there, only the subscribe-side reapply is needed.
+ */
+object ComponentTreeRefresher {
+    private val LOG = logger<ComponentTreeRefresher>()
+
+    /** Walks the component subtree at [root], then fires [notifyOnly]. */
+    fun walkAndNotify(
+        project: Project,
+        root: Component,
+    ) {
+        if (project.isDisposed) return
+        try {
+            IJSwingUtilities.updateComponentTreeUI(root)
+        } catch (exception: RuntimeException) {
+            LOG.warn("Component tree refresh failed for ${project.name}: ${exception.message}")
+        }
+        notifyOnly(project)
+    }
+
+    /**
+     * Publishes a refresh event without walking the tree — use when the platform or
+     * another caller has already refreshed the component tree (e.g. native LAF change)
+     * and we just need subscribers to reapply their overrides.
+     */
+    fun notifyOnly(project: Project) {
+        if (project.isDisposed) return
+        project.messageBus
+            .syncPublisher(ComponentTreeRefreshedTopic.TOPIC)
+            .afterRefresh(project)
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -72,6 +72,12 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>2.5.0</h3>
+    <ul>
+      <li>[Paid] Pin an accent color to a specific project — set it once from Settings and every time you switch to that window your accent is there</li>
+      <li>[Paid] Pin an accent color to a programming language — e.g. Kotlin → lime, Python → sky. Applies when a project's dominant language matches and no project override exists</li>
+      <li>Recent projects populate the add-project dialog so you can configure overrides without opening the project first</li>
+    </ul>
     <h3>2.4.2</h3>
     <ul>
       <li>[Paid] Install, delete, or reinstall curated fonts directly from Settings without opening the wizard</li>
@@ -172,6 +178,14 @@
         <!-- Persistent accent color state -->
         <applicationService
                 serviceImplementation="dev.ayuislands.settings.AyuIslandsSettings"/>
+
+        <!-- Per-project and per-language accent overrides -->
+        <applicationService
+                serviceImplementation="dev.ayuislands.settings.mappings.AccentMappingsSettings"/>
+
+        <!-- Swaps the active accent when user switches between project windows -->
+        <applicationService
+                serviceImplementation="dev.ayuislands.settings.mappings.ProjectAccentSwapService"/>
 
         <!-- Appearance sync (follow system Light/Dark mode) -->
         <applicationService

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsAppListenerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsAppListenerTest.kt
@@ -20,6 +20,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 
+@Suppress("UnstableApiUsage")
 class AyuIslandsAppListenerTest {
     private lateinit var state: AyuIslandsState
     private val listener = AyuIslandsAppListener()
@@ -67,7 +68,6 @@ class AyuIslandsAppListenerTest {
         val laf = mockk<UIThemeLookAndFeelInfo>()
         every { laf.name } returns "Ayu Mirage (Islands UI)"
         val lafManager = mockk<LafManager>()
-        @Suppress("UnstableApiUsage")
         every {
             lafManager.currentUIThemeLookAndFeel
         } returns laf
@@ -85,7 +85,6 @@ class AyuIslandsAppListenerTest {
         val laf = mockk<UIThemeLookAndFeelInfo>()
         every { laf.name } returns "Darcula"
         val lafManager = mockk<LafManager>()
-        @Suppress("UnstableApiUsage")
         every {
             lafManager.currentUIThemeLookAndFeel
         } returns laf
@@ -119,7 +118,6 @@ class AyuIslandsAppListenerTest {
             val laf = mockk<UIThemeLookAndFeelInfo>()
             every { laf.name } returns themeName
             val lafManager = mockk<LafManager>()
-            @Suppress("UnstableApiUsage")
             every { lafManager.currentUIThemeLookAndFeel } returns laf
             every { LafManager.getInstance() } returns lafManager
 
@@ -140,13 +138,11 @@ class AyuIslandsAppListenerTest {
 
         val nonIslandsLaf = mockk<UIThemeLookAndFeelInfo>()
         every { nonIslandsLaf.name } returns "Ayu Mirage"
-        @Suppress("UnstableApiUsage")
         every { lafManager.currentUIThemeLookAndFeel } returns nonIslandsLaf
         listener.appFrameCreated(mutableListOf())
 
         val islandsLaf = mockk<UIThemeLookAndFeelInfo>()
         every { islandsLaf.name } returns "Ayu Mirage (Islands UI)"
-        @Suppress("UnstableApiUsage")
         every { lafManager.currentUIThemeLookAndFeel } returns islandsLaf
         listener.appFrameCreated(mutableListOf())
 

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsAppListenerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsAppListenerTest.kt
@@ -6,6 +6,8 @@ import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
+import dev.ayuislands.settings.mappings.AccentMappingsSettings
+import dev.ayuislands.settings.mappings.AccentMappingsState
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -42,6 +44,13 @@ class AyuIslandsAppListenerTest {
         every {
             AyuIslandsSettings.getInstance()
         } returns settings
+
+        // AccentResolver consults AccentMappingsSettings before falling through to global;
+        // an empty state preserves pre-override behavior (resolver returns the global accent).
+        val mappingsSettings = mockk<AccentMappingsSettings>()
+        every { mappingsSettings.state } returns AccentMappingsState()
+        mockkObject(AccentMappingsSettings.Companion)
+        every { AccentMappingsSettings.getInstance() } returns mappingsSettings
 
         mockkStatic(LafManager::class)
         mockkObject(AccentApplicator)

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
@@ -2,7 +2,6 @@ package dev.ayuislands
 
 import com.intellij.testFramework.LoggedErrorProcessor
 import java.util.EnumSet
-import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -22,10 +21,8 @@ import kotlin.test.assertFailsWith
 class AyuIslandsStartupActivityTest {
     private val activity = AyuIslandsStartupActivity()
 
-    @AfterTest
-    fun tearDown() {
-        // Ensure the test logger doesn't leak between tests.
-    }
+    // No @AfterTest needed — LoggedErrorProcessor.executeWith restores the default
+    // processor at block end, and we don't mockkStatic/mockkObject anything global.
 
     @Test
     fun `runStep swallows RuntimeException so the next step can run`() {
@@ -64,10 +61,12 @@ class AyuIslandsStartupActivityTest {
     }
 
     @Test
-    fun `runStep swallows non-VM Error so optional-plugin LinkageError doesn't abort startup`() {
-        // LinkageError / NoClassDefFoundError typically mean an optional plugin dependency
-        // didn't load. The plugin's own startup should continue, not abort — otherwise a
-        // missing CodeGlance Pro etc. would silently kill remaining steps.
+    fun `runStep swallows non-VM Error so LinkageError from one step doesn't abort the rest`() {
+        // LinkageError / NoClassDefFoundError typically surface a class-loading issue in
+        // an individual step's transitive closure (e.g. a Kotlin stdlib mismatch from a
+        // lazily-loaded service). The plugin's remaining steps should continue
+        // independently — otherwise one class-load glitch silently kills all subsequent
+        // steps.
         val captured = mutableListOf<Pair<String, Throwable?>>()
         val processor = capturingProcessor(captured)
 

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
@@ -1,0 +1,96 @@
+package dev.ayuislands
+
+import com.intellij.testFramework.LoggedErrorProcessor
+import java.util.EnumSet
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * Locks in the [AyuIslandsStartupActivity.runStep] catch contract:
+ *
+ *  - [RuntimeException] → logged, swallowed, next call would proceed
+ *  - [VirtualMachineError] → logged then rethrown so the JVM crash reporter still gets it
+ *  - other [Error] → logged, swallowed (LinkageError / NoClassDefFoundError from optional
+ *    plugin deps shouldn't abort plugin startup)
+ *
+ * The split is non-trivial — a future widening of the Error catch to omit the rethrow
+ * (or narrowing it past LinkageError) would silently change startup behavior. These
+ * tests freeze the contract.
+ */
+class AyuIslandsStartupActivityTest {
+    private val activity = AyuIslandsStartupActivity()
+
+    @AfterTest
+    fun tearDown() {
+        // Ensure the test logger doesn't leak between tests.
+    }
+
+    @Test
+    fun `runStep swallows RuntimeException so the next step can run`() {
+        val captured = mutableListOf<Pair<String, Throwable?>>()
+        val processor = capturingProcessor(captured)
+
+        LoggedErrorProcessor.executeWith<RuntimeException>(processor) {
+            activity.runStepForTest("step-X") {
+                throw IllegalArgumentException("boom from step-X")
+            }
+        }
+
+        assertEquals(1, captured.size)
+        assertEquals("License startup step 'step-X' failed", captured.single().first)
+    }
+
+    @Test
+    fun `runStep rethrows VirtualMachineError so the JVM crash reporter receives it`() {
+        // Locks the rethrow: OOM, StackOverflowError, InternalError indicate unrecoverable
+        // JVM state and continuing would risk cascading corruption. The test triggers an
+        // InternalError (the cheapest VirtualMachineError to construct in a unit test).
+        val captured = mutableListOf<Pair<String, Throwable?>>()
+        val processor = capturingProcessor(captured)
+
+        assertFailsWith<InternalError> {
+            LoggedErrorProcessor.executeWith<Throwable>(processor) {
+                activity.runStepForTest("step-vm") {
+                    throw InternalError("simulated unrecoverable")
+                }
+            }
+        }
+
+        // Step name was logged before the rethrow.
+        assertEquals(1, captured.size)
+        assertEquals("License startup step 'step-vm' failed with VM error", captured.single().first)
+    }
+
+    @Test
+    fun `runStep swallows non-VM Error so optional-plugin LinkageError doesn't abort startup`() {
+        // LinkageError / NoClassDefFoundError typically mean an optional plugin dependency
+        // didn't load. The plugin's own startup should continue, not abort — otherwise a
+        // missing CodeGlance Pro etc. would silently kill remaining steps.
+        val captured = mutableListOf<Pair<String, Throwable?>>()
+        val processor = capturingProcessor(captured)
+
+        LoggedErrorProcessor.executeWith<Throwable>(processor) {
+            activity.runStepForTest("step-link") {
+                throw NoClassDefFoundError("optional plugin missing")
+            }
+        }
+
+        assertEquals(1, captured.size)
+        assertEquals("License startup step 'step-link' failed with Error", captured.single().first)
+    }
+
+    private fun capturingProcessor(captured: MutableList<Pair<String, Throwable?>>) =
+        object : LoggedErrorProcessor() {
+            override fun processError(
+                category: String,
+                message: String,
+                details: Array<out String>,
+                throwable: Throwable?,
+            ): Set<Action> {
+                captured += message to throwable
+                return EnumSet.noneOf(Action::class.java)
+            }
+        }
+}

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt
@@ -17,9 +17,10 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 /**
- * Locks in the contract of [AccentApplicator.applyForFocusedProject] — picked as a single
- * chokepoint by the DRY refactor, so these tests are the safety net that keeps the sequence
- * (focused-project selection → resolver → apply → swap-cache sync) from silently drifting.
+ * Locks in the contract of [AccentApplicator.applyForFocusedProject] — four production
+ * callers (settings panels, LAF listener, rotation tick, startup) previously hand-wired
+ * inconsistent variants of this sequence. These tests are the safety net that keeps the
+ * sequence (focused-project selection → resolver → apply → swap-cache sync) from drifting.
  *
  * Uses the real [AccentApplicator] object but mocks every collaborator:
  *  - [ProjectManager.getInstance] for the focused-project pick (first non-default, non-disposed)

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt
@@ -1,0 +1,126 @@
+package dev.ayuislands.accent
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
+import dev.ayuislands.settings.mappings.ProjectAccentSwapService
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Locks in the contract of [AccentApplicator.applyForFocusedProject] — picked as a single
+ * chokepoint by the DRY refactor, so these tests are the safety net that keeps the sequence
+ * (focused-project selection → resolver → apply → swap-cache sync) from silently drifting.
+ *
+ * Uses the real [AccentApplicator] object but mocks every collaborator:
+ *  - [ProjectManager.getInstance] for the focused-project pick (first non-default, non-disposed)
+ *  - [AccentResolver.resolve] for the resolver call (covered independently in AccentResolverTest)
+ *  - A partial mock on [AccentApplicator] itself to intercept `apply(hex)` — we only care that
+ *    the helper forwards the resolver's output, not the full UIManager side-effect chain
+ *  - [ProjectAccentSwapService.getInstance] for the notifyExternalApply assertion
+ */
+class AccentApplicatorFocusedProjectTest {
+    private lateinit var swapService: ProjectAccentSwapService
+
+    @BeforeTest
+    fun setUp() {
+        mockkStatic(ProjectManager::class)
+        mockkObject(AccentResolver)
+        mockkObject(AccentApplicator, recordPrivateCalls = false)
+        every { AccentApplicator.apply(any()) } just Runs
+
+        mockkObject(ProjectAccentSwapService.Companion)
+        swapService = mockk(relaxed = true)
+        every { ProjectAccentSwapService.getInstance() } returns swapService
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `applyForFocusedProject forwards the resolver output to apply and the swap cache`() {
+        val focused = stubProject(isDefault = false, isDisposed = false)
+        val manager = mockk<ProjectManager>()
+        every { manager.openProjects } returns arrayOf(focused)
+        every { ProjectManager.getInstance() } returns manager
+        every { AccentResolver.resolve(focused, AyuVariant.MIRAGE) } returns "#ABCDEF"
+
+        val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
+
+        assertEquals("#ABCDEF", applied)
+        verify(exactly = 1) { AccentApplicator.apply("#ABCDEF") }
+        verify(exactly = 1) { swapService.notifyExternalApply("#ABCDEF") }
+    }
+
+    @Test
+    fun `applyForFocusedProject skips default and disposed projects when picking focus`() {
+        val defaultProject = stubProject(isDefault = true, isDisposed = false)
+        val disposedProject = stubProject(isDefault = false, isDisposed = true)
+        val realFocus = stubProject(isDefault = false, isDisposed = false)
+        val manager = mockk<ProjectManager>()
+        every { manager.openProjects } returns arrayOf(defaultProject, disposedProject, realFocus)
+        every { ProjectManager.getInstance() } returns manager
+        every { AccentResolver.resolve(realFocus, AyuVariant.DARK) } returns "#123456"
+
+        val applied = AccentApplicator.applyForFocusedProject(AyuVariant.DARK)
+
+        assertEquals("#123456", applied)
+        verify(exactly = 1) { AccentResolver.resolve(realFocus, AyuVariant.DARK) }
+    }
+
+    @Test
+    fun `applyForFocusedProject passes null to resolver when no non-default project is open`() {
+        // Simulates the "Welcome screen / all projects closed" startup path. Resolver sees a null
+        // project, short-circuits to the global accent, and the helper still propagates it.
+        val manager = mockk<ProjectManager>()
+        every { manager.openProjects } returns emptyArray()
+        every { ProjectManager.getInstance() } returns manager
+        every { AccentResolver.resolve(null, AyuVariant.LIGHT) } returns "#F29718"
+
+        val applied = AccentApplicator.applyForFocusedProject(AyuVariant.LIGHT)
+
+        assertEquals("#F29718", applied)
+        verify(exactly = 1) { AccentApplicator.apply("#F29718") }
+        verify(exactly = 1) { swapService.notifyExternalApply("#F29718") }
+    }
+
+    @Test
+    fun `applyForFocusedProject ordering - resolver runs before apply, swap cache after`() {
+        // The swap cache's notifyExternalApply must fire AFTER apply, otherwise a concurrent
+        // window-activated event would see the cache updated for a hex that's not yet painted.
+        val focused = stubProject(isDefault = false, isDisposed = false)
+        val manager = mockk<ProjectManager>()
+        every { manager.openProjects } returns arrayOf(focused)
+        every { ProjectManager.getInstance() } returns manager
+        every { AccentResolver.resolve(focused, AyuVariant.MIRAGE) } returns "#FFCC66"
+
+        AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
+
+        io.mockk.verifyOrder {
+            AccentResolver.resolve(focused, AyuVariant.MIRAGE)
+            AccentApplicator.apply("#FFCC66")
+            swapService.notifyExternalApply("#FFCC66")
+        }
+    }
+
+    private fun stubProject(
+        isDefault: Boolean,
+        isDisposed: Boolean,
+    ): Project {
+        val project = mockk<Project>()
+        every { project.isDefault } returns isDefault
+        every { project.isDisposed } returns isDisposed
+        return project
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt
@@ -17,13 +17,20 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 /**
- * Locks in the contract of [AccentApplicator.applyForFocusedProject] — four production
- * callers (settings panels, LAF listener, rotation tick, startup) previously hand-wired
- * inconsistent variants of this sequence. These tests are the safety net that keeps the
- * sequence (focused-project selection → resolver → apply → swap-cache sync) from drifting.
+ * Locks in the contract of [AccentApplicator.applyForFocusedProject] — five production
+ * callers (the three settings panels, the LAF listener, the rotation tick) previously
+ * hand-wired inconsistent variants of this sequence (most skipped the swap-cache sync).
+ * These tests are the safety net that keeps the sequence (focused-project selection →
+ * resolver → apply → swap-cache sync) from drifting.
  *
  * Uses the real [AccentApplicator] object but mocks every collaborator:
- *  - [ProjectManager.getInstance] for the focused-project pick (first non-default, non-disposed)
+ *  - [com.intellij.openapi.wm.IdeFocusManager] is left unmocked → returns the headless
+ *    no-op manager whose `lastFocusedFrame` is `null`, so these tests exercise the
+ *    [ProjectManager] fallback path. Primary-path coverage (real focused frame) is left
+ *    to manual smoke / IDE integration; the production fallback chain is documented in
+ *    the helper's own KDoc.
+ *  - [ProjectManager.getInstance] for the fallback focused-project pick (first
+ *    non-default, non-disposed open project)
  *  - [AccentResolver.resolve] for the resolver call (covered independently in AccentResolverTest)
  *  - A partial mock on [AccentApplicator] itself to intercept `apply(hex)` — we only care that
  *    the helper forwards the resolver's output, not the full UIManager side-effect chain

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt
@@ -2,6 +2,8 @@ package dev.ayuislands.accent
 
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.wm.IdeFocusManager
+import com.intellij.openapi.wm.IdeFrame
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 import io.mockk.Runs
 import io.mockk.every
@@ -101,6 +103,73 @@ class AccentApplicatorFocusedProjectTest {
         assertEquals("#F29718", applied)
         verify(exactly = 1) { AccentApplicator.apply("#F29718") }
         verify(exactly = 1) { swapService.notifyExternalApply("#F29718") }
+    }
+
+    @Test
+    fun `applyForFocusedProject prefers IdeFocusManager focused frame over openProjects order`() {
+        // Locks the primary path of resolveFocusedProject: when IdeFocusManager.lastFocusedFrame
+        // resolves to a real project, that wins over openProjects enumeration. Multi-window
+        // bug R2 was about the OPPOSITE — silently picking the first open project regardless
+        // of which window the user is actually in. This test proves the fix prefers focus
+        // state.
+        val focusedProject = stubProject(isDefault = false, isDisposed = false)
+        val otherProject = stubProject(isDefault = false, isDisposed = false)
+
+        val focusedFrame =
+            mockk<IdeFrame> {
+                every { project } returns focusedProject
+            }
+        val focusManager =
+            mockk<IdeFocusManager> {
+                every { lastFocusedFrame } returns focusedFrame
+            }
+        mockkStatic(IdeFocusManager::class)
+        every { IdeFocusManager.getGlobalInstance() } returns focusManager
+
+        // Both projects are in openProjects; the focused-frame project must win even if
+        // it's NOT the first in enumeration order.
+        val manager = mockk<ProjectManager>()
+        every { manager.openProjects } returns arrayOf(otherProject, focusedProject)
+        every { ProjectManager.getInstance() } returns manager
+
+        every { AccentResolver.resolve(focusedProject, AyuVariant.MIRAGE) } returns "#FOCUSED"
+
+        val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
+
+        assertEquals("#FOCUSED", applied)
+        verify(exactly = 1) { AccentResolver.resolve(focusedProject, AyuVariant.MIRAGE) }
+        verify(exactly = 0) { AccentResolver.resolve(otherProject, any()) }
+    }
+
+    @Test
+    fun `applyForFocusedProject falls back to openProjects when focused frame project is disposed`() {
+        // Edge case in resolveFocusedProject: lastFocusedFrame returns a project that
+        // disposed between focus event and our read. The takeIf { isUsable() } guard
+        // discards it; the openProjects scan provides the fallback.
+        val disposedProject = stubProject(isDefault = false, isDisposed = true)
+        val healthyProject = stubProject(isDefault = false, isDisposed = false)
+
+        val staleFrame =
+            mockk<IdeFrame> {
+                every { project } returns disposedProject
+            }
+        val focusManager =
+            mockk<IdeFocusManager> {
+                every { lastFocusedFrame } returns staleFrame
+            }
+        mockkStatic(IdeFocusManager::class)
+        every { IdeFocusManager.getGlobalInstance() } returns focusManager
+
+        val manager = mockk<ProjectManager>()
+        every { manager.openProjects } returns arrayOf(healthyProject)
+        every { ProjectManager.getInstance() } returns manager
+
+        every { AccentResolver.resolve(healthyProject, AyuVariant.MIRAGE) } returns "#FALLBACK"
+
+        val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
+
+        assertEquals("#FALLBACK", applied)
+        verify(exactly = 1) { AccentResolver.resolve(healthyProject, AyuVariant.MIRAGE) }
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
@@ -841,7 +841,11 @@ class AccentApplicatorTest {
     }
 
     @Test
-    fun `apply invokes IndentRainbowSync when variant is non-null`() {
+    fun `apply invokes IndentRainbowSync with the exact accent hex passed in`() {
+        // Regression guard against passthrough drift: a future refactor that dropped the hex
+        // parameter and called AyuIslandsSettings.getInstance().getAccentForVariant(variant)
+        // internally would make IR paint the GLOBAL accent during rotation + override scenarios,
+        // but the old `any()` matcher would still pass. Assert the exact hex flows through.
         mockEpExtensionList(emptyList())
         mockkObject(IndentRainbowSync)
         every { IndentRainbowSync.apply(any(), any()) } returns Unit
@@ -850,7 +854,7 @@ class AccentApplicatorTest {
 
         AccentApplicator.apply("#FFCC66")
 
-        verify { IndentRainbowSync.apply(AyuVariant.MIRAGE, any()) }
+        verify { IndentRainbowSync.apply(AyuVariant.MIRAGE, "#FFCC66") }
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
@@ -829,7 +829,7 @@ class AccentApplicatorTest {
     fun `apply calls applyAlwaysOnUiKeys and applyAlwaysOnEditorKeys on EDT`() {
         mockEpExtensionList(emptyList())
         mockkObject(IndentRainbowSync)
-        every { IndentRainbowSync.apply(any()) } returns Unit
+        every { IndentRainbowSync.apply(any(), any()) } returns Unit
         state.cgpIntegrationEnabled = false
 
         AccentApplicator.apply("#FFCC66")
@@ -844,13 +844,13 @@ class AccentApplicatorTest {
     fun `apply invokes IndentRainbowSync when variant is non-null`() {
         mockEpExtensionList(emptyList())
         mockkObject(IndentRainbowSync)
-        every { IndentRainbowSync.apply(any()) } returns Unit
+        every { IndentRainbowSync.apply(any(), any()) } returns Unit
         state.cgpIntegrationEnabled = false
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
 
         AccentApplicator.apply("#FFCC66")
 
-        verify { IndentRainbowSync.apply(AyuVariant.MIRAGE) }
+        verify { IndentRainbowSync.apply(AyuVariant.MIRAGE, any()) }
     }
 
     @Test
@@ -862,14 +862,14 @@ class AccentApplicatorTest {
 
         AccentApplicator.apply("#FFCC66")
 
-        verify(exactly = 0) { IndentRainbowSync.apply(any()) }
+        verify(exactly = 0) { IndentRainbowSync.apply(any(), any()) }
     }
 
     @Test
     fun `apply calls repaintAllWindows`() {
         mockEpExtensionList(emptyList())
         mockkObject(IndentRainbowSync)
-        every { IndentRainbowSync.apply(any()) } returns Unit
+        every { IndentRainbowSync.apply(any(), any()) } returns Unit
         state.cgpIntegrationEnabled = false
         val mockWindow = mockk<Window>(relaxed = true)
         every { Window.getWindows() } returns arrayOf(mockWindow)
@@ -883,7 +883,7 @@ class AccentApplicatorTest {
     fun `apply runs work directly when on EDT`() {
         mockEpExtensionList(emptyList())
         mockkObject(IndentRainbowSync)
-        every { IndentRainbowSync.apply(any()) } returns Unit
+        every { IndentRainbowSync.apply(any(), any()) } returns Unit
         state.cgpIntegrationEnabled = false
         every { SwingUtilities.isEventDispatchThread() } returns true
 
@@ -897,7 +897,7 @@ class AccentApplicatorTest {
     fun `apply posts to invokeLater when not on EDT`() {
         mockEpExtensionList(emptyList())
         mockkObject(IndentRainbowSync)
-        every { IndentRainbowSync.apply(any()) } returns Unit
+        every { IndentRainbowSync.apply(any(), any()) } returns Unit
         state.cgpIntegrationEnabled = false
         every { SwingUtilities.isEventDispatchThread() } returns false
         every { mockApplication.invokeLater(any(), any<ModalityState>()) } answers {

--- a/src/test/kotlin/dev/ayuislands/accent/AccentResolverTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentResolverTest.kt
@@ -241,16 +241,14 @@ class AccentResolverTest {
     fun `projectKey logs once per project on canonicalization failure then dedups`() {
         // Hot-path callers (focus swap, rotation tick) must not flood idea.log when a
         // project's basePath is unresolvable. The dedup set ages out with project disposal.
-        // Capture warns via LoggedErrorProcessor so the dedup contract is assertable — the
-        // previous test returned null from all three calls even if the dedup was silently
-        // broken (warn fired 3 times instead of 1). Now the test FAILS if the dedup goes
-        // away. Path with embedded NUL causes File.canonicalPath to throw on most JVMs.
+        // Path with embedded NUL causes File.canonicalPath to throw on most JVMs.
         val project = mockk<Project>()
         every { project.basePath } returns "/tmp/path-with-nul-\u0000-byte/project"
         every { project.isDefault } returns false
         every { project.isDisposed } returns false
         every { project.name } returns "weird-project"
 
+        val expectedSubstring = "canonicalize basePath"
         val capturedWarns = mutableListOf<String>()
         val processor =
             object : com.intellij.testFramework.LoggedErrorProcessor() {
@@ -259,6 +257,7 @@ class AccentResolverTest {
                     message: String,
                     throwable: Throwable?,
                 ): Boolean {
+                    if (!message.contains(expectedSubstring)) return true
                     capturedWarns += message
                     return false
                 }
@@ -270,9 +269,45 @@ class AccentResolverTest {
 
         assertEquals(
             1,
-            capturedWarns.count { it.contains("canonicalize basePath") },
+            capturedWarns.count { it.contains(expectedSubstring) },
             "Dedup must collapse 3 calls with the same project into exactly 1 warn; " +
                 "got: $capturedWarns",
+        )
+    }
+
+    @Test
+    fun `projectKey logs once per project on basePath read failure then dedups`() {
+        // Symmetric to the canonicalization-failure test: when basePath access itself throws
+        // (platform race mid-dispose, project-type regression), the warn must fire once and
+        // then be collapsed by the dedup gate across repeated hot-path calls.
+        val project = mockk<Project>()
+        every { project.basePath } throws IllegalStateException("Already disposed: Project")
+        every { project.isDefault } returns false
+        every { project.isDisposed } returns false
+
+        val expectedSubstring = "Failed to read basePath"
+        val capturedWarns = mutableListOf<String>()
+        val processor =
+            object : com.intellij.testFramework.LoggedErrorProcessor() {
+                override fun processWarn(
+                    category: String,
+                    message: String,
+                    throwable: Throwable?,
+                ): Boolean {
+                    if (!message.contains(expectedSubstring)) return true
+                    capturedWarns += message
+                    return false
+                }
+            }
+
+        com.intellij.testFramework.LoggedErrorProcessor.executeWith<RuntimeException>(processor) {
+            repeat(3) { assertNull(AccentResolver.projectKey(project)) }
+        }
+
+        assertEquals(
+            1,
+            capturedWarns.count { it.contains(expectedSubstring) },
+            "basePath-throws dedup must collapse 3 calls into exactly 1 warn; got: $capturedWarns",
         )
     }
 

--- a/src/test/kotlin/dev/ayuislands/accent/AccentResolverTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentResolverTest.kt
@@ -226,6 +226,50 @@ class AccentResolverTest {
         assertEquals(AccentResolver.Source.GLOBAL, AccentResolver.source(project))
     }
 
+    @Test
+    fun `source returns GLOBAL when project is null even with stored mappings`() {
+        // Mirrors the null-project guard tested in `resolve returns global when project is null`
+        // for the source() projection. Together they lock the null-project branch of
+        // findOverride from both sides — resolve and source must agree.
+        val tmp = File(System.getProperty("java.io.tmpdir"), "null-src-proj").canonicalPath
+        mappingsState.projectAccents[tmp] = "#FACADE"
+
+        assertEquals(AccentResolver.Source.GLOBAL, AccentResolver.source(null))
+    }
+
+    @Test
+    fun `projectKey logs once per project on canonicalization failure then dedups`() {
+        // Hot-path callers (focus swap, rotation tick) must not flood idea.log when a
+        // project's basePath is unresolvable. The dedup set ages out with project disposal.
+        // Simulating: a `basePath` that throws on canonicalization (e.g. invalid file path
+        // characters on certain filesystems). We use a deeply nested null-byte path which
+        // causes File.canonicalPath to throw IOException on most JVMs.
+        val project = mockk<Project>()
+        every { project.basePath } returns "/tmp/path-with-nul-\u0000-byte/project"
+        every { project.isDefault } returns false
+        every { project.isDisposed } returns false
+        every { project.name } returns "weird-project"
+
+        // First call exercises the warn path; subsequent calls hit the dedup set.
+        // Both must return null without throwing.
+        assertNull(AccentResolver.projectKey(project))
+        assertNull(AccentResolver.projectKey(project))
+        assertNull(AccentResolver.projectKey(project))
+    }
+
+    @Test
+    fun `projectKey degrades to null when basePath access throws AlreadyDisposedException`() {
+        // Race condition: between the dispose check in findOverride and the basePath read in
+        // projectKey, the project finishes disposing on another thread. basePath access then
+        // throws — we must catch it and return null instead of escalating out of the resolver.
+        val project = mockk<Project>()
+        every { project.basePath } throws IllegalStateException("Already disposed: Project")
+        every { project.isDefault } returns false
+        every { project.isDisposed } returns false
+
+        assertNull(AccentResolver.projectKey(project))
+    }
+
     private fun stubProject(baseDir: File): Project {
         val project = mockk<Project>()
         every { project.isDefault } returns false

--- a/src/test/kotlin/dev/ayuislands/accent/AccentResolverTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentResolverTest.kt
@@ -1,0 +1,141 @@
+package dev.ayuislands.accent
+
+import com.intellij.openapi.project.Project
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.mappings.AccentMappingsSettings
+import dev.ayuislands.settings.mappings.AccentMappingsState
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import java.io.File
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Verifies the project > language > global priority chain and short-circuit behavior.
+ * Uses real temp directories so `AccentResolver.projectKey` canonicalization runs end-to-end.
+ */
+class AccentResolverTest {
+    private lateinit var mappingsState: AccentMappingsState
+    private val globalMirageAccent = "#FFCC66"
+
+    @BeforeTest
+    fun setUp() {
+        mappingsState = AccentMappingsState()
+
+        val globalSettings = mockk<AyuIslandsSettings>()
+        every { globalSettings.getAccentForVariant(AyuVariant.MIRAGE) } returns globalMirageAccent
+        every { globalSettings.getAccentForVariant(AyuVariant.DARK) } returns "#E6B450"
+        every { globalSettings.getAccentForVariant(AyuVariant.LIGHT) } returns "#F29718"
+        mockkObject(AyuIslandsSettings.Companion)
+        every { AyuIslandsSettings.getInstance() } returns globalSettings
+
+        val mappingsSettings = mockk<AccentMappingsSettings>()
+        every { mappingsSettings.state } returns mappingsState
+        mockkObject(AccentMappingsSettings.Companion)
+        every { AccentMappingsSettings.getInstance() } returns mappingsSettings
+
+        mockkObject(ProjectLanguageDetector)
+        every { ProjectLanguageDetector.dominant(any()) } returns null
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `resolve returns global when project is null`() {
+        assertEquals(globalMirageAccent, AccentResolver.resolve(null, AyuVariant.MIRAGE))
+    }
+
+    @Test
+    fun `resolve returns global when project has no matching override and no language mapping`() {
+        val project = stubProject(File(System.getProperty("java.io.tmpdir"), "no-map-proj"))
+
+        assertEquals(globalMirageAccent, AccentResolver.resolve(project, AyuVariant.MIRAGE))
+    }
+
+    @Test
+    fun `resolve prefers project override over global`() {
+        val tmp = File(System.getProperty("java.io.tmpdir"), "proj-override").canonicalPath
+        mappingsState.projectAccents[tmp] = "#123456"
+
+        val project = stubProject(File(tmp))
+        assertEquals("#123456", AccentResolver.resolve(project, AyuVariant.MIRAGE))
+    }
+
+    @Test
+    fun `resolve prefers language override over global when no project override`() {
+        mappingsState.languageAccents["kotlin"] = "#ABCDEF"
+        val project = stubProject(File(System.getProperty("java.io.tmpdir"), "kotlin-proj"))
+        every { ProjectLanguageDetector.dominant(project) } returns "kotlin"
+
+        assertEquals("#ABCDEF", AccentResolver.resolve(project, AyuVariant.MIRAGE))
+    }
+
+    @Test
+    fun `resolve prefers project override over language override`() {
+        val tmp = File(System.getProperty("java.io.tmpdir"), "both-overrides").canonicalPath
+        mappingsState.projectAccents[tmp] = "#111111"
+        mappingsState.languageAccents["kotlin"] = "#222222"
+
+        val project = stubProject(File(tmp))
+        every { ProjectLanguageDetector.dominant(project) } returns "kotlin"
+
+        assertEquals("#111111", AccentResolver.resolve(project, AyuVariant.MIRAGE))
+    }
+
+    @Test
+    fun `resolve skips language detector when language map is empty`() {
+        // No language overrides configured — detector must not be consulted at all.
+        val project = stubProject(File(System.getProperty("java.io.tmpdir"), "skip-detector"))
+
+        assertEquals(globalMirageAccent, AccentResolver.resolve(project, AyuVariant.MIRAGE))
+        io.mockk.verify(exactly = 0) { ProjectLanguageDetector.dominant(any()) }
+    }
+
+    @Test
+    fun `source reports PROJECT_OVERRIDE when project mapped`() {
+        val tmp = File(System.getProperty("java.io.tmpdir"), "src-proj").canonicalPath
+        mappingsState.projectAccents[tmp] = "#111111"
+        val project = stubProject(File(tmp))
+
+        assertEquals(AccentResolver.Source.PROJECT_OVERRIDE, AccentResolver.source(project, AyuVariant.MIRAGE))
+    }
+
+    @Test
+    fun `source reports LANGUAGE_OVERRIDE when only language mapped`() {
+        mappingsState.languageAccents["python"] = "#222222"
+        val project = stubProject(File(System.getProperty("java.io.tmpdir"), "src-lang"))
+        every { ProjectLanguageDetector.dominant(project) } returns "python"
+
+        assertEquals(AccentResolver.Source.LANGUAGE_OVERRIDE, AccentResolver.source(project, AyuVariant.MIRAGE))
+    }
+
+    @Test
+    fun `source reports GLOBAL when nothing matches`() {
+        val project = stubProject(File(System.getProperty("java.io.tmpdir"), "src-global"))
+        assertEquals(AccentResolver.Source.GLOBAL, AccentResolver.source(project, AyuVariant.MIRAGE))
+    }
+
+    @Test
+    fun `projectKey returns canonical path for valid project`() {
+        val dir = File(System.getProperty("java.io.tmpdir"), "canonical")
+        val project = stubProject(dir)
+
+        assertEquals(dir.canonicalPath, AccentResolver.projectKey(project))
+    }
+
+    private fun stubProject(baseDir: File): Project {
+        val project = mockk<Project>()
+        every { project.isDefault } returns false
+        every { project.isDisposed } returns false
+        every { project.basePath } returns baseDir.path
+        every { project.name } returns baseDir.name
+        return project
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/accent/AccentResolverTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentResolverTest.kt
@@ -380,6 +380,26 @@ class AccentResolverTest {
     }
 
     @Test
+    fun `projectKey propagates CancellationException from basePath access instead of swallowing`() {
+        // The resolver is called from AyuIslandsStartupActivity's coroutine body via
+        // `AccentApplicator.apply(accentHex)`. If project.basePath ever throws
+        // CancellationException (cooperative cancellation of the startup coroutine),
+        // swallowing it into `raw = null` and continuing would keep the cancelled
+        // coroutine alive past its structured-concurrency boundary. Must rethrow.
+        val project = mockk<Project>()
+        every { project.basePath } throws kotlin.coroutines.cancellation.CancellationException("startup cancelled")
+        every { project.isDefault } returns false
+        every { project.isDisposed } returns false
+        every { project.name } returns "cancelled-project"
+
+        val thrown =
+            kotlin.test.assertFailsWith<kotlin.coroutines.cancellation.CancellationException> {
+                AccentResolver.projectKey(project)
+            }
+        assertEquals("startup cancelled", thrown.message)
+    }
+
+    @Test
     fun `projectKey degrades to null when basePath access throws AlreadyDisposedException`() {
         // Race condition: between the dispose check in findOverride and the basePath read in
         // projectKey, the project finishes disposing on another thread. basePath access then

--- a/src/test/kotlin/dev/ayuislands/accent/AccentResolverTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentResolverTest.kt
@@ -142,7 +142,7 @@ class AccentResolverTest {
         val tmp = File(System.getProperty("java.io.tmpdir"), "default-proj").canonicalPath
         mappingsState.projectAccents[tmp] = "#111111"
 
-        val project = mockk<com.intellij.openapi.project.Project>()
+        val project = mockk<Project>()
         every { project.isDefault } returns true
         every { project.isDisposed } returns false
         every { project.basePath } returns tmp
@@ -156,7 +156,7 @@ class AccentResolverTest {
         val tmp = File(System.getProperty("java.io.tmpdir"), "disposed-proj").canonicalPath
         mappingsState.projectAccents[tmp] = "#111111"
 
-        val project = mockk<com.intellij.openapi.project.Project>()
+        val project = mockk<Project>()
         every { project.isDefault } returns false
         every { project.isDisposed } returns true
         every { project.basePath } returns tmp
@@ -167,7 +167,7 @@ class AccentResolverTest {
 
     @Test
     fun `projectKey returns null when basePath is null`() {
-        val project = mockk<com.intellij.openapi.project.Project>()
+        val project = mockk<Project>()
         every { project.basePath } returns null
         every { project.isDefault } returns false
         every { project.isDisposed } returns false

--- a/src/test/kotlin/dev/ayuislands/accent/AccentResolverTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentResolverTest.kt
@@ -241,20 +241,39 @@ class AccentResolverTest {
     fun `projectKey logs once per project on canonicalization failure then dedups`() {
         // Hot-path callers (focus swap, rotation tick) must not flood idea.log when a
         // project's basePath is unresolvable. The dedup set ages out with project disposal.
-        // Simulating: a `basePath` that throws on canonicalization (e.g. invalid file path
-        // characters on certain filesystems). We use a deeply nested null-byte path which
-        // causes File.canonicalPath to throw IOException on most JVMs.
+        // Capture warns via LoggedErrorProcessor so the dedup contract is assertable — the
+        // previous test returned null from all three calls even if the dedup was silently
+        // broken (warn fired 3 times instead of 1). Now the test FAILS if the dedup goes
+        // away. Path with embedded NUL causes File.canonicalPath to throw on most JVMs.
         val project = mockk<Project>()
         every { project.basePath } returns "/tmp/path-with-nul-\u0000-byte/project"
         every { project.isDefault } returns false
         every { project.isDisposed } returns false
         every { project.name } returns "weird-project"
 
-        // First call exercises the warn path; subsequent calls hit the dedup set.
-        // Both must return null without throwing.
-        assertNull(AccentResolver.projectKey(project))
-        assertNull(AccentResolver.projectKey(project))
-        assertNull(AccentResolver.projectKey(project))
+        val capturedWarns = mutableListOf<String>()
+        val processor =
+            object : com.intellij.testFramework.LoggedErrorProcessor() {
+                override fun processWarn(
+                    category: String,
+                    message: String,
+                    throwable: Throwable?,
+                ): Boolean {
+                    capturedWarns += message
+                    return false
+                }
+            }
+
+        com.intellij.testFramework.LoggedErrorProcessor.executeWith<RuntimeException>(processor) {
+            repeat(3) { assertNull(AccentResolver.projectKey(project)) }
+        }
+
+        assertEquals(
+            1,
+            capturedWarns.count { it.contains("canonicalize basePath") },
+            "Dedup must collapse 3 calls with the same project into exactly 1 warn; " +
+                "got: $capturedWarns",
+        )
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/accent/AccentResolverTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentResolverTest.kt
@@ -400,6 +400,25 @@ class AccentResolverTest {
     }
 
     @Test
+    fun `projectKey propagates CancellationException from project name probe in basePath warn branch`() {
+        // When basePath throws and we try to log a warn, the defensive `runCatching {
+        // project.name }` wrapper must preserve cancellation. Otherwise a coroutine
+        // cancelled mid-dispose-race would have its cancellation absorbed into the
+        // "<disposed>" default and the resolver would return null instead of unwinding.
+        val project = mockk<Project>()
+        every { project.basePath } throws IllegalStateException("Already disposed")
+        every { project.name } throws kotlin.coroutines.cancellation.CancellationException("name probe cancelled")
+        every { project.isDefault } returns false
+        every { project.isDisposed } returns false
+
+        val thrown =
+            kotlin.test.assertFailsWith<kotlin.coroutines.cancellation.CancellationException> {
+                AccentResolver.projectKey(project)
+            }
+        assertEquals("name probe cancelled", thrown.message)
+    }
+
+    @Test
     fun `projectKey degrades to null when basePath access throws AlreadyDisposedException`() {
         // Race condition: between the dispose check in findOverride and the basePath read in
         // projectKey, the project finishes disposing on another thread. basePath access then

--- a/src/test/kotlin/dev/ayuislands/accent/AccentResolverTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentResolverTest.kt
@@ -111,7 +111,7 @@ class AccentResolverTest {
         mappingsState.projectAccents[tmp] = "#111111"
         val project = stubProject(File(tmp))
 
-        assertEquals(AccentResolver.Source.PROJECT_OVERRIDE, AccentResolver.source(project, AyuVariant.MIRAGE))
+        assertEquals(AccentResolver.Source.PROJECT_OVERRIDE, AccentResolver.source(project))
     }
 
     @Test
@@ -120,13 +120,13 @@ class AccentResolverTest {
         val project = stubProject(File(System.getProperty("java.io.tmpdir"), "src-lang"))
         every { ProjectLanguageDetector.dominant(project) } returns "python"
 
-        assertEquals(AccentResolver.Source.LANGUAGE_OVERRIDE, AccentResolver.source(project, AyuVariant.MIRAGE))
+        assertEquals(AccentResolver.Source.LANGUAGE_OVERRIDE, AccentResolver.source(project))
     }
 
     @Test
     fun `source reports GLOBAL when nothing matches`() {
         val project = stubProject(File(System.getProperty("java.io.tmpdir"), "src-global"))
-        assertEquals(AccentResolver.Source.GLOBAL, AccentResolver.source(project, AyuVariant.MIRAGE))
+        assertEquals(AccentResolver.Source.GLOBAL, AccentResolver.source(project))
     }
 
     @Test
@@ -212,7 +212,7 @@ class AccentResolverTest {
         val project = stubProject(File(tmp))
         every { ProjectLanguageDetector.dominant(project) } returns "kotlin"
 
-        assertEquals(AccentResolver.Source.GLOBAL, AccentResolver.source(project, AyuVariant.MIRAGE))
+        assertEquals(AccentResolver.Source.GLOBAL, AccentResolver.source(project))
     }
 
     @Test
@@ -223,7 +223,7 @@ class AccentResolverTest {
         every { ProjectLanguageDetector.dominant(project) } returns "python"
 
         assertEquals(globalMirageAccent, AccentResolver.resolve(project, AyuVariant.MIRAGE))
-        assertEquals(AccentResolver.Source.GLOBAL, AccentResolver.source(project, AyuVariant.MIRAGE))
+        assertEquals(AccentResolver.Source.GLOBAL, AccentResolver.source(project))
     }
 
     private fun stubProject(baseDir: File): Project {

--- a/src/test/kotlin/dev/ayuislands/accent/AccentResolverTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentResolverTest.kt
@@ -1,6 +1,7 @@
 package dev.ayuislands.accent
 
 import com.intellij.openapi.project.Project
+import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.mappings.AccentMappingsSettings
 import dev.ayuislands.settings.mappings.AccentMappingsState
@@ -41,6 +42,11 @@ class AccentResolverTest {
 
         mockkObject(ProjectLanguageDetector)
         every { ProjectLanguageDetector.dominant(any()) } returns null
+
+        // Overrides are premium: default the license gate to licensed so the resolution
+        // logic under test runs. Individual tests override to verify the unlicensed path.
+        mockkObject(LicenseChecker)
+        every { LicenseChecker.isLicensedOrGrace() } returns true
     }
 
     @AfterTest
@@ -170,6 +176,43 @@ class AccentResolverTest {
         assertNull(AccentResolver.projectKey(project))
         // And resolve should still fall through to global without throwing.
         assertEquals(globalMirageAccent, AccentResolver.resolve(project, AyuVariant.MIRAGE))
+    }
+
+    @Test
+    fun `resolve returns global when unlicensed even with stored project override`() {
+        // Guards against trial expiry and manual XML import leaking premium behavior.
+        val tmp = File(System.getProperty("java.io.tmpdir"), "unlicensed-proj").canonicalPath
+        mappingsState.projectAccents[tmp] = "#111111"
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+
+        val project = stubProject(File(tmp))
+        assertEquals(globalMirageAccent, AccentResolver.resolve(project, AyuVariant.MIRAGE))
+    }
+
+    @Test
+    fun `resolve returns global when unlicensed even with stored language override`() {
+        mappingsState.languageAccents["kotlin"] = "#222222"
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+
+        val project = stubProject(File(System.getProperty("java.io.tmpdir"), "unlicensed-lang"))
+        every { ProjectLanguageDetector.dominant(project) } returns "kotlin"
+
+        assertEquals(globalMirageAccent, AccentResolver.resolve(project, AyuVariant.MIRAGE))
+    }
+
+    @Test
+    fun `source reports GLOBAL when unlicensed even with stored overrides`() {
+        // UI "Currently active: ..." must not claim a project/language override is live
+        // when the resolver itself would skip it because the license check fails.
+        val tmp = File(System.getProperty("java.io.tmpdir"), "unlicensed-src").canonicalPath
+        mappingsState.projectAccents[tmp] = "#111111"
+        mappingsState.languageAccents["kotlin"] = "#222222"
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+
+        val project = stubProject(File(tmp))
+        every { ProjectLanguageDetector.dominant(project) } returns "kotlin"
+
+        assertEquals(AccentResolver.Source.GLOBAL, AccentResolver.source(project, AyuVariant.MIRAGE))
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/accent/AccentResolverTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentResolverTest.kt
@@ -15,6 +15,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 /**
  * Verifies the project > language > global priority chain and short-circuit behavior.
@@ -47,6 +48,11 @@ class AccentResolverTest {
         // logic under test runs. Individual tests override to verify the unlicensed path.
         mockkObject(LicenseChecker)
         every { LicenseChecker.isLicensedOrGrace() } returns true
+
+        // AccentResolver's warn gates are object-scoped (process-lifetime), so state from
+        // one @Test can bleed into the next if the same Project mock is reused. Clear
+        // before every test so dedup-count assertions start from a known-empty budget.
+        AccentResolver.resetWarnGatesForTest()
     }
 
     @AfterTest
@@ -240,8 +246,9 @@ class AccentResolverTest {
     @Test
     fun `projectKey logs once per project on canonicalization failure then dedups`() {
         // Hot-path callers (focus swap, rotation tick) must not flood idea.log when a
-        // project's basePath is unresolvable. The dedup set ages out with project disposal.
-        // Path with embedded NUL causes File.canonicalPath to throw on most JVMs.
+        // project's basePath is unresolvable. The canonicalization dedup gate ages out
+        // with project disposal. Path with embedded NUL causes File.canonicalPath to
+        // throw on most JVMs.
         val project = mockk<Project>()
         every { project.basePath } returns "/tmp/path-with-nul-\u0000-byte/project"
         every { project.isDefault } returns false
@@ -279,9 +286,12 @@ class AccentResolverTest {
     fun `projectKey logs once per project on basePath read failure then dedups`() {
         // Symmetric to the canonicalization-failure test: when basePath access itself throws
         // (platform race mid-dispose, project-type regression), the warn must fire once and
-        // then be collapsed by the dedup gate across repeated hot-path calls.
+        // then be collapsed by the dedup gate across repeated hot-path calls. The warn also
+        // carries the project name as a breadcrumb — otherwise triage with several projects
+        // open can't tell which one hit the failure from the log alone.
         val project = mockk<Project>()
         every { project.basePath } throws IllegalStateException("Already disposed: Project")
+        every { project.name } returns "racy-project"
         every { project.isDefault } returns false
         every { project.isDisposed } returns false
 
@@ -308,6 +318,64 @@ class AccentResolverTest {
             1,
             capturedWarns.count { it.contains(expectedSubstring) },
             "basePath-throws dedup must collapse 3 calls into exactly 1 warn; got: $capturedWarns",
+        )
+        assertTrue(
+            capturedWarns.single().contains("racy-project"),
+            "basePath-throws warn must name the project for triage; got: ${capturedWarns.single()}",
+        )
+    }
+
+    @Test
+    fun `projectKey dedup gates are independent per failure mode`() {
+        // The warn gates for basePath-throws and canonicalization-throws are distinct sets.
+        // A single Project hitting BOTH failure modes across its lifetime must produce TWO
+        // warns (one per mode), not one — collapsing the sets back into a shared gate would
+        // silently drop the second mode's breadcrumb.
+        val project = mockk<Project>()
+        every { project.isDefault } returns false
+        every { project.isDisposed } returns false
+        every { project.name } returns "flaky-project"
+        // Phase 1 — basePath itself throws.
+        every { project.basePath } throws IllegalStateException("Already disposed: Project")
+
+        val basePathSubstring = "Failed to read basePath"
+        val canonicalSubstring = "canonicalize basePath"
+        val capturedWarns = mutableListOf<String>()
+        val processor =
+            object : com.intellij.testFramework.LoggedErrorProcessor() {
+                override fun processWarn(
+                    category: String,
+                    message: String,
+                    throwable: Throwable?,
+                ): Boolean {
+                    if (!message.contains(basePathSubstring) && !message.contains(canonicalSubstring)) {
+                        return true
+                    }
+                    capturedWarns += message
+                    return false
+                }
+            }
+
+        com.intellij.testFramework.LoggedErrorProcessor.executeWith<RuntimeException>(processor) {
+            assertNull(AccentResolver.projectKey(project))
+
+            // Phase 2 — basePath now yields a non-canonicalizable path (embedded NUL).
+            // The canonicalization branch has its own dedup, so a second warn must fire
+            // even though the project already tripped the basePath gate in phase 1.
+            every { project.basePath } returns "/tmp/path-with-nul-\u0000-byte/project"
+            assertNull(AccentResolver.projectKey(project))
+        }
+
+        assertEquals(
+            1,
+            capturedWarns.count { it.contains(basePathSubstring) },
+            "basePath-throws warn must fire exactly once; got: $capturedWarns",
+        )
+        assertEquals(
+            1,
+            capturedWarns.count { it.contains(canonicalSubstring) },
+            "canonicalize warn must fire exactly once AFTER the basePath gate was already " +
+                "tripped (proves the gates are per-mode, not shared); got: $capturedWarns",
         )
     }
 

--- a/src/test/kotlin/dev/ayuislands/accent/AccentResolverTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentResolverTest.kt
@@ -13,6 +13,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 /**
  * Verifies the project > language > global priority chain and short-circuit behavior.
@@ -128,6 +129,58 @@ class AccentResolverTest {
         val project = stubProject(dir)
 
         assertEquals(dir.canonicalPath, AccentResolver.projectKey(project))
+    }
+
+    @Test
+    fun `resolve returns global when project is default`() {
+        val tmp = File(System.getProperty("java.io.tmpdir"), "default-proj").canonicalPath
+        mappingsState.projectAccents[tmp] = "#111111"
+
+        val project = mockk<com.intellij.openapi.project.Project>()
+        every { project.isDefault } returns true
+        every { project.isDisposed } returns false
+        every { project.basePath } returns tmp
+        every { project.name } returns "default-proj"
+
+        assertEquals(globalMirageAccent, AccentResolver.resolve(project, AyuVariant.MIRAGE))
+    }
+
+    @Test
+    fun `resolve returns global when project is disposed`() {
+        val tmp = File(System.getProperty("java.io.tmpdir"), "disposed-proj").canonicalPath
+        mappingsState.projectAccents[tmp] = "#111111"
+
+        val project = mockk<com.intellij.openapi.project.Project>()
+        every { project.isDefault } returns false
+        every { project.isDisposed } returns true
+        every { project.basePath } returns tmp
+        every { project.name } returns "disposed-proj"
+
+        assertEquals(globalMirageAccent, AccentResolver.resolve(project, AyuVariant.MIRAGE))
+    }
+
+    @Test
+    fun `projectKey returns null when basePath is null`() {
+        val project = mockk<com.intellij.openapi.project.Project>()
+        every { project.basePath } returns null
+        every { project.isDefault } returns false
+        every { project.isDisposed } returns false
+        every { project.name } returns "no-path"
+
+        assertNull(AccentResolver.projectKey(project))
+        // And resolve should still fall through to global without throwing.
+        assertEquals(globalMirageAccent, AccentResolver.resolve(project, AyuVariant.MIRAGE))
+    }
+
+    @Test
+    fun `resolve falls through to global when dominant language is not mapped`() {
+        // Row 6 of the truth table: LM=Y, D=Y, L=N → global wins.
+        mappingsState.languageAccents["kotlin"] = "#ABCDEF"
+        val project = stubProject(File(System.getProperty("java.io.tmpdir"), "python-only"))
+        every { ProjectLanguageDetector.dominant(project) } returns "python"
+
+        assertEquals(globalMirageAccent, AccentResolver.resolve(project, AyuVariant.MIRAGE))
+        assertEquals(AccentResolver.Source.GLOBAL, AccentResolver.source(project, AyuVariant.MIRAGE))
     }
 
     private fun stubProject(baseDir: File): Project {

--- a/src/test/kotlin/dev/ayuislands/accent/CancellationSafeRunCatchingTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/CancellationSafeRunCatchingTest.kt
@@ -5,6 +5,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 /**
@@ -53,7 +54,7 @@ class CancellationSafeRunCatchingTest {
                 runCatchingPreservingCancellation<String> { throw boom }
             }
         assertEquals("coroutine cancelled mid-probe", thrown.message)
-        assertEquals(boom, thrown, "must rethrow the ORIGINAL instance, not a wrapper")
+        assertSame(boom, thrown, "must rethrow the ORIGINAL instance, not a wrapper")
     }
 
     @Test
@@ -68,6 +69,6 @@ class CancellationSafeRunCatchingTest {
             assertFailsWith<CancellationException> {
                 runCatchingPreservingCancellation<Unit> { throw boom }
             }
-        assertEquals(boom, thrown)
+        assertSame(boom, thrown, "subtype rethrow must preserve the original instance")
     }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/CancellationSafeRunCatchingTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/CancellationSafeRunCatchingTest.kt
@@ -1,0 +1,73 @@
+package dev.ayuislands.accent
+
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Pins the contract of [runCatchingPreservingCancellation] so that a future refactor
+ * cannot silently swap it back to raw [kotlin.runCatching]. Callers (AccentResolver,
+ * ProjectLanguageDetector) rely on both halves of the contract: success / non-cancellation
+ * Throwable is captured in `Result`, but `CancellationException` is rethrown.
+ */
+class CancellationSafeRunCatchingTest {
+    @Test
+    fun `success returns Result with the produced value`() {
+        val result = runCatchingPreservingCancellation { "ok" }
+        assertTrue(result.isSuccess, "successful block must yield Result.success")
+        assertEquals("ok", result.getOrNull())
+    }
+
+    @Test
+    fun `RuntimeException is captured as Result failure`() {
+        val boom = IllegalStateException("transient platform failure")
+        val result = runCatchingPreservingCancellation { throw boom }
+        assertTrue(result.isFailure, "RuntimeException must be captured, not rethrown")
+        assertEquals(boom, result.exceptionOrNull())
+        assertNull(result.getOrNull())
+    }
+
+    @Test
+    fun `Error subtypes are captured as Result failure`() {
+        // The helper's KDoc promises that Error subtypes (like NoClassDefFoundError from a
+        // mid-dispose race on a lazily-loaded service) keep the fall-back-to-null behavior
+        // of the original runCatching. Verify NoClassDefFoundError in particular — it's the
+        // one explicitly named in the KDoc.
+        val boom = NoClassDefFoundError("simulated class-loading race")
+        val result = runCatchingPreservingCancellation { throw boom }
+        assertTrue(result.isFailure, "Error subtypes must still be captured, not rethrown")
+        assertEquals(boom, result.exceptionOrNull())
+    }
+
+    @Test
+    fun `CancellationException is rethrown instead of being captured`() {
+        // Structured-concurrency guarantee: resolver chain callers run on coroutine bodies,
+        // so a captured CancellationException would keep a cancelled coroutine alive past
+        // its scope. The helper must rethrow.
+        val boom = CancellationException("coroutine cancelled mid-probe")
+        val thrown =
+            assertFailsWith<CancellationException> {
+                runCatchingPreservingCancellation<String> { throw boom }
+            }
+        assertEquals("coroutine cancelled mid-probe", thrown.message)
+        assertEquals(boom, thrown, "must rethrow the ORIGINAL instance, not a wrapper")
+    }
+
+    @Test
+    fun `CancellationException subtypes are also rethrown`() {
+        // JobCancellationException etc. extend CancellationException — the `is` check in
+        // the helper uses instanceof semantics so subtype coverage transfers automatically.
+        // This test pins that behavior against a refactor to `== CancellationException`.
+        class StartupCancelledException : CancellationException("startup cancelled")
+
+        val boom = StartupCancelledException()
+        val thrown =
+            assertFailsWith<CancellationException> {
+                runCatchingPreservingCancellation<Unit> { throw boom }
+            }
+        assertEquals(boom, thrown)
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
@@ -1,0 +1,279 @@
+package dev.ayuislands.accent
+
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.projectRoots.SdkTypeId
+import com.intellij.openapi.roots.ProjectRootManager
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Exercises the real heuristic of [ProjectLanguageDetector] — [AccentResolverTest]
+ * mocks the object out, so without this suite the SDK/module detection paths and
+ * cache behavior have zero real coverage.
+ *
+ * The first test (`dominant returns null without throwing ...`) started as the RED
+ * case that exposed a ConcurrentHashMap null-value NPE in the cache delegate; the
+ * rest lock in the detection rules.
+ */
+class ProjectLanguageDetectorTest {
+    @BeforeTest
+    fun setUp() {
+        mockkStatic(ProjectRootManager::class)
+        mockkStatic(ModuleManager::class)
+        ProjectLanguageDetector.clear()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+        ProjectLanguageDetector.clear()
+    }
+
+    @Test
+    fun `dominant returns null without throwing when no SDK and no matching modules`() {
+        val project = stubProject("/tmp/undetectable-${System.nanoTime()}")
+        wireProjectRootManager(project, sdkName = null)
+        wireModuleManager(project, moduleNames = emptyList())
+
+        assertNull(ProjectLanguageDetector.dominant(project))
+    }
+
+    // ---- SDK-based detection ----
+
+    @Test
+    fun `dominant detects kotlin from SDK type containing kotlin`() {
+        assertSdkDetects("KotlinSdkType", "kotlin")
+    }
+
+    @Test
+    fun `dominant detects python from SDK type containing python`() {
+        assertSdkDetects("Python SDK", "python")
+    }
+
+    @Test
+    fun `dominant detects javascript from SDK type containing node`() {
+        assertSdkDetects("Node.js", "javascript")
+    }
+
+    @Test
+    fun `dominant detects typescript from SDK type`() {
+        assertSdkDetects("typescript-sdk", "typescript")
+    }
+
+    @Test
+    fun `dominant detects rust from SDK type`() {
+        assertSdkDetects("RustSdkType", "rust")
+    }
+
+    @Test
+    fun `dominant detects go from SDK type containing go but not google`() {
+        assertSdkDetects("GoSdkType", "go")
+    }
+
+    @Test
+    fun `dominant does NOT detect go when SDK type contains google`() {
+        // Google Cloud SDK et al. must not match Go's "go" substring rule.
+        val project = stubProject("/tmp/google-proj-${System.nanoTime()}")
+        wireProjectRootManager(project, sdkName = "GoogleCloudSDK")
+        wireModuleManager(project, moduleNames = emptyList())
+        assertNull(ProjectLanguageDetector.dominant(project))
+    }
+
+    @Test
+    fun `dominant detects ruby from SDK type`() {
+        assertSdkDetects("Ruby SDK", "ruby")
+    }
+
+    @Test
+    fun `dominant detects php from SDK type`() {
+        assertSdkDetects("PHP SDK", "php")
+    }
+
+    @Test
+    fun `dominant detects dart from SDK type`() {
+        assertSdkDetects("Dart SDK", "dart")
+    }
+
+    @Test
+    fun `dominant detects scala from SDK type`() {
+        assertSdkDetects("Scala SDK", "scala")
+    }
+
+    @Test
+    fun `dominant detects java from SDK name containing JavaSDK`() {
+        assertSdkDetects("JavaSDK", "java")
+    }
+
+    @Test
+    fun `dominant detects java from SDK name containing JDK`() {
+        assertSdkDetects("OpenJDK", "java")
+    }
+
+    // ---- Module-name fallback ----
+
+    @Test
+    fun `dominant falls back to module name when SDK is absent — kotlin`() {
+        assertModuleDetects(moduleNames = listOf("my-kotlin-lib"), expected = "kotlin")
+    }
+
+    @Test
+    fun `dominant falls back to module name — flutter maps to dart`() {
+        assertModuleDetects(moduleNames = listOf("flutter_app"), expected = "dart")
+    }
+
+    @Test
+    fun `dominant falls back to module name — android maps to kotlin`() {
+        assertModuleDetects(moduleNames = listOf("android-core"), expected = "kotlin")
+    }
+
+    @Test
+    fun `dominant falls back to module name — python`() {
+        assertModuleDetects(moduleNames = listOf("backend-python-service"), expected = "python")
+    }
+
+    @Test
+    fun `dominant returns null when module names contain no language keywords`() {
+        val project = stubProject("/tmp/unmatched-${System.nanoTime()}")
+        wireProjectRootManager(project, sdkName = null)
+        wireModuleManager(project, moduleNames = listOf("utils", "lib", "main"))
+        assertNull(ProjectLanguageDetector.dominant(project))
+    }
+
+    // ---- Cache behavior ----
+
+    @Test
+    fun `dominant caches successful detection — detectInternal called once`() {
+        val project = stubProject("/tmp/cache-hit-${System.nanoTime()}")
+        wireProjectRootManager(project, sdkName = "KotlinSdkType")
+        wireModuleManager(project, moduleNames = emptyList())
+
+        assertEquals("kotlin", ProjectLanguageDetector.dominant(project))
+        assertEquals("kotlin", ProjectLanguageDetector.dominant(project))
+
+        // Static getInstance should have been called only on the first detection.
+        verify(exactly = 1) { ProjectRootManager.getInstance(project) }
+    }
+
+    @Test
+    fun `dominant caches negative detection — detectInternal called once for null`() {
+        val project = stubProject("/tmp/cache-miss-${System.nanoTime()}")
+        wireProjectRootManager(project, sdkName = null)
+        wireModuleManager(project, moduleNames = emptyList())
+
+        assertNull(ProjectLanguageDetector.dominant(project))
+        assertNull(ProjectLanguageDetector.dominant(project))
+
+        // Critical: a null detection must still be cached so we don't keep hammering
+        // ProjectRootManager/ModuleManager. Verifies the sentinel approach.
+        verify(exactly = 1) { ProjectRootManager.getInstance(project) }
+    }
+
+    @Test
+    fun `invalidate clears cache entry — detectInternal called twice after invalidate`() {
+        val project = stubProject("/tmp/invalidate-${System.nanoTime()}")
+        wireProjectRootManager(project, sdkName = "Python SDK")
+        wireModuleManager(project, moduleNames = emptyList())
+
+        assertEquals("python", ProjectLanguageDetector.dominant(project))
+        ProjectLanguageDetector.invalidate(project)
+        assertEquals("python", ProjectLanguageDetector.dominant(project))
+
+        verify(exactly = 2) { ProjectRootManager.getInstance(project) }
+    }
+
+    @Test
+    fun `clear empties all entries`() {
+        val a = stubProject("/tmp/a-${System.nanoTime()}")
+        val b = stubProject("/tmp/b-${System.nanoTime()}")
+        wireProjectRootManager(a, sdkName = "KotlinSdkType")
+        wireProjectRootManager(b, sdkName = "Python SDK")
+        wireModuleManager(a, moduleNames = emptyList())
+        wireModuleManager(b, moduleNames = emptyList())
+
+        ProjectLanguageDetector.dominant(a)
+        ProjectLanguageDetector.dominant(b)
+        ProjectLanguageDetector.clear()
+
+        ProjectLanguageDetector.dominant(a)
+        ProjectLanguageDetector.dominant(b)
+
+        verify(exactly = 2) { ProjectRootManager.getInstance(a) }
+        verify(exactly = 2) { ProjectRootManager.getInstance(b) }
+    }
+
+    // ---- Helpers ----
+
+    private fun assertSdkDetects(
+        sdkName: String,
+        expected: String,
+    ) {
+        val project = stubProject("/tmp/sdk-$sdkName-${System.nanoTime()}")
+        wireProjectRootManager(project, sdkName = sdkName)
+        wireModuleManager(project, moduleNames = emptyList())
+        assertEquals(expected, ProjectLanguageDetector.dominant(project))
+    }
+
+    private fun assertModuleDetects(
+        moduleNames: List<String>,
+        expected: String,
+    ) {
+        val project = stubProject("/tmp/module-${moduleNames.first()}-${System.nanoTime()}")
+        wireProjectRootManager(project, sdkName = null)
+        wireModuleManager(project, moduleNames = moduleNames)
+        assertEquals(expected, ProjectLanguageDetector.dominant(project))
+    }
+
+    private fun stubProject(basePath: String): Project {
+        val project = mockk<Project>()
+        every { project.basePath } returns basePath
+        every { project.isDefault } returns false
+        every { project.isDisposed } returns false
+        return project
+    }
+
+    private fun wireProjectRootManager(
+        project: Project,
+        sdkName: String?,
+    ) {
+        val prm = mockk<ProjectRootManager>()
+        val sdk =
+            if (sdkName != null) {
+                val sdkMock = mockk<Sdk>()
+                val sdkType = mockk<SdkTypeId>()
+                every { sdkType.name } returns sdkName
+                every { sdkMock.sdkType } returns sdkType
+                sdkMock
+            } else {
+                null
+            }
+        every { prm.projectSdk } returns sdk
+        every { ProjectRootManager.getInstance(project) } returns prm
+    }
+
+    private fun wireModuleManager(
+        project: Project,
+        moduleNames: List<String>,
+    ) {
+        val mm = mockk<ModuleManager>()
+        val modules =
+            moduleNames
+                .map { name ->
+                    val module = mockk<Module>()
+                    every { module.name } returns name
+                    module
+                }.toTypedArray()
+        every { mm.modules } returns modules
+        every { ModuleManager.getInstance(project) } returns mm
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
@@ -49,7 +49,7 @@ class ProjectLanguageDetectorTest {
         assertNull(ProjectLanguageDetector.dominant(project))
     }
 
-    // ---- SDK-based detection ----
+    // SDK-based detection
 
     @Test
     fun `dominant detects kotlin from SDK type containing kotlin`() {
@@ -120,7 +120,7 @@ class ProjectLanguageDetectorTest {
         assertSdkDetects("OpenJDK", "java")
     }
 
-    // ---- Module-name fallback ----
+    // Module-name fallback
 
     @Test
     fun `dominant falls back to module name when SDK is absent - kotlin`() {
@@ -150,7 +150,7 @@ class ProjectLanguageDetectorTest {
         assertNull(ProjectLanguageDetector.dominant(project))
     }
 
-    // ---- Cache behavior ----
+    // Cache behavior
 
     @Test
     fun `dominant caches successful detection - detectInternal called once`() {
@@ -243,7 +243,7 @@ class ProjectLanguageDetectorTest {
         verify(exactly = 2) { ProjectRootManager.getInstance(b) }
     }
 
-    // ---- Helpers ----
+    // Test helpers
 
     private fun assertSdkDetects(
         sdkName: String,

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
@@ -193,6 +193,37 @@ class ProjectLanguageDetectorTest {
     }
 
     @Test
+    fun `transient SDK lookup failure does not poison the cache`() {
+        // Regression guard: an earlier implementation silently swallowed the exception and stored
+        // a NULL_SENTINEL, so the next call served the poisoned entry and the user's language
+        // override was permanently broken until the next invalidate/restart.
+        val project = stubProject("/tmp/transient-sdk-${System.nanoTime()}")
+        every { ProjectRootManager.getInstance(project) } throws IllegalStateException("SDK list mutated")
+
+        // First call: underlying API threw → detector returns null WITHOUT caching.
+        assertNull(ProjectLanguageDetector.dominant(project))
+
+        // Second call: same project, now the API is healthy — detector must retry, not serve
+        // a cached sentinel.
+        wireProjectRootManager(project, sdkName = "KotlinSdkType")
+        wireModuleManager(project, moduleNames = emptyList())
+        assertEquals("kotlin", ProjectLanguageDetector.dominant(project))
+    }
+
+    @Test
+    fun `transient module lookup failure does not poison the cache`() {
+        val project = stubProject("/tmp/transient-modules-${System.nanoTime()}")
+        wireProjectRootManager(project, sdkName = null)
+        every { ModuleManager.getInstance(project) } throws IllegalStateException("ModuleManager disposed")
+
+        assertNull(ProjectLanguageDetector.dominant(project))
+
+        // Healthy retry: no cached poison.
+        wireModuleManager(project, moduleNames = listOf("my-kotlin-lib"))
+        assertEquals("kotlin", ProjectLanguageDetector.dominant(project))
+    }
+
+    @Test
     fun `clear empties all entries`() {
         val a = stubProject("/tmp/a-${System.nanoTime()}")
         val b = stubProject("/tmp/b-${System.nanoTime()}")

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
@@ -224,6 +224,41 @@ class ProjectLanguageDetectorTest {
     }
 
     @Test
+    fun `dominant propagates CancellationException from SDK lookup instead of swallowing`() {
+        // ProjectLanguageDetector.dominant is reachable from AyuIslandsStartupActivity.execute's
+        // coroutine body via AccentResolver.findOverride. Plain runCatching would absorb the
+        // CancellationException into Result.failure, log a "SDK lookup failed" WARN, return
+        // null, and the cancelled coroutine would keep walking the resolver chain. The helper
+        // runCatchingPreservingCancellation must rethrow so structured concurrency holds.
+        val project = stubProject("/tmp/cancel-sdk-${System.nanoTime()}")
+        every { ProjectRootManager.getInstance(project) } throws
+            kotlin.coroutines.cancellation.CancellationException("startup cancelled during SDK lookup")
+
+        val thrown =
+            kotlin.test.assertFailsWith<kotlin.coroutines.cancellation.CancellationException> {
+                ProjectLanguageDetector.dominant(project)
+            }
+        assertEquals("startup cancelled during SDK lookup", thrown.message)
+    }
+
+    @Test
+    fun `dominant propagates CancellationException from module lookup instead of swallowing`() {
+        // Parallel contract on the module-list branch — SDK returns no match, module lookup
+        // throws CancellationException. Without the rethrow, the detector would return null
+        // and the cancelled coroutine would continue.
+        val project = stubProject("/tmp/cancel-modules-${System.nanoTime()}")
+        wireProjectRootManager(project, sdkName = null)
+        every { ModuleManager.getInstance(project) } throws
+            kotlin.coroutines.cancellation.CancellationException("startup cancelled during module lookup")
+
+        val thrown =
+            kotlin.test.assertFailsWith<kotlin.coroutines.cancellation.CancellationException> {
+                ProjectLanguageDetector.dominant(project)
+            }
+        assertEquals("startup cancelled during module lookup", thrown.message)
+    }
+
+    @Test
     fun `clear empties all entries`() {
         val a = stubProject("/tmp/a-${System.nanoTime()}")
         val b = stubProject("/tmp/b-${System.nanoTime()}")

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
@@ -123,22 +123,22 @@ class ProjectLanguageDetectorTest {
     // ---- Module-name fallback ----
 
     @Test
-    fun `dominant falls back to module name when SDK is absent — kotlin`() {
+    fun `dominant falls back to module name when SDK is absent - kotlin`() {
         assertModuleDetects(moduleNames = listOf("my-kotlin-lib"), expected = "kotlin")
     }
 
     @Test
-    fun `dominant falls back to module name — flutter maps to dart`() {
+    fun `dominant falls back to module name - flutter maps to dart`() {
         assertModuleDetects(moduleNames = listOf("flutter_app"), expected = "dart")
     }
 
     @Test
-    fun `dominant falls back to module name — android maps to kotlin`() {
+    fun `dominant falls back to module name - android maps to kotlin`() {
         assertModuleDetects(moduleNames = listOf("android-core"), expected = "kotlin")
     }
 
     @Test
-    fun `dominant falls back to module name — python`() {
+    fun `dominant falls back to module name - python`() {
         assertModuleDetects(moduleNames = listOf("backend-python-service"), expected = "python")
     }
 
@@ -153,7 +153,7 @@ class ProjectLanguageDetectorTest {
     // ---- Cache behavior ----
 
     @Test
-    fun `dominant caches successful detection — detectInternal called once`() {
+    fun `dominant caches successful detection - detectInternal called once`() {
         val project = stubProject("/tmp/cache-hit-${System.nanoTime()}")
         wireProjectRootManager(project, sdkName = "KotlinSdkType")
         wireModuleManager(project, moduleNames = emptyList())
@@ -166,7 +166,7 @@ class ProjectLanguageDetectorTest {
     }
 
     @Test
-    fun `dominant caches negative detection — detectInternal called once for null`() {
+    fun `dominant caches negative detection - detectInternal called once for null`() {
         val project = stubProject("/tmp/cache-miss-${System.nanoTime()}")
         wireProjectRootManager(project, sdkName = null)
         wireModuleManager(project, moduleNames = emptyList())
@@ -180,7 +180,7 @@ class ProjectLanguageDetectorTest {
     }
 
     @Test
-    fun `invalidate clears cache entry — detectInternal called twice after invalidate`() {
+    fun `invalidate clears cache entry - detectInternal called twice after invalidate`() {
         val project = stubProject("/tmp/invalidate-${System.nanoTime()}")
         wireProjectRootManager(project, sdkName = "Python SDK")
         wireModuleManager(project, moduleNames = emptyList())

--- a/src/test/kotlin/dev/ayuislands/editor/EditorScrollbarManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/editor/EditorScrollbarManagerTest.kt
@@ -215,6 +215,37 @@ class EditorScrollbarManagerTest {
     }
 
     @Test
+    fun `apply re-hides scrollbar after platform reset simulation`() {
+        // Regression guard for the stale-flag bug (commit 64833a0): a previous version of
+        // applyToEditor gated hideScrollBar on `!patched.verticalHidden`. After startup the
+        // flag would read "true", the platform's LAF walk would reset preferredSize back to
+        // the default, and the subsequent apply() — triggered by LafListener via
+        // ComponentTreeRefreshedTopic — would see the true flag and skip re-hiding. Result:
+        // visible scrollbar until the user manually toggled off → on.
+        //
+        // Simulate the exact sequence and assert preferredSize stays at (0,0) after the second
+        // apply, regardless of what the internal state flag looked like before.
+        realState.hideEditorVScrollbar = true
+        val vBar = scrollPane.verticalScrollBar
+
+        val manager = createManager()
+        manager.apply()
+        assertEquals(Dimension(0, 0), vBar.preferredSize)
+
+        // Simulate what IJSwingUtilities.updateComponentTreeUI does to a patched scrollbar
+        // during a LAF change: the UI delegate is reinstalled, and preferredSize reverts to
+        // the default (some non-zero dimension computed by the new UI delegate).
+        vBar.preferredSize = Dimension(12, 100)
+
+        // The LafListener publishes ComponentTreeRefreshedTopic, subscribers call apply().
+        // The real contract: apply() must re-zero the scrollbar regardless of cached state.
+        manager.apply()
+
+        assertEquals(Dimension(0, 0), vBar.preferredSize)
+        manager.dispose()
+    }
+
+    @Test
     fun `editorCreated listener applies to new editors when licensed`() {
         realState.hideEditorVScrollbar = true
         createManager()

--- a/src/test/kotlin/dev/ayuislands/editor/EditorScrollbarManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/editor/EditorScrollbarManagerTest.kt
@@ -194,8 +194,12 @@ class EditorScrollbarManagerTest {
         val storedSize =
             vBar.getClientProperty("ayuIslands.originalPreferredSize") as? Dimension
         assertEquals(sizeBefore, storedSize)
-        // Verify it's a copy, not the same reference
-        assert(storedSize !== sizeBefore || sizeBefore == storedSize)
+        // Verify it's a defensive copy, not the same reference — the previous assertion
+        // (`storedSize !== sizeBefore || sizeBefore == storedSize`) was a tautology that
+        // passed regardless of whether a copy was actually made.
+        assert(storedSize !== sizeBefore) {
+            "Expected defensive copy of preferredSize, but stored the same reference"
+        }
         manager.dispose()
     }
 

--- a/src/test/kotlin/dev/ayuislands/editor/EditorScrollbarManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/editor/EditorScrollbarManagerTest.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.editor.event.EditorFactoryListener
 import com.intellij.openapi.editor.ex.EditorEx
 import com.intellij.openapi.project.Project
+import com.intellij.testFramework.LoggedErrorProcessor
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
@@ -14,6 +15,7 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.unmockkAll
+import io.mockk.verify
 import java.awt.Dimension
 import javax.swing.JScrollPane
 import kotlin.test.AfterTest
@@ -215,6 +217,49 @@ class EditorScrollbarManagerTest {
         realState.hideEditorVScrollbar = false
         manager.apply()
         assertNull(vBar.getClientProperty("ayuIslands.originalPreferredSize"))
+        manager.dispose()
+    }
+
+    @Test
+    fun `resetOriginalSizeCache tolerates putClientProperty failures`() {
+        // Listener body is `resetOriginalSizeCacheForTest() then apply()`. If a downstream
+        // Swing layer throws from putClientProperty (platform regression, disposed
+        // component) the listener must survive — otherwise the MessageBus dispatcher
+        // catches it as SEVERE and the follow-up apply() never runs (scrollbars stay
+        // unhidden after LAF change). Mocked scrollbar that throws on the null-value
+        // clear proves the per-pane try/catch keeps iteration alive.
+        val throwingVBar = mockk<javax.swing.JScrollBar>(relaxed = true)
+        every {
+            throwingVBar.putClientProperty(eq("ayuIslands.originalPreferredSize"), null)
+        } throws IllegalStateException("simulated putClientProperty failure")
+
+        val mockScrollPane = mockk<JScrollPane>(relaxed = true)
+        every { mockScrollPane.verticalScrollBar } returns throwingVBar
+        every { mockScrollPane.horizontalScrollBar } returns mockk(relaxed = true)
+        every { editorEx.scrollPane } returns mockScrollPane
+
+        realState.hideEditorVScrollbar = true
+        val manager = createManager()
+        manager.apply() // populates patchedScrollPanes; hideScrollBar's
+        // putClientProperty (with non-null Dimension) is the relaxed-mock no-op.
+
+        // Reset path: the null-value put on the vertical bar throws; the iteration must
+        // continue (horizontal bar still gets cleared) and no exception escapes.
+        val suppressLoggedErrors =
+            object : LoggedErrorProcessor() {
+                override fun processWarn(
+                    category: String,
+                    message: String,
+                    throwable: Throwable?,
+                ): Boolean = false
+            }
+        LoggedErrorProcessor.executeWith<Throwable>(suppressLoggedErrors) {
+            manager.resetOriginalSizeCacheForTest()
+        }
+
+        verify(atLeast = 1) {
+            throwingVBar.putClientProperty(eq("ayuIslands.originalPreferredSize"), null)
+        }
         manager.dispose()
     }
 

--- a/src/test/kotlin/dev/ayuislands/indent/IndentRainbowSyncTest.kt
+++ b/src/test/kotlin/dev/ayuislands/indent/IndentRainbowSyncTest.kt
@@ -39,12 +39,30 @@ class IndentRainbowSyncTest {
         mockkObject(AyuIslandsSettings.Companion)
         every { AyuIslandsSettings.getInstance() } returns mockSettings
         every { mockSettings.state } returns state
-        every { mockSettings.getAccentForVariant(any()) } returns "#FFCC66"
+        // getAccentForVariant stub used to be required because IR read the global accent
+        // itself. After the resolver refactor the caller passes the resolved hex in; the
+        // mock becomes dead code. Removed to keep setUp honest.
 
         mockkStatic(PluginManagerCore::class)
         every { PluginManagerCore.getPlugin(any()) } returns null
 
         resetSyncState()
+    }
+
+    /**
+     * Helper that invokes [IndentRainbowSync.apply] with the single test accent hex.
+     * Most tests in this suite verify flow (integration flag, plugin availability,
+     * reflection fallbacks, palette composition) rather than hex-specific behavior —
+     * pulling the hex into one constant removes 20 hardcoded strings and keeps each
+     * test readable as "call apply for variant X".
+     */
+    private fun callApply(variant: AyuVariant = AyuVariant.MIRAGE) {
+        IndentRainbowSync.apply(variant, TEST_ACCENT_HEX)
+    }
+
+    private companion object {
+        /** Fixed accent used by every `callApply(...)` invocation in this suite. */
+        const val TEST_ACCENT_HEX = "#FFCC66"
     }
 
     @AfterTest
@@ -57,7 +75,7 @@ class IndentRainbowSyncTest {
     fun `apply with integration disabled calls revert gracefully`() {
         state.irIntegrationEnabled = false
 
-        IndentRainbowSync.apply(AyuVariant.MIRAGE)
+        callApply()
 
         // Should not throw — revert also gracefully returns when IR not installed
     }
@@ -66,7 +84,7 @@ class IndentRainbowSyncTest {
     fun `apply with integration enabled but no IR plugin does not throw`() {
         state.irIntegrationEnabled = true
 
-        IndentRainbowSync.apply(AyuVariant.MIRAGE)
+        callApply()
 
         // resolveReflection finds no plugin, resolveOrReturn returns null, method exits
     }
@@ -123,7 +141,7 @@ class IndentRainbowSyncTest {
         state.irIntegrationEnabled = true
         for (variant in AyuVariant.entries) {
             resetSyncState()
-            IndentRainbowSync.apply(variant)
+            callApply(variant)
         }
     }
 
@@ -153,7 +171,7 @@ class IndentRainbowSyncTest {
         setPrivateField("refreshMethod", mockRefreshMethod)
         setPrivateField("irColorsInstance", mockColorsInstance)
 
-        IndentRainbowSync.apply(AyuVariant.MIRAGE)
+        callApply()
 
         // Verify a palette type was set to CUSTOM
         verify { mockPaletteTypeField[mockConfig] = "CUSTOM_ENUM" }
@@ -211,7 +229,7 @@ class IndentRainbowSyncTest {
         setPrivateField("refreshMethod", mockRefreshMethod)
         setPrivateField("irColorsInstance", mockColorsInstance)
 
-        IndentRainbowSync.apply(AyuVariant.MIRAGE)
+        callApply()
 
         // Should revert, not apply custom
         verify { mockPaletteTypeField[mockConfig] = "DEFAULT_ENUM" }
@@ -247,7 +265,7 @@ class IndentRainbowSyncTest {
 
         mockNotificationGroup()
 
-        IndentRainbowSync.apply(AyuVariant.MIRAGE)
+        callApply()
         // Should not throw — exception is caught and logged
     }
 
@@ -280,7 +298,7 @@ class IndentRainbowSyncTest {
 
         mockNotificationGroup()
 
-        IndentRainbowSync.apply(AyuVariant.MIRAGE)
+        callApply()
     }
 
     @Test
@@ -373,7 +391,7 @@ class IndentRainbowSyncTest {
         setPrivateField("refreshMethod", mockRefreshMethod)
         setPrivateField("irColorsInstance", mockColorsInstance)
 
-        IndentRainbowSync.apply(AyuVariant.MIRAGE)
+        callApply()
 
         // Verify the palette string was written (contains NEON alpha-based values)
         verify {
@@ -412,7 +430,7 @@ class IndentRainbowSyncTest {
         setPrivateField("refreshMethod", mockRefreshMethod)
         setPrivateField("irColorsInstance", mockColorsInstance)
 
-        IndentRainbowSync.apply(AyuVariant.DARK)
+        callApply(AyuVariant.DARK)
 
         verify { mockCustomPaletteField[mockConfig] = any<String>() }
     }
@@ -472,7 +490,7 @@ class IndentRainbowSyncTest {
         setPrivateField("refreshMethod", mockRefreshMethod)
         setPrivateField("irColorsInstance", mockColorsInstance)
 
-        IndentRainbowSync.apply(AyuVariant.MIRAGE)
+        callApply()
 
         verify(exactly = 0) { mockUpdateMethod.invoke(any(), any()) }
     }
@@ -518,7 +536,7 @@ class IndentRainbowSyncTest {
         setPrivateField("refreshMethod", mockRefreshMethod)
         setPrivateField("irColorsInstance", mockColorsInstance)
 
-        IndentRainbowSync.apply(AyuVariant.MIRAGE)
+        callApply()
 
         verify(exactly = 0) { mockUpdateMethod.invoke(any(), any()) }
     }
@@ -547,7 +565,7 @@ class IndentRainbowSyncTest {
         setPrivateField("refreshMethod", mockRefreshMethod)
         setPrivateField("irColorsInstance", mockColorsInstance)
 
-        IndentRainbowSync.apply(AyuVariant.MIRAGE)
+        callApply()
 
         verify(exactly = 0) { mockUpdateMethod.invoke(any(), any()) }
     }
@@ -581,7 +599,7 @@ class IndentRainbowSyncTest {
 
         mockNotificationGroup()
 
-        IndentRainbowSync.apply(AyuVariant.MIRAGE)
+        callApply()
         // Should not throw — caught by RuntimeException handler
     }
 
@@ -612,7 +630,7 @@ class IndentRainbowSyncTest {
         setPrivateField("refreshMethod", mockRefreshMethod)
         setPrivateField("irColorsInstance", mockColorsInstance)
 
-        IndentRainbowSync.apply(AyuVariant.MIRAGE)
+        callApply()
 
         // Verify palette string: error color (index 0) should use accent, not red
         verify {

--- a/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
@@ -11,6 +11,9 @@ import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
+import dev.ayuislands.settings.mappings.AccentMappingsSettings
+import dev.ayuislands.settings.mappings.AccentMappingsState
+import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -107,7 +110,45 @@ class AccentRotationServiceTest {
         mockkObject(AyuIslandsSettings.Companion)
         every { AyuIslandsSettings.getInstance() } returns settingsMock
         every { settingsMock.state } returns state
-        every { settingsMock.setAccentForVariant(any(), any()) } just Runs
+        // setAccentForVariant must persist into the state fields so the subsequent
+        // AccentResolver fallback (which reads getAccentForVariant) sees the rotated value.
+        every { settingsMock.setAccentForVariant(any(), any()) } answers {
+            val variant = firstArg<AyuVariant>()
+            val hex = secondArg<String>()
+            when (variant) {
+                AyuVariant.MIRAGE -> state.mirageAccent = hex
+                AyuVariant.DARK -> state.darkAccent = hex
+                AyuVariant.LIGHT -> state.lightAccent = hex
+            }
+        }
+        every { settingsMock.getAccentForVariant(any()) } answers {
+            val variant = firstArg<AyuVariant>()
+            when (variant) {
+                AyuVariant.MIRAGE -> state.mirageAccent ?: variant.defaultAccent
+                AyuVariant.DARK -> state.darkAccent ?: variant.defaultAccent
+                AyuVariant.LIGHT -> state.lightAccent ?: variant.defaultAccent
+            }
+        }
+
+        // AccentResolver reads AccentMappingsSettings and ProjectManager. Both must be mocked
+        // so rotation's apply path resolves cleanly to the (freshly-set) global hex with no
+        // project overrides in play.
+        val mappingsSettings = mockk<AccentMappingsSettings>()
+        every { mappingsSettings.state } returns AccentMappingsState()
+        mockkObject(AccentMappingsSettings.Companion)
+        every { AccentMappingsSettings.getInstance() } returns mappingsSettings
+
+        val projectManager = mockk<com.intellij.openapi.project.ProjectManager>()
+        every { projectManager.openProjects } returns emptyArray()
+        mockkStatic(com.intellij.openapi.project.ProjectManager::class)
+        every {
+            com.intellij.openapi.project.ProjectManager
+                .getInstance()
+        } returns projectManager
+
+        val swapService = mockk<ProjectAccentSwapService>(relaxed = true)
+        mockkObject(ProjectAccentSwapService.Companion)
+        every { ProjectAccentSwapService.getInstance() } returns swapService
 
         mockkObject(LicenseChecker)
         every { LicenseChecker.isLicensedOrGrace() } returns true

--- a/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
@@ -294,6 +294,49 @@ class AccentRotationServiceTest {
     }
 
     @Test
+    fun `circuit breaker does NOT trip at MAX_CONSECUTIVE_FAILURES minus 1`() {
+        // Lower-edge lock: driving exactly MAX-1 (= 2) failing ticks must NOT fire a
+        // notification. Catches an accidental shift from `<` to `<=` (which would trip
+        // early at count=3 with 3-tick boundary, leaving this test alone — but we keep
+        // both-edges-locked, positive and negative, because one-sided tests are brittle).
+        mockRotationEnvironment()
+        val (notificationGroup, _) = captureNotifications()
+        state.accentRotationEnabled = true
+        state.accentRotationMode = AccentRotationMode.PRESET.name
+        every { AccentApplicator.apply(any()) } throws RotationTestException("apply stage")
+
+        val service = AccentRotationService()
+        LoggedErrorProcessor.executeWith<Throwable>(suppressLoggedErrors()) {
+            repeat(TWO) { service.rotateAccent() }
+        }
+
+        verify(exactly = 0) {
+            notificationGroup.createNotification(any<String>(), any<String>(), any<NotificationType>())
+        }
+    }
+
+    @Test
+    fun `circuit breaker trips at EXACTLY MAX_CONSECUTIVE_FAILURES`() {
+        // Upper-edge lock: driving exactly MAX (= 3) failing ticks fires exactly once.
+        // Paired with the MAX-1 test to pin the trip point precisely. Catches a shift from
+        // `<` to `>` (would never trip) and a shift making the trip fire at count=2.
+        mockRotationEnvironment()
+        val (notificationGroup, _) = captureNotifications()
+        state.accentRotationEnabled = true
+        state.accentRotationMode = AccentRotationMode.PRESET.name
+        every { AccentApplicator.apply(any()) } throws RotationTestException("apply stage")
+
+        val service = AccentRotationService()
+        LoggedErrorProcessor.executeWith<Throwable>(suppressLoggedErrors()) {
+            repeat(THREE) { service.rotateAccent() }
+        }
+
+        verify(exactly = 1) {
+            notificationGroup.createNotification(any<String>(), any<String>(), any<NotificationType>())
+        }
+    }
+
+    @Test
     fun `successful tick between failures resets the circuit-breaker budget`() {
         // Regression guard for the reset-on-success path (consecutiveFailures = 0 after a
         // clean runApplyStage). Two fail + one success + two fail must NOT trip the breaker
@@ -405,6 +448,7 @@ class AccentRotationServiceTest {
     }
 
     companion object {
+        private const val TWO = 2
         private const val THREE = 3
         private const val FOUR = 4
         private const val FIVE = 5

--- a/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
@@ -122,8 +122,7 @@ class AccentRotationServiceTest {
             }
         }
         every { settingsMock.getAccentForVariant(any()) } answers {
-            val variant = firstArg<AyuVariant>()
-            when (variant) {
+            when (val variant = firstArg<AyuVariant>()) {
                 AyuVariant.MIRAGE -> state.mirageAccent ?: variant.defaultAccent
                 AyuVariant.DARK -> state.darkAccent ?: variant.defaultAccent
                 AyuVariant.LIGHT -> state.lightAccent ?: variant.defaultAccent

--- a/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
@@ -265,33 +265,28 @@ class AccentRotationServiceTest {
     }
 
     @Test
-    fun `three consecutive failures trip the circuit breaker and notify the user`() {
-        // Regression guard for commit e8345db: MAX_CONSECUTIVE_FAILURES = 3. Flipping the
-        // off-by-one, dropping the reset on success, or removing the notification should
-        // fail this test instead of shipping a silently-broken rotation feature.
+    fun `circuit breaker trips at MAX_CONSECUTIVE_FAILURES and the post-trip reset works`() {
+        // Circuit breaker contract: after MAX_CONSECUTIVE_FAILURES = 3 consecutive failed
+        // ticks, stopRotation() fires and the user gets a single warning notification. This
+        // test drives FOUR ticks with a failing applicator to cover both contracts in one go:
+        //  - Ticks 1..3 increment the counter to 3 → breaker trips, notification #1 fires,
+        //    stopRotation() resets the counter to 0.
+        //  - Tick 4 starts fresh (counter 0 → 1), still under threshold, so NO additional
+        //    notification fires. If the post-trip reset were missing, tick 4 would push the
+        //    counter to 4, re-trigger the trip path, and fire notification #2 — `exactly = 1`
+        //    catches that regression. If the off-by-one were flipped (`<= 3` instead of
+        //    `< 3`), only ticks 1..2 would fire and exactly = 1 would still fail (zero).
         mockRotationEnvironment()
         val (notificationGroup, createdNotifications) = captureNotifications()
         state.accentRotationEnabled = true
         state.accentRotationMode = AccentRotationMode.PRESET.name
-        every { AccentApplicator.apply(any()) } throws RuntimeException("stage=apply failed")
-
-        val suppressLoggedErrors =
-            object : LoggedErrorProcessor() {
-                override fun processError(
-                    category: String,
-                    message: String,
-                    details: Array<out String>,
-                    throwable: Throwable?,
-                ): Set<Action> = EnumSet.noneOf(Action::class.java)
-            }
+        every { AccentApplicator.apply(any()) } throws RotationTestException("apply stage")
 
         val service = AccentRotationService()
-        LoggedErrorProcessor.executeWith<RuntimeException>(suppressLoggedErrors) {
-            repeat(THREE) { service.rotateAccent() }
+        LoggedErrorProcessor.executeWith<Throwable>(suppressLoggedErrors()) {
+            repeat(FOUR) { service.rotateAccent() }
         }
 
-        // Notification fires exactly once — on the third consecutive failure, not earlier, not
-        // again on a hypothetical fourth tick after the breaker tripped.
         verify(exactly = 1) {
             notificationGroup.createNotification(any<String>(), any<String>(), NotificationType.WARNING)
         }
@@ -312,22 +307,11 @@ class AccentRotationServiceTest {
         every { AccentApplicator.apply(any()) } answers {
             applyCalls += firstArg<String>()
             if (applyCalls.size == THREE) return@answers Unit
-            @Suppress("TooGenericExceptionThrown") // Test-only simulation of applicator failure
-            throw RuntimeException("fail ${applyCalls.size}")
+            throw RotationTestException("fail ${applyCalls.size}")
         }
 
-        val suppressLoggedErrors =
-            object : LoggedErrorProcessor() {
-                override fun processError(
-                    category: String,
-                    message: String,
-                    details: Array<out String>,
-                    throwable: Throwable?,
-                ): Set<Action> = EnumSet.noneOf(Action::class.java)
-            }
-
         val service = AccentRotationService()
-        LoggedErrorProcessor.executeWith<RuntimeException>(suppressLoggedErrors) {
+        LoggedErrorProcessor.executeWith<Throwable>(suppressLoggedErrors()) {
             repeat(FIVE) { service.rotateAccent() }
         }
 
@@ -335,6 +319,29 @@ class AccentRotationServiceTest {
             notificationGroup.createNotification(any<String>(), any<String>(), any<NotificationType>())
         }
     }
+
+    /**
+     * Test-only RuntimeException — gives a named, searchable type for log forensics + lets
+     * the test code throw without `@Suppress("TooGenericExceptionThrown")` boilerplate.
+     */
+    private class RotationTestException(
+        message: String,
+    ) : RuntimeException(message)
+
+    /**
+     * `LoggedErrorProcessor` that suppresses (does not promote) every LOG.error to an
+     * AssertionError so the rotation tick path can run without TestLoggerFactory escalating
+     * the deliberate simulated failure into a test crash. Returns no actions = full suppress.
+     */
+    private fun suppressLoggedErrors(): LoggedErrorProcessor =
+        object : LoggedErrorProcessor() {
+            override fun processError(
+                category: String,
+                message: String,
+                details: Array<out String>,
+                throwable: Throwable?,
+            ): Set<Action> = EnumSet.noneOf(Action::class.java)
+        }
 
     /**
      * Wire `NotificationGroupManager.getInstance().getNotificationGroup("Ayu Islands")` to a
@@ -399,6 +406,7 @@ class AccentRotationServiceTest {
 
     companion object {
         private const val THREE = 3
+        private const val FOUR = 4
         private const val FIVE = 5
     }
 }

--- a/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
@@ -1,5 +1,9 @@
 package dev.ayuislands.rotation
 
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationGroup
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.util.Condition
@@ -261,6 +265,100 @@ class AccentRotationServiceTest {
     }
 
     @Test
+    fun `three consecutive failures trip the circuit breaker and notify the user`() {
+        // Regression guard for commit e8345db: MAX_CONSECUTIVE_FAILURES = 3. Flipping the
+        // off-by-one, dropping the reset on success, or removing the notification should
+        // fail this test instead of shipping a silently-broken rotation feature.
+        mockRotationEnvironment()
+        val (notificationGroup, createdNotifications) = captureNotifications()
+        state.accentRotationEnabled = true
+        state.accentRotationMode = AccentRotationMode.PRESET.name
+        every { AccentApplicator.apply(any()) } throws RuntimeException("stage=apply failed")
+
+        val suppressLoggedErrors =
+            object : LoggedErrorProcessor() {
+                override fun processError(
+                    category: String,
+                    message: String,
+                    details: Array<out String>,
+                    throwable: Throwable?,
+                ): Set<Action> = EnumSet.noneOf(Action::class.java)
+            }
+
+        val service = AccentRotationService()
+        LoggedErrorProcessor.executeWith<RuntimeException>(suppressLoggedErrors) {
+            repeat(THREE) { service.rotateAccent() }
+        }
+
+        // Notification fires exactly once — on the third consecutive failure, not earlier, not
+        // again on a hypothetical fourth tick after the breaker tripped.
+        verify(exactly = 1) {
+            notificationGroup.createNotification(any<String>(), any<String>(), NotificationType.WARNING)
+        }
+        assertEquals(1, createdNotifications.size)
+    }
+
+    @Test
+    fun `successful tick between failures resets the circuit-breaker budget`() {
+        // Regression guard for the reset-on-success path (consecutiveFailures = 0 after a
+        // clean runApplyStage). Two fail + one success + two fail must NOT trip the breaker
+        // because consecutive-failures counts go 1, 2, 0, 1, 2 — never reaches 3.
+        mockRotationEnvironment()
+        val (notificationGroup, _) = captureNotifications()
+        state.accentRotationEnabled = true
+        state.accentRotationMode = AccentRotationMode.PRESET.name
+
+        val applyCalls = mutableListOf<String>()
+        every { AccentApplicator.apply(any()) } answers {
+            applyCalls += firstArg<String>()
+            if (applyCalls.size == THREE) return@answers Unit
+            @Suppress("TooGenericExceptionThrown") // Test-only simulation of applicator failure
+            throw RuntimeException("fail ${applyCalls.size}")
+        }
+
+        val suppressLoggedErrors =
+            object : LoggedErrorProcessor() {
+                override fun processError(
+                    category: String,
+                    message: String,
+                    details: Array<out String>,
+                    throwable: Throwable?,
+                ): Set<Action> = EnumSet.noneOf(Action::class.java)
+            }
+
+        val service = AccentRotationService()
+        LoggedErrorProcessor.executeWith<RuntimeException>(suppressLoggedErrors) {
+            repeat(FIVE) { service.rotateAccent() }
+        }
+
+        verify(exactly = 0) {
+            notificationGroup.createNotification(any<String>(), any<String>(), any<NotificationType>())
+        }
+    }
+
+    /**
+     * Wire `NotificationGroupManager.getInstance().getNotificationGroup("Ayu Islands")` to a
+     * relaxed mock and return the group plus a capture list so tests can assert the circuit
+     * breaker's user-visible outcome without needing the real notification subsystem.
+     */
+    private fun captureNotifications(): Pair<NotificationGroup, MutableList<Notification>> {
+        val group = mockk<NotificationGroup>(relaxed = true)
+        val captured = mutableListOf<Notification>()
+        every {
+            group.createNotification(any<String>(), any<String>(), any<NotificationType>())
+        } answers {
+            val notification = mockk<Notification>(relaxed = true)
+            captured += notification
+            notification
+        }
+        val notificationManager = mockk<NotificationGroupManager>()
+        every { notificationManager.getNotificationGroup("Ayu Islands") } returns group
+        mockkStatic(NotificationGroupManager::class)
+        every { NotificationGroupManager.getInstance() } returns notificationManager
+        return group to captured
+    }
+
+    @Test
     fun `rotateAccent swallows AccentApplicator failures and still syncs glow`() {
         mockRotationEnvironment()
         state.accentRotationEnabled = true
@@ -297,5 +395,10 @@ class AccentRotationServiceTest {
         verify(exactly = 1) { GlowOverlayManager.syncGlowForAllProjects() }
         assertEquals(1, loggedErrors.size, "Expected exactly one LOG.error for the failed apply()")
         assertEquals("boom", loggedErrors.single()?.message)
+    }
+
+    companion object {
+        private const val THREE = 3
+        private const val FIVE = 5
     }
 }

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanelTest.kt
@@ -90,6 +90,59 @@ class AyuIslandsAccentPanelTest {
         LoggedErrorProcessor.executeWith<Throwable>(suppressLoggedErrors()) {
             panel.applyWithFallback(AyuVariant.MIRAGE, "#FFCC66")
         }
+        // notifyExternalApply must NOT be reached when the global-fallback apply throws.
+        verify(exactly = 0) { swapService.notifyExternalApply(any()) }
+    }
+
+    @Test
+    fun `applyWithFallback logs WARN when swap cache sync throws after successful global apply`() {
+        // Regression guard for failure mode #3: applyForFocusedProject throws, the
+        // global-fallback apply(effectiveAccent) succeeds, but notifyExternalApply
+        // throws (swap service mid-dispose, corrupted cache). The visible accent has
+        // already changed; only the focus-swap cache is stale. The panel must log at
+        // WARN (not ERROR, since apply actually worked) and must NOT rethrow — otherwise
+        // the Settings OK path degrades to a generic "Can't save" dialog on a path where
+        // the user's intent was actually applied.
+        every { AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE) } throws
+            IllegalStateException("override hex corrupted")
+        every { AccentApplicator.apply("#FFCC66") } just Runs
+        every { swapService.notifyExternalApply("#FFCC66") } throws
+            IllegalStateException("swap service disposed mid-save")
+
+        val expectedWarnSubstring = "swap-cache sync failed"
+        val capturedWarns = mutableListOf<String>()
+        val processor =
+            object : LoggedErrorProcessor() {
+                override fun processError(
+                    category: String,
+                    message: String,
+                    details: Array<out String>,
+                    throwable: Throwable?,
+                ): Set<Action> = java.util.EnumSet.noneOf(Action::class.java)
+
+                override fun processWarn(
+                    category: String,
+                    message: String,
+                    throwable: Throwable?,
+                ): Boolean {
+                    if (!message.contains(expectedWarnSubstring)) return true
+                    capturedWarns += message
+                    return false
+                }
+            }
+
+        val panel = AyuIslandsAccentPanel()
+        LoggedErrorProcessor.executeWith<Throwable>(processor) {
+            panel.applyWithFallback(AyuVariant.MIRAGE, "#FFCC66")
+        }
+
+        verify(exactly = 1) { AccentApplicator.apply("#FFCC66") }
+        verify(exactly = 1) { swapService.notifyExternalApply("#FFCC66") }
+        kotlin.test.assertEquals(
+            1,
+            capturedWarns.size,
+            "notifyExternalApply throw must produce exactly one WARN (not ERROR); got: $capturedWarns",
+        )
     }
 
     private fun suppressLoggedErrors(): LoggedErrorProcessor =

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanelTest.kt
@@ -16,12 +16,15 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 
 /**
- * Locks in the [AyuIslandsAccentPanel.applyWithFallbackForTest] failure-recovery contract:
+ * Locks in the [AyuIslandsAccentPanel.applyWithFallback] failure-recovery contract:
  *  - happy path: applyForFocusedProject runs; no fallback triggered
- *  - corrupted override: applyForFocusedProject throws, fallback applies global hex AND
- *    syncs the swap cache (the bug R5 closed — fallback used to skip the cache sync)
+ *  - corrupted override: applyForFocusedProject throws, fallback applies the global hex
+ *    AND syncs the swap cache (the swap-cache-sync omission was the original bug — the
+ *    fallback used to skip it, silently reintroducing the stale-cache → redundant-apply
+ *    pattern applyForFocusedProject was created to prevent)
  *  - corrupted global: BOTH paths throw; the panel stays operational, second LOG.error
- *    fires, no exception escapes (the bug R6 closed)
+ *    fires with "also failed" context, no exception escapes — avoids the generic
+ *    "Settings can't save" dialog a hand-edited global hex would otherwise trigger
  */
 class AyuIslandsAccentPanelTest {
     private lateinit var swapService: ProjectAccentSwapService
@@ -54,10 +57,10 @@ class AyuIslandsAccentPanelTest {
 
     @Test
     fun `applyWithFallback corrupted override falls back to global AND syncs swap cache`() {
-        // Regression guard for R5: the previous fallback applied the global accent but
-        // forgot to call ProjectAccentSwapService.notifyExternalApply, leaving the swap
-        // cache stale and silently re-introducing the exact bug applyForFocusedProject
-        // was created to prevent.
+        // Regression guard: a previous fallback applied the global accent but forgot to
+        // call ProjectAccentSwapService.notifyExternalApply, leaving the swap cache stale
+        // and silently re-introducing the exact bug applyForFocusedProject was created
+        // to prevent (next WINDOW_ACTIVATED would redundantly re-apply).
         every { AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE) } throws
             IllegalStateException("override hex corrupted")
         every { AccentApplicator.apply("#FFCC66") } just Runs
@@ -73,10 +76,10 @@ class AyuIslandsAccentPanelTest {
 
     @Test
     fun `applyWithFallback corrupted global ALSO does not propagate exception`() {
-        // Regression guard for R6: the fallback's own apply(effectiveAccent) can throw
-        // when the GLOBAL hex is corrupted (hand-edited XML, legacy writer). Without the
-        // second try/catch, the Settings "OK" path failed with a generic dialog. Now it
-        // logs and leaves the visible accent unchanged.
+        // Regression guard: the fallback's own apply(effectiveAccent) can throw when
+        // the GLOBAL hex is corrupted (hand-edited XML, legacy writer). Without the
+        // second try/catch, the Settings "OK" path would bubble up as a generic
+        // "Can't save" dialog. The catch logs and leaves the visible accent unchanged.
         every { AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE) } throws
             IllegalStateException("override hex corrupted")
         every { AccentApplicator.apply("#FFCC66") } throws

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanelTest.kt
@@ -1,0 +1,101 @@
+package dev.ayuislands.settings
+
+import com.intellij.testFramework.LoggedErrorProcessor
+import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.settings.mappings.ProjectAccentSwapService
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+/**
+ * Locks in the [AyuIslandsAccentPanel.applyWithFallbackForTest] failure-recovery contract:
+ *  - happy path: applyForFocusedProject runs; no fallback triggered
+ *  - corrupted override: applyForFocusedProject throws, fallback applies global hex AND
+ *    syncs the swap cache (the bug R5 closed — fallback used to skip the cache sync)
+ *  - corrupted global: BOTH paths throw; the panel stays operational, second LOG.error
+ *    fires, no exception escapes (the bug R6 closed)
+ */
+class AyuIslandsAccentPanelTest {
+    private lateinit var swapService: ProjectAccentSwapService
+
+    @BeforeTest
+    fun setUp() {
+        mockkObject(AccentApplicator)
+        swapService = mockk(relaxed = true)
+        mockkObject(ProjectAccentSwapService.Companion)
+        every { ProjectAccentSwapService.getInstance() } returns swapService
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `applyWithFallback happy path delegates to applyForFocusedProject and skips fallback`() {
+        every { AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE) } returns "#ABCDEF"
+
+        val panel = AyuIslandsAccentPanel()
+        panel.applyWithFallback(AyuVariant.MIRAGE, "#FFCC66")
+
+        verify(exactly = 1) { AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE) }
+        // Fallback path's apply(effectiveAccent) and notifyExternalApply must NOT fire.
+        verify(exactly = 0) { AccentApplicator.apply(any()) }
+        verify(exactly = 0) { swapService.notifyExternalApply(any()) }
+    }
+
+    @Test
+    fun `applyWithFallback corrupted override falls back to global AND syncs swap cache`() {
+        // Regression guard for R5: the previous fallback applied the global accent but
+        // forgot to call ProjectAccentSwapService.notifyExternalApply, leaving the swap
+        // cache stale and silently re-introducing the exact bug applyForFocusedProject
+        // was created to prevent.
+        every { AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE) } throws
+            IllegalStateException("override hex corrupted")
+        every { AccentApplicator.apply("#FFCC66") } just Runs
+
+        val panel = AyuIslandsAccentPanel()
+        LoggedErrorProcessor.executeWith<Throwable>(suppressLoggedErrors()) {
+            panel.applyWithFallback(AyuVariant.MIRAGE, "#FFCC66")
+        }
+
+        verify(exactly = 1) { AccentApplicator.apply("#FFCC66") }
+        verify(exactly = 1) { swapService.notifyExternalApply("#FFCC66") }
+    }
+
+    @Test
+    fun `applyWithFallback corrupted global ALSO does not propagate exception`() {
+        // Regression guard for R6: the fallback's own apply(effectiveAccent) can throw
+        // when the GLOBAL hex is corrupted (hand-edited XML, legacy writer). Without the
+        // second try/catch, the Settings "OK" path failed with a generic dialog. Now it
+        // logs and leaves the visible accent unchanged.
+        every { AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE) } throws
+            IllegalStateException("override hex corrupted")
+        every { AccentApplicator.apply("#FFCC66") } throws
+            IllegalStateException("global hex also corrupted")
+
+        val panel = AyuIslandsAccentPanel()
+        // No exception escapes — both throws are caught and logged.
+        LoggedErrorProcessor.executeWith<Throwable>(suppressLoggedErrors()) {
+            panel.applyWithFallback(AyuVariant.MIRAGE, "#FFCC66")
+        }
+    }
+
+    private fun suppressLoggedErrors(): LoggedErrorProcessor =
+        object : LoggedErrorProcessor() {
+            override fun processError(
+                category: String,
+                message: String,
+                details: Array<out String>,
+                throwable: Throwable?,
+            ): Set<Action> = java.util.EnumSet.noneOf(Action::class.java)
+        }
+}

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanelTest.kt
@@ -96,13 +96,13 @@ class AyuIslandsAccentPanelTest {
 
     @Test
     fun `applyWithFallback logs WARN when swap cache sync throws after successful global apply`() {
-        // Regression guard for failure mode #3: applyForFocusedProject throws, the
-        // global-fallback apply(effectiveAccent) succeeds, but notifyExternalApply
-        // throws (swap service mid-dispose, corrupted cache). The visible accent has
-        // already changed; only the focus-swap cache is stale. The panel must log at
-        // WARN (not ERROR, since apply actually worked) and must NOT rethrow — otherwise
-        // the Settings OK path degrades to a generic "Can't save" dialog on a path where
-        // the user's intent was actually applied.
+        // Regression guard for the notifyExternalApply-after-successful-fallback-apply
+        // stage: applyForFocusedProject throws, the global-fallback apply(effectiveAccent)
+        // succeeds, but notifyExternalApply throws (swap service mid-dispose, corrupted
+        // cache). The visible accent has already changed; only the focus-swap cache is
+        // stale. The panel must log at WARN (not ERROR, since apply actually worked) and
+        // must NOT rethrow — otherwise the Settings OK path degrades to a generic "Can't
+        // save" dialog on a path where the user's intent was actually applied.
         every { AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE) } throws
             IllegalStateException("override hex corrupted")
         every { AccentApplicator.apply("#FFCC66") } just Runs

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettingsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettingsTest.kt
@@ -1,0 +1,143 @@
+package dev.ayuislands.settings.mappings
+
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Verifies the `$USER_HOME$` path-macro migration in [AccentMappingsSettings.loadState].
+ *
+ * IntelliJ's storage layer historically wrote project paths with the `$USER_HOME$` macro
+ * substituted, but did not expand them on load for arbitrary map keys. Without the
+ * migration, `AccentResolver.projectKey(project)` (returning an absolute canonical path)
+ * never matches the macro-prefixed stored key and every override silently falls through
+ * to the global accent. The settings storage annotation now pins `usePathMacroManager = false`,
+ * but legacy XML files from older builds still contain the macro — this suite ensures the
+ * load-time rewrite survives.
+ */
+class AccentMappingsSettingsTest {
+    private var originalUserHome: String? = null
+
+    @BeforeTest
+    fun setUp() {
+        originalUserHome = System.getProperty("user.home")
+    }
+
+    @AfterTest
+    fun tearDown() {
+        val saved = originalUserHome
+        if (saved != null) {
+            System.setProperty("user.home", saved)
+        } else {
+            System.clearProperty("user.home")
+        }
+    }
+
+    @Test
+    fun `loadState expands USER_HOME macro in projectAccents keys`() {
+        System.setProperty("user.home", "/Users/alice")
+        val settings = AccentMappingsSettings()
+        val state =
+            AccentMappingsState().apply {
+                projectAccents["\$USER_HOME\$/dev/foo"] = "#FFCD66"
+            }
+
+        settings.loadState(state)
+
+        assertNull(settings.state.projectAccents["\$USER_HOME\$/dev/foo"], "macro key must be rewritten, not retained")
+        assertEquals("#FFCD66", settings.state.projectAccents["/Users/alice/dev/foo"])
+    }
+
+    @Test
+    fun `loadState expands USER_HOME macro in projectDisplayNames keys`() {
+        System.setProperty("user.home", "/Users/alice")
+        val settings = AccentMappingsSettings()
+        val state =
+            AccentMappingsState().apply {
+                projectDisplayNames["\$USER_HOME\$/dev/foo"] = "Foo"
+            }
+
+        settings.loadState(state)
+
+        assertEquals("Foo", settings.state.projectDisplayNames["/Users/alice/dev/foo"])
+        assertNull(settings.state.projectDisplayNames["\$USER_HOME\$/dev/foo"])
+    }
+
+    @Test
+    fun `loadState leaves absolute paths untouched`() {
+        System.setProperty("user.home", "/Users/alice")
+        val settings = AccentMappingsSettings()
+        val state =
+            AccentMappingsState().apply {
+                projectAccents["/tmp/already-absolute"] = "#FFCD66"
+                projectDisplayNames["/tmp/already-absolute"] = "AbsoluteProj"
+            }
+
+        settings.loadState(state)
+
+        assertEquals("#FFCD66", settings.state.projectAccents["/tmp/already-absolute"])
+        assertEquals("AbsoluteProj", settings.state.projectDisplayNames["/tmp/already-absolute"])
+    }
+
+    @Test
+    fun `loadState does not touch languageAccents even if a key starts with the macro-like prefix`() {
+        System.setProperty("user.home", "/Users/alice")
+        val settings = AccentMappingsSettings()
+        val state =
+            AccentMappingsState().apply {
+                languageAccents["kotlin"] = "#D5FF80"
+                projectAccents["\$USER_HOME\$/dev/foo"] = "#FFCD66"
+            }
+
+        settings.loadState(state)
+
+        assertEquals("#D5FF80", settings.state.languageAccents["kotlin"])
+        assertEquals("#FFCD66", settings.state.projectAccents["/Users/alice/dev/foo"])
+    }
+
+    @Test
+    fun `loadState is a no-op migration when user home is blank`() {
+        // Setting the property to a blank string triggers the `takeIf(isNotBlank)` guard
+        // — the migration must not attempt string concatenation with an empty home.
+        System.setProperty("user.home", "")
+        val settings = AccentMappingsSettings()
+        val state =
+            AccentMappingsState().apply {
+                projectAccents["\$USER_HOME\$/dev/foo"] = "#FFCD66"
+            }
+
+        settings.loadState(state)
+
+        // Macro stays as-is; migration skipped.
+        assertEquals("#FFCD66", settings.state.projectAccents["\$USER_HOME\$/dev/foo"])
+    }
+
+    @Test
+    fun `loadState migration is idempotent on already-migrated state`() {
+        System.setProperty("user.home", "/Users/alice")
+        val settings = AccentMappingsSettings()
+        val state =
+            AccentMappingsState().apply {
+                projectAccents["\$USER_HOME\$/dev/foo"] = "#FFCD66"
+            }
+        settings.loadState(state)
+
+        // Second load of the already-rewritten state should leave it alone.
+        val afterFirstLoad = settings.state.projectAccents.toMap()
+        settings.loadState(settings.state)
+
+        assertEquals(afterFirstLoad, settings.state.projectAccents.toMap())
+    }
+
+    @Test
+    fun `getInstance returns a usable service — companion wired correctly`() {
+        // Defensive: constructor should not throw and companion accessor should compile.
+        val settings = AccentMappingsSettings()
+        assertNotNull(settings.state)
+        assertTrue(settings.state.projectAccents.isEmpty())
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettingsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettingsTest.kt
@@ -273,6 +273,89 @@ class AccentMappingsSettingsTest {
     }
 
     @Test
+    fun `migrateUserHomeMacro logs only the names cause when accents rewrite succeeds`() {
+        // Mirror of the accents-fails-only asymmetry test: proves the `primary =
+        // accentsCause ?: namesCause` precedence correctly promotes `namesCause` when
+        // it's the only failure. A regression flipping the precedence (e.g.
+        // `namesCause ?: accentsCause`) would pass the accents-only test but fail this one.
+        System.setProperty("user.home", "/Users/alice")
+        val settings = AccentMappingsSettings()
+        val namesBoom = ConcurrentModificationException("names-only boom")
+        val healthyAccents = mutableMapOf<String, String>("/tmp/proj" to "#FFCD66")
+        val throwingNames = ThrowingMap(namesBoom)
+
+        val capturedThrowables = mutableListOf<Throwable?>()
+        val processor =
+            object : LoggedErrorProcessor() {
+                override fun processWarn(
+                    category: String,
+                    message: String,
+                    throwable: Throwable?,
+                ): Boolean {
+                    if (message.contains("Failed to migrate")) {
+                        capturedThrowables += throwable
+                    }
+                    return false
+                }
+            }
+
+        LoggedErrorProcessor.executeWith<RuntimeException>(processor) {
+            settings.migrateUserHomeMacro(healthyAccents, throwingNames)
+        }
+
+        val primary =
+            assertNotNull(
+                capturedThrowables.single(),
+                "single-failure warn must carry a non-null cause",
+            )
+        assertEquals(namesBoom, primary, "single-failure warn must carry the names cause")
+        assertTrue(
+            primary.suppressed.isEmpty(),
+            "no addSuppressed linkage when only one rewrite failed; got suppressed=${primary.suppressed.toList()}",
+        )
+    }
+
+    @Test
+    fun `migrateUserHomeMacro swallows exceptions from legacy-key probe when user home is blank`() {
+        // The defensive `runCatching` in `logBlankUserHomeIfLegacyKeysPresent` exists because
+        // probing `.keys` on a platform-backed BaseState map during startup deserialization
+        // could theoretically race with a concurrent write. Exercise it directly: blank
+        // user.home drives the no-migration branch, and a throwing map simulates the CME so
+        // settings loading must still complete without propagating.
+        System.setProperty("user.home", "")
+        val settings = AccentMappingsSettings()
+        val probeBoom = ConcurrentModificationException("keys probed mid-write")
+        val throwingAccents = ThrowingMap(probeBoom)
+        val throwingNames = ThrowingMap(probeBoom)
+
+        val capturedMessages = mutableListOf<String>()
+        val processor =
+            object : LoggedErrorProcessor() {
+                override fun processWarn(
+                    category: String,
+                    message: String,
+                    throwable: Throwable?,
+                ): Boolean {
+                    capturedMessages += message
+                    return false
+                }
+            }
+
+        LoggedErrorProcessor.executeWith<RuntimeException>(processor) {
+            settings.migrateUserHomeMacro(throwingAccents, throwingNames)
+        }
+
+        // The "legacy keys" warn must NOT fire — the probe returned false by default after
+        // catching the CME. If the runCatching were removed, the probe would propagate and
+        // the migration path would escalate out of loadState.
+        assertTrue(
+            capturedMessages.none { it.contains("Cannot migrate legacy") },
+            "Blank user.home + throwing probe must not fire the 'legacy keys' warn " +
+                "(probe's runCatching swallows the CME to default=false); got: $capturedMessages",
+        )
+    }
+
+    @Test
     fun `migrateUserHomeMacro logs only the accents cause when names rewrite succeeds`() {
         // Asymmetry check: when ONLY the accents rewrite throws, the warn must carry the
         // accents cause unchanged — no spurious `addSuppressed` wiring when there's no
@@ -315,11 +398,14 @@ class AccentMappingsSettingsTest {
     }
 
     /**
-     * Throws a caller-specified exception on every iteration-shaped access (`entries`,
-     * `keys`, `values`). Delegates reads like `size` / `isEmpty` / `containsKey` to a
-     * non-empty backing map so `Map.none { ... }` doesn't short-circuit via its isEmpty
-     * fast-path — the throw only fires from iteration, which is what we want to exercise
-     * the `runCatching { rewriteKeys(...) }` branch in
+     * Throws a caller-specified exception on every iteration-shaped accessor
+     * (`entries`, `keys`, `values`). `size` / `isEmpty` / `containsKey` delegate to a
+     * non-empty backing map so unrelated probes inside `rewriteKeys` or the stdlib's
+     * collection extensions don't surface a surprise throw before the intended iteration
+     * reaches `entries`. (`Map.none(predicate)` itself has no `isEmpty` short-circuit —
+     * only the no-arg `Map.none()` does — but keeping the non-empty backing keeps the
+     * helper well-behaved as a general-purpose `MutableMap` for any future caller.)
+     * Exercises the `runCatching { rewriteKeys(...) }` branch in
      * [AccentMappingsSettings.migrateUserHomeMacro] without reflection or instrumentation.
      */
     private class ThrowingMap(

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettingsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettingsTest.kt
@@ -1,5 +1,6 @@
 package dev.ayuislands.settings.mappings
 
+import com.intellij.testFramework.LoggedErrorProcessor
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -131,6 +132,79 @@ class AccentMappingsSettingsTest {
         settings.loadState(settings.state)
 
         assertEquals(afterFirstLoad, settings.state.projectAccents.toMap())
+    }
+
+    @Test
+    fun `loadState warns when legacy keys exist but user home is unavailable`() {
+        // Red-green guard for the actionable breadcrumb commit b1c1e4e added: without
+        // user.home, stored `$USER_HOME$/...` keys can never be migrated, so the user's
+        // overrides invisibly fall through to the global accent. The warn log is the only
+        // signal an affected user has — removing it would silently regress the migration UX.
+        System.setProperty("user.home", "")
+        val settings = AccentMappingsSettings()
+        val state =
+            AccentMappingsState().apply {
+                projectAccents["\$USER_HOME\$/dev/foo"] = "#FFCD66"
+            }
+
+        val capturedMessages = mutableListOf<String>()
+        val processor =
+            object : LoggedErrorProcessor() {
+                override fun processWarn(
+                    category: String,
+                    message: String,
+                    throwable: Throwable?,
+                ): Boolean {
+                    capturedMessages += message
+                    return false // suppress promotion to AssertionError in test environment
+                }
+            }
+
+        LoggedErrorProcessor.executeWith<RuntimeException>(processor) {
+            settings.loadState(state)
+        }
+
+        assertTrue(
+            capturedMessages.any { it.contains("legacy") && it.contains("user.home") },
+            "Expected a warn about legacy \$USER_HOME\$ keys + missing user.home, " +
+                "got: $capturedMessages",
+        )
+    }
+
+    @Test
+    fun `loadState does NOT warn when user home is blank but no legacy keys exist`() {
+        // Symmetric guard: the warn is gated on legacy keys being present. A user with a
+        // blank user.home and no legacy keys should NOT see the breadcrumb (false-positive
+        // would cry wolf and dilute the signal for actually-affected users).
+        System.setProperty("user.home", "")
+        val settings = AccentMappingsSettings()
+        val state =
+            AccentMappingsState().apply {
+                projectAccents["/Users/alice/dev/foo"] = "#FFCD66"
+            }
+
+        val capturedMessages = mutableListOf<String>()
+        val processor =
+            object : LoggedErrorProcessor() {
+                override fun processWarn(
+                    category: String,
+                    message: String,
+                    throwable: Throwable?,
+                ): Boolean {
+                    capturedMessages += message
+                    return false // suppress promotion to AssertionError in test environment
+                }
+            }
+
+        LoggedErrorProcessor.executeWith<RuntimeException>(processor) {
+            settings.loadState(state)
+        }
+
+        assertTrue(
+            capturedMessages.none { it.contains("legacy") },
+            "No legacy-key warn should fire when no \$USER_HOME\$ keys are present, " +
+                "got: $capturedMessages",
+        )
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettingsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettingsTest.kt
@@ -1,6 +1,7 @@
 package dev.ayuislands.settings.mappings
 
 import com.intellij.testFramework.LoggedErrorProcessor
+import java.util.ConcurrentModificationException
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -213,5 +214,123 @@ class AccentMappingsSettingsTest {
         val settings = AccentMappingsSettings()
         assertNotNull(settings.state)
         assertTrue(settings.state.projectAccents.isEmpty())
+    }
+
+    @Test
+    fun `migrateUserHomeMacro links both rewrite failures via addSuppressed`() {
+        // When both map rewrites throw (e.g., concurrent structural modification during
+        // startup deserialization), triage must see BOTH causes — not just the first.
+        // Without addSuppressed linkage, collapsing to `primary ?: secondary` loses the
+        // second failure mode, which matters when the two exceptions carry different
+        // context (different map, different mutating thread, different stack).
+        //
+        // BaseState-delegated maps on the real `AccentMappingsState` can't easily be
+        // swapped for throwing ones — instead, we go through the `@internal` seam and
+        // hand it maps whose iteration deliberately throws.
+        System.setProperty("user.home", "/Users/alice")
+        val settings = AccentMappingsSettings()
+        val accentsBoom = ConcurrentModificationException("accents map mutated during load")
+        val namesBoom = ConcurrentModificationException("names map mutated during load")
+        val throwingAccents = ThrowingMap(accentsBoom)
+        val throwingNames = ThrowingMap(namesBoom)
+
+        val captured = mutableListOf<Pair<String, Throwable?>>()
+        val processor =
+            object : LoggedErrorProcessor() {
+                override fun processWarn(
+                    category: String,
+                    message: String,
+                    throwable: Throwable?,
+                ): Boolean {
+                    captured += message to throwable
+                    return false
+                }
+            }
+
+        LoggedErrorProcessor.executeWith<RuntimeException>(processor) {
+            settings.migrateUserHomeMacro(throwingAccents, throwingNames)
+        }
+
+        val migrationWarn =
+            captured.firstOrNull { it.first.contains("Failed to migrate") }
+                ?: error("Expected a 'Failed to migrate' warn, got: $captured")
+        val primary =
+            assertNotNull(
+                migrationWarn.second,
+                "warn must carry the primary exception for triage",
+            )
+        assertEquals(
+            accentsBoom,
+            primary,
+            "accents cause must be the primary exception (not the names cause)",
+        )
+        assertEquals(
+            listOf(namesBoom),
+            primary.suppressed.toList(),
+            "names cause must be linked via addSuppressed so both failure modes are " +
+                "visible in the stack trace; got suppressed=${primary.suppressed.toList()}",
+        )
+    }
+
+    @Test
+    fun `migrateUserHomeMacro logs only the accents cause when names rewrite succeeds`() {
+        // Asymmetry check: when ONLY the accents rewrite throws, the warn must carry the
+        // accents cause unchanged — no spurious `addSuppressed` wiring when there's no
+        // secondary cause to link.
+        System.setProperty("user.home", "/Users/alice")
+        val settings = AccentMappingsSettings()
+        val accentsBoom = ConcurrentModificationException("accents-only boom")
+        val throwingAccents = ThrowingMap(accentsBoom)
+        val healthyNames = mutableMapOf<String, String>("/tmp/proj" to "Foo")
+
+        val capturedThrowables = mutableListOf<Throwable?>()
+        val processor =
+            object : LoggedErrorProcessor() {
+                override fun processWarn(
+                    category: String,
+                    message: String,
+                    throwable: Throwable?,
+                ): Boolean {
+                    if (message.contains("Failed to migrate")) {
+                        capturedThrowables += throwable
+                    }
+                    return false
+                }
+            }
+
+        LoggedErrorProcessor.executeWith<RuntimeException>(processor) {
+            settings.migrateUserHomeMacro(throwingAccents, healthyNames)
+        }
+
+        val primary =
+            assertNotNull(
+                capturedThrowables.single(),
+                "single-failure warn must carry a non-null cause",
+            )
+        assertEquals(accentsBoom, primary, "single-failure warn must carry the accents cause")
+        assertTrue(
+            primary.suppressed.isEmpty(),
+            "no addSuppressed linkage when only one rewrite failed; got suppressed=${primary.suppressed.toList()}",
+        )
+    }
+
+    /**
+     * Throws a caller-specified exception on every iteration-shaped access (`entries`,
+     * `keys`, `values`). Delegates reads like `size` / `isEmpty` / `containsKey` to a
+     * non-empty backing map so `Map.none { ... }` doesn't short-circuit via its isEmpty
+     * fast-path — the throw only fires from iteration, which is what we want to exercise
+     * the `runCatching { rewriteKeys(...) }` branch in
+     * [AccentMappingsSettings.migrateUserHomeMacro] without reflection or instrumentation.
+     */
+    private class ThrowingMap(
+        private val boom: RuntimeException,
+        private val backing: MutableMap<String, String> = mutableMapOf("/seed" to "value"),
+    ) : MutableMap<String, String> by backing {
+        override val entries: MutableSet<MutableMap.MutableEntry<String, String>>
+            get() = throw boom
+        override val keys: MutableSet<String>
+            get() = throw boom
+        override val values: MutableCollection<String>
+            get() = throw boom
     }
 }

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettingsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettingsTest.kt
@@ -210,6 +210,43 @@ class AccentMappingsSettingsTest {
     }
 
     @Test
+    fun `warnMigrationFailed defensive branch fires marker WARN when both causes are null`() {
+        // Algorithmic test for documented dead-from-current-callers defensive insurance:
+        // the call site at line 80 gates with `isFailure || isFailure` so at least one
+        // Throwable is always non-null in production. The `?: run { LOG.warn("...call-site
+        // gate regressed...") return }` exists so a future regression in the caller
+        // doesn't NPE inside the log path. Pure logic test that pins the marker WARN so
+        // a refactor dropping it can't slip through unnoticed.
+        val settings = AccentMappingsSettings()
+
+        val capturedMessages = mutableListOf<String>()
+        val processor =
+            object : LoggedErrorProcessor() {
+                override fun processWarn(
+                    category: String,
+                    message: String,
+                    throwable: Throwable?,
+                ): Boolean {
+                    capturedMessages += message
+                    return false
+                }
+            }
+
+        LoggedErrorProcessor.executeWith<RuntimeException>(processor) {
+            settings.warnMigrationFailed(null, null)
+        }
+
+        assertTrue(
+            capturedMessages.any { it.contains("call-site gate regressed") },
+            "defensive both-null branch must emit the marker WARN; got: $capturedMessages",
+        )
+        assertTrue(
+            capturedMessages.none { it.contains("Failed to migrate") },
+            "marker WARN must NOT be followed by the regular migration WARN; got: $capturedMessages",
+        )
+    }
+
+    @Test
     fun `getInstance returns a usable service — companion wired correctly`() {
         // Defensive: constructor should not throw and companion accessor should compile.
         val settings = AccentMappingsSettings()

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettingsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettingsTest.kt
@@ -2,6 +2,7 @@ package dev.ayuislands.settings.mappings
 
 import com.intellij.testFramework.LoggedErrorProcessor
 import java.util.ConcurrentModificationException
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -322,6 +323,10 @@ class AccentMappingsSettingsTest {
         // could theoretically race with a concurrent write. Exercise it directly: blank
         // user.home drives the no-migration branch, and a throwing map simulates the CME so
         // settings loading must still complete without propagating.
+        //
+        // Positive-evidence assertion: check ThrowingMap.iterationAccessCount > 0 to prove
+        // the probe ACTUALLY RAN and threw. Without this, an absence-assertion alone would
+        // pass trivially if a future refactor early-returned before invoking the probe.
         System.setProperty("user.home", "")
         val settings = AccentMappingsSettings()
         val probeBoom = ConcurrentModificationException("keys probed mid-write")
@@ -344,6 +349,15 @@ class AccentMappingsSettingsTest {
         LoggedErrorProcessor.executeWith<RuntimeException>(processor) {
             settings.migrateUserHomeMacro(throwingAccents, throwingNames)
         }
+
+        // Probe must have actually executed (accessed one of the iteration members) before
+        // the runCatching caught the throw. Guards against a refactor that skips the probe
+        // altogether — the absence-assertion below would pass trivially in that case.
+        assertTrue(
+            throwingAccents.iterationAccessCount.get() > 0,
+            "Probe must actually access projectAccents iteration members before catching; " +
+                "iterationAccessCount=${throwingAccents.iterationAccessCount.get()}",
+        )
 
         // The "legacy keys" warn must NOT fire — the probe returned false by default after
         // catching the CME. If the runCatching were removed, the probe would propagate and
@@ -400,11 +414,15 @@ class AccentMappingsSettingsTest {
     /**
      * Throws a caller-specified exception on every iteration-shaped accessor
      * (`entries`, `keys`, `values`). `size` / `isEmpty` / `containsKey` delegate to a
-     * non-empty backing map so unrelated probes inside `rewriteKeys` or the stdlib's
-     * collection extensions don't surface a surprise throw before the intended iteration
-     * reaches `entries`. (`Map.none(predicate)` itself has no `isEmpty` short-circuit —
-     * only the no-arg `Map.none()` does — but keeping the non-empty backing keeps the
-     * helper well-behaved as a general-purpose `MutableMap` for any future caller.)
+     * non-empty backing map — this matters load-bearingly: Kotlin's
+     * `Map.none(predicate)` stdlib extension short-circuits to `true` when `isEmpty()` is
+     * true (see `_Maps.kt` in the stdlib — the fast-path applies to both the no-arg and
+     * predicate overloads). An empty backing would make `source.none { it.key.startsWith
+     * (USER_HOME_MACRO) }` inside `rewriteKeys` return `true` immediately, skipping the
+     * iteration over `entries` that actually throws. The non-empty seed forces the
+     * implementation past the fast-path into the `for (element in this)` loop, which
+     * accesses `entries` — and that's where [boom] finally fires.
+     *
      * Exercises the `runCatching { rewriteKeys(...) }` branch in
      * [AccentMappingsSettings.migrateUserHomeMacro] without reflection or instrumentation.
      */
@@ -412,11 +430,22 @@ class AccentMappingsSettingsTest {
         private val boom: RuntimeException,
         private val backing: MutableMap<String, String> = mutableMapOf("/seed" to "value"),
     ) : MutableMap<String, String> by backing {
+        val iterationAccessCount = AtomicInteger(0)
+
         override val entries: MutableSet<MutableMap.MutableEntry<String, String>>
-            get() = throw boom
+            get() {
+                iterationAccessCount.incrementAndGet()
+                throw boom
+            }
         override val keys: MutableSet<String>
-            get() = throw boom
+            get() {
+                iterationAccessCount.incrementAndGet()
+                throw boom
+            }
         override val values: MutableCollection<String>
-            get() = throw boom
+            get() {
+                iterationAccessCount.incrementAndGet()
+                throw boom
+            }
     }
 }

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/AccentMappingsStateTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/AccentMappingsStateTest.kt
@@ -1,0 +1,33 @@
+package dev.ayuislands.settings.mappings
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Smoke tests for the state DTO — the real serialization concerns live in IntelliJ's
+ * BaseState, but this guards against accidental field renames and ensures a fresh
+ * instance starts empty.
+ */
+class AccentMappingsStateTest {
+    @Test
+    fun `fresh state has empty maps`() {
+        val state = AccentMappingsState()
+
+        assertTrue(state.projectAccents.isEmpty())
+        assertTrue(state.languageAccents.isEmpty())
+        assertTrue(state.projectDisplayNames.isEmpty())
+    }
+
+    @Test
+    fun `maps are mutable for serialization round-trip`() {
+        val state = AccentMappingsState()
+        state.projectAccents["/tmp/a"] = "#111111"
+        state.projectDisplayNames["/tmp/a"] = "Alpha"
+        state.languageAccents["kotlin"] = "#222222"
+
+        assertEquals("#111111", state.projectAccents["/tmp/a"])
+        assertEquals("Alpha", state.projectDisplayNames["/tmp/a"])
+        assertEquals("#222222", state.languageAccents["kotlin"])
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/LanguageMappingsTableModelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/LanguageMappingsTableModelTest.kt
@@ -80,4 +80,100 @@ class LanguageMappingsTableModelTest {
         assertEquals("#ABCDEF", model.getValueAt(0, LanguageMappingsTableModel.COLUMN_COLOR))
         assertEquals("Kotlin", model.getValueAt(0, LanguageMappingsTableModel.COLUMN_LANGUAGE))
     }
+
+    @Test
+    fun `LanguageMapping constructor rejects blank language id`() {
+        // Defensive guard against a UI regression that would let an empty option through —
+        // a blank id would silently match against `containsLanguage("")` and corrupt the
+        // table-row identity.
+        assertFailsWith<IllegalArgumentException> {
+            LanguageMapping(" ", "Whitespace", "#111111")
+        }
+    }
+
+    @Test
+    fun `LanguageMapping constructor rejects malformed hex`() {
+        // The Settings panel persists hex via setAccentForVariant which never inserts a
+        // bad value, but a hand-edited XML or future migration could feed `"oops"` /
+        // `"#FFF"` / `"#ZZZZZZ"`. The require() guard surfaces a clear error at the seam.
+        assertFailsWith<IllegalArgumentException> {
+            LanguageMapping("kotlin", "Kotlin", "no-hash")
+        }
+        assertFailsWith<IllegalArgumentException> {
+            LanguageMapping("kotlin", "Kotlin", "#FFF") // 3-digit hex not accepted
+        }
+        assertFailsWith<IllegalArgumentException> {
+            LanguageMapping("kotlin", "Kotlin", "#ZZZZZZ")
+        }
+    }
+
+    @Test
+    fun `remove out-of-bounds row is a silent no-op`() {
+        // Defensive bound check — UI code calls remove(selectedRow) and selectedRow can be
+        // -1 when nothing is selected. A regression dropping the `if (row !in rows.indices)`
+        // guard would NPE inside ArrayList.removeAt and kill the Settings dialog.
+        val model = LanguageMappingsTableModel()
+        model.add(LanguageMapping("kotlin", "Kotlin", "#111111"))
+
+        model.remove(-1)
+        model.remove(99)
+
+        assertEquals(1, model.rowCount, "out-of-bounds remove must not mutate the table")
+    }
+
+    @Test
+    fun `updateHex out-of-bounds row is a silent no-op`() {
+        // Symmetric to remove: same UI code path can hand updateHex a stale or -1 index.
+        val model = LanguageMappingsTableModel()
+        model.add(LanguageMapping("kotlin", "Kotlin", "#111111"))
+
+        model.updateHex(-1, "#FFFFFF")
+        model.updateHex(99, "#FFFFFF")
+
+        assertEquals("#111111", model.getValueAt(0, LanguageMappingsTableModel.COLUMN_COLOR))
+    }
+
+    @Test
+    fun `getValueAt out-of-bounds row returns null without throwing`() {
+        // Swing JTable can request stale row indices during repaint races. A regression
+        // dropping the `rowAt(rowIndex) ?: return null` guard would surface as NPE inside
+        // the table renderer thread.
+        val model = LanguageMappingsTableModel()
+        assertEquals(null, model.getValueAt(0, LanguageMappingsTableModel.COLUMN_COLOR))
+        assertEquals(null, model.getValueAt(99, LanguageMappingsTableModel.COLUMN_LANGUAGE))
+    }
+
+    @Test
+    fun `getValueAt unknown column returns null`() {
+        // Future column-count growth would leave the existing JTable schema querying
+        // out-of-range columns until repaint catches up. The `else -> null` arm prevents
+        // those reads from throwing.
+        val model = LanguageMappingsTableModel()
+        model.add(LanguageMapping("kotlin", "Kotlin", "#ABCDEF"))
+
+        assertEquals(null, model.getValueAt(0, 99))
+    }
+
+    @Test
+    fun `getColumnName out-of-bounds returns empty string`() {
+        // Algorithmic guard for JTable header renderer probes that may go beyond the
+        // declared column count during animation/resize. Pure logic test — locks in the
+        // `getOrElse { "" }` arm so a future refactor that drops it can't ship.
+        val model = LanguageMappingsTableModel()
+
+        assertEquals("", model.getColumnName(99))
+    }
+
+    @Test
+    fun `isCellEditable always returns false`() {
+        // Algorithmic guard: edits flow exclusively through the Edit dialog, never inline.
+        // A regression returning true would let users type into the cell and bypass the
+        // dialog's validation seam — the user-visible failure is "edit lands without
+        // hex / language-id checks", but the regression itself is at the model level.
+        val model = LanguageMappingsTableModel()
+        model.add(LanguageMapping("kotlin", "Kotlin", "#111111"))
+
+        assertFalse(model.isCellEditable(0, LanguageMappingsTableModel.COLUMN_COLOR))
+        assertFalse(model.isCellEditable(0, LanguageMappingsTableModel.COLUMN_LANGUAGE))
+    }
 }

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/LanguageMappingsTableModelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/LanguageMappingsTableModelTest.kt
@@ -38,14 +38,26 @@ class LanguageMappingsTableModelTest {
     }
 
     @Test
-    fun `containsLanguage is case-insensitive`() {
+    fun `containsLanguage is exact match against the stored lowercase id`() {
+        // LanguageMapping's init block enforces that `languageId` is always lowercase, and
+        // AddLanguageMappingDialog.doOKAction lowercases the probe before calling this — so
+        // the model doesn't need an ignoreCase compensator. The invariant lives in the type.
         val model = LanguageMappingsTableModel()
         model.add(LanguageMapping("kotlin", "Kotlin", "#111111"))
 
         assertTrue(model.containsLanguage("kotlin"))
-        assertTrue(model.containsLanguage("Kotlin"))
-        assertTrue(model.containsLanguage("KOTLIN"))
         assertFalse(model.containsLanguage("python"))
+    }
+
+    @Test
+    fun `LanguageMapping constructor rejects non-lowercase language id`() {
+        // Regression guard: the type-level invariant catches a future caller that forgets
+        // to .lowercase() before constructing — what used to be a silent drift is now a
+        // loud IllegalArgumentException at the seam.
+        val thrown =
+            runCatching { LanguageMapping("Kotlin", "Kotlin", "#111111") }
+                .exceptionOrNull()
+        assertTrue(thrown is IllegalArgumentException)
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/LanguageMappingsTableModelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/LanguageMappingsTableModelTest.kt
@@ -2,6 +2,7 @@ package dev.ayuislands.settings.mappings
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -54,10 +55,9 @@ class LanguageMappingsTableModelTest {
         // Regression guard: the type-level invariant catches a future caller that forgets
         // to .lowercase() before constructing — what used to be a silent drift is now a
         // loud IllegalArgumentException at the seam.
-        val thrown =
-            runCatching { LanguageMapping("Kotlin", "Kotlin", "#111111") }
-                .exceptionOrNull()
-        assertTrue(thrown is IllegalArgumentException)
+        assertFailsWith<IllegalArgumentException> {
+            LanguageMapping("Kotlin", "Kotlin", "#111111")
+        }
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/LanguageMappingsTableModelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/LanguageMappingsTableModelTest.kt
@@ -1,0 +1,71 @@
+package dev.ayuislands.settings.mappings
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class LanguageMappingsTableModelTest {
+    @Test
+    fun `replaceAll resets rows`() {
+        val model = LanguageMappingsTableModel()
+        model.add(LanguageMapping("kotlin", "Kotlin", "#111111"))
+
+        model.replaceAll(listOf(LanguageMapping("python", "Python", "#222222")))
+
+        assertEquals(1, model.rowCount)
+        assertEquals("Python", model.getValueAt(0, LanguageMappingsTableModel.COLUMN_LANGUAGE))
+    }
+
+    @Test
+    fun `add appends and returns insertion index`() {
+        val model = LanguageMappingsTableModel()
+
+        assertEquals(0, model.add(LanguageMapping("kotlin", "Kotlin", "#111111")))
+        assertEquals(1, model.add(LanguageMapping("python", "Python", "#222222")))
+    }
+
+    @Test
+    fun `updateHex mutates only the target row`() {
+        val model = LanguageMappingsTableModel()
+        model.add(LanguageMapping("kotlin", "Kotlin", "#111111"))
+        model.add(LanguageMapping("python", "Python", "#222222"))
+
+        model.updateHex(0, "#FFEEDD")
+
+        assertEquals("#FFEEDD", model.getValueAt(0, LanguageMappingsTableModel.COLUMN_COLOR))
+        assertEquals("#222222", model.getValueAt(1, LanguageMappingsTableModel.COLUMN_COLOR))
+    }
+
+    @Test
+    fun `containsLanguage is case-insensitive`() {
+        val model = LanguageMappingsTableModel()
+        model.add(LanguageMapping("kotlin", "Kotlin", "#111111"))
+
+        assertTrue(model.containsLanguage("kotlin"))
+        assertTrue(model.containsLanguage("Kotlin"))
+        assertTrue(model.containsLanguage("KOTLIN"))
+        assertFalse(model.containsLanguage("python"))
+    }
+
+    @Test
+    fun `remove drops the row and shifts indices`() {
+        val model = LanguageMappingsTableModel()
+        model.add(LanguageMapping("kotlin", "Kotlin", "#111111"))
+        model.add(LanguageMapping("python", "Python", "#222222"))
+
+        model.remove(0)
+
+        assertEquals(1, model.rowCount)
+        assertEquals("python", model.rowAt(0)?.languageId)
+    }
+
+    @Test
+    fun `getValueAt returns column payload by index`() {
+        val model = LanguageMappingsTableModel()
+        model.add(LanguageMapping("kotlin", "Kotlin", "#ABCDEF"))
+
+        assertEquals("#ABCDEF", model.getValueAt(0, LanguageMappingsTableModel.COLUMN_COLOR))
+        assertEquals("Kotlin", model.getValueAt(0, LanguageMappingsTableModel.COLUMN_LANGUAGE))
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderPendingTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderPendingTest.kt
@@ -113,17 +113,27 @@ class OverridesGroupBuilderPendingTest {
     @Test
     fun `resolvePending matches lowercase language id exactly, not case-insensitively`() {
         // LanguageMapping.init enforces lowercase, ProjectLanguageDetector returns lowercase —
-        // case-sensitive equality is the consistent choice across the code base, mirroring
-        // LanguageMappingsTableModel.containsLanguage. If a future detector ever returns
-        // "Kotlin" instead of "kotlin", the invariant is violated upstream and should surface
-        // as a test failure here rather than be silently compensated by ignoreCase = true.
+        // case-sensitive equality is the consistent choice across the codebase, mirroring
+        // LanguageMappingsTableModel.containsLanguage. Both halves of the invariant matter:
+        //  - lowercase detector output matches stored lowercase id (positive)
+        //  - non-lowercase detector output does NOT match (negative — locks the contract from
+        //    both sides; reintroducing `ignoreCase = true` in resolvePending would silently
+        //    pass the positive assertion alone)
         mappingsState.languageAccents["kotlin"] = "#CAFE00"
-        val project = stubProject(File(System.getProperty("java.io.tmpdir"), "case-test"))
-        every { ProjectLanguageDetector.dominant(project) } returns "kotlin"
 
         val builder = OverridesGroupBuilder().apply { loadFromStateForTest() }
 
-        assertEquals("#CAFE00", builder.resolvePending(project, "#FFCC66"))
+        val lowercaseProject = stubProject(File(System.getProperty("java.io.tmpdir"), "case-lower"))
+        every { ProjectLanguageDetector.dominant(lowercaseProject) } returns "kotlin"
+        assertEquals("#CAFE00", builder.resolvePending(lowercaseProject, "#FFCC66"))
+
+        val mixedCaseProject = stubProject(File(System.getProperty("java.io.tmpdir"), "case-mixed"))
+        every { ProjectLanguageDetector.dominant(mixedCaseProject) } returns "Kotlin"
+        assertEquals(
+            "#FFCC66",
+            builder.resolvePending(mixedCaseProject, "#FFCC66"),
+            "Mixed-case detector output must not match lowercase stored id",
+        )
     }
 
     private fun stubProject(baseDir: File): Project {

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderPendingTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderPendingTest.kt
@@ -1,0 +1,136 @@
+package dev.ayuislands.settings.mappings
+
+import com.intellij.openapi.project.Project
+import dev.ayuislands.accent.AccentResolver
+import dev.ayuislands.accent.ProjectLanguageDetector
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import java.io.File
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Covers [OverridesGroupBuilder.resolvePending] and [OverridesGroupBuilder.sourcePending] —
+ * the parallel in-memory resolver the settings UI uses to drive the "Currently active:
+ * ... (project override)" label while the user edits the tables, before Apply commits the
+ * changes.
+ *
+ * These behave like [AccentResolver] but read from the pending table models rather than the
+ * persistent AccentMappingsSettings. Without tests, the two can silently drift — e.g. a
+ * case-sensitivity mismatch on language ids would make the live label claim "language override"
+ * while the resolver served the global accent after Apply.
+ */
+class OverridesGroupBuilderPendingTest {
+    private lateinit var mappingsState: AccentMappingsState
+
+    @BeforeTest
+    fun setUp() {
+        mappingsState = AccentMappingsState()
+        val settings = mockk<AccentMappingsSettings>()
+        every { settings.state } returns mappingsState
+        mockkObject(AccentMappingsSettings.Companion)
+        every { AccentMappingsSettings.getInstance() } returns settings
+
+        mockkObject(ProjectLanguageDetector)
+        every { ProjectLanguageDetector.dominant(any()) } returns null
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `resolvePending returns project override when stored in pending model`() {
+        val tmp = File(System.getProperty("java.io.tmpdir"), "pending-project").canonicalPath
+        mappingsState.projectAccents[tmp] = "#ABCDEF"
+        val project = stubProject(File(tmp))
+
+        val builder = OverridesGroupBuilder().apply { loadFromStateForTest() }
+
+        assertEquals("#ABCDEF", builder.resolvePending(project, "#FFCC66"))
+        assertEquals(AccentResolver.Source.PROJECT_OVERRIDE, builder.sourcePending(project))
+    }
+
+    @Test
+    fun `resolvePending returns language override when project has no pending entry`() {
+        mappingsState.languageAccents["kotlin"] = "#112233"
+        val project = stubProject(File(System.getProperty("java.io.tmpdir"), "pending-lang"))
+        every { ProjectLanguageDetector.dominant(project) } returns "kotlin"
+
+        val builder = OverridesGroupBuilder().apply { loadFromStateForTest() }
+
+        assertEquals("#112233", builder.resolvePending(project, "#FFCC66"))
+        assertEquals(AccentResolver.Source.LANGUAGE_OVERRIDE, builder.sourcePending(project))
+    }
+
+    @Test
+    fun `resolvePending prefers project override over language override`() {
+        val tmp = File(System.getProperty("java.io.tmpdir"), "pending-both").canonicalPath
+        mappingsState.projectAccents[tmp] = "#111111"
+        mappingsState.languageAccents["kotlin"] = "#222222"
+        val project = stubProject(File(tmp))
+        every { ProjectLanguageDetector.dominant(project) } returns "kotlin"
+
+        val builder = OverridesGroupBuilder().apply { loadFromStateForTest() }
+
+        assertEquals("#111111", builder.resolvePending(project, "#FFCC66"))
+        assertEquals(AccentResolver.Source.PROJECT_OVERRIDE, builder.sourcePending(project))
+    }
+
+    @Test
+    fun `resolvePending falls back to global when no pending entry matches`() {
+        val project = stubProject(File(System.getProperty("java.io.tmpdir"), "pending-none"))
+
+        val builder = OverridesGroupBuilder().apply { loadFromStateForTest() }
+
+        assertEquals("#FFCC66", builder.resolvePending(project, "#FFCC66"))
+        assertEquals(AccentResolver.Source.GLOBAL, builder.sourcePending(project))
+    }
+
+    @Test
+    fun `resolvePending skips default and disposed projects`() {
+        val tmp = File(System.getProperty("java.io.tmpdir"), "pending-default").canonicalPath
+        mappingsState.projectAccents[tmp] = "#111111"
+        val defaultProject =
+            mockk<Project>().apply {
+                every { isDefault } returns true
+                every { isDisposed } returns false
+                every { basePath } returns tmp
+                every { name } returns "default"
+            }
+
+        val builder = OverridesGroupBuilder().apply { loadFromStateForTest() }
+
+        assertEquals("#FFCC66", builder.resolvePending(defaultProject, "#FFCC66"))
+        assertEquals(AccentResolver.Source.GLOBAL, builder.sourcePending(defaultProject))
+    }
+
+    @Test
+    fun `resolvePending is case-insensitive on language id vs detector output`() {
+        // The language detector returns lowercase ids (e.g. "kotlin"), and LanguageMapping now
+        // enforces lowercase at construction — so both sides are effectively lowercase. This
+        // test locks in that fact + the defensive `ignoreCase = true` in resolvePending, so
+        // if a future detector ever returns "Kotlin" we still match.
+        mappingsState.languageAccents["kotlin"] = "#CAFE00"
+        val project = stubProject(File(System.getProperty("java.io.tmpdir"), "case-test"))
+        every { ProjectLanguageDetector.dominant(project) } returns "Kotlin" // hypothetical drift
+
+        val builder = OverridesGroupBuilder().apply { loadFromStateForTest() }
+
+        assertEquals("#CAFE00", builder.resolvePending(project, "#FFCC66"))
+    }
+
+    private fun stubProject(baseDir: File): Project {
+        val project = mockk<Project>()
+        every { project.isDefault } returns false
+        every { project.isDisposed } returns false
+        every { project.basePath } returns baseDir.path
+        every { project.name } returns baseDir.name
+        return project
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderPendingTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderPendingTest.kt
@@ -111,14 +111,15 @@ class OverridesGroupBuilderPendingTest {
     }
 
     @Test
-    fun `resolvePending is case-insensitive on language id vs detector output`() {
-        // The language detector returns lowercase ids (e.g. "kotlin"), and LanguageMapping now
-        // enforces lowercase at construction — so both sides are effectively lowercase. This
-        // test locks in that fact + the defensive `ignoreCase = true` in resolvePending, so
-        // if a future detector ever returns "Kotlin" we still match.
+    fun `resolvePending matches lowercase language id exactly, not case-insensitively`() {
+        // LanguageMapping.init enforces lowercase, ProjectLanguageDetector returns lowercase —
+        // case-sensitive equality is the consistent choice across the code base, mirroring
+        // LanguageMappingsTableModel.containsLanguage. If a future detector ever returns
+        // "Kotlin" instead of "kotlin", the invariant is violated upstream and should surface
+        // as a test failure here rather than be silently compensated by ignoreCase = true.
         mappingsState.languageAccents["kotlin"] = "#CAFE00"
         val project = stubProject(File(System.getProperty("java.io.tmpdir"), "case-test"))
-        every { ProjectLanguageDetector.dominant(project) } returns "Kotlin" // hypothetical drift
+        every { ProjectLanguageDetector.dominant(project) } returns "kotlin"
 
         val builder = OverridesGroupBuilder().apply { loadFromStateForTest() }
 

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt
@@ -22,8 +22,8 @@ import java.awt.Window
 import java.awt.event.AWTEventListener
 import java.awt.event.WindowEvent
 import javax.swing.JComponent
-import javax.swing.JFrame
-import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.SwingUtilities
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -39,6 +39,11 @@ import kotlin.test.assertTrue
  * cache hook — is unit-tested via the [ProjectAccentSwapService.onWindowActivatedForTest]
  * seam plus mockkObject wrappers around AccentResolver / AccentApplicator / AyuVariant /
  * ComponentTreeRefresher and a static mock on WindowManager.
+ *
+ * Headless-safe: mocks [Window] (real `JFrame` / `JDialog` instantiation throws
+ * `HeadlessException` on CI) and stubs [SwingUtilities.getWindowAncestor] so frame-to-window
+ * reconciliation works without bringing up a graphics environment. Components are `JPanel`,
+ * which is purely lightweight (no native peer) and works in headless.
  */
 class ProjectAccentSwapServiceTest {
     @BeforeTest
@@ -53,12 +58,19 @@ class ProjectAccentSwapServiceTest {
 
         mockkStatic(WindowManager::class)
         // Default: no project frames. Tests that need a matching frame override via
-        // `wireMatchingFrame(window, project)`.
+        // `wireMatchingFrame()`.
         val windowManager =
             mockk<WindowManager> {
                 every { allProjectFrames } returns emptyArray()
             }
         every { WindowManager.getInstance() } returns windowManager
+
+        // SwingUtilities.getWindowAncestor walks up component.parent looking for a Window.
+        // In headless tests the components have no real window ancestor, so we stub the
+        // static lookup explicitly. Default: returns null; tests override per call site
+        // when they need a matching window.
+        mockkStatic(SwingUtilities::class)
+        every { SwingUtilities.getWindowAncestor(any()) } returns null
     }
 
     @AfterTest
@@ -113,8 +125,8 @@ class ProjectAccentSwapServiceTest {
         // otherwise activating a popup / dialog window would re-apply the accent on every
         // alt-tab, defeating the whole point of the cache.
         val service = ProjectAccentSwapService()
-        val window = JFrame() // not registered with WindowManager — no matching frame
-        val event = WindowEvent(window, WindowEvent.WINDOW_ACTIVATED)
+        val window = mockk<Window>(relaxed = true) // no matching frame in WindowManager
+        val event = makeEvent(window)
 
         service.onWindowActivatedForTest(event)
 
@@ -133,9 +145,8 @@ class ProjectAccentSwapServiceTest {
         val (window, project) = wireMatchingFrame()
         every { AyuVariant.detect() } returns null
         val service = ProjectAccentSwapService()
-        val event = WindowEvent(window, WindowEvent.WINDOW_ACTIVATED)
 
-        service.onWindowActivatedForTest(event)
+        service.onWindowActivatedForTest(makeEvent(window))
 
         verify(exactly = 1) { AyuVariant.detect() }
         verify(exactly = 0) { AccentResolver.resolve(project, any()) }
@@ -149,9 +160,8 @@ class ProjectAccentSwapServiceTest {
         // disposed project (which would throw deeper inside AccentResolver).
         val (window, project) = wireMatchingFrame(disposed = true)
         val service = ProjectAccentSwapService()
-        val event = WindowEvent(window, WindowEvent.WINDOW_ACTIVATED)
 
-        service.onWindowActivatedForTest(event)
+        service.onWindowActivatedForTest(makeEvent(window))
 
         verify(exactly = 0) { AccentResolver.resolve(project, any()) }
         verify(exactly = 0) { AccentApplicator.apply(any()) }
@@ -165,7 +175,7 @@ class ProjectAccentSwapServiceTest {
         val (window, project) = wireMatchingFrame()
         every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returns "#FFCC66"
         val service = ProjectAccentSwapService()
-        val event = WindowEvent(window, WindowEvent.WINDOW_ACTIVATED)
+        val event = makeEvent(window)
 
         service.onWindowActivatedForTest(event) // primes cache
         service.onWindowActivatedForTest(event) // same project — must short-circuit
@@ -183,19 +193,21 @@ class ProjectAccentSwapServiceTest {
         // state is already correct.
         val projectA = stubProject("project-a")
         val projectB = stubProject("project-b")
-        val windowA = JFrame()
-        val windowB = JFrame()
-        val labelA = JLabel().also { windowA.add(it) }
-        val labelB = JLabel().also { windowB.add(it) }
-        val frameA = stubIdeFrame(projectA, labelA)
-        val frameB = stubIdeFrame(projectB, labelB)
+        val windowA = mockk<Window>(relaxed = true)
+        val windowB = mockk<Window>(relaxed = true)
+        val componentA = JPanel()
+        val componentB = JPanel()
+        every { SwingUtilities.getWindowAncestor(componentA) } returns windowA
+        every { SwingUtilities.getWindowAncestor(componentB) } returns windowB
+        val frameA = stubIdeFrame(projectA, componentA)
+        val frameB = stubIdeFrame(projectB, componentB)
         every { WindowManager.getInstance().allProjectFrames } returns arrayOf(frameA, frameB)
         every { AccentResolver.resolve(projectA, AyuVariant.MIRAGE) } returns "#FFCC66"
         every { AccentResolver.resolve(projectB, AyuVariant.MIRAGE) } returns "#FFCC66"
 
         val service = ProjectAccentSwapService()
-        service.onWindowActivatedForTest(WindowEvent(windowA, WindowEvent.WINDOW_ACTIVATED))
-        service.onWindowActivatedForTest(WindowEvent(windowB, WindowEvent.WINDOW_ACTIVATED))
+        service.onWindowActivatedForTest(makeEvent(windowA))
+        service.onWindowActivatedForTest(makeEvent(windowB))
 
         // Both projects went through resolve (different cached project identity) but apply
         // fired only once because the effective hex hadn't changed.
@@ -215,9 +227,8 @@ class ProjectAccentSwapServiceTest {
         val (window, project) = wireMatchingFrame()
         every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returns "#FFCC66"
         val service = ProjectAccentSwapService()
-        val event = WindowEvent(window, WindowEvent.WINDOW_ACTIVATED)
 
-        service.onWindowActivatedForTest(event)
+        service.onWindowActivatedForTest(makeEvent(window))
 
         verify(exactly = 1) { ComponentTreeRefresher.walkAndNotify(project, window) }
     }
@@ -233,7 +244,7 @@ class ProjectAccentSwapServiceTest {
         val service = ProjectAccentSwapService()
 
         service.notifyExternalApply("#FFCC66") // priming write
-        service.onWindowActivatedForTest(WindowEvent(window, WindowEvent.WINDOW_ACTIVATED))
+        service.onWindowActivatedForTest(makeEvent(window))
 
         // resolve was called (project changed from null to projectA) but apply was skipped
         // because the effective hex matches the cache.
@@ -254,7 +265,7 @@ class ProjectAccentSwapServiceTest {
         every { WindowManager.getInstance().allProjectFrames } returns arrayOf(brokenFrame)
 
         val service = ProjectAccentSwapService()
-        val event = WindowEvent(JFrame(), WindowEvent.WINDOW_ACTIVATED)
+        val event = makeEvent(mockk<Window>(relaxed = true))
 
         val capturedWarns = mutableListOf<String>()
         val processor =
@@ -324,15 +335,27 @@ class ProjectAccentSwapServiceTest {
     // Test helpers
 
     /**
+     * Builds a [WindowEvent] whose `window` getter returns [window]. Direct construction
+     * via `WindowEvent(window, id)` works on macOS dev machines but indirectly touches
+     * graphics on some platforms; mocking the event keeps the test fully headless-safe.
+     */
+    private fun makeEvent(window: Window): WindowEvent =
+        mockk {
+            every { id } returns WindowEvent.WINDOW_ACTIVATED
+            every { this@mockk.window } returns window
+        }
+
+    /**
      * Returns (window, project) where the mocked WindowManager.allProjectFrames contains a
      * single IdeFrame whose component's window ancestor is `window` and whose project is
      * the returned mock. Lets [handleWindowActivated] reach AyuVariant.detect / resolve /
-     * apply on a real Swing tree.
+     * apply on a real Swing tree without instantiating a [java.awt.Frame] (which throws
+     * `HeadlessException` on CI).
      */
     private fun wireMatchingFrame(disposed: Boolean = false): Pair<Window, Project> {
-        val window = JFrame()
-        val component = JLabel()
-        window.add(component) // window becomes the ancestor of component
+        val window = mockk<Window>(relaxed = true)
+        val component = JPanel() // lightweight, headless-safe
+        every { SwingUtilities.getWindowAncestor(component) } returns window
         val project = stubProject("test-project", disposed = disposed)
         val frame = stubIdeFrame(project, component)
         every { WindowManager.getInstance().allProjectFrames } returns arrayOf(frame)

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt
@@ -47,7 +47,7 @@ class ProjectAccentSwapServiceTest {
     }
 
     @Test
-    fun `install is idempotent — second call is a no-op`() {
+    fun `install is idempotent - second call is a no-op`() {
         // The `if (listener != null) return` guard means calling install twice should not
         // throw, and should not register a second AWTEventListener (which would double-fire
         // on every WINDOW_ACTIVATED). We verify the non-throwing contract directly; the

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt
@@ -16,7 +16,10 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
+import java.awt.AWTEvent
+import java.awt.Toolkit
 import java.awt.Window
+import java.awt.event.AWTEventListener
 import java.awt.event.WindowEvent
 import javax.swing.JComponent
 import javax.swing.JFrame
@@ -61,19 +64,6 @@ class ProjectAccentSwapServiceTest {
     @AfterTest
     fun tearDown() {
         unmockkAll()
-    }
-
-    @Test
-    fun `notifyExternalApply is non-throwing for the hex shapes callers pass`() {
-        // Real callers pass: valid hex after rotation, different hex after settings Apply, and
-        // the blank "follow system accent" sentinel. If any of these shapes starts throwing
-        // (e.g. a future null-check on a blank argument), the downstream swap-cache semantics
-        // break and every focus-swap would reapply even when hex is unchanged.
-        val service = ProjectAccentSwapService()
-
-        service.notifyExternalApply("#FFCC66")
-        service.notifyExternalApply("#ABCDEF")
-        service.notifyExternalApply("")
     }
 
     @Test
@@ -293,6 +283,42 @@ class ProjectAccentSwapServiceTest {
             capturedWarns.size,
             "Frame-resolution dedup must collapse 3 broken-frame failures into 1 WARN; got: $capturedWarns",
         )
+    }
+
+    @Test
+    fun `install registers AWTEventListener exactly once across repeated calls`() {
+        // Reentrancy guard: install() is invoked from every ProjectActivity (per project open).
+        // Without `if (listener != null) return`, each project window double-registers the
+        // listener, so the focus-swap handler would fire N times per WINDOW_ACTIVATED for an
+        // N-window IDE — straight perf regression and possible visible flicker.
+        val toolkit = mockk<Toolkit>(relaxed = true)
+        mockkStatic(Toolkit::class)
+        every { Toolkit.getDefaultToolkit() } returns toolkit
+        val service = ProjectAccentSwapService()
+
+        service.install()
+        service.install()
+        service.install()
+
+        verify(exactly = 1) {
+            toolkit.addAWTEventListener(any<AWTEventListener>(), AWTEvent.WINDOW_EVENT_MASK)
+        }
+    }
+
+    @Test
+    fun `dispose removes the AWTEventListener and clears the swap cache`() {
+        // Without removing the listener, AWT keeps dispatching to a service whose backing
+        // state is being torn down — guaranteed NPE inside handleWindowActivated. Also clears
+        // lastAppliedProject/Hex so a re-install on a fresh service starts with a clean cache.
+        val toolkit = mockk<Toolkit>(relaxed = true)
+        mockkStatic(Toolkit::class)
+        every { Toolkit.getDefaultToolkit() } returns toolkit
+        val service = ProjectAccentSwapService()
+        service.install()
+
+        service.dispose()
+
+        verify(exactly = 1) { toolkit.removeAWTEventListener(any<AWTEventListener>()) }
     }
 
     // Test helpers

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt
@@ -1,10 +1,13 @@
 package dev.ayuislands.settings.mappings
 
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.IdeFrame
 import com.intellij.openapi.wm.WindowManager
 import com.intellij.testFramework.LoggedErrorProcessor
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.ui.ComponentTreeRefresher
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -13,11 +16,16 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
+import java.awt.Window
 import java.awt.event.WindowEvent
+import javax.swing.JComponent
 import javax.swing.JFrame
+import javax.swing.JLabel
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 /**
@@ -26,7 +34,8 @@ import kotlin.test.assertTrue
  * `Toolkit.getDefaultToolkit()` would leak across headless test runs). Everything else —
  * the handler logic, short-circuit gates, exception catching, and the `notifyExternalApply`
  * cache hook — is unit-tested via the [ProjectAccentSwapService.onWindowActivatedForTest]
- * seam plus mockkObject wrappers around AccentResolver / AccentApplicator / AyuVariant.
+ * seam plus mockkObject wrappers around AccentResolver / AccentApplicator / AyuVariant /
+ * ComponentTreeRefresher and a static mock on WindowManager.
  */
 class ProjectAccentSwapServiceTest {
     @BeforeTest
@@ -34,14 +43,14 @@ class ProjectAccentSwapServiceTest {
         mockkObject(AccentResolver)
         mockkObject(AccentApplicator)
         mockkObject(AyuVariant.Companion)
+        mockkObject(ComponentTreeRefresher)
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
         every { AccentApplicator.apply(any()) } just Runs
+        every { ComponentTreeRefresher.walkAndNotify(any(), any()) } just Runs
 
-        // WindowManager is a platform singleton; without static mocking, getInstance()
-        // returns null in headless tests and the handler NPEs. Stubbing it to return a
-        // WindowManager whose allProjectFrames is empty drives findProjectForWindow to
-        // return null cleanly — exactly the "no matching frame" path we want to test.
         mockkStatic(WindowManager::class)
+        // Default: no project frames. Tests that need a matching frame override via
+        // `wireMatchingFrame(window, project)`.
         val windowManager =
             mockk<WindowManager> {
                 every { allProjectFrames } returns emptyArray()
@@ -59,8 +68,7 @@ class ProjectAccentSwapServiceTest {
         // Real callers pass: valid hex after rotation, different hex after settings Apply, and
         // the blank "follow system accent" sentinel. If any of these shapes starts throwing
         // (e.g. a future null-check on a blank argument), the downstream swap-cache semantics
-        // break and every focus-swap would reapply even when hex is unchanged — this test
-        // catches that at the smallest unit level.
+        // break and every focus-swap would reapply even when hex is unchanged.
         val service = ProjectAccentSwapService()
 
         service.notifyExternalApply("#FFCC66")
@@ -69,20 +77,19 @@ class ProjectAccentSwapServiceTest {
     }
 
     @Test
-    fun `onWindowActivated catches RuntimeException and converts to LOG error`() {
+    fun `onWindowActivated catches RuntimeException and converts to LOG error with the original cause`() {
         // The handler runs from an AWTEventListener that AWT does not remove on failure —
         // an uncaught exception here would dump a generic SEVERE trace into idea.log on
         // every alt-tab. Verify the catch at onWindowActivated() converts it into an
-        // actionable LOG.error WITH context (the message must mention "swap failed").
+        // actionable LOG.error WITH context (message + the ORIGINAL throwable so Sentry /
+        // log triage doesn't lose the stack).
         val service = ProjectAccentSwapService()
-        // Use a non-Window event so cast-to-WindowEvent forces a quick path; but force a
-        // RuntimeException higher in the chain. Easiest: hand a fully-mocked WindowEvent
-        // whose `window` getter throws.
+        val boom = IllegalStateException("frame disposed mid-event")
         val event = mockk<WindowEvent>()
         every { event.id } returns WindowEvent.WINDOW_ACTIVATED
-        every { event.window } throws IllegalStateException("frame disposed mid-event")
+        every { event.window } throws boom
 
-        val capturedErrors = mutableListOf<String>()
+        val capturedErrors = mutableListOf<Pair<String, Throwable?>>()
         val processor =
             object : LoggedErrorProcessor() {
                 override fun processError(
@@ -91,7 +98,7 @@ class ProjectAccentSwapServiceTest {
                     details: Array<out String>,
                     throwable: Throwable?,
                 ): Set<Action> {
-                    capturedErrors += message
+                    capturedErrors += message to throwable
                     return java.util.EnumSet.noneOf(Action::class.java)
                 }
             }
@@ -100,68 +107,228 @@ class ProjectAccentSwapServiceTest {
             service.onWindowActivatedForTest(event)
         }
 
-        assertTrue(
-            capturedErrors.any { it.contains("Project accent swap failed") },
-            "RuntimeException must produce an actionable LOG.error; got: $capturedErrors",
+        val matched = capturedErrors.firstOrNull { it.first.contains("Project accent swap failed") }
+        assertTrue(matched != null, "RuntimeException must produce LOG.error; got: $capturedErrors")
+        assertSame(
+            boom,
+            matched.second,
+            "LOG.error must carry the ORIGINAL exception so triage doesn't lose the stack",
         )
     }
 
     @Test
-    fun `onWindowActivated short-circuits when activated window is not a project frame`() {
+    fun `onWindowActivated short-circuits when no project frame matches the activated window`() {
         // findProjectForWindow returns null (no matching frame in WindowManager). The handler
         // must early-exit without calling AccentResolver.resolve or AccentApplicator.apply —
         // otherwise activating a popup / dialog window would re-apply the accent on every
         // alt-tab, defeating the whole point of the cache.
         val service = ProjectAccentSwapService()
-        val window = JFrame() // not registered with WindowManager
+        val window = JFrame() // not registered with WindowManager — no matching frame
         val event = WindowEvent(window, WindowEvent.WINDOW_ACTIVATED)
 
-        // Should not invoke any apply path.
         service.onWindowActivatedForTest(event)
 
         verify(exactly = 0) { AccentApplicator.apply(any()) }
         verify(exactly = 0) { AccentResolver.resolve(any(), any()) }
+        verify(exactly = 0) { AyuVariant.detect() }
     }
 
     @Test
     fun `onWindowActivated short-circuits when AyuVariant detect returns null`() {
-        // Non-Ayu theme is active — the handler must NOT apply, even if the activated window
-        // is a real project frame. A regression that called apply() with a null variant would
-        // either crash or silently overwrite a non-Ayu theme's accent.
+        // Non-Ayu theme is active — the handler must NOT apply even after window resolution
+        // succeeds. A regression dropping the `AyuVariant.detect() ?: return` guard would
+        // pass apply with whatever default variant other code defaults to. This test wires
+        // a real matching frame so the handler reaches AyuVariant.detect, then asserts no
+        // apply happens AND detect was actually consulted.
+        val (window, project) = wireMatchingFrame()
         every { AyuVariant.detect() } returns null
         val service = ProjectAccentSwapService()
+        val event = WindowEvent(window, WindowEvent.WINDOW_ACTIVATED)
 
-        // Skip the WindowManager.getInstance dance — give the handler a window that won't
-        // resolve, and assert AyuVariant.detect was NEVER called (handler exited earlier).
-        // To force the handler PAST the window resolution short-circuit, we'd need to mock
-        // WindowManager.getInstance which is out of scope. Instead, verify the logical
-        // chain: when window resolution fails, AyuVariant.detect is also never called.
-        val event = WindowEvent(JFrame(), WindowEvent.WINDOW_ACTIVATED)
         service.onWindowActivatedForTest(event)
 
+        verify(exactly = 1) { AyuVariant.detect() }
+        verify(exactly = 0) { AccentResolver.resolve(project, any()) }
         verify(exactly = 0) { AccentApplicator.apply(any()) }
     }
 
     @Test
-    fun `notifyExternalApply updates cache so next swap of same hex is a no-op`() {
-        // Verify the cache contract: after notifyExternalApply("#X"), if a future
-        // handleWindowActivated computes the same hex, it must skip apply(). Indirect
-        // verification through the no-side-effect property: notifyExternalApply must write
-        // to lastAppliedHex such that effectiveHex == lastAppliedHex returns true.
-        // We can't easily call handleWindowActivated end-to-end without WindowManager
-        // mocking, so this test pins the public API contract that notifyExternalApply
-        // is the cache-write side. Together with the no-throw test above it covers the
-        // surface a future regression could break.
+    fun `onWindowActivated short-circuits when project is disposed or default`() {
+        // Race: between WindowManager enumeration and the dispose-check inside the handler,
+        // a project transitions to disposed. Guard prevents calling resolve/apply on a
+        // disposed project (which would throw deeper inside AccentResolver).
+        val (window, project) = wireMatchingFrame(disposed = true)
         val service = ProjectAccentSwapService()
-        service.notifyExternalApply("#FFCC66")
-        // Calling again with the same hex must remain a no-op (no exception, no observable
-        // side effect from our perspective — the cache is just overwritten with the same value).
-        service.notifyExternalApply("#FFCC66")
-        // Different hex updates the cache; subsequent call with original re-overwrites.
-        service.notifyExternalApply("#ABCDEF")
-        service.notifyExternalApply("#FFCC66")
-        // No assertions beyond no-throw — the contract surface is covered by the
-        // onWindowActivated tests above and by the AyuIslandsAccentPanelTest that
-        // verifies notifyExternalApply is called from the global-fallback path.
+        val event = WindowEvent(window, WindowEvent.WINDOW_ACTIVATED)
+
+        service.onWindowActivatedForTest(event)
+
+        verify(exactly = 0) { AccentResolver.resolve(project, any()) }
+        verify(exactly = 0) { AccentApplicator.apply(any()) }
     }
+
+    @Test
+    fun `onWindowActivated short-circuits on same-project re-activation`() {
+        // The whole point of the cache: alt-tabbing within the same project window must NOT
+        // re-apply the accent on every focus event. After the first activation primes the
+        // cache, the second call with the same project must skip resolve+apply.
+        val (window, project) = wireMatchingFrame()
+        every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returns "#FFCC66"
+        val service = ProjectAccentSwapService()
+        val event = WindowEvent(window, WindowEvent.WINDOW_ACTIVATED)
+
+        service.onWindowActivatedForTest(event) // primes cache
+        service.onWindowActivatedForTest(event) // same project — must short-circuit
+
+        // resolve called exactly once on the priming pass; apply called exactly once.
+        verify(exactly = 1) { AccentResolver.resolve(project, AyuVariant.MIRAGE) }
+        verify(exactly = 1) { AccentApplicator.apply("#FFCC66") }
+    }
+
+    @Test
+    fun `onWindowActivated short-circuits on same-hex re-activation across different projects`() {
+        // Two different projects sharing the same effective accent hex (e.g. same global
+        // override). Activating the second after priming with the first must update the
+        // lastAppliedProject reference but skip the apply, because the visible UIManager
+        // state is already correct.
+        val projectA = stubProject("project-a")
+        val projectB = stubProject("project-b")
+        val windowA = JFrame()
+        val windowB = JFrame()
+        val labelA = JLabel().also { windowA.add(it) }
+        val labelB = JLabel().also { windowB.add(it) }
+        val frameA = stubIdeFrame(projectA, labelA)
+        val frameB = stubIdeFrame(projectB, labelB)
+        every { WindowManager.getInstance().allProjectFrames } returns arrayOf(frameA, frameB)
+        every { AccentResolver.resolve(projectA, AyuVariant.MIRAGE) } returns "#FFCC66"
+        every { AccentResolver.resolve(projectB, AyuVariant.MIRAGE) } returns "#FFCC66"
+
+        val service = ProjectAccentSwapService()
+        service.onWindowActivatedForTest(WindowEvent(windowA, WindowEvent.WINDOW_ACTIVATED))
+        service.onWindowActivatedForTest(WindowEvent(windowB, WindowEvent.WINDOW_ACTIVATED))
+
+        // Both projects went through resolve (different cached project identity) but apply
+        // fired only once because the effective hex hadn't changed.
+        verify(exactly = 1) { AccentResolver.resolve(projectA, AyuVariant.MIRAGE) }
+        verify(exactly = 1) { AccentResolver.resolve(projectB, AyuVariant.MIRAGE) }
+        verify(exactly = 1) { AccentApplicator.apply("#FFCC66") }
+    }
+
+    @Test
+    fun `onWindowActivated invokes ComponentTreeRefresher walkAndNotify after apply`() {
+        // AccentApplicator updates UIManager + editor scheme but leaves cached JBColor on
+        // already-painted components. The handler must follow apply() with a tree-walk so
+        // toolbar / tab underlines / scrollbar chrome pick up the new accent. Regression
+        // dropping the walkAndNotify call would silently break per-project visual isolation
+        // (apply would update UIManager but the visible UI would stay stale until the next
+        // organic refresh).
+        val (window, project) = wireMatchingFrame()
+        every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returns "#FFCC66"
+        val service = ProjectAccentSwapService()
+        val event = WindowEvent(window, WindowEvent.WINDOW_ACTIVATED)
+
+        service.onWindowActivatedForTest(event)
+
+        verify(exactly = 1) { ComponentTreeRefresher.walkAndNotify(project, window) }
+    }
+
+    @Test
+    fun `notifyExternalApply primes cache so next matching swap skips apply`() {
+        // Exercises the cache-write contract end-to-end: after notifyExternalApply primes
+        // lastAppliedHex, an onWindowActivated that resolves the same hex must skip apply.
+        // Without the cache write, every focus-swap after a Settings panel apply would
+        // redundantly re-apply the accent.
+        val (window, project) = wireMatchingFrame()
+        every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returns "#FFCC66"
+        val service = ProjectAccentSwapService()
+
+        service.notifyExternalApply("#FFCC66") // priming write
+        service.onWindowActivatedForTest(WindowEvent(window, WindowEvent.WINDOW_ACTIVATED))
+
+        // resolve was called (project changed from null to projectA) but apply was skipped
+        // because the effective hex matches the cache.
+        verify(exactly = 1) { AccentResolver.resolve(project, AyuVariant.MIRAGE) }
+        verify(exactly = 0) { AccentApplicator.apply(any()) }
+    }
+
+    @Test
+    fun `findProjectForWindow logs first-frame failure at WARN then dedups subsequent failures to DEBUG`() {
+        // The frameResolutionFailureLogged gate prevents log spam on every alt-tab when one
+        // broken frame keeps throwing on access. First failure must produce a WARN; later
+        // failures (same handler invocation or subsequent invocations) must NOT produce
+        // additional WARNs. A regression dropping the gate would flood idea.log.
+        val brokenFrame =
+            mockk<IdeFrame> {
+                every { project } throws IllegalStateException("frame mid-dispose")
+            }
+        every { WindowManager.getInstance().allProjectFrames } returns arrayOf(brokenFrame)
+
+        val service = ProjectAccentSwapService()
+        val event = WindowEvent(JFrame(), WindowEvent.WINDOW_ACTIVATED)
+
+        val capturedWarns = mutableListOf<String>()
+        val processor =
+            object : LoggedErrorProcessor() {
+                override fun processWarn(
+                    category: String,
+                    message: String,
+                    throwable: Throwable?,
+                ): Boolean {
+                    if (!message.contains("Skipping frame")) return true
+                    capturedWarns += message
+                    return false
+                }
+            }
+
+        LoggedErrorProcessor.executeWith<Throwable>(processor) {
+            // Three consecutive activations all hit the broken frame — only the first must
+            // produce a WARN; the next two must log at DEBUG (not captured here).
+            service.onWindowActivatedForTest(event)
+            service.onWindowActivatedForTest(event)
+            service.onWindowActivatedForTest(event)
+        }
+
+        assertEquals(
+            1,
+            capturedWarns.size,
+            "Frame-resolution dedup must collapse 3 broken-frame failures into 1 WARN; got: $capturedWarns",
+        )
+    }
+
+    // Test helpers
+
+    /**
+     * Returns (window, project) where the mocked WindowManager.allProjectFrames contains a
+     * single IdeFrame whose component's window ancestor is `window` and whose project is
+     * the returned mock. Lets [handleWindowActivated] reach AyuVariant.detect / resolve /
+     * apply on a real Swing tree.
+     */
+    private fun wireMatchingFrame(disposed: Boolean = false): Pair<Window, Project> {
+        val window = JFrame()
+        val component = JLabel()
+        window.add(component) // window becomes the ancestor of component
+        val project = stubProject("test-project", disposed = disposed)
+        val frame = stubIdeFrame(project, component)
+        every { WindowManager.getInstance().allProjectFrames } returns arrayOf(frame)
+        return window to project
+    }
+
+    private fun stubProject(
+        name: String,
+        disposed: Boolean = false,
+    ): Project =
+        mockk {
+            every { isDisposed } returns disposed
+            every { isDefault } returns false
+            every { this@mockk.name } returns name
+        }
+
+    private fun stubIdeFrame(
+        project: Project,
+        component: JComponent,
+    ): IdeFrame =
+        mockk {
+            every { this@mockk.project } returns project
+            every { this@mockk.component } returns component
+        }
 }

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt
@@ -3,23 +3,19 @@ package dev.ayuislands.settings.mappings
 import io.mockk.unmockkAll
 import kotlin.test.AfterTest
 import kotlin.test.Test
-import kotlin.test.assertSame
 
 /**
- * Covers the non-AWT behavior of [ProjectAccentSwapService]. The AWTEventListener itself is
- * impractical to test without a real Toolkit; its registration and the inner
- * `handleWindowActivated` flow are verified at the IDE level via manual smoke and the
- * ProjectAccentSwapService-backed rotation / LAF flows already exercised by
- * AccentRotationServiceTest.
+ * Non-AWT behavior of [ProjectAccentSwapService]. The AWTEventListener inside `install()` is
+ * covered by manual smoke / integration. These tests exercise only what is unit-testable:
+ *  - [ProjectAccentSwapService.notifyExternalApply] is defined and non-throwing for the hex
+ *    shapes real callers pass, so downstream code (settings panel, rotation, LAF listener)
+ *    can rely on the public API being stable.
  *
- * What this suite locks down:
- *  - `notifyExternalApply` updates the internal cache so subsequent focus swaps don't
- *    trigger redundant apply calls. This is the contract the settings-panel, rotation,
- *    and LAF listener depend on.
- *  - Install idempotence — calling install twice must not double-register the listener.
- *    The existing production code guards against this with `if (listener != null) return`;
- *    we verify that guard stays in place by calling install twice and confirming no
- *    exception escapes (the real Toolkit.addAWTEventListener would be called once).
+ * `install()` and `handleWindowActivated` are deliberately *not* unit-tested here: `install`
+ * registers a real AWTEventListener against `Toolkit.getDefaultToolkit()` which leaks across
+ * headless test runs, and `handleWindowActivated` is `private` + AWT-event-driven. The prior
+ * "install is idempotent" and "getInstance companion" tests asserted tautologies (no-throw
+ * + reference equality of `Companion` to itself) and gave false coverage signal — removed.
  */
 class ProjectAccentSwapServiceTest {
     @AfterTest
@@ -28,52 +24,16 @@ class ProjectAccentSwapServiceTest {
     }
 
     @Test
-    fun `notifyExternalApply updates the cache without side effects`() {
-        // The service's constructor does not touch the AWT toolkit (install is lazy), so we
-        // can instantiate a fresh service directly in a unit test. notifyExternalApply is a
-        // simple cache setter — verify it accepts any hex without throwing, so the swap cache
-        // stays addressable from the settings panel / rotation / LAF listener without needing
-        // an EDT or an active AWT listener.
+    fun `notifyExternalApply is non-throwing for the hex shapes callers pass`() {
+        // Real callers pass: valid hex after rotation, different hex after settings Apply, and
+        // the blank "follow system accent" sentinel. If any of these shapes starts throwing
+        // (e.g. a future null-check on a blank argument), the downstream swap-cache semantics
+        // break and every focus-swap would reapply even when hex is unchanged — this test
+        // catches that at the smallest unit level.
         val service = ProjectAccentSwapService()
 
         service.notifyExternalApply("#FFCC66")
         service.notifyExternalApply("#ABCDEF")
-        service.notifyExternalApply("") // blank hex should be cached as-is — not validated here
-
-        // No assertion on the private cache field — the effect is observable only through a
-        // subsequent onWindowActivated call. What we're proving is the public API is stable
-        // and non-throwing for all of the values callers actually pass (valid hex, different
-        // hex, empty string from the "follow system accent" path).
-    }
-
-    @Test
-    fun `install is idempotent - second call is a no-op`() {
-        // The `if (listener != null) return` guard means calling install twice should not
-        // throw, and should not register a second AWTEventListener (which would double-fire
-        // on every WINDOW_ACTIVATED). We verify the non-throwing contract directly; the
-        // double-registration guard is testable only against a real Toolkit which is out of
-        // scope here — but the guard is a one-line early return with 100% branch coverage
-        // from this test, so any future regression (accidental removal of the guard or flip
-        // of the condition) would show up as an exception or second AWT registration in the
-        // IDE, not a silent pass.
-        val service = ProjectAccentSwapService()
-
-        service.install()
-        service.install()
-
-        // Reach-through assertion: the service is still usable, no exception escaped, cache
-        // still works after double-install. Any regression that broke install's self-guard
-        // would very likely also break notifyExternalApply (shared state), so we probe it.
-        service.notifyExternalApply("#FFCC66")
-    }
-
-    @Test
-    fun `getInstance returns the singleton wired through ApplicationManager`() {
-        // Smoke test for the companion accessor — defensive against a future rename that
-        // breaks the wiring at service-graph-resolution time. We don't have an Application
-        // in tests, so we just verify the companion's type is accessible, not the full
-        // resolution chain (that's an integration concern).
-        val companion = ProjectAccentSwapService.Companion
-        assertSame(ProjectAccentSwapService.Companion, companion)
+        service.notifyExternalApply("")
     }
 }

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt
@@ -1,0 +1,79 @@
+package dev.ayuislands.settings.mappings
+
+import io.mockk.unmockkAll
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertSame
+
+/**
+ * Covers the non-AWT behavior of [ProjectAccentSwapService]. The AWTEventListener itself is
+ * impractical to test without a real Toolkit; its registration and the inner
+ * `handleWindowActivated` flow are verified at the IDE level via manual smoke and the
+ * ProjectAccentSwapService-backed rotation / LAF flows already exercised by
+ * AccentRotationServiceTest.
+ *
+ * What this suite locks down:
+ *  - `notifyExternalApply` updates the internal cache so subsequent focus swaps don't
+ *    trigger redundant apply calls. This is the contract the settings-panel, rotation,
+ *    and LAF listener depend on.
+ *  - Install idempotence — calling install twice must not double-register the listener.
+ *    The existing production code guards against this with `if (listener != null) return`;
+ *    we verify that guard stays in place by calling install twice and confirming no
+ *    exception escapes (the real Toolkit.addAWTEventListener would be called once).
+ */
+class ProjectAccentSwapServiceTest {
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `notifyExternalApply updates the cache without side effects`() {
+        // The service's constructor does not touch the AWT toolkit (install is lazy), so we
+        // can instantiate a fresh service directly in a unit test. notifyExternalApply is a
+        // simple cache setter — verify it accepts any hex without throwing, so the swap cache
+        // stays addressable from the settings panel / rotation / LAF listener without needing
+        // an EDT or an active AWT listener.
+        val service = ProjectAccentSwapService()
+
+        service.notifyExternalApply("#FFCC66")
+        service.notifyExternalApply("#ABCDEF")
+        service.notifyExternalApply("") // blank hex should be cached as-is — not validated here
+
+        // No assertion on the private cache field — the effect is observable only through a
+        // subsequent onWindowActivated call. What we're proving is the public API is stable
+        // and non-throwing for all of the values callers actually pass (valid hex, different
+        // hex, empty string from the "follow system accent" path).
+    }
+
+    @Test
+    fun `install is idempotent — second call is a no-op`() {
+        // The `if (listener != null) return` guard means calling install twice should not
+        // throw, and should not register a second AWTEventListener (which would double-fire
+        // on every WINDOW_ACTIVATED). We verify the non-throwing contract directly; the
+        // double-registration guard is testable only against a real Toolkit which is out of
+        // scope here — but the guard is a one-line early return with 100% branch coverage
+        // from this test, so any future regression (accidental removal of the guard or flip
+        // of the condition) would show up as an exception or second AWT registration in the
+        // IDE, not a silent pass.
+        val service = ProjectAccentSwapService()
+
+        service.install()
+        service.install()
+
+        // Reach-through assertion: the service is still usable, no exception escaped, cache
+        // still works after double-install. Any regression that broke install's self-guard
+        // would very likely also break notifyExternalApply (shared state), so we probe it.
+        service.notifyExternalApply("#FFCC66")
+    }
+
+    @Test
+    fun `getInstance returns the singleton wired through ApplicationManager`() {
+        // Smoke test for the companion accessor — defensive against a future rename that
+        // breaks the wiring at service-graph-resolution time. We don't have an Application
+        // in tests, so we just verify the companion's type is accessible, not the full
+        // resolution chain (that's an integration concern).
+        val companion = ProjectAccentSwapService.Companion
+        assertSame(ProjectAccentSwapService.Companion, companion)
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt
@@ -1,23 +1,54 @@
 package dev.ayuislands.settings.mappings
 
+import com.intellij.openapi.wm.WindowManager
+import com.intellij.testFramework.LoggedErrorProcessor
+import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentResolver
+import dev.ayuislands.accent.AyuVariant
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
 import io.mockk.unmockkAll
+import io.mockk.verify
+import java.awt.event.WindowEvent
+import javax.swing.JFrame
 import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertTrue
 
 /**
- * Non-AWT behavior of [ProjectAccentSwapService]. The AWTEventListener inside `install()` is
- * covered by manual smoke / integration. These tests exercise only what is unit-testable:
- *  - [ProjectAccentSwapService.notifyExternalApply] is defined and non-throwing for the hex
- *    shapes real callers pass, so downstream code (settings panel, rotation, LAF listener)
- *    can rely on the public API being stable.
- *
- * `install()` and `handleWindowActivated` are deliberately *not* unit-tested here: `install`
- * registers a real AWTEventListener against `Toolkit.getDefaultToolkit()` which leaks across
- * headless test runs, and `handleWindowActivated` is `private` + AWT-event-driven. The prior
- * "install is idempotent" and "getInstance companion" tests asserted tautologies (no-throw
- * + reference equality of `Companion` to itself) and gave false coverage signal — removed.
+ * Behavior tests for [ProjectAccentSwapService]. The AWTEventListener registered by
+ * `install()` is covered by manual smoke / integration (registering a real listener against
+ * `Toolkit.getDefaultToolkit()` would leak across headless test runs). Everything else —
+ * the handler logic, short-circuit gates, exception catching, and the `notifyExternalApply`
+ * cache hook — is unit-tested via the [ProjectAccentSwapService.onWindowActivatedForTest]
+ * seam plus mockkObject wrappers around AccentResolver / AccentApplicator / AyuVariant.
  */
 class ProjectAccentSwapServiceTest {
+    @BeforeTest
+    fun setUp() {
+        mockkObject(AccentResolver)
+        mockkObject(AccentApplicator)
+        mockkObject(AyuVariant.Companion)
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        every { AccentApplicator.apply(any()) } just Runs
+
+        // WindowManager is a platform singleton; without static mocking, getInstance()
+        // returns null in headless tests and the handler NPEs. Stubbing it to return a
+        // WindowManager whose allProjectFrames is empty drives findProjectForWindow to
+        // return null cleanly — exactly the "no matching frame" path we want to test.
+        mockkStatic(WindowManager::class)
+        val windowManager =
+            mockk<WindowManager> {
+                every { allProjectFrames } returns emptyArray()
+            }
+        every { WindowManager.getInstance() } returns windowManager
+    }
+
     @AfterTest
     fun tearDown() {
         unmockkAll()
@@ -35,5 +66,102 @@ class ProjectAccentSwapServiceTest {
         service.notifyExternalApply("#FFCC66")
         service.notifyExternalApply("#ABCDEF")
         service.notifyExternalApply("")
+    }
+
+    @Test
+    fun `onWindowActivated catches RuntimeException and converts to LOG error`() {
+        // The handler runs from an AWTEventListener that AWT does not remove on failure —
+        // an uncaught exception here would dump a generic SEVERE trace into idea.log on
+        // every alt-tab. Verify the catch at onWindowActivated() converts it into an
+        // actionable LOG.error WITH context (the message must mention "swap failed").
+        val service = ProjectAccentSwapService()
+        // Use a non-Window event so cast-to-WindowEvent forces a quick path; but force a
+        // RuntimeException higher in the chain. Easiest: hand a fully-mocked WindowEvent
+        // whose `window` getter throws.
+        val event = mockk<WindowEvent>()
+        every { event.id } returns WindowEvent.WINDOW_ACTIVATED
+        every { event.window } throws IllegalStateException("frame disposed mid-event")
+
+        val capturedErrors = mutableListOf<String>()
+        val processor =
+            object : LoggedErrorProcessor() {
+                override fun processError(
+                    category: String,
+                    message: String,
+                    details: Array<out String>,
+                    throwable: Throwable?,
+                ): Set<Action> {
+                    capturedErrors += message
+                    return java.util.EnumSet.noneOf(Action::class.java)
+                }
+            }
+
+        LoggedErrorProcessor.executeWith<Throwable>(processor) {
+            service.onWindowActivatedForTest(event)
+        }
+
+        assertTrue(
+            capturedErrors.any { it.contains("Project accent swap failed") },
+            "RuntimeException must produce an actionable LOG.error; got: $capturedErrors",
+        )
+    }
+
+    @Test
+    fun `onWindowActivated short-circuits when activated window is not a project frame`() {
+        // findProjectForWindow returns null (no matching frame in WindowManager). The handler
+        // must early-exit without calling AccentResolver.resolve or AccentApplicator.apply —
+        // otherwise activating a popup / dialog window would re-apply the accent on every
+        // alt-tab, defeating the whole point of the cache.
+        val service = ProjectAccentSwapService()
+        val window = JFrame() // not registered with WindowManager
+        val event = WindowEvent(window, WindowEvent.WINDOW_ACTIVATED)
+
+        // Should not invoke any apply path.
+        service.onWindowActivatedForTest(event)
+
+        verify(exactly = 0) { AccentApplicator.apply(any()) }
+        verify(exactly = 0) { AccentResolver.resolve(any(), any()) }
+    }
+
+    @Test
+    fun `onWindowActivated short-circuits when AyuVariant detect returns null`() {
+        // Non-Ayu theme is active — the handler must NOT apply, even if the activated window
+        // is a real project frame. A regression that called apply() with a null variant would
+        // either crash or silently overwrite a non-Ayu theme's accent.
+        every { AyuVariant.detect() } returns null
+        val service = ProjectAccentSwapService()
+
+        // Skip the WindowManager.getInstance dance — give the handler a window that won't
+        // resolve, and assert AyuVariant.detect was NEVER called (handler exited earlier).
+        // To force the handler PAST the window resolution short-circuit, we'd need to mock
+        // WindowManager.getInstance which is out of scope. Instead, verify the logical
+        // chain: when window resolution fails, AyuVariant.detect is also never called.
+        val event = WindowEvent(JFrame(), WindowEvent.WINDOW_ACTIVATED)
+        service.onWindowActivatedForTest(event)
+
+        verify(exactly = 0) { AccentApplicator.apply(any()) }
+    }
+
+    @Test
+    fun `notifyExternalApply updates cache so next swap of same hex is a no-op`() {
+        // Verify the cache contract: after notifyExternalApply("#X"), if a future
+        // handleWindowActivated computes the same hex, it must skip apply(). Indirect
+        // verification through the no-side-effect property: notifyExternalApply must write
+        // to lastAppliedHex such that effectiveHex == lastAppliedHex returns true.
+        // We can't easily call handleWindowActivated end-to-end without WindowManager
+        // mocking, so this test pins the public API contract that notifyExternalApply
+        // is the cache-write side. Together with the no-throw test above it covers the
+        // surface a future regression could break.
+        val service = ProjectAccentSwapService()
+        service.notifyExternalApply("#FFCC66")
+        // Calling again with the same hex must remain a no-op (no exception, no observable
+        // side effect from our perspective — the cache is just overwritten with the same value).
+        service.notifyExternalApply("#FFCC66")
+        // Different hex updates the cache; subsequent call with original re-overwrites.
+        service.notifyExternalApply("#ABCDEF")
+        service.notifyExternalApply("#FFCC66")
+        // No assertions beyond no-throw — the contract surface is covered by the
+        // onWindowActivated tests above and by the AyuIslandsAccentPanelTest that
+        // verifies notifyExternalApply is called from the global-fallback path.
     }
 }

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectMappingsTableModelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectMappingsTableModelTest.kt
@@ -132,4 +132,60 @@ class ProjectMappingsTableModelTest {
         assertFalse(model.isCellEditable(0, 1))
         assertFalse(model.isCellEditable(0, 2))
     }
+
+    @Test
+    fun `updateHex out-of-bounds row is a silent no-op`() {
+        // Mirror of `remove at invalid index is a no-op` for the second mutator. UI code
+        // calls updateHex(selectedRow, ...) and selectedRow can be -1 when nothing is
+        // selected; without the bound guard this would throw IndexOutOfBoundsException
+        // from the underlying ArrayList.set, killing the Settings dialog.
+        val model = ProjectMappingsTableModel()
+        model.add(ProjectMapping("/tmp/a", "A", "#111111"))
+
+        model.updateHex(-1, "#FFFFFF")
+        model.updateHex(99, "#FFFFFF")
+
+        assertEquals("#111111", model.getValueAt(0, ProjectMappingsTableModel.COLUMN_COLOR))
+    }
+
+    @Test
+    fun `getValueAt out-of-bounds row returns null`() {
+        // Swing JTable can request stale row indices during repaint races; the
+        // `rowAt(rowIndex) ?: return null` guard must hand back null instead of NPE'ing.
+        val model = ProjectMappingsTableModel()
+        assertNull(model.getValueAt(0, ProjectMappingsTableModel.COLUMN_COLOR))
+        assertNull(model.getValueAt(99, ProjectMappingsTableModel.COLUMN_PATH))
+    }
+
+    @Test
+    fun `isOrphan returns false for out-of-bounds row`() {
+        // The renderer's prepareRenderer hook calls isOrphan(viewIndex), which can be stale
+        // mid-repaint. Without the `rowAt(...) ?: return false` guard the access would NPE
+        // and surface as a SEVERE in idea.log on every repaint.
+        val model = ProjectMappingsTableModel()
+        assertFalse(model.isOrphan(0), "no rows yet — out-of-bounds must report false")
+        assertFalse(model.isOrphan(-1))
+    }
+
+    @Test
+    fun `isOrphan returns true for path that does not exist on disk`() {
+        // The whole point of the orphan flag — when a project is moved/deleted, the stored
+        // canonicalPath stops resolving to a directory and the row should be styled
+        // differently. A regression that flipped the !isDirectory check would mark every
+        // valid mapping as orphaned.
+        val model = ProjectMappingsTableModel()
+        model.add(ProjectMapping("/this/path/definitely/does/not/exist", "Gone", "#111111"))
+
+        assertTrue(model.isOrphan(0))
+    }
+
+    @Test
+    fun `isOrphan returns false for path that resolves to a real directory`() {
+        // System tempdir always exists on every platform — use it as the canonical "live"
+        // directory so the test is portable across CI runners.
+        val model = ProjectMappingsTableModel()
+        model.add(ProjectMapping(System.getProperty("java.io.tmpdir"), "Tmp", "#111111"))
+
+        assertFalse(model.isOrphan(0))
+    }
 }

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectMappingsTableModelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectMappingsTableModelTest.kt
@@ -2,6 +2,7 @@ package dev.ayuislands.settings.mappings
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -90,6 +91,36 @@ class ProjectMappingsTableModelTest {
         assertEquals("Alpha", model.getValueAt(0, ProjectMappingsTableModel.COLUMN_PROJECT))
         assertEquals("/tmp/a", model.getValueAt(0, ProjectMappingsTableModel.COLUMN_PATH))
         assertNull(model.getValueAt(0, 99))
+    }
+
+    @Test
+    fun `ProjectMapping rejects blank canonicalPath`() {
+        assertFailsWith<IllegalArgumentException> {
+            ProjectMapping(canonicalPath = "", displayName = "Empty", hex = "#FFCC66")
+        }
+    }
+
+    @Test
+    fun `ProjectMapping rejects malformed hex`() {
+        // Three classes of malformed hex the regex ^#[0-9A-Fa-f]{6}$ rejects: short, long,
+        // missing octothorpe. Each surfaces as IllegalArgumentException at the seam instead
+        // of silently flowing into Color.decode downstream.
+        assertFailsWith<IllegalArgumentException> {
+            ProjectMapping(canonicalPath = "/tmp/a", displayName = "A", hex = "#FFC")
+        }
+        assertFailsWith<IllegalArgumentException> {
+            ProjectMapping(canonicalPath = "/tmp/a", displayName = "A", hex = "#AABBCCDD")
+        }
+        assertFailsWith<IllegalArgumentException> {
+            ProjectMapping(canonicalPath = "/tmp/a", displayName = "A", hex = "FFCC66")
+        }
+    }
+
+    @Test
+    fun `ProjectMapping accepts mixed-case hex`() {
+        // The regex permits both upper and lower hex digits — production writers normalize to
+        // upper, but legacy XML or hand-edits using `#aabbcc` shouldn't fail construction.
+        ProjectMapping(canonicalPath = "/tmp/a", displayName = "A", hex = "#aAbBcC")
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectMappingsTableModelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectMappingsTableModelTest.kt
@@ -1,0 +1,104 @@
+package dev.ayuislands.settings.mappings
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ProjectMappingsTableModelTest {
+    @Test
+    fun `replaceAll resets rows and fires structural change`() {
+        val model = ProjectMappingsTableModel()
+        model.add(ProjectMapping("/tmp/a", "A", "#111111"))
+
+        model.replaceAll(listOf(ProjectMapping("/tmp/b", "B", "#222222")))
+
+        assertEquals(1, model.rowCount)
+        assertEquals("B", model.getValueAt(0, ProjectMappingsTableModel.COLUMN_PROJECT))
+    }
+
+    @Test
+    fun `add returns inserted row index`() {
+        val model = ProjectMappingsTableModel()
+
+        assertEquals(0, model.add(ProjectMapping("/tmp/a", "A", "#111111")))
+        assertEquals(1, model.add(ProjectMapping("/tmp/b", "B", "#222222")))
+    }
+
+    @Test
+    fun `remove at valid index drops the row`() {
+        val model = ProjectMappingsTableModel()
+        model.add(ProjectMapping("/tmp/a", "A", "#111111"))
+        model.add(ProjectMapping("/tmp/b", "B", "#222222"))
+
+        model.remove(0)
+
+        assertEquals(1, model.rowCount)
+        assertEquals("/tmp/b", model.getValueAt(0, ProjectMappingsTableModel.COLUMN_PATH))
+    }
+
+    @Test
+    fun `remove at invalid index is a no-op`() {
+        val model = ProjectMappingsTableModel()
+        model.add(ProjectMapping("/tmp/a", "A", "#111111"))
+
+        model.remove(-1)
+        model.remove(99)
+
+        assertEquals(1, model.rowCount)
+    }
+
+    @Test
+    fun `updateHex mutates the target row only`() {
+        val model = ProjectMappingsTableModel()
+        model.add(ProjectMapping("/tmp/a", "A", "#111111"))
+        model.add(ProjectMapping("/tmp/b", "B", "#222222"))
+
+        model.updateHex(1, "#ABCDEF")
+
+        assertEquals("#111111", model.getValueAt(0, ProjectMappingsTableModel.COLUMN_COLOR))
+        assertEquals("#ABCDEF", model.getValueAt(1, ProjectMappingsTableModel.COLUMN_COLOR))
+    }
+
+    @Test
+    fun `containsPath is a pure lookup`() {
+        val model = ProjectMappingsTableModel()
+        model.add(ProjectMapping("/tmp/a", "A", "#111111"))
+
+        assertTrue(model.containsPath("/tmp/a"))
+        assertFalse(model.containsPath("/tmp/b"))
+    }
+
+    @Test
+    fun `snapshot returns a defensive copy`() {
+        val model = ProjectMappingsTableModel()
+        model.add(ProjectMapping("/tmp/a", "A", "#111111"))
+
+        val snap = model.snapshot()
+        model.add(ProjectMapping("/tmp/b", "B", "#222222"))
+
+        assertEquals(1, snap.size)
+    }
+
+    @Test
+    fun `getValueAt returns column payload by index`() {
+        val model = ProjectMappingsTableModel()
+        model.add(ProjectMapping("/tmp/a", "Alpha", "#ABCDEF"))
+
+        assertEquals("#ABCDEF", model.getValueAt(0, ProjectMappingsTableModel.COLUMN_COLOR))
+        assertEquals("Alpha", model.getValueAt(0, ProjectMappingsTableModel.COLUMN_PROJECT))
+        assertEquals("/tmp/a", model.getValueAt(0, ProjectMappingsTableModel.COLUMN_PATH))
+        assertNull(model.getValueAt(0, 99))
+    }
+
+    @Test
+    fun `cells are not editable`() {
+        val model = ProjectMappingsTableModel()
+        model.add(ProjectMapping("/tmp/a", "A", "#111111"))
+
+        assertFalse(model.isCellEditable(0, 0))
+        assertFalse(model.isCellEditable(0, 1))
+        assertFalse(model.isCellEditable(0, 2))
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/RoundedSwatchRendererFormatTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/RoundedSwatchRendererFormatTest.kt
@@ -31,7 +31,7 @@ class RoundedSwatchRendererFormatTest {
     }
 
     @Test
-    fun `formatLabel preset match is case-insensitive on hex — output upper`() {
+    fun `formatLabel preset match is case-insensitive on hex - output upper`() {
         assertEquals("Gold (#FFCD66)", RoundedSwatchRenderer.formatLabel("#ffcd66"))
     }
 

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/RoundedSwatchRendererFormatTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/RoundedSwatchRendererFormatTest.kt
@@ -1,0 +1,57 @@
+package dev.ayuislands.settings.mappings
+
+import dev.ayuislands.accent.AYU_ACCENT_PRESETS
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pure-function coverage for [RoundedSwatchRenderer.formatLabel] — the label shown
+ * in the Overrides table's Color column. Preset matches inherit the curated name,
+ * custom colors fall back to plain uppercase hex.
+ */
+class RoundedSwatchRendererFormatTest {
+    @Test
+    fun `formatLabel returns empty string for null`() {
+        assertEquals("", RoundedSwatchRenderer.formatLabel(null))
+    }
+
+    @Test
+    fun `formatLabel returns empty string for empty input`() {
+        assertEquals("", RoundedSwatchRenderer.formatLabel(""))
+    }
+
+    @Test
+    fun `formatLabel returns empty string for blank input`() {
+        assertEquals("", RoundedSwatchRenderer.formatLabel("   "))
+    }
+
+    @Test
+    fun `formatLabel decorates known preset hex with its curated name`() {
+        assertEquals("Gold (#FFCD66)", RoundedSwatchRenderer.formatLabel("#FFCD66"))
+    }
+
+    @Test
+    fun `formatLabel preset match is case-insensitive on hex — output upper`() {
+        assertEquals("Gold (#FFCD66)", RoundedSwatchRenderer.formatLabel("#ffcd66"))
+    }
+
+    @Test
+    fun `formatLabel returns plain uppercase hex for custom colors`() {
+        assertEquals("#ABCDEF", RoundedSwatchRenderer.formatLabel("#abcdef"))
+    }
+
+    @Test
+    fun `formatLabel returns plain hex when hex shape is unusual`() {
+        // No preset match, not validated — the label passes through uppercase-only.
+        assertEquals("#12345678", RoundedSwatchRenderer.formatLabel("#12345678"))
+    }
+
+    @Test
+    fun `formatLabel renders a label for every curated preset`() {
+        for (preset in AYU_ACCENT_PRESETS) {
+            val label = RoundedSwatchRenderer.formatLabel(preset.hex)
+            val expected = "${preset.name} (${preset.hex.uppercase()})"
+            assertEquals(expected, label, "Preset ${preset.name} should render as \"$expected\"")
+        }
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/ui/ComponentTreeRefresherTest.kt
+++ b/src/test/kotlin/dev/ayuislands/ui/ComponentTreeRefresherTest.kt
@@ -11,7 +11,6 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
 import java.awt.Component
-import java.util.EnumSet
 import javax.swing.JPanel
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -87,21 +86,30 @@ class ComponentTreeRefresherTest {
         // the EditorScrollbarManager / ProjectViewScrollbarManager reapply path.
         every { IJSwingUtilities.updateComponentTreeUI(root) } throws IllegalStateException("boom")
 
-        val suppressLoggedErrors =
+        // Production code logs at LOG.warn — override processWarn (not processError) so the
+        // TestLoggerFactory warn-to-failure promotion is suppressed for THIS test's
+        // intentional throw, but any unexpected LOG.error elsewhere still escalates.
+        val capturedWarns = mutableListOf<String>()
+        val processor =
             object : LoggedErrorProcessor() {
-                override fun processError(
+                override fun processWarn(
                     category: String,
                     message: String,
-                    details: Array<out String>,
                     throwable: Throwable?,
-                ): Set<Action> = EnumSet.noneOf(Action::class.java)
+                ): Boolean {
+                    capturedWarns += message
+                    return false
+                }
             }
 
-        LoggedErrorProcessor.executeWith<Throwable>(suppressLoggedErrors) {
+        LoggedErrorProcessor.executeWith<Throwable>(processor) {
             ComponentTreeRefresher.walkAndNotify(project, root)
         }
 
         verify(exactly = 1) { listener.afterRefresh(project) }
+        assert(capturedWarns.any { it.contains("Component tree refresh failed") }) {
+            "Expected warn about failed tree refresh, got: $capturedWarns"
+        }
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/ui/ComponentTreeRefresherTest.kt
+++ b/src/test/kotlin/dev/ayuislands/ui/ComponentTreeRefresherTest.kt
@@ -1,0 +1,123 @@
+package dev.ayuislands.ui
+
+import com.intellij.openapi.project.Project
+import com.intellij.testFramework.LoggedErrorProcessor
+import com.intellij.util.IJSwingUtilities
+import com.intellij.util.messages.MessageBus
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import java.awt.Component
+import java.util.EnumSet
+import javax.swing.JPanel
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+/**
+ * Locks in the contract of [ComponentTreeRefresher] — the central pipeline subscribers
+ * (EditorScrollbarManager, ProjectViewScrollbarManager) hang their self-heal logic off.
+ *
+ * The two surfaces under test:
+ *  - [walkAndNotify] walks the subtree via [IJSwingUtilities.updateComponentTreeUI] then
+ *    publishes [ComponentTreeRefreshedTopic.TOPIC] so subscribers reapply.
+ *  - [notifyOnly] publishes the same topic without walking — for callers (LAF listener)
+ *    where the platform has already done the walk.
+ *
+ * Disposal guards on both methods are exercised; the inner try/catch around the walk is
+ * exercised so a Swing refresh failure doesn't propagate out of subscribers.
+ */
+class ComponentTreeRefresherTest {
+    private lateinit var project: Project
+    private lateinit var messageBus: MessageBus
+    private lateinit var listener: ComponentTreeRefreshedListener
+    private lateinit var root: Component
+
+    @BeforeTest
+    fun setUp() {
+        listener = mockk(relaxed = true)
+        messageBus = mockk()
+        every { messageBus.syncPublisher(ComponentTreeRefreshedTopic.TOPIC) } returns listener
+
+        project =
+            mockk {
+                every { isDisposed } returns false
+                every { name } returns "test-project"
+                every { this@mockk.messageBus } returns this@ComponentTreeRefresherTest.messageBus
+            }
+
+        root = JPanel()
+
+        mockkStatic(IJSwingUtilities::class)
+        justRun { IJSwingUtilities.updateComponentTreeUI(any()) }
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `walkAndNotify on disposed project is a no-op`() {
+        every { project.isDisposed } returns true
+
+        ComponentTreeRefresher.walkAndNotify(project, root)
+
+        verify(exactly = 0) { IJSwingUtilities.updateComponentTreeUI(any()) }
+        verify(exactly = 0) { listener.afterRefresh(any()) }
+    }
+
+    @Test
+    fun `walkAndNotify on healthy project walks the tree then publishes the topic`() {
+        ComponentTreeRefresher.walkAndNotify(project, root)
+
+        io.mockk.verifyOrder {
+            IJSwingUtilities.updateComponentTreeUI(root)
+            listener.afterRefresh(project)
+        }
+    }
+
+    @Test
+    fun `walkAndNotify still publishes the topic even if the tree walk throws`() {
+        // Subscribers must always get a chance to reapply their overrides — a Swing refresh
+        // failure (LAF mid-swap, ClassCastException on legacy components) shouldn't blackhole
+        // the EditorScrollbarManager / ProjectViewScrollbarManager reapply path.
+        every { IJSwingUtilities.updateComponentTreeUI(root) } throws IllegalStateException("boom")
+
+        val suppressLoggedErrors =
+            object : LoggedErrorProcessor() {
+                override fun processError(
+                    category: String,
+                    message: String,
+                    details: Array<out String>,
+                    throwable: Throwable?,
+                ): Set<Action> = EnumSet.noneOf(Action::class.java)
+            }
+
+        LoggedErrorProcessor.executeWith<Throwable>(suppressLoggedErrors) {
+            ComponentTreeRefresher.walkAndNotify(project, root)
+        }
+
+        verify(exactly = 1) { listener.afterRefresh(project) }
+    }
+
+    @Test
+    fun `notifyOnly on disposed project is a no-op`() {
+        every { project.isDisposed } returns true
+
+        ComponentTreeRefresher.notifyOnly(project)
+
+        verify(exactly = 0) { listener.afterRefresh(any()) }
+    }
+
+    @Test
+    fun `notifyOnly on healthy project publishes the topic without walking the tree`() {
+        ComponentTreeRefresher.notifyOnly(project)
+
+        verify(exactly = 1) { listener.afterRefresh(project) }
+        verify(exactly = 0) { IJSwingUtilities.updateComponentTreeUI(any()) }
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/ui/ComponentTreeRefresherTest.kt
+++ b/src/test/kotlin/dev/ayuislands/ui/ComponentTreeRefresherTest.kt
@@ -15,6 +15,7 @@ import javax.swing.JPanel
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertTrue
 
 /**
  * Locks in the contract of [ComponentTreeRefresher] — the central pipeline subscribers
@@ -88,7 +89,10 @@ class ComponentTreeRefresherTest {
 
         // Production code logs at LOG.warn — override processWarn (not processError) so the
         // TestLoggerFactory warn-to-failure promotion is suppressed for THIS test's
-        // intentional throw, but any unexpected LOG.error elsewhere still escalates.
+        // intentional throw, but any unexpected LOG.error elsewhere still escalates. Match
+        // the expected message substring so unrelated warns still propagate and fail the test
+        // instead of being silently absorbed by a blanket suppressor.
+        val expectedMessage = "Component tree refresh failed"
         val capturedWarns = mutableListOf<String>()
         val processor =
             object : LoggedErrorProcessor() {
@@ -97,6 +101,7 @@ class ComponentTreeRefresherTest {
                     message: String,
                     throwable: Throwable?,
                 ): Boolean {
+                    if (!message.contains(expectedMessage)) return true
                     capturedWarns += message
                     return false
                 }
@@ -107,9 +112,10 @@ class ComponentTreeRefresherTest {
         }
 
         verify(exactly = 1) { listener.afterRefresh(project) }
-        assert(capturedWarns.any { it.contains("Component tree refresh failed") }) {
-            "Expected warn about failed tree refresh, got: $capturedWarns"
-        }
+        assertTrue(
+            capturedWarns.any { it.contains(expectedMessage) },
+            "Expected warn about failed tree refresh, got: $capturedWarns",
+        )
     }
 
     @Test


### PR DESCRIPTION
── Summary ─────────────────────────────────

One global accent color is fine until you juggle three projects and want each to feel visually distinct — or you work in both Kotlin and Python and want the underline color to cue which language context you're in. This PR introduces per-project and per-language accent overrides that stack on top of the existing global accent, with the overrides winning in that priority order:

1. Project override (keyed by canonical base path)
2. Language override (keyed by the detected dominant language of the project)
3. Global accent (the existing per-variant stored hex)

Plus a few side cleanups that piled up while the feature took shape: a Gradle plugin pin, scrollbar toggle stability fixes, and an inspection sweep.

── Changes ─────────────────────────────────

**Per-project / per-language overrides (the feature)**

| Type | Path | What |
|------|------|------|
| feat | `src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt` | Priority-chain resolver with license gate. Project > language > global |
| feat | `src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt` | Detects dominant language from SDK type / module names, with negative-result caching |
| feat | `src/main/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettings.kt` | App-level persistent state with `$USER_HOME$` macro migration for legacy XML |
| feat | `src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt` | Settings UI — dual JBTable (projects / languages), ToolbarDecorator, auto-packing columns |
| feat | `src/main/kotlin/dev/ayuislands/settings/mappings/EditAccentColorDialog.kt` | Modal with preset swatch picker + custom hex |
| feat | `src/main/kotlin/dev/ayuislands/settings/mappings/AddProjectMappingDialog.kt` | Add flow with recent-projects picker |
| feat | `src/main/kotlin/dev/ayuislands/settings/mappings/AddLanguageMappingDialog.kt` | Add flow for language overrides |
| feat | `src/main/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapService.kt` | AWT focus-swap listener that re-resolves accent per focused project window |
| feat | `src/main/kotlin/dev/ayuislands/settings/mappings/RoundedSwatchRenderer.kt` | Swatch + preset-name label renderer for tables |

**Accent apply pipeline**

| Type | Path | What |
|------|------|------|
| refactor | `src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt` | New `applyForFocusedProject(variant)` helper centralizes the resolve → apply → swap-cache sync sequence |
| fix | `src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt` | Rotation now applies the resolved accent so per-project overrides aren't stomped |
| fix | `src/main/kotlin/dev/ayuislands/indent/IndentRainbowSync.kt` | Accepts resolved hex instead of re-reading global — rotation + overrides now match |
| fix | `src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt` | Removed duplicate UIManager writes; routes through resolver |
| fix | `src/main/kotlin/dev/ayuislands/AyuIslandsLafListener.kt` | Uses helper + publishes to ComponentTreeRefreshedTopic per open project |
| fix | `src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt` | Eager-instantiates scrollbar managers before the first refresh event so they subscribe in time |

**Settings UI reorg**

| Type | Path | What |
|------|------|------|
| refactor | `src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt` | Accent Color first; Rotation + Overrides + Elements as collapsibles with persistence |
| refactor | `src/main/kotlin/dev/ayuislands/settings/AyuIslandsAppearancePanel.kt` | Merged into a System collapsible group with Follow-system-accent |
| refactor | `src/main/kotlin/dev/ayuislands/settings/AyuIslandsElementsPanel.kt` | Single Accent Elements group wrapping Bracket Scope + Active Tab subsections |
| refactor | `src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt` | Panel ordering + system-accent row bridge |
| feat | `src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt` | Persistence fields for collapsible-group expanded state |

**Scrollbar toggle stability (found while testing)**

| Type | Path | What |
|------|------|------|
| feat | `src/main/kotlin/dev/ayuislands/ui/ComponentTreeRefreshedTopic.kt` + `ComponentTreeRefresher.kt` | MessageBus topic so scrollbar/override managers self-heal after `updateComponentTreeUI` resets their patches |
| fix | `src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt` | Idempotent apply — no more stale `patched.verticalHidden` guard blocking re-hide after LAF change |
| fix | `src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt` | Subscribes to the refresh topic |

**Misc**

| Type | Path | What |
|------|------|------|
| chore | `build.gradle.kts`, `.github/dependabot.yml`, `proguard-rules.pro` | Pin `org.jetbrains.intellij.platform` < 2.14.0 (blocked by upstream regression) |
| chore | Multiple | IDE inspection cleanup — redundant qualifiers, em-dash in test names, named boolean args, experimental-API suppression hoisted to class level |

**Tests**

| Type | Path | What |
|------|------|------|
| test | `src/test/kotlin/dev/ayuislands/accent/AccentResolverTest.kt` | Priority chain + license-gate coverage (licensed → override wins, unlicensed → always global) |
| test | `src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt` | 23 tests covering SDK-type heuristic, module-name fallback, cache semantics, NPE regression |
| test | `src/test/kotlin/dev/ayuislands/settings/mappings/AccentMappingsSettingsTest.kt` | `$USER_HOME$` macro migration on loadState |
| test | `src/test/kotlin/dev/ayuislands/settings/mappings/ProjectMappingsTableModelTest.kt` + `LanguageMappingsTableModelTest.kt` | Table model lifecycle |
| test | `src/test/kotlin/dev/ayuislands/settings/mappings/RoundedSwatchRendererFormatTest.kt` | Preset-name lookup + custom hex casing |

── Validation ──────────────────────────────

```bash
./gradlew ktlintCheck detekt test
```

Expected: BUILD SUCCESSFUL, all tests green.

Manual smoke test:
1. Open two projects side-by-side, set a per-project override for one. Switch focus between windows — accent follows the focused project, not whichever was last to run apply.
2. Add a per-language override for a language the current project matches. Disable the per-project override — language override takes over.
3. Enable accent rotation — overrides keep winning during rotation ticks, global accent still cycles underneath.
4. Toggle editor / Project View hide-scrollbar. Change IDE theme. Re-open IDE. Scrollbars stay hidden across all three events — no need to toggle off/on manually.
5. Let the trial expire (or temporarily force `LicenseChecker.isLicensedOrGrace() = false`). Any stored overrides must stop applying — resolver short-circuits to global.

── Notes ───────────────────────────────────

- **License gate lives in `AccentResolver`**, not at callers. Single chokepoint — trial expiry with previously-added overrides falls back to global, and manual settings-XML import can't bypass it either.
- **Scrollbar self-healing** uses a MessageBus topic instead of hand-wiring managers from every refresh caller. Plan agent flagged the original coupling; the event bus is the cleaner architecture for "something refreshed the component tree, please reapply your overrides."
- **Startup race**: managers are now eagerly instantiated from `AyuIslandsStartupActivity` *before* the first `walkAndNotify` fires, otherwise they miss the initial refresh event (they'd been lazily created later in `initWorkspaceServices` on a subsequent EDT turn).
- **Settings UI**: every override panel follows the same pattern as existing ones — progressive disclosure, detect-don't-assume, never touch userspace without consent. Disabled + "Pro feature" label when unlicensed.
- **Gradle pin**: blocks `intellij.platform` 2.14.0+ until the upstream regression is resolved. Dependabot rule added so the pin isn't accidentally lifted.

## Summary by Sourcery

Add safeguards around IntelliJ Platform Gradle plugin updates to avoid known regressions in the test framework.

Build:
- Pin org.jetbrains.intellij.platform Gradle plugin below 2.14.0 in Dependabot configuration to avoid a regression that removes LoggedErrorProcessor from the test classpath.

Chores:
- Document the upstream IntelliJ Platform Gradle plugin regression and conditions for lifting the pin in Dependabot configuration comments.