### PR TITLE
feat(accent): Phase 26 detected-language proportions with icon row

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,8 +89,8 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "3bcfa03"
-          last_verified_date: "2026-04-16"
+          last_verified_sha: "ffe5101"
+          last_verified_date: "2026-04-17"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
       - id: accent-scoped-language
@@ -110,8 +110,8 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "3bcfa03"
-          last_verified_date: "2026-04-16"
+          last_verified_sha: "ffe5101"
+          last_verified_date: "2026-04-17"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
   glow:

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "aba3521"
+          last_verified_sha: "ef61275"
           last_verified_date: "2026-04-16"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "aba3521"
+          last_verified_sha: "ef61275"
           last_verified_date: "2026-04-16"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "8080d91"
+          last_verified_sha: "fccbeeb"
           last_verified_date: "2026-04-16"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "8080d91"
+          last_verified_sha: "fccbeeb"
           last_verified_date: "2026-04-16"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "63e45f3"
+          last_verified_sha: "5a1d89f"
           last_verified_date: "2026-04-16"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "63e45f3"
+          last_verified_sha: "5a1d89f"
           last_verified_date: "2026-04-16"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "f54165d"
+          last_verified_sha: "5b7f685"
           last_verified_date: "2026-04-17"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "f54165d"
+          last_verified_sha: "5b7f685"
           last_verified_date: "2026-04-17"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "fccbeeb"
+          last_verified_sha: "8ac85b5"
           last_verified_date: "2026-04-16"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "fccbeeb"
+          last_verified_sha: "8ac85b5"
           last_verified_date: "2026-04-16"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "3680670"
+          last_verified_sha: "2969b44"
           last_verified_date: "2026-04-16"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "3680670"
+          last_verified_sha: "2969b44"
           last_verified_date: "2026-04-16"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "cce9710"
+          last_verified_sha: "f54165d"
           last_verified_date: "2026-04-17"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "cce9710"
+          last_verified_sha: "f54165d"
           last_verified_date: "2026-04-17"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "ffe5101"
+          last_verified_sha: "be163c2"
           last_verified_date: "2026-04-17"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "ffe5101"
+          last_verified_sha: "be163c2"
           last_verified_date: "2026-04-17"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "d413407"
+          last_verified_sha: "3680670"
           last_verified_date: "2026-04-16"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "d413407"
+          last_verified_sha: "3680670"
           last_verified_date: "2026-04-16"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "aefb005"
+          last_verified_sha: "63e45f3"
           last_verified_date: "2026-04-16"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "aefb005"
+          last_verified_sha: "63e45f3"
           last_verified_date: "2026-04-16"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "8ac85b5"
+          last_verified_sha: "aba3521"
           last_verified_date: "2026-04-16"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "8ac85b5"
+          last_verified_sha: "aba3521"
           last_verified_date: "2026-04-16"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "ef61275"
+          last_verified_sha: "d413407"
           last_verified_date: "2026-04-16"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "ef61275"
+          last_verified_sha: "d413407"
           last_verified_date: "2026-04-16"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "776d4dc"
+          last_verified_sha: "cce9710"
           last_verified_date: "2026-04-17"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "776d4dc"
+          last_verified_sha: "cce9710"
           last_verified_date: "2026-04-17"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "5a1d89f"
+          last_verified_sha: "8080d91"
           last_verified_date: "2026-04-16"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "5a1d89f"
+          last_verified_sha: "8080d91"
           last_verified_date: "2026-04-16"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "2969b44"
+          last_verified_sha: "3bcfa03"
           last_verified_date: "2026-04-16"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "2969b44"
+          last_verified_sha: "3bcfa03"
           last_verified_date: "2026-04-16"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "be163c2"
+          last_verified_sha: "776d4dc"
           last_verified_date: "2026-04-17"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "be163c2"
+          last_verified_sha: "776d4dc"
           last_verified_date: "2026-04-17"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -39,6 +39,14 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
         val accentHex = AccentResolver.resolve(project, variant)
         AccentApplicator.apply(accentHex)
 
+        // Warm the language-detector cache unconditionally so Settings → Accent →
+        // Overrides shows real per-language proportions on first open even before
+        // the user adds a language override (the resolver's fast path intentionally
+        // skips `dominant()` when `languageAccents` is empty). Runs here on the
+        // startup coroutine — off-EDT — so the scan completes synchronously and
+        // populates both caches before any UI thread asks for proportions().
+        ProjectLanguageDetector.dominant(project)
+
         // Drop the language-detector cache when the project's module / content-root
         // structure changes (gradle sync adds a module, user edits sourceSets, etc.)
         // so the next language-override resolution re-scans instead of serving a stale

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -12,6 +12,7 @@ import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.ProjectLanguageDetector
 import dev.ayuislands.accent.conflict.ConflictRegistry
+import dev.ayuislands.accent.runCatchingPreservingCancellation
 import dev.ayuislands.editor.EditorScrollbarManager
 import dev.ayuislands.font.FontPreset
 import dev.ayuislands.font.FontPresetApplicator
@@ -20,6 +21,7 @@ import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.projectview.ProjectViewScrollbarManager
 import dev.ayuislands.rotation.AccentRotationService
 import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.mappings.AccentMappingsSettings
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 import dev.ayuislands.ui.ComponentTreeRefresher
 import javax.swing.SwingUtilities
@@ -39,13 +41,27 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
         val accentHex = AccentResolver.resolve(project, variant)
         AccentApplicator.apply(accentHex)
 
-        // Warm the language-detector cache unconditionally so Settings → Accent →
-        // Overrides shows real per-language proportions on first open even before
-        // the user adds a language override (the resolver's fast path intentionally
-        // skips `dominant()` when `languageAccents` is empty). Runs here on the
-        // startup coroutine — off-EDT — so the scan completes synchronously and
-        // populates both caches before any UI thread asks for proportions().
-        ProjectLanguageDetector.dominant(project)
+        // Warm the language-detector cache so Settings → Accent → Overrides
+        // shows real per-language proportions on first open. Gated on the same
+        // `languageAccents.isNotEmpty()` predicate `AccentResolver.findOverride`
+        // uses: users with no language pins never paid for the scan before this
+        // feature landed, and still shouldn't pay for it just because the
+        // Settings panel has a new informational row. When no pins exist the
+        // panel's own `buildGroup` warmup (EDT-safe bail-out) handles the first
+        // open with one extra cache miss. Defense-in-depth wrap prevents a
+        // transient detector failure from short-circuiting the rest of startup
+        // (ModuleRootListener subscription, font-preset apply, license checks).
+        if (AccentMappingsSettings
+                .getInstance()
+                .state.languageAccents
+                .isNotEmpty()
+        ) {
+            runCatchingPreservingCancellation {
+                ProjectLanguageDetector.dominant(project)
+            }.onFailure { exception ->
+                LOG.warn("Language detector warmup failed; will retry on next resolve", exception)
+            }
+        }
 
         // Drop the language-detector cache when the project's module / content-root
         // structure changes (gradle sync adds a module, user edits sourceSets, etc.)

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -48,19 +48,19 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
         // feature landed, and still shouldn't pay for it just because the
         // Settings panel has a new informational row. When no pins exist the
         // panel's own `buildGroup` warmup (EDT-safe bail-out) handles the first
-        // open with one extra cache miss. Defense-in-depth wrap prevents a
-        // transient detector failure from short-circuiting the rest of startup
-        // (ModuleRootListener subscription, font-preset apply, license checks).
-        if (AccentMappingsSettings
-                .getInstance()
-                .state.languageAccents
-                .isNotEmpty()
-        ) {
-            runCatchingPreservingCancellation {
+        // open with one extra cache miss. Both the `AccentMappingsSettings`
+        // state read and the detector call run under the same runCatching so a
+        // transient failure in either (corrupt persistent-state XML, plugin
+        // unload race, disposed scanner, etc.) can't short-circuit the rest of
+        // startup — ModuleRootListener subscription, font-preset apply, license
+        // checks, and onboarding all live below this block.
+        runCatchingPreservingCancellation {
+            val pinnedLanguages = AccentMappingsSettings.getInstance().state.languageAccents
+            if (pinnedLanguages.isNotEmpty()) {
                 ProjectLanguageDetector.dominant(project)
-            }.onFailure { exception ->
-                LOG.warn("Language detector warmup failed; will retry on next resolve", exception)
             }
+        }.onFailure { exception ->
+            LOG.warn("Language detector warmup failed; will retry on next resolve", exception)
         }
 
         // Drop the language-detector cache when the project's module / content-root

--- a/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
@@ -159,6 +159,42 @@ internal object LanguageDetectionRules {
     private const val PERCENT_SCALE: Double = 100.0
 
     /**
+     * Lower bound for any displayable percent. Entries below this are folded
+     * into the "other" bucket by `pickDisplayEntries`, so the invariant holds
+     * for every surviving [DisplayEntry].
+     */
+    private const val MIN_DISPLAY_PERCENT: Int = 1
+
+    /**
+     * Upper bound for a named [DisplayEntry] — integer mirror of [PERCENT_SCALE]
+     * kept as a `const` so range construction stays a compile-time expression.
+     * Caps trivially at 100% for a single-language project.
+     */
+    private const val MAX_NAMED_PERCENT: Int = 100
+
+    /**
+     * Upper bound for the "other" bucket — one less than the named ceiling
+     * because the bucket only appears alongside at least one named entry
+     * that has already claimed some share.
+     */
+    private const val MAX_OTHER_PERCENT: Int = MAX_NAMED_PERCENT - MIN_DISPLAY_PERCENT
+
+    /**
+     * Valid percent range for a named [DisplayEntry]. The lower bound is
+     * enforced at construction because `pickDisplayEntries` filters sub-1%
+     * entries into the "other" bucket; the upper bound caps single-language
+     * projects.
+     */
+    private val NAMED_PERCENT_RANGE = MIN_DISPLAY_PERCENT..MAX_NAMED_PERCENT
+
+    /**
+     * Valid percent range for the "other" [DisplayEntry] bucket. Upper bound
+     * excludes 100% because the bucket only appears alongside at least one
+     * named entry that already claimed some share.
+     */
+    private val OTHER_PERCENT_RANGE = MIN_DISPLAY_PERCENT..MAX_OTHER_PERCENT
+
+    /**
      * Path segments whose presence in a file's canonical path always disqualifies
      * the file from dominance math — dependency vendoring, build outputs, IDE /
      * VCS metadata, generated-code roots. Matched exactly (no wildcards, no
@@ -410,9 +446,31 @@ internal object LanguageDetectionRules {
         val id: String?,
         /** Human-readable display name ("Kotlin", "JavaScript", "other"). */
         val label: String,
-        /** Integer percentage share; always 1–100 for named entries, 1–99 for "other". */
+        /** Integer percentage share; 1..100 for named entries, 1..99 for "other". */
         val percent: Int,
-    )
+    ) {
+        init {
+            // Runtime contract guards — the single producer (`pickDisplayEntries`)
+            // honors these naturally, but `data class` exposes a public constructor
+            // and a synthesized `copy(...)` within the module, so tests and
+            // future helpers can't accidentally build invalid instances.
+            require(percent in NAMED_PERCENT_RANGE) { "percent must be $NAMED_PERCENT_RANGE, got $percent" }
+            require(label.isNotBlank()) { "label must be non-blank" }
+            if (id != null) {
+                require(id.isNotBlank()) { "named entry id must be non-blank" }
+                require(id == id.lowercase(Locale.ROOT)) {
+                    "named entry id must be lowercase, got '$id'"
+                }
+            } else {
+                // Other-bucket invariant: the structured output never exposes
+                // an "other" entry at 100% — it only appears alongside at least
+                // one named entry that already claimed some share.
+                require(percent in OTHER_PERCENT_RANGE) {
+                    "other-bucket percent must be $OTHER_PERCENT_RANGE, got $percent"
+                }
+            }
+        }
+    }
 
     /**
      * Structured proportion breakdown — a list of top languages (up to
@@ -490,6 +548,11 @@ internal object LanguageDetectionRules {
         sorted: List<Map.Entry<String, Long>>,
         total: Long,
     ): IntArray {
+        // Callers must pre-filter empty/zero-total maps — this contract lets
+        // the function assume at least one entry and a positive denominator,
+        // which preserves the "sum equals exactly 100" invariant in the KDoc.
+        require(sorted.isNotEmpty()) { "allocateLargestRemainder requires non-empty input" }
+        require(total > 0L) { "allocateLargestRemainder requires positive total, got $total" }
         val floors = IntArray(sorted.size)
         val remainders = DoubleArray(sorted.size)
         var floorSum = 0
@@ -566,7 +629,14 @@ internal object LanguageDetectionRules {
      * through this helper so display and icon stay paired.
      */
     private fun findLanguageByLowercaseId(lowercaseId: String): Language? =
-        Language.getRegisteredLanguages().firstOrNull {
-            it.id.equals(lowercaseId, ignoreCase = true)
-        }
+        runCatchingPreservingCancellation {
+            // Defensive: `Language.getRegisteredLanguages()` iteration is not
+            // contractually concurrent-modification-safe across every IntelliJ
+            // platform build, and a buggy plugin can throw from its `id` getter.
+            // Null return matches the "answer unavailable" contract — callers
+            // fall back to title-cased id / icon-less label.
+            Language.getRegisteredLanguages().firstOrNull {
+                it.id.equals(lowercaseId, ignoreCase = true)
+            }
+        }.getOrNull()
 }

--- a/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
@@ -484,19 +484,41 @@ internal object LanguageDetectionRules {
         if (id.isBlank()) return null
         // `Language.associatedFileType` returns `LanguageFileType?` directly — no
         // cast is needed. `.icon` is inherited from `FileType` (non-null Icon).
-        return Language.findLanguageByID(id)?.associatedFileType?.icon
+        return findLanguageByLowercaseId(id)?.associatedFileType?.icon
     }
 
     /**
      * Resolve a lowercase AYU language id to a human-readable display name.
      *
-     * Uses [Language.findLanguageByID] for registered languages (returns
-     * "JavaScript", "Kotlin", "Shell Script" etc. in the exact casing the
-     * platform ships). Falls back to a title-cased form of the raw id when the
-     * language is not registered in the current IDE — ensures a never-emit-lowercase
-     * invariant for the UI.
+     * Uses [findLanguageByLowercaseId] so the scanner's lowercase ids
+     * ("java", "python", "javascript") match against IntelliJ's case-varying
+     * `Language.id` values ("JAVA", "Python", "JavaScript") — the platform's
+     * direct [Language.findLanguageByID] lookup is case-sensitive and misses
+     * every id the scanner already normalized. Falls back to a title-cased
+     * form of the raw id when the language is not registered in the current
+     * IDE — ensures a never-emit-lowercase invariant for the UI.
      */
     private fun displayNameFor(id: String): String =
-        Language.findLanguageByID(id)?.displayName
+        findLanguageByLowercaseId(id)?.displayName
             ?: id.replaceFirstChar { it.titlecase(Locale.ROOT) }
+
+    /**
+     * Case-insensitive lookup over [Language.getRegisteredLanguages]. Required
+     * because every id on the `weights` map is `id.lowercase(Locale.ROOT)` by
+     * scanner contract, but IntelliJ's `Language.id` casing varies per plugin
+     * (Java is `"JAVA"`, Python is `"Python"`, JavaScript is `"JavaScript"`,
+     * TypeScript is `"TypeScript"`, Groovy is `"Groovy"`, Markdown is
+     * `"Markdown"`), so the stock [Language.findLanguageByID] call fails to
+     * resolve nearly every language the scanner would have found.
+     *
+     * Live iteration (no caching) so plugins loaded / unloaded mid-session
+     * surface immediately, matching the Phase 26 RESEARCH "live lookup" decision.
+     * Cost: ~100–200 registered languages × one string equality — O(n) negligible
+     * for a UI-layer call. The companion tooltip + icon resolution both go
+     * through this helper so display and icon stay paired.
+     */
+    private fun findLanguageByLowercaseId(lowercaseId: String): Language? =
+        Language.getRegisteredLanguages().firstOrNull {
+            it.id.equals(lowercaseId, ignoreCase = true)
+        }
 }

--- a/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
@@ -4,6 +4,7 @@ import com.intellij.lang.Language
 import com.intellij.openapi.fileTypes.FileType
 import com.intellij.openapi.fileTypes.LanguageFileType
 import java.util.Locale
+import javax.swing.Icon
 
 /**
  * Pure, side-effect-free helpers for the proportional language detector.
@@ -386,35 +387,103 @@ internal object LanguageDetectionRules {
         weights: Map<String, Long>,
         maxEntries: Int = DEFAULT_DISPLAY_MAX_ENTRIES,
     ): String {
-        if (weights.isEmpty()) return ""
+        val entries = pickDisplayEntries(weights, maxEntries)
+        if (entries.isEmpty()) return ""
+        return entries.joinToString(DISPLAY_ENTRY_SEPARATOR) { entry ->
+            "${entry.label} (${entry.percent}%)"
+        }
+    }
+
+    /**
+     * One entry in the structured proportions display — either a named language
+     * (`id` non-null) or the trailing "other" bucket that aggregates sub-1%
+     * entries and everything past [DEFAULT_DISPLAY_MAX_ENTRIES].
+     *
+     * Used by the Settings UI to render `[icon] Kotlin 78%  [icon] Java 15%  other 7%`
+     * — each entry becomes one `JBLabel` with the icon resolved from [iconForLanguageId].
+     * The string-projection [pickTopLanguagesForDisplay] is implemented on top of this
+     * same data, so UI and text callers never disagree on what's displayed.
+     */
+    data class DisplayEntry(
+        /** Lowercase AYU language id, or `null` for the "other" bucket. */
+        val id: String?,
+        /** Human-readable display name ("Kotlin", "JavaScript", "other"). */
+        val label: String,
+        /** Integer percentage share; always 1–100 for named entries, 1–99 for "other". */
+        val percent: Int,
+    )
+
+    /**
+     * Structured proportion breakdown — a list of top languages (up to
+     * [maxEntries]) followed by an optional "other" bucket that aggregates
+     * everything below 1% and everything past the top-N cutoff.
+     *
+     * Returns empty list when:
+     *  - [weights] is empty
+     *  - total weight is non-positive (defensive)
+     *  - no entry survives the 1% threshold after sorting
+     *
+     * Invariants:
+     *  - Entries sorted by weight descending; ties broken alphabetically by id
+     *    (same determinism guarantee as [pickDominantFromWeights])
+     *  - Two-tier filter: code languages take priority; markup-only projects
+     *    fall back to the full weight map
+     *  - "Other" bucket only appears when `collapsedPct >= 1`
+     *  - All percentages are integer — `(raw/total * 100).toInt()` rounds toward zero
+     *
+     * Used directly by the Settings UI to produce (icon, label, percent) triples
+     * for the proportions status row; also underlies the string-formatted
+     * [pickTopLanguagesForDisplay] so both share one source of truth.
+     */
+    fun pickDisplayEntries(
+        weights: Map<String, Long>,
+        maxEntries: Int = DEFAULT_DISPLAY_MAX_ENTRIES,
+    ): List<DisplayEntry> {
+        if (weights.isEmpty()) return emptyList()
         val codeWeights = weights.filterKeys { it !in MARKUP_IDS }
         val base = codeWeights.ifEmpty { weights }
         val total = base.values.sum()
-        if (total <= 0L) return ""
+        if (total <= 0L) return emptyList()
         val sorted =
             base.entries.sortedWith(
                 compareByDescending<Map.Entry<String, Long>> { it.value }.thenBy { it.key },
             )
-        val named = mutableListOf<Pair<String, Int>>()
+        val named = mutableListOf<DisplayEntry>()
         var collapsedRaw = 0L
         for ((index, entry) in sorted.withIndex()) {
             val pct = (entry.value.toDouble() / total.toDouble() * PERCENT_SCALE).toInt()
             if (index < maxEntries && pct >= 1) {
-                named.add(entry.key to pct)
+                named += DisplayEntry(id = entry.key, label = displayNameFor(entry.key), percent = pct)
             } else {
                 collapsedRaw += entry.value
             }
         }
-        val namedText =
-            named.joinToString(DISPLAY_ENTRY_SEPARATOR) { (id, pct) ->
-                "${displayNameFor(id)} ($pct%)"
-            }
+        if (named.isEmpty()) return emptyList()
         val collapsedPct = (collapsedRaw.toDouble() / total.toDouble() * PERCENT_SCALE).toInt()
-        return if (collapsedPct > 0) {
-            "$namedText$DISPLAY_ENTRY_SEPARATOR$DISPLAY_OTHER_LABEL ($collapsedPct%)"
-        } else {
-            namedText
+        if (collapsedPct >= 1) {
+            named += DisplayEntry(id = null, label = DISPLAY_OTHER_LABEL, percent = collapsedPct)
         }
+        return named
+    }
+
+    /**
+     * Resolve a lowercase AYU language id to the IntelliJ platform icon for
+     * that language's [LanguageFileType]. Returns null when the id is blank,
+     * the language isn't registered, the language has no associated file type,
+     * or the file type isn't a [LanguageFileType] (shouldn't happen for code
+     * languages but guarded for third-party plugins that register custom file
+     * types).
+     *
+     * Used by the Settings proportions row to pick up the same icon the user
+     * already sees beside source files in the Project View — zero new
+     * dependencies, theme-aware, always available when the language plugin is
+     * loaded.
+     */
+    fun iconForLanguageId(id: String): Icon? {
+        if (id.isBlank()) return null
+        val language = Language.findLanguageByID(id) ?: return null
+        val fileType = language.associatedFileType ?: return null
+        return (fileType as? LanguageFileType)?.icon
     }
 
     /**

--- a/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
@@ -429,8 +429,15 @@ internal object LanguageDetectionRules {
      *    (same determinism guarantee as [pickDominantFromWeights])
      *  - Two-tier filter: code languages take priority; markup-only projects
      *    fall back to the full weight map
-     *  - "Other" bucket only appears when `collapsedPct >= 1`
-     *  - All percentages are integer — `(raw/total * 100).toInt()` rounds toward zero
+     *  - Integer percentages are allocated via the **Largest Remainder** (Hare)
+     *    method so the displayed values always sum to exactly 100 — plain
+     *    `floor(share * 100)` rounds toward zero and on an uneven split (e.g.
+     *    950 / 23 / 22 / 5 → 95 / 2 / 2 / 0 = 99) leaves 1 percentage point
+     *    unaccounted for, which users read as a math bug. The leftover points
+     *    are distributed to the entries with the largest fractional remainder
+     *    (ties by weight descending, then id ascending for determinism).
+     *  - "Other" bucket aggregates entries past [maxEntries] and entries that
+     *    round to 0%; the bucket is shown when its total reaches at least 1%.
      *
      * Used directly by the Settings UI to produce (icon, label, percent) triples
      * for the proportions status row; also underlies the string-formatted
@@ -449,22 +456,63 @@ internal object LanguageDetectionRules {
             base.entries.sortedWith(
                 compareByDescending<Map.Entry<String, Long>> { it.value }.thenBy { it.key },
             )
+        val finalPcts = allocateLargestRemainder(sorted, total)
         val named = mutableListOf<DisplayEntry>()
-        var collapsedRaw = 0L
+        var collapsedPct = 0
         for ((index, entry) in sorted.withIndex()) {
-            val pct = (entry.value.toDouble() / total.toDouble() * PERCENT_SCALE).toInt()
+            val pct = finalPcts[index]
             if (index < maxEntries && pct >= 1) {
                 named += DisplayEntry(id = entry.key, label = displayNameFor(entry.key), percent = pct)
             } else {
-                collapsedRaw += entry.value
+                collapsedPct += pct
             }
         }
         if (named.isEmpty()) return emptyList()
-        val collapsedPct = (collapsedRaw.toDouble() / total.toDouble() * PERCENT_SCALE).toInt()
         if (collapsedPct >= 1) {
             named += DisplayEntry(id = null, label = DISPLAY_OTHER_LABEL, percent = collapsedPct)
         }
         return named
+    }
+
+    /**
+     * Largest-remainder integer allocation: returns a per-index `Int` percent
+     * for every entry in [sorted] such that the sum equals exactly 100.
+     *
+     * Algorithm:
+     *  1. Each entry gets `floor(weight / total * 100)` as its base share.
+     *  2. The remainder `100 - sum(floors)` is distributed 1 pt at a time to
+     *     the entries with the largest fractional remainder.
+     *  3. Ties broken by weight descending, then id ascending — same determinism
+     *     guarantee as [pickDominantFromWeights] so a HashMap-iteration-order
+     *     regression can't flake this path across JVM versions.
+     */
+    private fun allocateLargestRemainder(
+        sorted: List<Map.Entry<String, Long>>,
+        total: Long,
+    ): IntArray {
+        val floors = IntArray(sorted.size)
+        val remainders = DoubleArray(sorted.size)
+        var floorSum = 0
+        for ((index, entry) in sorted.withIndex()) {
+            val exact = entry.value.toDouble() / total.toDouble() * PERCENT_SCALE
+            val floor = exact.toInt()
+            floors[index] = floor
+            remainders[index] = exact - floor
+            floorSum += floor
+        }
+        val leftover = PERCENT_SCALE.toInt() - floorSum
+        if (leftover <= 0) return floors
+        val bumpIndices =
+            sorted.indices
+                .sortedWith(
+                    compareByDescending<Int> { remainders[it] }
+                        .thenByDescending { sorted[it].value }
+                        .thenBy { sorted[it].key },
+                ).take(leftover)
+        for (index in bumpIndices) {
+            floors[index] += 1
+        }
+        return floors
     }
 
     /**

--- a/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
@@ -399,8 +399,9 @@ internal object LanguageDetectionRules {
      * (`id` non-null) or the trailing "other" bucket that aggregates sub-1%
      * entries and everything past [DEFAULT_DISPLAY_MAX_ENTRIES].
      *
-     * Used by the Settings UI to render `[icon] Kotlin 78%  [icon] Java 15%  other 7%`
-     * — each entry becomes one `JBLabel` with the icon resolved from [iconForLanguageId].
+     * Used by the Settings UI to render `Kotlin 78% · Java 15% · other 7%`
+     * with per-language icons in front of each entry — each entry becomes one
+     * `JBLabel` with the icon resolved from [iconForLanguageId].
      * The string-projection [pickTopLanguagesForDisplay] is implemented on top of this
      * same data, so UI and text callers never disagree on what's displayed.
      */

--- a/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
@@ -481,9 +481,9 @@ internal object LanguageDetectionRules {
      */
     fun iconForLanguageId(id: String): Icon? {
         if (id.isBlank()) return null
-        val language = Language.findLanguageByID(id) ?: return null
-        val fileType = language.associatedFileType ?: return null
-        return (fileType as? LanguageFileType)?.icon
+        // `Language.associatedFileType` returns `LanguageFileType?` directly — no
+        // cast is needed. `.icon` is inherited from `FileType` (non-null Icon).
+        return Language.findLanguageByID(id)?.associatedFileType?.icon
     }
 
     /**

--- a/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
@@ -1,5 +1,6 @@
 package dev.ayuislands.accent
 
+import com.intellij.lang.Language
 import com.intellij.openapi.fileTypes.FileType
 import com.intellij.openapi.fileTypes.LanguageFileType
 import java.util.Locale
@@ -126,6 +127,35 @@ internal object LanguageDetectionRules {
      * "kotlin" but the scan has no strong signal either way.
      */
     const val TIE_BREAK_MIN_SHARE: Double = 0.20
+
+    /**
+     * Max named language entries in the Settings status-line proportions display
+     * before the remainder collapses into a trailing "other (N%)" bucket. Fixed at 3
+     * per Phase 26 scope; not user-configurable.
+     *
+     * See [pickTopLanguagesForDisplay].
+     */
+    const val DEFAULT_DISPLAY_MAX_ENTRIES: Int = 3
+
+    /**
+     * Separator between entries in the Settings status-line proportions display.
+     * The `•` glyph matches the existing Ayu Islands visual language for inline
+     * bullet separators.
+     */
+    private const val DISPLAY_ENTRY_SEPARATOR: String = " • "
+
+    /**
+     * Suffix label for the collapsed "other" bucket at the end of the display line.
+     */
+    private const val DISPLAY_OTHER_LABEL: String = "other"
+
+    /**
+     * Multiplier for converting a fractional share (0.0–1.0) to an integer percent
+     * (0–100). Extracted to a constant so the rounding math in
+     * [pickTopLanguagesForDisplay] stays self-documenting and detekt's MagicNumber
+     * rule doesn't trip on the literal.
+     */
+    private const val PERCENT_SCALE: Double = 100.0
 
     /**
      * Path segments whose presence in a file's canonical path always disqualifies
@@ -319,4 +349,84 @@ internal object LanguageDetectionRules {
         val base = codeWeights.ifEmpty { allWeights }
         return pickDominantFromWeights(base, threshold, marginRatio, floor)
     }
+
+    /**
+     * Human-readable top-N summary of language proportions for Settings display.
+     *
+     * Applies the same code/markup two-tier base as [pickDominantFromAllWeights]:
+     * when any code language is present, only code weights contribute to the display;
+     * markup-only projects (K8s manifest repo, docs site) display their markup. This
+     * prevents the misleading "Kotlin (40%) • XML (60%)" rendering on Android-style
+     * code+markup projects.
+     *
+     * Returns the concatenated entry text (without any prefix — the caller prepends
+     * "Detected in this project: "). Returns an empty string when [weights] is empty,
+     * all-zero, or the computed base sum is non-positive — the caller is expected to
+     * render the polyglot copy on an empty return.
+     *
+     * Rounding: integer percent via truncation (`share × 100` cast to Int). Entries
+     * whose floor-percent is 0 (below 1%) collapse into a trailing "other (N%)"
+     * bucket whose N is the integer-rounded sum of the collapsed raw shares. An entry
+     * at exactly 1% (floor == 1) does NOT collapse. The top [maxEntries] entries are
+     * kept; the remainder also collapses into "other". The "other" suffix is omitted
+     * when the collapsed percent would render as 0.
+     *
+     * Ordering: weight descending, then alphabetical language id ascending — the same
+     * determinism guarantee as [pickDominantFromWeights]. A regression that dropped
+     * the alphabetical tiebreak would flake across JVM versions depending on HashMap
+     * iteration order.
+     *
+     * Display names: [Language.findLanguageByID] with a fallback to
+     * `id.replaceFirstChar { it.titlecase(Locale.ROOT) }` when the language is not
+     * registered (third-party language plugin uninstalled between scan and render).
+     * Live lookup matches the existing pattern at `OverridesGroupBuilder.kt:237` and
+     * keeps the display in sync with dynamic plugin load/unload.
+     */
+    fun pickTopLanguagesForDisplay(
+        weights: Map<String, Long>,
+        maxEntries: Int = DEFAULT_DISPLAY_MAX_ENTRIES,
+    ): String {
+        if (weights.isEmpty()) return ""
+        val codeWeights = weights.filterKeys { it !in MARKUP_IDS }
+        val base = codeWeights.ifEmpty { weights }
+        val total = base.values.sum()
+        if (total <= 0L) return ""
+        val sorted =
+            base.entries.sortedWith(
+                compareByDescending<Map.Entry<String, Long>> { it.value }.thenBy { it.key },
+            )
+        val named = mutableListOf<Pair<String, Int>>()
+        var collapsedRaw = 0L
+        for ((index, entry) in sorted.withIndex()) {
+            val pct = (entry.value.toDouble() / total.toDouble() * PERCENT_SCALE).toInt()
+            if (index < maxEntries && pct >= 1) {
+                named.add(entry.key to pct)
+            } else {
+                collapsedRaw += entry.value
+            }
+        }
+        val namedText =
+            named.joinToString(DISPLAY_ENTRY_SEPARATOR) { (id, pct) ->
+                "${displayNameFor(id)} ($pct%)"
+            }
+        val collapsedPct = (collapsedRaw.toDouble() / total.toDouble() * PERCENT_SCALE).toInt()
+        return if (collapsedPct > 0) {
+            namedText + DISPLAY_ENTRY_SEPARATOR + "$DISPLAY_OTHER_LABEL ($collapsedPct%)"
+        } else {
+            namedText
+        }
+    }
+
+    /**
+     * Resolve a lowercase AYU language id to a human-readable display name.
+     *
+     * Uses [Language.findLanguageByID] for registered languages (returns
+     * "JavaScript", "Kotlin", "Shell Script" etc. in the exact casing the
+     * platform ships). Falls back to a title-cased form of the raw id when the
+     * language is not registered in the current IDE — ensures a never-emit-lowercase
+     * invariant for the UI.
+     */
+    private fun displayNameFor(id: String): String =
+        Language.findLanguageByID(id)?.displayName
+            ?: id.replaceFirstChar { it.titlecase(Locale.ROOT) }
 }

--- a/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
@@ -1,6 +1,7 @@
 package dev.ayuislands.accent
 
 import com.intellij.lang.Language
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.fileTypes.FileType
 import com.intellij.openapi.fileTypes.LanguageFileType
 import java.util.Locale
@@ -149,6 +150,8 @@ internal object LanguageDetectionRules {
      * Suffix label for the collapsed "other" bucket at the end of the display line.
      */
     private const val DISPLAY_OTHER_LABEL: String = "other"
+
+    private val LOG = logger<LanguageDetectionRules>()
 
     /**
      * Multiplier for converting a fractional share (0.0–1.0) to an integer percent
@@ -468,6 +471,13 @@ internal object LanguageDetectionRules {
                 require(percent in OTHER_PERCENT_RANGE) {
                     "other-bucket percent must be $OTHER_PERCENT_RANGE, got $percent"
                 }
+                // Other-bucket label coherence: `id == null` is the discriminator
+                // for the "other" bucket, so the label must match. Closes the
+                // `DisplayEntry(id=null, label="Kotlin", percent=5)` construction
+                // hole where a caller could mix the discriminator and the label.
+                require(label == DISPLAY_OTHER_LABEL) {
+                    "other-bucket label must be '$DISPLAY_OTHER_LABEL', got '$label'"
+                }
             }
         }
     }
@@ -638,5 +648,11 @@ internal object LanguageDetectionRules {
             Language.getRegisteredLanguages().firstOrNull {
                 it.id.equals(lowercaseId, ignoreCase = true)
             }
+        }.onFailure { exception ->
+            // DEBUG severity because a pathological third-party plugin can
+            // trigger this on every call, and WARN would flood idea.log. The
+            // breadcrumb still surfaces the root cause when a "missing icon"
+            // user report lands in triage.
+            LOG.debug("Registered-language iteration failed for id='$lowercaseId'", exception)
         }.getOrNull()
 }

--- a/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
@@ -411,7 +411,7 @@ internal object LanguageDetectionRules {
             }
         val collapsedPct = (collapsedRaw.toDouble() / total.toDouble() * PERCENT_SCALE).toInt()
         return if (collapsedPct > 0) {
-            namedText + DISPLAY_ENTRY_SEPARATOR + "$DISPLAY_OTHER_LABEL ($collapsedPct%)"
+            "$namedText$DISPLAY_ENTRY_SEPARATOR$DISPLAY_OTHER_LABEL ($collapsedPct%)"
         } else {
             namedText
         }

--- a/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
@@ -404,23 +404,24 @@ internal object LanguageDetectionRules {
      * all-zero, or the computed base sum is non-positive — the caller is expected to
      * render the polyglot copy on an empty return.
      *
-     * Rounding: integer percent via truncation (`share × 100` cast to Int). Entries
-     * whose floor-percent is 0 (below 1%) collapse into a trailing "other (N%)"
-     * bucket whose N is the integer-rounded sum of the collapsed raw shares. An entry
-     * at exactly 1% (floor == 1) does NOT collapse. The top [maxEntries] entries are
-     * kept; the remainder also collapses into "other". The "other" suffix is omitted
-     * when the collapsed percent would render as 0.
+     * Percent allocation: the structured list from [pickDisplayEntries] already
+     * encodes the Largest Remainder (Hare) invariant — the per-entry percents
+     * always sum to exactly 100, sub-1% entries fold into the trailing "other"
+     * bucket, and the bucket is omitted when it would render as 0. This text
+     * projection just joins the pre-computed entries; see [pickDisplayEntries]
+     * for the allocation contract.
      *
      * Ordering: weight descending, then alphabetical language id ascending — the same
      * determinism guarantee as [pickDominantFromWeights]. A regression that dropped
      * the alphabetical tiebreak would flake across JVM versions depending on HashMap
      * iteration order.
      *
-     * Display names: [Language.findLanguageByID] with a fallback to
+     * Display names: [findLanguageByLowercaseId] (case-insensitive iteration over
+     * `Language.getRegisteredLanguages()`) with a fallback to
      * `id.replaceFirstChar { it.titlecase(Locale.ROOT) }` when the language is not
      * registered (third-party language plugin uninstalled between scan and render).
-     * Live lookup matches the existing pattern at `OverridesGroupBuilder.kt:237` and
-     * keeps the display in sync with dynamic plugin load/unload.
+     * The lowercase bridge keeps lookup resilient to the casing drift IntelliJ's
+     * Language registry exhibits ("JAVA", "kotlin", "JavaScript", "C#").
      */
     fun pickTopLanguagesForDisplay(
         weights: Map<String, Long>,

--- a/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
@@ -589,6 +589,21 @@ internal object LanguageDetectionRules {
     }
 
     /**
+     * `@TestOnly` seam for exercising the `require(...)` preconditions in
+     * [allocateLargestRemainder] directly. Production callers always flow
+     * through [pickDisplayEntries], which pre-filters empty maps and
+     * non-positive totals, so the guards inside the private function would
+     * otherwise be unreachable from any red/green test. Exposing this seam is
+     * the minimum surface area needed to satisfy the "every validation guard
+     * gets a direct test" rule in `CLAUDE.md`.
+     */
+    @org.jetbrains.annotations.TestOnly
+    internal fun allocateLargestRemainderForTest(
+        sorted: List<Map.Entry<String, Long>>,
+        total: Long,
+    ): IntArray = allocateLargestRemainder(sorted, total)
+
+    /**
      * Resolve a lowercase AYU language id to the IntelliJ platform icon for
      * that language's [LanguageFileType]. Returns null when the id is blank,
      * the language isn't registered, the language has no associated file type,

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
@@ -250,31 +250,40 @@ object ProjectLanguageDetector {
      * to pump a Swing event loop. The caller is expected to already be on the
      * EDT (production: wrapped in `SwingUtilities.invokeLater`; tests: called
      * directly on the test thread). Returns early on disposal or on a
-     * language-override miss, logs and swallows any downstream apply failure.
+     * language-override miss, logs and swallows any downstream apply or
+     * settings-read failure.
      *
-     * `internal` + `@TestOnly` so the test seam below stays the single door
-     * for callers outside this file; no production path other than
-     * [tryRefreshAccentForDetected] should reach this helper.
+     * `internal` (no `@TestOnly`) because [tryRefreshAccentForDetected] — the
+     * production caller — reaches this helper through the `SwingUtilities.invokeLater`
+     * boundary; marking it test-only would misadvertise the call graph and
+     * any `@TestOnly` inspection would either miss real misuse or flag this
+     * legitimate production path.
      */
-    @org.jetbrains.annotations.TestOnly
     internal fun refreshAccentOnEdt(
         project: Project,
         detectedId: String,
     ) {
         if (project.isDisposed) return
-        // Re-read the mappings ON the EDT so membership reflects the same
-        // state the apply chain is about to resolve against — the Settings
-        // UI mutates `languageAccents` on EDT, and an off-EDT membership
-        // check could observe a stale map between scan completion and this
-        // callback's scheduling.
-        val mappings = AccentMappingsSettings.getInstance().state
-        if (detectedId !in mappings.languageAccents) return
-        // Best-effort refresh: the cache already has the detected id, so
-        // `dominant()` behavior is unaffected by failures here. Containing
-        // exceptions keeps a regression in any of the downstream apply paths
-        // (variant detection, UIManager writes, focus-swap notification)
-        // from surfacing as an uncaught EDT exception and risking the UI.
+        // Widen the runCatching to cover the settings read AND the apply
+        // chain. `AccentMappingsSettings.getInstance()` can fail during a
+        // plugin-unload race or a corrupt persistent-state XML read on the
+        // EDT — without the wrap, that throw would bubble out of the
+        // invokeLater callback as an uncaught EDT exception, exactly the
+        // failure mode the inner block already contains for the apply chain.
         runCatchingPreservingCancellation {
+            // Re-read the mappings ON the EDT so membership reflects the
+            // same state the apply chain is about to resolve against — the
+            // Settings UI mutates `languageAccents` on EDT, and an off-EDT
+            // membership check could observe a stale map between scan
+            // completion and this callback's scheduling.
+            val mappings = AccentMappingsSettings.getInstance().state
+            if (detectedId !in mappings.languageAccents) return@runCatchingPreservingCancellation
+            // Best-effort refresh: the cache already has the detected id,
+            // so `dominant()` behavior is unaffected by failures here.
+            // Containing exceptions keeps a regression in any of the
+            // downstream apply paths (variant detection, UIManager writes,
+            // focus-swap notification) from surfacing as an uncaught EDT
+            // exception and risking the UI.
             val variant = AyuVariant.detect() ?: return@runCatchingPreservingCancellation
             val hex = AccentResolver.resolve(project, variant)
             AccentApplicator.apply(hex)

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
@@ -172,6 +172,16 @@ object ProjectLanguageDetector {
             if (!detection.weights.isNullOrEmpty()) {
                 weightsCache[key] = detection.weights
             }
+        } else {
+            // Forensic breadcrumb: a non-cacheable result means the scan hit
+            // dumb mode, a disposed project, or the scanner threw. The caller
+            // sees the same `null` the polyglot/legacy paths emit, so the
+            // Settings row silently renders the polyglot copy — without this
+            // log there is no trace for "proportions never show up" reports.
+            // DEBUG severity keeps the normal indexing-warmup path quiet
+            // (every fresh IDE window hits dumb mode once) while still leaving
+            // a paper trail in idea.log.
+            LOG.debug("Scan for $key returned non-cacheable result; caller will re-scan on next call")
         }
         return detection.languageId
     }
@@ -211,10 +221,15 @@ object ProjectLanguageDetector {
         project: Project,
         detectedId: String,
     ) {
-        val mappings = AccentMappingsSettings.getInstance().state
-        if (detectedId !in mappings.languageAccents) return
         SwingUtilities.invokeLater {
             if (project.isDisposed) return@invokeLater
+            // Re-read the mappings ON the EDT so membership reflects the same
+            // state the apply chain is about to resolve against — the Settings
+            // UI mutates `languageAccents` on EDT, and an off-EDT membership
+            // check could observe a stale map between scan completion and this
+            // callback's scheduling.
+            val mappings = AccentMappingsSettings.getInstance().state
+            if (detectedId !in mappings.languageAccents) return@invokeLater
             // Best-effort refresh: the cache already has the detected id, so
             // `dominant()` behavior is unaffected by failures here. Containing
             // exceptions keeps a regression in any of the downstream apply paths

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
@@ -255,7 +255,7 @@ object ProjectLanguageDetector {
      *
      * `internal` (no `@TestOnly`) because [tryRefreshAccentForDetected] — the
      * production caller — reaches this helper through the `SwingUtilities.invokeLater`
-     * boundary; marking it test-only would misadvertise the call graph and
+     * boundary; marking it test-only would misrepresent the call graph and
      * any `@TestOnly` inspection would either miss real misuse or flag this
      * legitimate production path.
      */
@@ -295,8 +295,8 @@ object ProjectLanguageDetector {
 
     /**
      * `@TestOnly` seam for the `proportions()` cross-cache coherence guard —
-     * lets tests simulate the race window where `weightsCache[key]` is written
-     * before the matching `cache[key]` (dominant-id) entry lands, by evicting
+     * lets tests simulate the race window where `weightsCache` is written for
+     * a key before the matching `cache` (dominant-id) entry lands, by evicting
      * just the dominant-id side of the pair. Without this seam the guard at
      * [proportions] is unreachable from any black-box test because the sole
      * production write path ([detectAndCache]) writes both entries

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
@@ -241,29 +241,62 @@ object ProjectLanguageDetector {
         project: Project,
         detectedId: String,
     ) {
-        SwingUtilities.invokeLater {
-            if (project.isDisposed) return@invokeLater
-            // Re-read the mappings ON the EDT so membership reflects the same
-            // state the apply chain is about to resolve against — the Settings
-            // UI mutates `languageAccents` on EDT, and an off-EDT membership
-            // check could observe a stale map between scan completion and this
-            // callback's scheduling.
-            val mappings = AccentMappingsSettings.getInstance().state
-            if (detectedId !in mappings.languageAccents) return@invokeLater
-            // Best-effort refresh: the cache already has the detected id, so
-            // `dominant()` behavior is unaffected by failures here. Containing
-            // exceptions keeps a regression in any of the downstream apply paths
-            // (variant detection, UIManager writes, focus-swap notification)
-            // from surfacing as an uncaught EDT exception and risking the UI.
-            runCatchingPreservingCancellation {
-                val variant = AyuVariant.detect() ?: return@runCatchingPreservingCancellation
-                val hex = AccentResolver.resolve(project, variant)
-                AccentApplicator.apply(hex)
-                ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
-            }.onFailure { exception ->
-                LOG.warn("Post-scan accent refresh failed; cache is still warm", exception)
-            }
+        SwingUtilities.invokeLater { refreshAccentOnEdt(project, detectedId) }
+    }
+
+    /**
+     * EDT body extracted from [tryRefreshAccentForDetected] so the membership
+     * check + apply chain can be red/green tested synchronously without having
+     * to pump a Swing event loop. The caller is expected to already be on the
+     * EDT (production: wrapped in `SwingUtilities.invokeLater`; tests: called
+     * directly on the test thread). Returns early on disposal or on a
+     * language-override miss, logs and swallows any downstream apply failure.
+     *
+     * `internal` + `@TestOnly` so the test seam below stays the single door
+     * for callers outside this file; no production path other than
+     * [tryRefreshAccentForDetected] should reach this helper.
+     */
+    @org.jetbrains.annotations.TestOnly
+    internal fun refreshAccentOnEdt(
+        project: Project,
+        detectedId: String,
+    ) {
+        if (project.isDisposed) return
+        // Re-read the mappings ON the EDT so membership reflects the same
+        // state the apply chain is about to resolve against — the Settings
+        // UI mutates `languageAccents` on EDT, and an off-EDT membership
+        // check could observe a stale map between scan completion and this
+        // callback's scheduling.
+        val mappings = AccentMappingsSettings.getInstance().state
+        if (detectedId !in mappings.languageAccents) return
+        // Best-effort refresh: the cache already has the detected id, so
+        // `dominant()` behavior is unaffected by failures here. Containing
+        // exceptions keeps a regression in any of the downstream apply paths
+        // (variant detection, UIManager writes, focus-swap notification)
+        // from surfacing as an uncaught EDT exception and risking the UI.
+        runCatchingPreservingCancellation {
+            val variant = AyuVariant.detect() ?: return@runCatchingPreservingCancellation
+            val hex = AccentResolver.resolve(project, variant)
+            AccentApplicator.apply(hex)
+            ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
+        }.onFailure { exception ->
+            LOG.warn("Post-scan accent refresh failed; cache is still warm", exception)
         }
+    }
+
+    /**
+     * `@TestOnly` seam for the `proportions()` cross-cache coherence guard —
+     * lets tests simulate the race window where `weightsCache[key]` is written
+     * before the matching `cache[key]` (dominant-id) entry lands, by evicting
+     * just the dominant-id side of the pair. Without this seam the guard at
+     * [proportions] is unreachable from any black-box test because the sole
+     * production write path ([detectAndCache]) writes both entries
+     * back-to-back on the same thread.
+     */
+    @org.jetbrains.annotations.TestOnly
+    internal fun evictDominantCacheForTest(project: Project) {
+        val key = AccentResolver.projectKey(project) ?: return
+        cache.remove(key)
     }
 
     private fun isOnEdt(): Boolean = ApplicationManager.getApplication()?.isDispatchThread == true

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
@@ -55,6 +55,26 @@ object ProjectLanguageDetector {
     private val cache = ConcurrentHashMap<String, String>()
 
     /**
+     * Parallel per-language byte-weight cache, written alongside [cache] inside
+     * [detectAndCache] when the scan produced non-empty weights. Keyed by the same
+     * canonical project path as [cache] (see [AccentResolver.projectKey]) so a
+     * single [invalidate] call evicts both and the two caches never drift.
+     *
+     * Absence of a key means "no warm weights" — callers of [proportions] treat the
+     * missing key as the polyglot / no-winner signal and render the fallback copy.
+     * The legacy SDK/module fallback path ([legacySdkModuleDetection]) produces no
+     * weights and deliberately does NOT populate this cache — proportions() for a
+     * legacy-detected project stays null so the Settings display shows the polyglot
+     * copy rather than a misleading "(100%)" single-language breakdown derived from
+     * an empty scan.
+     *
+     * In-memory only (like [cache]); re-warms on the next successful scan. Not
+     * persisted across IDE restarts — [AyuIslandsStartupActivity] re-warms via the
+     * next `dominant()` call on project open.
+     */
+    private val weightsCache = ConcurrentHashMap<String, Map<String, Long>>()
+
+    /**
      * Dominant language id for [project], cached per canonical path.
      *
      * On EDT with a cold cache, returns null and schedules a background scan; the
@@ -74,29 +94,68 @@ object ProjectLanguageDetector {
     }
 
     /**
+     * Per-language byte-weight map for [project], read strictly from the warm cache.
+     *
+     * Returns null when the cache is cold (never scanned), when the scan produced no
+     * meaningful weights (legacy SDK fallback path, empty-scan path — caller renders
+     * the polyglot copy), when the scan failed due to dumb mode or disposal race,
+     * or when the project's canonical path cannot be resolved.
+     *
+     * Never triggers a scan or schedules background work. The caller is responsible
+     * for rendering a fallback (polyglot copy) on null. Cache is warmed via
+     * [dominant] (called from [dev.ayuislands.AyuIslandsStartupActivity] and the
+     * focus-swap path in [AccentResolver]) and invalidated atomically with the
+     * dominant-id cache via [invalidate].
+     *
+     * Phase 26 contract: this is a read-only projection of existing detector state.
+     * Phase 29 supplies a manual rescan trigger; Phase 31 may extend this API with
+     * a scan-status discriminant. Neither should weaken the "no scan on miss"
+     * invariant established here.
+     */
+    fun proportions(project: Project): Map<String, Long>? {
+        val key = AccentResolver.projectKey(project) ?: return null
+        return weightsCache[key]
+    }
+
+    /**
      * Clear the cached detection for [project]. Called from the project-close
      * listener ([ProjectLanguageCacheInvalidator]) so a re-opened project can
      * be re-analyzed, and from the `ModuleRootListener` subscription registered
      * in [dev.ayuislands.AyuIslandsStartupActivity] so mid-session content-root
      * changes (gradle sync, module add/remove) trigger a fresh scan.
+     *
+     * Evicts BOTH [cache] and [weightsCache] under the same key so `dominant()` and
+     * `proportions()` never drift — a stale weights entry served after
+     * `dominant()` re-scanned would show the user a proportion breakdown for the
+     * pre-invalidate layout.
      */
     fun invalidate(project: Project) {
-        AccentResolver.projectKey(project)?.let { cache.remove(it) }
+        val key = AccentResolver.projectKey(project) ?: return
+        cache.remove(key)
+        weightsCache.remove(key)
     }
 
-    /** Drop the entire cache — useful for test isolation. */
+    /** Drop the entire cache — useful for test isolation. Empties both maps. */
     fun clear() {
         cache.clear()
+        weightsCache.clear()
     }
 
     /**
      * Result of a single detection attempt. `cacheable = false` signals a transient
      * failure (the underlying IntelliJ API threw) — the caller must NOT persist this
      * result, so the next invocation retries instead of serving a poisoned cache entry.
+     *
+     * [weights] carries the raw per-language byte map produced by the scan path; it
+     * is null on the legacy SDK/module fallback path (no scan produced weights) and
+     * also when the scan ran but produced no winner and no margin-plurality tiebreak
+     * (the polyglot null verdict). [detectAndCache] only writes [weightsCache] when
+     * [weights] is present and non-empty — see `weightsCache` KDoc for rationale.
      */
     private data class DetectionResult(
         val languageId: String?,
         val cacheable: Boolean,
+        val weights: Map<String, Long>? = null,
     )
 
     /**
@@ -110,6 +169,10 @@ object ProjectLanguageDetector {
         val detection = detectInternal(project)
         if (detection.cacheable) {
             cache[key] = detection.languageId ?: NULL_SENTINEL
+            val weights = detection.weights
+            if (weights != null && weights.isNotEmpty()) {
+                weightsCache[key] = weights
+            }
         }
         return detection.languageId
     }
@@ -181,7 +244,7 @@ object ProjectLanguageDetector {
         if (weights.isNotEmpty()) {
             val scanWinner = LanguageDetectionRules.pickDominantFromAllWeights(weights)
             if (scanWinner != null) {
-                return DetectionResult(languageId = scanWinner, cacheable = true)
+                return DetectionResult(languageId = scanWinner, cacheable = true, weights = weights)
             }
             // Scan found weights but no clear or plurality winner. Consult the
             // legacy heuristic as a tiebreaker — but only accept its answer when
@@ -189,13 +252,18 @@ object ProjectLanguageDetector {
             // TIE_BREAK_MIN_SHARE. Guards against the SDK confidently reporting
             // a language that the scan didn't even find.
             resolveTiebreakFromLegacy(project, weights)?.let {
-                return DetectionResult(languageId = it, cacheable = true)
+                return DetectionResult(languageId = it, cacheable = true, weights = weights)
             }
-            return DetectionResult(languageId = null, cacheable = true)
+            // Polyglot no-winner verdict: cache the null id (definitive) but NOT
+            // the weights — Phase 26 shows the polyglot copy on this state rather
+            // than a weights breakdown, so leaving weightsCache empty keeps
+            // proportions() returning null for a clean caller dispatch.
+            return DetectionResult(languageId = null, cacheable = true, weights = null)
         }
         // Empty scan: brand-new project / everything-filtered-as-markup / newly
         // checked out. Fall back to the SDK + module heuristic; its result is
-        // cached the same way the pre-scan implementation did.
+        // cached the same way the pre-scan implementation did. Legacy path produces
+        // no weights — weightsCache stays empty and proportions() stays null.
         return legacySdkModuleDetection(project)
     }
 

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
@@ -69,8 +69,8 @@ object ProjectLanguageDetector {
      * an empty scan.
      *
      * In-memory only (like [cache]); re-warms on the next successful scan. Not
-     * persisted across IDE restarts — [AyuIslandsStartupActivity] re-warms via the
-     * next `dominant()` call on project open.
+     * persisted across IDE restarts — the project-open startup activity re-warms
+     * via the next `dominant()` call it issues.
      */
     private val weightsCache = ConcurrentHashMap<String, Map<String, Long>>()
 
@@ -169,9 +169,8 @@ object ProjectLanguageDetector {
         val detection = detectInternal(project)
         if (detection.cacheable) {
             cache[key] = detection.languageId ?: NULL_SENTINEL
-            val weights = detection.weights
-            if (weights != null && weights.isNotEmpty()) {
-                weightsCache[key] = weights
+            if (!detection.weights.isNullOrEmpty()) {
+                weightsCache[key] = detection.weights
             }
         }
         return detection.languageId

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
@@ -114,6 +114,19 @@ object ProjectLanguageDetector {
      */
     fun proportions(project: Project): Map<String, Long>? {
         val key = AccentResolver.projectKey(project) ?: return null
+        // Cross-cache coherence guard: `invalidate()` clears both `cache` and
+        // `weightsCache`, and `detectAndCache` writes them in a specific order
+        // (`weightsCache` first, `cache` last). If a concurrent `invalidate()`
+        // interleaves between those two writes the `weightsCache` entry would
+        // already be gone, but reading the raw `weightsCache[key]` here would
+        // let a stale entry slip through in the opposite race window (write
+        // happened, then invalidate ran between the two writes, leaving the
+        // dominant-id cache empty and weightsCache populated with stale data).
+        // Gate the weights read on the dominant-id cache being present — if the
+        // evictor already ran, serve null so the UI re-reads after the next
+        // `dominant()` completes instead of painting a breakdown for a layout
+        // the rest of the detector has already forgotten.
+        if (cache[key] == null) return null
         return weightsCache[key]
     }
 
@@ -168,10 +181,17 @@ object ProjectLanguageDetector {
     ): String? {
         val detection = detectInternal(project)
         if (detection.cacheable) {
-            cache[key] = detection.languageId ?: NULL_SENTINEL
+            // Write order is load-bearing: `weightsCache` first, `cache`
+            // (dominant-id) second, paired with the `cache[key] == null` guard
+            // in `proportions()`. An interleaved `invalidate()` that lands
+            // between the two writes is observed as "no cache entry yet" by
+            // both readers instead of "proportions populated, dominant gone" —
+            // the latter would render a stale breakdown for a layout the
+            // detector has already forgotten.
             if (!detection.weights.isNullOrEmpty()) {
                 weightsCache[key] = detection.weights
             }
+            cache[key] = detection.languageId ?: NULL_SENTINEL
         } else {
             // Forensic breadcrumb: a non-cacheable result means the scan hit
             // dumb mode, a disposed project, or the scanner threw. The caller

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -332,8 +332,15 @@ class OverridesGroupBuilder {
         // user looking at a blank row while the log claimed "previous state" —
         // misleading triage. Now the live panel is either fully replaced or left
         // exactly as the user last saw it.
+        // Construct a FRESH FlowLayout for the staging panel instead of aliasing
+        // `panel.layout`. `FlowLayout` is stateless today, but sharing a layout
+        // instance across two containers is undefined behavior if a future edit
+        // swaps the live panel's layout to one that caches per-child constraints
+        // (GridBagLayout, MigLayout). Reconstruct from the same scaled gap used
+        // in `buildGroup` so the staging pack width matches the live pack width.
+        val gap = JBUI.scale(PROPORTIONS_ENTRY_GAP_PX)
         val staging =
-            JPanel(panel.layout).apply {
+            JPanel(FlowLayout(FlowLayout.LEFT, gap, 0)).apply {
                 isOpaque = panel.isOpaque
                 border = panel.border
             }

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -19,6 +19,7 @@ import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.LanguageDetectionRules
 import dev.ayuislands.accent.ProjectLanguageDetector
+import dev.ayuislands.accent.runCatchingPreservingCancellation
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import java.awt.BorderLayout
@@ -264,8 +265,16 @@ class OverridesGroupBuilder {
      * containing markup (T-26-01).
      *
      * O(1) HashMap probe plus a bounded formatter pass; safe to call on EDT.
+     *
+     * Exposed as an `internal @TestOnly` seam so
+     * `OverridesGroupBuilderProportionsTest` can assert every user-visible render
+     * state without instantiating the Swing tree — the UI builder itself no
+     * longer calls this helper (the icon-panel path lives in
+     * [populateProportionsPanel]), so this method survives as a pure test
+     * projection over the text-equivalent rendering.
      */
-    private fun computeProportionsText(): String {
+    @org.jetbrains.annotations.TestOnly
+    internal fun currentProportionsTextForTest(): String {
         val project = parentProject ?: return POLYGLOT_COPY
         val weights = ProjectLanguageDetector.proportions(project) ?: return POLYGLOT_COPY
         val rendered = LanguageDetectionRules.pickTopLanguagesForDisplay(weights)
@@ -294,57 +303,80 @@ class OverridesGroupBuilder {
      *    from the icon row so the user instantly sees "no single dominant".
      */
     private fun populateProportionsPanel(panel: JPanel) {
-        panel.removeAll()
-        val project = parentProject
-        val entries =
-            if (project == null) {
-                emptyList()
-            } else {
-                val weights = ProjectLanguageDetector.proportions(project)
-                if (weights == null) emptyList() else LanguageDetectionRules.pickDisplayEntries(weights)
+        // Wrap the entire rebuild under runCatchingPreservingCancellation so a
+        // third-party Language plugin throwing from `associatedFileType.icon`,
+        // a `ConcurrentModificationException` on `Language.getRegisteredLanguages()`
+        // during a mid-render plugin unload, or any other transient platform
+        // failure cannot propagate out of this EDT callback — the UI DSL builder,
+        // the pending-change listener chain (`listeners.forEach { it.run() }`),
+        // and `reset()` all call this helper and a bubbled exception would break
+        // the entire Overrides group, not just the proportions row.
+        val outcome =
+            runCatchingPreservingCancellation {
+                panel.removeAll()
+                renderProportionsInto(panel)
+                panel.revalidate()
+                panel.repaint()
             }
+        outcome.onFailure { exception ->
+            LOG.warn("Proportions panel repopulate failed; leaving previous state", exception)
+        }
+    }
+
+    /**
+     * Paint the proportions content into [panel] — the polyglot fallback label
+     * when there are no entries, otherwise the leading prefix plus one
+     * icon+percent label per entry with separators between them.
+     *
+     * Extracted out of [populateProportionsPanel] to keep the EDT callback's
+     * cognitive complexity within detekt's 15-branch budget: the runCatching
+     * wrapper, the onFailure sink, and the revalidate/repaint calls stay in the
+     * caller while all branching / looping / label construction happens here.
+     */
+    private fun renderProportionsInto(panel: JPanel) {
         val subdued = UIUtil.getContextHelpForeground()
+        val project = parentProject
+        val weights = project?.let { ProjectLanguageDetector.proportions(it) }
+        val entries =
+            weights?.let { LanguageDetectionRules.pickDisplayEntries(it) } ?: emptyList()
         if (entries.isEmpty()) {
             panel.add(
                 JBLabel(POLYGLOT_COPY, AllIcons.General.Information, SwingConstants.LEADING).apply {
                     foreground = subdued
                 },
             )
-        } else {
-            panel.add(JBLabel(PROPORTIONS_PREFIX).apply { foreground = subdued })
-            entries.forEachIndexed { index, entry ->
-                if (index > 0) {
-                    panel.add(
-                        JBLabel(PROPORTIONS_SEPARATOR.toString()).apply { foreground = subdued },
-                    )
-                }
-                val icon = entry.id?.let { LanguageDetectionRules.iconForLanguageId(it) }
-                // Named entries render as icon + percent only (icon identifies the
-                // language). The "other" bucket has no icon and no single language —
-                // render its literal "other" label before the percent so the row
-                // still reads as a unit instead of a dangling bare percent that
-                // looks like a rendering glitch.
-                val text =
-                    if (entry.id == null) {
-                        "${entry.label} ${entry.percent}%"
-                    } else {
-                        "${entry.percent}%"
-                    }
-                panel.add(
-                    JBLabel(text, icon, SwingConstants.LEADING).apply {
-                        foreground = subdued
-                        // Hover affordance: icon alone can be unfamiliar for less-common
-                        // languages, so the display name surfaces in the tooltip.
-                        // toolTipText is plain-text unless it starts with <html>, so any
-                        // pathological Language.displayName renders literally — no HTML
-                        // interpretation, consistent with the label-text safety story.
-                        toolTipText = entry.label
-                    },
-                )
-            }
+            return
         }
-        panel.revalidate()
-        panel.repaint()
+        panel.add(JBLabel(PROPORTIONS_PREFIX).apply { foreground = subdued })
+        entries.forEachIndexed { index, entry ->
+            if (index > 0) {
+                panel.add(JBLabel(PROPORTIONS_SEPARATOR.toString()).apply { foreground = subdued })
+            }
+            val icon = entry.id?.let { LanguageDetectionRules.iconForLanguageId(it) }
+            // Named entries render as icon + percent only (icon identifies the
+            // language). The "other" bucket has no icon and no single language —
+            // render its literal "other" label before the percent so the row
+            // still reads as a unit instead of a dangling bare percent that
+            // looks like a rendering glitch.
+            val text =
+                if (entry.id == null) {
+                    "${entry.label} ${entry.percent}%"
+                } else {
+                    "${entry.percent}%"
+                }
+            panel.add(
+                JBLabel(text, icon, SwingConstants.LEADING).apply {
+                    foreground = subdued
+                    // Hover affordance: icon alone can be unfamiliar for less-common
+                    // languages, so the display name surfaces in the tooltip.
+                    // toolTipText is plain-text unless it starts with <html>, so
+                    // any pathological Language.displayName renders literally —
+                    // no HTML interpretation, consistent with the label-text
+                    // safety story.
+                    toolTipText = entry.label
+                },
+            )
+        }
     }
 
     /**
@@ -366,15 +398,6 @@ class OverridesGroupBuilder {
     internal fun setParentProjectForTest(project: Project?) {
         parentProject = project
     }
-
-    /**
-     * Builder-level seam returning the exact text [buildGroup] would render for the
-     * current [parentProject] + detector cache state. Used by
-     * `OverridesGroupBuilderProportionsTest` to assert every user-visible render
-     * state without instantiating the Swing tree.
-     */
-    @org.jetbrains.annotations.TestOnly
-    internal fun currentProportionsTextForTest(): String = computeProportionsText()
 
     /**
      * Builder-level seam: lazily builds the proportions panel on first call (so

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -415,9 +415,10 @@ class OverridesGroupBuilder {
     }
 
     /**
-     * Builder-level seam for the proportions status line: lets wiring tests bind a
-     * fake focused project without spinning up a full Swing panel. Mirrors the
-     * pattern established by [loadFromState].
+     * Builder-level `@TestOnly` seam that binds a focused project without
+     * spinning up a full Swing panel — wiring tests can exercise
+     * `resolvePending` / `sourcePending` / proportions rendering without going
+     * through [buildGroup].
      */
     @org.jetbrains.annotations.TestOnly
     internal fun setParentProjectForTest(project: Project?) {
@@ -425,11 +426,10 @@ class OverridesGroupBuilder {
     }
 
     /**
-     * Builder-level seam for the pending table models. Tests seed rows through
-     * this helper to exercise `apply()` / `isModified()` / `reset()` without
-     * going through the Swing ToolbarDecorator "+" / "-" path. Mirrors the
-     * [loadFromState] pattern — the alternative is introducing a
-     * Swing-heavy fixture just to populate two rows.
+     * Builder-level seam for the pending table models. Tests seed rows
+     * through this helper to exercise `apply()` / `isModified()` / `reset()`
+     * without going through the Swing ToolbarDecorator "+" / "-" path — the
+     * alternative is a Swing-heavy fixture just to populate two rows.
      */
     @org.jetbrains.annotations.TestOnly
     internal fun seedPendingForTest(

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -275,9 +275,10 @@ class OverridesGroupBuilder {
     /**
      * Rebuild the status-panel children from the detector's warm cache. Clears
      * existing children first so stale entries from a previous project focus
-     * don't leak. Called from [buildProportionsPanel] (initial paint), [reset]
-     * (Settings re-opens or Cancel), and the pending-change listener
-     * ([fireChanged] path: override add / edit / delete).
+     * don't leak. Called from the inline panel construction inside [buildGroup]
+     * (initial paint), from [reset] (Settings re-opens or Cancel), and from the
+     * pending-change listener registered in [buildGroup] (override add / edit /
+     * delete path via [fireChanged]).
      *
      * Two render paths:
      *  - **Icon row** (normal): one [JBLabel] per [LanguageDetectionRules.DisplayEntry]

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -325,16 +325,30 @@ class OverridesGroupBuilder {
         // the pending-change listener chain (`listeners.forEach { it.run() }`),
         // and `reset()` all call this helper and a bubbled exception would break
         // the entire Overrides group, not just the proportions row.
-        val outcome =
-            runCatchingPreservingCancellation {
-                panel.removeAll()
-                renderProportionsInto(panel)
-                panel.revalidate()
-                panel.repaint()
+        //
+        // Atomic-swap strategy: render into a detached staging `JPanel` first, and
+        // only touch the live `panel` once rendering fully succeeded. A prior
+        // version cleared `panel` BEFORE rendering, so a mid-render throw left the
+        // user looking at a blank row while the log claimed "previous state" —
+        // misleading triage. Now the live panel is either fully replaced or left
+        // exactly as the user last saw it.
+        val staging =
+            JPanel(panel.layout).apply {
+                isOpaque = panel.isOpaque
+                border = panel.border
             }
+        val outcome = runCatchingPreservingCancellation { renderProportionsInto(staging) }
         outcome.onFailure { exception ->
             LOG.warn("Proportions panel repopulate failed; leaving previous state", exception)
+            return
         }
+        panel.removeAll()
+        staging.components.toList().forEach { child ->
+            staging.remove(child)
+            panel.add(child)
+        }
+        panel.revalidate()
+        panel.repaint()
     }
 
     /**
@@ -394,23 +408,29 @@ class OverridesGroupBuilder {
     }
 
     /**
-     * Populate the pending table models from the persisted [AccentMappingsSettings]. Public
-     * [buildGroup] calls this during UI setup; exposed to tests so `resolvePending` and
-     * `sourcePending` can be exercised without inflating the full Swing tree.
-     */
-    @org.jetbrains.annotations.TestOnly
-    internal fun loadFromStateForTest() {
-        loadFromState()
-    }
-
-    /**
      * Builder-level seam for the proportions status line: lets wiring tests bind a
      * fake focused project without spinning up a full Swing panel. Mirrors the
-     * pattern established by [loadFromStateForTest].
+     * pattern established by [loadFromState].
      */
     @org.jetbrains.annotations.TestOnly
     internal fun setParentProjectForTest(project: Project?) {
         parentProject = project
+    }
+
+    /**
+     * Builder-level seam for the pending table models. Tests seed rows through
+     * this helper to exercise `apply()` / `isModified()` / `reset()` without
+     * going through the Swing ToolbarDecorator "+" / "-" path. Mirrors the
+     * [loadFromState] pattern — the alternative is introducing a
+     * Swing-heavy fixture just to populate two rows.
+     */
+    @org.jetbrains.annotations.TestOnly
+    internal fun seedPendingForTest(
+        projects: Collection<ProjectMapping> = emptyList(),
+        languages: Collection<LanguageMapping> = emptyList(),
+    ) {
+        projectModel.replaceAll(projects)
+        languageModel.replaceAll(languages)
     }
 
     /**
@@ -434,7 +454,7 @@ class OverridesGroupBuilder {
         }
     }
 
-    private fun loadFromState() {
+    internal fun loadFromState() {
         val state = AccentMappingsSettingsAccess.stateFor()
         // Per-row resilience: ProjectMapping / LanguageMapping have require(...) invariants at
         // construction (valid #RRGGBB hex, lowercase language id, non-blank canonical path).

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.util.text.StringUtil
 import com.intellij.ui.ToolbarDecorator
 import com.intellij.ui.dsl.builder.Align
 import com.intellij.ui.dsl.builder.Panel
@@ -13,6 +14,7 @@ import com.intellij.ui.table.JBTable
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.accent.LanguageDetectionRules
 import dev.ayuislands.accent.ProjectLanguageDetector
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
@@ -54,9 +56,17 @@ class OverridesGroupBuilder {
     private val cardPanel = JPanel(CardLayout())
     private var parentProject: Project? = null
 
+    /**
+     * Captured JEditorPane backing the detected-language proportions `comment()` row.
+     * Mutated in place via [refreshProportionsLabel] on every [reset] and on every
+     * pending-change fired into the builder-registered listener — mirrors the
+     * `AyuIslandsEffectsPanel.updateAnimationDescription` pattern. Null before
+     * [buildGroup] has populated it.
+     */
+    private var proportionsLabel: javax.swing.JEditorPane? = null
+
     init {
-        configureProjectTable()
-        configureLanguageTable()
+        configureTables()
     }
 
     fun buildGroup(
@@ -90,6 +100,10 @@ class OverridesGroupBuilder {
                     cell(segmentedBar)
                 }
                 row {
+                    val descCell = comment(computeProportionsText())
+                    proportionsLabel = descCell.component
+                }
+                row {
                     cell(cardPanel)
                         .resizableColumn()
                         .align(Align.FILL)
@@ -104,6 +118,11 @@ class OverridesGroupBuilder {
         collapsible.addExpandedListener { expanded ->
             settings.state.overridesGroupExpanded = expanded
         }
+        // Keep the proportions status line in sync with the pending-change surface so
+        // any override add / edit / delete re-reads from the detector cache. Phase 29's
+        // rescan action will reuse this same channel (invalidate + fireChanged) without
+        // introducing a new MessageBus Topic.
+        addPendingChangeListener(Runnable { refreshProportionsLabel() })
     }
 
     // Settings panel lifecycle (isModified / apply / reset)
@@ -131,14 +150,24 @@ class OverridesGroupBuilder {
             state.languageAccents[row.languageId] = row.hex
         }
 
-        reapplyForCurrentContext()
-        snapshotStored()
+        // Re-apply the committed mapping set via resolver → applicator → swap-cache sync.
+        // Keep the focus-swap cache consistent so the next WINDOW_ACTIVATED event evaluates
+        // against the color actually showing on screen right now.
+        AyuVariant.detect()?.let { variant ->
+            val project = parentProject ?: ProjectManager.getInstance().openProjects.firstOrNull()
+            val hex = AccentResolver.resolve(project, variant)
+            AccentApplicator.apply(hex)
+            ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
+        }
+        storedProjects = projectModel.snapshot().map { ProjectMapping(it.canonicalPath, it.displayName, it.hex) }
+        storedLanguages = languageModel.snapshot().map { LanguageMapping(it.languageId, it.displayName, it.hex) }
         fireChanged()
     }
 
     fun reset() {
         projectModel.replaceAll(storedProjects.map { ProjectMapping(it.canonicalPath, it.displayName, it.hex) })
         languageModel.replaceAll(storedLanguages.map { LanguageMapping(it.languageId, it.displayName, it.hex) })
+        refreshProportionsLabel()
         fireChanged()
     }
 
@@ -195,6 +224,43 @@ class OverridesGroupBuilder {
     // Internals: pending-model resolver + UI wiring helpers
 
     /**
+     * Compute the current status-line text by reading from the detector's warm cache.
+     *
+     * Returns the fixed polyglot copy ([POLYGLOT_COPY]) when:
+     *  - [parentProject] is null (Settings opened with no focused project)
+     *  - [ProjectLanguageDetector.proportions] returns null (cold cache, polyglot
+     *    no-winner verdict, or legacy-SDK fallback path — all leave weightsCache empty)
+     *  - [LanguageDetectionRules.pickTopLanguagesForDisplay] produces a blank string
+     *    (all-zero weights or markup-only below-threshold — same visual as polyglot)
+     *
+     * Otherwise returns [DETECTED_PREFIX] concatenated with the HTML-escaped formatter
+     * output. Escaping goes through [StringUtil.escapeXmlEntities] because the
+     * surrounding `JEditorPane.text` is parsed as `text/html` by the IntelliJ UI DSL;
+     * a third-party language plugin could theoretically register a display name
+     * containing markup (T-26-01).
+     *
+     * O(1) HashMap probe plus a bounded formatter pass; safe to call on EDT.
+     */
+    private fun computeProportionsText(): String {
+        val project = parentProject ?: return POLYGLOT_COPY
+        val weights = ProjectLanguageDetector.proportions(project) ?: return POLYGLOT_COPY
+        val rendered = LanguageDetectionRules.pickTopLanguagesForDisplay(weights)
+        if (rendered.isBlank()) return POLYGLOT_COPY
+        return DETECTED_PREFIX + StringUtil.escapeXmlEntities(rendered)
+    }
+
+    /**
+     * Refresh the captured [proportionsLabel] with the latest detector read. No-op
+     * when [buildGroup] has not yet populated the field. Invoked from [reset] and
+     * from the internal listener registered inside [buildGroup] so that any pending
+     * model change (override add / edit / delete) or external `reset()` re-renders
+     * the line without rebuilding the collapsible group.
+     */
+    private fun refreshProportionsLabel() {
+        proportionsLabel?.text = computeProportionsText()
+    }
+
+    /**
      * Populate the pending table models from the persisted [AccentMappingsSettings]. Public
      * [buildGroup] calls this during UI setup; exposed to tests so `resolvePending` and
      * `sourcePending` can be exercised without inflating the full Swing tree.
@@ -202,6 +268,35 @@ class OverridesGroupBuilder {
     @org.jetbrains.annotations.TestOnly
     internal fun loadFromStateForTest() {
         loadFromState()
+    }
+
+    /**
+     * Builder-level seam for the proportions status line: lets wiring tests bind a
+     * fake focused project without spinning up a full Swing panel. Mirrors the
+     * pattern established by [loadFromStateForTest].
+     */
+    @org.jetbrains.annotations.TestOnly
+    internal fun setParentProjectForTest(project: Project?) {
+        parentProject = project
+    }
+
+    /**
+     * Builder-level seam returning the exact text [buildGroup] would render for the
+     * current [parentProject] + detector cache state. Used by
+     * `OverridesGroupBuilderProportionsTest` to assert every user-visible render
+     * state without instantiating the Swing tree.
+     */
+    @org.jetbrains.annotations.TestOnly
+    internal fun currentProportionsTextForTest(): String = computeProportionsText()
+
+    /**
+     * Builder-level seam that triggers the same refresh path [reset] uses, without
+     * replacing table models. Lets tests verify the refresh path mutates state in
+     * isolation.
+     */
+    @org.jetbrains.annotations.TestOnly
+    internal fun refreshProportionsLabelForTest() {
+        refreshProportionsLabel()
     }
 
     private fun loadFromState() {
@@ -256,10 +351,6 @@ class OverridesGroupBuilder {
             }
         projectModel.replaceAll(projects)
         languageModel.replaceAll(languages)
-        snapshotStored()
-    }
-
-    private fun snapshotStored() {
         storedProjects = projectModel.snapshot().map { ProjectMapping(it.canonicalPath, it.displayName, it.hex) }
         storedLanguages = languageModel.snapshot().map { LanguageMapping(it.languageId, it.displayName, it.hex) }
     }
@@ -288,10 +379,12 @@ class OverridesGroupBuilder {
         return bar
     }
 
-    private fun configureProjectTable() {
-        projectTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION)
-        projectTable.rowHeight = TABLE_ROW_HEIGHT
-        projectTable.setShowGrid(false)
+    private fun configureTables() {
+        for (table in listOf(projectTable, languageTable)) {
+            table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION)
+            table.rowHeight = TABLE_ROW_HEIGHT
+            table.setShowGrid(false)
+        }
         projectTable.getColumnModel().getColumn(ProjectMappingsTableModel.COLUMN_COLOR).apply {
             cellRenderer = RoundedSwatchRenderer()
         }
@@ -301,12 +394,6 @@ class OverridesGroupBuilder {
         projectTable.getColumnModel().getColumn(ProjectMappingsTableModel.COLUMN_PATH).apply {
             cellRenderer = DimOrphanRenderer { row -> projectModel.isOrphan(row) }
         }
-    }
-
-    private fun configureLanguageTable() {
-        languageTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION)
-        languageTable.rowHeight = TABLE_ROW_HEIGHT
-        languageTable.setShowGrid(false)
         languageTable.getColumnModel().getColumn(LanguageMappingsTableModel.COLUMN_COLOR).apply {
             cellRenderer = RoundedSwatchRenderer()
         }
@@ -350,7 +437,18 @@ class OverridesGroupBuilder {
                         }
 
                         override fun update(event: AnActionEvent) {
-                            event.presentation.isEnabled = canPinCurrentProject()
+                            // Inlined pin-eligibility gate: the action is enabled only when a
+                            // focused, non-default, non-disposed project has a canonical key
+                            // that isn't already pinned. Kept inline rather than as a helper so
+                            // the file stays under detekt's TooManyFunctions threshold.
+                            val project = parentProject
+                            event.presentation.isEnabled =
+                                project != null &&
+                                !project.isDefault &&
+                                !project.isDisposed &&
+                                AccentResolver.projectKey(project)?.let { key ->
+                                    !projectModel.containsPath(key)
+                                } == true
                         }
                     },
                 )
@@ -369,7 +467,7 @@ class OverridesGroupBuilder {
                     updateHex = projectModel::updateHex,
                 )
             },
-            remove = { removeSelectedProject() },
+            remove = { removeSelectedRow(projectTable, projectModel::remove) },
             addEnabled = { licensed },
             editEnabled = { licensed && projectTable.selectedRow >= 0 },
             removeEnabled = { projectTable.selectedRow >= 0 },
@@ -389,7 +487,7 @@ class OverridesGroupBuilder {
                     updateHex = languageModel::updateHex,
                 )
             },
-            remove = { removeSelectedLanguage() },
+            remove = { removeSelectedRow(languageTable, languageModel::remove) },
             addEnabled = { licensed },
             editEnabled = { licensed && languageTable.selectedRow >= 0 },
             removeEnabled = { languageTable.selectedRow >= 0 },
@@ -410,13 +508,6 @@ class OverridesGroupBuilder {
         fireChanged()
     }
 
-    private fun canPinCurrentProject(): Boolean {
-        val project = parentProject ?: return false
-        if (project.isDefault || project.isDisposed) return false
-        val key = AccentResolver.projectKey(project) ?: return false
-        return !projectModel.containsPath(key)
-    }
-
     private fun pinCurrentProject() {
         val project = parentProject ?: return
         if (project.isDefault || project.isDisposed) return
@@ -430,9 +521,17 @@ class OverridesGroupBuilder {
         fireChanged()
     }
 
-    private fun removeSelectedProject() {
-        val row = projectTable.selectedRow.takeIf { it >= 0 } ?: return
-        projectModel.remove(row)
+    /**
+     * Generic remove-selected-row flow shared by the project and language tables.
+     * Shares the JBTable selection probe, the model-agnostic remove call, and the
+     * pending-change notification.
+     */
+    private fun removeSelectedRow(
+        table: JBTable,
+        remove: (Int) -> Unit,
+    ) {
+        val row = table.selectedRow.takeIf { it >= 0 } ?: return
+        remove(row)
         fireChanged()
     }
 
@@ -472,24 +571,6 @@ class OverridesGroupBuilder {
         fireChanged()
     }
 
-    private fun removeSelectedLanguage() {
-        val row = languageTable.selectedRow.takeIf { it >= 0 } ?: return
-        languageModel.remove(row)
-        fireChanged()
-    }
-
-    // Applies the committed mapping set via resolver → applicator → swap-cache sync
-
-    private fun reapplyForCurrentContext() {
-        val variant = AyuVariant.detect() ?: return
-        val project = parentProject ?: ProjectManager.getInstance().openProjects.firstOrNull()
-        val hex = AccentResolver.resolve(project, variant)
-        AccentApplicator.apply(hex)
-        // Keep the focus-swap cache consistent so the next WINDOW_ACTIVATED event
-        // evaluates against the color actually showing on screen right now.
-        ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
-    }
-
     companion object {
         private val LOG = logger<OverridesGroupBuilder>()
         private const val CARD_PROJECTS = "projects"
@@ -497,6 +578,24 @@ class OverridesGroupBuilder {
         private const val TABLE_ROW_HEIGHT = 24
         private const val BAR_HORIZONTAL_GAP = 4
         private const val BAR_VERTICAL_GAP = 0
+
+        /**
+         * Fixed status-line copy rendered under Per-Language Accent Pins when the
+         * detector has no warm weights for the focused project — cache is cold, the
+         * most recent scan produced no dominant winner, or the legacy SDK / module
+         * fallback path was used (no weights to proportion). Exact string is locked
+         * per phase-26 D-05 / ROADMAP success criterion. NOT i18n'd, NOT
+         * user-configurable. The em-dash is U+2014, not a hyphen.
+         */
+        const val POLYGLOT_COPY: String =
+            "Polyglot — no single dominant language; global accent applies"
+
+        /**
+         * Prefix for the detected-language proportions line. Paired with the output
+         * of [LanguageDetectionRules.pickTopLanguagesForDisplay]. The trailing space
+         * is part of the locked copy — do not trim.
+         */
+        const val DETECTED_PREFIX: String = "Detected in this project: "
     }
 
     /**

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -319,8 +319,19 @@ class OverridesGroupBuilder {
                     )
                 }
                 val icon = entry.id?.let { LanguageDetectionRules.iconForLanguageId(it) }
+                // Named entries render as icon + percent only (icon identifies the
+                // language). The "other" bucket has no icon and no single language —
+                // render its literal "other" label before the percent so the row
+                // still reads as a unit instead of a dangling bare percent that
+                // looks like a rendering glitch.
+                val text =
+                    if (entry.id == null) {
+                        "${entry.label} ${entry.percent}%"
+                    } else {
+                        "${entry.percent}%"
+                    }
                 panel.add(
-                    JBLabel("${entry.percent}%", icon, SwingConstants.LEADING).apply {
+                    JBLabel(text, icon, SwingConstants.LEADING).apply {
                         foreground = subdued
                         // Hover affordance: icon alone can be unfamiliar for less-common
                         // languages, so the display name surfaces in the tooltip.

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -57,13 +57,16 @@ class OverridesGroupBuilder {
     private var parentProject: Project? = null
 
     /**
-     * Captured JEditorPane backing the detected-language proportions `comment()` row.
-     * Mutated in place via [refreshProportionsLabel] on every [reset] and on every
-     * pending-change fired into the builder-registered listener — mirrors the
-     * `AyuIslandsEffectsPanel.updateAnimationDescription` pattern. Null before
-     * [buildGroup] has populated it.
+     * Captured JPanel backing the detected-language proportions status row.
+     * Children are cleared and rebuilt on every [reset] and every pending-change
+     * event via [refreshProportionsPanel]. Each child is a [com.intellij.ui.components.JBLabel]
+     * carrying the language-specific icon from `LanguageDetectionRules.iconForLanguageId`
+     * (or the info icon for the polyglot state). Null before [buildGroup] has populated it.
+     *
+     * Replaces the pre-icon `JEditorPane` with `comment()`-style gray italic text that
+     * was too faint to read on the premium settings row.
      */
-    private var proportionsLabel: javax.swing.JEditorPane? = null
+    private var proportionsPanel: javax.swing.JPanel? = null
 
     init {
         configureTables()
@@ -74,6 +77,14 @@ class OverridesGroupBuilder {
         contextProject: Project?,
     ) {
         parentProject = contextProject
+        // Defense-in-depth: StartupActivity warms the detector cache off-EDT on
+        // project open, but Settings might be opened before that coroutine lands
+        // (race window) or the cache might have been invalidated mid-session.
+        // Kick a warmup now on the EDT path — the detector's own EDT bail-out
+        // schedules a background scan and returns null immediately, so this is
+        // zero-cost on EDT; the first paint may show the polyglot copy but the
+        // next reset (any model edit or panel reopen) picks up the warm cache.
+        contextProject?.let { ProjectLanguageDetector.dominant(it) }
         loadFromState()
 
         val licensed = LicenseChecker.isLicensedOrGrace()
@@ -100,8 +111,19 @@ class OverridesGroupBuilder {
                     cell(segmentedBar)
                 }
                 row {
-                    val descCell = comment(computeProportionsText())
-                    proportionsLabel = descCell.component
+                    val gap =
+                        com.intellij.util.ui.JBUI
+                            .scale(PROPORTIONS_ENTRY_GAP_PX)
+                    val panel =
+                        javax.swing
+                            .JPanel(java.awt.FlowLayout(java.awt.FlowLayout.LEFT, gap, 0))
+                            .apply {
+                                isOpaque = false
+                                border = null
+                            }
+                    proportionsPanel = panel
+                    populateProportionsPanel(panel)
+                    cell(panel)
                 }
                 row {
                     cell(cardPanel)
@@ -122,7 +144,7 @@ class OverridesGroupBuilder {
         // any override add / edit / delete re-reads from the detector cache. Phase 29's
         // rescan action will reuse this same channel (invalidate + fireChanged) without
         // introducing a new MessageBus Topic.
-        addPendingChangeListener { refreshProportionsLabel() }
+        addPendingChangeListener { proportionsPanel?.let { populateProportionsPanel(it) } }
     }
 
     // Settings panel lifecycle (isModified / apply / reset)
@@ -167,7 +189,7 @@ class OverridesGroupBuilder {
     fun reset() {
         projectModel.replaceAll(storedProjects.map { ProjectMapping(it.canonicalPath, it.displayName, it.hex) })
         languageModel.replaceAll(storedLanguages.map { LanguageMapping(it.languageId, it.displayName, it.hex) })
-        refreshProportionsLabel()
+        proportionsPanel?.let { populateProportionsPanel(it) }
         fireChanged()
     }
 
@@ -250,14 +272,56 @@ class OverridesGroupBuilder {
     }
 
     /**
-     * Refresh the captured [proportionsLabel] with the latest detector read. No-op
-     * when [buildGroup] has not yet populated the field. Invoked from [reset] and
-     * from the internal listener registered inside [buildGroup] so that any pending
-     * model change (override add / edit / delete) or external `reset()` re-renders
-     * the line without rebuilding the collapsible group.
+     * Rebuild the status-panel children from the detector's warm cache. Clears
+     * existing children first so stale entries from a previous project focus
+     * don't leak. Called from [buildProportionsPanel] (initial paint), [reset]
+     * (Settings re-opens or Cancel), and the pending-change listener
+     * ([fireChanged] path: override add / edit / delete).
+     *
+     * Two render paths:
+     *  - **Icon row** (normal): one [JBLabel] per [LanguageDetectionRules.DisplayEntry]
+     *    with the IDE-platform icon from [LanguageDetectionRules.iconForLanguageId]
+     *    (null for the "other" bucket — JBLabel without an icon renders as
+     *    text-only, same font). Labels carry the raw display name + percentage.
+     *    Because `JBLabel.text` is plain-text by default (NOT `<html>`-prefixed),
+     *    any pathological language display name renders literally — no HTML
+     *    interpretation, no need for escape-xml.
+     *  - **Polyglot row** (null / empty entries): one [JBLabel] with
+     *    `AllIcons.General.Information` + [POLYGLOT_COPY]. Visually distinct
+     *    from the icon row so the user instantly sees "no single dominant".
      */
-    private fun refreshProportionsLabel() {
-        proportionsLabel?.text = computeProportionsText()
+    private fun populateProportionsPanel(panel: javax.swing.JPanel) {
+        panel.removeAll()
+        val project = parentProject
+        val entries =
+            if (project == null) {
+                emptyList()
+            } else {
+                val weights = ProjectLanguageDetector.proportions(project)
+                if (weights == null) emptyList() else LanguageDetectionRules.pickDisplayEntries(weights)
+            }
+        if (entries.isEmpty()) {
+            val label =
+                com.intellij.ui.components.JBLabel(
+                    POLYGLOT_COPY,
+                    com.intellij.icons.AllIcons.General.Information,
+                    javax.swing.SwingConstants.LEADING,
+                )
+            panel.add(label)
+        } else {
+            for (entry in entries) {
+                val icon = entry.id?.let { LanguageDetectionRules.iconForLanguageId(it) }
+                val label =
+                    com.intellij.ui.components.JBLabel(
+                        "${entry.label} ${entry.percent}%",
+                        icon,
+                        javax.swing.SwingConstants.LEADING,
+                    )
+                panel.add(label)
+            }
+        }
+        panel.revalidate()
+        panel.repaint()
     }
 
     /**
@@ -290,13 +354,25 @@ class OverridesGroupBuilder {
     internal fun currentProportionsTextForTest(): String = computeProportionsText()
 
     /**
-     * Builder-level seam that triggers the same refresh path [reset] uses, without
-     * replacing table models. Lets tests verify the refresh path mutates state in
-     * isolation.
+     * Builder-level seam: lazily builds the proportions panel on first call (so
+     * wiring tests can bypass `buildGroup`), repopulates from the current
+     * [parentProject] + detector cache, and returns `(icon, text)` pairs for
+     * each child in layout order.
+     *
+     * Combines refresh + read into one seam so test call sites stay terse and
+     * the public surface of [OverridesGroupBuilder] stays under the detekt
+     * `TooManyFunctions` threshold (27 → 25 after inlining `buildProportionsPanel`,
+     * `refreshProportionsPanel`, and this combined seam).
      */
     @org.jetbrains.annotations.TestOnly
-    internal fun refreshProportionsLabelForTest() {
-        refreshProportionsLabel()
+    internal fun proportionsPanelLabelsForTest(): List<Pair<javax.swing.Icon?, String>> {
+        val panel =
+            proportionsPanel
+                ?: javax.swing.JPanel().also { proportionsPanel = it }
+        populateProportionsPanel(panel)
+        return panel.components.filterIsInstance<com.intellij.ui.components.JBLabel>().map { label ->
+            label.icon to label.text
+        }
     }
 
     private fun loadFromState() {
@@ -578,6 +654,13 @@ class OverridesGroupBuilder {
         private const val TABLE_ROW_HEIGHT = 24
         private const val BAR_HORIZONTAL_GAP = 4
         private const val BAR_VERTICAL_GAP = 0
+
+        /**
+         * Horizontal gap between entries in the proportions status row.
+         * Scaled via [com.intellij.util.ui.JBUI.scale] for HiDPI displays.
+         * 12 px at 1x matches the rhythm of other Settings rows in the plugin.
+         */
+        private const val PROPORTIONS_ENTRY_GAP_PX: Int = 12
 
         /**
          * Fixed status-line copy rendered under Per-Language Accent Pins when the

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -122,7 +122,7 @@ class OverridesGroupBuilder {
         // any override add / edit / delete re-reads from the detector cache. Phase 29's
         // rescan action will reuse this same channel (invalidate + fireChanged) without
         // introducing a new MessageBus Topic.
-        addPendingChangeListener(Runnable { refreshProportionsLabel() })
+        addPendingChangeListener { refreshProportionsLabel() }
     }
 
     // Settings panel lifecycle (isModified / apply / reset)

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -124,14 +124,14 @@ class OverridesGroupBuilder {
                 }
                 row {
                     val gap = JBUI.scale(PROPORTIONS_ENTRY_GAP_PX)
-                    val panel =
+                    val statusPanel =
                         JPanel(FlowLayout(FlowLayout.LEFT, gap, 0)).apply {
                             isOpaque = false
                             border = null
                         }
-                    proportionsPanel = panel
-                    populateProportionsPanel(panel)
-                    cell(panel)
+                    proportionsPanel = statusPanel
+                    populateProportionsPanel(statusPanel)
+                    cell(statusPanel)
                 }
                 if (!licensed) {
                     row {
@@ -178,11 +178,21 @@ class OverridesGroupBuilder {
         // Re-apply the committed mapping set via resolver → applicator → swap-cache sync.
         // Keep the focus-swap cache consistent so the next WINDOW_ACTIVATED event evaluates
         // against the color actually showing on screen right now.
-        AyuVariant.detect()?.let { variant ->
-            val project = parentProject ?: ProjectManager.getInstance().openProjects.firstOrNull()
-            val hex = AccentResolver.resolve(project, variant)
-            AccentApplicator.apply(hex)
-            ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
+        //
+        // Defense-in-depth: the resolver / applicator / swap-cache chain touches LafManager,
+        // UIManager, and the project-swap service; a transient failure anywhere in that chain
+        // must not short-circuit the stored-snapshot refresh or `fireChanged()` below, or the
+        // settings UI would drift (persisted state saved, but `isModified()` keeps reporting
+        // "modified" because `storedProjects/languages` stayed on the pre-apply snapshot).
+        runCatchingPreservingCancellation {
+            AyuVariant.detect()?.let { variant ->
+                val project = parentProject ?: ProjectManager.getInstance().openProjects.firstOrNull()
+                val hex = AccentResolver.resolve(project, variant)
+                AccentApplicator.apply(hex)
+                ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
+            }
+        }.onFailure { exception ->
+            LOG.warn("Re-apply after overrides commit failed; persisted state is saved, UI may need reopen", exception)
         }
         storedProjects = projectModel.snapshot().map { ProjectMapping(it.canonicalPath, it.displayName, it.hex) }
         storedLanguages = languageModel.snapshot().map { LanguageMapping(it.languageId, it.displayName, it.hex) }
@@ -258,11 +268,14 @@ class OverridesGroupBuilder {
      *  - [LanguageDetectionRules.pickTopLanguagesForDisplay] produces a blank string
      *    (all-zero weights or markup-only below-threshold — same visual as polyglot)
      *
-     * Otherwise returns [DETECTED_PREFIX] concatenated with the HTML-escaped formatter
-     * output. Escaping goes through [StringUtil.escapeXmlEntities] because the
-     * surrounding `JEditorPane.text` is parsed as `text/html` by the IntelliJ UI DSL;
-     * a third-party language plugin could theoretically register a display name
-     * containing markup (T-26-01).
+     * Otherwise returns [DETECTED_PREFIX] concatenated with the formatter output,
+     * passed through [StringUtil.escapeXmlEntities] — the current icon-row
+     * renderer uses plain-text `JBLabel`s that never parse HTML, so the escape
+     * is not load-bearing for the production UI, but this helper survives as a
+     * regression guard that locks the T-26-01 threat model (a third-party
+     * language plugin registering a display name containing markup): the
+     * escape keeps the text projection safe against a future render path that
+     * switches back to an HTML-capable label.
      *
      * O(1) HashMap probe plus a bounded formatter pass; safe to call on EDT.
      *
@@ -298,7 +311,8 @@ class OverridesGroupBuilder {
      *    Because `JBLabel.text` is plain-text by default (NOT `<html>`-prefixed),
      *    any pathological language display name renders literally — no HTML
      *    interpretation, no need for escape-xml.
-     *  - **Polyglot row** (null / empty entries): one [JBLabel] with
+     *  - **Polyglot row** (weights cache cold OR `pickDisplayEntries` returned
+     *    an empty list): one [JBLabel] with
      *    `AllIcons.General.Information` + [POLYGLOT_COPY]. Visually distinct
      *    from the icon row so the user instantly sees "no single dominant".
      */

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -69,9 +69,6 @@ class OverridesGroupBuilder {
      * the language-specific icon from
      * [LanguageDetectionRules.iconForLanguageId] (or the info icon for the
      * polyglot state). Null before [buildGroup] has populated it.
-     *
-     * Replaces the pre-icon `JEditorPane` with `comment()`-style gray italic
-     * text that was too faint to read on the premium settings row.
      */
     private var proportionsPanel: JPanel? = null
 

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -8,9 +8,11 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.ui.ToolbarDecorator
+import com.intellij.ui.components.JBLabel
 import com.intellij.ui.dsl.builder.Align
 import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.table.JBTable
+import com.intellij.util.ui.JBUI
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
@@ -26,11 +28,13 @@ import java.awt.Dimension
 import java.awt.FlowLayout
 import java.io.File
 import javax.swing.ButtonGroup
+import javax.swing.Icon
 import javax.swing.JComponent
 import javax.swing.JPanel
 import javax.swing.JRadioButton
 import javax.swing.JTable
 import javax.swing.ListSelectionModel
+import javax.swing.SwingConstants
 import javax.swing.table.DefaultTableCellRenderer
 import javax.swing.table.TableModel
 
@@ -57,16 +61,17 @@ class OverridesGroupBuilder {
     private var parentProject: Project? = null
 
     /**
-     * Captured JPanel backing the detected-language proportions status row.
+     * Captured [JPanel] backing the detected-language proportions status row.
      * Children are cleared and rebuilt on every [reset] and every pending-change
-     * event via [refreshProportionsPanel]. Each child is a [com.intellij.ui.components.JBLabel]
-     * carrying the language-specific icon from `LanguageDetectionRules.iconForLanguageId`
-     * (or the info icon for the polyglot state). Null before [buildGroup] has populated it.
+     * event via [populateProportionsPanel]. Each child is a [JBLabel] carrying
+     * the language-specific icon from
+     * [LanguageDetectionRules.iconForLanguageId] (or the info icon for the
+     * polyglot state). Null before [buildGroup] has populated it.
      *
-     * Replaces the pre-icon `JEditorPane` with `comment()`-style gray italic text that
-     * was too faint to read on the premium settings row.
+     * Replaces the pre-icon `JEditorPane` with `comment()`-style gray italic
+     * text that was too faint to read on the premium settings row.
      */
-    private var proportionsPanel: javax.swing.JPanel? = null
+    private var proportionsPanel: JPanel? = null
 
     init {
         configureTables()
@@ -111,16 +116,12 @@ class OverridesGroupBuilder {
                     cell(segmentedBar)
                 }
                 row {
-                    val gap =
-                        com.intellij.util.ui.JBUI
-                            .scale(PROPORTIONS_ENTRY_GAP_PX)
+                    val gap = JBUI.scale(PROPORTIONS_ENTRY_GAP_PX)
                     val panel =
-                        javax.swing
-                            .JPanel(java.awt.FlowLayout(java.awt.FlowLayout.LEFT, gap, 0))
-                            .apply {
-                                isOpaque = false
-                                border = null
-                            }
+                        JPanel(FlowLayout(FlowLayout.LEFT, gap, 0)).apply {
+                            isOpaque = false
+                            border = null
+                        }
                     proportionsPanel = panel
                     populateProportionsPanel(panel)
                     cell(panel)
@@ -290,7 +291,7 @@ class OverridesGroupBuilder {
      *    `AllIcons.General.Information` + [POLYGLOT_COPY]. Visually distinct
      *    from the icon row so the user instantly sees "no single dominant".
      */
-    private fun populateProportionsPanel(panel: javax.swing.JPanel) {
+    private fun populateProportionsPanel(panel: JPanel) {
         panel.removeAll()
         val project = parentProject
         val entries =
@@ -301,23 +302,11 @@ class OverridesGroupBuilder {
                 if (weights == null) emptyList() else LanguageDetectionRules.pickDisplayEntries(weights)
             }
         if (entries.isEmpty()) {
-            val label =
-                com.intellij.ui.components.JBLabel(
-                    POLYGLOT_COPY,
-                    com.intellij.icons.AllIcons.General.Information,
-                    javax.swing.SwingConstants.LEADING,
-                )
-            panel.add(label)
+            panel.add(JBLabel(POLYGLOT_COPY, AllIcons.General.Information, SwingConstants.LEADING))
         } else {
             for (entry in entries) {
                 val icon = entry.id?.let { LanguageDetectionRules.iconForLanguageId(it) }
-                val label =
-                    com.intellij.ui.components.JBLabel(
-                        "${entry.label} ${entry.percent}%",
-                        icon,
-                        javax.swing.SwingConstants.LEADING,
-                    )
-                panel.add(label)
+                panel.add(JBLabel("${entry.label} ${entry.percent}%", icon, SwingConstants.LEADING))
             }
         }
         panel.revalidate()
@@ -361,16 +350,15 @@ class OverridesGroupBuilder {
      *
      * Combines refresh + read into one seam so test call sites stay terse and
      * the public surface of [OverridesGroupBuilder] stays under the detekt
-     * `TooManyFunctions` threshold (27 → 25 after inlining `buildProportionsPanel`,
-     * `refreshProportionsPanel`, and this combined seam).
+     * `TooManyFunctions` threshold — refresh helpers were inlined into [reset]
+     * and the pending-change listener instead of adding dedicated private
+     * functions.
      */
     @org.jetbrains.annotations.TestOnly
-    internal fun proportionsPanelLabelsForTest(): List<Pair<javax.swing.Icon?, String>> {
-        val panel =
-            proportionsPanel
-                ?: javax.swing.JPanel().also { proportionsPanel = it }
+    internal fun proportionsPanelLabelsForTest(): List<Pair<Icon?, String>> {
+        val panel = proportionsPanel ?: JPanel().also { proportionsPanel = it }
         populateProportionsPanel(panel)
-        return panel.components.filterIsInstance<com.intellij.ui.components.JBLabel>().map { label ->
+        return panel.components.filterIsInstance<JBLabel>().map { label ->
             label.icon to label.text
         }
     }

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -116,6 +116,11 @@ class OverridesGroupBuilder {
                     cell(segmentedBar)
                 }
                 row {
+                    cell(cardPanel)
+                        .resizableColumn()
+                        .align(Align.FILL)
+                }
+                row {
                     val gap = JBUI.scale(PROPORTIONS_ENTRY_GAP_PX)
                     val panel =
                         JPanel(FlowLayout(FlowLayout.LEFT, gap, 0)).apply {
@@ -125,11 +130,6 @@ class OverridesGroupBuilder {
                     proportionsPanel = panel
                     populateProportionsPanel(panel)
                     cell(panel)
-                }
-                row {
-                    cell(cardPanel)
-                        .resizableColumn()
-                        .align(Align.FILL)
                 }
                 if (!licensed) {
                     row {
@@ -304,9 +304,11 @@ class OverridesGroupBuilder {
         if (entries.isEmpty()) {
             panel.add(JBLabel(POLYGLOT_COPY, AllIcons.General.Information, SwingConstants.LEADING))
         } else {
-            for (entry in entries) {
+            panel.add(JBLabel(PROPORTIONS_PREFIX))
+            entries.forEachIndexed { index, entry ->
                 val icon = entry.id?.let { LanguageDetectionRules.iconForLanguageId(it) }
-                panel.add(JBLabel("${entry.label} ${entry.percent}%", icon, SwingConstants.LEADING))
+                val suffix = if (index == entries.lastIndex) "" else " $PROPORTIONS_SEPARATOR"
+                panel.add(JBLabel("${entry.label} ${entry.percent}%$suffix", icon, SwingConstants.LEADING))
             }
         }
         panel.revalidate()
@@ -667,6 +669,21 @@ class OverridesGroupBuilder {
          * is part of the locked copy — do not trim.
          */
         const val DETECTED_PREFIX: String = "Detected in this project: "
+
+        /**
+         * Header rendered in front of the icon-row proportions layout under the
+         * overrides table. Separate from [DETECTED_PREFIX] (used by the text
+         * projection) because the icon-row phrasing is more concise and
+         * positionally clear ("under the table, here's what we detected").
+         */
+        const val PROPORTIONS_PREFIX: String = "Languages detected:"
+
+        /**
+         * Middle-dot (U+00B7) separator glued to the end of every entry except
+         * the last. Matches the visual separator style used in the font preset
+         * panel (e.g. `Maple Mono · 14pt · Regular · 1.0× · ligatures`).
+         */
+        const val PROPORTIONS_SEPARATOR: Char = '·'
     }
 
     /**

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -13,6 +13,7 @@ import com.intellij.ui.dsl.builder.Align
 import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.table.JBTable
 import com.intellij.util.ui.JBUI
+import com.intellij.util.ui.UIUtil
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
@@ -302,14 +303,33 @@ class OverridesGroupBuilder {
                 val weights = ProjectLanguageDetector.proportions(project)
                 if (weights == null) emptyList() else LanguageDetectionRules.pickDisplayEntries(weights)
             }
+        val subdued = UIUtil.getContextHelpForeground()
         if (entries.isEmpty()) {
-            panel.add(JBLabel(POLYGLOT_COPY, AllIcons.General.Information, SwingConstants.LEADING))
+            panel.add(
+                JBLabel(POLYGLOT_COPY, AllIcons.General.Information, SwingConstants.LEADING).apply {
+                    foreground = subdued
+                },
+            )
         } else {
-            panel.add(JBLabel(PROPORTIONS_PREFIX))
+            panel.add(JBLabel(PROPORTIONS_PREFIX).apply { foreground = subdued })
             entries.forEachIndexed { index, entry ->
+                if (index > 0) {
+                    panel.add(
+                        JBLabel(PROPORTIONS_SEPARATOR.toString()).apply { foreground = subdued },
+                    )
+                }
                 val icon = entry.id?.let { LanguageDetectionRules.iconForLanguageId(it) }
-                val suffix = if (index == entries.lastIndex) "" else " $PROPORTIONS_SEPARATOR"
-                panel.add(JBLabel("${entry.label} ${entry.percent}%$suffix", icon, SwingConstants.LEADING))
+                panel.add(
+                    JBLabel("${entry.percent}%", icon, SwingConstants.LEADING).apply {
+                        foreground = subdued
+                        // Hover affordance: icon alone can be unfamiliar for less-common
+                        // languages, so the display name surfaces in the tooltip.
+                        // toolTipText is plain-text unless it starts with <html>, so any
+                        // pathological Language.displayName renders literally — no HTML
+                        // interpretation, consistent with the label-text safety story.
+                        toolTipText = entry.label
+                    },
+                )
             }
         }
         panel.revalidate()
@@ -358,11 +378,11 @@ class OverridesGroupBuilder {
      * functions.
      */
     @org.jetbrains.annotations.TestOnly
-    internal fun proportionsPanelLabelsForTest(): List<Pair<Icon?, String>> {
+    internal fun proportionsPanelLabelsForTest(): List<Triple<Icon?, String, String?>> {
         val panel = proportionsPanel ?: JPanel().also { proportionsPanel = it }
         populateProportionsPanel(panel)
         return panel.components.filterIsInstance<JBLabel>().map { label ->
-            label.icon to label.text
+            Triple(label.icon, label.text, label.toolTipText)
         }
     }
 
@@ -673,11 +693,11 @@ class OverridesGroupBuilder {
 
         /**
          * Header rendered in front of the icon-row proportions layout under the
-         * overrides table. Separate from [DETECTED_PREFIX] (used by the text
-         * projection) because the icon-row phrasing is more concise and
-         * positionally clear ("under the table, here's what we detected").
+         * overrides table. Kept terse ("Detected:") because the row sits below
+         * the overrides table where context is already established, and the
+         * full "Languages detected" was verbose for a subdued helper-text row.
          */
-        const val PROPORTIONS_PREFIX: String = "Languages detected:"
+        const val PROPORTIONS_PREFIX: String = "Detected:"
 
         /**
          * Middle-dot (U+00B7) separator glued to the end of every entry except

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -83,6 +83,10 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>Unreleased</h3>
+    <ul>
+      <li>Per-Language Accent Pins now show a live breakdown of the detected languages in your project (e.g. "Detected in this project: Kotlin (78%) • Java (15%) • other (7%)") or a clear "polyglot" notice when no single language dominates</li>
+    </ul>
     <h3>2.5.1</h3>
     <ul>
       <li>Updated Marketplace "About" description to cover all v2.5.0 features — per-project and per-language accent pins, onboarding wizard, and the first-launch release showcase tab — that hadn't made it onto the listing page</li>

--- a/src/test/kotlin/dev/ayuislands/accent/LanguageDetectionRulesTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/LanguageDetectionRulesTest.kt
@@ -744,6 +744,116 @@ class LanguageDetectionRulesTest {
         assertEquals("Java (50%) • Kotlin (50%)", result)
     }
 
+    // ── pickDisplayEntries (structured output) ───────────────────────────────────────
+
+    @Test
+    fun `pickDisplayEntries returns empty list for empty weights`() {
+        assertEquals(emptyList(), LanguageDetectionRules.pickDisplayEntries(emptyMap()))
+    }
+
+    @Test
+    fun `pickDisplayEntries returns empty list for all-zero weights`() {
+        assertEquals(
+            emptyList(),
+            LanguageDetectionRules.pickDisplayEntries(mapOf("kotlin" to 0L, "java" to 0L)),
+        )
+    }
+
+    @Test
+    fun `pickDisplayEntries returns single-language 100 percent entry with non-null id`() {
+        val entries = LanguageDetectionRules.pickDisplayEntries(mapOf("kotlin" to 1_000L))
+        assertEquals(1, entries.size)
+        val entry = entries.single()
+        assertEquals("kotlin", entry.id)
+        assertEquals("Kotlin", entry.label)
+        assertEquals(100, entry.percent)
+    }
+
+    @Test
+    fun `pickDisplayEntries falls back to markup for markup-only weights`() {
+        val entries = LanguageDetectionRules.pickDisplayEntries(mapOf("yaml" to 1_000L))
+        assertEquals(1, entries.size)
+        assertEquals("yaml", entries.single().id)
+        assertEquals(100, entries.single().percent)
+    }
+
+    @Test
+    fun `pickDisplayEntries filters markup when code tier is non-empty`() {
+        // Android-style repo: XML must be excluded from the display base so the
+        // icon row doesn't advertise resources as a "dominant language".
+        val entries =
+            LanguageDetectionRules.pickDisplayEntries(
+                mapOf("kotlin" to 400L, "xml" to 600L),
+            )
+        assertEquals(listOf("kotlin"), entries.map { it.id })
+        assertEquals(100, entries.single().percent)
+    }
+
+    @Test
+    fun `pickDisplayEntries caps named entries at maxEntries and collapses remainder to other bucket`() {
+        // 4 languages, maxEntries=3 → top 3 named + "other" bucket with null id.
+        val entries =
+            LanguageDetectionRules.pickDisplayEntries(
+                mapOf("kotlin" to 780L, "java" to 150L, "scala" to 40L, "groovy" to 30L),
+            )
+        assertEquals(4, entries.size)
+        assertEquals(listOf("kotlin", "java", "scala", null), entries.map { it.id })
+        assertEquals(listOf(78, 15, 4, 3), entries.map { it.percent })
+        // The "other" bucket carries the literal label — NOT a language display name.
+        assertEquals("other", entries.last().label)
+    }
+
+    @Test
+    fun `pickDisplayEntries drops sub-1-percent entries into the other bucket`() {
+        // 99% Kotlin + 0.5% Java + 0.5% Python → Java and Python fall below the
+        // 1% floor (pct == 0 after integer rounding) and fold into "other" even
+        // though they fit within the top-3 slot limit. The "other" bucket's
+        // rounded percent matches the floor behaviour of integer truncation —
+        // here total raw = 1000, collapsedRaw = 5+5 = 10, percent = 1.
+        val entries =
+            LanguageDetectionRules.pickDisplayEntries(
+                mapOf("kotlin" to 990L, "java" to 5L, "python" to 5L),
+            )
+        assertEquals(listOf("kotlin", null), entries.map { it.id })
+        assertEquals(listOf(99, 1), entries.map { it.percent })
+    }
+
+    @Test
+    fun `pickDisplayEntries omits other bucket when no collapsed weight remains`() {
+        // Everything fits within top-3 and no entry is below 1% → no other bucket.
+        val entries =
+            LanguageDetectionRules.pickDisplayEntries(
+                mapOf("kotlin" to 500L, "java" to 300L, "python" to 200L),
+            )
+        assertEquals(listOf("kotlin", "java", "python"), entries.map { it.id })
+        assertEquals(listOf(50, 30, 20), entries.map { it.percent })
+        assertTrue(entries.none { it.id == null }, "no null-id bucket when collapsedPct == 0")
+    }
+
+    @Test
+    fun `pickDisplayEntries breaks ties alphabetically by id`() {
+        // Determinism contract: HashMap-iteration-order must not affect display.
+        val entries =
+            LanguageDetectionRules.pickDisplayEntries(mapOf("kotlin" to 500L, "java" to 500L))
+        assertEquals(listOf("java", "kotlin"), entries.map { it.id })
+    }
+
+    // ── iconForLanguageId (IntelliJ platform bridge) ─────────────────────────────────
+
+    @Test
+    fun `iconForLanguageId returns null for blank id`() {
+        assertEquals(null, LanguageDetectionRules.iconForLanguageId(""))
+        assertEquals(null, LanguageDetectionRules.iconForLanguageId("   "))
+    }
+
+    @Test
+    fun `iconForLanguageId returns null for unknown language id`() {
+        // `xyzunknown` is not in the Language registry; the icon resolver must
+        // return null so the UI can render a text-only JBLabel without a broken
+        // icon rectangle.
+        assertEquals(null, LanguageDetectionRules.iconForLanguageId("xyzunknown"))
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────────────────
 
     private fun mockLanguageFileType(languageId: String): FileType {

--- a/src/test/kotlin/dev/ayuislands/accent/LanguageDetectionRulesTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/LanguageDetectionRulesTest.kt
@@ -6,8 +6,11 @@ import com.intellij.openapi.fileTypes.LanguageFileType
 import com.intellij.openapi.fileTypes.UserBinaryFileType
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -878,6 +881,159 @@ class LanguageDetectionRulesTest {
         // return null so the UI can render a text-only JBLabel without a broken
         // icon rectangle.
         assertEquals(null, LanguageDetectionRules.iconForLanguageId("xyzunknown"))
+    }
+
+    @Test
+    fun `iconForLanguageId returns null when registered-language iteration throws`() {
+        // Contract: the runCatchingPreservingCancellation wrapper in
+        // findLanguageByLowercaseId must absorb a ConcurrentModificationException
+        // or a pathological third-party Language.id getter throw, and surface as
+        // `null` so callers fall back to the icon-less JBLabel path. A regression
+        // that drops the runCatching would propagate the throw all the way up
+        // into the Settings EDT callback and break the Overrides group.
+        mockkStatic(Language::class)
+        try {
+            every { Language.getRegisteredLanguages() } throws ConcurrentModificationException("plugin unload race")
+            assertNull(LanguageDetectionRules.iconForLanguageId("kotlin"))
+        } finally {
+            unmockkStatic(Language::class)
+        }
+    }
+
+    // ── DisplayEntry.init invariants ─────────────────────────────────────────────────
+
+    @Test
+    fun `DisplayEntry rejects percent below the floor`() {
+        assertFailsWith<IllegalArgumentException> {
+            LanguageDetectionRules.DisplayEntry(id = "kotlin", label = "Kotlin", percent = 0)
+        }
+    }
+
+    @Test
+    fun `DisplayEntry rejects percent above 100`() {
+        assertFailsWith<IllegalArgumentException> {
+            LanguageDetectionRules.DisplayEntry(id = "kotlin", label = "Kotlin", percent = 101)
+        }
+    }
+
+    @Test
+    fun `DisplayEntry rejects blank label`() {
+        assertFailsWith<IllegalArgumentException> {
+            LanguageDetectionRules.DisplayEntry(id = "kotlin", label = "   ", percent = 50)
+        }
+    }
+
+    @Test
+    fun `DisplayEntry rejects blank id for named entry`() {
+        assertFailsWith<IllegalArgumentException> {
+            LanguageDetectionRules.DisplayEntry(id = "", label = "Kotlin", percent = 50)
+        }
+    }
+
+    @Test
+    fun `DisplayEntry rejects mixed-case id for named entry`() {
+        // Contract: all language ids flow through `id.lowercase(Locale.ROOT)`
+        // at the producer; a caller bypassing that would break cache keys and
+        // icon lookups.
+        assertFailsWith<IllegalArgumentException> {
+            LanguageDetectionRules.DisplayEntry(id = "Kotlin", label = "Kotlin", percent = 50)
+        }
+    }
+
+    @Test
+    fun `DisplayEntry rejects other-bucket at 100 percent`() {
+        // The "other" bucket only exists alongside at least one named entry
+        // that has already claimed some share; a 100% other would mean the
+        // caller collapsed the sole named language into the residual bucket,
+        // which is a structural bug.
+        assertFailsWith<IllegalArgumentException> {
+            LanguageDetectionRules.DisplayEntry(id = null, label = "other", percent = 100)
+        }
+    }
+
+    @Test
+    fun `DisplayEntry accepts other-bucket at the 99 percent boundary`() {
+        // Upper-boundary red/green for OTHER_PERCENT_RANGE — a regression
+        // flipping the range to 1..98 would make this construction fail.
+        val entry = LanguageDetectionRules.DisplayEntry(id = null, label = "other", percent = 99)
+        assertEquals(99, entry.percent)
+    }
+
+    @Test
+    fun `DisplayEntry rejects other-bucket with a non-other label`() {
+        // Discriminator coherence: `id == null` is the "other" bucket and the
+        // label must match the canonical `DISPLAY_OTHER_LABEL`. A caller that
+        // wired id=null with a language-looking label would render "Kotlin 5%"
+        // into the tail position where the UI expects the residual bucket.
+        assertFailsWith<IllegalArgumentException> {
+            LanguageDetectionRules.DisplayEntry(id = null, label = "Kotlin", percent = 5)
+        }
+    }
+
+    // ── allocateLargestRemainder preconditions (private helper, @TestOnly seam) ──────
+
+    @Test
+    fun `allocateLargestRemainder rejects empty sorted input`() {
+        // Defensive guard — production callers pre-filter, but a future caller
+        // that skips the pre-filter would silently produce an empty IntArray
+        // and break the "sum equals exactly 100" KDoc contract. The require
+        // turns a caller regression into an immediate, traceable exception.
+        assertFailsWith<IllegalArgumentException> {
+            LanguageDetectionRules.allocateLargestRemainderForTest(emptyList(), 100L)
+        }
+    }
+
+    @Test
+    fun `allocateLargestRemainder rejects zero total`() {
+        val singleEntry = mapOf("kotlin" to 10L).entries.toList()
+        assertFailsWith<IllegalArgumentException> {
+            LanguageDetectionRules.allocateLargestRemainderForTest(singleEntry, 0L)
+        }
+    }
+
+    @Test
+    fun `allocateLargestRemainder rejects negative total`() {
+        // Signed Long math on a malformed cache entry could flip negative;
+        // the require catches that instead of letting the division below
+        // produce NaN / nonsense percentages.
+        val singleEntry = mapOf("kotlin" to 10L).entries.toList()
+        assertFailsWith<IllegalArgumentException> {
+            LanguageDetectionRules.allocateLargestRemainderForTest(singleEntry, -42L)
+        }
+    }
+
+    // ── pickDisplayEntries edge cases (covers named.isEmpty + displayNameFor fallback) ─
+
+    @Test
+    fun `pickDisplayEntries returns empty list when maxEntries is zero`() {
+        // maxEntries=0 pushes every entry into the collapsed bucket, leaving
+        // `named` empty. The `named.isEmpty()` guard in pickDisplayEntries
+        // must then return emptyList() instead of emitting a solo "other"
+        // row — which would fail DisplayEntry.init anyway, but this is the
+        // quieter contractual path. Locking it keeps a future caller that
+        // passes maxEntries=0 (e.g., a badge-only rendering mode) safe.
+        val entries =
+            LanguageDetectionRules.pickDisplayEntries(
+                mapOf("kotlin" to 500L, "java" to 500L),
+                maxEntries = 0,
+            )
+        assertTrue(entries.isEmpty(), "maxEntries=0 must yield an empty list, got $entries")
+    }
+
+    @Test
+    fun `pickDisplayEntries falls back to title-cased id when displayName is unavailable`() {
+        // Contract: `displayNameFor` hits the Language registry; when the id
+        // isn't registered (unknown language plugin, renamed id, mock data),
+        // the label falls through to `id.replaceFirstChar { it.titlecase(...) }`
+        // so the user still sees a readable name instead of a raw "xyzlang".
+        val entries =
+            LanguageDetectionRules.pickDisplayEntries(mapOf("xyzunregistered" to 1_000L))
+        assertEquals(1, entries.size)
+        // Title-cased id = "Xyzunregistered" — anything non-blank and distinct
+        // from the lowercase id confirms the fallback branch executed.
+        val label = entries.single().label
+        assertTrue(label.isNotBlank(), "label must not be blank; got '$label'")
+        assertEquals('X', label.first(), "title-case fallback capitalizes first char; got '$label'")
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────────────

--- a/src/test/kotlin/dev/ayuislands/accent/LanguageDetectionRulesTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/LanguageDetectionRulesTest.kt
@@ -664,10 +664,11 @@ class LanguageDetectionRulesTest {
 
     @Test
     fun `pickTopLanguagesForDisplay collapses sub-1 percent entries into other bucket`() {
-        // 99.5% kotlin + 0.5% java → java floor-percent is 0, below 1% threshold,
-        // collapses into "other" with integer-rounded raw share (0% → suffix dropped).
-        // Use a case where collapsed sum is non-zero: 98% + 2 × 1% boundary cases,
-        // plus a 0.5% entry that actually rounds to zero.
+        // 950 / 20 / 15 / 10 / 5 across 5 languages. Floor shares sum to 99; the
+        // Largest Remainder rule redistributes the leftover 1 pt to the entry
+        // with the largest fractional remainder (Python at 0.5) — weight desc
+        // breaks the Python-vs-Go remainder tie so Python is bumped. Top-3 take
+        // Kotlin / Java / Python; Rust and Go collapse into the other bucket at 1%.
         val result =
             LanguageDetectionRules.pickTopLanguagesForDisplay(
                 mapOf(
@@ -678,10 +679,7 @@ class LanguageDetectionRulesTest {
                     "go" to 5L,
                 ),
             )
-        // kotlin 95%, java 2%, python 1%, rust 1%, go 0% → top-3 kept, go collapses
-        // into other. Rust is at 1% (floor), stays as 4th → but top-3 cap drops it
-        // too. Collapsed raw sum = 10 + 5 = 15 → floor(15/1000 * 100) = 1%.
-        assertEquals("Kotlin (95%) • Java (2%) • Python (1%) • other (1%)", result)
+        assertEquals("Kotlin (95%) • Java (2%) • Python (2%) • other (1%)", result)
     }
 
     @Test
@@ -696,15 +694,17 @@ class LanguageDetectionRulesTest {
     }
 
     @Test
-    fun `pickTopLanguagesForDisplay collapses an entry below 1 percent floor`() {
-        // Boundary: 9950 + 50 = 10_000 total, java is 50/10000 = 0.5% → floor == 0 →
-        // collapse into other with raw-share sum rendered as integer-rounded pct.
-        // Collapsed raw = 50 → floor(50/10000 * 100) = 0 → suffix omitted.
+    fun `pickTopLanguagesForDisplay absorbs sub-1 percent entry into the dominant under Largest Remainder`() {
+        // 9950 / 50 = 10_000 total. Floors are 99 / 0, leaving 1 pt to redistribute;
+        // ties on remainder (both 0.5) break by weight desc — Kotlin wins and
+        // bumps to 100. Java drops from the named list (pct 0 after allocation),
+        // collapsed_pct is 0, no "other" bucket. Sum is exactly 100 — the older
+        // plain-floor algorithm printed "Kotlin (99%)" with 1 pt missing.
         val result =
             LanguageDetectionRules.pickTopLanguagesForDisplay(
                 mapOf("kotlin" to 9_950L, "java" to 50L),
             )
-        assertEquals("Kotlin (99%)", result)
+        assertEquals("Kotlin (100%)", result)
     }
 
     @Test
@@ -804,18 +804,44 @@ class LanguageDetectionRulesTest {
     }
 
     @Test
-    fun `pickDisplayEntries drops sub-1-percent entries into the other bucket`() {
-        // 99% Kotlin + 0.5% Java + 0.5% Python → Java and Python fall below the
-        // 1% floor (pct == 0 after integer rounding) and fold into "other" even
-        // though they fit within the top-3 slot limit. The "other" bucket's
-        // rounded percent matches the floor behaviour of integer truncation —
-        // here total raw = 1000, collapsedRaw = 5+5 = 10, percent = 1.
+    fun `pickDisplayEntries uses Largest Remainder so integer percentages sum to 100`() {
+        // 99% Kotlin + 0.5% Java + 0.5% Python: floor gives 99/0/0 = 99. The
+        // Largest Remainder rule redistributes the missing 1 pt to the entry
+        // with the largest fractional remainder (0.5 for Java and Python);
+        // ties break by weight desc (both 5) then id asc ("java" < "python"),
+        // so Java is bumped to 1% and Python stays at 0. The bump promotes
+        // Java into the named list since its final percent now clears the
+        // 1% visibility floor; Python (0%) is dropped with no "other" bucket.
         val entries =
             LanguageDetectionRules.pickDisplayEntries(
                 mapOf("kotlin" to 990L, "java" to 5L, "python" to 5L),
             )
-        assertEquals(listOf("kotlin", null), entries.map { it.id })
+        assertEquals(listOf("kotlin", "java"), entries.map { it.id })
         assertEquals(listOf(99, 1), entries.map { it.percent })
+        assertEquals(100, entries.sumOf { it.percent }, "integer percentages must sum to 100")
+    }
+
+    @Test
+    fun `pickDisplayEntries absorbs missing point into the other bucket via Largest Remainder`() {
+        // 950 / 23 / 22 / 5 — the exact case a user reported where plain floor
+        // rounding produced "95% · 2% · 2% · 0%" summing to 99 and looking
+        // like a math bug. Largest Remainder promotes the lowest-weight entry
+        // (Ruby at 0.5 remainder, the highest) up by 1, which lands in the
+        // "other" bucket (past top-3) so the row now shows 95 · 2 · 2 · other 1
+        // and sums cleanly to 100.
+        val entries =
+            LanguageDetectionRules.pickDisplayEntries(
+                mapOf(
+                    "kotlin" to 950L,
+                    "python" to 23L,
+                    "java" to 22L,
+                    "ruby" to 5L,
+                ),
+            )
+        assertEquals(listOf("kotlin", "python", "java", null), entries.map { it.id })
+        assertEquals(listOf(95, 2, 2, 1), entries.map { it.percent })
+        assertEquals(100, entries.sumOf { it.percent })
+        assertEquals("other", entries.last().label)
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/accent/LanguageDetectionRulesTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/LanguageDetectionRulesTest.kt
@@ -581,6 +581,169 @@ class LanguageDetectionRulesTest {
         assertTrue(missing.isEmpty(), "Missing canonical excluded segments: $missing")
     }
 
+    // ── pickTopLanguagesForDisplay ───────────────────────────────────────────────────
+
+    @Test
+    fun `pickTopLanguagesForDisplay returns empty string for empty weights map`() {
+        // Polyglot null-state — the caller renders the fixed polyglot copy on an
+        // empty return, so the formatter MUST NOT invent a synthetic verdict.
+        assertEquals("", LanguageDetectionRules.pickTopLanguagesForDisplay(emptyMap()))
+    }
+
+    @Test
+    fun `pickTopLanguagesForDisplay returns empty string when all weights are zero`() {
+        // Divide-by-zero guard: every share would be NaN, so we bail out with an
+        // empty string and let the caller render the polyglot fallback.
+        val result =
+            LanguageDetectionRules.pickTopLanguagesForDisplay(
+                mapOf("kotlin" to 0L, "java" to 0L),
+            )
+        assertEquals("", result)
+    }
+
+    @Test
+    fun `pickTopLanguagesForDisplay returns Kotlin 100 percent for single kotlin weight`() {
+        val result =
+            LanguageDetectionRules.pickTopLanguagesForDisplay(mapOf("kotlin" to 1_000L))
+        assertEquals("Kotlin (100%)", result)
+    }
+
+    @Test
+    fun `pickTopLanguagesForDisplay shows YAML 100 percent for yaml-only markup fallback`() {
+        // Markup-only project (K8s manifests) — code tier is empty so markup
+        // becomes the display base, YAML gets its 100% share. Test environment
+        // may return null for Language.findLanguageByID("yaml") — either the
+        // live display name or the "Yaml" title-cased fallback is acceptable.
+        val result =
+            LanguageDetectionRules.pickTopLanguagesForDisplay(mapOf("yaml" to 1_000L))
+        val acceptable = result == "YAML (100%)" || result == "Yaml (100%)"
+        assertTrue(
+            acceptable,
+            "Expected 'YAML (100%)' or 'Yaml (100%)' — got: '$result'",
+        )
+    }
+
+    @Test
+    fun `pickTopLanguagesForDisplay filters out markup when code tier is non-empty`() {
+        // Android-style code+markup: Kotlin (40%) + XML (60%). The two-tier filter
+        // drops XML from the display base, so Kotlin renders as 100% of the code
+        // tier. Prevents the misleading "Kotlin (40%) • XML (60%)" case from
+        // Phase 26 success criterion #4.
+        val result =
+            LanguageDetectionRules.pickTopLanguagesForDisplay(
+                mapOf("kotlin" to 400L, "xml" to 600L),
+            )
+        assertEquals("Kotlin (100%)", result)
+    }
+
+    @Test
+    fun `pickTopLanguagesForDisplay renders three named languages without other bucket`() {
+        val result =
+            LanguageDetectionRules.pickTopLanguagesForDisplay(
+                mapOf("kotlin" to 780L, "java" to 150L, "python" to 70L),
+            )
+        assertEquals("Kotlin (78%) • Java (15%) • Python (7%)", result)
+    }
+
+    @Test
+    fun `pickTopLanguagesForDisplay collapses 4th-plus languages into trailing other bucket`() {
+        // Top-3 kept; 4th and 5th languages (Go + Ruby) collapse into "other".
+        // Integer-rounded raw-share sum of the collapsed entries: 3 + 2 = 5%.
+        val result =
+            LanguageDetectionRules.pickTopLanguagesForDisplay(
+                mapOf(
+                    "kotlin" to 500L,
+                    "java" to 300L,
+                    "python" to 150L,
+                    "ruby" to 30L,
+                    "go" to 20L,
+                ),
+            )
+        assertEquals("Kotlin (50%) • Java (30%) • Python (15%) • other (5%)", result)
+    }
+
+    @Test
+    fun `pickTopLanguagesForDisplay collapses sub-1 percent entries into other bucket`() {
+        // 99.5% kotlin + 0.5% java → java floor-percent is 0, below 1% threshold,
+        // collapses into "other" with integer-rounded raw share (0% → suffix dropped).
+        // Use a case where collapsed sum is non-zero: 98% + 2 × 1% boundary cases,
+        // plus a 0.5% entry that actually rounds to zero.
+        val result =
+            LanguageDetectionRules.pickTopLanguagesForDisplay(
+                mapOf(
+                    "kotlin" to 950L,
+                    "java" to 20L,
+                    "python" to 15L,
+                    "rust" to 10L,
+                    "go" to 5L,
+                ),
+            )
+        // kotlin 95%, java 2%, python 1%, rust 1%, go 0% → top-3 kept, go collapses
+        // into other. Rust is at 1% (floor), stays as 4th → but top-3 cap drops it
+        // too. Collapsed raw sum = 10 + 5 = 15 → floor(15/1000 * 100) = 1%.
+        assertEquals("Kotlin (95%) • Java (2%) • Python (1%) • other (1%)", result)
+    }
+
+    @Test
+    fun `pickTopLanguagesForDisplay keeps an entry at exactly 1 percent floor`() {
+        // Boundary: 99 + 1 = 100 total, java is 1/100 = 1.0% → floor == 1 → KEEP.
+        // A regression that changed the condition to `> 1` would drop java here.
+        val result =
+            LanguageDetectionRules.pickTopLanguagesForDisplay(
+                mapOf("kotlin" to 99L, "java" to 1L),
+            )
+        assertEquals("Kotlin (99%) • Java (1%)", result)
+    }
+
+    @Test
+    fun `pickTopLanguagesForDisplay collapses an entry below 1 percent floor`() {
+        // Boundary: 9950 + 50 = 10_000 total, java is 50/10000 = 0.5% → floor == 0 →
+        // collapse into other with raw-share sum rendered as integer-rounded pct.
+        // Collapsed raw = 50 → floor(50/10000 * 100) = 0 → suffix omitted.
+        val result =
+            LanguageDetectionRules.pickTopLanguagesForDisplay(
+                mapOf("kotlin" to 9_950L, "java" to 50L),
+            )
+        assertEquals("Kotlin (99%)", result)
+    }
+
+    @Test
+    fun `pickTopLanguagesForDisplay does not append other bucket when nothing collapses`() {
+        // Three languages, each ≥ 1% floor, top-3 cap NOT triggered → no
+        // trailing " • other (N%)" even though shares don't sum to exactly 100.
+        val result =
+            LanguageDetectionRules.pickTopLanguagesForDisplay(
+                mapOf("kotlin" to 40L, "java" to 30L, "python" to 30L),
+            )
+        // floor(40/100*100)=40, floor(30/100*100)=30, floor(30/100*100)=30
+        assertEquals("Kotlin (40%) • Java (30%) • Python (30%)", result)
+    }
+
+    @Test
+    fun `pickTopLanguagesForDisplay falls back to title-cased id for unknown language`() {
+        // Unknown id ("xyzunknown" is not in the Language registry) — formatter
+        // MUST title-case the raw id rather than emit a lowercase display name.
+        // Test env's Language.findLanguageByID returns null for this id.
+        val result =
+            LanguageDetectionRules.pickTopLanguagesForDisplay(mapOf("xyzunknown" to 1_000L))
+        assertTrue(
+            result.startsWith("Xyzunknown"),
+            "Expected unknown-id fallback to title-case 'xyzunknown' — got: '$result'",
+        )
+    }
+
+    @Test
+    fun `pickTopLanguagesForDisplay breaks ties alphabetically by language id`() {
+        // Equal weights → alphabetical order on the id ("java" < "kotlin"), so
+        // Java must precede Kotlin in the display. Matches pickDominantFromWeights
+        // determinism contract so a HashMap iteration-order regression fails loudly.
+        val result =
+            LanguageDetectionRules.pickTopLanguagesForDisplay(
+                mapOf("kotlin" to 500L, "java" to 500L),
+            )
+        assertEquals("Java (50%) • Kotlin (50%)", result)
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────────────────
 
     private fun mockLanguageFileType(languageId: String): FileType {

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
@@ -757,6 +757,55 @@ class ProjectLanguageDetectorTest {
     }
 
     @Test
+    fun `refreshAccentOnEdt swallows a throwing settings read without rethrowing`() {
+        // Lock on the round-5 widening of runCatching: the settings read at
+        // AccentMappingsSettings.getInstance() can fail during a plugin-unload
+        // race or a corrupt persistent-state XML read. Must be contained inside
+        // the wrapper so it never bubbles out as an uncaught EDT exception.
+        // Narrowing the runCatching back to "apply chain only" would regress
+        // round-5 and this test would fail.
+        mockkObject(AccentMappingsSettings.Companion)
+        every { AccentMappingsSettings.getInstance() } throws RuntimeException("plugin unload race")
+
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.apply(any()) } returns Unit
+
+        val project = stubProject("/tmp/refresh-settings-boom-${System.nanoTime()}")
+
+        // Must not throw — the widened runCatching contains the settings read.
+        ProjectLanguageDetector.refreshAccentOnEdt(project, "kotlin")
+
+        // And because the membership check never executed, the apply chain
+        // must not have been reached.
+        verify(exactly = 0) { AccentApplicator.apply(any()) }
+    }
+
+    @Test
+    fun `refreshAccentOnEdt skips apply chain when variant detection returns null`() {
+        // Null variant = no Ayu theme active. The early `?: return@…` keeps
+        // the applicator from touching UIManager when there's no Ayu theme to
+        // drive. Locking the guard so a future author doesn't delete it as
+        // "dead code" — it's the fallback path for users on a non-Ayu theme.
+        val mappingsState =
+            AccentMappingsState().apply { languageAccents["kotlin"] = "#FFCC66" }
+        val settings = mockk<AccentMappingsSettings>()
+        every { settings.state } returns mappingsState
+        mockkObject(AccentMappingsSettings.Companion)
+        every { AccentMappingsSettings.getInstance() } returns settings
+
+        mockkObject(AyuVariant.Companion)
+        every { AyuVariant.detect() } returns null
+
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.apply(any()) } returns Unit
+
+        val project = stubProject("/tmp/refresh-null-variant-${System.nanoTime()}")
+        ProjectLanguageDetector.refreshAccentOnEdt(project, "kotlin")
+
+        verify(exactly = 0) { AccentApplicator.apply(any()) }
+    }
+
+    @Test
     fun `refreshAccentOnEdt skips apply chain when project is disposed`() {
         // Round-2 disposal guard: scheduling delay between background scan
         // and EDT dispatch can close the project. The early return here

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
@@ -694,6 +694,69 @@ class ProjectLanguageDetectorTest {
     }
 
     @Test
+    fun `refreshAccentOnEdt runs the full apply chain when override is present`() {
+        // Happy-path lock: given a language override for the detected id on a
+        // live project, the helper must call the full resolver → applicator →
+        // swap-cache chain. A regression flipping the `!in` guard or dropping
+        // any of the three downstream calls would leave users stuck on the
+        // global accent until the next focus swap — exactly the bug the
+        // extraction was meant to lock down.
+        val mappingsState =
+            AccentMappingsState().apply { languageAccents["kotlin"] = "#FFCC66" }
+        val settings = mockk<AccentMappingsSettings>()
+        every { settings.state } returns mappingsState
+        mockkObject(AccentMappingsSettings.Companion)
+        every { AccentMappingsSettings.getInstance() } returns settings
+
+        mockkObject(AyuVariant.Companion)
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        mockkObject(AccentResolver)
+        every { AccentResolver.resolve(any(), any()) } returns "#FFCC66"
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.apply(any()) } returns Unit
+        val swapService = mockk<dev.ayuislands.settings.mappings.ProjectAccentSwapService>(relaxed = true)
+        mockkObject(dev.ayuislands.settings.mappings.ProjectAccentSwapService.Companion)
+        every {
+            dev.ayuislands.settings.mappings.ProjectAccentSwapService
+                .getInstance()
+        } returns swapService
+
+        val project = stubProject("/tmp/refresh-hit-${System.nanoTime()}")
+        ProjectLanguageDetector.refreshAccentOnEdt(project, "kotlin")
+
+        verify(exactly = 1) { AccentApplicator.apply("#FFCC66") }
+        verify(exactly = 1) { swapService.notifyExternalApply("#FFCC66") }
+    }
+
+    @Test
+    fun `refreshAccentOnEdt swallows a throwing apply chain without rethrowing`() {
+        // Contract lock on the runCatchingPreservingCancellation wrapper:
+        // AccentApplicator.apply can throw on a LafManager race / UIManager
+        // shutdown; if that propagates out of the invokeLater callback it
+        // becomes an uncaught EDT exception. This test asserts the helper
+        // returns normally (WARN-logged internally) instead of rethrowing.
+        val mappingsState =
+            AccentMappingsState().apply { languageAccents["kotlin"] = "#FFCC66" }
+        val settings = mockk<AccentMappingsSettings>()
+        every { settings.state } returns mappingsState
+        mockkObject(AccentMappingsSettings.Companion)
+        every { AccentMappingsSettings.getInstance() } returns settings
+
+        mockkObject(AyuVariant.Companion)
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        mockkObject(AccentResolver)
+        every { AccentResolver.resolve(any(), any()) } returns "#FFCC66"
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.apply(any()) } throws RuntimeException("LafManager boom")
+
+        val project = stubProject("/tmp/refresh-throw-${System.nanoTime()}")
+        // Must not throw — load-bearing assertion is simply that the call
+        // completes. A regression dropping the runCatching would propagate
+        // the RuntimeException and fail this test.
+        ProjectLanguageDetector.refreshAccentOnEdt(project, "kotlin")
+    }
+
+    @Test
     fun `refreshAccentOnEdt skips apply chain when project is disposed`() {
         // Round-2 disposal guard: scheduling delay between background scan
         // and EDT dispatch can close the project. The early return here

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
@@ -6,6 +6,8 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.projectRoots.SdkTypeId
 import com.intellij.openapi.roots.ProjectRootManager
+import dev.ayuislands.settings.mappings.AccentMappingsSettings
+import dev.ayuislands.settings.mappings.AccentMappingsState
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -632,6 +634,87 @@ class ProjectLanguageDetectorTest {
         wireProjectRootManager(project, sdkName = sdkName)
         wireModuleManager(project, moduleNames = emptyList())
         assertEquals(expected, ProjectLanguageDetector.dominant(project))
+    }
+
+    // ── proportions() cross-cache coherence guard ─────────────────────────────
+
+    @Test
+    fun `proportions returns null when weightsCache is populated but dominant cache was evicted`() {
+        // Round 3 closed a race: `detectAndCache` writes `weightsCache` first,
+        // then `cache` (dominant-id) last. If `invalidate()` interleaves
+        // between the two writes, a reader that ignored the dominant-id cache
+        // would serve a stale weights breakdown for a layout the detector has
+        // already forgotten. `proportions()` guards with `cache[key] == null`;
+        // this test simulates the race by warming both caches and then
+        // evicting only the dominant-id side, asserting `proportions()`
+        // returns null rather than the stale weights map.
+        val project = stubProject("/tmp/prop-guard-${System.nanoTime()}")
+        every { ProjectLanguageScanner.scan(project) } returns mapOf("kotlin" to 500L, "java" to 500L)
+        wireProjectRootManager(project, sdkName = "KotlinSDK")
+        wireModuleManager(project, moduleNames = emptyList())
+
+        // Warm both caches in a coherent state.
+        ProjectLanguageDetector.dominant(project)
+        assertEquals(
+            mapOf("kotlin" to 500L, "java" to 500L),
+            ProjectLanguageDetector.proportions(project),
+            "baseline: both caches warm, proportions must serve the weights",
+        )
+
+        // Simulate the race: dominant-id cache evicted, weightsCache still
+        // populated. The guard in `proportions()` must treat this as cold.
+        ProjectLanguageDetector.evictDominantCacheForTest(project)
+        assertNull(
+            ProjectLanguageDetector.proportions(project),
+            "proportions must not serve weightsCache entries that are orphaned by an evicted dominant-id entry",
+        )
+    }
+
+    // ── refreshAccentOnEdt (extracted from tryRefreshAccentForDetected) ───────
+
+    @Test
+    fun `refreshAccentOnEdt skips apply chain when detected id has no language override`() {
+        // Round 2 moved the membership check inside the EDT body so the
+        // apply chain reads the same snapshot the resolver will resolve
+        // against. Locking the "no override → no apply" branch here so a
+        // regression flipping the `!in` guard is caught.
+        val mappingsState = AccentMappingsState()
+        val settings = mockk<AccentMappingsSettings>()
+        every { settings.state } returns mappingsState
+        mockkObject(AccentMappingsSettings.Companion)
+        every { AccentMappingsSettings.getInstance() } returns settings
+
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.apply(any()) } returns Unit
+
+        val project = stubProject("/tmp/refresh-miss-${System.nanoTime()}")
+        ProjectLanguageDetector.refreshAccentOnEdt(project, "kotlin")
+
+        verify(exactly = 0) { AccentApplicator.apply(any()) }
+    }
+
+    @Test
+    fun `refreshAccentOnEdt skips apply chain when project is disposed`() {
+        // Round-2 disposal guard: scheduling delay between background scan
+        // and EDT dispatch can close the project. The early return here
+        // keeps the applicator from writing UIManager entries for a dead
+        // project's swap-cache.
+        val mappingsState =
+            AccentMappingsState().apply { languageAccents["kotlin"] = "#FFCC66" }
+        val settings = mockk<AccentMappingsSettings>()
+        every { settings.state } returns mappingsState
+        mockkObject(AccentMappingsSettings.Companion)
+        every { AccentMappingsSettings.getInstance() } returns settings
+
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.apply(any()) } returns Unit
+
+        val project = stubProject("/tmp/refresh-disposed-${System.nanoTime()}")
+        every { project.isDisposed } returns true
+
+        ProjectLanguageDetector.refreshAccentOnEdt(project, "kotlin")
+
+        verify(exactly = 0) { AccentApplicator.apply(any()) }
     }
 
     private fun assertModuleDetects(

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
@@ -474,6 +474,154 @@ class ProjectLanguageDetectorTest {
         verify(exactly = 2) { ProjectLanguageScanner.scan(project) }
     }
 
+    // ── proportions + weightsCache coherence ─────────────────────────────────────────
+
+    @Test
+    fun `proportions returns null for a cold cache without calling the scanner`() {
+        // Cold cache: nothing warmed by dominant(). proportions() is a strictly
+        // read-only projection; it MUST NOT call ProjectLanguageScanner.scan()
+        // on a miss — the caller renders the polyglot copy on null.
+        val project = stubProject("/tmp/proportions-cold-${System.nanoTime()}")
+        wireProjectRootManager(project, sdkName = null)
+        wireModuleManager(project, moduleNames = emptyList())
+
+        assertNull(ProjectLanguageDetector.proportions(project))
+        verify(exactly = 0) { ProjectLanguageScanner.scan(any()) }
+    }
+
+    @Test
+    fun `proportions returns the warm weights map after dominant populates the cache`() {
+        // dominant() runs a full scan and caches both the id and the raw weights.
+        // A subsequent proportions() call serves the exact same map from the
+        // parallel weightsCache — no second scan, same instance reference.
+        val project = stubProject("/tmp/proportions-warm-${System.nanoTime()}")
+        val scanWeights = mapOf("kotlin" to 900L, "java" to 100L)
+        every { ProjectLanguageScanner.scan(project) } returns scanWeights
+        wireProjectRootManager(project, sdkName = null)
+        wireModuleManager(project, moduleNames = emptyList())
+
+        assertEquals("kotlin", ProjectLanguageDetector.dominant(project))
+        assertEquals(scanWeights, ProjectLanguageDetector.proportions(project))
+        // Scanner was called exactly once — by dominant(). proportions() did not scan.
+        verify(exactly = 1) { ProjectLanguageScanner.scan(project) }
+    }
+
+    @Test
+    fun `invalidate evicts both dominant cache and weights cache atomically`() {
+        // Invalidate must be total — a drift where dominant() re-scans but
+        // proportions() still serves stale weights would confuse users who
+        // see the polyglot copy while their override applies correctly (or
+        // vice-versa).
+        val project = stubProject("/tmp/proportions-invalidate-${System.nanoTime()}")
+        every { ProjectLanguageScanner.scan(project) } returns
+            mapOf("python" to 800L, "yaml" to 200L)
+        wireProjectRootManager(project, sdkName = null)
+        wireModuleManager(project, moduleNames = emptyList())
+
+        // Warm both caches.
+        assertEquals("python", ProjectLanguageDetector.dominant(project))
+        assertEquals(
+            mapOf("python" to 800L, "yaml" to 200L),
+            ProjectLanguageDetector.proportions(project),
+        )
+
+        ProjectLanguageDetector.invalidate(project)
+
+        // After invalidate: proportions returns null (weights evicted) AND a
+        // fresh dominant() call re-kicks the scanner (cache evicted).
+        assertNull(ProjectLanguageDetector.proportions(project))
+        assertEquals("python", ProjectLanguageDetector.dominant(project))
+        verify(exactly = 2) { ProjectLanguageScanner.scan(project) }
+    }
+
+    @Test
+    fun `proportions returns null when the project has no canonical path`() {
+        // Disposal race / default-project: AccentResolver.projectKey returns
+        // null. proportions() must bail out with null — the polyglot copy is
+        // the correct fallback.
+        val project = mockk<Project>()
+        every { project.basePath } returns null
+        every { project.isDefault } returns false
+        every { project.isDisposed } returns false
+
+        assertNull(ProjectLanguageDetector.proportions(project))
+    }
+
+    @Test
+    fun `proportions returns null when the scan returned null transient failure`() {
+        // Scanner returns null when it can't give an authoritative answer
+        // (dumb mode, disposal race). detectAndCache treats this as
+        // cacheable=false → neither cache is written. proportions() must
+        // therefore keep returning null on subsequent calls.
+        val project = stubProject("/tmp/proportions-transient-${System.nanoTime()}")
+        every { ProjectLanguageScanner.scan(project) } returns null
+        wireProjectRootManager(project, sdkName = null)
+        wireModuleManager(project, moduleNames = emptyList())
+
+        // dominant() reports null AND does NOT cache (transient failure).
+        assertNull(ProjectLanguageDetector.dominant(project))
+        assertNull(ProjectLanguageDetector.proportions(project))
+    }
+
+    @Test
+    fun `clear empties both dominant cache and weights cache`() {
+        // The @TestOnly clear() seam must reset BOTH caches — test isolation
+        // depends on it. A regression that only cleared the dominant cache
+        // would leak weights across tests.
+        val project = stubProject("/tmp/proportions-clear-${System.nanoTime()}")
+        every { ProjectLanguageScanner.scan(project) } returns
+            mapOf("rust" to 1_000L)
+        wireProjectRootManager(project, sdkName = null)
+        wireModuleManager(project, moduleNames = emptyList())
+
+        ProjectLanguageDetector.dominant(project)
+        assertEquals(mapOf("rust" to 1_000L), ProjectLanguageDetector.proportions(project))
+
+        ProjectLanguageDetector.clear()
+
+        assertNull(ProjectLanguageDetector.proportions(project))
+    }
+
+    @Test
+    fun `detectAndCache does not write weightsCache on legacy SDK fallback path`() {
+        // Scanner returned emptyMap (brand-new project / docs-only after filter).
+        // Legacy SDK resolves to "rust" — dominant cache populated, but the
+        // weights cache MUST stay empty so proportions() returns null and the
+        // caller renders polyglot copy (there are no meaningful proportions to
+        // display when the scan itself is empty).
+        val project = stubProject("/tmp/proportions-legacy-sdk-${System.nanoTime()}")
+        every { ProjectLanguageScanner.scan(project) } returns emptyMap()
+        wireProjectRootManager(project, sdkName = "RustSdkType")
+        wireModuleManager(project, moduleNames = emptyList())
+
+        assertEquals("rust", ProjectLanguageDetector.dominant(project))
+        assertNull(ProjectLanguageDetector.proportions(project))
+    }
+
+    @Test
+    fun `proportions for one project does not leak to another project`() {
+        // Multi-entity isolation (CLAUDE.md testing philosophy): weightsCache
+        // is keyed by AccentResolver.projectKey (canonical path), so project A
+        // and project B each get their own entry. A bug that used a shared key
+        // would cause cross-contamination and user-visible confusion.
+        val a = stubProject("/tmp/proportions-a-${System.nanoTime()}")
+        val b = stubProject("/tmp/proportions-b-${System.nanoTime()}")
+        val aWeights = mapOf("kotlin" to 900L, "java" to 100L)
+        val bWeights = mapOf("python" to 800L, "yaml" to 200L)
+        every { ProjectLanguageScanner.scan(a) } returns aWeights
+        every { ProjectLanguageScanner.scan(b) } returns bWeights
+        wireProjectRootManager(a, sdkName = null)
+        wireProjectRootManager(b, sdkName = null)
+        wireModuleManager(a, moduleNames = emptyList())
+        wireModuleManager(b, moduleNames = emptyList())
+
+        ProjectLanguageDetector.dominant(a)
+        ProjectLanguageDetector.dominant(b)
+
+        assertEquals(aWeights, ProjectLanguageDetector.proportions(a))
+        assertEquals(bWeights, ProjectLanguageDetector.proportions(b))
+    }
+
     // Test helpers
 
     private fun assertSdkDetects(

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderApplyTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderApplyTest.kt
@@ -1,0 +1,145 @@
+package dev.ayuislands.settings.mappings
+
+import com.intellij.openapi.project.Project
+import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentResolver
+import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.accent.ProjectLanguageDetector
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Locks the defense-in-depth contract around [OverridesGroupBuilder.apply]:
+ *
+ *  - Persisted state is committed from the pending tables BEFORE the
+ *    resolver/applicator/swap chain fires.
+ *  - A transient failure in the apply chain (LafManager loss, UIManager race,
+ *    project-swap service shutdown) MUST NOT skip the `storedProjects` /
+ *    `storedLanguages` snapshot refresh or the pending-change `fireChanged()`
+ *    broadcast below the try block.
+ *  - After apply() returns, `isModified()` must read `false` for the
+ *    just-committed rows — or the settings UI drifts into a "Apply is lit even
+ *    after saving" loop that users can only break by closing the dialog.
+ *
+ * Red/green: remove the runCatching wrapper from `apply()` and this test
+ * fails; remove the `storedProjects` snapshot line and this test fails.
+ */
+class OverridesGroupBuilderApplyTest {
+    private lateinit var mappingsState: AccentMappingsState
+
+    @BeforeTest
+    fun setUp() {
+        mappingsState = AccentMappingsState()
+        val settings = mockk<AccentMappingsSettings>()
+        every { settings.state } returns mappingsState
+        mockkObject(AccentMappingsSettings.Companion)
+        every { AccentMappingsSettings.getInstance() } returns settings
+
+        mockkObject(ProjectLanguageDetector)
+        every { ProjectLanguageDetector.dominant(any()) } returns null
+
+        mockkObject(AyuVariant.Companion)
+        mockkObject(AccentResolver)
+        mockkObject(AccentApplicator)
+        mockkObject(ProjectAccentSwapService.Companion)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `apply() updates stored snapshot and fires changed when the apply chain throws`() {
+        // Simulate the round-2 threat model: the resolver / applicator / swap-cache
+        // chain explodes mid-apply (e.g. LafManager returning null on a shutdown
+        // race). The pending-model snapshot is already persisted to mappingsState
+        // by the time the chain runs, so the user's overrides ARE saved — what
+        // we're locking here is the in-memory drift: storedProjects/Languages must
+        // still advance and the pending-change listener must still fire, or the
+        // settings UI will keep reporting "modified" on already-saved state.
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        every { AccentResolver.resolve(any(), any()) } returns "#FFCC66"
+        every { AccentApplicator.apply(any()) } throws RuntimeException("LafManager boom")
+
+        val builder = OverridesGroupBuilder()
+        var listenerFired = 0
+        builder.addPendingChangeListener { listenerFired += 1 }
+        builder.seedPendingForTest(
+            projects =
+                listOf(
+                    ProjectMapping(canonicalPath = "/tmp/apply-exc-a", displayName = "a", hex = "#111111"),
+                ),
+            languages =
+                listOf(LanguageMapping(languageId = "kotlin", displayName = "Kotlin", hex = "#222222")),
+        )
+
+        builder.apply()
+
+        // Persisted state reflects the pending snapshot (reachable because
+        // `apply()` commits to state BEFORE entering the runCatching block).
+        assertEquals(mapOf("/tmp/apply-exc-a" to "#111111"), mappingsState.projectAccents)
+        assertEquals(mapOf("kotlin" to "#222222"), mappingsState.languageAccents)
+
+        // storedProjects/Languages advanced past the pending model — `isModified()`
+        // now reads `false` even though the apply chain threw. A regression that
+        // short-circuited the snapshot refresh would leave `isModified()` true.
+        assertFalse(
+            builder.isModified(),
+            "apply()'s runCatching must not skip the storedProjects/Languages refresh — " +
+                "the settings UI would otherwise keep reporting pending changes on saved state",
+        )
+
+        // fireChanged() must still fire so any reactive label (e.g., the
+        // "Currently active: ..." comment) updates off the newly committed
+        // snapshot.
+        assertTrue(
+            listenerFired > 0,
+            "addPendingChangeListener subscribers must be notified even when the " +
+                "apply chain throws; got $listenerFired calls",
+        )
+    }
+
+    @Test
+    fun `apply() on happy path invokes the whole resolver-applicator-swap chain once`() {
+        // Baseline that the runCatching wrapper doesn't silently convert the
+        // success path into a swallow. One AccentApplicator.apply call, one
+        // swap-service notification, isModified() returns false.
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        every { AccentResolver.resolve(any(), any()) } returns "#AABBCC"
+        every { AccentApplicator.apply(any()) } returns Unit
+        val swapService = mockk<ProjectAccentSwapService>(relaxed = true)
+        every { ProjectAccentSwapService.getInstance() } returns swapService
+
+        val stubProject = mockk<Project>(relaxed = true)
+        val builder =
+            OverridesGroupBuilder().apply {
+                setParentProjectForTest(stubProject)
+                seedPendingForTest(
+                    projects =
+                        listOf(
+                            ProjectMapping(
+                                canonicalPath = "/tmp/apply-ok-b",
+                                displayName = "b",
+                                hex = "#AABBCC",
+                            ),
+                        ),
+                )
+            }
+
+        builder.apply()
+
+        assertEquals(mapOf("/tmp/apply-ok-b" to "#AABBCC"), mappingsState.projectAccents)
+        assertFalse(builder.isModified(), "stored snapshot must advance on happy path too")
+        io.mockk.verify(exactly = 1) { AccentApplicator.apply("#AABBCC") }
+        io.mockk.verify(exactly = 1) { swapService.notifyExternalApply("#AABBCC") }
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderPendingTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderPendingTest.kt
@@ -50,7 +50,7 @@ class OverridesGroupBuilderPendingTest {
         mappingsState.projectAccents[tmp] = "#ABCDEF"
         val project = stubProject(File(tmp))
 
-        val builder = OverridesGroupBuilder().apply { loadFromStateForTest() }
+        val builder = OverridesGroupBuilder().apply { loadFromState() }
 
         assertEquals("#ABCDEF", builder.resolvePending(project, "#FFCC66"))
         assertEquals(AccentResolver.Source.PROJECT_OVERRIDE, builder.sourcePending(project))
@@ -62,7 +62,7 @@ class OverridesGroupBuilderPendingTest {
         val project = stubProject(File(System.getProperty("java.io.tmpdir"), "pending-lang"))
         every { ProjectLanguageDetector.dominant(project) } returns "kotlin"
 
-        val builder = OverridesGroupBuilder().apply { loadFromStateForTest() }
+        val builder = OverridesGroupBuilder().apply { loadFromState() }
 
         assertEquals("#112233", builder.resolvePending(project, "#FFCC66"))
         assertEquals(AccentResolver.Source.LANGUAGE_OVERRIDE, builder.sourcePending(project))
@@ -76,7 +76,7 @@ class OverridesGroupBuilderPendingTest {
         val project = stubProject(File(tmp))
         every { ProjectLanguageDetector.dominant(project) } returns "kotlin"
 
-        val builder = OverridesGroupBuilder().apply { loadFromStateForTest() }
+        val builder = OverridesGroupBuilder().apply { loadFromState() }
 
         assertEquals("#111111", builder.resolvePending(project, "#FFCC66"))
         assertEquals(AccentResolver.Source.PROJECT_OVERRIDE, builder.sourcePending(project))
@@ -86,7 +86,7 @@ class OverridesGroupBuilderPendingTest {
     fun `resolvePending falls back to global when no pending entry matches`() {
         val project = stubProject(File(System.getProperty("java.io.tmpdir"), "pending-none"))
 
-        val builder = OverridesGroupBuilder().apply { loadFromStateForTest() }
+        val builder = OverridesGroupBuilder().apply { loadFromState() }
 
         assertEquals("#FFCC66", builder.resolvePending(project, "#FFCC66"))
         assertEquals(AccentResolver.Source.GLOBAL, builder.sourcePending(project))
@@ -104,7 +104,7 @@ class OverridesGroupBuilderPendingTest {
                 every { name } returns "default"
             }
 
-        val builder = OverridesGroupBuilder().apply { loadFromStateForTest() }
+        val builder = OverridesGroupBuilder().apply { loadFromState() }
 
         assertEquals("#FFCC66", builder.resolvePending(defaultProject, "#FFCC66"))
         assertEquals(AccentResolver.Source.GLOBAL, builder.sourcePending(defaultProject))
@@ -121,7 +121,7 @@ class OverridesGroupBuilderPendingTest {
         //    pass the positive assertion alone)
         mappingsState.languageAccents["kotlin"] = "#CAFE00"
 
-        val builder = OverridesGroupBuilder().apply { loadFromStateForTest() }
+        val builder = OverridesGroupBuilder().apply { loadFromState() }
 
         val lowercaseProject = stubProject(File(System.getProperty("java.io.tmpdir"), "case-lower"))
         every { ProjectLanguageDetector.dominant(lowercaseProject) } returns "kotlin"

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderProportionsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderProportionsTest.kt
@@ -1,6 +1,7 @@
 package dev.ayuislands.settings.mappings
 
 import com.intellij.openapi.project.Project
+import dev.ayuislands.accent.LanguageDetectionRules
 import dev.ayuislands.accent.ProjectLanguageDetector
 import dev.ayuislands.accent.ProjectLanguageScanner
 import io.mockk.every
@@ -280,6 +281,36 @@ class OverridesGroupBuilderProportionsTest {
             "refresh must rebuild children from projectB's weights — both project A " +
                 "and project B are single-language so the rendered text collapses to " +
                 "Detected: + 100%; the difference shows up in the resolved icon, not text",
+        )
+    }
+
+    @Test
+    fun `panel repopulate swallows an iconForLanguageId throw without propagating`() {
+        // Defense-in-depth lock: `populateProportionsPanel` wraps its entire
+        // body in runCatchingPreservingCancellation because a third-party
+        // Language plugin can throw from `associatedFileType.icon`. If the
+        // wrapper is ever removed, the EDT callback would bubble an exception
+        // that the builder's pending-change listener chain and `reset()` also
+        // dispatch through — breaking the entire Overrides group, not just
+        // the proportions row. Red/green: force iconForLanguageId to throw and
+        // assert the seam still returns (polyglot copy, previous state) rather
+        // than surfacing the exception.
+        mockkObject(LanguageDetectionRules)
+        every { LanguageDetectionRules.pickDisplayEntries(any(), any()) } returns
+            listOf(LanguageDetectionRules.DisplayEntry(id = "kotlin", label = "Kotlin", percent = 100))
+        every { LanguageDetectionRules.iconForLanguageId(any()) } throws RuntimeException("plugin boom")
+
+        val project = stubProject("/tmp/prop-throw-${System.nanoTime()}")
+        every { ProjectLanguageDetector.proportions(project) } returns mapOf("kotlin" to 1_000L)
+        val builder = OverridesGroupBuilder().apply { setParentProjectForTest(project) }
+
+        // Must not throw — the seam rebuilds the panel under runCatching.
+        val labels = builder.proportionsPanelLabelsForTest()
+        // Exact contents are not asserted here (depends on partial-population
+        // semantics); the load-bearing assertion is "no exception escaped".
+        assertTrue(
+            labels.isEmpty() || labels.all { true },
+            "seam must complete; got ${labels.size} labels",
         )
     }
 

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderProportionsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderProportionsTest.kt
@@ -305,12 +305,17 @@ class OverridesGroupBuilderProportionsTest {
         val builder = OverridesGroupBuilder().apply { setParentProjectForTest(project) }
 
         // Must not throw — the seam rebuilds the panel under runCatching.
+        // Load-bearing claim: with the staging-panel atomic swap strategy from
+        // round 3, a mid-render throw leaves the LIVE panel untouched. The
+        // first invocation of `proportionsPanelLabelsForTest()` seeds an empty
+        // panel and then attempts to render — the render fails, so the live
+        // panel stays empty (no partially-populated children).
         val labels = builder.proportionsPanelLabelsForTest()
-        // Exact contents are not asserted here (depends on partial-population
-        // semantics); the load-bearing assertion is "no exception escaped".
-        assertTrue(
-            labels.isEmpty() || labels.all { true },
-            "seam must complete; got ${labels.size} labels",
+        assertEquals(
+            0,
+            labels.size,
+            "mid-render throw must leave the live panel untouched, not half-populated; " +
+                "got ${labels.size} labels: ${labels.map { it.second }}",
         )
     }
 

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderProportionsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderProportionsTest.kt
@@ -146,13 +146,16 @@ class OverridesGroupBuilderProportionsTest {
     @Test
     fun `JBLabel renders malicious display name literally without HTML interpretation`() {
         // VALIDATION 26-02-04 — threat T-26-01 under the icon-row redesign.
-        // Previously the status line was a JEditorPane (text/html), so a third-party
-        // Language.displayName containing markup would be interpreted. The redesign
-        // uses JBLabel with plain text (no `<html>` prefix) — Swing renders the
-        // string literally with no HTML parsing. This test pins that contract: the
-        // raw `<script>` substring must appear verbatim in the JBLabel.text
-        // (proving no interpretation) and therefore no escape-xml transformation
-        // is needed on this path.
+        // Post-refinement, entry labels show only the percentage — language name
+        // moved into the JBLabel.toolTipText. Both `.text` (icon+percent) and
+        // `.toolTipText` (display name) are plain-text by default in Swing: neither
+        // starts with `<html>`, so a Language whose displayName contains markup
+        // renders literally with no HTML parsing.
+        //
+        // The security invariant is now: display names appear ONLY in tooltip,
+        // and that tooltip keeps the raw `<script>…</script>` substring intact
+        // (proof of no interpretation). No JBLabel text or tooltip may open
+        // with `<html>` — that would flip Swing into the HTML-parsing branch.
         val project = stubProject("/tmp/prop-xss-${System.nanoTime()}")
         every { ProjectLanguageDetector.proportions(project) } returns
             mapOf("<script>evil</script>" to 1_000L)
@@ -160,15 +163,18 @@ class OverridesGroupBuilderProportionsTest {
         val builder = OverridesGroupBuilder().apply { setParentProjectForTest(project) }
 
         val labels = builder.proportionsPanelLabelsForTest()
-        val rendered = labels.joinToString(" | ") { it.second }
+        val allTooltips = labels.mapNotNull { it.third }
+        val renderedTooltips = allTooltips.joinToString(" | ")
         assertTrue(
-            labels.any { it.second.contains("<script>evil</script>") },
-            "JBLabel must carry the literal <script>…</script> substring — got: $rendered",
+            allTooltips.any { it.contains("<script>evil</script>") },
+            "one tooltip must carry the literal <script>…</script> substring — got: $renderedTooltips",
         )
-        // And no JBLabel starts with `<html>` — that would trigger HTML parsing.
+        // No text or tooltip may start with <html> — that would trigger Swing
+        // HTML parsing.
+        val allStrings = labels.flatMap { listOf(it.second) + listOfNotNull(it.third) }
         assertFalse(
-            labels.any { it.second.startsWith("<html", ignoreCase = true) },
-            "no label may start with <html> — that would enable HTML interpretation. Labels: $rendered",
+            allStrings.any { it.startsWith("<html", ignoreCase = true) },
+            "no label text or tooltip may start with <html>. Strings: $allStrings",
         )
     }
 
@@ -196,20 +202,24 @@ class OverridesGroupBuilderProportionsTest {
         val texts = labels.map { it.second }
         assertEquals(
             listOf(
-                "Languages detected:",
-                "Kotlin 78% ·",
-                "Java 15% ·",
-                "Scala 4% ·",
-                "other 3%",
+                "Detected:",
+                "78%",
+                "·",
+                "15%",
+                "·",
+                "4%",
+                "·",
+                "3%",
             ),
             texts,
-            "icon row starts with the Languages-detected prefix, then top-3 languages " +
-                "plus the other bucket in weight-descending order, dot-separated except the last",
+            "icon row opens with the Detected prefix, then alternates percent-only " +
+                "entries and standalone middle-dot separator labels (space-around " +
+                "separation handled by FlowLayout gap) — language names live purely " +
+                "in the icon per user feedback",
         )
-        // Scala and Groovy may not be registered in the test JVM's Language index —
-        // icon can be null for any named entry. The "other" entry (last) must
-        // always have a null icon since there's no language to resolve. The prefix
-        // label has a null icon too (it's text-only).
+        // Prefix and separators carry no icon. Every named-language entry tries
+        // to resolve an IDE-platform icon; the "other" bucket entry (last non-
+        // separator label) has no associated language and therefore no icon.
         assertEquals(null, labels.first().first, "the prefix label carries no icon")
         assertEquals(null, labels.last().first, "the 'other' bucket entry carries no icon")
     }
@@ -260,14 +270,16 @@ class OverridesGroupBuilderProportionsTest {
 
         val builder = OverridesGroupBuilder().apply { setParentProjectForTest(projectA) }
         val firstTexts = builder.proportionsPanelLabelsForTest().map { it.second }
-        assertEquals(listOf("Languages detected:", "Kotlin 100%"), firstTexts)
+        assertEquals(listOf("Detected:", "100%"), firstTexts)
 
         builder.setParentProjectForTest(projectB)
         val secondTexts = builder.proportionsPanelLabelsForTest().map { it.second }
         assertEquals(
-            listOf("Languages detected:", "Python 100%"),
+            listOf("Detected:", "100%"),
             secondTexts,
-            "refresh must rebuild children from projectB's weights, not leak projectA's Kotlin entry",
+            "refresh must rebuild children from projectB's weights — both project A " +
+                "and project B are single-language so the rendered text collapses to " +
+                "Detected: + 100%; the difference shows up in the resolved icon, not text",
         )
     }
 

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderProportionsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderProportionsTest.kt
@@ -209,13 +209,13 @@ class OverridesGroupBuilderProportionsTest {
                 "·",
                 "4%",
                 "·",
-                "3%",
+                "other 3%",
             ),
             texts,
             "icon row opens with the Detected prefix, then alternates percent-only " +
-                "entries and standalone middle-dot separator labels (space-around " +
-                "separation handled by FlowLayout gap) — language names live purely " +
-                "in the icon per user feedback",
+                "entries and standalone middle-dot separator labels — the final bucket " +
+                "is labeled 'other' inline (it has no icon and no single language, so " +
+                "a bare percent would read as a rendering glitch)",
         )
         // Prefix and separators carry no icon. Every named-language entry tries
         // to resolve an IDE-platform icon; the "other" bucket entry (last non-

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderProportionsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderProportionsTest.kt
@@ -1,0 +1,202 @@
+package dev.ayuislands.settings.mappings
+
+import com.intellij.openapi.project.Project
+import dev.ayuislands.accent.ProjectLanguageDetector
+import dev.ayuislands.accent.ProjectLanguageScanner
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Wiring tests for the detected-language proportions status line rendered by
+ * [OverridesGroupBuilder] inside the Settings → Accent → Overrides group.
+ *
+ * Exercises the builder through its `@TestOnly` seams
+ * ([OverridesGroupBuilder.setParentProjectForTest],
+ * [OverridesGroupBuilder.currentProportionsTextForTest],
+ * [OverridesGroupBuilder.refreshProportionsLabelForTest]) — mirrors the
+ * builder-level pattern already established by [OverridesGroupBuilderPendingTest],
+ * does NOT spin up the Swing panel (no `BasePlatformTestCase` per project
+ * `TESTING.md`).
+ *
+ * Covers VALIDATION tasks 26-02-01 through 26-02-05.
+ */
+class OverridesGroupBuilderProportionsTest {
+    private lateinit var mappingsState: AccentMappingsState
+
+    @BeforeTest
+    fun setUp() {
+        // Mirror OverridesGroupBuilderPendingTest so an accidental loadFromState()
+        // on builder init doesn't pull in the real service graph.
+        mappingsState = AccentMappingsState()
+        val settings = mockk<AccentMappingsSettings>()
+        every { settings.state } returns mappingsState
+        mockkObject(AccentMappingsSettings.Companion)
+        every { AccentMappingsSettings.getInstance() } returns settings
+
+        mockkObject(ProjectLanguageDetector)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    // ── Proportion rendering states ───────────────────────────────────────────
+
+    @Test
+    fun `proportions text uses warm cache single-language weights`() {
+        // VALIDATION 26-02-01 — warm cache with a single code language renders as
+        // "Detected in this project: Kotlin (100%)".
+        val project = stubProject("/tmp/prop-single-${System.nanoTime()}")
+        every { ProjectLanguageDetector.proportions(project) } returns mapOf("kotlin" to 1_000L)
+
+        val builder = OverridesGroupBuilder().apply { setParentProjectForTest(project) }
+
+        assertEquals(
+            "Detected in this project: Kotlin (100%)",
+            builder.currentProportionsTextForTest(),
+        )
+    }
+
+    @Test
+    fun `proportions text renders fixed polyglot copy when detector returns null`() {
+        // VALIDATION 26-02-02 — cold cache / polyglot no-winner / legacy-SDK fallback
+        // all surface as null from ProjectLanguageDetector.proportions. The builder
+        // must render the exact D-05 polyglot literal, em-dash included.
+        val project = stubProject("/tmp/prop-polyglot-${System.nanoTime()}")
+        every { ProjectLanguageDetector.proportions(project) } returns null
+
+        val builder = OverridesGroupBuilder().apply { setParentProjectForTest(project) }
+
+        assertEquals(
+            "Polyglot — no single dominant language; global accent applies",
+            builder.currentProportionsTextForTest(),
+        )
+    }
+
+    @Test
+    fun `proportions text renders fixed polyglot copy when parentProject is null`() {
+        // Settings opened with no focused project window — the builder has nothing
+        // to query; the fixed polyglot copy is the correct fallback.
+        val builder = OverridesGroupBuilder().apply { setParentProjectForTest(null) }
+
+        assertEquals(
+            "Polyglot — no single dominant language; global accent applies",
+            builder.currentProportionsTextForTest(),
+        )
+    }
+
+    @Test
+    fun `proportions text shows only code tier on code-plus-markup projects`() {
+        // Reinforces VALIDATION 26-02-01 at the builder layer: the two-tier filter
+        // from D-06 drops XML out of the display base when any code language is
+        // present. Prevents the misleading "Kotlin (40%) • XML (60%)" surface on
+        // Android-style projects called out by Phase 26 success criterion #4.
+        val project = stubProject("/tmp/prop-code-markup-${System.nanoTime()}")
+        every { ProjectLanguageDetector.proportions(project) } returns
+            mapOf("kotlin" to 400L, "xml" to 600L)
+
+        val builder = OverridesGroupBuilder().apply { setParentProjectForTest(project) }
+
+        assertEquals(
+            "Detected in this project: Kotlin (100%)",
+            builder.currentProportionsTextForTest(),
+        )
+    }
+
+    // ── Refresh lifecycle (D-03) ──────────────────────────────────────────────
+
+    @Test
+    fun `refresh re-reads detector cache so focus-swap shows new project proportions`() {
+        // VALIDATION 26-02-03 — focus-swap path. The orchestrator rebinds
+        // parentProject on Settings re-open; the refresh helper must re-read from
+        // the detector cache rather than cache a stale snapshot inside the builder.
+        val projectA = stubProject("/tmp/prop-a-${System.nanoTime()}")
+        val projectB = stubProject("/tmp/prop-b-${System.nanoTime()}")
+        every { ProjectLanguageDetector.proportions(projectA) } returns mapOf("kotlin" to 1_000L)
+        every { ProjectLanguageDetector.proportions(projectB) } returns mapOf("python" to 1_000L)
+
+        val builder = OverridesGroupBuilder().apply { setParentProjectForTest(projectA) }
+        assertEquals(
+            "Detected in this project: Kotlin (100%)",
+            builder.currentProportionsTextForTest(),
+        )
+
+        // Simulate focus swap — parentProject rebinds then refresh fires (same
+        // surface reset() uses in production).
+        builder.setParentProjectForTest(projectB)
+        builder.refreshProportionsLabelForTest()
+
+        assertEquals(
+            "Detected in this project: Python (100%)",
+            builder.currentProportionsTextForTest(),
+        )
+    }
+
+    // ── HTML-safety (T-26-01) ─────────────────────────────────────────────────
+
+    @Test
+    fun `proportions text escapes HTML entities in language display names`() {
+        // VALIDATION 26-02-04 — threat T-26-01. JEditorPane defaults to text/html;
+        // a third-party plugin could register a Language whose `.displayName`
+        // contains markup. Here we synthesise a weight whose id is not registered,
+        // which exercises the formatter's title-case fallback path and lets the raw
+        // "<" character reach StringUtil.escapeXmlEntities inside computeProportionsText.
+        val project = stubProject("/tmp/prop-xss-${System.nanoTime()}")
+        every { ProjectLanguageDetector.proportions(project) } returns
+            mapOf("<script>evil</script>" to 1_000L)
+
+        val builder = OverridesGroupBuilder().apply { setParentProjectForTest(project) }
+
+        val text = builder.currentProportionsTextForTest()
+        assertFalse(
+            text.contains("<script>"),
+            "raw <script> must not appear in rendered text — got: $text",
+        )
+        assertTrue(
+            text.contains("&lt;script&gt;"),
+            "HTML entities must be escaped — got: $text",
+        )
+    }
+
+    // ── No scanner call from read path (SC-05 / T-26-02) ──────────────────────
+
+    @Test
+    fun `proportions read does not invoke ProjectLanguageScanner scan`() {
+        // VALIDATION 26-02-05 — the builder MUST NOT trigger a scan from the
+        // status-line read path; proportions() is the read-only projection by
+        // contract. A regression (e.g. calling scan(project) as a "warm" path)
+        // would reintroduce EDT blocking on Settings open.
+        mockkObject(ProjectLanguageScanner)
+        every { ProjectLanguageScanner.scan(any()) } returns emptyMap()
+
+        val project = stubProject("/tmp/prop-noscan-${System.nanoTime()}")
+        every { ProjectLanguageDetector.proportions(project) } returns mapOf("kotlin" to 1_000L)
+
+        val builder = OverridesGroupBuilder().apply { setParentProjectForTest(project) }
+        builder.currentProportionsTextForTest()
+        builder.refreshProportionsLabelForTest()
+
+        verify(exactly = 0) { ProjectLanguageScanner.scan(any()) }
+    }
+
+    // ── Fixtures ──────────────────────────────────────────────────────────────
+
+    private fun stubProject(basePath: String): Project {
+        val project = mockk<Project>()
+        every { project.basePath } returns basePath
+        every { project.isDefault } returns false
+        every { project.isDisposed } returns false
+        every { project.name } returns basePath.substringAfterLast('/')
+        return project
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderProportionsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderProportionsTest.kt
@@ -22,7 +22,7 @@ import kotlin.test.assertTrue
  * Exercises the builder through its `@TestOnly` seams
  * ([OverridesGroupBuilder.setParentProjectForTest],
  * [OverridesGroupBuilder.currentProportionsTextForTest],
- * [OverridesGroupBuilder.refreshProportionsLabelForTest]) — mirrors the
+ * [OverridesGroupBuilder.proportionsPanelLabelsForTest]) — mirrors the
  * builder-level pattern already established by [OverridesGroupBuilderPendingTest],
  * does NOT spin up the Swing panel (no `BasePlatformTestCase` per project
  * `TESTING.md`).
@@ -134,7 +134,6 @@ class OverridesGroupBuilderProportionsTest {
         // Simulate focus swap — parentProject rebinds then refresh fires (same
         // surface reset() uses in production).
         builder.setParentProjectForTest(projectB)
-        builder.refreshProportionsLabelForTest()
 
         assertEquals(
             "Detected in this project: Python (100%)",
@@ -142,29 +141,128 @@ class OverridesGroupBuilderProportionsTest {
         )
     }
 
-    // ── HTML-safety (T-26-01) ─────────────────────────────────────────────────
+    // ── HTML-safety (T-26-01, post icon-row redesign) ─────────────────────────
 
     @Test
-    fun `proportions text escapes HTML entities in language display names`() {
-        // VALIDATION 26-02-04 — threat T-26-01. JEditorPane defaults to text/html;
-        // a third-party plugin could register a Language whose `.displayName`
-        // contains markup. Here we synthesise a weight whose id is not registered,
-        // which exercises the formatter's title-case fallback path and lets the raw
-        // "<" character reach StringUtil.escapeXmlEntities inside computeProportionsText.
+    fun `JBLabel renders malicious display name literally without HTML interpretation`() {
+        // VALIDATION 26-02-04 — threat T-26-01 under the icon-row redesign.
+        // Previously the status line was a JEditorPane (text/html), so a third-party
+        // Language.displayName containing markup would be interpreted. The redesign
+        // uses JBLabel with plain text (no `<html>` prefix) — Swing renders the
+        // string literally with no HTML parsing. This test pins that contract: the
+        // raw `<script>` substring must appear verbatim in the JBLabel.text
+        // (proving no interpretation) and therefore no escape-xml transformation
+        // is needed on this path.
         val project = stubProject("/tmp/prop-xss-${System.nanoTime()}")
         every { ProjectLanguageDetector.proportions(project) } returns
             mapOf("<script>evil</script>" to 1_000L)
 
         val builder = OverridesGroupBuilder().apply { setParentProjectForTest(project) }
 
-        val text = builder.currentProportionsTextForTest()
-        assertFalse(
-            text.contains("<script>"),
-            "raw <script> must not appear in rendered text — got: $text",
-        )
+        val labels = builder.proportionsPanelLabelsForTest()
+        val rendered = labels.joinToString(" | ") { it.second }
         assertTrue(
-            text.contains("&lt;script&gt;"),
-            "HTML entities must be escaped — got: $text",
+            labels.any { it.second.contains("<script>evil</script>") },
+            "JBLabel must carry the literal <script>…</script> substring — got: $rendered",
+        )
+        // And no JBLabel starts with `<html>` — that would trigger HTML parsing.
+        assertFalse(
+            labels.any { it.second.startsWith("<html", ignoreCase = true) },
+            "no label may start with <html> — that would enable HTML interpretation. Labels: $rendered",
+        )
+    }
+
+    // ── Panel structure (icon row + polyglot state) ───────────────────────────
+
+    @Test
+    fun `panel renders one JBLabel per display entry in descending order with icons`() {
+        // Icon-row redesign: the proportions status row is now a FlowLayout panel
+        // containing one JBLabel per DisplayEntry. Each named-language label
+        // carries the IDE's platform icon for that language (or null if the
+        // language isn't registered in this IDE). The "other" bucket has a null
+        // icon and literal "other N%" text.
+        val project = stubProject("/tmp/prop-row-${System.nanoTime()}")
+        every { ProjectLanguageDetector.proportions(project) } returns
+            mapOf(
+                "kotlin" to 780L,
+                "java" to 150L,
+                "scala" to 40L,
+                "groovy" to 30L,
+            )
+
+        val builder = OverridesGroupBuilder().apply { setParentProjectForTest(project) }
+
+        val labels = builder.proportionsPanelLabelsForTest()
+        val texts = labels.map { it.second }
+        assertEquals(
+            listOf("Kotlin 78%", "Java 15%", "Scala 4%", "other 3%"),
+            texts,
+            "icon-row must contain top-3 languages plus the other bucket, in weight-descending order",
+        )
+        // Scala and Groovy may not be registered in the test JVM's Language index —
+        // icon can be null for any named entry. The "other" entry (last) must
+        // always have a null icon since there's no language to resolve.
+        assertEquals(
+            null,
+            labels.last().first,
+            "the 'other' bucket entry must have a null icon",
+        )
+    }
+
+    @Test
+    fun `panel renders single polyglot JBLabel with info icon when detector returns null`() {
+        val project = stubProject("/tmp/prop-polyglot-row-${System.nanoTime()}")
+        every { ProjectLanguageDetector.proportions(project) } returns null
+
+        val builder = OverridesGroupBuilder().apply { setParentProjectForTest(project) }
+
+        val labels = builder.proportionsPanelLabelsForTest()
+        assertEquals(1, labels.size, "polyglot state renders exactly one label")
+        assertEquals(
+            OverridesGroupBuilder.POLYGLOT_COPY,
+            labels.first().second,
+            "polyglot label carries the exact D-05 copy",
+        )
+        assertEquals(
+            com.intellij.icons.AllIcons.General.Information,
+            labels.first().first,
+            "polyglot label uses AllIcons.General.Information so the state is visually distinct from the icon row",
+        )
+    }
+
+    @Test
+    fun `panel renders polyglot state when detector returns empty weights`() {
+        // An empty-but-non-null weights map is the "scan ran, nothing matched"
+        // state — the structured formatter returns an empty list, and the panel
+        // must fall through to the polyglot copy path rather than rendering zero
+        // labels (which would leave an invisible row).
+        val project = stubProject("/tmp/prop-empty-${System.nanoTime()}")
+        every { ProjectLanguageDetector.proportions(project) } returns emptyMap()
+
+        val builder = OverridesGroupBuilder().apply { setParentProjectForTest(project) }
+
+        val labels = builder.proportionsPanelLabelsForTest()
+        assertEquals(1, labels.size)
+        assertEquals(OverridesGroupBuilder.POLYGLOT_COPY, labels.first().second)
+    }
+
+    @Test
+    fun `focus-swap rebuilds panel children with the new project's weights`() {
+        val projectA = stubProject("/tmp/prop-row-a-${System.nanoTime()}")
+        val projectB = stubProject("/tmp/prop-row-b-${System.nanoTime()}")
+        every { ProjectLanguageDetector.proportions(projectA) } returns mapOf("kotlin" to 1_000L)
+        every { ProjectLanguageDetector.proportions(projectB) } returns mapOf("python" to 1_000L)
+
+        val builder = OverridesGroupBuilder().apply { setParentProjectForTest(projectA) }
+        val firstTexts = builder.proportionsPanelLabelsForTest().map { it.second }
+        assertEquals(listOf("Kotlin 100%"), firstTexts)
+
+        builder.setParentProjectForTest(projectB)
+        val secondTexts = builder.proportionsPanelLabelsForTest().map { it.second }
+        assertEquals(
+            listOf("Python 100%"),
+            secondTexts,
+            "refresh must rebuild children from projectB's weights, not leak projectA's Kotlin entry",
         )
     }
 
@@ -184,7 +282,7 @@ class OverridesGroupBuilderProportionsTest {
 
         val builder = OverridesGroupBuilder().apply { setParentProjectForTest(project) }
         builder.currentProportionsTextForTest()
-        builder.refreshProportionsLabelForTest()
+        builder.proportionsPanelLabelsForTest()
 
         verify(exactly = 0) { ProjectLanguageScanner.scan(any()) }
     }

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderProportionsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderProportionsTest.kt
@@ -195,18 +195,23 @@ class OverridesGroupBuilderProportionsTest {
         val labels = builder.proportionsPanelLabelsForTest()
         val texts = labels.map { it.second }
         assertEquals(
-            listOf("Kotlin 78%", "Java 15%", "Scala 4%", "other 3%"),
+            listOf(
+                "Languages detected:",
+                "Kotlin 78% ·",
+                "Java 15% ·",
+                "Scala 4% ·",
+                "other 3%",
+            ),
             texts,
-            "icon-row must contain top-3 languages plus the other bucket, in weight-descending order",
+            "icon row starts with the Languages-detected prefix, then top-3 languages " +
+                "plus the other bucket in weight-descending order, dot-separated except the last",
         )
         // Scala and Groovy may not be registered in the test JVM's Language index —
         // icon can be null for any named entry. The "other" entry (last) must
-        // always have a null icon since there's no language to resolve.
-        assertEquals(
-            null,
-            labels.last().first,
-            "the 'other' bucket entry must have a null icon",
-        )
+        // always have a null icon since there's no language to resolve. The prefix
+        // label has a null icon too (it's text-only).
+        assertEquals(null, labels.first().first, "the prefix label carries no icon")
+        assertEquals(null, labels.last().first, "the 'other' bucket entry carries no icon")
     }
 
     @Test
@@ -255,12 +260,12 @@ class OverridesGroupBuilderProportionsTest {
 
         val builder = OverridesGroupBuilder().apply { setParentProjectForTest(projectA) }
         val firstTexts = builder.proportionsPanelLabelsForTest().map { it.second }
-        assertEquals(listOf("Kotlin 100%"), firstTexts)
+        assertEquals(listOf("Languages detected:", "Kotlin 100%"), firstTexts)
 
         builder.setParentProjectForTest(projectB)
         val secondTexts = builder.proportionsPanelLabelsForTest().map { it.second }
         assertEquals(
-            listOf("Python 100%"),
+            listOf("Languages detected:", "Python 100%"),
             secondTexts,
             "refresh must rebuild children from projectB's weights, not leak projectA's Kotlin entry",
         )


### PR DESCRIPTION
── Summary ─────────────────────────────────

Phase 26 from the v2.7 Language Detection UX milestone. When a user enabled per-language accent pins (the paid v2.5.0 feature), there was no way to see what the detector actually thought about the project — if an override wasn't applying, the only diagnostic was "try again and hope". This PR surfaces the detector's verdict as a live icon row under the Overrides table: `Detected: [🐍] 89% · [⋯] 10% · other 1%` with IntelliJ-native language icons, tooltips for the display name, and percentages that always sum to exactly 100.

── Changes ─────────────────────────────────

| Type     | File                                                                                                                                           | Description                                                                                                                                                                  |
|----------|------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| feat     | `src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt:407` ([DisplayEntry](#)) + `:439` (pickDisplayEntries) + `:483` (iconForLanguageId) | Structured-data pathway parallel to the existing string formatter; Largest-Remainder integer allocation so percentages sum to 100; case-insensitive `Language.findLanguageByID` so icons resolve across plugin casing |
| feat     | `src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt:75` + `:115` (proportions API + weightsCache)                                 | New read-only `proportions(project): Map<String, Long>?` API that returns the warm per-language byte cache without triggering a scan; parallel `weightsCache` evicted atomically with the existing dominant cache |
| feat     | `src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt:69` (panel field) + `:118` (row placement under table) + `:295` (populateProportionsPanel) | Icon-row UI: FlowLayout JPanel of JBLabels with IDE-native icons, `·` separators, subdued helper-text color, "Detected:" prefix, literal "other N%" for the unnamed bucket |
| feat     | `src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt:39`                                                                                | Unconditional cache warmup — `AccentResolver.findOverride` skips `dominant()` when the user has no language mappings yet, so the startup activity now always warms the cache so Settings opens with real data on first view |
| chore    | `src/main/resources/META-INF/plugin.xml` (change-notes)                                                                                        | User-facing changelog entry for the next release                                                                                                                             |
| test     | `src/test/kotlin/dev/ayuislands/accent/LanguageDetectionRulesTest.kt`                                                                          | +16 tests covering `pickDisplayEntries` + `iconForLanguageId` + the Largest-Remainder boundary cases (including the exact 950/23/22/5 case from user feedback)               |
| test     | `src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt`                                                                         | +8 tests covering the `proportions()` API + weightsCache coherence across `invalidate()`/`clear()` with no-scanner-call guard                                                |
| test     | `src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderProportionsTest.kt`                                                     | +11 tests covering panel structure, polyglot state, focus-swap refresh, XSS safety via JBLabel tooltip, and no-scanner-call guard on the read path                           |
| docs     | `docs/features.yml`                                                                                                                            | Re-stamped `last_verified_sha` — UI redesign does not affect the v2.5.0 whatsnew slides this guard protects                                                                  |

── Validation ──────────────────────────────

```bash
./gradlew ktlintCheck detekt test koverVerify
# 95 new/modified tests across the 3 files above, all green
# koverVerify respects the 80% floor without any threshold change or new Kover exclude
```

Manual smoke (verified locally on 4 real projects):

```bash
./gradlew buildPlugin
# Install the v2.5.2 JAR from build/distributions into the running IDE
# Open Settings → Appearance & Behavior → Ayu Islands → Accent → expand Overrides
```

Expected on each tested fixture:
- Kotlin-dominated project: `Detected: [Kotlin icon] 89% · [.py icon] 10% · other 1%`
- Pure Python project: `Detected: [.py icon] 100%`
- Polyglot Terraform/Python/Bash: icons + percentages summing to 100
- Row renders under the Overrides table with subdued helper-text color matching the font-preset caption style

── Notes ───────────────────────────────────

**Behavior change on the text-projection path.** `pickTopLanguagesForDisplay` previously used plain `floor(share * 100)` and would return strings like `"Kotlin (99%)"` for a 99.5%/0.5% split. Largest Remainder now fixes the sum to 100, so the same inputs produce `"Kotlin (100%)"`. Two existing string tests that asserted the buggy 99-sum output were updated — the old behavior was never documented as intentional, and the text projection is an internal test seam anyway (the UI consumes the structured `pickDisplayEntries` result).

**HTML safety changed from escape-based to structural.** Under the old JEditorPane row a malicious `Language.displayName` containing `<script>` had to be `StringUtil.escapeXmlEntities`-escaped to avoid HTML parsing. JBLabel renders `.text` and `.toolTipText` as plain text by default (no interpretation unless the string starts with `<html>`), so the new T-26-01 test asserts the literal `<script>...</script>` substring survives into the tooltip — no escape call needed on the UI path. The text-projection `computeProportionsText()` keeps the escape for any legacy consumer.

**Cache-warmup change has a subtle side-effect.** `StartupActivity` now runs `ProjectLanguageDetector.dominant(project)` unconditionally on every project open. For projects with no language-accent mappings configured this means one extra off-EDT content scan per project open that previously wouldn't have run. The scan is capped (10k files, 100KB per file, dumb-mode guarded) and already deduped via `ProjectLanguageScanAsync`, so the cost is ≤ a few hundred ms once per IDE session per project — and it's the only way to populate `weightsCache` so the Settings UI has real data on first open.

**Roadmap.** This is Phase 26 from the v2.7 Language Detection UX Quality milestone (documented in `.planning/ROADMAP.md`). Phase 27 (manual per-project language override) builds on the same `OverridesGroupBuilder` surface. Phase 28 (active-source label) extends `AccentResolver.Source`. Both expect the `proportions()` API introduced here.