### PR TITLE
fix(accent): keep project override sticky across rotation ticks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -234,6 +234,18 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+      # GitHub-hosted runners ship with ~25 GB of pre-installed toolchains we don't need.
+      # Plugin Verifier downloads + extracts 5-6 IDE builds per group (~10-12 GB) and the
+      # Group B job has hit "No space left on device" on the runner diag log partition.
+      # Prune the large toolchains we don't touch so the IDE extraction window has room.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/boost
+          df -h /
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: temurin

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "5b7f685"
+          last_verified_sha: "ec4e064"
           last_verified_date: "2026-04-17"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "5b7f685"
+          last_verified_sha: "ec4e064"
           last_verified_date: "2026-04-17"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "9a891f2"
+          last_verified_sha: "1587c0d"
           last_verified_date: "2026-04-17"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "9a891f2"
+          last_verified_sha: "1587c0d"
           last_verified_date: "2026-04-17"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "a9faa79"
+          last_verified_sha: "9a891f2"
           last_verified_date: "2026-04-17"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "a9faa79"
+          last_verified_sha: "9a891f2"
           last_verified_date: "2026-04-17"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "ec4e064"
+          last_verified_sha: "a9faa79"
           last_verified_date: "2026-04-17"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "ec4e064"
+          last_verified_sha: "a9faa79"
           last_verified_date: "2026-04-17"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -13,6 +13,7 @@ import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.wm.IdeFocusManager
+import com.intellij.openapi.wm.WindowManager
 import com.intellij.ui.ColorUtil
 import dev.ayuislands.accent.conflict.ConflictRegistry
 import dev.ayuislands.glow.GlowStyle
@@ -164,27 +165,59 @@ object AccentApplicator {
     }
 
     /**
-     * Resolves the *actually* focused project — the one whose window has OS-level focus,
-     * not just "the first open project in enumeration order". With two or more project
-     * windows open, a naive `ProjectManager.openProjects.firstOrNull` would silently apply
-     * the wrong project's override (rotation tick, settings Apply, LAF change would flow
-     * through it for the wrong window). Fallback chain:
+     * Resolves the *actually* focused project — the one whose window is currently on top
+     * for the user. The cascade walks from strongest signal (OS-level window activity) to
+     * weakest (first non-disposed open project) so rotation ticks, settings Apply, and LAF
+     * changes route through the window the user is visually on, not the one the focus
+     * manager happened to bookmark most recently.
      *
-     *  1. [IdeFocusManager.lastFocusedFrame]'s project — real focus state
-     *  2. First non-default non-disposed open project — pre-focus-manager startup, or
-     *     shutdown edge cases where the focus manager is torn down
-     *  3. `null` — no project open; resolver will return the global accent
+     *  1. First `WindowManager.allProjectFrames` whose ancestor window reports
+     *     [Window.isActive]. This is the ground truth for "which project window has OS
+     *     focus right now" and matches the same mechanism
+     *     [dev.ayuislands.settings.mappings.ProjectAccentSwapService.findProjectForWindow]
+     *     uses for WINDOW_ACTIVATED — both paths stay consistent.
+     *  2. [IdeFocusManager.lastFocusedFrame]'s project — fallback when the IDE is
+     *     alt-tabbed out (no frame has OS focus) or the window ancestor lookup is
+     *     temporarily unavailable.
+     *  3. First non-default non-disposed open project — pre-focus-manager startup or
+     *     shutdown edge cases.
+     *  4. `null` — no project open; resolver will return the global accent.
      */
-    private fun resolveFocusedProject(): com.intellij.openapi.project.Project? =
+    private fun resolveFocusedProject(): com.intellij.openapi.project.Project? {
+        osActiveProjectFrame()?.let { return it }
         IdeFocusManager
             .getGlobalInstance()
             .lastFocusedFrame
             ?.project
             ?.takeIf { it.isUsable() }
-            ?: ProjectManager
-                .getInstance()
-                .openProjects
-                .firstOrNull { it.isUsable() }
+            ?.let { return it }
+        return ProjectManager
+            .getInstance()
+            .openProjects
+            .firstOrNull { it.isUsable() }
+    }
+
+    /**
+     * Scans open project frames for the one whose ancestor window is OS-active. Each frame
+     * access is wrapped in try/catch because frames can be mid-dispose during a shutdown
+     * race; one bad frame must not break the scan for a healthy one. Failures log at DEBUG
+     * to keep idea.log quiet on alt-tab storms while still being visible under verbose
+     * logging for user-submitted reports.
+     */
+    private fun osActiveProjectFrame(): com.intellij.openapi.project.Project? {
+        val windowManager = WindowManager.getInstance() ?: return null
+        for (frame in windowManager.allProjectFrames) {
+            try {
+                val project = frame.project ?: continue
+                if (!project.isUsable()) continue
+                val window = SwingUtilities.getWindowAncestor(frame.component) ?: continue
+                if (window.isActive) return project
+            } catch (exception: RuntimeException) {
+                log.debug("Skipping frame during OS-active resolution", exception)
+            }
+        }
+        return null
+    }
 
     private fun com.intellij.openapi.project.Project.isUsable(): Boolean = !isDefault && !isDisposed
 

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -35,6 +35,19 @@ object AccentApplicator {
         )
 
     private val log = logger<AccentApplicator>()
+
+    // First-WARN-then-DEBUG gates for osActiveProjectFrame error paths. Without the gate,
+    // a broken frame mid-shutdown or an unavailable WindowManager would either spam idea.log
+    // on every apply (LAF listener, rotation tick, Settings panel Apply all go through the
+    // OS-active scan) or silently degrade with no trace. The first failure surfaces at WARN
+    // so user-submitted logs make the pathology visible; subsequent failures degrade to
+    // DEBUG so interactive sessions don't drown in noise. Declared `internal` so tests in
+    // the same module can reset between runs — `AccentApplicator` is a JVM-wide object and
+    // gate state persists across tests without the reset.
+    @Volatile internal var osActiveFrameFailureLogged = false
+
+    @Volatile internal var windowManagerUnavailableLogged = false
+
     private const val DARK_FOREGROUND_HEX = 0x1F2430
     private val DARK_FOREGROUND = Color(DARK_FOREGROUND_HEX)
     private const val TAB_ACCENT_BG_ALPHA = 50
@@ -172,10 +185,10 @@ object AccentApplicator {
      * manager happened to bookmark most recently.
      *
      *  1. First `WindowManager.allProjectFrames` whose ancestor window reports
-     *     [Window.isActive]. This is the ground truth for "which project window has OS
-     *     focus right now" and matches the same mechanism
-     *     [dev.ayuislands.settings.mappings.ProjectAccentSwapService.findProjectForWindow]
-     *     uses for WINDOW_ACTIVATED — both paths stay consistent.
+     *     `Window.isActive`. Uses the same frame-enumeration pattern as
+     *     `ProjectAccentSwapService.findProjectForWindow` (which matches by reference
+     *     equality on a listener-provided window); here we need the OS-active window, so
+     *     the match predicate is `Window.isActive`.
      *  2. [IdeFocusManager.lastFocusedFrame]'s project — fallback when the IDE is
      *     alt-tabbed out (no frame has OS focus) or the window ancestor lookup is
      *     temporarily unavailable.
@@ -200,12 +213,26 @@ object AccentApplicator {
     /**
      * Scans open project frames for the one whose ancestor window is OS-active. Each frame
      * access is wrapped in try/catch because frames can be mid-dispose during a shutdown
-     * race; one bad frame must not break the scan for a healthy one. Failures log at DEBUG
-     * to keep idea.log quiet on alt-tab storms while still being visible under verbose
-     * logging for user-submitted reports.
+     * race; one bad frame must not break the scan for a healthy one. Error paths — a null
+     * `WindowManager` service and per-frame failures — log at WARN on first occurrence then
+     * degrade to DEBUG (see [osActiveFrameFailureLogged] / [windowManagerUnavailableLogged])
+     * so user-submitted idea.log captures the pathology while interactive sessions do not
+     * drown in noise across repeated Apply / LAF-change / rotation-tick calls.
      */
     private fun osActiveProjectFrame(): com.intellij.openapi.project.Project? {
-        val windowManager = WindowManager.getInstance() ?: return null
+        val windowManager = WindowManager.getInstance()
+        if (windowManager == null) {
+            if (!windowManagerUnavailableLogged) {
+                windowManagerUnavailableLogged = true
+                log.warn(
+                    "WindowManager unavailable during OS-active project resolution; " +
+                        "falling back to IdeFocusManager cascade (further occurrences at DEBUG)",
+                )
+            } else {
+                log.debug("WindowManager unavailable during OS-active project resolution")
+            }
+            return null
+        }
         for (frame in windowManager.allProjectFrames) {
             try {
                 val project = frame.project ?: continue
@@ -213,7 +240,16 @@ object AccentApplicator {
                 val window = SwingUtilities.getWindowAncestor(frame.component) ?: continue
                 if (window.isActive) return project
             } catch (exception: RuntimeException) {
-                log.debug("Skipping frame during OS-active resolution", exception)
+                if (!osActiveFrameFailureLogged) {
+                    osActiveFrameFailureLogged = true
+                    log.warn(
+                        "Skipping frame during OS-active resolution " +
+                            "(further failures logged at DEBUG)",
+                        exception,
+                    )
+                } else {
+                    log.debug("Skipping frame during OS-active resolution", exception)
+                }
             }
         }
         return null

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -25,6 +25,7 @@ import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 import java.awt.Color
 import java.awt.Window
 import java.lang.reflect.Method
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.swing.SwingUtilities
 import javax.swing.UIManager
 
@@ -36,17 +37,18 @@ object AccentApplicator {
 
     private val log = logger<AccentApplicator>()
 
-    // First-WARN-then-DEBUG gates for osActiveProjectFrame error paths. Without the gate,
-    // a broken frame mid-shutdown or an unavailable WindowManager would either spam idea.log
+    // First-WARN-then-DEBUG gates for osActiveProjectFrame error paths. Without them, a
+    // broken frame mid-shutdown or an unavailable WindowManager would either spam idea.log
     // on every apply (LAF listener, rotation tick, Settings panel Apply all go through the
-    // OS-active scan) or silently degrade with no trace. The first failure surfaces at WARN
-    // so user-submitted logs make the pathology visible; subsequent failures degrade to
-    // DEBUG so interactive sessions don't drown in noise. Declared `internal` so tests in
-    // the same module can reset between runs — `AccentApplicator` is a JVM-wide object and
-    // gate state persists across tests without the reset.
-    @Volatile internal var osActiveFrameFailureLogged = false
+    // OS-active scan) or silently degrade with no trace.
+    //
+    // Rotation runs on `AppScheduledExecutorService`; the other callers are on EDT.
+    // Concurrent first-failure across threads is rare but real, so the gate uses
+    // `AtomicBoolean.compareAndSet` — not `@Volatile Boolean` — so exactly one caller wins
+    // the WARN even when two threads race to log the same shutdown-race failure.
+    internal val osActiveFrameFailureLogged = AtomicBoolean(false)
 
-    @Volatile internal var windowManagerUnavailableLogged = false
+    internal val windowManagerUnavailableLogged = AtomicBoolean(false)
 
     private const val DARK_FOREGROUND_HEX = 0x1F2430
     private val DARK_FOREGROUND = Color(DARK_FOREGROUND_HEX)
@@ -185,13 +187,15 @@ object AccentApplicator {
      * manager happened to bookmark most recently.
      *
      *  1. First `WindowManager.allProjectFrames` whose ancestor window reports
-     *     `Window.isActive`. Uses the same frame-enumeration pattern as
-     *     `ProjectAccentSwapService.findProjectForWindow` (which matches by reference
-     *     equality on a listener-provided window); here we need the OS-active window, so
-     *     the match predicate is `Window.isActive`.
-     *  2. [IdeFocusManager.lastFocusedFrame]'s project — fallback when the IDE is
-     *     alt-tabbed out (no frame has OS focus) or the window ancestor lookup is
-     *     temporarily unavailable.
+     *     `Window.isActive`. Iterates all project frames, calls
+     *     `SwingUtilities.getWindowAncestor(frame.component)`, and matches where
+     *     `window.isActive` is true. (The sibling swap-service uses the same frame
+     *     enumeration but matches by reference equality against a listener-provided
+     *     window — identical iteration, different predicate.)
+     *  2. [IdeFocusManager.lastFocusedFrame]'s project — fallback when the OS-active
+     *     scan returns null for any reason: the IDE is alt-tabbed out, the window
+     *     ancestor lookup is temporarily unavailable, or `WindowManager` itself is
+     *     null during startup / shutdown.
      *  3. First non-default non-disposed open project — pre-focus-manager startup or
      *     shutdown edge cases.
      *  4. `null` — no project open; resolver will return the global accent.
@@ -215,40 +219,44 @@ object AccentApplicator {
      * access is wrapped in try/catch because frames can be mid-dispose during a shutdown
      * race; one bad frame must not break the scan for a healthy one. Error paths — a null
      * `WindowManager` service and per-frame failures — log at WARN on first occurrence then
-     * degrade to DEBUG (see [osActiveFrameFailureLogged] / [windowManagerUnavailableLogged])
-     * so user-submitted idea.log captures the pathology while interactive sessions do not
-     * drown in noise across repeated Apply / LAF-change / rotation-tick calls.
+     * degrade to DEBUG so user-submitted idea.log captures the pathology while interactive
+     * sessions do not drown in noise across repeated Apply / LAF-change / rotation-tick
+     * calls.
      */
     private fun osActiveProjectFrame(): com.intellij.openapi.project.Project? {
         val windowManager = WindowManager.getInstance()
         if (windowManager == null) {
-            if (!windowManagerUnavailableLogged) {
-                windowManagerUnavailableLogged = true
+            val context = "thread=${Thread.currentThread().name}"
+            if (windowManagerUnavailableLogged.compareAndSet(false, true)) {
                 log.warn(
-                    "WindowManager unavailable during OS-active project resolution; " +
+                    "WindowManager unavailable during OS-active project resolution ($context); " +
                         "falling back to IdeFocusManager cascade (further occurrences at DEBUG)",
                 )
             } else {
-                log.debug("WindowManager unavailable during OS-active project resolution")
+                log.debug("WindowManager unavailable during OS-active project resolution ($context)")
             }
             return null
         }
-        for (frame in windowManager.allProjectFrames) {
+        for ((index, frame) in windowManager.allProjectFrames.withIndex()) {
+            var probedName: String? = null
             try {
                 val project = frame.project ?: continue
+                probedName = runCatching { project.name }.getOrNull()
                 if (!project.isUsable()) continue
                 val window = SwingUtilities.getWindowAncestor(frame.component) ?: continue
                 if (window.isActive) return project
             } catch (exception: RuntimeException) {
-                if (!osActiveFrameFailureLogged) {
-                    osActiveFrameFailureLogged = true
+                val context =
+                    "index=$index, project=${probedName ?: "<unresolved>"}, " +
+                        "thread=${Thread.currentThread().name}"
+                if (osActiveFrameFailureLogged.compareAndSet(false, true)) {
                     log.warn(
-                        "Skipping frame during OS-active resolution " +
+                        "Skipping frame during OS-active resolution ($context) " +
                             "(further failures logged at DEBUG)",
                         exception,
                     )
                 } else {
-                    log.debug("Skipping frame during OS-active resolution", exception)
+                    log.debug("Skipping frame during OS-active resolution ($context)", exception)
                 }
             }
         }

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -48,6 +48,7 @@ object AccentApplicator {
     // the WARN even when two threads race to log the same shutdown-race failure.
     internal val osActiveFrameFailureLogged = AtomicBoolean(false)
 
+    // Paired gate; see osActiveFrameFailureLogged above for the WARN/DEBUG rationale.
     internal val windowManagerUnavailableLogged = AtomicBoolean(false)
 
     private const val DARK_FOREGROUND_HEX = 0x1F2430

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapService.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapService.kt
@@ -88,8 +88,13 @@ class ProjectAccentSwapService : Disposable {
         val window = (event as? WindowEvent)?.window ?: return
         val project = findProjectForWindow(window) ?: return
         if (project.isDisposed || project.isDefault) return
-        if (project === lastAppliedProject) return
 
+        // No project-equality short-circuit on top of the hex check: alt-tab away to a non-IDE
+        // app and back reports the same project, but an external apply (rotation tick, settings
+        // Apply) may have pushed a different color into the JVM-wide UIManager/globalScheme
+        // since the last activation. Re-resolving is cheap (canonicalPath + HashMap lookup);
+        // the hex gate below still skips the expensive apply + component-tree walk when the
+        // resolver output hasn't drifted.
         val variant = AyuVariant.detect() ?: return
         val effectiveHex = AccentResolver.resolve(project, variant)
 

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapService.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapService.kt
@@ -32,9 +32,6 @@ import javax.swing.SwingUtilities
  */
 class ProjectAccentSwapService : Disposable {
     @Volatile
-    private var lastAppliedProject: Project? = null
-
-    @Volatile
     private var lastAppliedHex: String? = null
 
     private var listener: AWTEventListener? = null
@@ -89,16 +86,15 @@ class ProjectAccentSwapService : Disposable {
         val project = findProjectForWindow(window) ?: return
         if (project.isDisposed || project.isDefault) return
 
-        // No project-equality short-circuit on top of the hex check: alt-tab away to a non-IDE
-        // app and back reports the same project, but an external apply (rotation tick, settings
-        // Apply) may have pushed a different color into the JVM-wide UIManager/globalScheme
-        // since the last activation. Re-resolving is cheap (canonicalPath + HashMap lookup);
-        // the hex gate below still skips the expensive apply + component-tree walk when the
-        // resolver output hasn't drifted.
+        // Re-resolve on every activation. Alt-tab away to a non-IDE app and back reports the
+        // same project, but any external apply (rotation tick, Settings panel Apply, LAF
+        // change — anything that reaches `notifyExternalApply`) may have pushed a different
+        // color into the JVM-wide UIManager/globalScheme since the last activation. The
+        // resolver call is cheap (canonicalPath + HashMap lookup); the hex gate below still
+        // skips the expensive apply + component-tree walk when the resolver output matches.
         val variant = AyuVariant.detect() ?: return
         val effectiveHex = AccentResolver.resolve(project, variant)
 
-        lastAppliedProject = project
         if (effectiveHex == lastAppliedHex) return
 
         lastAppliedHex = effectiveHex
@@ -159,7 +155,6 @@ class ProjectAccentSwapService : Disposable {
             Toolkit.getDefaultToolkit().removeAWTEventListener(it)
             listener = null
         }
-        lastAppliedProject = null
         lastAppliedHex = null
         LOG.info("ProjectAccentSwapService disposed")
     }

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt
@@ -60,9 +60,9 @@ class AccentApplicatorFocusedProjectTest {
         every { ProjectAccentSwapService.getInstance() } returns swapService
 
         // AccentApplicator is a JVM-wide object; WARN-gate flags persist across tests.
-        // Reset them so each gate-observation test starts from a clean slate.
-        AccentApplicator.osActiveFrameFailureLogged = false
-        AccentApplicator.windowManagerUnavailableLogged = false
+        // Reset before AND after so cross-file test ordering (Gradle forks, parallel
+        // execution) cannot observe stale gate state.
+        resetLogGates()
 
         // Default: empty frames + null window ancestor so `resolveFocusedProject` falls
         // through to the IdeFocusManager / ProjectManager chain. OS-active-path tests
@@ -80,7 +80,13 @@ class AccentApplicatorFocusedProjectTest {
 
     @AfterTest
     fun tearDown() {
+        resetLogGates()
         unmockkAll()
+    }
+
+    private fun resetLogGates() {
+        AccentApplicator.osActiveFrameFailureLogged.set(false)
+        AccentApplicator.windowManagerUnavailableLogged.set(false)
     }
 
     @Test
@@ -218,10 +224,10 @@ class AccentApplicatorFocusedProjectTest {
 
     @Test
     fun `applyForFocusedProject prefers OS-active project frame over IdeFocusManager lastFocusedFrame`() {
-        // When two IDE project windows are open, IdeFocusManager.lastFocusedFrame can still
-        // point at the previously-clicked IDE frame (not the one currently on top). The
-        // OS-active-frame path is the ground truth for "which project window is the user
-        // visually on right now", and must win over lastFocusedFrame when they disagree.
+        // IdeFocusManager.lastFocusedFrame can still point at the previously-clicked IDE
+        // frame even when the user has since alt-tabbed to the other open project. OS-level
+        // window activity is the ground truth for "which project window is visible right now"
+        // and must win over lastFocusedFrame when they disagree.
         val osActiveProject = stubProject(isDefault = false, isDisposed = false)
         val lastFocusedProject = stubProject(isDefault = false, isDisposed = false)
 
@@ -489,11 +495,11 @@ class AccentApplicatorFocusedProjectTest {
 
     @Test
     fun `applyForFocusedProject disposed OS-active frame falls through to IdeFocusManager not ProjectManager`() {
-        // Covers the middle tier of the cascade: OS-active-but-disposed must reach
-        // IdeFocusManager (tier 2), not skip all the way to ProjectManager.openProjects
-        // (tier 3). A regression that collapsed tiers 2+3 would pass the existing
-        // "fall back to openProjects" test but break ordering in a way only this test
-        // detects.
+        // A regression that collapsed tiers 2+3 of the cascade would pass the existing
+        // "fall back to openProjects" test (empty tier-1, empty tier-2, hits tier-3 as
+        // expected) but silently reach tier-3 instead of tier-2 when tier-1 returns an
+        // unusable match. This test forces tier-1 to return disposed, leaves tier-2
+        // healthy, and asserts tier-2 wins.
         val disposedProject = stubProject(isDefault = false, isDisposed = true)
         val disposedWindow = mockk<Window>(relaxed = true)
         every { disposedWindow.isActive } returns true

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.wm.IdeFocusManager
 import com.intellij.openapi.wm.IdeFrame
 import com.intellij.openapi.wm.WindowManager
+import com.intellij.testFramework.LoggedErrorProcessor
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 import io.mockk.Runs
 import io.mockk.every
@@ -22,6 +23,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Locks in the contract of [AccentApplicator.applyForFocusedProject] — five production
@@ -57,10 +59,14 @@ class AccentApplicatorFocusedProjectTest {
         swapService = mockk(relaxed = true)
         every { ProjectAccentSwapService.getInstance() } returns swapService
 
-        // Default: no OS-active project frames. resolveFocusedProject's new primary path
-        // (OS-active IDE frame) short-circuits to null so tests that exercise the
-        // IdeFocusManager / ProjectManager fallback chain behave as before. Tests covering
-        // the OS-active path override this explicitly.
+        // AccentApplicator is a JVM-wide object; WARN-gate flags persist across tests.
+        // Reset them so each gate-observation test starts from a clean slate.
+        AccentApplicator.osActiveFrameFailureLogged = false
+        AccentApplicator.windowManagerUnavailableLogged = false
+
+        // Default: empty frames + null window ancestor so `resolveFocusedProject` falls
+        // through to the IdeFocusManager / ProjectManager chain. OS-active-path tests
+        // override per test.
         mockkStatic(WindowManager::class)
         val windowManager =
             mockk<WindowManager> {
@@ -212,9 +218,8 @@ class AccentApplicatorFocusedProjectTest {
 
     @Test
     fun `applyForFocusedProject prefers OS-active project frame over IdeFocusManager lastFocusedFrame`() {
-        // Regression guard for the rotation-override bug. When rotation tick fires while the
-        // user is alt-tabbed between IDE project windows, IdeFocusManager.lastFocusedFrame can
-        // still point at the previously-clicked IDE frame (not the one currently on top). The
+        // When two IDE project windows are open, IdeFocusManager.lastFocusedFrame can still
+        // point at the previously-clicked IDE frame (not the one currently on top). The
         // OS-active-frame path is the ground truth for "which project window is the user
         // visually on right now", and must win over lastFocusedFrame when they disagree.
         val osActiveProject = stubProject(isDefault = false, isDisposed = false)
@@ -250,11 +255,10 @@ class AccentApplicatorFocusedProjectTest {
 
     @Test
     fun `applyForFocusedProject falls back to IdeFocusManager when no project frame is OS-active`() {
-        // User alt-tabbed to a non-IDE app (browser, Slack) when rotation tick fires. No
-        // project frame has OS focus, so the OS-active-frame path returns null and the
-        // cascade falls through to IdeFocusManager.lastFocusedFrame. The scheduler runs on
-        // EDT via invokeLater, so lastFocusedFrame is the best available signal for "which
-        // project the user was most recently in".
+        // User alt-tabbed to a non-IDE app (browser, Slack). No project frame has OS focus,
+        // so the OS-active-frame path returns null and the cascade falls through to
+        // IdeFocusManager.lastFocusedFrame — the best available signal for "which project
+        // the user was most recently in".
         val lastFocusedProject = stubProject(isDefault = false, isDisposed = false)
 
         val inactiveWindow = mockk<Window>(relaxed = true)
@@ -288,9 +292,10 @@ class AccentApplicatorFocusedProjectTest {
     @Test
     fun `applyForFocusedProject skips OS-active frame whose project is disposed and continues the cascade`() {
         // Shutdown race: a project frame is OS-active but its project has just been disposed.
-        // The isUsable() guard inside the OS-active scan must drop it; the cascade falls
-        // through to IdeFocusManager / ProjectManager. Without the guard, resolve() would be
-        // called with a disposed project and throw inside AccentResolver.projectKey.
+        // The isUsable() guard inside the OS-active scan must drop it so the cascade reaches
+        // IdeFocusManager / ProjectManager. AccentResolver.findOverride has its own isDisposed
+        // early-return, but relying on that would route every mid-dispose frame through a
+        // wasted lookup; drop it here and keep the cascade hygienic.
         val disposedProject = stubProject(isDefault = false, isDisposed = true)
 
         val osActiveWindow = mockk<Window>(relaxed = true)
@@ -315,6 +320,216 @@ class AccentApplicatorFocusedProjectTest {
     }
 
     @Test
+    fun `applyForFocusedProject falls through to IdeFocusManager when WindowManager service is null`() {
+        // Early-startup or mid-shutdown edge case: the Application service registry has not
+        // yet produced a WindowManager (or has just torn it down). The OS-active path must
+        // degrade cleanly to the middle tier of the cascade rather than NPE out of the whole
+        // apply.
+        every { WindowManager.getInstance() } returns null
+
+        val focusedProject = stubProject(isDefault = false, isDisposed = false)
+        val focusedFrame =
+            mockk<IdeFrame> {
+                every { project } returns focusedProject
+            }
+        val focusManager =
+            mockk<IdeFocusManager> {
+                every { lastFocusedFrame } returns focusedFrame
+            }
+        mockkStatic(IdeFocusManager::class)
+        every { IdeFocusManager.getGlobalInstance() } returns focusManager
+
+        every { AccentResolver.resolve(focusedProject, AyuVariant.MIRAGE) } returns "#FALLBACK"
+
+        val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
+
+        assertEquals("#FALLBACK", applied)
+        verify(exactly = 1) { AccentResolver.resolve(focusedProject, AyuVariant.MIRAGE) }
+    }
+
+    @Test
+    fun `applyForFocusedProject logs WARN once then DEBUG for repeated null WindowManager`() {
+        // Sibling parity with ProjectAccentSwapService.findProjectForWindow: first occurrence
+        // surfaces in user-submitted idea.log at WARN, subsequent ones degrade to DEBUG so
+        // repeated Apply / LAF-change / rotation-tick calls during a prolonged null-service
+        // window do not flood the log. A regression that flips the gate would either spam
+        // WARNs every call or hide the first failure below the default log level.
+        every { WindowManager.getInstance() } returns null
+
+        val projectManager = mockk<ProjectManager>()
+        every { projectManager.openProjects } returns emptyArray()
+        every { ProjectManager.getInstance() } returns projectManager
+        every { AccentResolver.resolve(null, AyuVariant.MIRAGE) } returns "#GLOBAL"
+
+        val capturedWarns = mutableListOf<String>()
+        val processor =
+            object : LoggedErrorProcessor() {
+                override fun processWarn(
+                    category: String,
+                    message: String,
+                    throwable: Throwable?,
+                ): Boolean {
+                    if (!message.contains("WindowManager unavailable")) return true
+                    capturedWarns += message
+                    return false
+                }
+            }
+
+        LoggedErrorProcessor.executeWith<Throwable>(processor) {
+            AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
+            AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
+            AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
+        }
+
+        assertEquals(
+            1,
+            capturedWarns.size,
+            "null WindowManager must WARN once then dedup; got: $capturedWarns",
+        )
+        assertTrue(
+            capturedWarns.single().contains("further occurrences at DEBUG"),
+            "first WARN must announce the dedup contract; got: ${capturedWarns.single()}",
+        )
+    }
+
+    @Test
+    fun `applyForFocusedProject skips frame with null project in OS-active scan`() {
+        // IdeFrame.getProject is @Nullable on the platform — a welcome frame, a newly-opened
+        // but not-yet-bound project window, or a frame mid-dispose can legitimately return
+        // null. The scan must skip and keep looking; crashing here would NPE every Apply.
+        val nullProjectFrame =
+            mockk<IdeFrame> {
+                every { project } returns null
+            }
+
+        val healthyProject = stubProject(isDefault = false, isDisposed = false)
+        val healthyWindow = mockk<Window>(relaxed = true)
+        every { healthyWindow.isActive } returns true
+        val healthyComponent = JPanel()
+        every { SwingUtilities.getWindowAncestor(healthyComponent) } returns healthyWindow
+        val healthyFrame = stubIdeFrame(healthyProject, healthyComponent)
+
+        every {
+            WindowManager.getInstance().allProjectFrames
+        } returns arrayOf(nullProjectFrame, healthyFrame)
+
+        every { AccentResolver.resolve(healthyProject, AyuVariant.MIRAGE) } returns "#HEALTHY"
+
+        val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
+
+        assertEquals("#HEALTHY", applied)
+        verify(exactly = 1) { AccentResolver.resolve(healthyProject, AyuVariant.MIRAGE) }
+    }
+
+    @Test
+    fun `applyForFocusedProject picks first OS-active frame when multiple are marked active`() {
+        // Two frames briefly report `isActive = true` during alt-tab transitions before the
+        // OS settles. The scan returns the first match; locking that contract red/green
+        // catches a refactor that flips to `lastOrNull` or filters differently. In reality
+        // only one window is active at a time, but the observable output must still be
+        // deterministic under the platform's enumeration order.
+        val firstProject = stubProject(isDefault = false, isDisposed = false)
+        val secondProject = stubProject(isDefault = false, isDisposed = false)
+
+        val firstWindow = mockk<Window>(relaxed = true)
+        every { firstWindow.isActive } returns true
+        val firstComponent = JPanel()
+        every { SwingUtilities.getWindowAncestor(firstComponent) } returns firstWindow
+        val firstFrame = stubIdeFrame(firstProject, firstComponent)
+
+        val secondWindow = mockk<Window>(relaxed = true)
+        every { secondWindow.isActive } returns true
+        val secondComponent = JPanel()
+        every { SwingUtilities.getWindowAncestor(secondComponent) } returns secondWindow
+        val secondFrame = stubIdeFrame(secondProject, secondComponent)
+
+        every {
+            WindowManager.getInstance().allProjectFrames
+        } returns arrayOf(firstFrame, secondFrame)
+
+        every { AccentResolver.resolve(firstProject, AyuVariant.MIRAGE) } returns "#FIRST"
+
+        val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
+
+        assertEquals("#FIRST", applied)
+        verify(exactly = 1) { AccentResolver.resolve(firstProject, AyuVariant.MIRAGE) }
+        verify(exactly = 0) { AccentResolver.resolve(secondProject, any()) }
+    }
+
+    @Test
+    fun `applyForFocusedProject continues scan when a frame has no window ancestor`() {
+        // SwingUtilities.getWindowAncestor can return null for a frame whose component has
+        // been detached from the tree (rare, but observed during startup animation). The
+        // null-ancestor branch must `continue` the loop, not exit with null — otherwise a
+        // later active-window frame would be missed.
+        val detachedProject = stubProject(isDefault = false, isDisposed = false)
+        val detachedComponent = JPanel()
+        every { SwingUtilities.getWindowAncestor(detachedComponent) } returns null
+        val detachedFrame = stubIdeFrame(detachedProject, detachedComponent)
+
+        val healthyProject = stubProject(isDefault = false, isDisposed = false)
+        val healthyWindow = mockk<Window>(relaxed = true)
+        every { healthyWindow.isActive } returns true
+        val healthyComponent = JPanel()
+        every { SwingUtilities.getWindowAncestor(healthyComponent) } returns healthyWindow
+        val healthyFrame = stubIdeFrame(healthyProject, healthyComponent)
+
+        every {
+            WindowManager.getInstance().allProjectFrames
+        } returns arrayOf(detachedFrame, healthyFrame)
+
+        every { AccentResolver.resolve(healthyProject, AyuVariant.MIRAGE) } returns "#HEALTHY"
+
+        val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
+
+        assertEquals("#HEALTHY", applied)
+        verify(exactly = 1) { AccentResolver.resolve(healthyProject, AyuVariant.MIRAGE) }
+        verify(exactly = 0) { AccentResolver.resolve(detachedProject, any()) }
+    }
+
+    @Test
+    fun `applyForFocusedProject disposed OS-active frame falls through to IdeFocusManager not ProjectManager`() {
+        // Covers the middle tier of the cascade: OS-active-but-disposed must reach
+        // IdeFocusManager (tier 2), not skip all the way to ProjectManager.openProjects
+        // (tier 3). A regression that collapsed tiers 2+3 would pass the existing
+        // "fall back to openProjects" test but break ordering in a way only this test
+        // detects.
+        val disposedProject = stubProject(isDefault = false, isDisposed = true)
+        val disposedWindow = mockk<Window>(relaxed = true)
+        every { disposedWindow.isActive } returns true
+        val disposedComponent = JPanel()
+        every { SwingUtilities.getWindowAncestor(disposedComponent) } returns disposedWindow
+        val disposedFrame = stubIdeFrame(disposedProject, disposedComponent)
+
+        every { WindowManager.getInstance().allProjectFrames } returns arrayOf(disposedFrame)
+
+        val focusedProject = stubProject(isDefault = false, isDisposed = false)
+        val focusedFrame =
+            mockk<IdeFrame> {
+                every { project } returns focusedProject
+            }
+        val focusManager =
+            mockk<IdeFocusManager> {
+                every { lastFocusedFrame } returns focusedFrame
+            }
+        mockkStatic(IdeFocusManager::class)
+        every { IdeFocusManager.getGlobalInstance() } returns focusManager
+
+        val projectManagerProject = stubProject(isDefault = false, isDisposed = false)
+        val projectManager = mockk<ProjectManager>()
+        every { projectManager.openProjects } returns arrayOf(projectManagerProject)
+        every { ProjectManager.getInstance() } returns projectManager
+
+        every { AccentResolver.resolve(focusedProject, AyuVariant.MIRAGE) } returns "#FOCUS"
+
+        val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
+
+        assertEquals("#FOCUS", applied)
+        verify(exactly = 1) { AccentResolver.resolve(focusedProject, AyuVariant.MIRAGE) }
+        verify(exactly = 0) { AccentResolver.resolve(projectManagerProject, any()) }
+    }
+
+    @Test
     fun `applyForFocusedProject survives a frame throwing during OS-active resolution`() {
         // Frame access can throw when the frame is mid-dispose during shutdown. The OS-active
         // scan wraps each frame access in try/catch so one bad frame doesn't break resolution
@@ -334,10 +549,72 @@ class AccentApplicatorFocusedProjectTest {
 
         every { AccentResolver.resolve(healthyProject, AyuVariant.MIRAGE) } returns "#HEALTHY"
 
-        val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
+        val loggedErrors = mutableListOf<Throwable?>()
+        val processor =
+            object : LoggedErrorProcessor() {
+                override fun processWarn(
+                    category: String,
+                    message: String,
+                    throwable: Throwable?,
+                ): Boolean {
+                    if (!message.contains("Skipping frame during OS-active resolution")) return true
+                    loggedErrors += throwable
+                    return false
+                }
+            }
+
+        var applied: String? = null
+        LoggedErrorProcessor.executeWith<Throwable>(processor) {
+            applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
+        }
 
         assertEquals("#HEALTHY", applied)
         verify(exactly = 1) { AccentResolver.resolve(healthyProject, AyuVariant.MIRAGE) }
+    }
+
+    @Test
+    fun `applyForFocusedProject WARN-gates per-frame failures then degrades to DEBUG`() {
+        // Three consecutive apply cycles each hit the same broken frame. The first must WARN
+        // (so user-submitted idea.log captures it); subsequent failures must DEBUG-log so
+        // interactive sessions calling Apply multiple times per minute don't drown the log.
+        // Without the gate, this would emit three WARNs or zero WARNs — both regress against
+        // the sibling pattern in ProjectAccentSwapService.findProjectForWindow.
+        val brokenFrame =
+            mockk<IdeFrame> {
+                every { project } throws IllegalStateException("frame mid-dispose")
+            }
+        every { WindowManager.getInstance().allProjectFrames } returns arrayOf(brokenFrame)
+
+        val projectManager = mockk<ProjectManager>()
+        every { projectManager.openProjects } returns emptyArray()
+        every { ProjectManager.getInstance() } returns projectManager
+        every { AccentResolver.resolve(null, AyuVariant.MIRAGE) } returns "#GLOBAL"
+
+        val capturedWarns = mutableListOf<String>()
+        val processor =
+            object : LoggedErrorProcessor() {
+                override fun processWarn(
+                    category: String,
+                    message: String,
+                    throwable: Throwable?,
+                ): Boolean {
+                    if (!message.contains("Skipping frame during OS-active resolution")) return true
+                    capturedWarns += message
+                    return false
+                }
+            }
+
+        LoggedErrorProcessor.executeWith<Throwable>(processor) {
+            AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
+            AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
+            AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
+        }
+
+        assertEquals(
+            1,
+            capturedWarns.size,
+            "Per-frame exception must WARN once then dedup; got: $capturedWarns",
+        )
     }
 
     private fun stubProject(

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt
@@ -174,6 +174,35 @@ class AccentApplicatorFocusedProjectTest {
     }
 
     @Test
+    fun `applyForFocusedProject falls back to openProjects when focused frame has null project`() {
+        // IdeFrame.getProject is @Nullable on the platform; the lastFocusedFrame may itself
+        // be non-null but return null for its project (welcome-frame edge). The cascade must
+        // treat that the same as "no focused frame" and fall through to ProjectManager.
+        val nullProjectFrame =
+            mockk<IdeFrame> {
+                every { project } returns null
+            }
+        val focusManager =
+            mockk<IdeFocusManager> {
+                every { lastFocusedFrame } returns nullProjectFrame
+            }
+        mockkStatic(IdeFocusManager::class)
+        every { IdeFocusManager.getGlobalInstance() } returns focusManager
+
+        val healthyProject = stubProject(isDefault = false, isDisposed = false)
+        val manager = mockk<ProjectManager>()
+        every { manager.openProjects } returns arrayOf(healthyProject)
+        every { ProjectManager.getInstance() } returns manager
+
+        every { AccentResolver.resolve(healthyProject, AyuVariant.MIRAGE) } returns "#FALLBACK"
+
+        val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
+
+        assertEquals("#FALLBACK", applied)
+        verify(exactly = 1) { AccentResolver.resolve(healthyProject, AyuVariant.MIRAGE) }
+    }
+
+    @Test
     fun `applyForFocusedProject falls back to openProjects when focused frame project is disposed`() {
         // Edge case in resolveFocusedProject: lastFocusedFrame returns a project that
         // disposed between focus event and our read. The takeIf { isUsable() } guard
@@ -585,6 +614,54 @@ class AccentApplicatorFocusedProjectTest {
 
         assertEquals("#HEALTHY", applied)
         verify(exactly = 1) { AccentResolver.resolve(healthyProject, AyuVariant.MIRAGE) }
+    }
+
+    @Test
+    fun `applyForFocusedProject WARN context includes resolved project name when name succeeded before throw`() {
+        // Exercises the other branch of `probedName ?: "<unresolved>"` in the WARN context
+        // string: when `project.name` succeeds but a later state probe (isUsable / window
+        // ancestor) throws, the catch must credit the resolved name in the log so triage
+        // can tell WHICH project's frame broke. The "<unresolved>" branch is covered by
+        // the throwing-frame tests above where `.project` itself throws.
+        val probedProject =
+            mockk<Project> {
+                every { name } returns "frame-project"
+                every { isDefault } throws IllegalStateException("probe after name")
+            }
+        val probedFrame =
+            mockk<IdeFrame> {
+                every { project } returns probedProject
+            }
+        every { WindowManager.getInstance().allProjectFrames } returns arrayOf(probedFrame)
+
+        val projectManager = mockk<ProjectManager>()
+        every { projectManager.openProjects } returns emptyArray()
+        every { ProjectManager.getInstance() } returns projectManager
+        every { AccentResolver.resolve(null, AyuVariant.MIRAGE) } returns "#GLOBAL"
+
+        val capturedWarns = mutableListOf<String>()
+        val processor =
+            object : LoggedErrorProcessor() {
+                override fun processWarn(
+                    category: String,
+                    message: String,
+                    throwable: Throwable?,
+                ): Boolean {
+                    if (!message.contains("Skipping frame during OS-active resolution")) return true
+                    capturedWarns += message
+                    return false
+                }
+            }
+
+        LoggedErrorProcessor.executeWith<Throwable>(processor) {
+            AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
+        }
+
+        val firstWarn = capturedWarns.single()
+        assertTrue(
+            firstWarn.contains("project=frame-project"),
+            "WARN must carry the resolved project name when it was captured before the throw; got: $firstWarn",
+        )
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt
@@ -23,6 +23,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
@@ -59,9 +60,9 @@ class AccentApplicatorFocusedProjectTest {
         swapService = mockk(relaxed = true)
         every { ProjectAccentSwapService.getInstance() } returns swapService
 
-        // AccentApplicator is a JVM-wide object; WARN-gate flags persist across tests.
-        // Reset before AND after so cross-file test ordering (Gradle forks, parallel
-        // execution) cannot observe stale gate state.
+        // AccentApplicator is a JVM-wide object; WARN-gate flags persist across tests in
+        // the same JVM. Reset before AND after so other test classes running in the same
+        // fork can neither poison this suite nor inherit stale state from it.
         resetLogGates()
 
         // Default: empty frames + null window ancestor so `resolveFocusedProject` falls
@@ -396,6 +397,14 @@ class AccentApplicatorFocusedProjectTest {
             capturedWarns.single().contains("further occurrences at DEBUG"),
             "first WARN must announce the dedup contract; got: ${capturedWarns.single()}",
         )
+        assertTrue(
+            capturedWarns.single().contains("thread="),
+            "WARN must carry thread-name context so idea.log distinguishes callers; got: ${capturedWarns.single()}",
+        )
+        assertFalse(
+            AccentApplicator.osActiveFrameFailureLogged.get(),
+            "WindowManager gate must not flip the per-frame gate; the two are independent",
+        )
     }
 
     @Test
@@ -620,6 +629,19 @@ class AccentApplicatorFocusedProjectTest {
             1,
             capturedWarns.size,
             "Per-frame exception must WARN once then dedup; got: $capturedWarns",
+        )
+        val firstWarn = capturedWarns.single()
+        assertTrue(
+            firstWarn.contains("further failures logged at DEBUG"),
+            "first WARN must announce the dedup contract; got: $firstWarn",
+        )
+        assertTrue(
+            firstWarn.contains("index=") && firstWarn.contains("thread="),
+            "WARN must carry frame index and thread name so idea.log makes triage possible; got: $firstWarn",
+        )
+        assertFalse(
+            AccentApplicator.windowManagerUnavailableLogged.get(),
+            "per-frame gate must not flip the WindowManager gate; the two are independent",
         )
     }
 

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.wm.IdeFocusManager
 import com.intellij.openapi.wm.IdeFrame
+import com.intellij.openapi.wm.WindowManager
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 import io.mockk.Runs
 import io.mockk.every
@@ -13,6 +14,10 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
+import java.awt.Window
+import javax.swing.JComponent
+import javax.swing.JPanel
+import javax.swing.SwingUtilities
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -51,6 +56,20 @@ class AccentApplicatorFocusedProjectTest {
         mockkObject(ProjectAccentSwapService.Companion)
         swapService = mockk(relaxed = true)
         every { ProjectAccentSwapService.getInstance() } returns swapService
+
+        // Default: no OS-active project frames. resolveFocusedProject's new primary path
+        // (OS-active IDE frame) short-circuits to null so tests that exercise the
+        // IdeFocusManager / ProjectManager fallback chain behave as before. Tests covering
+        // the OS-active path override this explicitly.
+        mockkStatic(WindowManager::class)
+        val windowManager =
+            mockk<WindowManager> {
+                every { allProjectFrames } returns emptyArray()
+            }
+        every { WindowManager.getInstance() } returns windowManager
+
+        mockkStatic(SwingUtilities::class)
+        every { SwingUtilities.getWindowAncestor(any()) } returns null
     }
 
     @AfterTest
@@ -191,6 +210,136 @@ class AccentApplicatorFocusedProjectTest {
         }
     }
 
+    @Test
+    fun `applyForFocusedProject prefers OS-active project frame over IdeFocusManager lastFocusedFrame`() {
+        // Regression guard for the rotation-override bug. When rotation tick fires while the
+        // user is alt-tabbed between IDE project windows, IdeFocusManager.lastFocusedFrame can
+        // still point at the previously-clicked IDE frame (not the one currently on top). The
+        // OS-active-frame path is the ground truth for "which project window is the user
+        // visually on right now", and must win over lastFocusedFrame when they disagree.
+        val osActiveProject = stubProject(isDefault = false, isDisposed = false)
+        val lastFocusedProject = stubProject(isDefault = false, isDisposed = false)
+
+        val osActiveWindow = mockk<Window>(relaxed = true)
+        every { osActiveWindow.isActive } returns true
+        val osActiveComponent = JPanel()
+        every { SwingUtilities.getWindowAncestor(osActiveComponent) } returns osActiveWindow
+        val osActiveFrame = stubIdeFrame(osActiveProject, osActiveComponent)
+
+        every { WindowManager.getInstance().allProjectFrames } returns arrayOf(osActiveFrame)
+
+        val lastFocusedFrame =
+            mockk<IdeFrame> {
+                every { project } returns lastFocusedProject
+            }
+        val focusManager =
+            mockk<IdeFocusManager> {
+                every { this@mockk.lastFocusedFrame } returns lastFocusedFrame
+            }
+        mockkStatic(IdeFocusManager::class)
+        every { IdeFocusManager.getGlobalInstance() } returns focusManager
+
+        every { AccentResolver.resolve(osActiveProject, AyuVariant.MIRAGE) } returns "#OS"
+
+        val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
+
+        assertEquals("#OS", applied)
+        verify(exactly = 1) { AccentResolver.resolve(osActiveProject, AyuVariant.MIRAGE) }
+        verify(exactly = 0) { AccentResolver.resolve(lastFocusedProject, any()) }
+    }
+
+    @Test
+    fun `applyForFocusedProject falls back to IdeFocusManager when no project frame is OS-active`() {
+        // User alt-tabbed to a non-IDE app (browser, Slack) when rotation tick fires. No
+        // project frame has OS focus, so the OS-active-frame path returns null and the
+        // cascade falls through to IdeFocusManager.lastFocusedFrame. The scheduler runs on
+        // EDT via invokeLater, so lastFocusedFrame is the best available signal for "which
+        // project the user was most recently in".
+        val lastFocusedProject = stubProject(isDefault = false, isDisposed = false)
+
+        val inactiveWindow = mockk<Window>(relaxed = true)
+        every { inactiveWindow.isActive } returns false
+        val inactiveComponent = JPanel()
+        every { SwingUtilities.getWindowAncestor(inactiveComponent) } returns inactiveWindow
+        val otherProject = stubProject(isDefault = false, isDisposed = false)
+        val inactiveFrame = stubIdeFrame(otherProject, inactiveComponent)
+
+        every { WindowManager.getInstance().allProjectFrames } returns arrayOf(inactiveFrame)
+
+        val lastFocusedFrame =
+            mockk<IdeFrame> {
+                every { project } returns lastFocusedProject
+            }
+        val focusManager =
+            mockk<IdeFocusManager> {
+                every { this@mockk.lastFocusedFrame } returns lastFocusedFrame
+            }
+        mockkStatic(IdeFocusManager::class)
+        every { IdeFocusManager.getGlobalInstance() } returns focusManager
+
+        every { AccentResolver.resolve(lastFocusedProject, AyuVariant.MIRAGE) } returns "#LAST"
+
+        val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
+
+        assertEquals("#LAST", applied)
+        verify(exactly = 1) { AccentResolver.resolve(lastFocusedProject, AyuVariant.MIRAGE) }
+    }
+
+    @Test
+    fun `applyForFocusedProject skips OS-active frame whose project is disposed and continues the cascade`() {
+        // Shutdown race: a project frame is OS-active but its project has just been disposed.
+        // The isUsable() guard inside the OS-active scan must drop it; the cascade falls
+        // through to IdeFocusManager / ProjectManager. Without the guard, resolve() would be
+        // called with a disposed project and throw inside AccentResolver.projectKey.
+        val disposedProject = stubProject(isDefault = false, isDisposed = true)
+
+        val osActiveWindow = mockk<Window>(relaxed = true)
+        every { osActiveWindow.isActive } returns true
+        val osActiveComponent = JPanel()
+        every { SwingUtilities.getWindowAncestor(osActiveComponent) } returns osActiveWindow
+        val disposedFrame = stubIdeFrame(disposedProject, osActiveComponent)
+
+        every { WindowManager.getInstance().allProjectFrames } returns arrayOf(disposedFrame)
+
+        val healthyProject = stubProject(isDefault = false, isDisposed = false)
+        val manager = mockk<ProjectManager>()
+        every { manager.openProjects } returns arrayOf(healthyProject)
+        every { ProjectManager.getInstance() } returns manager
+
+        every { AccentResolver.resolve(healthyProject, AyuVariant.MIRAGE) } returns "#FALLBACK"
+
+        val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
+
+        assertEquals("#FALLBACK", applied)
+        verify(exactly = 0) { AccentResolver.resolve(disposedProject, any()) }
+    }
+
+    @Test
+    fun `applyForFocusedProject survives a frame throwing during OS-active resolution`() {
+        // Frame access can throw when the frame is mid-dispose during shutdown. The OS-active
+        // scan wraps each frame access in try/catch so one bad frame doesn't break resolution
+        // of a healthy one — same defensive pattern as ProjectAccentSwapService.findProjectForWindow.
+        val brokenFrame =
+            mockk<IdeFrame> {
+                every { project } throws IllegalStateException("frame mid-dispose")
+            }
+        val healthyProject = stubProject(isDefault = false, isDisposed = false)
+        val healthyWindow = mockk<Window>(relaxed = true)
+        every { healthyWindow.isActive } returns true
+        val healthyComponent = JPanel()
+        every { SwingUtilities.getWindowAncestor(healthyComponent) } returns healthyWindow
+        val healthyFrame = stubIdeFrame(healthyProject, healthyComponent)
+
+        every { WindowManager.getInstance().allProjectFrames } returns arrayOf(brokenFrame, healthyFrame)
+
+        every { AccentResolver.resolve(healthyProject, AyuVariant.MIRAGE) } returns "#HEALTHY"
+
+        val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
+
+        assertEquals("#HEALTHY", applied)
+        verify(exactly = 1) { AccentResolver.resolve(healthyProject, AyuVariant.MIRAGE) }
+    }
+
     private fun stubProject(
         isDefault: Boolean,
         isDisposed: Boolean,
@@ -200,4 +349,13 @@ class AccentApplicatorFocusedProjectTest {
         every { project.isDisposed } returns isDisposed
         return project
     }
+
+    private fun stubIdeFrame(
+        project: Project,
+        component: JComponent,
+    ): IdeFrame =
+        mockk {
+            every { this@mockk.project } returns project
+            every { this@mockk.component } returns component
+        }
 }

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerTrialExpiryTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerTrialExpiryTest.kt
@@ -334,9 +334,19 @@ class LicenseCheckerTrialExpiryTest {
         assertEquals(true, state.trialExpiryWarningShown)
     }
 
-    /** Create a [Date] representing [daysFromNow] days in the future (or past if negative). */
+    /**
+     * Create a [Date] representing [daysFromNow] days in the future (or past if negative).
+     *
+     * Anchors the base date in UTC, not the JVM's system zone. Production
+     * [LicenseChecker.getTrialDaysRemaining] computes the day diff as
+     * `DAYS.between(LocalDate.now(UTC), expirationDay)`, so the fixture must use the same
+     * zone — otherwise, during the few hours each day when the system zone and UTC are on
+     * different calendar days (Kyiv/EEST 00:00–03:00 local ≈ previous-day 21:00–00:00 UTC),
+     * `dateFromNow(N)` yields `N+1` days under production's UTC-anchored calculation and
+     * every day-sensitive assertion fails off-by-one.
+     */
     private fun dateFromNow(daysFromNow: Long): Date {
-        val localDate = LocalDate.now().plusDays(daysFromNow)
+        val localDate = LocalDate.now(ZoneId.of("UTC")).plusDays(daysFromNow)
         val instant = localDate.atStartOfDay(ZoneId.of("UTC")).toInstant()
         return Date.from(instant)
     }

--- a/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
@@ -149,6 +149,18 @@ class AccentRotationServiceTest {
                 .getInstance()
         } returns projectManager
 
+        // AccentApplicator.resolveFocusedProject scans WindowManager.allProjectFrames for the
+        // OS-active project frame. The rotation tick path exercises this scan, so the static
+        // must be stubbed; empty frames cleanly falls through to the IdeFocusManager /
+        // ProjectManager cascade that the rest of this test's mocks already cover.
+        val windowManager = mockk<com.intellij.openapi.wm.WindowManager>()
+        every { windowManager.allProjectFrames } returns emptyArray()
+        mockkStatic(com.intellij.openapi.wm.WindowManager::class)
+        every {
+            com.intellij.openapi.wm.WindowManager
+                .getInstance()
+        } returns windowManager
+
         val swapService = mockk<ProjectAccentSwapService>(relaxed = true)
         mockkObject(ProjectAccentSwapService.Companion)
         every { ProjectAccentSwapService.getInstance() } returns swapService

--- a/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
@@ -6,10 +6,13 @@ import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Condition
+import com.intellij.openapi.wm.IdeFrame
 import com.intellij.testFramework.LoggedErrorProcessor
 import dev.ayuislands.accent.AYU_ACCENT_PRESETS
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.licensing.LicenseChecker
@@ -149,10 +152,8 @@ class AccentRotationServiceTest {
                 .getInstance()
         } returns projectManager
 
-        // AccentApplicator.resolveFocusedProject scans WindowManager.allProjectFrames for the
-        // OS-active project frame. The rotation tick path exercises this scan, so the static
-        // must be stubbed; empty frames cleanly falls through to the IdeFocusManager /
-        // ProjectManager cascade that the rest of this test's mocks already cover.
+        // OS-active scan calls WindowManager.getInstance(); empty frames so the cascade
+        // reaches the IdeFocusManager / ProjectManager mocks already set up below.
         val windowManager = mockk<com.intellij.openapi.wm.WindowManager>()
         every { windowManager.allProjectFrames } returns emptyArray()
         mockkStatic(com.intellij.openapi.wm.WindowManager::class)
@@ -361,8 +362,9 @@ class AccentRotationServiceTest {
         val applyCalls = mutableListOf<String>()
         every { AccentApplicator.apply(any()) } answers {
             applyCalls += firstArg<String>()
-            if (applyCalls.size == THREE) return@answers Unit
-            throw RotationTestException("fail ${applyCalls.size}")
+            if (applyCalls.size != THREE) {
+                throw RotationTestException("fail ${applyCalls.size}")
+            }
         }
 
         val service = AccentRotationService()
@@ -457,6 +459,75 @@ class AccentRotationServiceTest {
         verify(exactly = 1) { GlowOverlayManager.syncGlowForAllProjects() }
         assertEquals(1, loggedErrors.size, "Expected exactly one LOG.error for the failed apply()")
         assertEquals("boom", loggedErrors.single()?.message)
+    }
+
+    @Test
+    fun `rotateAccent resolves for the OS-active project when two projects are open`() {
+        // Integration-level proof of the headline bug fix. With two projects open (A
+        // OS-active, B not), a rotation tick must resolve through AccentResolver.resolve(A,
+        // ...) — not B — so A's override sticks across the tick. This is the exact asymmetry
+        // the original bug produced: rotation picked the wrong project, glow stayed correct
+        // per-project (because GlowOverlayManager iterates explicitly), and the visible tab
+        // underline on the OS-active window ended up with B's or the global color.
+        //
+        // Test asserts on AccentResolver.resolve — the production entry point where the
+        // cascade's output flows into the applied hex. `AccentApplicator.applyForFocusedProject`
+        // is locked in AccentApplicatorFocusedProjectTest; here we prove the rotation scheduler
+        // actually routes through it with the right project.
+        mockRotationEnvironment()
+        state.accentRotationEnabled = true
+        state.accentRotationMode = AccentRotationMode.PRESET.name
+        state.accentRotationPresetIndex = 0
+
+        val osActiveProject = stubProject("project-A")
+        val inactiveProject = stubProject("project-B")
+
+        val osActiveFrame = stubFrame(osActiveProject, isActive = true)
+        val inactiveFrame = stubFrame(inactiveProject, isActive = false)
+        every {
+            com.intellij.openapi.wm.WindowManager
+                .getInstance()
+                .allProjectFrames
+        } returns arrayOf(osActiveFrame, inactiveFrame)
+        every {
+            com.intellij.openapi.project.ProjectManager
+                .getInstance()
+                .openProjects
+        } returns arrayOf(osActiveProject, inactiveProject)
+
+        mockkObject(AccentResolver)
+        every { AccentResolver.resolve(osActiveProject, AyuVariant.MIRAGE) } returns "#5CCFE6"
+        every { AccentResolver.resolve(inactiveProject, any()) } returns "#DFBFFF"
+        every { AccentResolver.resolve(null, any()) } returns "#GLOBAL"
+
+        val service = AccentRotationService()
+        service.rotateAccent()
+
+        verify(exactly = 1) { AccentResolver.resolve(osActiveProject, AyuVariant.MIRAGE) }
+        verify(exactly = 0) { AccentResolver.resolve(inactiveProject, any()) }
+        verify(exactly = 1) { AccentApplicator.apply("#5CCFE6") }
+    }
+
+    private fun stubProject(name: String): Project =
+        mockk {
+            every { isDisposed } returns false
+            every { isDefault } returns false
+            every { this@mockk.name } returns name
+        }
+
+    private fun stubFrame(
+        project: Project,
+        isActive: Boolean,
+    ): IdeFrame {
+        val window = mockk<java.awt.Window>(relaxed = true)
+        every { window.isActive } returns isActive
+        val component = javax.swing.JPanel()
+        mockkStatic(javax.swing.SwingUtilities::class)
+        every { javax.swing.SwingUtilities.getWindowAncestor(component) } returns window
+        return mockk {
+            every { this@mockk.project } returns project
+            every { this@mockk.component } returns component
+        }
     }
 
     companion object {

--- a/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
@@ -463,37 +463,35 @@ class AccentRotationServiceTest {
 
     @Test
     fun `rotateAccent resolves for the OS-active project when two projects are open`() {
-        // Integration-level proof of the headline bug fix. With two projects open (A
-        // OS-active, B not), a rotation tick must resolve through AccentResolver.resolve(A,
-        // ...) — not B — so A's override sticks across the tick. This is the exact asymmetry
-        // the original bug produced: rotation picked the wrong project, glow stayed correct
-        // per-project (because GlowOverlayManager iterates explicitly), and the visible tab
-        // underline on the OS-active window ended up with B's or the global color.
-        //
-        // Test asserts on AccentResolver.resolve — the production entry point where the
-        // cascade's output flows into the applied hex. `AccentApplicator.applyForFocusedProject`
-        // is locked in AccentApplicatorFocusedProjectTest; here we prove the rotation scheduler
-        // actually routes through it with the right project.
+        // Two projects open, A is OS-active. A rotation tick must resolve through
+        // AccentResolver.resolve(A, ...) — not B — so A's override sticks across the tick.
+        // Cascade internals are locked in AccentApplicatorFocusedProjectTest; this test
+        // proves the rotation scheduler routes through it with the OS-active project.
         mockRotationEnvironment()
         state.accentRotationEnabled = true
         state.accentRotationMode = AccentRotationMode.PRESET.name
         state.accentRotationPresetIndex = 0
 
+        mockkStatic(javax.swing.SwingUtilities::class)
         val osActiveProject = stubProject("project-A")
         val inactiveProject = stubProject("project-B")
 
         val osActiveFrame = stubFrame(osActiveProject, isActive = true)
         val inactiveFrame = stubFrame(inactiveProject, isActive = false)
+        // Inactive frame first in both arrays: if a regression reverted
+        // resolveFocusedProject to `openProjects.firstOrNull` or `allProjectFrames[0]`, that
+        // regression would pick B and this test would fail. With A winning only through the
+        // OS-active predicate, the tier-1 cascade is the sole reason the test passes.
         every {
             com.intellij.openapi.wm.WindowManager
                 .getInstance()
                 .allProjectFrames
-        } returns arrayOf(osActiveFrame, inactiveFrame)
+        } returns arrayOf(inactiveFrame, osActiveFrame)
         every {
             com.intellij.openapi.project.ProjectManager
                 .getInstance()
                 .openProjects
-        } returns arrayOf(osActiveProject, inactiveProject)
+        } returns arrayOf(inactiveProject, osActiveProject)
 
         mockkObject(AccentResolver)
         every { AccentResolver.resolve(osActiveProject, AyuVariant.MIRAGE) } returns "#5CCFE6"
@@ -522,7 +520,6 @@ class AccentRotationServiceTest {
         val window = mockk<java.awt.Window>(relaxed = true)
         every { window.isActive } returns isActive
         val component = javax.swing.JPanel()
-        mockkStatic(javax.swing.SwingUtilities::class)
         every { javax.swing.SwingUtilities.getWindowAncestor(component) } returns window
         return mockk {
             every { this@mockk.project } returns project

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt
@@ -189,15 +189,13 @@ class ProjectAccentSwapServiceTest {
 
     @Test
     fun `onWindowActivated re-applies when external apply drifted hex for same project`() {
-        // Regression guard for the rotation-override bug. When AccentRotationService fires a
-        // tick while the user is alt-tabbed to a non-IDE app, resolveFocusedProject may pick
-        // a project that differs from the one the user is visually on, then push that
-        // project's resolved color into the JVM-wide UIManager/globalScheme (via
-        // AccentApplicator.apply + notifyExternalApply). Alt-tab back to the original project
-        // fires WINDOW_ACTIVATED with the SAME project as before the tick; without the fix,
-        // the project-equality short-circuit skipped the handler entirely and the user was
-        // stuck with the wrong accent on tabs/toolbars while glow (per-project) stayed
-        // correct — the exact asymmetry reported by the user.
+        // Rotation tick / Settings Apply / LAF change can push a color resolved for a DIFFERENT
+        // focused project into the JVM-wide UIManager/globalScheme (via AccentApplicator.apply
+        // + notifyExternalApply). Re-activating the same project later must notice the drift
+        // and re-apply the correct resolved color — the only signal that the visible UI needs
+        // to be rewritten is a cache-hex that no longer matches the resolver's output. Without
+        // the re-apply, tabs/toolbars (global scheme) would stay on the wrong color while
+        // glow (per-project) stayed on the correct override.
         val (window, project) = wireMatchingFrame()
         val service = ProjectAccentSwapService()
 
@@ -220,9 +218,10 @@ class ProjectAccentSwapServiceTest {
     @Test
     fun `onWindowActivated short-circuits on same-hex re-activation across different projects`() {
         // Two different projects sharing the same effective accent hex (e.g. same global
-        // override). Activating the second after priming with the first must update the
-        // lastAppliedProject reference but skip the apply, because the visible UIManager
-        // state is already correct.
+        // override). Activating the second after priming with the first must resolve the
+        // new project but skip the apply, because the visible UIManager state is already
+        // correct — the hex gate carries the dedup load now that project identity alone is
+        // no longer enough to prove staleness.
         val projectA = stubProject("project-a")
         val projectB = stubProject("project-b")
         val windowA = mockk<Window>(relaxed = true)

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt
@@ -168,21 +168,53 @@ class ProjectAccentSwapServiceTest {
     }
 
     @Test
-    fun `onWindowActivated short-circuits on same-project re-activation`() {
-        // The whole point of the cache: alt-tabbing within the same project window must NOT
-        // re-apply the accent on every focus event. After the first activation primes the
-        // cache, the second call with the same project must skip resolve+apply.
+    fun `onWindowActivated re-resolves on same-project re-activation and skips apply when hex matches`() {
+        // Same-project re-activation (alt-tab out to a non-IDE app and back) MUST re-resolve
+        // because an external apply — rotation tick, settings panel — may have drifted the
+        // JVM-wide UIManager/globalScheme color since the last activation. The apply itself
+        // is still skipped when the resolver output matches lastAppliedHex, so alt-tab within
+        // a stable project is cheap (one HashMap lookup, no component-tree walk).
         val (window, project) = wireMatchingFrame()
         every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returns "#FFCC66"
         val service = ProjectAccentSwapService()
         val event = makeEvent(window)
 
         service.onWindowActivatedForTest(event) // primes cache
-        service.onWindowActivatedForTest(event) // same project — must short-circuit
+        service.onWindowActivatedForTest(event) // same project — re-resolves, hex matches, skips apply
 
-        // resolve called exactly once on the priming pass; apply called exactly once.
-        verify(exactly = 1) { AccentResolver.resolve(project, AyuVariant.MIRAGE) }
+        verify(exactly = 2) { AccentResolver.resolve(project, AyuVariant.MIRAGE) }
         verify(exactly = 1) { AccentApplicator.apply("#FFCC66") }
+        verify(exactly = 1) { ComponentTreeRefresher.walkAndNotify(project, window) }
+    }
+
+    @Test
+    fun `onWindowActivated re-applies when external apply drifted hex for same project`() {
+        // Regression guard for the rotation-override bug. When AccentRotationService fires a
+        // tick while the user is alt-tabbed to a non-IDE app, resolveFocusedProject may pick
+        // a project that differs from the one the user is visually on, then push that
+        // project's resolved color into the JVM-wide UIManager/globalScheme (via
+        // AccentApplicator.apply + notifyExternalApply). Alt-tab back to the original project
+        // fires WINDOW_ACTIVATED with the SAME project as before the tick; without the fix,
+        // the project-equality short-circuit skipped the handler entirely and the user was
+        // stuck with the wrong accent on tabs/toolbars while glow (per-project) stayed
+        // correct — the exact asymmetry reported by the user.
+        val (window, project) = wireMatchingFrame()
+        val service = ProjectAccentSwapService()
+
+        // First activation primes the cache with the project's real override color.
+        every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returns "#5CCFE6"
+        service.onWindowActivatedForTest(makeEvent(window))
+
+        // Rotation tick path: external apply pushed a DIFFERENT color into UIManager
+        // (because the tick resolved for a different focused project) and synced the cache.
+        service.notifyExternalApply("#DFBFFF")
+
+        // Alt-tab back to the original project. Resolver still returns the override color;
+        // cache-hex is lavender; the handler must notice the drift and re-apply cyan.
+        service.onWindowActivatedForTest(makeEvent(window))
+
+        verify(exactly = 2) { AccentApplicator.apply("#5CCFE6") }
+        verify(exactly = 2) { ComponentTreeRefresher.walkAndNotify(project, window) }
     }
 
     @Test
@@ -348,7 +380,7 @@ class ProjectAccentSwapServiceTest {
     /**
      * Returns (window, project) where the mocked WindowManager.allProjectFrames contains a
      * single IdeFrame whose component's window ancestor is `window` and whose project is
-     * the returned mock. Lets [handleWindowActivated] reach AyuVariant.detect / resolve /
+     * the returned mock. Lets `handleWindowActivated` reach AyuVariant.detect / resolve /
      * apply on a real Swing tree without instantiating a [java.awt.Frame] (which throws
      * `HeadlessException` on CI).
      */


### PR DESCRIPTION
── Summary ─────────────────────────────────

Accent rotation was overwriting the visible project's override on the JVM-wide UIManager/globalScheme whenever the focus heuristic picked the wrong project at tick time. Users saw tabs flip to the rotation color while glow (per-project) stayed on the real override — the asymmetry reported when looking at a pinned-cyan project and seeing a lavender tab underline. Alt-tab to another project and back "fixed" it because the swap service re-applied on WINDOW_ACTIVATED, but alt-tab into the IDE from an external app didn't, because of a project-equality short-circuit that short-circuited valid drift detection.

Fix routes the focused-project choice through OS-level window activity (ground truth) and drops the swap service's short-circuit so hex drift from any external apply is corrected on the next activation.

── Changes ─────────────────────────────────

| Type     | Path | Description |
|----------|------|-------------|
| Fix      | `src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt:201` | New `osActiveProjectFrame()` cascade: scan `WindowManager.allProjectFrames` for the `Window.isActive` match before falling through to `IdeFocusManager.lastFocusedFrame` and `ProjectManager.openProjects`. |
| Fix      | `src/main/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapService.kt:87` | Dropped `if (project === lastAppliedProject) return` short-circuit so alt-tab back to the same project still re-resolves and re-applies when an external apply drifted `lastAppliedHex`. Removed the now-dead `lastAppliedProject` field. |
| Refactor | `src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt:46` | Error paths (null `WindowManager`, per-frame exception) gated by `AtomicBoolean.compareAndSet` — first occurrence WARNs with thread name + frame index + project context; subsequent occurrences log at DEBUG. Mirrors `ProjectAccentSwapService.findProjectForWindow`. |
| Test     | `src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt:214` | 11 new tests: tier-1 OS-active wins over `lastFocusedFrame`, tier-2 fallback, disposed/null-project/null-ancestor skip, first-of-multiple-active, tier-1→tier-2 (not tier-3) cascade, broken-frame survival, both WARN gates with context-payload and independence assertions. |
| Test     | `src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt:465` | Rotation integration test: two projects open, inactive-first array order (so A wins only through the OS-active predicate), assert `resolve(A)` is called and `resolve(B)` is not. |
| Test     | `src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt:190` | Hex-drift regression: prime with cyan, simulate external apply pushing lavender, re-activate same project — assert re-apply fires. |
| Test     | `src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerTrialExpiryTest.kt:337` | `dateFromNow` helper anchored in UTC to match production `LocalDate.now(UTC)`. Fixes 8 off-by-one flakes during the Kyiv/EEST 00:00–03:00 window. Unrelated to the accent bug but discovered during verification. |

── Validation ──────────────────────────────

```bash
./gradlew detekt ktlintCheck test koverVerify
```

Expected: 1412 tests pass, detekt clean, ktlint clean, kover verify passes the 80% line threshold.

Manual smoke in sandbox IDE:

1. `./gradlew runIde`, open two projects, set a project override (e.g., cyan on project A).
2. Enable accent rotation (Settings → Accent → Rotation → Preset cycle, temporarily drop interval in source for verification).
3. Focus on project A, alt-tab to browser, wait for tick, alt-tab back.
4. Expect: tab underline on A stays cyan, glow stays cyan — no more asymmetry.
5. `grep "accent swapped" idea.log` shows re-apply for A after alt-tab-back if rotation picked a different project during the tick.

── Notes ───────────────────────────────────

- **Pre-existing out-of-scope**: `ProjectAccentSwapService.findProjectForWindow` does not guard null `WindowManager` the way `AccentApplicator.osActiveProjectFrame` now does. Flagged during review, deferred to a separate follow-up for parity — not a regression from this PR.
- Every CRITICAL/IMPORTANT finding from 3 rounds of `/pr-review-toolkit:review-pr` (code-reviewer, pr-test-analyzer, silent-failure-hunter, comment-analyzer) addressed across commits 2–5 before this push. Round 4 returned clean.