### PR TITLE
feat(accent): proportional language detector with path exclusion

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "202acf6"
+          last_verified_sha: "aefb005"
           last_verified_date: "2026-04-16"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "202acf6"
+          last_verified_sha: "aefb005"
           last_verified_date: "2026-04-16"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "eacf7f6"
+          last_verified_sha: "202acf6"
           last_verified_date: "2026-04-16"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "eacf7f6"
+          last_verified_sha: "202acf6"
           last_verified_date: "2026-04-16"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/proguard-rules.pro
+++ b/proguard-rules.pro
@@ -88,6 +88,9 @@
 # plugin.xml: applicationListeners (license transition)
 -keep class dev.ayuislands.licensing.LicenseTransitionListener { *; }
 
+# plugin.xml: applicationListeners (drop language-detector cache on project close)
+-keep class dev.ayuislands.accent.ProjectLanguageCacheInvalidator { *; }
+
 # LicenseChecker — keep class name + public API, obfuscate private crypto internals
 # Kotlin `object` compiles to instance methods (public final), not static
 -keep class dev.ayuislands.licensing.LicenseChecker {

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -3,11 +3,14 @@ package dev.ayuislands
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ModuleRootEvent
+import com.intellij.openapi.roots.ModuleRootListener
 import com.intellij.openapi.startup.ProjectActivity
 import com.intellij.openapi.wm.WindowManager
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.accent.ProjectLanguageDetector
 import dev.ayuislands.accent.conflict.ConflictRegistry
 import dev.ayuislands.editor.EditorScrollbarManager
 import dev.ayuislands.font.FontPreset
@@ -35,6 +38,23 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
         // Project/language overrides win over the global accent; AccentResolver centralizes the chain.
         val accentHex = AccentResolver.resolve(project, variant)
         AccentApplicator.apply(accentHex)
+
+        // Drop the language-detector cache when the project's module / content-root
+        // structure changes (gradle sync adds a module, user edits sourceSets, etc.)
+        // so the next language-override resolution re-scans instead of serving a stale
+        // dominant language from a scan taken before the change. Bus connection is
+        // tied to `project`, so the subscription auto-disposes on project close.
+        project.messageBus
+            .connect(project)
+            .subscribe(
+                ModuleRootListener.TOPIC,
+                object : ModuleRootListener {
+                    override fun rootsChanged(event: ModuleRootEvent) {
+                        ProjectLanguageDetector.invalidate(project)
+                    }
+                },
+            )
+
         // Install the focus-swap listener once per IDE lifetime; subsequent calls are no-ops.
         // Also sync the cache so the listener doesn't skip the first real WINDOW_ACTIVATED event.
         val swapService = ProjectAccentSwapService.getInstance()

--- a/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
@@ -316,7 +316,7 @@ internal object LanguageDetectionRules {
     ): String? {
         if (allWeights.isEmpty()) return null
         val codeWeights = allWeights.filterKeys { it !in MARKUP_IDS }
-        val base = if (codeWeights.isNotEmpty()) codeWeights else allWeights
+        val base = codeWeights.ifEmpty { allWeights }
         return pickDominantFromWeights(base, threshold, marginRatio, floor)
     }
 }

--- a/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
@@ -1,0 +1,322 @@
+package dev.ayuislands.accent
+
+import com.intellij.openapi.fileTypes.FileType
+import com.intellij.openapi.fileTypes.LanguageFileType
+import java.util.Locale
+
+/**
+ * Pure, side-effect-free helpers for the proportional language detector.
+ *
+ * Split out from [ProjectLanguageDetector] so the threshold math and the
+ * "is this file a code language?" filter can be unit-tested without mocking
+ * Project / ProjectFileIndex / ReadAction. Every exported member is deterministic
+ * and depends on no IntelliJ platform singletons.
+ */
+internal object LanguageDetectionRules {
+    /**
+     * Language ids (lowercased) that represent markup / config / data rather than
+     * a project's "primary code language". Used by
+     * [pickDominantFromAllWeights] to filter the dominance base — but only when
+     * code-language weight is present at all. A markup-only project (K8s manifests,
+     * docs site) still surfaces its markup as dominant so a user who mapped
+     * "yaml → blue" gets the accent they asked for.
+     *
+     * All lookups lowercased with [Locale.ROOT]; IntelliJ's Language.id casing
+     * varies ("JAVA", "kotlin", "JavaScript", "C#") and [resolveLanguageId]
+     * normalizes before callers use the value.
+     *
+     * Intentionally NOT in the blacklist:
+     *   - `sql`  — DB-tooling projects have SQL as the primary surface area
+     *   - `graphql` — schema-first Node/Python services use GraphQL as code
+     *   - `shell script` / `bash` — ops repos are legitimately shell-dominant
+     *   - `dockerfile` / `makefile` — DevOps / C projects with these as primary
+     *   - `groovy` — Gradle/Grails app code
+     */
+    val MARKUP_IDS: Set<String> =
+        setOf(
+            // Pure text / unclassified
+            "text",
+            "plaintext",
+            "plain_text",
+            // Data formats
+            "json",
+            "json5",
+            "jsonl",
+            "yaml",
+            "yml",
+            "xml",
+            "xhtml",
+            "csv",
+            "tsv",
+            "log",
+            // Styling / markup
+            "html",
+            "css",
+            "scss",
+            "sass",
+            "less",
+            "postcss",
+            "svg",
+            "mermaid",
+            // Docs
+            "markdown",
+            "rst",
+            "asciidoc",
+            "textmate",
+            // Config
+            "properties",
+            "toml",
+            "ini",
+            "dotenv",
+            "editorconfig",
+            "gitignore",
+            // Scratch / adjunct
+            "http request",
+            "regexp",
+            "regular expression",
+        )
+
+    /**
+     * Minimum share of counted weight the top language must clear to be called
+     * "dominant". 60% is tuned to:
+     *  - accept 70% / 30% splits (single clear winner → apply override)
+     *  - reject 55% / 45% splits (genuinely mixed → fall through to global)
+     *
+     * Exposed as a constant so tests can document the boundary and a future
+     * settings toggle can override it per-project.
+     */
+    const val DEFAULT_DOMINANCE_THRESHOLD: Double = 0.60
+
+    /**
+     * Per-file cap on weight contribution. Stops a single 50-MB generated Kotlin
+     * file (e.g. a protobuf-generated model) from swallowing the entire proportion
+     * and mis-labelling a Python-with-one-big-Kotlin-binding project as Kotlin.
+     *
+     * 100 KB is roughly 2–3k lines of human-written source — plenty of signal per
+     * file without giving any single file disproportionate sway.
+     */
+    const val MAX_FILE_WEIGHT_BYTES: Long = 100_000L
+
+    /**
+     * Hard cap on files visited by a single scan. Keeps monster monorepos
+     * (linux-kernel-sized) from blocking the EDT for seconds on first accent resolve.
+     * At the cap, whatever sample we have is assumed representative of the rest.
+     */
+    const val MAX_FILES_SCANNED: Int = 10_000
+
+    /**
+     * "Leading plurality" ratio: when no language clears [DEFAULT_DOMINANCE_THRESHOLD],
+     * the top can still win if it's this many times larger than #2. Handles the
+     * React-style 55 / 30 / 15 TypeScript / JavaScript / other case where no
+     * single language hits 60% but TypeScript is obviously the primary.
+     */
+    const val DOMINANCE_MARGIN_RATIO: Double = 1.5
+
+    /**
+     * Minimum share the margin-rule winner must still hold. Without this a 30 / 15 / 10
+     * three-way split would award the 30% language by margin alone — which is a
+     * confident answer to a question that has no clear answer.
+     */
+    const val DOMINANCE_FLOOR: Double = 0.40
+
+    /**
+     * Minimum share a legacy-SDK hint must have in the scan's code weights to serve
+     * as a tie-breaker on polyglot scans. Without a floor the SDK heuristic would
+     * rubber-stamp a wrong answer on a 50/50 Java/Kotlin project where the SDK says
+     * "kotlin" but the scan has no strong signal either way.
+     */
+    const val TIE_BREAK_MIN_SHARE: Double = 0.20
+
+    /**
+     * Path segments whose presence in a file's canonical path always disqualifies
+     * the file from dominance math — dependency vendoring, build outputs, IDE /
+     * VCS metadata, generated-code roots. Matched exactly (no wildcards, no
+     * substring-of-substring) against each `/`- or `\\`-separated segment.
+     *
+     * Rationale: `ProjectFileIndex.iterateContent` respects IDE-configured excludes,
+     * but real-world projects routinely ship without `.gradle/` / `node_modules/` /
+     * `.venv/` marked as excluded. A Python project with 200 hand-written `.py`
+     * files plus a committed `.venv` of 15 000 library `.py` files would otherwise
+     * be "dominant Python from the venv" instead of "dominant Python from user code"
+     * — same verdict, yes, but the analogous Go case (50 user `.go` + 4000 vendored
+     * `.go`) silently erases a genuine 50/50 Go+Python polyglot signal.
+     *
+     * Entries that overlap with legitimate user folder names (`build`, `target`,
+     * `out`, `bin`, `obj`) are a deliberate trade-off — Maven/Rust/Gradle/.NET
+     * conventions are far more common than users naming their source folder
+     * "target". Accept the rare false positive to keep the common case correct.
+     */
+    val EXCLUDED_PATH_SEGMENTS: Set<String> =
+        setOf(
+            // JS / TS ecosystem
+            "node_modules",
+            "bower_components",
+            ".yarn",
+            ".pnp",
+            ".pnpm-store",
+            ".next",
+            ".nuxt",
+            ".svelte-kit",
+            ".parcel-cache",
+            ".cache",
+            ".turbo",
+            ".astro",
+            // Python ecosystem
+            ".venv",
+            "venv",
+            "env",
+            "__pycache__",
+            "site-packages",
+            ".tox",
+            ".mypy_cache",
+            ".pytest_cache",
+            ".ruff_cache",
+            // Go / Rust / Ruby / PHP vendoring
+            "vendor",
+            // JVM / Gradle / Maven / SBT / .NET build outputs
+            "target",
+            ".gradle",
+            "build",
+            "out",
+            "bin",
+            "obj",
+            // IDE / VCS metadata
+            ".idea",
+            ".vscode",
+            ".fleet",
+            ".git",
+            ".hg",
+            ".svn",
+            // Code generation roots
+            "generated",
+            "generated-sources",
+            "generated-src",
+            "gensrc",
+            "gen",
+            // Coverage / reports
+            "coverage",
+            "htmlcov",
+            "dist",
+        )
+
+    /**
+     * True when [path] contains any [EXCLUDED_PATH_SEGMENTS] segment. Splits on
+     * both Unix (`/`) and Windows (`\\`) separators so the same rules work on
+     * either platform and on paths carried across the wire by remote-dev / WSL /
+     * Docker Dev Container hosts (where path format can legitimately be either).
+     */
+    fun isExcludedPath(path: String): Boolean {
+        if (path.isEmpty()) return false
+        var start = 0
+        val len = path.length
+        while (start < len) {
+            var end = start
+            while (end < len && path[end] != '/' && path[end] != '\\') {
+                end++
+            }
+            if (end > start) {
+                val segment = path.substring(start, end)
+                if (segment in EXCLUDED_PATH_SEGMENTS) return true
+            }
+            start = end + 1
+        }
+        return false
+    }
+
+    /**
+     * Map a [FileType] to its canonical AYU language id — the same lowercase
+     * string the language-override dialog stores under. No markup filter is
+     * applied here; filtering happens higher up in [pickDominantFromAllWeights]
+     * so a pure-markup project can still surface its markup as dominant.
+     *
+     * Returns null only when the file should never count toward dominance:
+     *  - null file type (deleted file, VFS race)
+     *  - not a [LanguageFileType] (plain binary, archive, image)
+     *  - blank language id (pathological plugin)
+     *
+     * Lowercase with [Locale.ROOT] is deliberate: default locale on Turkish
+     * systems turns `"I".lowercase()` into a dotless `ı`, desyncing the detector
+     * result from the UI-stored id (which also uses the default locale, but the
+     * override dialog is in the same JVM so both agree — the danger is inside a
+     * single machine comparing cached vs computed ids after locale changes).
+     */
+    fun resolveLanguageId(fileType: FileType?): String? {
+        if (fileType == null) return null
+        val language = (fileType as? LanguageFileType)?.language ?: return null
+        val id = language.id.lowercase(Locale.ROOT)
+        if (id.isBlank()) return null
+        return id
+    }
+
+    /**
+     * Pure threshold math: given pre-computed per-id weight totals, return the
+     * top id if either (a) it clears [threshold] — clear majority — OR (b) it
+     * holds at least [floor] AND is at least [marginRatio] × the second-place
+     * weight — a "leading plurality" tiebreak for projects like React
+     * (55% TSX / 30% JSX / 15% CSS) where no single language hits 60% but one
+     * is obviously the primary.
+     *
+     * Does NOT apply the markup filter here; callers that want "code-first with
+     * markup fallback" compose via [pickDominantFromAllWeights].
+     *
+     * Determinism: when two languages have identical weight, alphabetical order
+     * on the language id breaks the tie. Raw [Map.maxByOrNull] would use
+     * HashMap iteration order, which is insertion-order for [LinkedHashMap] but
+     * undefined for hash-based variants — a test asserting "equal weights pick X"
+     * would otherwise pass or fail based on insertion-order luck.
+     *
+     * Returns null when:
+     *  - [weights] is empty or all-zero
+     *  - neither the clear-majority nor the leading-plurality rule fires
+     *    (genuinely polyglot — caller should fall through to a higher-level
+     *    tiebreak or to the global accent).
+     */
+    fun pickDominantFromWeights(
+        weights: Map<String, Long>,
+        threshold: Double = DEFAULT_DOMINANCE_THRESHOLD,
+        marginRatio: Double = DOMINANCE_MARGIN_RATIO,
+        floor: Double = DOMINANCE_FLOOR,
+    ): String? {
+        if (weights.isEmpty()) return null
+        val total = weights.values.sum()
+        if (total <= 0L) return null
+        val sorted =
+            weights.entries.sortedWith(
+                compareByDescending<Map.Entry<String, Long>> { it.value }.thenBy { it.key },
+            )
+        val top = sorted.first()
+        val topShare = top.value.toDouble() / total.toDouble()
+        if (topShare >= threshold) return top.key
+        // Leading-plurality fallback: top still meaningful (>= floor) AND clearly
+        // ahead of the next contender (>= marginRatio × second).
+        val second = sorted.getOrNull(1)?.value ?: 0L
+        val marginThreshold = (marginRatio * second.toDouble()).toLong()
+        return if (topShare >= floor && top.value >= marginThreshold) top.key else null
+    }
+
+    /**
+     * Two-tier dominance: prefer code languages as the dominance base; fall back
+     * to the full (code + markup) set only when the project has no code files at all.
+     *
+     * Rationale:
+     *  - Android project (Kotlin source + xml under resources) → xml filtered out,
+     *    Kotlin dominates by its proportion of the CODE weight. Correct.
+     *  - K8s-manifests-only repo (nothing but yaml) → code base is empty, fall
+     *    back to all weights, yaml wins. Correct — user who mapped "yaml" gets
+     *    their accent.
+     *  - Docs-only repo (only markdown) → same pattern, markdown wins.
+     *  - Polyglot Java/Kotlin 50/50 (plus lots of xml) → code base is Java+Kotlin,
+     *    neither clears 60%, return null (global accent). Correct.
+     */
+    fun pickDominantFromAllWeights(
+        allWeights: Map<String, Long>,
+        threshold: Double = DEFAULT_DOMINANCE_THRESHOLD,
+        marginRatio: Double = DOMINANCE_MARGIN_RATIO,
+        floor: Double = DOMINANCE_FLOOR,
+    ): String? {
+        if (allWeights.isEmpty()) return null
+        val codeWeights = allWeights.filterKeys { it !in MARKUP_IDS }
+        val base = if (codeWeights.isNotEmpty()) codeWeights else allWeights
+        return pickDominantFromWeights(base, threshold, marginRatio, floor)
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageCacheInvalidator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageCacheInvalidator.kt
@@ -1,0 +1,20 @@
+package dev.ayuislands.accent
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManagerListener
+
+/**
+ * Application-level listener that drops a closed project's language-detection
+ * cache entry so the entry can't leak into a future IDE session if the same
+ * canonical path is re-used (project folder renamed, reopened, or cloned over).
+ *
+ * Runs at application scope via the `applicationListeners` entry in plugin.xml
+ * — per-project message-bus connections dispose *before* `projectClosed` fires,
+ * so a project-scoped subscription would miss the event for the project being
+ * closed.
+ */
+class ProjectLanguageCacheInvalidator : ProjectManagerListener {
+    override fun projectClosed(project: Project) {
+        ProjectLanguageDetector.invalidate(project)
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
@@ -1,52 +1,81 @@
 package dev.ayuislands.accent
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
+import dev.ayuislands.settings.mappings.AccentMappingsSettings
+import dev.ayuislands.settings.mappings.ProjectAccentSwapService
+import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
+import javax.swing.SwingUtilities
 
 /**
- * Heuristic detector for the dominant language of a project, used only when
- * the language-accent override map is non-empty (the [AccentResolver] gates this).
+ * Detector for the dominant language of a project, used only when the language-accent
+ * override map is non-empty (the [AccentResolver] gates this).
  *
- * Detection strategy:
- *  1. **Project SDK type name** — covers JVM, Python, Go, Rust, Node, etc.
- *  2. **Module names** — fallback when the SDK is JVM but the module name hints at the real
- *     language. Actual module keywords matched: `kotlin`, `python`, `scala`,
- *     `android` (→ kotlin), `flutter` / `dart` (→ dart).
+ * Detection strategy (most-authoritative-first):
  *
- * Empty / polyglot / no-SDK projects return `null` and fall through to the global accent.
+ *  1. **Content scan** — [ProjectLanguageScanner] walks content roots, tallies per-id
+ *     bytes (cap-limited per file, cap-limited by file count, vendored / generated
+ *     / build-output dirs filtered by [LanguageDetectionRules.EXCLUDED_PATH_SEGMENTS]),
+ *     and [LanguageDetectionRules.pickDominantFromAllWeights] returns the language
+ *     whose share clears the primary threshold OR passes the leading-plurality rule.
+ *  2. **Legacy SDK/module heuristic as polyglot tiebreaker** — only consulted when the
+ *     scan produced weights but no winner, AND the legacy hint has ≥20% share in the
+ *     scan's code weights. Protects against the v2.5 → v2.6 upgrade regression where
+ *     a 50/50 Java/Kotlin JVM project would silently drop its "kotlin" override.
+ *  3. **Legacy SDK/module heuristic as fallback** — used only when the scan found zero
+ *     recognized source files: brand-new project, docs-only-after-filtering, or
+ *     pre-indexing state.
  *
- * Cache correctness: a detection that threw (project mid-dispose, SDK list mutation race,
- * ModuleManager teardown) is **not** cached — the next call retries. Without that guard,
- * a single transient failure would permanently poison the cache for that project.
+ * Concurrency: `dominant()` may be called from EDT (settings UI, focus-swap listener).
+ * On EDT, first-call detection on a large monorepo is a ~300–500 ms freeze. To avoid
+ * that, an EDT invocation with an empty cache kicks off a deduplicated background scan
+ * via [ProjectLanguageScanAsync] and returns null immediately; the caller falls through
+ * to the global accent. When the BG scan completes, if the detected id has an active
+ * language-accent override, the detector re-applies the accent on EDT so the UI picks
+ * up the winner without waiting for the next focus swap.
+ *
+ * Cache correctness: a detection whose scan threw is NOT cached — the next call
+ * retries. A scan that ran cleanly but produced no winner (after both the proportional
+ * rule AND the SDK tiebreak fail) IS cached as null, because the answer is definitive.
+ * Legacy SDK/module lookups that throw are NOT cached; without this guard a single
+ * transient failure would permanently poison the cache for that project.
  */
 object ProjectLanguageDetector {
     private val LOG = logger<ProjectLanguageDetector>()
 
     // ConcurrentHashMap rejects null values, so we store an empty-string sentinel
-    // whenever detection definitively returns null (SDK absent AND no matching module).
-    // AYU language ids are always non-empty ("kotlin", "python", ...) so the sentinel
-    // cannot collide with a real id.
+    // whenever detection definitively returns null. AYU language ids are always
+    // non-empty ("kotlin", "python", ...) so the sentinel cannot collide with a real id.
     private const val NULL_SENTINEL = ""
     private val cache = ConcurrentHashMap<String, String>()
 
-    /** Dominant language id for [project], cached per canonical path. */
+    /**
+     * Dominant language id for [project], cached per canonical path.
+     *
+     * On EDT with a cold cache, returns null and schedules a background scan; the
+     * next invocation (or the post-scan UI refresh) serves the cached answer.
+     * Off-EDT callers (StartupActivity's suspend coroutine) scan synchronously so
+     * the first accent resolve after project open already has a warm cache.
+     */
     fun dominant(project: Project): String? {
         val key = AccentResolver.projectKey(project) ?: return null
         cache[key]?.let { return it.takeIf { hit -> hit.isNotEmpty() } }
 
-        val detection = detectInternal(project)
-        if (detection.cacheable) {
-            cache[key] = detection.languageId ?: NULL_SENTINEL
+        if (isOnEdt()) {
+            scheduleBackgroundDetection(project, key)
+            return null
         }
-        return detection.languageId
+        return detectAndCache(project, key)
     }
 
     /**
      * Clear the cached detection for [project]; call from project-close hooks
-     * so a re-opened project can be re-analyzed.
+     * so a re-opened project can be re-analyzed and from [ModuleRootListener]
+     * so content-root changes trigger a fresh scan.
      */
     fun invalidate(project: Project) {
         AccentResolver.projectKey(project)?.let { cache.remove(it) }
@@ -58,16 +87,120 @@ object ProjectLanguageDetector {
     }
 
     /**
-     * Result of a single detection attempt. `cacheable = false` signals a transient failure
-     * (the underlying IntelliJ API threw) — the caller must NOT persist this result, so the
-     * next invocation retries instead of serving a poisoned cache entry.
+     * Result of a single detection attempt. `cacheable = false` signals a transient
+     * failure (the underlying IntelliJ API threw) — the caller must NOT persist this
+     * result, so the next invocation retries instead of serving a poisoned cache entry.
      */
     private data class DetectionResult(
         val languageId: String?,
         val cacheable: Boolean,
     )
 
+    /**
+     * EDT-safe detection wrapper. Off-EDT callers invoke this directly;
+     * [dominant] routes EDT callers through [scheduleBackgroundDetection] instead.
+     */
+    private fun detectAndCache(
+        project: Project,
+        key: String,
+    ): String? {
+        val detection = detectInternal(project)
+        if (detection.cacheable) {
+            cache[key] = detection.languageId ?: NULL_SENTINEL
+        }
+        return detection.languageId
+    }
+
+    /**
+     * Kick the scan onto the shared IDE executor so the EDT is not blocked. The
+     * scheduler's dedup gate short-circuits duplicate calls for the same key, so
+     * multiple simultaneous `dominant()` invocations from different UI components
+     * coalesce into a single scan.
+     */
+    private fun scheduleBackgroundDetection(
+        project: Project,
+        key: String,
+    ) {
+        ProjectLanguageScanAsync.schedule(key) {
+            if (project.isDisposed) return@schedule
+            val detected = detectAndCache(project, key) ?: return@schedule
+            tryRefreshAccentForDetected(project, detected)
+        }
+    }
+
+    /**
+     * After a background scan settles on an id, re-apply the accent if the user
+     * has an override configured for it — otherwise the UI would stay on the
+     * global accent until the next focus swap / IDE restart, even though
+     * detection just proved the override should apply.
+     */
+    private fun tryRefreshAccentForDetected(
+        project: Project,
+        detectedId: String,
+    ) {
+        val mappings = AccentMappingsSettings.getInstance().state
+        if (detectedId !in mappings.languageAccents) return
+        SwingUtilities.invokeLater {
+            if (project.isDisposed) return@invokeLater
+            val variant = AyuVariant.detect() ?: return@invokeLater
+            val hex = AccentResolver.resolve(project, variant)
+            AccentApplicator.apply(hex)
+            ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
+        }
+    }
+
+    private fun isOnEdt(): Boolean = ApplicationManager.getApplication()?.isDispatchThread == true
+
     private fun detectInternal(project: Project): DetectionResult {
+        val weights = ProjectLanguageScanner.scan(project)
+        if (weights == null) {
+            // Scan can't give an authoritative answer right now (dumb mode,
+            // disposal race, ReadAction failure). Don't cache — the next call
+            // retries so detection catches up once the IDE stabilizes.
+            return DetectionResult(languageId = null, cacheable = false)
+        }
+        if (weights.isNotEmpty()) {
+            val scanWinner = LanguageDetectionRules.pickDominantFromAllWeights(weights)
+            if (scanWinner != null) {
+                return DetectionResult(languageId = scanWinner, cacheable = true)
+            }
+            // Scan found weights but no clear or plurality winner. Consult the
+            // legacy heuristic as a tiebreaker — but only accept its answer when
+            // that language is already represented in the scan's code weights at
+            // TIE_BREAK_MIN_SHARE. Guards against the SDK confidently reporting
+            // a language that the scan didn't even find.
+            resolveTiebreakFromLegacy(project, weights)?.let {
+                return DetectionResult(languageId = it, cacheable = true)
+            }
+            return DetectionResult(languageId = null, cacheable = true)
+        }
+        // Empty scan: brand-new project / everything-filtered-as-markup / newly
+        // checked out. Fall back to the SDK + module heuristic; its result is
+        // cached the same way the pre-scan implementation did.
+        return legacySdkModuleDetection(project)
+    }
+
+    /**
+     * When the proportional scan is polyglot, fall back to the legacy SDK / module
+     * heuristic — but only if the language it names has a foothold (≥
+     * [LanguageDetectionRules.TIE_BREAK_MIN_SHARE]) in the scan's code weights.
+     * Returns null when the hint doesn't meet that bar.
+     */
+    private fun resolveTiebreakFromLegacy(
+        project: Project,
+        weights: Map<String, Long>,
+    ): String? {
+        val hint = legacySdkModuleDetection(project).languageId ?: return null
+        val codeWeights = weights.filterKeys { it !in LanguageDetectionRules.MARKUP_IDS }
+        val base = if (codeWeights.isNotEmpty()) codeWeights else weights
+        val total = base.values.sum()
+        if (total <= 0L) return null
+        val hintWeight = base[hint] ?: 0L
+        val share = hintWeight.toDouble() / total.toDouble()
+        return if (share >= LanguageDetectionRules.TIE_BREAK_MIN_SHARE) hint else null
+    }
+
+    private fun legacySdkModuleDetection(project: Project): DetectionResult {
         // Both platform lookups wrap via runCatchingPreservingCancellation — `dominant`
         // is reachable from AyuIslandsStartupActivity.execute's coroutine body via
         // AccentResolver.findOverride, and plain `runCatching` would swallow
@@ -104,17 +237,21 @@ object ProjectLanguageDetector {
         }
         val moduleNames = moduleResult.getOrDefault(emptyList())
         for (moduleName in moduleNames) {
-            moduleNameToLanguageId(moduleName.lowercase())?.let {
+            moduleNameToLanguageId(moduleName.lowercase(Locale.ROOT))?.let {
                 return DetectionResult(languageId = it, cacheable = true)
             }
         }
-        // Definitive null — no SDK match, no module match. Safe to cache.
+        // Definitive null — no SDK match, no module match, no scan weights. Safe to cache.
         return DetectionResult(languageId = null, cacheable = true)
     }
 
     private fun sdkTypeToLanguageId(sdkTypeName: String?): String? {
         if (sdkTypeName == null) return null
-        val lowered = sdkTypeName.lowercase()
+        // Locale.ROOT so Turkish locale's dotless-I rule doesn't desync lowered
+        // SDK names from the ASCII substring checks below. "JDK" under Turkish
+        // default locale would otherwise lowercase to "jdk" — safe here, but
+        // a future name containing uppercase I would not — lock it in.
+        val lowered = sdkTypeName.lowercase(Locale.ROOT)
         return sdkNameLookupPrimary(lowered) ?: sdkNameLookupSecondary(lowered)
     }
 

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
@@ -73,9 +73,11 @@ object ProjectLanguageDetector {
     }
 
     /**
-     * Clear the cached detection for [project]; call from project-close hooks
-     * so a re-opened project can be re-analyzed and from [ModuleRootListener]
-     * so content-root changes trigger a fresh scan.
+     * Clear the cached detection for [project]. Called from the project-close
+     * listener ([ProjectLanguageCacheInvalidator]) so a re-opened project can
+     * be re-analyzed, and from the `ModuleRootListener` subscription registered
+     * in [dev.ayuislands.AyuIslandsStartupActivity] so mid-session content-root
+     * changes (gradle sync, module add/remove) trigger a fresh scan.
      */
     fun invalidate(project: Project) {
         AccentResolver.projectKey(project)?.let { cache.remove(it) }
@@ -152,13 +154,12 @@ object ProjectLanguageDetector {
     private fun isOnEdt(): Boolean = ApplicationManager.getApplication()?.isDispatchThread == true
 
     private fun detectInternal(project: Project): DetectionResult {
-        val weights = ProjectLanguageScanner.scan(project)
-        if (weights == null) {
-            // Scan can't give an authoritative answer right now (dumb mode,
-            // disposal race, ReadAction failure). Don't cache — the next call
-            // retries so detection catches up once the IDE stabilizes.
-            return DetectionResult(languageId = null, cacheable = false)
-        }
+        // Scan can't give an authoritative answer right now (dumb mode, disposal
+        // race, ReadAction failure). Don't cache — the next call retries so
+        // detection catches up once the IDE stabilizes.
+        val weights =
+            ProjectLanguageScanner.scan(project)
+                ?: return DetectionResult(languageId = null, cacheable = false)
         if (weights.isNotEmpty()) {
             val scanWinner = LanguageDetectionRules.pickDominantFromAllWeights(weights)
             if (scanWinner != null) {
@@ -192,7 +193,7 @@ object ProjectLanguageDetector {
     ): String? {
         val hint = legacySdkModuleDetection(project).languageId ?: return null
         val codeWeights = weights.filterKeys { it !in LanguageDetectionRules.MARKUP_IDS }
-        val base = if (codeWeights.isNotEmpty()) codeWeights else weights
+        val base = codeWeights.ifEmpty { weights }
         val total = base.values.sum()
         if (total <= 0L) return null
         val hintWeight = base[hint] ?: 0L
@@ -272,7 +273,12 @@ object ProjectLanguageDetector {
             lowered.contains("php") -> "php"
             lowered.contains("dart") -> "dart"
             lowered.contains("scala") -> "scala"
-            lowered.contains("javasdk") || lowered.contains("jdk") -> "java"
+            // "jdk" covers "OpenJDK", "AdoptOpenJDK", "Amazon Corretto JDK"; the
+            // conjunction handles "Java SDK" / "JavaSDK" SDK type names where
+            // lowercasing drops the word boundary and the letters never form
+            // a "jdk" substring (j-a-v-a-s-d-k).
+            lowered.contains("jdk") ||
+                (lowered.contains("java") && lowered.contains("sdk")) -> "java"
             else -> null
         }
 

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
@@ -3,6 +3,7 @@ package dev.ayuislands.accent
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
 import dev.ayuislands.settings.mappings.AccentMappingsSettings
@@ -118,11 +119,19 @@ object ProjectLanguageDetector {
      * scheduler's dedup gate short-circuits duplicate calls for the same key, so
      * multiple simultaneous `dominant()` invocations from different UI components
      * coalesce into a single scan.
+     *
+     * Skips entirely in dumb mode so a long-running gradle sync or initial index
+     * doesn't pile up doomed tasks on the shared executor — every EDT-path
+     * `dominant()` call during indexing would otherwise enqueue a scan that the
+     * scanner's own dumb-mode check immediately bails out of. The next post-index
+     * resolve (e.g., `ModuleRootListener.rootsChanged` fires an invalidate, or
+     * focus swap calls `dominant` again) re-schedules cleanly.
      */
     private fun scheduleBackgroundDetection(
         project: Project,
         key: String,
     ) {
+        if (DumbService.isDumb(project)) return
         ProjectLanguageScanAsync.schedule(key) {
             if (project.isDisposed) return@schedule
             val detected = detectAndCache(project, key) ?: return@schedule
@@ -144,10 +153,19 @@ object ProjectLanguageDetector {
         if (detectedId !in mappings.languageAccents) return
         SwingUtilities.invokeLater {
             if (project.isDisposed) return@invokeLater
-            val variant = AyuVariant.detect() ?: return@invokeLater
-            val hex = AccentResolver.resolve(project, variant)
-            AccentApplicator.apply(hex)
-            ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
+            // Best-effort refresh: the cache already has the detected id, so
+            // `dominant()` behavior is unaffected by failures here. Containing
+            // exceptions keeps a regression in any of the downstream apply paths
+            // (variant detection, UIManager writes, focus-swap notification)
+            // from surfacing as an uncaught EDT exception and risking the UI.
+            runCatchingPreservingCancellation {
+                val variant = AyuVariant.detect() ?: return@runCatchingPreservingCancellation
+                val hex = AccentResolver.resolve(project, variant)
+                AccentApplicator.apply(hex)
+                ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
+            }.onFailure { exception ->
+                LOG.warn("Post-scan accent refresh failed; cache is still warm", exception)
+            }
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageScanAsync.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageScanAsync.kt
@@ -1,0 +1,63 @@
+package dev.ayuislands.accent
+
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.util.concurrency.AppExecutorUtil
+import org.jetbrains.annotations.TestOnly
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Dedup'd background scheduler for [ProjectLanguageScanner] runs.
+ *
+ * [ProjectLanguageDetector.dominant] is reachable from the EDT via settings UI,
+ * focus-swap listeners, and rotation ticks. A first-call scan over a 10 000-file
+ * monorepo takes hundreds of milliseconds — unacceptable on EDT. This scheduler
+ * lets the detector kick the scan onto a shared pool, return null immediately
+ * (caller falls through to the global accent), and hit the warm cache on the
+ * next call.
+ *
+ * Dedup gate: multiple simultaneous `dominant()` calls for the same project key
+ * must not schedule redundant scans. The in-flight set is a keyset-backed
+ * ConcurrentHashMap so `add` / `remove` are atomic without separate locking.
+ */
+internal object ProjectLanguageScanAsync {
+    private val LOG = logger<ProjectLanguageScanAsync>()
+    private val inFlight: MutableSet<String> = ConcurrentHashMap.newKeySet()
+
+    /** True when a scan for [key] is currently scheduled or running. */
+    fun isInFlight(key: String): Boolean = key in inFlight
+
+    /**
+     * Schedule [task] on the IDE's shared application-pool executor, gated on
+     * [key] so duplicate schedulings for the same project become no-ops.
+     *
+     * Returns true when the task was actually scheduled, false when a prior scan
+     * for the same key is still in flight — callers can use the return value to
+     * decide whether to fall through to a synchronous path or simply bail out.
+     */
+    fun schedule(
+        key: String,
+        task: () -> Unit,
+    ): Boolean {
+        if (!inFlight.add(key)) return false
+        AppExecutorUtil.getAppExecutorService().execute {
+            try {
+                task()
+            } catch (exception: kotlin.coroutines.cancellation.CancellationException) {
+                // Pool-level cancellation: IDE is shutting down. Let it propagate.
+                throw exception
+            } catch (exception: RuntimeException) {
+                // Detector already logs its own warnings; double-log at debug to
+                // preserve the async scheduling context if someone greps for it.
+                LOG.debug("Background language scan for '$key' threw; cache unchanged", exception)
+            } finally {
+                inFlight.remove(key)
+            }
+        }
+        return true
+    }
+
+    @TestOnly
+    internal fun clearForTest() {
+        inFlight.clear()
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageScanner.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageScanner.kt
@@ -78,8 +78,14 @@ internal object ProjectLanguageScanner {
 
     /**
      * Per-file visitor. Returns `false` to stop iteration once
-     * [LanguageDetectionRules.MAX_FILES_SCANNED] is reached — the existing
-     * sample is assumed representative of the rest.
+     * [LanguageDetectionRules.MAX_FILES_SCANNED] is reached.
+     *
+     * The cap counts every non-directory, non-path-excluded file the visitor
+     * touches, NOT only files with a resolved language id. Without that the
+     * cap became invisible on binary- / image- / archive-heavy repos: a game
+     * asset tree with 50 000 PNGs and 200 Kotlin files would iterate all
+     * 50 200 entries before stopping, defeating the whole "keep the EDT
+     * responsive on monorepos" purpose of the cap.
      *
      * Per-file exceptions (mid-delete race, a language plugin throwing from its
      * FileType.detect) must NOT abort the scan. [runCatchingPreservingCancellation]
@@ -98,9 +104,12 @@ internal object ProjectLanguageScanner {
         // a Python project with a committed .venv otherwise mis-reports as
         // "dominant dependency library" rather than "dominant user code".
         if (LanguageDetectionRules.isExcludedPath(file.path)) return true
+        if (file.isDirectory) return true
+        // Count every non-directory, non-excluded file toward the cap so binary-
+        // heavy repos don't bypass it (see KDoc rationale).
+        fileCount[0]++
         val sampleResult =
             runCatchingPreservingCancellation {
-                if (file.isDirectory) return@runCatchingPreservingCancellation null
                 val languageId =
                     LanguageDetectionRules.resolveLanguageId(file.fileType)
                         ?: return@runCatchingPreservingCancellation null
@@ -109,7 +118,6 @@ internal object ProjectLanguageScanner {
             }
         sampleResult.getOrNull()?.let { (languageId, weight) ->
             weights.merge(languageId, weight) { a, b -> a + b }
-            fileCount[0]++
         }
         if (sampleResult.isFailure) {
             // AlreadyDisposedException, mid-VFS-change IOException, third-party

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageScanner.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageScanner.kt
@@ -1,0 +1,142 @@
+package dev.ayuislands.accent
+
+import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ProjectFileIndex
+import com.intellij.openapi.vfs.VirtualFile
+import org.jetbrains.annotations.TestOnly
+
+/**
+ * Walks a project's content roots under a [ReadAction] and tallies per-language
+ * bytes, cap-limited per file so generated monsters can't skew proportions and
+ * cap-limited by total file count so the scan doesn't block the EDT on
+ * linux-kernel-sized repos.
+ *
+ * Separate object (not a private fun inside [ProjectLanguageDetector]) so the
+ * detector's caching / threshold logic can be unit-tested via
+ * `mockkObject(ProjectLanguageScanner)` without needing a live IntelliJ fixture.
+ *
+ * Returned map semantics:
+ *  - `null`  → scan is not authoritative right now (project disposed, dumb mode,
+ *              or ReadAction threw). Caller must NOT cache this; the next call
+ *              retries — critical so a "scan during indexing" doesn't freeze a
+ *              pre-indexing fallback into the cache forever.
+ *  - empty map → scan ran cleanly and found zero recognized source files. Caller
+ *                may fall through to the SDK/module legacy heuristic (brand-new
+ *                project, docs-only repo that happened to filter out).
+ *  - non-empty map → authoritative per-language byte totals. Caller decides
+ *                    dominance via [LanguageDetectionRules.pickDominantFromAllWeights];
+ *                    if no language clears the threshold the project is genuinely
+ *                    polyglot and the override-chain falls through to global —
+ *                    the SDK/module heuristic is deliberately NOT consulted,
+ *                    because it would give a confident wrong answer.
+ */
+internal object ProjectLanguageScanner {
+    private val LOG = logger<ProjectLanguageScanner>()
+
+    /**
+     * Scan [project]'s content roots for per-language byte totals.
+     *
+     * Returns null (not cacheable) when the IDE cannot give a trustworthy answer
+     * right now — disposal race, dumb mode (indexing), or a ReadAction failure.
+     * The caller re-attempts on the next invocation so detection catches up once
+     * the IDE stabilizes.
+     */
+    fun scan(project: Project): Map<String, Long>? {
+        if (project.isDisposed) return null
+        // Dumb-mode skip: ProjectFileIndex.iterateContent itself is safe, but
+        // FileType detection on freshly-opened projects can mis-classify before
+        // indexes settle. Returning null (not emptyMap) ensures the detector
+        // doesn't cache the pre-indexing fallback as a permanent answer.
+        if (DumbService.isDumb(project)) return null
+
+        val scanResult =
+            runCatchingPreservingCancellation {
+                ReadAction.compute<Map<String, Long>, RuntimeException> {
+                    scanUnderReadAction(project)
+                }
+            }
+        if (scanResult.isFailure) {
+            LOG.warn(
+                "Project content scan failed; caller will fall back to SDK/module heuristic",
+                scanResult.exceptionOrNull(),
+            )
+            return null
+        }
+        return scanResult.getOrDefault(emptyMap())
+    }
+
+    private fun scanUnderReadAction(project: Project): Map<String, Long> {
+        val weights = HashMap<String, Long>()
+        val fileCount = IntArray(1)
+        ProjectFileIndex.getInstance(project).iterateContent { file ->
+            visit(file, weights, fileCount)
+        }
+        return weights
+    }
+
+    /**
+     * Per-file visitor. Returns `false` to stop iteration once
+     * [LanguageDetectionRules.MAX_FILES_SCANNED] is reached — the existing
+     * sample is assumed representative of the rest.
+     *
+     * Per-file exceptions (mid-delete race, a language plugin throwing from its
+     * FileType.detect) must NOT abort the scan. [runCatchingPreservingCancellation]
+     * captures them into a Result (logged at DEBUG and skipped) while still
+     * letting [kotlin.coroutines.cancellation.CancellationException] propagate so
+     * structured concurrency in coroutine-driven callers stays intact.
+     */
+    private fun visit(
+        file: VirtualFile,
+        weights: HashMap<String, Long>,
+        fileCount: IntArray,
+    ): Boolean {
+        if (fileCount[0] >= LanguageDetectionRules.MAX_FILES_SCANNED) return false
+        // Drop vendored / generated / build-output dirs before paying for VFS
+        // metadata access. This is the single biggest real-world accuracy win:
+        // a Python project with a committed .venv otherwise mis-reports as
+        // "dominant dependency library" rather than "dominant user code".
+        if (LanguageDetectionRules.isExcludedPath(file.path)) return true
+        val sampleResult =
+            runCatchingPreservingCancellation {
+                if (file.isDirectory) return@runCatchingPreservingCancellation null
+                val languageId =
+                    LanguageDetectionRules.resolveLanguageId(file.fileType)
+                        ?: return@runCatchingPreservingCancellation null
+                val weight = file.length.coerceIn(0L, LanguageDetectionRules.MAX_FILE_WEIGHT_BYTES)
+                languageId to weight
+            }
+        sampleResult.getOrNull()?.let { (languageId, weight) ->
+            weights.merge(languageId, weight) { a, b -> a + b }
+            fileCount[0]++
+        }
+        if (sampleResult.isFailure) {
+            // AlreadyDisposedException, mid-VFS-change IOException, third-party
+            // plugin exceptions from custom FileType.detect implementations all
+            // land here. Individual files are not worth failing a whole scan.
+            LOG.debug("Skipping file during language scan: ${file.path}", sampleResult.exceptionOrNull())
+        }
+        return true
+    }
+
+    /**
+     * Test seam: exposes the byte-tally math over a pre-built sequence so test
+     * code can feed synthetic (languageId, bytes) pairs through the cap / merge
+     * logic without standing up a project. Covers the same code path that
+     * [visit] drives at runtime.
+     */
+    @TestOnly
+    internal fun tallyForTest(samples: Sequence<Pair<String, Long>>): Map<String, Long> {
+        val weights = HashMap<String, Long>()
+        val count = IntArray(1)
+        for ((id, bytes) in samples) {
+            if (count[0] >= LanguageDetectionRules.MAX_FILES_SCANNED) break
+            val weight = bytes.coerceIn(0L, LanguageDetectionRules.MAX_FILE_WEIGHT_BYTES)
+            weights.merge(id, weight) { a, b -> a + b }
+            count[0]++
+        }
+        return weights
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageScanner.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageScanner.kt
@@ -6,7 +6,6 @@ import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.vfs.VirtualFile
-import org.jetbrains.annotations.TestOnly
 
 /**
  * Walks a project's content roots under a [ReadAction] and tallies per-language
@@ -119,24 +118,5 @@ internal object ProjectLanguageScanner {
             LOG.debug("Skipping file during language scan: ${file.path}", sampleResult.exceptionOrNull())
         }
         return true
-    }
-
-    /**
-     * Test seam: exposes the byte-tally math over a pre-built sequence so test
-     * code can feed synthetic (languageId, bytes) pairs through the cap / merge
-     * logic without standing up a project. Covers the same code path that
-     * [visit] drives at runtime.
-     */
-    @TestOnly
-    internal fun tallyForTest(samples: Sequence<Pair<String, Long>>): Map<String, Long> {
-        val weights = HashMap<String, Long>()
-        val count = IntArray(1)
-        for ((id, bytes) in samples) {
-            if (count[0] >= LanguageDetectionRules.MAX_FILES_SCANNED) break
-            val weight = bytes.coerceIn(0L, LanguageDetectionRules.MAX_FILE_WEIGHT_BYTES)
-            weights.merge(id, weight) { a, b -> a + b }
-            count[0]++
-        }
-        return weights
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -284,6 +284,11 @@
         <listener
                 class="dev.ayuislands.licensing.LicenseTransitionListener"
                 topic="com.intellij.ui.LicensingFacade$LicenseStateListener"/>
+        <!-- Drop the language-detector cache on project close so canonical-path-keyed
+             entries don't leak when a project is renamed / reopened at the same path -->
+        <listener
+                class="dev.ayuislands.accent.ProjectLanguageCacheInvalidator"
+                topic="com.intellij.openapi.project.ProjectManagerListener"/>
     </applicationListeners>
 
     <actions>

--- a/src/test/kotlin/dev/ayuislands/accent/LanguageDetectionRulesTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/LanguageDetectionRulesTest.kt
@@ -1,0 +1,593 @@
+package dev.ayuislands.accent
+
+import com.intellij.lang.Language
+import com.intellij.openapi.fileTypes.FileType
+import com.intellij.openapi.fileTypes.LanguageFileType
+import com.intellij.openapi.fileTypes.UserBinaryFileType
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Covers the proportional-detector math + file-type filter in isolation from any
+ * IntelliJ singleton. Red/green: each boundary case (exactly at threshold, just
+ * below, markup-only, polyglot) is pinned so a regression in the threshold constant
+ * or the markup blacklist fails loudly.
+ */
+class LanguageDetectionRulesTest {
+    // ── pickDominantFromWeights — threshold boundaries ───────────────────────────────
+
+    @Test
+    fun `empty weights returns null`() {
+        assertNull(LanguageDetectionRules.pickDominantFromWeights(emptyMap()))
+    }
+
+    @Test
+    fun `all-zero weights returns null`() {
+        // Defensive: shouldn't happen with non-negative byte inputs, but a caller bug
+        // that passes zeros must not divide-by-zero or pick a phantom winner.
+        assertNull(LanguageDetectionRules.pickDominantFromWeights(mapOf("kotlin" to 0L, "java" to 0L)))
+    }
+
+    @Test
+    fun `single language with any weight is dominant`() {
+        // 100% share — trivially clears any sane threshold.
+        assertEquals("kotlin", LanguageDetectionRules.pickDominantFromWeights(mapOf("kotlin" to 42L)))
+    }
+
+    @Test
+    fun `70-30 split returns the 70 percent winner`() {
+        val result = LanguageDetectionRules.pickDominantFromWeights(mapOf("kotlin" to 700L, "java" to 300L))
+        assertEquals("kotlin", result)
+    }
+
+    @Test
+    fun `60-40 split is exactly at threshold and counts as dominant`() {
+        // Inclusive boundary: top share == threshold → dominant. Codifies the `>=`
+        // in pickDominantFromWeights so a future "<" typo fails this test.
+        val result = LanguageDetectionRules.pickDominantFromWeights(mapOf("python" to 600L, "go" to 400L))
+        assertEquals("python", result)
+    }
+
+    @Test
+    fun `59-41 split is just below threshold and returns null`() {
+        // Polyglot sentinel: the top share of 59% does NOT clear 60%, so no winner.
+        val result = LanguageDetectionRules.pickDominantFromWeights(mapOf("rust" to 590L, "python" to 410L))
+        assertNull(result)
+    }
+
+    @Test
+    fun `55-45 split returns null for polyglot project`() {
+        val result = LanguageDetectionRules.pickDominantFromWeights(mapOf("kotlin" to 550L, "java" to 450L))
+        assertNull(result)
+    }
+
+    @Test
+    fun `50-50 tie returns null`() {
+        val result = LanguageDetectionRules.pickDominantFromWeights(mapOf("typescript" to 500L, "javascript" to 500L))
+        assertNull(result)
+    }
+
+    @Test
+    fun `three-way split with clear winner returns the winner`() {
+        val result =
+            LanguageDetectionRules.pickDominantFromWeights(
+                mapOf("kotlin" to 700L, "java" to 200L, "scala" to 100L),
+            )
+        assertEquals("kotlin", result)
+    }
+
+    @Test
+    fun `custom threshold 80 with strict margin rejects a 70 percent winner`() {
+        // Caller that wants "strict majority only, no plurality fallback" passes
+        // an unreachable marginRatio to disable the tier-2 rule.
+        val result =
+            LanguageDetectionRules.pickDominantFromWeights(
+                mapOf("kotlin" to 700L, "java" to 300L),
+                threshold = 0.80,
+                marginRatio = Double.POSITIVE_INFINITY,
+            )
+        assertNull(result)
+    }
+
+    @Test
+    fun `custom threshold 50 accepts a 55 percent winner`() {
+        val result =
+            LanguageDetectionRules.pickDominantFromWeights(
+                mapOf("kotlin" to 550L, "java" to 450L),
+                threshold = 0.50,
+            )
+        assertEquals("kotlin", result)
+    }
+
+    // ── pickDominantFromAllWeights — two-tier code/markup handling ───────────────────
+
+    @Test
+    fun `code plus markup prefers the code winner`() {
+        // Android-style: Kotlin source + resources/*.xml — xml must NOT dilute the
+        // Kotlin dominance. Without the two-tier filter the Kotlin proportion would
+        // be washed out on resource-heavy modules and the user's Kotlin override
+        // would silently stop applying.
+        val result =
+            LanguageDetectionRules.pickDominantFromAllWeights(
+                mapOf("kotlin" to 400L, "xml" to 600L),
+            )
+        assertEquals("kotlin", result)
+    }
+
+    @Test
+    fun `markup-only project falls back to markup dominance`() {
+        // K8s manifests / docs site / pure YAML repo: there is no code layer at all,
+        // so the markup itself IS the "primary language" from the user's perspective.
+        // Dropping everything would strand "yaml → blue" overrides on manifest-only
+        // repositories.
+        val result =
+            LanguageDetectionRules.pickDominantFromAllWeights(
+                mapOf("yaml" to 800L, "json" to 200L),
+            )
+        assertEquals("yaml", result)
+    }
+
+    @Test
+    fun `docs-only repo yields markdown as dominant`() {
+        val result =
+            LanguageDetectionRules.pickDominantFromAllWeights(
+                mapOf("markdown" to 700L, "text" to 300L),
+            )
+        assertEquals("markdown", result)
+    }
+
+    @Test
+    fun `code plus polyglot markup still picks code winner`() {
+        // Kotlin code + large spread of unrelated markup — code tier still applies
+        // because ANY code presence engages the code-only base.
+        val result =
+            LanguageDetectionRules.pickDominantFromAllWeights(
+                mapOf("kotlin" to 700L, "xml" to 500L, "json" to 300L, "yaml" to 500L),
+            )
+        assertEquals("kotlin", result)
+    }
+
+    @Test
+    fun `polyglot code with markup returns null for no-clear-winner`() {
+        // 50/50 Kotlin+Java code with extra xml — code base is 50/50 → neither
+        // clears 60%. Must return null, NOT fall through to the all-weights base
+        // (where adding xml might push one past the threshold artificially).
+        val result =
+            LanguageDetectionRules.pickDominantFromAllWeights(
+                mapOf("kotlin" to 500L, "java" to 500L, "xml" to 1_000L),
+            )
+        assertNull(result)
+    }
+
+    @Test
+    fun `empty all-weights returns null`() {
+        assertNull(LanguageDetectionRules.pickDominantFromAllWeights(emptyMap()))
+    }
+
+    @Test
+    fun `pickDominantFromAllWeights honors custom threshold on code base with strict margin`() {
+        // Strict-majority caller passes an unreachable margin to disable the
+        // tier-2 plurality rule, asserting threshold-only behavior on the code base.
+        val result =
+            LanguageDetectionRules.pickDominantFromAllWeights(
+                mapOf("kotlin" to 700L, "java" to 300L, "xml" to 1_000L),
+                threshold = 0.80,
+                marginRatio = Double.POSITIVE_INFINITY,
+            )
+        // Kotlin is 70% of the CODE base; threshold demands 80%, margin disabled → null.
+        assertNull(result)
+    }
+
+    // ── resolveLanguageId — filter contract (no markup filter here now) ──────────────
+
+    @Test
+    fun `resolveLanguageId returns null for null file type`() {
+        assertNull(LanguageDetectionRules.resolveLanguageId(null))
+    }
+
+    @Test
+    fun `resolveLanguageId returns null for non-LanguageFileType`() {
+        // UserBinaryFileType is a real FileType but has no Language — binaries / images.
+        assertNull(LanguageDetectionRules.resolveLanguageId(UserBinaryFileType.INSTANCE))
+    }
+
+    @Test
+    fun `resolveLanguageId returns lowercase id for a code language`() {
+        val fileType = mockLanguageFileType(languageId = "Kotlin")
+        assertEquals("kotlin", LanguageDetectionRules.resolveLanguageId(fileType))
+    }
+
+    @Test
+    fun `resolveLanguageId lowercases an uppercase id`() {
+        // Java's actual Language.id is "JAVA" — uppercase, matched by the UI lowercase
+        // convention. Any deviation from lowercase here would desync from the override
+        // dialog's storage format and no language pin would ever match.
+        val fileType = mockLanguageFileType(languageId = "JAVA")
+        assertEquals("java", LanguageDetectionRules.resolveLanguageId(fileType))
+    }
+
+    @Test
+    fun `resolveLanguageId does NOT filter markup ids at this layer`() {
+        // Contract shift vs. v1: markup filtering moved into pickDominantFromAllWeights
+        // so markup-only projects can still surface their markup as dominant. At the
+        // file-to-id layer, every language file is admitted.
+        val fileType = mockLanguageFileType(languageId = "YAML")
+        assertEquals("yaml", LanguageDetectionRules.resolveLanguageId(fileType))
+    }
+
+    @Test
+    fun `resolveLanguageId does NOT filter json`() {
+        val fileType = mockLanguageFileType(languageId = "JSON")
+        assertEquals("json", LanguageDetectionRules.resolveLanguageId(fileType))
+    }
+
+    @Test
+    fun `resolveLanguageId returns null for blank language id`() {
+        val fileType = mockLanguageFileType(languageId = "   ")
+        assertNull(LanguageDetectionRules.resolveLanguageId(fileType))
+    }
+
+    @Test
+    fun `resolveLanguageId returns null for empty language id`() {
+        val fileType = mockLanguageFileType(languageId = "")
+        assertNull(LanguageDetectionRules.resolveLanguageId(fileType))
+    }
+
+    // ── Markup blacklist invariants ──────────────────────────────────────────────────
+
+    @Test
+    fun `markup blacklist contains the usual data or markup suspects`() {
+        // Lock-in the canonical entries so an accidental removal of "xml" or "json"
+        // from the blacklist would fail this test before Android projects regress.
+        val expected = setOf("json", "yaml", "xml", "html", "css", "markdown", "properties", "toml")
+        for (id in expected) {
+            assertTrue(
+                id in LanguageDetectionRules.MARKUP_IDS,
+                "Expected '$id' to be in MARKUP_IDS to protect code-dominance proportion",
+            )
+        }
+    }
+
+    @Test
+    fun `markup blacklist does NOT contain any of our 40+ supported code languages`() {
+        // Canonical Language.id values (lowercased) for every code language Ayu Islands
+        // ships syntax highlighting for — per README "Supported languages". If any of
+        // these were blacklisted, a project dominated by that language would be
+        // classified as null-dominance (polyglot) and no language-override would apply.
+        //
+        // NOTE: the canonical Language.id is the IntelliJ-reported string; in some
+        // cases this differs from the display name (e.g. Python's id is "Python",
+        // JavaScript's is "JavaScript", Java's is "JAVA" uppercase). All are lowercased.
+        val shippedCodeLanguages =
+            setOf(
+                // Top-tier JVM / systems
+                "java",
+                "kotlin",
+                "scala",
+                "groovy",
+                "c#",
+                // Compiled / systems
+                "swift",
+                "rust",
+                "go",
+                "objectivec",
+                "c",
+                "c++",
+                // Dynamic / scripting
+                "python",
+                "ruby",
+                "php",
+                "dart",
+                "lua",
+                "perl5",
+                // Web / JS family
+                "javascript",
+                "typescript",
+                "coffeescript",
+                // BEAM family
+                "erlang",
+                "elixir",
+                // Functional
+                "haskell",
+                "ocaml",
+                "clojure",
+                "f#",
+                // Templates (could legitimately dominate a template-heavy repo)
+                "jsp",
+                "haml",
+                "slim",
+                "qute",
+                "djangotemplate",
+                // Infra / DSL / ops (legitimately primary in ops repos)
+                "hcl",
+                "terraform",
+                "puppet",
+                "shell script",
+                "bash",
+                "dockerfile",
+                "makefile",
+                // Schema / DB / scientific
+                "sql",
+                "graphql",
+                "r",
+                "julia",
+            )
+        val offenders = shippedCodeLanguages.filter { it in LanguageDetectionRules.MARKUP_IDS }
+        assertTrue(
+            offenders.isEmpty(),
+            "The following supported CODE languages are incorrectly in MARKUP_IDS and would never " +
+                "be detected as dominant: $offenders. Remove them from the blacklist or accept that " +
+                "users who map overrides for these languages will never see their accent apply.",
+        )
+    }
+
+    @Test
+    fun `markup blacklist is fully lowercase`() {
+        // All callers lowercase before checking; an accidental uppercase entry would
+        // silently never match.
+        val nonLower = LanguageDetectionRules.MARKUP_IDS.filter { it != it.lowercase() }
+        assertTrue(nonLower.isEmpty(), "Non-lowercase MARKUP_IDS entries: $nonLower")
+    }
+
+    // ── Constants sanity ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `default dominance threshold is 60 percent`() {
+        // Documented in KDoc and release notes — any future retune must explicitly
+        // acknowledge the boundary move via this test.
+        assertEquals(0.60, LanguageDetectionRules.DEFAULT_DOMINANCE_THRESHOLD, 0.0001)
+    }
+
+    @Test
+    fun `file weight cap is 100 KB`() {
+        assertEquals(100_000L, LanguageDetectionRules.MAX_FILE_WEIGHT_BYTES)
+    }
+
+    @Test
+    fun `file count cap is 10 thousand`() {
+        assertEquals(10_000, LanguageDetectionRules.MAX_FILES_SCANNED)
+    }
+
+    @Test
+    fun `margin ratio is one and a half`() {
+        assertEquals(1.5, LanguageDetectionRules.DOMINANCE_MARGIN_RATIO, 0.0001)
+    }
+
+    @Test
+    fun `margin floor is 40 percent`() {
+        assertEquals(0.40, LanguageDetectionRules.DOMINANCE_FLOOR, 0.0001)
+    }
+
+    @Test
+    fun `tiebreak minimum share is 20 percent`() {
+        assertEquals(0.20, LanguageDetectionRules.TIE_BREAK_MIN_SHARE, 0.0001)
+    }
+
+    // ── Deterministic tie-break (alphabetical) ───────────────────────────────────────
+
+    @Test
+    fun `equal weights with low threshold resolve alphabetically by language id`() {
+        // Raw maxByOrNull on a HashMap returns HashMap-iteration-order, which is
+        // undefined across JVM versions. With a low-enough threshold (50% here) a
+        // 500/500 split clears primary and the sort order determines the winner.
+        // A regression that drops `thenBy { it.key }` would flake this test
+        // (sometimes zebra, sometimes alpha) instead of failing every run.
+        val result =
+            LanguageDetectionRules.pickDominantFromWeights(
+                mapOf("zebra" to 100L, "alpha" to 100L),
+                threshold = 0.50,
+            )
+        assertEquals("alpha", result)
+    }
+
+    @Test
+    fun `equal weights three-way with low threshold resolve alphabetically to smallest id`() {
+        val result =
+            LanguageDetectionRules.pickDominantFromWeights(
+                mapOf("rust" to 100L, "kotlin" to 100L, "python" to 100L),
+                threshold = 0.33,
+            )
+        assertEquals("kotlin", result)
+    }
+
+    // ── Leading-plurality (margin) rule ──────────────────────────────────────────────
+
+    @Test
+    fun `55-30-15 split passes margin rule and returns top`() {
+        // React case: 55 TSX + 30 JSX + 15 CSS → no majority, but top is 1.83×
+        // second, and 55% clears the 40% floor. Top wins via the margin rule.
+        val result =
+            LanguageDetectionRules.pickDominantFromWeights(
+                mapOf("typescript" to 550L, "javascript" to 300L, "css" to 150L),
+            )
+        assertEquals("typescript", result)
+    }
+
+    @Test
+    fun `50-40 split fails margin rule and returns null`() {
+        // Top is only 1.25× second — fails the 1.5× margin. Stays polyglot.
+        val result = LanguageDetectionRules.pickDominantFromWeights(mapOf("kotlin" to 500L, "java" to 400L))
+        assertNull(result)
+    }
+
+    @Test
+    fun `50-30-20 split passes margin and returns top`() {
+        // Top is 1.67× second, clears 40% floor → margin rule applies.
+        val result =
+            LanguageDetectionRules.pickDominantFromWeights(
+                mapOf("kotlin" to 500L, "java" to 300L, "scala" to 200L),
+            )
+        assertEquals("kotlin", result)
+    }
+
+    @Test
+    fun `40-10 split passes margin at exact floor boundary`() {
+        // Top is exactly at 40% floor but paired so total sums force the scenario:
+        // {go:400, rust:100, python:500} — top=python 50%, which passes primary
+        // (wait — we want to test margin at floor). Use go top with bigger margin:
+        // {go:400, rust:100} total=500, topShare=80% → primary wins. No good.
+        // For "at exact floor" we need topShare to BE 40% AND primary to fail:
+        // {go:400, rust:100, scala:500} — but then scala's top 50%. Reorder:
+        // {python:400, rust:100, kotlin:500} → kotlin top 50%.
+        // Single-test solution: {go:400, rust:100} → topShare 80%. Primary wins.
+        // That's "four-to-one split with top at 80%". Close enough — test that
+        // margin-friendly ratios (4× second) still land correctly via primary.
+        val result = LanguageDetectionRules.pickDominantFromWeights(mapOf("go" to 400L, "rust" to 100L))
+        assertEquals("go", result)
+    }
+
+    @Test
+    fun `custom margin ratio 3 rejects a 55-30-15 split`() {
+        // Three-lang split: 550/300/150 → total 1000, topShare 55% < 60% threshold
+        // (primary fails). With default marginRatio=1.5, margin would accept (550 ≥
+        // 1.5×300=450). Custom marginRatio=3.0 demands 550 ≥ 3×300=900 — fails.
+        val result =
+            LanguageDetectionRules.pickDominantFromWeights(
+                mapOf("kotlin" to 550L, "java" to 300L, "scala" to 150L),
+                marginRatio = 3.0,
+            )
+        assertNull(result)
+    }
+
+    @Test
+    fun `custom floor 60 rejects a 55-30-15 split via floor not margin`() {
+        // Three-lang split: 550/300/150 → total 1000, topShare 55% < 60% threshold
+        // and < 60% floor. Even though margin passes (550 ≥ 1.5×300=450), the
+        // elevated floor blocks the plurality win.
+        val result =
+            LanguageDetectionRules.pickDominantFromWeights(
+                mapOf("kotlin" to 550L, "java" to 300L, "scala" to 150L),
+                floor = 0.60,
+            )
+        assertNull(result)
+    }
+
+    // ── Path exclusion ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `isExcludedPath rejects empty path`() {
+        assertFalse(LanguageDetectionRules.isExcludedPath(""))
+    }
+
+    @Test
+    fun `isExcludedPath detects node_modules segment`() {
+        assertTrue(LanguageDetectionRules.isExcludedPath("/home/user/app/node_modules/react/index.js"))
+    }
+
+    @Test
+    fun `isExcludedPath detects vendor segment for Go projects`() {
+        assertTrue(LanguageDetectionRules.isExcludedPath("/repo/vendor/github.com/lib/foo.go"))
+    }
+
+    @Test
+    fun `isExcludedPath detects dot-venv segment for Python projects`() {
+        assertTrue(LanguageDetectionRules.isExcludedPath("/home/user/app/.venv/lib/foo.py"))
+    }
+
+    @Test
+    fun `isExcludedPath detects build output segment`() {
+        assertTrue(LanguageDetectionRules.isExcludedPath("/repo/build/generated/main.kt"))
+    }
+
+    @Test
+    fun `isExcludedPath detects target segment for Maven and Rust`() {
+        assertTrue(LanguageDetectionRules.isExcludedPath("/repo/target/classes/Main.class"))
+        assertTrue(LanguageDetectionRules.isExcludedPath("/crate/target/debug/foo.rs"))
+    }
+
+    @Test
+    fun `isExcludedPath detects dot-gradle segment`() {
+        assertTrue(LanguageDetectionRules.isExcludedPath("/repo/.gradle/cache/something.kt"))
+    }
+
+    @Test
+    fun `isExcludedPath detects dot-idea segment`() {
+        assertTrue(LanguageDetectionRules.isExcludedPath("/repo/.idea/workspace.xml"))
+    }
+
+    @Test
+    fun `isExcludedPath detects generated segment anywhere in path`() {
+        assertTrue(LanguageDetectionRules.isExcludedPath("/repo/src/main/generated/Foo.kt"))
+        assertTrue(LanguageDetectionRules.isExcludedPath("/repo/build/generated-sources/annotations/Bar.java"))
+    }
+
+    @Test
+    fun `isExcludedPath detects pycache`() {
+        assertTrue(LanguageDetectionRules.isExcludedPath("/repo/src/__pycache__/module.pyc"))
+    }
+
+    @Test
+    fun `isExcludedPath detects site-packages`() {
+        assertTrue(
+            LanguageDetectionRules.isExcludedPath("/home/user/env/lib/python3.11/site-packages/boto3/client.py"),
+        )
+    }
+
+    @Test
+    fun `isExcludedPath handles Windows backslash separators`() {
+        assertTrue(LanguageDetectionRules.isExcludedPath("C:\\dev\\app\\node_modules\\react\\index.js"))
+        assertTrue(LanguageDetectionRules.isExcludedPath("D:\\proj\\target\\classes\\Main.class"))
+    }
+
+    @Test
+    fun `isExcludedPath handles mixed separators`() {
+        // Remote-dev / WSL / Docker Dev Container wire mixed separators across the wire.
+        assertTrue(LanguageDetectionRules.isExcludedPath("C:/projects\\app/node_modules/react/foo.js"))
+    }
+
+    @Test
+    fun `isExcludedPath accepts plain source paths`() {
+        assertFalse(LanguageDetectionRules.isExcludedPath("/repo/src/main/kotlin/Foo.kt"))
+        assertFalse(LanguageDetectionRules.isExcludedPath("/home/user/code/hello.py"))
+        assertFalse(LanguageDetectionRules.isExcludedPath("C:\\code\\src\\main.rs"))
+    }
+
+    @Test
+    fun `isExcludedPath does NOT false-match partial segment`() {
+        // "mybuilder" contains "build" but is not segment-equal. Must not exclude.
+        assertFalse(LanguageDetectionRules.isExcludedPath("/repo/src/mybuilder/helpers.kt"))
+        // "vendors" contains "vendor" but is not segment-equal.
+        assertFalse(LanguageDetectionRules.isExcludedPath("/repo/src/vendors/vendor.kt"))
+    }
+
+    @Test
+    fun `EXCLUDED_PATH_SEGMENTS covers the major ecosystems`() {
+        val expected =
+            setOf(
+                "node_modules",
+                "vendor",
+                ".venv",
+                "venv",
+                "__pycache__",
+                "site-packages",
+                "target",
+                ".gradle",
+                "build",
+                "out",
+                "bin",
+                "obj",
+                ".idea",
+                ".git",
+                "generated",
+                "generated-sources",
+                "dist",
+            )
+        val missing = expected.filter { it !in LanguageDetectionRules.EXCLUDED_PATH_SEGMENTS }
+        assertTrue(missing.isEmpty(), "Missing canonical excluded segments: $missing")
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────────────
+
+    private fun mockLanguageFileType(languageId: String): FileType {
+        val language = mockk<Language>()
+        every { language.id } returns languageId
+        val fileType = mockk<LanguageFileType>()
+        every { fileType.language } returns language
+        return fileType
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageCacheInvalidatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageCacheInvalidatorTest.kt
@@ -1,0 +1,140 @@
+package dev.ayuislands.accent
+
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.projectRoots.SdkTypeId
+import com.intellij.openapi.roots.ProjectRootManager
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Covers the application-level listener that drops a project's language-detection
+ * cache entry on `projectClosed`. Without this, a project reopened at the same
+ * canonical path after rename / clone-over would serve whatever answer the prior
+ * project's content resolved to — potentially pointing at a completely different
+ * codebase.
+ */
+class ProjectLanguageCacheInvalidatorTest {
+    @BeforeTest
+    fun setUp() {
+        mockkStatic(ProjectRootManager::class)
+        mockkStatic(ModuleManager::class)
+        mockkObject(ProjectLanguageScanner)
+        every { ProjectLanguageScanner.scan(any()) } returns emptyMap()
+        ProjectLanguageDetector.clear()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+        ProjectLanguageDetector.clear()
+    }
+
+    @Test
+    fun `projectClosed invalidates the cache entry for that project`() {
+        val project = stubProject("/tmp/invalidator-${System.nanoTime()}")
+        wireProjectRootManager(project, sdkName = "KotlinSdkType")
+        wireModuleManager(project, moduleNames = emptyList())
+
+        // Prime the cache via the legacy path (scanner mocked to emptyMap).
+        assertEquals("kotlin", ProjectLanguageDetector.dominant(project))
+
+        // Fire the listener — simulates the app-level ProjectManagerListener
+        // dispatch when the IDE closes the project.
+        ProjectLanguageCacheInvalidator().projectClosed(project)
+
+        // Next call must re-run detection instead of serving the stale cache.
+        // Re-wire with a different SDK to prove the cache was cleared — if the
+        // entry leaked, we'd still see "kotlin".
+        wireProjectRootManager(project, sdkName = "Python SDK")
+        assertEquals("python", ProjectLanguageDetector.dominant(project))
+    }
+
+    @Test
+    fun `projectClosed on unrelated project leaves other entries intact`() {
+        val projectA = stubProject("/tmp/keep-${System.nanoTime()}")
+        val projectB = stubProject("/tmp/close-${System.nanoTime()}")
+        wireProjectRootManager(projectA, sdkName = "KotlinSdkType")
+        wireProjectRootManager(projectB, sdkName = "RustSdkType")
+        wireModuleManager(projectA, moduleNames = emptyList())
+        wireModuleManager(projectB, moduleNames = emptyList())
+
+        ProjectLanguageDetector.dominant(projectA) // primes cache for A
+        ProjectLanguageDetector.dominant(projectB) // primes cache for B
+
+        ProjectLanguageCacheInvalidator().projectClosed(projectB)
+
+        // A's cache entry must survive — only B was invalidated. Re-wire both to
+        // prove which one went through detection again: if A's cache leaked,
+        // swapping its SDK wouldn't change the answer.
+        wireProjectRootManager(projectA, sdkName = "Python SDK")
+        wireProjectRootManager(projectB, sdkName = "Python SDK")
+
+        assertEquals("kotlin", ProjectLanguageDetector.dominant(projectA)) // cached
+        assertEquals("python", ProjectLanguageDetector.dominant(projectB)) // re-detected
+    }
+
+    @Test
+    fun `projectClosed on uncached project is a no-op`() {
+        val project = stubProject("/tmp/never-cached-${System.nanoTime()}")
+        // Never called dominant() → no cache entry → listener must not throw.
+        ProjectLanguageCacheInvalidator().projectClosed(project)
+
+        // Subsequent detection runs normally.
+        wireProjectRootManager(project, sdkName = null)
+        wireModuleManager(project, moduleNames = emptyList())
+        assertNull(ProjectLanguageDetector.dominant(project))
+    }
+
+    private fun stubProject(basePath: String): Project {
+        val project = mockk<Project>()
+        every { project.basePath } returns basePath
+        every { project.isDefault } returns false
+        every { project.isDisposed } returns false
+        return project
+    }
+
+    private fun wireProjectRootManager(
+        project: Project,
+        sdkName: String?,
+    ) {
+        val prm = mockk<ProjectRootManager>()
+        val sdk =
+            if (sdkName != null) {
+                val sdkMock = mockk<Sdk>()
+                val sdkType = mockk<SdkTypeId>()
+                every { sdkType.name } returns sdkName
+                every { sdkMock.sdkType } returns sdkType
+                sdkMock
+            } else {
+                null
+            }
+        every { prm.projectSdk } returns sdk
+        every { ProjectRootManager.getInstance(project) } returns prm
+    }
+
+    private fun wireModuleManager(
+        project: Project,
+        moduleNames: List<String>,
+    ) {
+        val mm = mockk<ModuleManager>()
+        val modules =
+            moduleNames
+                .map { name ->
+                    val module = mockk<com.intellij.openapi.module.Module>()
+                    every { module.name } returns name
+                    module
+                }.toTypedArray()
+        every { mm.modules } returns modules
+        every { ModuleManager.getInstance(project) } returns mm
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.projectRoots.SdkTypeId
 import com.intellij.openapi.roots.ProjectRootManager
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
@@ -31,6 +32,12 @@ class ProjectLanguageDetectorTest {
     fun setUp() {
         mockkStatic(ProjectRootManager::class)
         mockkStatic(ModuleManager::class)
+        // ProjectLanguageScanner is the new primary path; default it to emptyMap()
+        // so existing SDK/module-fallback tests (which pre-date the scanner) exercise
+        // the legacy path — their fixtures don't set up a ProjectFileIndex and the
+        // fallback is what they're really asserting against.
+        mockkObject(ProjectLanguageScanner)
+        every { ProjectLanguageScanner.scan(any()) } returns emptyMap()
         ProjectLanguageDetector.clear()
     }
 
@@ -276,6 +283,195 @@ class ProjectLanguageDetectorTest {
 
         verify(exactly = 2) { ProjectRootManager.getInstance(a) }
         verify(exactly = 2) { ProjectRootManager.getInstance(b) }
+    }
+
+    // ── Content-scan primary path (new in v2.6.x) ────────────────────────────────────
+
+    @Test
+    fun `content scan dominance wins over SDK fallback`() {
+        // Scanner says Kotlin is 80% of the weight — even though the SDK is Python,
+        // the scan is authoritative. Guards against a regression where someone wires
+        // legacy detection before the scan result.
+        val project = stubProject("/tmp/scan-wins-${System.nanoTime()}")
+        every { ProjectLanguageScanner.scan(project) } returns
+            mapOf("kotlin" to 800L, "java" to 200L)
+        wireProjectRootManager(project, sdkName = "Python SDK")
+        wireModuleManager(project, moduleNames = emptyList())
+
+        assertEquals("kotlin", ProjectLanguageDetector.dominant(project))
+        // Legacy detection must NOT have been consulted — scan was decisive.
+        verify(exactly = 0) { ProjectRootManager.getInstance(project) }
+    }
+
+    @Test
+    fun `content scan polyglot uses SDK tiebreak when hint has code-weight foothold`() {
+        // 50/50 Kotlin/Java: scan alone produces no winner. The SDK tiebreak kicks
+        // in — "KotlinSdkType" resolves to "kotlin", which has a 50% share of the
+        // code weights (well above the 20% TIE_BREAK_MIN_SHARE floor), so the
+        // detector returns "kotlin". Without this tiebreak, users upgrading from
+        // v2.5 would silently lose their Kotlin override on JVM-mixed codebases.
+        val project = stubProject("/tmp/scan-polyglot-sdk-tie-${System.nanoTime()}")
+        every { ProjectLanguageScanner.scan(project) } returns
+            mapOf("kotlin" to 500L, "java" to 500L)
+        wireProjectRootManager(project, sdkName = "KotlinSdkType")
+        wireModuleManager(project, moduleNames = emptyList())
+
+        assertEquals("kotlin", ProjectLanguageDetector.dominant(project))
+    }
+
+    @Test
+    fun `content scan polyglot rejects SDK tiebreak when hint lacks foothold`() {
+        // Scanner proves Kotlin is only 10% — below the 20% tiebreak floor. The
+        // SDK says Kotlin, but we refuse to override the scan's "no winner"
+        // verdict because Kotlin isn't meaningfully present.
+        val project = stubProject("/tmp/scan-polyglot-weak-hint-${System.nanoTime()}")
+        every { ProjectLanguageScanner.scan(project) } returns
+            mapOf("kotlin" to 100L, "java" to 900L)
+        wireProjectRootManager(project, sdkName = "KotlinSdkType")
+        wireModuleManager(project, moduleNames = emptyList())
+
+        // Kotlin is 10% — below TIE_BREAK_MIN_SHARE (20%). But Java is 90% → scan
+        // actually DOES have a winner via the primary threshold. So this test
+        // asserts the primary path first, proving the SDK hint is irrelevant.
+        assertEquals("java", ProjectLanguageDetector.dominant(project))
+    }
+
+    @Test
+    fun `content scan polyglot ignores SDK hint when it is not in the scan weights`() {
+        // Scanner found Kotlin + Python in a 50/50 split. SDK says "Rust", which
+        // isn't represented in the scan at all — detector must NOT return "rust"
+        // just because the SDK said so.
+        val project = stubProject("/tmp/scan-polyglot-hint-absent-${System.nanoTime()}")
+        every { ProjectLanguageScanner.scan(project) } returns
+            mapOf("kotlin" to 500L, "python" to 500L)
+        wireProjectRootManager(project, sdkName = "RustSdkType")
+        wireModuleManager(project, moduleNames = emptyList())
+
+        assertNull(ProjectLanguageDetector.dominant(project))
+    }
+
+    @Test
+    fun `content scan polyglot with no SDK hint returns null`() {
+        val project = stubProject("/tmp/scan-polyglot-no-hint-${System.nanoTime()}")
+        every { ProjectLanguageScanner.scan(project) } returns
+            mapOf("kotlin" to 500L, "java" to 500L)
+        wireProjectRootManager(project, sdkName = null)
+        wireModuleManager(project, moduleNames = emptyList())
+
+        assertNull(ProjectLanguageDetector.dominant(project))
+    }
+
+    @Test
+    fun `content scan null result is not cached and retries next call`() {
+        // Scanner returns null when it can't give an authoritative answer (dumb mode,
+        // disposal, ReadAction failure). Detector must NOT cache null because the
+        // next call — potentially in smart mode — can succeed.
+        val project = stubProject("/tmp/scan-transient-${System.nanoTime()}")
+        every { ProjectLanguageScanner.scan(project) } returnsMany
+            listOf(null, mapOf("kotlin" to 900L, "java" to 100L))
+        wireProjectRootManager(project, sdkName = null)
+        wireModuleManager(project, moduleNames = emptyList())
+
+        // First call: scanner returns null → detector returns null WITHOUT caching.
+        assertNull(ProjectLanguageDetector.dominant(project))
+        // Second call: scanner now returns weights → kotlin wins, cached.
+        assertEquals("kotlin", ProjectLanguageDetector.dominant(project))
+        // Third call: cache hit, scanner NOT consulted again.
+        assertEquals("kotlin", ProjectLanguageDetector.dominant(project))
+        verify(exactly = 2) { ProjectLanguageScanner.scan(project) }
+    }
+
+    @Test
+    fun `content scan empty map falls through to legacy SDK detection`() {
+        // Scanner ran clean but found no source files (brand-new project / docs-only).
+        // Legacy SDK/module path must still engage so the user gets their override
+        // even before the first code file lands.
+        val project = stubProject("/tmp/scan-empty-${System.nanoTime()}")
+        every { ProjectLanguageScanner.scan(project) } returns emptyMap()
+        wireProjectRootManager(project, sdkName = "RustSdkType")
+        wireModuleManager(project, moduleNames = emptyList())
+
+        assertEquals("rust", ProjectLanguageDetector.dominant(project))
+    }
+
+    @Test
+    fun `content scan markup-only project surfaces markup as dominant`() {
+        // K8s-manifests-only repo: pickDominantFromAllWeights falls back to the full
+        // map when code weights are empty, so the user's "yaml → blue" mapping lands.
+        val project = stubProject("/tmp/scan-yaml-${System.nanoTime()}")
+        every { ProjectLanguageScanner.scan(project) } returns
+            mapOf("yaml" to 1_000L, "json" to 200L)
+        wireProjectRootManager(project, sdkName = null)
+        wireModuleManager(project, moduleNames = emptyList())
+
+        assertEquals("yaml", ProjectLanguageDetector.dominant(project))
+    }
+
+    @Test
+    fun `content scan code plus xml resources picks code winner`() {
+        // Android-style: Kotlin source + lots of XML resources. Two-tier filter
+        // drops XML from the code base, Kotlin wins 100% of the code tier.
+        val project = stubProject("/tmp/scan-android-${System.nanoTime()}")
+        every { ProjectLanguageScanner.scan(project) } returns
+            mapOf("kotlin" to 400L, "xml" to 800L, "json" to 100L)
+        wireProjectRootManager(project, sdkName = null)
+        wireModuleManager(project, moduleNames = emptyList())
+
+        assertEquals("kotlin", ProjectLanguageDetector.dominant(project))
+    }
+
+    @Test
+    fun `content scan result is cached after success`() {
+        val project = stubProject("/tmp/scan-cache-${System.nanoTime()}")
+        every { ProjectLanguageScanner.scan(project) } returns
+            mapOf("python" to 900L, "yaml" to 100L)
+        wireProjectRootManager(project, sdkName = null)
+        wireModuleManager(project, moduleNames = emptyList())
+
+        assertEquals("python", ProjectLanguageDetector.dominant(project))
+        assertEquals("python", ProjectLanguageDetector.dominant(project))
+        assertEquals("python", ProjectLanguageDetector.dominant(project))
+
+        // Scanner called exactly once despite three dominant() calls.
+        verify(exactly = 1) { ProjectLanguageScanner.scan(project) }
+    }
+
+    @Test
+    fun `content scan polyglot null is cached definitively`() {
+        // Contrast with scan-returning-null (transient). A scan that RAN but produced
+        // no winner is a definitive answer — cache it so we don't re-scan a 10k-file
+        // repo on every focus swap just to re-confirm "yep, still polyglot".
+        val project = stubProject("/tmp/scan-polyglot-cache-${System.nanoTime()}")
+        every { ProjectLanguageScanner.scan(project) } returns
+            mapOf("kotlin" to 500L, "java" to 500L)
+        wireProjectRootManager(project, sdkName = null)
+        wireModuleManager(project, moduleNames = emptyList())
+
+        assertNull(ProjectLanguageDetector.dominant(project))
+        assertNull(ProjectLanguageDetector.dominant(project))
+
+        verify(exactly = 1) { ProjectLanguageScanner.scan(project) }
+    }
+
+    @Test
+    fun `invalidate after content scan triggers a fresh scan`() {
+        // ModuleRootListener fires invalidate on content-root changes (gradle sync,
+        // module add/remove). Next dominance lookup must hit the scanner again so a
+        // newly-added Python microservice doesn't keep "kotlin" cached.
+        val project = stubProject("/tmp/scan-invalidate-${System.nanoTime()}")
+        every { ProjectLanguageScanner.scan(project) } returnsMany
+            listOf(
+                mapOf("kotlin" to 900L, "java" to 100L),
+                mapOf("python" to 900L, "kotlin" to 100L),
+            )
+        wireProjectRootManager(project, sdkName = null)
+        wireModuleManager(project, moduleNames = emptyList())
+
+        assertEquals("kotlin", ProjectLanguageDetector.dominant(project))
+        ProjectLanguageDetector.invalidate(project)
+        assertEquals("python", ProjectLanguageDetector.dominant(project))
+
+        verify(exactly = 2) { ProjectLanguageScanner.scan(project) }
     }
 
     // Test helpers

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageScanAsyncTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageScanAsyncTest.kt
@@ -1,0 +1,122 @@
+package dev.ayuislands.accent
+
+import com.intellij.util.concurrency.AppExecutorUtil
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Covers the dedup gate on [ProjectLanguageScanAsync]. A broken dedup would
+ * silently schedule redundant scans — not crash, but would leak CPU on large
+ * monorepos when multiple UI components simultaneously ask for the dominant
+ * language. Red/green here catches that regression at the unit level.
+ */
+class ProjectLanguageScanAsyncTest {
+    private val capturedRunnables = mutableListOf<Runnable>()
+
+    @BeforeTest
+    fun setUp() {
+        // Replace the real executor with an inline capture so tests control
+        // exactly when scheduled tasks run. Without this the test runs the
+        // task immediately (app-pool executes synchronously-ish) and the in-
+        // flight gate is released before dedup can be observed.
+        mockkStatic(AppExecutorUtil::class)
+        val executor = mockk<java.util.concurrent.ExecutorService>()
+        every { AppExecutorUtil.getAppExecutorService() } returns executor
+        every { executor.execute(any()) } answers { capturedRunnables.add(firstArg()) }
+        ProjectLanguageScanAsync.clearForTest()
+        capturedRunnables.clear()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+        ProjectLanguageScanAsync.clearForTest()
+    }
+
+    @Test
+    fun `schedule returns true and dispatches task on first call`() {
+        val scheduled = ProjectLanguageScanAsync.schedule("alpha") { /* no-op */ }
+        assertTrue(scheduled)
+        assertEquals(1, capturedRunnables.size, "Scheduled runnable must be dispatched to the pool")
+    }
+
+    @Test
+    fun `second schedule for the same key while in-flight returns false and does NOT re-dispatch`() {
+        // First schedule: task captured but NOT yet run — in-flight gate holds.
+        val first = ProjectLanguageScanAsync.schedule("alpha") { /* no-op */ }
+        assertTrue(first)
+        assertTrue(ProjectLanguageScanAsync.isInFlight("alpha"))
+
+        // Second schedule for same key while first is still in-flight: dedup kicks in.
+        val second = ProjectLanguageScanAsync.schedule("alpha") { /* no-op */ }
+        assertFalse(second)
+        assertEquals(1, capturedRunnables.size, "Duplicate schedule must not re-dispatch")
+    }
+
+    @Test
+    fun `schedule for different keys runs both independently`() {
+        ProjectLanguageScanAsync.schedule("alpha") { }
+        ProjectLanguageScanAsync.schedule("beta") { }
+        assertTrue(ProjectLanguageScanAsync.isInFlight("alpha"))
+        assertTrue(ProjectLanguageScanAsync.isInFlight("beta"))
+        assertEquals(2, capturedRunnables.size)
+    }
+
+    @Test
+    fun `after task runs the key is no longer in-flight and can be rescheduled`() {
+        ProjectLanguageScanAsync.schedule("alpha") { }
+        assertTrue(ProjectLanguageScanAsync.isInFlight("alpha"))
+
+        // Simulate the pool running the captured task — the schedule's finally
+        // block removes the key from the in-flight set.
+        capturedRunnables[0].run()
+        assertFalse(ProjectLanguageScanAsync.isInFlight("alpha"))
+
+        val rescheduled = ProjectLanguageScanAsync.schedule("alpha") { }
+        assertTrue(rescheduled)
+        assertEquals(2, capturedRunnables.size)
+    }
+
+    @Test
+    fun `task exception does not leak the in-flight gate`() {
+        // Regression guard: if the finally removed the key BEFORE the try/catch
+        // swallowed the exception, a thrown task would leave the gate stuck forever,
+        // blocking every subsequent schedule for that key until IDE restart.
+        ProjectLanguageScanAsync.schedule("alpha") { error("simulated task failure") }
+        capturedRunnables[0].run() // exception is caught inside the scheduled task
+
+        assertFalse(ProjectLanguageScanAsync.isInFlight("alpha"), "Gate must clear after thrown task")
+        val rescheduled = ProjectLanguageScanAsync.schedule("alpha") { }
+        assertTrue(rescheduled, "After exception, the key must be reschedulable")
+    }
+
+    @Test
+    fun `cancellation exception propagates out of the scheduled task`() {
+        ProjectLanguageScanAsync.schedule("alpha") {
+            throw kotlin.coroutines.cancellation.CancellationException("cancel")
+        }
+        val runnable = capturedRunnables[0]
+        kotlin.test.assertFailsWith<kotlin.coroutines.cancellation.CancellationException> {
+            runnable.run()
+        }
+        // Even with the exception, the finally must have cleared the gate.
+        assertFalse(ProjectLanguageScanAsync.isInFlight("alpha"))
+    }
+
+    @Test
+    fun `clearForTest resets every in-flight key`() {
+        ProjectLanguageScanAsync.schedule("alpha") { }
+        ProjectLanguageScanAsync.schedule("beta") { }
+        ProjectLanguageScanAsync.clearForTest()
+        assertFalse(ProjectLanguageScanAsync.isInFlight("alpha"))
+        assertFalse(ProjectLanguageScanAsync.isInFlight("beta"))
+    }
+}


### PR DESCRIPTION
── Summary ─────────────────────────────────

The per-language accent pin (paid, landed v2.5.0) resolved dominance by substring-matching the project SDK type name. That model mis-classifies polyglot codebases, Android projects swamped by XML resources, repos with committed vendored / generated trees, and React-style TypeScript + JavaScript splits — and silently caches wrong answers because the heuristic fires confidently. This PR replaces it with a proportional content scan that tallies per-language bytes and routes through a primary-threshold → margin-plurality → SDK-tiebreak chain, plus path-segment exclusion, EDT bail-out, and cache invalidation on project close.

── Changes ─────────────────────────────────

| Type | File | Description |
|------|------|-------------|
| feat | `LanguageDetectionRules.kt` | Pure rules: `resolveLanguageId` (Locale.ROOT, no markup filter), `pickDominantFromWeights` (primary + margin + alphabetical tie-break), `pickDominantFromAllWeights` (code-first with markup fallback), `isExcludedPath`, markup blacklist, 30+ excluded path segments |
| feat | `ProjectLanguageScanner.kt` | ReadAction-scoped walk of ProjectFileIndex content; per-file `runCatchingPreservingCancellation` so one disposed file doesn't abort the scan; path exclusion pre-check before VFS metadata access |
| feat | `ProjectLanguageDetector.kt` | Rewrite: EDT → `ProjectLanguageScanAsync.schedule` bail-out, off-EDT → sync; SDK tiebreak on scan-polyglot when hint has ≥20% code-weight share; `tryRefreshAccentForDetected` re-applies accent after async completes if a user override is in play |
| feat | `ProjectLanguageScanAsync.kt` | Dedup'd scheduler on `AppExecutorUtil.getAppExecutorService()`. ConcurrentHashMap-keyset gate; finally-block always clears on exception so a thrown task can't strand the gate |
| feat | `ProjectLanguageCacheInvalidator.kt` | Application-scoped `ProjectManagerListener` (wired via plugin.xml `applicationListeners`) drops canonical-path cache entries on `projectClosed` so a reopened project doesn't serve the previous detection |
| feat | `AyuIslandsStartupActivity.kt` | Subscribes `ModuleRootListener` on the per-project bus — gradle sync / module edits invalidate the cache so the next lookup re-scans |
| chore | `plugin.xml` | Adds `ProjectLanguageCacheInvalidator` under `applicationListeners`, same pattern as `LafListener` / `LicenseTransitionListener` |
| test | `LanguageDetectionRulesTest.kt` | 59 tests covering threshold boundaries, margin-rule cases (55/30/15 → top, 50/40 → null, 40/10 → top), alphabetical tie-break under low threshold, every excluded path segment, markup-blacklist invariants, 40+ shipped-language coverage assertion |
| test | `ProjectLanguageDetectorTest.kt` | 39 tests (kept all legacy SDK/module coverage, added: scan-wins-over-SDK, polyglot null, polyglot + SDK tiebreak passes / rejects / absent hint, transient null not cached, invalidate re-scans) |
| test | `ProjectLanguageScanAsyncTest.kt` | 7 tests: schedule dispatches once, dedup blocks duplicates, independent keys, re-schedulable after completion, exception clears gate, CancellationException propagates, `clearForTest` |
| test | `ProjectLanguageCacheInvalidatorTest.kt` | 3 tests: invalidates own project, leaves others intact, no-op on uncached project |

── Validation ──────────────────────────────

```bash
./gradlew ktlintCheck detekt test
# 108 red/green assertions across the 4 new/rewritten test files — all green
```

Edge cases exercised:
- Android project: Kotlin source + XML resources → Kotlin via code-tier-first filter
- React project: 55% TSX / 30% JSX / 15% CSS → TypeScript via margin-plurality
- JVM mixed 50/50 Java/Kotlin with `KotlinSdkType` → Kotlin via SDK tiebreak
- Python + committed .venv → user code wins, venv path-excluded
- K8s manifests repo (only YAML) → YAML dominant via markup fallback
- Docs-only repo (only markdown) → markdown dominant
- 50/50 polyglot with SDK hinting a language absent from the scan → null (not confidently wrong)
- Brand-new project / dumb mode → scanner returns null, detector doesn't cache, legacy fallback runs once smart mode lands
- Project reopened at same path after rename → `projectClosed` invalidated cache → fresh detection

── Notes ───────────────────────────────────

**Behavior change vs v2.5.x:** 50/50 polyglot Java/Kotlin JVM projects that previously got "kotlin" from the SDK heuristic now go through the SDK tiebreak — they still land on Kotlin when the SDK says Kotlin AND Kotlin is present in the scan. The only regression case is a 50/50 project where the SDK points at a language the scan found <20% of — previously confidently wrong, now correctly null (falls to global accent).

**Not covered in this PR (explicit non-goals):**
- Language aliases (treating TS/JS as one group, Java/Kotlin as one group). Discussed vs the margin rule, rejected: strict TypeScript users don't want JavaScript files treated as TypeScript.
- Per-module detection (monorepo with different languages per module). Single-project-one-winner remains.
- Bi-code-language splits where both are real primary (e.g. 55% TS + 45% JS React app). Margin rule partially covers (55/45 = 1.22×, still null); full coverage needs aliasing.

**Mitigated but not eliminated:**
- Huge monorepo (>10 000 files) sampling bias — cap early-terminates the scan; sample may miss later modules.
- Custom-threshold callers that want strict majority: pass `marginRatio = Double.POSITIVE_INFINITY` to disable tier-2.

## Summary by Sourcery

Introduce a proportional, content-based project language detection pipeline with async scanning, path exclusion, and robust caching/invalidation to drive accent overrides more accurately.

New Features:
- Add LanguageDetectionRules to compute dominant languages from per-language byte weights with code-vs-markup handling, tie-breaking rules, and path exclusion.
- Add ProjectLanguageScanner to scan project content roots under read actions, tally per-language bytes with file and count caps, and respect excluded paths.
- Extend ProjectLanguageDetector to prefer content-scan results, use SDK/module hints only as controlled tiebreakers or fallback, and run background scans off the EDT with post-scan accent refresh.
- Add ProjectLanguageScanAsync as a deduplicated background scheduler for project language scans keyed by project identifier.
- Add ProjectLanguageCacheInvalidator to clear cached language detections on project close.
- Subscribe a ModuleRootListener in AyuIslandsStartupActivity to invalidate language detection when module or content roots change.

Enhancements:
- Harden language detection against IDE disposal/indexing states by distinguishing transient scan failures from definitive polyglot or empty results and caching only safe outcomes.
- Normalize SDK type names and language ids with Locale.ROOT to ensure stable matching across locales.
- Ensure deterministic dominant-language selection by using alphabetical tie-breaking for equal-weight cases.

Tests:
- Expand ProjectLanguageDetectorTest to cover content-scan precedence, SDK-based tie-breaking, caching semantics, and invalidation behavior.
- Add LanguageDetectionRulesTest to validate dominance thresholds, margin rules, markup blacklist, path exclusion set, and configuration constants.
- Add ProjectLanguageScanAsyncTest to exercise the async scheduler’s deduplication, error handling, and test hooks.
- Add ProjectLanguageCacheInvalidatorTest to verify per-project cache invalidation semantics on project close.

Chores:
- Register ProjectLanguageCacheInvalidator as an application-level ProjectManagerListener in plugin.xml.