### PR TITLE
chore(release): cut v2.5.1 + add Marketplace-sync guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.5.1] - 2026-04-16
+
+### Changed
+- Marketplace "About" description now lists all v2.5.0 features — per-project and per-language accent pins, onboarding wizard, first-launch release showcase, and Settings-based font install — that were missing from the listing page when v2.5.0 was published
+
 ## [2.5.0] - 2026-04-16
 
 ### Added

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -23,6 +23,23 @@
 
 schema_version: 1
 
+# ─── Release-sync guard ───────────────────────────────────────────────────
+# Tracks the plugin.xml <description> CDATA hash as it was at the time of
+# the last successful Marketplace publish. verify-docs.py refuses to pass
+# when `gradle.properties.pluginVersion == last_published_version` AND the
+# current <description> SHA-256 differs — because that means main has copy
+# edits the live Marketplace JAR does NOT reflect (the exact trap that
+# caused v2.5.0's Marketplace "About" page to stay on 2.4.x copy after
+# PR #131 landed description updates without a version bump).
+#
+# /release-plugin recomputes last_published_description_sha256 as part of
+# the version-bump commit, so the guard resets automatically after a real
+# release. Between releases the hash is intentionally frozen to the last
+# published state — any copy edit without a version bump fails lint.
+release_sync:
+  last_published_version: "2.5.1"
+  last_published_description_sha256: "8d8996c596cacd275b73d104db05ed775649489c3f6aaae408914dfe598f6e8b"
+
 categories:
   accent:
     title: "Accent control"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.5.0
+pluginVersion=2.5.1
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/scripts/verify-docs.py
+++ b/scripts/verify-docs.py
@@ -22,6 +22,7 @@ CLI:
 from __future__ import annotations
 
 import argparse
+import functools
 import hashlib
 import re
 import subprocess
@@ -377,13 +378,21 @@ _ASSET_SEARCH_ROOTS = ("assets", "src/main/resources/whatsnew")
 GRADLE_PROPERTIES = REPO_ROOT / "gradle.properties"
 
 
-def _read_plugin_version() -> str:
-    """Extract pluginVersion=X.Y.Z from gradle.properties."""
+@functools.cache
+def _read_plugin_version() -> str | None:
+    """Extract pluginVersion=X.Y.Z from gradle.properties.
+
+    Tolerates `pluginVersion = X`, `pluginVersion\t=\tX`, etc. — any whitespace
+    around the `=`. Returns None when the key is absent or has no value so
+    callers fail loudly instead of silently no-op'ing the sync guard.
+    """
     for line in GRADLE_PROPERTIES.read_text(encoding="utf-8").splitlines():
         stripped = line.strip()
-        if stripped.startswith("pluginVersion="):
-            return stripped.split("=", 1)[1].strip()
-    return ""
+        key, sep, value = stripped.partition("=")
+        if sep and key.strip() == "pluginVersion":
+            version = value.strip()
+            return version or None
+    return None
 
 
 def check_marketplace_sync(data: dict, report: Report) -> None:
@@ -404,6 +413,14 @@ def check_marketplace_sync(data: dict, report: Report) -> None:
         return  # Bootstrap mode — no last-published state recorded yet.
 
     current_version = _read_plugin_version()
+    if current_version is None:
+        report.error(
+            "_release_sync_",
+            "gradle.properties is missing a `pluginVersion=X.Y.Z` line — "
+            "the Marketplace-sync guard cannot verify anything without it. "
+            "Restore the key or fix the format.",
+        )
+        return
     if current_version != expected_version:
         # Mid-development; main is ahead of the last-published version.
         # The next /release-plugin run will refresh the hash.

--- a/scripts/verify-docs.py
+++ b/scripts/verify-docs.py
@@ -374,6 +374,57 @@ def check_required_links(data: dict, report: Report) -> None:
 _ASSET_EXTENSIONS = (".png", ".gif", ".svg", ".jpg", ".jpeg", ".webp")
 _ASSET_SEARCH_ROOTS = ("assets", "src/main/resources/whatsnew")
 
+GRADLE_PROPERTIES = REPO_ROOT / "gradle.properties"
+
+
+def _read_plugin_version() -> str:
+    """Extract pluginVersion=X.Y.Z from gradle.properties."""
+    for line in GRADLE_PROPERTIES.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("pluginVersion="):
+            return stripped.split("=", 1)[1].strip()
+    return ""
+
+
+def check_marketplace_sync(data: dict, report: Report) -> None:
+    """Invariant 6: when gradle pluginVersion matches the last-published version,
+    the current plugin.xml <description> hash must match what shipped.
+
+    Guards the trap where someone edits <description> without bumping the
+    version — changes land on main but the Marketplace "About" page keeps
+    showing whatever the last published JAR carried. After `/release-plugin`
+    bumps the version and re-publishes, it also refreshes
+    `release_sync.last_published_description_sha256` so this check stays
+    silent during the window the published version == the on-disk version.
+    """
+    sync = data.get("release_sync") or {}
+    expected_version = (sync.get("last_published_version") or "").strip()
+    expected_sha = (sync.get("last_published_description_sha256") or "").strip()
+    if not expected_version or not expected_sha:
+        return  # Bootstrap mode — no last-published state recorded yet.
+
+    current_version = _read_plugin_version()
+    if current_version != expected_version:
+        # Mid-development; main is ahead of the last-published version.
+        # The next /release-plugin run will refresh the hash.
+        return
+
+    current_sha = hashlib.sha256(
+        extract_plugin_xml_description().encode("utf-8")
+    ).hexdigest()
+    if current_sha == expected_sha:
+        return
+
+    report.error(
+        "_release_sync_",
+        f"plugin.xml <description> has changed since v{expected_version} was "
+        f"published to Marketplace (expected SHA {expected_sha[:12]}..., got "
+        f"{current_sha[:12]}...). The Marketplace 'About' page still serves "
+        f"the old copy. Either (a) bump pluginVersion + re-run /release-plugin "
+        f"so the new description ships, OR (b) revert the <description> edit "
+        f"to match the currently-published state.",
+    )
+
 
 def check_asset_inventory(data: dict, report: Report) -> None:
     """Invariant 5: every on-disk image under the tracked roots is inventoried,
@@ -488,6 +539,7 @@ def main() -> int:
     check_screenshots(data, report)
     check_required_links(data, report)
     check_asset_inventory(data, report)
+    check_marketplace_sync(data, report)
     report.print()
     return 1 if report.has_errors else 0
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -87,6 +87,10 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>2.5.1</h3>
+    <ul>
+      <li>Updated Marketplace "About" description to cover all v2.5.0 features — per-project and per-language accent pins, onboarding wizard, and the first-launch release showcase tab — that hadn't made it onto the listing page</li>
+    </ul>
     <h3>2.5.0</h3>
     <ul>
       <li>[Paid] Pin an accent color to a specific project — set it once from Settings and every time you switch to that window your accent is there</li>


### PR DESCRIPTION
── Summary ─────────────────────────────────

v2.5.0 shipped before the `docs/features.yml` SSOT work landed, so the live Marketplace "About" page still renders 2.4.x copy — none of the new Pro features (per-project/per-language accent pins, onboarding wizard, release showcase, Settings-based font install) are listed. Cutting 2.5.1 republishes the full v2.5.0 feature list. The new `check_marketplace_sync()` guard in `verify-docs.py` blocks a repeat: any future edit to the `<description>` CDATA without a version bump fails lint.

── Changes ─────────────────────────────────

| Type     | File                                                          | Description                                                                    |
|----------|---------------------------------------------------------------|--------------------------------------------------------------------------------|
| chore    | `gradle.properties:3`                                         | Bump `pluginVersion` 2.5.0 → 2.5.1 (metadata-only; `release-date` / `release-version` stay on the 2.5.x-shared values per the locked-release-date rule) |
| docs     | `CHANGELOG.md:3-6`                                            | Add `[2.5.1] - 2026-04-16` section explaining why the copy refresh matters     |
| docs     | `src/main/resources/META-INF/plugin.xml:90-93`                | Add `<h3>2.5.1</h3>` change-notes entry                                        |
| feat     | `docs/features.yml:39-41`                                     | New `release_sync` block capturing `last_published_version` + SHA-256 of the last-published `<description>` CDATA |
| feat     | `scripts/verify-docs.py:check_marketplace_sync`               | New invariant: when `gradle.pluginVersion == last_published_version` AND the current `<description>` hash differs → fail. Resets automatically on next version bump |

── Validation ──────────────────────────────

```bash
./scripts/verify-docs.py
# → docs/features.yml in sync with README + plugin.xml + CHANGELOG

grep '^pluginVersion' gradle.properties
# → pluginVersion=2.5.1

head -20 CHANGELOG.md | grep '2.5.1'
# → ## [2.5.1] - 2026-04-16
```

Manual check after merge: tag `v2.5.1` → CI `release.yml` publishes to Marketplace → verify `plugins.jetbrains.com/plugin/30373` shows the updated "About" copy (per-project accent pins, release showcase, Settings-based font install).

── Notes ───────────────────────────────────

- No `UpdateNotifier.RELEASE_NOTES` entry for 2.5.1 — metadata-only bump. The null-notes INFO-log-and-skip branch handles it silently (no balloon, no What's New tab).
- `release-date="20260416"` / `release-version="25"` shared with v2.5.0 per the locked-per-major-minor rule.
- The `release_sync` hash is frozen between releases; the `/release-plugin` skill will auto-recompute it as part of the version-bump commit in future bumps (follow-up outside this repo).

## Summary by Sourcery

Release v2.5.1 to refresh the Marketplace listing copy and enforce that future Marketplace description changes stay in sync with published versions.

New Features:
- Introduce a release_sync metadata block to track the last published version and Marketplace description hash.
- Add a docs verification guard that fails when the on-disk plugin description changes without a corresponding version bump.

Enhancements:
- Update plugin change notes and Marketplace description to reflect all v2.5.0 features.

Documentation:
- Add a 2.5.1 changelog entry describing the Marketplace copy refresh.

Chores:
- Bump pluginVersion from 2.5.0 to 2.5.1 in gradle.properties.