### PR TITLE
fix(accent): Settings panels route through OS-active project cascade

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "1587c0d"
+          last_verified_sha: "8346595"
           last_verified_date: "2026-04-17"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "1587c0d"
+          last_verified_sha: "8346595"
           last_verified_date: "2026-04-17"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "cb6e03c"
+          last_verified_sha: "85fed84"
           last_verified_date: "2026-04-17"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "cb6e03c"
+          last_verified_sha: "85fed84"
           last_verified_date: "2026-04-17"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -174,7 +174,7 @@ categories:
           sources:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "cb6e03c"
+          last_verified_sha: "85fed84"
           last_verified_date: "2026-04-16"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "cc07f53"
+          last_verified_sha: "57ebf12"
           last_verified_date: "2026-04-17"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "cc07f53"
+          last_verified_sha: "57ebf12"
           last_verified_date: "2026-04-17"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -174,7 +174,7 @@ categories:
           sources:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "cc07f53"
+          last_verified_sha: "57ebf12"
           last_verified_date: "2026-04-16"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "54984b9"
+          last_verified_sha: "cc07f53"
           last_verified_date: "2026-04-17"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "54984b9"
+          last_verified_sha: "cc07f53"
           last_verified_date: "2026-04-17"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -174,7 +174,7 @@ categories:
           sources:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "54984b9"
+          last_verified_sha: "cc07f53"
           last_verified_date: "2026-04-16"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "8346595"
+          last_verified_sha: "cb6e03c"
           last_verified_date: "2026-04-17"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "8346595"
+          last_verified_sha: "cb6e03c"
           last_verified_date: "2026-04-17"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -174,7 +174,7 @@ categories:
           sources:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "35acead"
+          last_verified_sha: "cb6e03c"
           last_verified_date: "2026-04-16"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "85fed84"
+          last_verified_sha: "54984b9"
           last_verified_date: "2026-04-17"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "85fed84"
+          last_verified_sha: "54984b9"
           last_verified_date: "2026-04-17"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -174,7 +174,7 @@ categories:
           sources:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "85fed84"
+          last_verified_sha: "54984b9"
           last_verified_date: "2026-04-16"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -183,9 +183,15 @@ object AccentApplicator {
     /**
      * Resolves the *actually* focused project — the one whose window is currently on top
      * for the user. The cascade walks from strongest signal (OS-level window activity) to
-     * weakest (first non-disposed open project) so rotation ticks, settings Apply, and LAF
-     * changes route through the window the user is visually on, not the one the focus
-     * manager happened to bookmark most recently.
+     * weakest (first non-disposed open project) so rotation ticks, settings Apply, LAF
+     * changes, AND Settings-panel initialisation route through the window the user is
+     * visually on, not the one the focus manager happened to bookmark most recently.
+     *
+     * Exposed as `internal` so Settings panels (AccentPanel, OverridesGroupBuilder,
+     * FontPresetPanel) can reuse the same cascade instead of hand-rolling
+     * `ProjectManager.openProjects.firstOrNull` — which silently picked the wrong
+     * project when the user had two or more windows open, producing stale "Currently
+     * active:" / "Detected:" readouts keyed to the enumeration-first project.
      *
      *  1. First `WindowManager.allProjectFrames` whose ancestor window reports
      *     `Window.isActive`. Iterates all project frames, calls
@@ -201,7 +207,7 @@ object AccentApplicator {
      *     shutdown edge cases.
      *  4. `null` — no project open; resolver will return the global accent.
      */
-    private fun resolveFocusedProject(): com.intellij.openapi.project.Project? {
+    internal fun resolveFocusedProject(): com.intellij.openapi.project.Project? {
         osActiveProjectFrame()?.let { return it }
         IdeFocusManager
             .getGlobalInstance()

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -173,11 +173,11 @@ object AccentApplicator {
      * specific project the platform hands it, not the focused one, so it bypasses this helper
      * and calls [AccentResolver.resolve] + [apply] directly with that project.
      *
-     * EDT-only: [resolveFocusedProject] is annotated [RequiresEdt] for the same reason
-     * (WindowManager / IdeFocusManager / ProjectManager access). The [apply] call itself
-     * hops to the EDT internally via [invokeLaterSafe], so the helper is safe against
-     * accidental background-thread reentry, but the focused-project resolve step still
-     * requires the caller to be on the EDT.
+     * EDT-only. [resolveFocusedProject] is `@RequiresEdt` because it traverses WindowManager
+     * / IdeFocusManager / ProjectManager; [ProjectAccentSwapService.notifyExternalApply]
+     * touches a shared volatile without its own dispatch. Only the inner [apply] call
+     * self-dispatches to the EDT via [invokeLaterSafe] — the helper as a whole is not
+     * self-protecting, so callers MUST already be on the EDT.
      */
     @RequiresEdt
     fun applyForFocusedProject(variant: AyuVariant): String {
@@ -197,9 +197,9 @@ object AccentApplicator {
      *
      * Exposed as `internal` so UI entry points (settings panels, LAF listener, rotation
      * scheduler, etc.) share one cascade instead of hand-rolling
-     * `ProjectManager.openProjects.firstOrNull` — which silently picked the wrong
-     * project when the user had two or more windows open, producing stale "Currently
-     * active:" / "Detected:" readouts keyed to the enumeration-first project.
+     * `ProjectManager.openProjects.firstOrNull` — that pattern silently binds to the
+     * enumeration-first project in multi-window setups, producing stale status-label
+     * readouts in the Accent settings panel that don't match the visible window.
      *
      * Must run on the EDT: traverses `WindowManager`, `IdeFocusManager`, and
      * `ProjectManager`, all of which are EDT-only platform APIs. Annotated with

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -173,11 +173,12 @@ object AccentApplicator {
      * specific project the platform hands it, not the focused one, so it bypasses this helper
      * and calls [AccentResolver.resolve] + [apply] directly with that project.
      *
-     * EDT-only. [resolveFocusedProject] is `@RequiresEdt` because it traverses WindowManager
-     * / IdeFocusManager / ProjectManager; [ProjectAccentSwapService.notifyExternalApply]
-     * touches a shared volatile without its own dispatch. Only the inner [apply] call
-     * self-dispatches to the EDT via [invokeLaterSafe] — the helper as a whole is not
-     * self-protecting, so callers MUST already be on the EDT.
+     * EDT-only. Neither this helper nor [resolveFocusedProject] self-dispatch; only the
+     * inner [apply] call hops to the EDT internally via [invokeLaterSafe], and that hop
+     * does NOT rescue the preceding [resolveFocusedProject] + [AccentResolver.resolve]
+     * steps (the first traverses EDT-only platform APIs, the second reads settings state
+     * that may race off-EDT). [ProjectAccentSwapService.notifyExternalApply] is likewise
+     * a bare volatile write with no dispatch. Callers MUST already be on the EDT.
      */
     @RequiresEdt
     fun applyForFocusedProject(variant: AyuVariant): String {
@@ -195,11 +196,12 @@ object AccentApplicator {
      * changes, and any UI entry point route through the window the user is visually on,
      * not the one the focus manager happened to bookmark most recently.
      *
-     * Exposed as `internal` so UI entry points (settings panels, LAF listener, rotation
-     * scheduler, etc.) share one cascade instead of hand-rolling
-     * `ProjectManager.openProjects.firstOrNull` — that pattern silently binds to the
-     * enumeration-first project in multi-window setups, producing stale status-label
-     * readouts in the Accent settings panel that don't match the visible window.
+     * Exposed as `internal` so every UI entry point that needs the focused project shares
+     * one cascade instead of hand-rolling `ProjectManager.openProjects.firstOrNull` — that
+     * pattern silently binds to the enumeration-first project in multi-window setups,
+     * producing stale status-label readouts in the Accent settings panel that don't match
+     * the visible window. Most callers reach this via [applyForFocusedProject]; settings
+     * panels that only need to READ the focused project (without applying) call it directly.
      *
      * Must run on the EDT: traverses `WindowManager`, `IdeFocusManager`, and
      * `ProjectManager`, all of which are EDT-only platform APIs. Annotated with

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -15,6 +15,7 @@ import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.wm.IdeFocusManager
 import com.intellij.openapi.wm.WindowManager
 import com.intellij.ui.ColorUtil
+import com.intellij.util.concurrency.annotations.RequiresEdt
 import dev.ayuislands.accent.conflict.ConflictRegistry
 import dev.ayuislands.glow.GlowStyle
 import dev.ayuislands.glow.GlowTabMode
@@ -171,7 +172,14 @@ object AccentApplicator {
      * Note: [dev.ayuislands.AyuIslandsStartupActivity] is NOT a caller — it operates on the
      * specific project the platform hands it, not the focused one, so it bypasses this helper
      * and calls [AccentResolver.resolve] + [apply] directly with that project.
+     *
+     * EDT-only: [resolveFocusedProject] is annotated [RequiresEdt] for the same reason
+     * (WindowManager / IdeFocusManager / ProjectManager access). The [apply] call itself
+     * hops to the EDT internally via [invokeLaterSafe], so the helper is safe against
+     * accidental background-thread reentry, but the focused-project resolve step still
+     * requires the caller to be on the EDT.
      */
+    @RequiresEdt
     fun applyForFocusedProject(variant: AyuVariant): String {
         val focusedProject = resolveFocusedProject()
         val hex = AccentResolver.resolve(focusedProject, variant)
@@ -184,14 +192,19 @@ object AccentApplicator {
      * Resolves the *actually* focused project — the one whose window is currently on top
      * for the user. The cascade walks from strongest signal (OS-level window activity) to
      * weakest (first non-disposed open project) so rotation ticks, settings Apply, LAF
-     * changes, AND Settings-panel initialisation route through the window the user is
-     * visually on, not the one the focus manager happened to bookmark most recently.
+     * changes, and any UI entry point route through the window the user is visually on,
+     * not the one the focus manager happened to bookmark most recently.
      *
-     * Exposed as `internal` so Settings panels (AccentPanel, OverridesGroupBuilder,
-     * FontPresetPanel) can reuse the same cascade instead of hand-rolling
+     * Exposed as `internal` so UI entry points (settings panels, LAF listener, rotation
+     * scheduler, etc.) share one cascade instead of hand-rolling
      * `ProjectManager.openProjects.firstOrNull` — which silently picked the wrong
      * project when the user had two or more windows open, producing stale "Currently
      * active:" / "Detected:" readouts keyed to the enumeration-first project.
+     *
+     * Must run on the EDT: traverses `WindowManager`, `IdeFocusManager`, and
+     * `ProjectManager`, all of which are EDT-only platform APIs. Annotated with
+     * [RequiresEdt] so accidental off-EDT callers surface through IntelliJ's threading
+     * checker rather than deadlocking or throwing deep inside the platform.
      *
      *  1. First `WindowManager.allProjectFrames` whose ancestor window reports
      *     `Window.isActive`. Iterates all project frames, calls
@@ -207,6 +220,7 @@ object AccentApplicator {
      *     shutdown edge cases.
      *  4. `null` — no project open; resolver will return the global accent.
      */
+    @RequiresEdt
     internal fun resolveFocusedProject(): com.intellij.openapi.project.Project? {
         osActiveProjectFrame()?.let { return it }
         IdeFocusManager

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -63,10 +63,10 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
     ) {
         initializeState(variant)
         // Route through AccentApplicator.resolveFocusedProject so the panel picks the
-        // window the user is visually on (same cascade rotation + apply paths use). A
-        // prior `openProjects.firstOrNull` silently bound to the enumeration-first
-        // project — producing wrong "Currently active:" and "Detected:" readouts when
-        // two or more projects were open.
+        // window the user is visually on (same cascade rotation + apply paths use). Do
+        // NOT substitute `ProjectManager.openProjects.firstOrNull { … }` — that silently
+        // binds to the enumeration-first project in multi-window setups, so "Currently
+        // active:" and "Detected:" read out the wrong project.
         contextProject = AccentApplicator.resolveFocusedProject()
         val colorPanel = createAccentColorPanel()
         applyInitialSelection(colorPanel, storedAccent)

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -2,7 +2,6 @@ package dev.ayuislands.settings
 
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.ui.ColorPicker
 import com.intellij.ui.components.JBCheckBox
@@ -63,11 +62,12 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
         variant: AyuVariant,
     ) {
         initializeState(variant)
-        contextProject =
-            ProjectManager
-                .getInstance()
-                .openProjects
-                .firstOrNull { !it.isDefault && !it.isDisposed }
+        // Route through AccentApplicator.resolveFocusedProject so the panel picks the
+        // window the user is visually on (same cascade rotation + apply paths use). A
+        // prior `openProjects.firstOrNull` silently bound to the enumeration-first
+        // project — producing wrong "Currently active:" and "Detected:" readouts when
+        // two or more projects were open.
+        contextProject = AccentApplicator.resolveFocusedProject()
         val colorPanel = createAccentColorPanel()
         applyInitialSelection(colorPanel, storedAccent)
         updateHeroGlow()
@@ -245,11 +245,7 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
      * lines up with what's actually on screen.
      */
     private fun applyRotationRespectingOverrides(currentVariant: AyuVariant) {
-        val focusedProject =
-            ProjectManager
-                .getInstance()
-                .openProjects
-                .firstOrNull { !it.isDefault && !it.isDisposed }
+        val focusedProject = AccentApplicator.resolveFocusedProject()
         val resolvedHex = AccentResolver.resolve(focusedProject, currentVariant)
         AccentApplicator.apply(resolvedHex)
         ProjectAccentSwapService.getInstance().notifyExternalApply(resolvedHex)

--- a/src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
@@ -4,12 +4,12 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.ide.CopyPasteManager
 import com.intellij.openapi.observable.properties.AtomicBooleanProperty
-import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.ui.SimpleListCellRenderer
 import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.dsl.builder.SegmentedButton
+import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.font.FontCatalog
 import dev.ayuislands.font.FontDetector
@@ -260,7 +260,7 @@ class FontPresetPanel : AyuIslandsSettingsPanel {
     private fun triggerLifecycleAction(uninstall: Boolean) {
         try {
             val preset = FontPreset.fromName(pendingPreset)
-            val project = ProjectManager.getInstance().openProjects.firstOrNull()
+            val project = AccentApplicator.resolveFocusedProject()
             val entry = FontCatalog.forPreset(preset)
             val refresh = {
                 ApplicationManager.getApplication().invokeLater {
@@ -332,7 +332,7 @@ class FontPresetPanel : AyuIslandsSettingsPanel {
                 if (state.fontInstallTerminal == "SYSTEM") {
                     ProcessBuilder("open", "-a", "Terminal").start()
                 } else {
-                    val project = ProjectManager.getInstance().openProjects.firstOrNull() ?: return@link
+                    val project = AccentApplicator.resolveFocusedProject() ?: return@link
                     ToolWindowManager.getInstance(project).getToolWindow("Terminal")?.activate(null)
                 }
             }

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -5,7 +5,6 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.ui.ToolbarDecorator
 import com.intellij.ui.components.JBLabel
@@ -183,7 +182,9 @@ class OverridesGroupBuilder {
         // "modified" because `storedProjects/languages` stayed on the pre-apply snapshot).
         runCatchingPreservingCancellation {
             AyuVariant.detect()?.let { variant ->
-                val project = parentProject ?: ProjectManager.getInstance().openProjects.firstOrNull()
+                // Fall through to the OS-active cascade when the builder has no parentProject
+                // bound yet — same priority order used by rotation, LAF, and Settings Apply.
+                val project = parentProject ?: AccentApplicator.resolveFocusedProject()
                 val hex = AccentResolver.resolve(project, variant)
                 AccentApplicator.apply(hex)
                 ProjectAccentSwapService.getInstance().notifyExternalApply(hex)

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -183,7 +183,7 @@ class OverridesGroupBuilder {
         runCatchingPreservingCancellation {
             AyuVariant.detect()?.let { variant ->
                 // Fall through to the OS-active cascade when the builder has no parentProject
-                // bound yet — same priority order used by rotation, LAF, and Settings Apply.
+                // bound yet — same helper every apply path ultimately converges on.
                 val project = parentProject ?: AccentApplicator.resolveFocusedProject()
                 val hex = AccentResolver.resolve(project, variant)
                 AccentApplicator.apply(hex)

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderApplyTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderApplyTest.kt
@@ -149,7 +149,7 @@ class OverridesGroupBuilderApplyTest {
         // has not been called (e.g. Settings Apply reached here before the panel finished
         // binding the context project), the builder MUST route through the shared cascade —
         // NOT `ProjectManager.openProjects.firstOrNull`, which picks the enumeration-first
-        // project and reproduces the multi-window bug #138 fixed upstream. A regression that
+        // project and reproduces the multi-window status-label mismatch. A regression that
         // swaps resolveFocusedProject back to openProjects.firstOrNull would pass the two
         // tests above (parentProject is bound there) but fail this one.
         val focusedProject =

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderApplyTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderApplyTest.kt
@@ -142,4 +142,47 @@ class OverridesGroupBuilderApplyTest {
         io.mockk.verify(exactly = 1) { AccentApplicator.apply("#AABBCC") }
         io.mockk.verify(exactly = 1) { swapService.notifyExternalApply("#AABBCC") }
     }
+
+    @Test
+    fun `apply() falls back to AccentApplicator resolveFocusedProject when parentProject is not bound`() {
+        // Guards the second-tier project source inside apply(): when setParentProjectForTest
+        // has not been called (e.g. Settings Apply reached here before the panel finished
+        // binding the context project), the builder MUST route through the shared cascade —
+        // NOT `ProjectManager.openProjects.firstOrNull`, which picks the enumeration-first
+        // project and reproduces the multi-window bug #138 fixed upstream. A regression that
+        // swaps resolveFocusedProject back to openProjects.firstOrNull would pass the two
+        // tests above (parentProject is bound there) but fail this one.
+        val focusedProject =
+            mockk<Project>(relaxed = true) {
+                every { isDisposed } returns false
+                every { isDefault } returns false
+            }
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        every { AccentApplicator.resolveFocusedProject() } returns focusedProject
+        every { AccentResolver.resolve(focusedProject, AyuVariant.MIRAGE) } returns "#5CCFE6"
+        every { AccentApplicator.apply(any()) } returns Unit
+        val swapService = mockk<ProjectAccentSwapService>(relaxed = true)
+        every { ProjectAccentSwapService.getInstance() } returns swapService
+
+        val builder =
+            OverridesGroupBuilder().apply {
+                // Deliberately do NOT call setParentProjectForTest — exercise the fallback.
+                seedPendingForTest(
+                    projects =
+                        listOf(
+                            ProjectMapping(
+                                canonicalPath = "/tmp/apply-fallback",
+                                displayName = "fallback",
+                                hex = "#5CCFE6",
+                            ),
+                        ),
+                )
+            }
+
+        builder.apply()
+
+        io.mockk.verify(exactly = 1) { AccentApplicator.resolveFocusedProject() }
+        io.mockk.verify(exactly = 1) { AccentResolver.resolve(focusedProject, AyuVariant.MIRAGE) }
+        io.mockk.verify(exactly = 1) { AccentApplicator.apply("#5CCFE6") }
+    }
 }


### PR DESCRIPTION
── Summary ─────────────────────────────────

Follow-up to #138. Same root cause, different surface — four Settings-panel call sites still picked the "current project" via `ProjectManager.openProjects.firstOrNull`, the same enumeration-order anti-pattern that #138 fixed for rotation and the window-activated swap service. With two or more projects open, opening Settings from one project bound the panel to whichever project was opened first — producing stale "Currently active: …" and "Detected: 95% Kotlin" readouts on a pure-Python workspace.

Spotted while verifying #138 in sandbox: settings opened in a Python-only project showed Cyan (project override for "ayu-jetbrains") and Kotlin-dominant detected languages.

── Changes ─────────────────────────────────

| Type     | Path | Description |
|----------|------|-------------|
| Fix      | `src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt:204` | `resolveFocusedProject` flipped `private` → `internal` with KDoc enumerating the Settings callers and the bug class they prevent. Single source of truth for the cascade. |
| Fix      | `src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt:66` | `contextProject` now comes from the cascade; "Currently active:" / "Detected:" / per-project pin now key to the visible window. `applyRotationRespectingOverrides` got the same drop-in. |
| Fix      | `src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt:186` | `apply()` commit fallback routes through the cascade when `parentProject` isn't bound yet. |
| Fix      | `src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt:263` | Install consent + terminal flows use the cascade (two sites). |

── Validation ──────────────────────────────

```bash
./gradlew detekt ktlintCheck test koverVerify
```

Expected: 1412 tests pass, detekt clean, ktlint clean, kover verify passes.

Manual smoke:

1. `./gradlew runIde` with two projects open (A Kotlin + override cyan, B Python + override gold).
2. Focus B (Python window), open Settings → Ayu Islands → Accent.
3. Expect: "Currently active: Gold (project override for 'B')" and "Detected:" row shows Python-dominant. Pre-fix: showed Cyan + Kotlin-dominant.

── Notes ───────────────────────────────────

- The cascade itself (`resolveFocusedProject` + `osActiveProjectFrame` + WARN gates) is fully tested in `AccentApplicatorFocusedProjectTest`. No new tests needed for this PR — the Settings panels are thin wrappers that delegate.
- `ProjectAccentSwapService.findProjectForWindow` still doesn't guard null `WindowManager` the way `AccentApplicator.osActiveProjectFrame` does (flagged during #138 review). Separate follow-up if you want parity there too.

## Summary by Sourcery

Route settings-related accent and font operations through the centralized focused-project resolution so behavior matches the OS-active project window.

Bug Fixes:
- Ensure the Accent settings panel binds its context project and rotation actions to the OS-active project instead of the first open project.
- Fix overrides group apply behavior to resolve accents using the focused project when no parent project is bound.
- Align font preset install and terminal actions to operate on the focused project rather than an arbitrary open project.

Documentation:
- Update feature verification metadata for accent-related settings and mappings.