### PR TITLE
chore: bump version to 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.5.0] - 2026-04-16
+
+### Added
+- [Paid] Pin an accent color to a specific project — set it once from Settings and every time you switch to that window your accent is there
+- [Paid] Pin an accent color to a programming language — e.g. Kotlin → lime, Python → sky. Applies when a project's dominant language matches and no project override exists
+- Recent projects populate the add-project dialog so you can configure overrides without opening the project first
+- First-launch release showcase opens automatically in the editor on upgrade, with captioned screenshots of the marquee features; reopen anytime via Tools → Ayu Islands → Show What's New
+
 ## [2.4.2] - 2026-04-12
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.4.2
+pluginVersion=2.5.0
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
@@ -58,6 +58,13 @@ internal object UpdateNotifier {
 
     private val RELEASE_NOTES =
         mapOf(
+            "2.5.0" to
+                "<ul>" +
+                "<li>Pin an accent color to a specific project</li>" +
+                "<li>Pin an accent color to a programming language</li>" +
+                "<li>Recent projects populate the add-project dialog</li>" +
+                "<li>First-launch release showcase with captioned screenshots</li>" +
+                "</ul>",
             "2.4.2" to
                 "<ul>" +
                 "<li>Install, delete, or reinstall fonts from Settings</li>" +

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -146,8 +146,8 @@
 
     <product-descriptor
             code="PAYUISLANDS"
-            release-date="20260410"
-            release-version="24"
+            release-date="20260416"
+            release-version="25"
             optional="true"/>
 
     <extensionPoints>


### PR DESCRIPTION
Release sync PR — the commit (ca54edc) is already tagged as v2.5.0 and release.yml is publishing to the Marketplace. This PR brings main's branch tip in line with the released commit so future bumps diff cleanly.

── Changes ─────────────────────────────────────────────────────

- gradle.properties: 2.4.2 → 2.5.0
- plugin.xml: release-date=20260416, release-version=25
- plugin.xml change-notes: 2.5.0 block (was added in the What's New feature PR, re-appears here for completeness)
- CHANGELOG.md: [2.5.0] section with the four user-facing bullets
- UpdateNotifier.RELEASE_NOTES: 2.5.0 balloon entry

── Validation ──────────────────────────────────────────────────

- ./gradlew clean buildPlugin — green
- ./gradlew verifyPlugin — green
- Tag v2.5.0 pushed; release.yml is in_progress uploading to Marketplace

── Notes ───────────────────────────────────────────────────────

- No code changes, just version + changelog bookkeeping
- Branch protection required a PR (direct push to main rejected); tag ref already holds the commit so release pipeline is unaffected

## Summary by Sourcery

Bump the plugin to version 2.5.0 and align release metadata, changelog, and in-IDE release notes with the new release.

New Features:
- Document new 2.5.0 features including project- and language-pinned accent colors, recent-projects support in the add-project dialog, and the first-launch release showcase.

Enhancements:
- Update plugin version, release date, and release version metadata for the 2.5.0 release.
- Add 2.5.0 HTML release notes entry to the in-IDE update notifier.

Documentation:
- Add a 2.5.0 section to the changelog describing the key user-visible changes.