### PR TITLE
fix(marketplace): render Premium features as bullet list

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.5.1
+pluginVersion=2.5.2
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -32,46 +32,42 @@
     </ul>
 
     <h3>Premium — make the IDE feel yours</h3>
-
-    <p><b>Glow</b> — a soft light beneath tabs and panels: Soft, Sharp Neon,
-    or Gradient. Add Pulse, Breathe, or Reactive animation. Control intensity,
-    width, and which of the 7 panels glow.</p>
-
-    <p><b>Accent control</b> — decide exactly where your accent color appears:
-    scrollbars, links, caret line, search highlights, progress bars, bracket
-    matches, inlay hints, tag matches. Eight independent switches.</p>
-
-    <p><b>Accent rotation</b> — automatic preset cycling or contrast-aware
-    random. Your IDE palette evolves on its own.</p>
-
-    <p><b>Per-project accent pins</b> — bind a color to a specific project;
-    it applies whenever you focus that window, no keyboard shortcut needed.
-    <b>Per-language accent pins</b> — bind a color to a language (Kotlin → cyan,
-    Python → gold); applies when the project's dominant language matches and no
-    project override exists.</p>
-
-    <p><b>Workspace</b> — auto-fit or fixed width for Project View, Commit,
-    and Git panels with min/max bounds. Git panel splitter control for branches
-    and file changes trees. Hide the filesystem path and scrollbar from
-    the Project View.</p>
-
-    <p><b>Tab styling</b> — Islands UI: underline, full accent bar, or none.
-    Classic UI: underline thickness from hairline to bold.</p>
-
-    <p><b>Plugin sync</b> — accent into CodeGlance Pro minimap and Indent
-    Rainbow guides (3 Ayu presets). More integrations in development.</p>
-
-    <p><b>Bracket scope</b> — a colored gutter stripe showing the full scope
-    when your cursor lands on a bracket.</p>
-
-    <p><b>Onboarding wizard</b> — a full-tab welcome on first install with
-    preset cards, theme variant picker, and accent swatches. After upgrades,
-    a <b>release showcase</b> tab opens automatically with captioned screenshots
-    of the marquee features; reopen anytime from Tools → Ayu Islands.</p>
-
-    <p><b>Font presets</b> — 4 curated Nerd Fonts with one-click apply.
-    <b>Install, delete, or reinstall fonts</b> directly from Settings — every
-    filesystem change gets a consent dialog showing the exact folder path.</p>
+    <ul>
+      <li><b>Glow</b> — a soft light beneath tabs and panels: Soft, Sharp Neon,
+          or Gradient. Add Pulse, Breathe, or Reactive animation. Control
+          intensity, width, and which of the 7 panels glow.</li>
+      <li><b>Accent control</b> — decide exactly where your accent color
+          appears: scrollbars, links, caret line, search highlights, progress
+          bars, bracket matches, inlay hints, tag matches. Eight independent
+          switches.</li>
+      <li><b>Accent rotation</b> — automatic preset cycling or contrast-aware
+          random. Your IDE palette evolves on its own.</li>
+      <li><b>Per-project accent pins</b> — bind a color to a specific project;
+          it applies whenever you focus that window, no keyboard shortcut
+          needed.</li>
+      <li><b>Per-language accent pins</b> — bind a color to a language
+          (Kotlin → cyan, Python → gold); applies when the project's dominant
+          language matches and no project override exists.</li>
+      <li><b>Workspace</b> — auto-fit or fixed width for Project View, Commit,
+          and Git panels with min/max bounds. Git panel splitter control for
+          branches and file changes trees. Hide the filesystem path and
+          scrollbar from the Project View.</li>
+      <li><b>Tab styling</b> — Islands UI: underline, full accent bar, or none.
+          Classic UI: underline thickness from hairline to bold.</li>
+      <li><b>Plugin sync</b> — accent into CodeGlance Pro minimap and Indent
+          Rainbow guides (3 Ayu presets). More integrations in development.</li>
+      <li><b>Bracket scope</b> — a colored gutter stripe showing the full
+          scope when your cursor lands on a bracket.</li>
+      <li><b>Onboarding wizard</b> — a full-tab welcome on first install with
+          preset cards, theme variant picker, and accent swatches. After
+          upgrades, a <b>release showcase</b> tab opens automatically with
+          captioned screenshots of the marquee features; reopen anytime from
+          Tools → Ayu Islands.</li>
+      <li><b>Font presets</b> — 4 curated Nerd Fonts with one-click apply.
+          <b>Install, delete, or reinstall fonts</b> directly from Settings —
+          every filesystem change gets a consent dialog showing the exact
+          folder path.</li>
+    </ul>
 
     <p><b>Try everything free for 30 days.</b> No credit card.
     Install, explore, decide later.</p>


### PR DESCRIPTION
── Summary ─────────────────────────────────

On the live Marketplace "About" page the Premium section renders as a wall of text — the 10 stacked `<p><b>Name</b> — ...</p>` blocks collapse their inter-paragraph spacing under Marketplace's HTML renderer, so Glow / Accent control / Accent rotation / Per-project pins / … all run together with no visual break. Converts that stack to a single `<ul>` so the next release renders scannable bullets instead.

Not urgent — the currently-published v2.5.1 keeps the wall; fix ships with whatever 2.5.2 carries next.

── Changes ─────────────────────────────────

| Type | File                                                | Description                                                                                             |
|------|-----------------------------------------------------|---------------------------------------------------------------------------------------------------------|
| fix  | `src/main/resources/META-INF/plugin.xml:34-78`      | Premium block: 10 `<p>` → 1 `<ul>` with 10 `<li>`. Splits the merged per-project + per-language sentence into two separate bullets. "Try free for 30 days" stays as a standalone `<p>` footer. |
| chore | `gradle.properties:3`                              | Bump `pluginVersion` 2.5.1 → 2.5.2. Keeps `release_sync.last_published_version=2.5.1` guard silent (current != published) until `/release-plugin` runs and refreshes the hash. |

── Validation ──────────────────────────────

```bash
./scripts/verify-docs.py
# → docs/features.yml in sync with README + plugin.xml + CHANGELOG

./gradlew ktlintCheck detekt
# → green
```

Visual check: will be verified when v2.5.2 publishes to Marketplace and the "About" page refreshes. Structurally mirrors the existing "What sets it apart" `<ul>` block above Premium, which already renders correctly today.

── Notes ───────────────────────────────────

- No CHANGELOG.md / `<change-notes>` entry yet for 2.5.2 — this is a marketing-copy fix riding on whichever release ships next. Changelog gets written at release time.
- The `release_sync` guard in `verify-docs.py` is exactly the mechanism that would have caught this earlier: after v2.5.1 was published, any edit to `<description>` without a version bump fails lint. Bumping to 2.5.2 is the correct path out of that state.

## Summary by Sourcery

Render the Premium features section on the Marketplace About page as a bulleted list and bump the plugin version for the next release.

Bug Fixes:
- Fix collapsed spacing of Premium features on the Marketplace About page by converting the feature list into proper HTML bullets.

Build:
- Bump pluginVersion from 2.5.1 to 2.5.2 in gradle.properties to prepare the next plugin release.