### PR TITLE
fix(docs): tolerate orphaned last_verified_sha after squash-merge

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,3 +62,17 @@ repos:
         pass_filenames: false
         # Run on any edit to one of the inputs/outputs of the sync check.
         files: ^(docs/features\.yml|README\.md|CHANGELOG\.md|src/main/resources/META-INF/plugin\.xml|src/main/kotlin/.*\.kt|assets/feature-.*\.png)$
+
+      # Manual-stage helper: `pre-commit run verify-docs-restamp` rewrites
+      # every orphaned last_verified_sha in features.yml to current HEAD.
+      # NOT auto-invoked — amending stamp metadata mid-commit would change
+      # the diff the user just staged. Explicit invocation only; the main
+      # `verify-docs` hook above surfaces the exact command in its error
+      # message when an orphan stamp is detected on a feature branch that
+      # touches tracked sources.
+      - id: verify-docs-restamp
+        name: re-stamp orphaned last_verified_sha to HEAD (manual)
+        entry: scripts/verify-docs.py --restamp
+        language: system
+        pass_filenames: false
+        stages: [manual]

--- a/scripts/verify-docs.py
+++ b/scripts/verify-docs.py
@@ -243,8 +243,8 @@ def _handle_orphan_stamp(
 ) -> None:
     # SHA-identity check instead of branch-name equality so the main path also
     # covers CI runs that check out `origin/main` in detached-HEAD state —
-    # `_current_branch()` would return "HEAD" there and incorrectly drop us
-    # into the feature-branch diff logic.
+    # `git rev-parse --abbrev-ref HEAD` returns the literal string "HEAD"
+    # there and would misroute us into the feature-branch diff logic.
     if _head_points_at_primary():
         report.warn(
             fid,
@@ -310,6 +310,13 @@ def _is_ancestor_of_head(sha: str) -> bool:
     False on the classic post-squash-merge state: the feature-branch SHAs
     that were stamped during PR iteration sit on a now-unreferenced branch
     whose tip isn't an ancestor of the squash commit on main.
+
+    Git's `merge-base --is-ancestor` exits 0 on "is ancestor", 1 on
+    "not ancestor", and 128 on a genuine repo error (bad object, missing
+    ref, corrupt pack). Exit 128 gets the same False treatment as exit 1
+    here — a corrupted repo is already in a state where the freshness
+    story is moot, and `_handle_orphan_stamp` downstream surfaces the
+    SHA as orphaned with enough context for a human to investigate.
     """
     result = subprocess.run(
         ["git", "merge-base", "--is-ancestor", sha, "HEAD"],
@@ -345,13 +352,18 @@ def _head_points_at_primary() -> bool:
 
     SHA-identity check — correct under both named-branch checkouts (local
     `main` tracking `origin/main`) and detached-HEAD checkouts (CI runs
-    that check out `origin/main` as a disconnected ref). The alternative
-    `_current_branch() == "main"` check misses the detached case because
-    `git rev-parse --abbrev-ref HEAD` returns the literal string "HEAD".
+    that check out `origin/main` as a disconnected ref). An
+    `abbrev-ref HEAD == 'main'` alternative misses the detached case
+    because `git rev-parse --abbrev-ref HEAD` returns the literal string
+    "HEAD" when not on a named branch.
     """
     head_sha = _rev_parse("HEAD")
     primary_sha = _rev_parse(_primary_ref())
-    return bool(head_sha) and head_sha == primary_sha
+    # Guard both sides: `_rev_parse` returns "" on failure, and "" == ""
+    # would spuriously match if a future refactor widened the failure
+    # surface. Keeping the `bool(primary_sha)` check makes the invariant
+    # explicit instead of relying on the short-circuit.
+    return bool(head_sha) and bool(primary_sha) and head_sha == primary_sha
 
 
 def _rev_parse(ref: str) -> str:

--- a/scripts/verify-docs.py
+++ b/scripts/verify-docs.py
@@ -38,9 +38,6 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
-# PyYAML is a small, widely-available dependency; the CI workflow installs it
-# via `pip install pyyaml` before running this script. Let ImportError bubble
-# with its default message — no sentinel dance that would confuse type-checkers.
 import yaml
 
 
@@ -244,20 +241,26 @@ def _check_freshness_by_state(
 def _handle_orphan_stamp(
     fid: str, path: str, sha: str, sources: list[str], report: Report, *, reason: str
 ) -> None:
-    if _current_branch() == "main":
+    # SHA-identity check instead of branch-name equality so the main path also
+    # covers CI runs that check out `origin/main` in detached-HEAD state —
+    # `_current_branch()` would return "HEAD" there and incorrectly drop us
+    # into the feature-branch diff logic.
+    if _head_points_at_primary():
         report.warn(
             fid,
             f"last_verified_sha '{sha[:8]}' is orphaned ({reason}) — expected on "
-            f"main after a squash-merge + branch delete. content_sha256 remains "
-            f"the pixel-drift guard; the next PR that touches sources must re-stamp.",
+            f"the primary branch after a squash-merge + branch delete. "
+            f"content_sha256 remains the pixel-drift guard; the next PR that "
+            f"touches sources must re-stamp.",
         )
         return
-    base = _merge_base_with_origin_main()
+    base = _merge_base_with_primary()
     if base is None:
         report.warn(
             fid,
-            f"last_verified_sha '{sha[:8]}' is orphaned ({reason}) and origin/main "
-            f"is not fetched — cannot diff branch changes; re-fetch or re-stamp.",
+            f"last_verified_sha '{sha[:8]}' is orphaned ({reason}) and the "
+            f"primary branch ref is not fetched — cannot diff branch changes; "
+            f"re-fetch or re-stamp.",
         )
         return
     _check_source_freshness_since(
@@ -316,10 +319,45 @@ def _is_ancestor_of_head(sha: str) -> bool:
     return result.returncode == 0
 
 
-def _current_branch() -> str:
-    """Return the current branch name; empty string on detached HEAD."""
+@functools.cache
+def _primary_ref() -> str:
+    """Return the remote primary-branch ref (e.g. `origin/main`).
+
+    Derives from `git symbolic-ref refs/remotes/origin/HEAD` when that ref
+    exists (set by `git clone` and recoverable via `git remote set-head
+    origin -a`); falls back to `origin/main` for repos that never had the
+    symbolic ref initialized. Caching keeps the lookup cheap when every
+    feature in features.yml runs through the freshness pipeline.
+    """
     result = subprocess.run(
-        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        ["git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    ref = result.stdout.strip() if result.returncode == 0 else ""
+    return ref or "origin/main"
+
+
+def _head_points_at_primary() -> bool:
+    """True when HEAD's commit SHA equals the primary branch's commit SHA.
+
+    SHA-identity check — correct under both named-branch checkouts (local
+    `main` tracking `origin/main`) and detached-HEAD checkouts (CI runs
+    that check out `origin/main` as a disconnected ref). The alternative
+    `_current_branch() == "main"` check misses the detached case because
+    `git rev-parse --abbrev-ref HEAD` returns the literal string "HEAD".
+    """
+    head_sha = _rev_parse("HEAD")
+    primary_sha = _rev_parse(_primary_ref())
+    return bool(head_sha) and head_sha == primary_sha
+
+
+def _rev_parse(ref: str) -> str:
+    """Resolve `ref` to a full commit SHA; empty string on failure."""
+    result = subprocess.run(
+        ["git", "rev-parse", ref],
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
@@ -328,10 +366,11 @@ def _current_branch() -> str:
     return result.stdout.strip() if result.returncode == 0 else ""
 
 
-def _merge_base_with_origin_main() -> str | None:
-    """Return merge-base SHA with `origin/main`, or None if not computable."""
+def _merge_base_with_primary() -> str | None:
+    """Return merge-base SHA with the remote primary branch, or None if the
+    primary ref is not fetched (shallow clone, new repo without `origin/HEAD`)."""
     result = subprocess.run(
-        ["git", "merge-base", "origin/main", "HEAD"],
+        ["git", "merge-base", _primary_ref(), "HEAD"],
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,

--- a/scripts/verify-docs.py
+++ b/scripts/verify-docs.py
@@ -8,7 +8,9 @@ Three invariants (see docs/features.yml header for the rationale):
      to at least one feature with matching `introduced: X.Y.Z`
   3. Screenshots declared under a feature aren't stale:
      - sources' files exist
-     - `git log <last_verified_sha>..HEAD -- <sources>` is empty
+     - `git log <last_verified_sha>..HEAD -- <sources>` is empty, with a branch
+       -aware fallback so a squash-merged stamp on `main` warns instead of
+       erroring (see `_check_freshness_by_state`)
      - file content SHA-256 matches `content_sha256` (or content_sha256 is empty
        meaning "seed me"; script offers --update-hashes to populate)
 
@@ -17,6 +19,12 @@ CLI:
   scripts/verify-docs.py --update-hashes  # recompute content_sha256 for every
                                           # screenshot and rewrite features.yml
                                           # (use when intentionally re-capturing)
+  scripts/verify-docs.py --restamp        # rewrite every orphaned
+                                          # last_verified_sha to current HEAD;
+                                          # use after a squash-merge lands, or
+                                          # when a feature branch inherits an
+                                          # orphaned stamp from main before
+                                          # editing tracked sources
 """
 
 from __future__ import annotations
@@ -191,9 +199,7 @@ def _check_one_screenshot(fid: str, shot: dict, report: Report) -> None:
         return
 
     _check_source_paths_exist(fid, sources, report)
-    if not _check_commit_exists(fid, sha, report):
-        return
-    _check_source_freshness(fid, path, sha, sources, report)
+    _check_freshness_by_state(fid, path, sha, sources, report)
     _check_content_hash(fid, screenshot_file, stored_hash, report)
 
 
@@ -205,36 +211,136 @@ def _check_source_paths_exist(fid: str, sources: list[str], report: Report) -> N
             )
 
 
-def _check_commit_exists(fid: str, sha: str, report: Report) -> bool:
-    if _git_commit_exists(sha):
-        return True
-    report.error(fid, f"last_verified_sha '{sha}' is not a known git commit")
-    return False
-
-
-def _check_source_freshness(
+def _check_freshness_by_state(
     fid: str, path: str, sha: str, sources: list[str], report: Report
 ) -> None:
+    """Dispatch source-freshness check based on how the stamp relates to HEAD.
+
+    Three cases:
+      (A) Stamp is ancestor of HEAD (happy path) → diff sources since stamp;
+          any change is an ERROR (re-stamp or re-capture required).
+      (B) Stamp is orphaned (not ancestor of HEAD) AND we are on `main` →
+          post-squash-merge state; emit a warn and lean on content_sha256 to
+          catch pixel drift. A future PR that actually touches sources will
+          be caught by case (C) on its feature branch.
+      (C) Stamp is orphaned AND we are on a non-main branch → use the merge
+          base with `origin/main` as the "since" ref. Any source change
+          introduced by the current branch is an ERROR that demands
+          re-stamping to HEAD (use `scripts/verify-docs.py --restamp`).
+    """
+    if not _git_commit_exists(sha):
+        _handle_orphan_stamp(
+            fid, path, sha, sources, report, reason="not in local git object db"
+        )
+        return
+    if _is_ancestor_of_head(sha):
+        _check_source_freshness_since(fid, path, sha, sources, report, strict_msg=True)
+        return
+    _handle_orphan_stamp(
+        fid, path, sha, sources, report, reason="not an ancestor of HEAD"
+    )
+
+
+def _handle_orphan_stamp(
+    fid: str, path: str, sha: str, sources: list[str], report: Report, *, reason: str
+) -> None:
+    if _current_branch() == "main":
+        report.warn(
+            fid,
+            f"last_verified_sha '{sha[:8]}' is orphaned ({reason}) — expected on "
+            f"main after a squash-merge + branch delete. content_sha256 remains "
+            f"the pixel-drift guard; the next PR that touches sources must re-stamp.",
+        )
+        return
+    base = _merge_base_with_origin_main()
+    if base is None:
+        report.warn(
+            fid,
+            f"last_verified_sha '{sha[:8]}' is orphaned ({reason}) and origin/main "
+            f"is not fetched — cannot diff branch changes; re-fetch or re-stamp.",
+        )
+        return
+    _check_source_freshness_since(
+        fid, path, base, sources, report, strict_msg=False, orphan_sha=sha
+    )
+
+
+def _check_source_freshness_since(
+    fid: str,
+    path: str,
+    since_ref: str,
+    sources: list[str],
+    report: Report,
+    *,
+    strict_msg: bool,
+    orphan_sha: str | None = None,
+) -> None:
     try:
-        changed = _git_changed_since(sha, sources)
+        changed = _git_changed_since(since_ref, sources)
     except RuntimeError as exc:
-        # `git log` returned non-zero — let the lint surface the real error
-        # instead of swallowing it as "no changes". The empty-set fallthrough
-        # would silently let a stale screenshot through if the ref became
-        # unreachable (CI shallow clone, force-pushed branch, etc.).
         report.error(fid, f"git freshness check failed for {path}: {exc}")
         return
     if not changed:
         return
     preview = ", ".join(sorted(changed)[:3])
     more = f" (+{len(changed) - 3} more)" if len(changed) > 3 else ""
-    report.error(
-        fid,
-        f"sources changed since last_verified_sha {sha[:8]}: {preview}{more}. "
-        f"Re-capture {path} and bump last_verified_sha + content_sha256, "
-        f"OR if the UI didn't visually change, re-stamp last_verified_sha "
-        f"to the current HEAD.",
+    if strict_msg:
+        report.error(
+            fid,
+            f"sources changed since last_verified_sha {since_ref[:8]}: {preview}{more}. "
+            f"Re-capture {path} and bump last_verified_sha + content_sha256, "
+            f"OR if the UI didn't visually change, re-stamp last_verified_sha "
+            f"to the current HEAD (or run `scripts/verify-docs.py --restamp`).",
+        )
+    else:
+        report.error(
+            fid,
+            f"last_verified_sha '{(orphan_sha or since_ref)[:8]}' is orphaned AND "
+            f"this branch touches tracked sources: {preview}{more}. Re-stamp to "
+            f"current HEAD before pushing (`scripts/verify-docs.py --restamp`).",
+        )
+
+
+def _is_ancestor_of_head(sha: str) -> bool:
+    """Return True when `sha` is reachable from HEAD via parent edges.
+
+    False on the classic post-squash-merge state: the feature-branch SHAs
+    that were stamped during PR iteration sit on a now-unreferenced branch
+    whose tip isn't an ancestor of the squash commit on main.
+    """
+    result = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", sha, "HEAD"],
+        cwd=REPO_ROOT,
+        capture_output=True,
     )
+    return result.returncode == 0
+
+
+def _current_branch() -> str:
+    """Return the current branch name; empty string on detached HEAD."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def _merge_base_with_origin_main() -> str | None:
+    """Return merge-base SHA with `origin/main`, or None if not computable."""
+    result = subprocess.run(
+        ["git", "merge-base", "origin/main", "HEAD"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    base = result.stdout.strip()
+    return base or None
 
 
 def _check_content_hash(
@@ -321,6 +427,80 @@ def update_hashes(data: dict) -> int:
     if updated:
         FEATURES_YAML.write_text(text, encoding="utf-8")
     return updated
+
+
+def restamp_orphaned(data: dict) -> int:
+    """Rewrite every orphaned `last_verified_sha` in features.yml to HEAD.
+
+    "Orphaned" = `git merge-base --is-ancestor sha HEAD` returns non-zero.
+    Keeps ancestor stamps untouched so an intentional pre-verified marker
+    (the stamp was pinned to a specific commit for a reason) survives.
+
+    Used two ways:
+      - `scripts/verify-docs.py --restamp` after a squash-merge landed on
+        main, to realign docs/features.yml with the merge commit.
+      - `scripts/verify-docs.py --restamp` on a feature branch that
+        inherited an orphaned stamp from main and needs to reclaim it
+        before editing tracked sources.
+    """
+    head_sha = _head_short_sha()
+    if head_sha is None:
+        print("Cannot resolve HEAD SHA; refusing to re-stamp.", file=sys.stderr)
+        return 0
+    text = FEATURES_YAML.read_text(encoding="utf-8")
+    updated = 0
+    for feat in iter_features(data):
+        shot = feat.get("screenshot") or {}
+        stored_sha = (shot.get("last_verified_sha") or "").strip()
+        path = (shot.get("path") or "").strip()
+        if not stored_sha or not path:
+            continue
+        if _is_ancestor_of_head(stored_sha):
+            continue  # stamp is still on the live history — leave alone
+        text, changed = _replace_last_verified_sha(text, path, head_sha)
+        if changed:
+            updated += 1
+
+    if updated:
+        FEATURES_YAML.write_text(text, encoding="utf-8")
+    return updated
+
+
+def _head_short_sha() -> str | None:
+    """Return `git rev-parse --short HEAD` output, or None on failure."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--short", "HEAD"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return None if result.returncode != 0 else result.stdout.strip() or None
+
+
+def _replace_last_verified_sha(text: str, path: str, new_sha: str) -> tuple[str, bool]:
+    """Replace `last_verified_sha:` immediately following a given `path:` line.
+
+    Mirrors `_replace_content_hash`: regex anchor on the path to scope the
+    rewrite to one screenshot block, preserve surrounding YAML comments
+    and formatting. Returns (new_text, changed).
+    """
+    escaped = re.escape(path)
+    pattern = re.compile(
+        rf"(path:\s*{escaped}\s*\n(?:.*\n){{0,40}}?\s*last_verified_sha:\s*)"
+        rf"\"?(?P<old>[0-9a-fA-F]*)\"?",
+        re.MULTILINE,
+    )
+    match = pattern.search(text)
+    if not match:
+        return text, False
+    if match["old"] == new_sha:
+        return text, False
+    # Preserve the quoted form: existing "abcdef1" stays quoted, bare abcdef1 stays bare.
+    quoted = match[0].rstrip().endswith('"')
+    replacement = f'"{new_sha}"' if quoted else new_sha
+    new_text = text[: match.start()] + match[1] + replacement + text[match.end() :]
+    return new_text, True
 
 
 def _replace_content_hash(text: str, path: str, new_hash: str) -> tuple[str, bool]:
@@ -539,6 +719,14 @@ def main() -> int:
         action="store_true",
         help="Recompute content_sha256 for every screenshot and rewrite features.yml",
     )
+    ap.add_argument(
+        "--restamp",
+        action="store_true",
+        help="Rewrite every screenshot's last_verified_sha to the current HEAD "
+        "when the existing stamp is orphaned (not an ancestor of HEAD). "
+        "Use after a squash-merge rebase or when adopting the inherited "
+        "stamp from main onto a fresh feature branch.",
+    )
     args = ap.parse_args()
 
     data = load_features()
@@ -547,6 +735,14 @@ def main() -> int:
         count = update_hashes(data)
         print(
             f"Updated {count} content_sha256 entry/entries in {FEATURES_YAML.relative_to(REPO_ROOT)}"
+        )
+        return 0
+
+    if args.restamp:
+        count = restamp_orphaned(data)
+        print(
+            f"Re-stamped {count} orphaned last_verified_sha entry/entries in "
+            f"{FEATURES_YAML.relative_to(REPO_ROOT)} to current HEAD"
         )
         return 0
 


### PR DESCRIPTION
── Summary ─────────────────────────────────

CI on main broke the moment PR #136 squash-merged because `docs/features.yml` still stamped two screenshots at `5b7f685` — a feature-branch commit that became orphaned when `--delete-branch` ran. The strict `git log sha..HEAD` freshness check then surfaced the squash commit itself as a false "source changed" signal on every subsequent main checkout.

This PR makes the verifier branch-aware: orphaned stamps on `main` (expected post-squash) become warnings; orphaned stamps on a feature branch still ERROR *only when that branch touches tracked sources*. A new `--restamp` flag auto-rewrites orphaned stamps to HEAD in one command.

── Changes ─────────────────────────────────

| Type | File                                                                        | Description                                                                                                                       |
|------|-----------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
| Fix  | [scripts/verify-docs.py:175](scripts/verify-docs.py#L175)                   | Split freshness check by stamp state: `_check_freshness_by_state` dispatches to ancestor-strict / main-warn / branch-diff helpers |
| Fix  | [scripts/verify-docs.py:237](scripts/verify-docs.py#L237)                   | `_handle_orphan_stamp` — warn on main, error on feature-branch-with-source-changes (diff against merge-base with `origin/main`)   |
| Feat | [scripts/verify-docs.py:388](scripts/verify-docs.py#L388)                   | `--restamp` CLI flag: rewrites every orphaned `last_verified_sha` to current HEAD (ancestor stamps left untouched)                |
| Chore| [.pre-commit-config.yaml:66](.pre-commit-config.yaml#L66)                   | Manual-stage hook `verify-docs-restamp` for explicit `pre-commit run verify-docs-restamp` invocation                              |
| Docs | [scripts/verify-docs.py:2](scripts/verify-docs.py#L2)                       | Module docstring documents the branch-aware semantics and the `--restamp` flag                                                    |

── Validation ──────────────────────────────

```bash
# 1. On main post-merge — script warns, exits 0 (previous behavior: ERROR + exit 1)
git checkout main
python3 scripts/verify-docs.py
# Expect: "docs/features.yml in sync with README + plugin.xml + CHANGELOG"

# 2. Feature branch with orphan stamp + source edit — script errors loudly
git checkout -b scratch/verify-test
echo "// probe" >> src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
git add -A && git commit -m "probe" --no-verify
python3 scripts/verify-docs.py
# Expect: [ERROR] … 'is orphaned AND this branch touches tracked sources' …

# 3. --restamp re-aligns orphaned stamps
python3 scripts/verify-docs.py --restamp
# Expect: "Re-stamped 2 orphaned last_verified_sha entry/entries … to current HEAD"
python3 scripts/verify-docs.py
# Expect: "docs/features.yml in sync with …"

# 4. Pre-commit manual stage helper
pre-commit run verify-docs-restamp --hook-stage manual
# Expect: same as direct --restamp invocation
```

── Notes ───────────────────────────────────

- Content-hash (`content_sha256`) enforcement is unchanged — it remains the pixel-drift guard regardless of stamp state.
- Ancestor stamps (valid, reachable from HEAD) keep their existing strict freshness check — no change for pre-merge CI behavior.
- Old behavior is preserved behind `_check_source_freshness_since` with the `strict_msg` flag; the wording of the strict error message is identical to the prior version plus a hint to try `--restamp`.
- `--restamp` never touches non-orphan stamps, so pinning a stamp to a specific commit for investigative purposes still works.

## Summary by Sourcery

Adjust docs verification to handle orphaned screenshot stamps after squash merges and add a helper to automatically restamp them.

New Features:
- Add a --restamp CLI option to rewrite orphaned last_verified_sha entries in docs/features.yml to the current HEAD without touching valid ancestor stamps.

Bug Fixes:
- Treat orphaned last_verified_sha stamps differently on main versus feature branches so squash merges no longer cause failing doc freshness checks on main.
- Ensure orphaned stamps on feature branches only error when the branch has modified tracked sources and provide clearer error messaging.

Enhancements:
- Introduce branch-aware freshness checks that distinguish ancestor stamps from orphaned ones and rely on content hashes as the pixel-drift guard.
- Add utilities to inspect git history (ancestor checks, current branch, merge-base with origin/main) to support nuanced doc stamp validation.

Documentation:
- Document the new branch-aware screenshot verification semantics and the restamp workflow in the verify-docs script.

Chores:
- Add a manual pre-commit hook to restamp orphaned last_verified_sha values via the verify-docs script.