### PR TITLE
feat(accent): add manual Rescan Project Language trigger

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "f9b6639"
+          last_verified_sha: "c9e1021"
           last_verified_date: "2026-04-19"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "f9b6639"
+          last_verified_sha: "c9e1021"
           last_verified_date: "2026-04-19"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "5bd0f7d"
+          last_verified_sha: "f3b7fc6"
           last_verified_date: "2026-04-19"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "5bd0f7d"
+          last_verified_sha: "f3b7fc6"
           last_verified_date: "2026-04-19"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "c9e1021"
+          last_verified_sha: "5bd0f7d"
           last_verified_date: "2026-04-19"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "c9e1021"
+          last_verified_sha: "5bd0f7d"
           last_verified_date: "2026-04-19"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,8 +89,8 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "232e835"
-          last_verified_date: "2026-04-17"
+          last_verified_sha: "f9b6639"
+          last_verified_date: "2026-04-19"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
       - id: accent-scoped-language
@@ -110,8 +110,8 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "232e835"
-          last_verified_date: "2026-04-17"
+          last_verified_sha: "f9b6639"
+          last_verified_date: "2026-04-19"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
       - id: accent-language-breakdown

--- a/proguard-rules.pro
+++ b/proguard-rules.pro
@@ -80,6 +80,9 @@
 # plugin.xml: action (Tools → Show What's New…)
 -keep class dev.ayuislands.whatsnew.ShowWhatsNewAction { *; }
 
+# plugin.xml: action (Tools → Ayu Islands → Rescan Project Language)
+-keep class dev.ayuislands.actions.RescanLanguageAction { *; }
+
 # Public API singletons (called from kept classes)
 -keep class dev.ayuislands.accent.AccentApplicator { *; }
 -keep class dev.ayuislands.accent.AccentColor { *; }

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetectionListener.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetectionListener.kt
@@ -1,0 +1,44 @@
+package dev.ayuislands.accent
+
+import com.intellij.util.messages.Topic
+
+/**
+ * Project-scoped notification emitted by [ProjectLanguageDetector] after a
+ * background scan finishes — whether the scan produced a dominant id, a
+ * polyglot null verdict, or hit a transient failure path.
+ *
+ * Subscribers refresh UI projections over the detector cache (the Settings
+ * proportions status row, the Tools-menu Rescan balloon). Listener runs on
+ * the EDT so handlers can touch Swing directly without their own
+ * `invokeLater` wrap; [ProjectLanguageDetector.publishScanCompleted] is the
+ * sole producer and already dispatches the publish onto EDT.
+ *
+ * Project-scoped (not application-scoped) so the subscription list is
+ * automatically cleared when the project closes and the `Project`-keyed
+ * `MessageBus` instance is disposed. Application-level would leak stale
+ * subscribers across project close/reopen cycles and force every subscriber
+ * to implement its own project-disposed defense.
+ */
+internal fun interface ProjectLanguageDetectionListener {
+    /**
+     * Invoked after [ProjectLanguageDetector.detectAndCache] lands (successful
+     * or non-cacheable).
+     *
+     * @param detectedId the dominant language id the detector settled on,
+     *   or `null` when the scan was polyglot, hit dumb mode, raced with
+     *   disposal, or the scanner threw. Callers rendering proportions MUST
+     *   re-query [ProjectLanguageDetector.proportions] instead of relying on
+     *   this id alone — the weights cache is the authoritative source for
+     *   the proportions row and may be populated (or deliberately empty)
+     *   independently of the winner id.
+     */
+    fun scanCompleted(detectedId: String?)
+
+    companion object {
+        val TOPIC: Topic<ProjectLanguageDetectionListener> =
+            Topic.create(
+                "Ayu Islands project language scan",
+                ProjectLanguageDetectionListener::class.java,
+            )
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetectionListener.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetectionListener.kt
@@ -21,15 +21,23 @@ import com.intellij.util.messages.Topic
  */
 internal fun interface ProjectLanguageDetectionListener {
     /**
-     * Invoked after [ProjectLanguageDetector.detectAndCache] lands (successful
-     * or non-cacheable).
+     * Invoked after `ProjectLanguageDetector` settles a scan (successful or
+     * non-cacheable transient failure) OR after a `rescan` call whose
+     * `AccentResolver.projectKey` returned null (the scheduler is bypassed
+     * but the listener still fires so one-shot subscribers can unblock).
      *
      * @param detectedId the dominant language id the detector settled on,
-     *   or `null` when the scan was polyglot, hit dumb mode, raced with
-     *   disposal, or the scanner threw. Callers rendering proportions MUST
-     *   re-query [ProjectLanguageDetector.proportions] instead of relying on
-     *   this id alone — the weights cache is the authoritative source for
-     *   the proportions row and may be populated (or deliberately empty)
+     *   or `null` when the scan was polyglot (definitive no-winner verdict),
+     *   hit a non-cacheable transient failure (scanner threw, index read
+     *   aborted), or the caller was a `rescan` with an unresolvable project
+     *   key. Note: dumb mode and pre-scan disposal short-circuit inside
+     *   `scheduleBackgroundDetection` and produce *no* publish at all;
+     *   subscribers must not treat absence of `scanCompleted` as an error.
+     *
+     *   Callers rendering proportions MUST re-query
+     *   [ProjectLanguageDetector.proportions] instead of relying on this id
+     *   alone — the weights cache is the authoritative source for the
+     *   proportions row and may be populated (or deliberately empty)
      *   independently of the winner id.
      */
     fun scanCompleted(detectedId: String?)

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
@@ -148,6 +148,36 @@ object ProjectLanguageDetector {
         weightsCache.remove(key)
     }
 
+    /**
+     * Manual entry point that forces a fresh scan: clears the cache for [project]
+     * and kicks [scheduleBackgroundDetection]. Bound to the Tools-menu
+     * `RescanLanguageAction` and to the inline "Rescan" affordance in the
+     * Settings → Accent → Overrides proportions row; both reuse a single public
+     * surface so the scheduler's dedup gate (keyed by canonical path inside
+     * [ProjectLanguageScanAsync]) coalesces rapid-fire spam from either source
+     * into one actual scan.
+     *
+     * Side effects:
+     *  - Evicts both dominant-id and weights caches for [project].
+     *  - Schedules a background scan on the shared IDE pool (no-op in dumb mode
+     *    — the startup activity's `ModuleRootListener` subscription re-runs
+     *    detection once indexing completes).
+     *  - On scan completion, [ProjectLanguageDetectionListener.scanCompleted] fires
+     *    on EDT via [publishScanCompleted], so UI subscribers (the Settings
+     *    proportions row, the action's balloon) receive the new state without
+     *    polling.
+     *
+     * Safe to call from EDT: invalidate is a two-`ConcurrentHashMap.remove`
+     * pair, and `scheduleBackgroundDetection` immediately returns after
+     * enqueuing the task on `AppExecutorUtil.getAppExecutorService()`.
+     */
+    fun rescan(project: Project) {
+        val key = AccentResolver.projectKey(project) ?: return
+        cache.remove(key)
+        weightsCache.remove(key)
+        scheduleBackgroundDetection(project, key)
+    }
+
     /** Drop the entire cache — useful for test isolation. Empties both maps. */
     fun clear() {
         cache.clear()
@@ -226,8 +256,45 @@ object ProjectLanguageDetector {
         if (DumbService.isDumb(project)) return
         ProjectLanguageScanAsync.schedule(key) {
             if (project.isDisposed) return@schedule
-            val detected = detectAndCache(project, key) ?: return@schedule
-            tryRefreshAccentForDetected(project, detected)
+            val detected = detectAndCache(project, key)
+            // Publish even when `detected` is null — UI subscribers (the
+            // Settings proportions row, the Rescan balloon) need to refresh
+            // their projection of the cache regardless of whether the scan
+            // produced a winner, a polyglot null, or a non-cacheable
+            // transient failure. A null publish after a Rescan click is the
+            // only way the UI can exit the stale "old winner" state when
+            // the project has since drifted into polyglot territory.
+            if (detected != null) {
+                tryRefreshAccentForDetected(project, detected)
+            }
+            publishScanCompleted(project, detected)
+        }
+    }
+
+    /**
+     * Dispatch [ProjectLanguageDetectionListener.scanCompleted] on EDT so
+     * subscribers can touch Swing directly. Separate from the scan task body
+     * so the scheduler's executor thread never reaches the MessageBus
+     * `syncPublisher` machinery — syncPublisher's invocation handler can run
+     * arbitrary subscriber code, and keeping that off the scan pool prevents
+     * a misbehaving subscriber from stalling the shared executor. Double
+     * dispose-guard (before and after invokeLater) because project disposal
+     * can race with a late-arriving scan completion.
+     */
+    private fun publishScanCompleted(
+        project: Project,
+        detectedId: String?,
+    ) {
+        if (project.isDisposed) return
+        SwingUtilities.invokeLater {
+            if (project.isDisposed) return@invokeLater
+            runCatchingPreservingCancellation {
+                project.messageBus
+                    .syncPublisher(ProjectLanguageDetectionListener.TOPIC)
+                    .scanCompleted(detectedId)
+            }.onFailure { exception ->
+                LOG.warn("scanCompleted publish failed; subscribers will not refresh for this scan", exception)
+            }
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
@@ -159,20 +159,38 @@ object ProjectLanguageDetector {
      *
      * Side effects:
      *  - Evicts both dominant-id and weights caches for [project].
-     *  - Schedules a background scan on the shared IDE pool (no-op in dumb mode
-     *    — the startup activity's `ModuleRootListener` subscription re-runs
-     *    detection once indexing completes).
-     *  - On scan completion, [ProjectLanguageDetectionListener.scanCompleted] fires
-     *    on EDT via [publishScanCompleted], so UI subscribers (the Settings
-     *    proportions row, the action's balloon) receive the new state without
-     *    polling.
+     *  - Schedules a background scan on the shared IDE pool (no-op in dumb
+     *    mode — the user must re-click after indexing finishes, or wait for
+     *    the next `ModuleRootListener.rootsChanged` to re-trigger detection
+     *    on a Gradle sync / module change).
+     *  - On scan completion, [ProjectLanguageDetectionListener.scanCompleted]
+     *    fires on EDT via [publishScanCompleted], so UI subscribers (the
+     *    Settings proportions row, the action's balloon) receive the new
+     *    state without polling.
+     *  - When [project] has no canonical path (disposal race, default
+     *    project), publishes `scanCompleted(null)` immediately so one-shot
+     *    subscribers (notably the [dev.ayuislands.actions.RescanLanguageAction]
+     *    balloon) fire and disconnect instead of silently hanging on the
+     *    MessageBus until project close.
      *
      * Safe to call from EDT: invalidate is a two-`ConcurrentHashMap.remove`
      * pair, and `scheduleBackgroundDetection` immediately returns after
      * enqueuing the task on `AppExecutorUtil.getAppExecutorService()`.
      */
     fun rescan(project: Project) {
-        val key = AccentResolver.projectKey(project) ?: return
+        val key =
+            AccentResolver.projectKey(project) ?: run {
+                // No canonical path: bail out of the cache+schedule work, but
+                // still publish a null scanCompleted so subscribers (especially
+                // the one-shot action balloon) fire and release their
+                // MessageBus connection instead of silently leaking until
+                // project close. `AccentResolver.projectKey` already logged the
+                // reason it returned null (base-path throw, canonicalization
+                // failure) — this branch is about the *user-facing* symptom.
+                LOG.info("rescan: projectKey unavailable; publishing null scanCompleted so subscribers unblock")
+                publishScanCompleted(project, null)
+                return
+            }
         cache.remove(key)
         weightsCache.remove(key)
         scheduleBackgroundDetection(project, key)
@@ -253,9 +271,19 @@ object ProjectLanguageDetector {
         project: Project,
         key: String,
     ) {
-        if (DumbService.isDumb(project)) return
+        if (DumbService.isDumb(project)) {
+            // Breadcrumb for the "user clicked Rescan, nothing happened"
+            // triage path: the dumb-mode gate deliberately drops the task,
+            // and without this log a Tools-menu click during indexing
+            // produces no balloon and no log trace.
+            LOG.debug("scheduleBackgroundDetection skipped for $key: DumbService.isDumb == true")
+            return
+        }
         ProjectLanguageScanAsync.schedule(key) {
-            if (project.isDisposed) return@schedule
+            if (project.isDisposed) {
+                LOG.debug("scheduleBackgroundDetection task aborted for $key: project disposed before scan body ran")
+                return@schedule
+            }
             val detected = detectAndCache(project, key)
             // Publish even when `detected` is null — UI subscribers (the
             // Settings proportions row, the Rescan balloon) need to refresh
@@ -285,9 +313,15 @@ object ProjectLanguageDetector {
         project: Project,
         detectedId: String?,
     ) {
-        if (project.isDisposed) return
+        if (project.isDisposed) {
+            LOG.debug("publishScanCompleted dropped before invokeLater: project already disposed")
+            return
+        }
         SwingUtilities.invokeLater {
-            if (project.isDisposed) return@invokeLater
+            if (project.isDisposed) {
+                LOG.debug("publishScanCompleted dropped inside invokeLater: project disposed during EDT hop")
+                return@invokeLater
+            }
             runCatchingPreservingCancellation {
                 project.messageBus
                     .syncPublisher(ProjectLanguageDetectionListener.TOPIC)

--- a/src/main/kotlin/dev/ayuislands/actions/RescanLanguageAction.kt
+++ b/src/main/kotlin/dev/ayuislands/actions/RescanLanguageAction.kt
@@ -1,0 +1,121 @@
+package dev.ayuislands.actions
+
+import com.intellij.lang.Language
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.DumbAwareAction
+import com.intellij.openapi.project.Project
+import dev.ayuislands.accent.ProjectLanguageDetectionListener
+import dev.ayuislands.accent.ProjectLanguageDetector
+import dev.ayuislands.accent.runCatchingPreservingCancellation
+
+/**
+ * Tools-menu action that forces a fresh project-language detection scan.
+ *
+ * Why it exists: the detector normally re-runs only on project open, on
+ * content-root changes (gradle sync, module add/remove), and on project close
+ * — so after a major manual refactor (language migration, mass rename) the
+ * user can be stuck on a stale winner until the next Gradle sync. This action
+ * is the manual bypass.
+ *
+ * Single-scan-per-click: the subscription to [ProjectLanguageDetectionListener.TOPIC]
+ * is a one-shot — it disconnects inside the callback so rapid-fire clicks don't
+ * pile subscriptions on the bus. The scheduler's dedup gate coalesces concurrent
+ * scans, so one balloon fires per *completed* scan regardless of click spam.
+ */
+internal class RescanLanguageAction : DumbAwareAction() {
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
+
+    override fun update(event: AnActionEvent) {
+        val project = event.project
+        event.presentation.isEnabledAndVisible =
+            project != null &&
+            !project.isDefault &&
+            !project.isDisposed
+    }
+
+    override fun actionPerformed(event: AnActionEvent) {
+        val project = event.project ?: return
+        if (project.isDefault || project.isDisposed) return
+        subscribeOnceForBalloon(project)
+        ProjectLanguageDetector.rescan(project)
+    }
+
+    /**
+     * Wire a one-shot subscription that fires the result balloon and
+     * immediately disconnects. Protects against click spam by verifying the
+     * `AtomicBoolean` latch inside the callback — the MessageBus will deliver
+     * to every live subscriber even after we call disconnect, and we don't
+     * want two balloons for one scan when two clicks raced a single scan
+     * completion.
+     */
+    private fun subscribeOnceForBalloon(project: Project) {
+        val connection = project.messageBus.connect()
+        val fired =
+            java.util.concurrent.atomic
+                .AtomicBoolean(false)
+        val listener =
+            ProjectLanguageDetectionListener { detectedId ->
+                if (!fired.compareAndSet(false, true)) return@ProjectLanguageDetectionListener
+                runCatchingPreservingCancellation { connection.disconnect() }
+                    .onFailure { exception ->
+                        LOG.debug("Rescan balloon connection disconnect failed", exception)
+                    }
+                notifyUser(project, detectedId)
+            }
+        connection.subscribe(ProjectLanguageDetectionListener.TOPIC, listener)
+    }
+
+    private fun notifyUser(
+        project: Project,
+        detectedId: String?,
+    ) {
+        if (project.isDisposed) return
+        val label = humanLabelFor(detectedId)
+        runCatchingPreservingCancellation {
+            NotificationGroupManager
+                .getInstance()
+                .getNotificationGroup(NOTIFICATION_GROUP_ID)
+                .createNotification(
+                    NOTIFICATION_TITLE,
+                    label,
+                    NotificationType.INFORMATION,
+                ).notify(project)
+        }.onFailure { exception ->
+            LOG.warn("Rescan balloon emit failed; cache is still warm", exception)
+        }
+    }
+
+    /**
+     * Resolve an AYU language id to a display name using the platform registry,
+     * falling back to the raw id when the language plugin has been unloaded
+     * between scan and render. Null id means "no dominant language" —
+     * render the polyglot copy.
+     *
+     * Case-insensitive lookup because `Language.id` casing varies per plugin
+     * (`"JAVA"` / `"kotlin"` / `"JavaScript"`) while the detector always
+     * normalizes to lowercase via [dev.ayuislands.accent.LanguageDetectionRules].
+     */
+    private fun humanLabelFor(detectedId: String?): String {
+        if (detectedId == null) return POLYGLOT_LABEL
+        val display =
+            runCatchingPreservingCancellation {
+                Language
+                    .getRegisteredLanguages()
+                    .firstOrNull { it.id.equals(detectedId, ignoreCase = true) }
+                    ?.displayName
+            }.getOrNull()
+        return display?.takeIf { it.isNotBlank() } ?: detectedId
+    }
+
+    companion object {
+        private val LOG = logger<RescanLanguageAction>()
+        private const val NOTIFICATION_GROUP_ID = "Ayu Islands"
+        private const val NOTIFICATION_TITLE = "Project language re-detected"
+        private const val POLYGLOT_LABEL =
+            "Polyglot — no single dominant language; global accent applies"
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/actions/RescanLanguageAction.kt
+++ b/src/main/kotlin/dev/ayuislands/actions/RescanLanguageAction.kt
@@ -110,6 +110,12 @@ internal class RescanLanguageAction : DumbAwareAction() {
                     .getRegisteredLanguages()
                     .firstOrNull { it.id.equals(detectedId, ignoreCase = true) }
                     ?.displayName
+            }.onFailure { exception ->
+                // DEBUG not WARN: a corrupted third-party Language
+                // registry can fire on every rescan, and WARN would
+                // spam idea.log. DEBUG leaves a triage breadcrumb so
+                // "balloon shows raw id" reports can be diagnosed.
+                LOG.debug("Language registry lookup threw for id='$detectedId'; falling back to raw id", exception)
             }.getOrNull()
         return display?.takeIf { it.isNotBlank() } ?: detectedId
     }

--- a/src/main/kotlin/dev/ayuislands/actions/RescanLanguageAction.kt
+++ b/src/main/kotlin/dev/ayuislands/actions/RescanLanguageAction.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.project.Project
 import dev.ayuislands.accent.ProjectLanguageDetectionListener
 import dev.ayuislands.accent.ProjectLanguageDetector
 import dev.ayuislands.accent.runCatchingPreservingCancellation
+import dev.ayuislands.licensing.LicenseChecker
 
 /**
  * Tools-menu action that forces a fresh project-language detection scan.
@@ -34,12 +35,14 @@ internal class RescanLanguageAction : DumbAwareAction() {
         event.presentation.isEnabledAndVisible =
             project != null &&
             !project.isDefault &&
-            !project.isDisposed
+            !project.isDisposed &&
+            LicenseChecker.isLicensedOrGrace()
     }
 
     override fun actionPerformed(event: AnActionEvent) {
         val project = event.project ?: return
         if (project.isDefault || project.isDisposed) return
+        if (!LicenseChecker.isLicensedOrGrace()) return
         subscribeOnceForBalloon(project)
         ProjectLanguageDetector.rescan(project)
     }

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -45,7 +45,7 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
     private var storedRotationInterval: Int = AyuIslandsState.DEFAULT_ROTATION_INTERVAL_HOURS
     private var rotationEnabledCheckbox: JBCheckBox? = null
 
-    private val overrides = OverridesGroupBuilder()
+    internal val overrides = OverridesGroupBuilder()
     private var contextProject: Project? = null
     private var currentlyActiveLabel: JEditorPane? = null
 

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt
@@ -303,8 +303,19 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
         // directly via the `internal val overrides` field rather than
         // layering a second dispose override, which would bump
         // AccentPanel past detekt's 25-function class budget.
-        panels.forEach { it.dispose() }
-        accentPanel.overrides.dispose()
+        //
+        // Each dispose call is individually wrapped so a throwing panel
+        // (or a future override with a platform-API failure mode) does
+        // not prevent the remaining panels or the mandatory super call
+        // from running. The MessageBus subscription in overrides is the
+        // load-bearing cleanup — a skipped super would leak the
+        // BoundConfigurable binding too.
+        panels.forEach { panel ->
+            runCatching { panel.dispose() }
+                .onFailure { log.warn("Panel dispose threw for ${panel.javaClass.simpleName}", it) }
+        }
+        runCatching { accentPanel.overrides.dispose() }
+            .onFailure { log.warn("OverridesGroupBuilder dispose threw", it) }
         super.disposeUIResources()
     }
 

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt
@@ -295,6 +295,7 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
     override fun disposeUIResources() {
         activeTimers.forEach { it.stop() }
         activeTimers.clear()
+        accentPanel.overrides.dispose()
         super.disposeUIResources()
     }
 

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt
@@ -295,6 +295,15 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
     override fun disposeUIResources() {
         activeTimers.forEach { it.stop() }
         activeTimers.clear()
+        // Drive platform-owned subscriptions shut down through the
+        // AyuIslandsSettingsPanel.dispose() default no-op; panels that
+        // hold platform lifecycle state override it. AyuIslandsAccentPanel
+        // additionally owns OverridesGroupBuilder whose detection-Topic
+        // MessageBus connection needs explicit disconnect — reach it
+        // directly via the `internal val overrides` field rather than
+        // layering a second dispose override, which would bump
+        // AccentPanel past detekt's 25-function class budget.
+        panels.forEach { it.dispose() }
         accentPanel.overrides.dispose()
         super.disposeUIResources()
     }

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsSettingsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsSettingsPanel.kt
@@ -15,4 +15,19 @@ interface AyuIslandsSettingsPanel {
     fun apply()
 
     fun reset()
+
+    /**
+     * Release platform resources (MessageBus subscriptions, timers) that
+     * the panel acquired during [buildPanel]. Default no-op because most
+     * settings panels hold no platform lifecycle state — they own Swing
+     * components whose cleanup is already driven by the enclosing
+     * Configurable's `disposeUIResources` chain. Override only when the
+     * panel acquires something the platform can't reclaim on its own.
+     * Called from [AyuIslandsConfigurable.disposeUIResources].
+     */
+    fun dispose() {
+        // Empty by default. Panels with platform-backed resources
+        // (e.g. AyuIslandsAccentPanel, which owns OverridesGroupBuilder's
+        // detection-Topic MessageBus subscription) override this.
+    }
 }

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -12,6 +12,7 @@ import com.intellij.ui.components.JBLabel
 import com.intellij.ui.dsl.builder.Align
 import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.table.JBTable
+import com.intellij.util.messages.MessageBusConnection
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
 import dev.ayuislands.accent.AccentApplicator
@@ -77,8 +78,61 @@ class OverridesGroupBuilder {
      */
     private var proportionsPanel: JPanel? = null
 
+    /**
+     * Live `MessageBusConnection` subscribing the proportions panel to
+     * [ProjectLanguageDetectionListener.TOPIC]. Stored so [dispose] can tear
+     * down the subscription when the Settings panel closes — otherwise every
+     * Settings open on the same project accumulates another live subscriber
+     * that survives until project close, and every scan completion walks the
+     * accumulated list to hit a `panel.isDisplayable` no-op on every stale
+     * builder. Null before [buildGroup] runs and after [dispose] has
+     * disconnected; [buildGroup] disconnects any prior connection on re-entry
+     * so a builder rebuilt in place (variant swap while Settings stays open)
+     * doesn't double-subscribe either.
+     */
+    private var detectionConnection: MessageBusConnection? = null
+
+    /**
+     * Snapshot of the focused project captured at [buildGroup] time, nulled
+     * out when the user is unlicensed so the rescan affordance is suppressed
+     * without an inline `&&` check inside [renderProportionsInto]. Rescan is
+     * a Pro feature by project policy (all new features premium by default)
+     * and reading the license once in [buildGroup] keeps the hot render path
+     * under the detekt cyclomatic budget.
+     */
+    private var rescanAffordanceProject: Project? = null
+
     init {
-        configureTables()
+        for (table in listOf(projectTable, languageTable)) {
+            table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION)
+            table.rowHeight = TABLE_ROW_HEIGHT
+            table.setShowGrid(false)
+        }
+        projectTable.getColumnModel().getColumn(ProjectMappingsTableModel.COLUMN_COLOR).apply {
+            cellRenderer = RoundedSwatchRenderer()
+        }
+        projectTable.getColumnModel().getColumn(ProjectMappingsTableModel.COLUMN_PROJECT).apply {
+            cellRenderer = DimOrphanRenderer { row -> projectModel.isOrphan(row) }
+        }
+        projectTable.getColumnModel().getColumn(ProjectMappingsTableModel.COLUMN_PATH).apply {
+            cellRenderer = DimOrphanRenderer { row -> projectModel.isOrphan(row) }
+        }
+        languageTable.getColumnModel().getColumn(LanguageMappingsTableModel.COLUMN_COLOR).apply {
+            cellRenderer = RoundedSwatchRenderer()
+        }
+    }
+
+    /**
+     * Tear down the detection-Topic subscription. Called from
+     * [dev.ayuislands.settings.AyuIslandsConfigurable.disposeUIResources]
+     * (which reaches the builder through the `internal val overrides` field
+     * exposed by [dev.ayuislands.settings.AyuIslandsAccentPanel]) so the
+     * live subscriber count doesn't grow by one per Settings open. Safe to
+     * call multiple times; no-op when the builder was never wired up.
+     */
+    fun dispose() {
+        detectionConnection?.disconnect()
+        detectionConnection = null
     }
 
     fun buildGroup(
@@ -97,6 +151,11 @@ class OverridesGroupBuilder {
         loadFromState()
 
         val licensed = LicenseChecker.isLicensedOrGrace()
+        // Capture the rescan-eligible project up front so the render hot path
+        // (`renderProportionsInto`) stays under the detekt cyclomatic budget;
+        // see `rescanAffordanceProject` KDoc for why the license check lives
+        // here rather than inline.
+        rescanAffordanceProject = contextProject?.takeIf { licensed }
 
         val projectsRadio = JRadioButton("Projects", true)
         val languagesRadio = JRadioButton("Languages", false)
@@ -169,13 +228,20 @@ class OverridesGroupBuilder {
         //    `ProjectLanguageDetectionListener.scanCompleted` on EDT — the only signal
         //    the row has to exit a stale winner state without a settings edit.
         addPendingChangeListener { proportionsPanel?.let { populateProportionsPanel(it) } }
-        // Lifetime of the Topic subscription is tied to the project's MessageBus
-        // (auto-cleared on project close); the panel-displayable guard below
-        // covers the window where Settings has been closed but the project is
-        // still alive — `populateProportionsPanel` on a detached panel would
+        // Subscription lifetime is tied to the Settings panel (disconnected by
+        // [dispose] from the Configurable's disposeUIResources). Any prior
+        // connection on this same builder is torn down first so a rebuild in
+        // place can't double-subscribe. The project MessageBus is the ultimate
+        // safety net — if the Settings panel is orphaned without disposeUI
+        // firing, the connection still drops when the project closes.
+        detectionConnection?.disconnect()
+        detectionConnection = null
+        // The panel-displayable guard below covers the window where Settings has
+        // been closed but dispose hasn't fired yet — `populateProportionsPanel`
         // paint into nothing and waste EDT budget.
         contextProject?.let { project ->
             val connection = project.messageBus.connect()
+            detectionConnection = connection
             connection.subscribe(
                 ProjectLanguageDetectionListener.TOPIC,
                 ProjectLanguageDetectionListener {
@@ -455,11 +521,14 @@ class OverridesGroupBuilder {
         }
         // Trailing Rescan affordance appended in BOTH paths (normal + polyglot)
         // so the user is never stuck on a stale verdict without an escape hatch.
-        // Skipped when project is null (Settings opened without a focused project):
-        // `ProjectLanguageDetector.rescan` would have nowhere to dispatch.
-        if (project != null) {
+        // Source of truth: [rescanAffordanceProject] — null when there is no
+        // focused project OR when the user is unlicensed (see its KDoc).
+        // Reading it here as a single `?.let` keeps this method inside detekt's
+        // cyclomatic budget now that Rescan is behind a Pro-feature license
+        // gate.
+        rescanAffordanceProject?.let { rescanProject ->
             panel.add(JBLabel(PROPORTIONS_SEPARATOR.toString()).apply { foreground = subdued })
-            panel.add(buildRescanAffordanceLabel(project, subdued))
+            panel.add(buildRescanAffordanceLabel(rescanProject, subdued))
         }
     }
 
@@ -522,8 +591,21 @@ class OverridesGroupBuilder {
      * through [buildGroup].
      */
     @org.jetbrains.annotations.TestOnly
-    internal fun setParentProjectForTest(project: Project?) {
+    internal fun setParentProjectForTest(
+        project: Project?,
+        licensed: Boolean = true,
+    ) {
         parentProject = project
+        // Tests bypass `buildGroup`, so `rescanAffordanceProject` would
+        // otherwise stay null and the inline Rescan affordance would never
+        // appear under test. The `licensed` parameter mirrors the gate that
+        // `buildGroup` reads from `LicenseChecker.isLicensedOrGrace()` in
+        // production — default `true` keeps every existing test driving the
+        // rescan-affordance-visible path without having to stand up the
+        // platform `ApplicationManager` service graph just to mock
+        // `LicenseChecker`. A dedicated unlicensed-suppression spec passes
+        // `licensed = false` to lock the inverse contract.
+        rescanAffordanceProject = project?.takeIf { licensed }
     }
 
     /**
@@ -619,26 +701,6 @@ class OverridesGroupBuilder {
     }
 
     private val fireChanged: () -> Unit = { listeners.forEach { it.run() } }
-
-    private fun configureTables() {
-        for (table in listOf(projectTable, languageTable)) {
-            table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION)
-            table.rowHeight = TABLE_ROW_HEIGHT
-            table.setShowGrid(false)
-        }
-        projectTable.getColumnModel().getColumn(ProjectMappingsTableModel.COLUMN_COLOR).apply {
-            cellRenderer = RoundedSwatchRenderer()
-        }
-        projectTable.getColumnModel().getColumn(ProjectMappingsTableModel.COLUMN_PROJECT).apply {
-            cellRenderer = DimOrphanRenderer { row -> projectModel.isOrphan(row) }
-        }
-        projectTable.getColumnModel().getColumn(ProjectMappingsTableModel.COLUMN_PATH).apply {
-            cellRenderer = DimOrphanRenderer { row -> projectModel.isOrphan(row) }
-        }
-        languageTable.getColumnModel().getColumn(LanguageMappingsTableModel.COLUMN_COLOR).apply {
-            cellRenderer = RoundedSwatchRenderer()
-        }
-    }
 
     private fun decorateTable(
         table: JBTable,

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -156,7 +156,18 @@ class OverridesGroupBuilder {
      * to call multiple times; no-op when the builder was never wired up.
      */
     fun dispose() {
-        detectionConnection?.disconnect()
+        // Wrap the disconnect in runCatchingPreservingCancellation to
+        // match the sibling defence in RescanLanguageAction: the platform
+        // has been observed to throw `AlreadyDisposedException` from
+        // `MessageBusConnection.disconnect()` during a plugin-unload
+        // race. Without the wrap, a throw here propagates up through
+        // `AyuIslandsConfigurable.disposeUIResources` and skips both the
+        // remaining panel teardown and `super.disposeUIResources`, which
+        // would leak the `BoundConfigurable` binding cleanup.
+        runCatchingPreservingCancellation { detectionConnection?.disconnect() }
+            .onFailure { exception ->
+                LOG.debug("OverridesGroupBuilder detection disconnect failed", exception)
+            }
         detectionConnection = null
     }
 
@@ -256,10 +267,17 @@ class OverridesGroupBuilder {
         // Subscription lifetime is tied to the Settings panel (disconnected by
         // [dispose] from the Configurable's disposeUIResources). Any prior
         // connection on this same builder is torn down first so a rebuild in
-        // place can't double-subscribe. The project MessageBus is the ultimate
-        // safety net — if the Settings panel is orphaned without disposeUI
-        // firing, the connection still drops when the project closes.
-        detectionConnection?.disconnect()
+        // place can't double-subscribe. Wrapped in runCatchingPreservingCancellation
+        // so a platform regression throwing from `disconnect()` (observed as
+        // `AlreadyDisposedException` during plugin-unload races) doesn't
+        // propagate out of `buildGroup` and break the Settings render path.
+        // The project MessageBus is the ultimate safety net — if Settings is
+        // orphaned without disposeUI firing, the connection still drops on
+        // project close.
+        runCatchingPreservingCancellation { detectionConnection?.disconnect() }
+            .onFailure { exception ->
+                LOG.debug("OverridesGroupBuilder re-entry disconnect failed", exception)
+            }
         detectionConnection = null
         // The `panel.isDisplayable` guard inside invokeLater below covers
         // the window where Settings has been closed but dispose hasn't
@@ -595,6 +613,17 @@ class OverridesGroupBuilder {
                                     AyuVariant.detect()
                                         ?: return@runCatchingPreservingCancellation subdued
                                 ColorUtil.fromHex(AccentResolver.resolve(project, variant))
+                            }.onFailure { exception ->
+                                // DEBUG not WARN: hover fires on every
+                                // pointer entry, so a systemic regression
+                                // (malformed stored hex, plugin-unload
+                                // race) must not spam idea.log. Still
+                                // leaves a triage breadcrumb when a user
+                                // reports "hover doesn't light up".
+                                LOG.debug(
+                                    "Rescan hover AccentResolver threw; falling back to subdued",
+                                    exception,
+                                )
                             }.getOrDefault(subdued)
                         repaint()
                     }

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.text.StringUtil
+import com.intellij.ui.ColorUtil
 import com.intellij.ui.ToolbarDecorator
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.dsl.builder.Align
@@ -17,6 +18,7 @@ import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.LanguageDetectionRules
+import dev.ayuislands.accent.ProjectLanguageDetectionListener
 import dev.ayuislands.accent.ProjectLanguageDetector
 import dev.ayuislands.accent.runCatchingPreservingCancellation
 import dev.ayuislands.licensing.LicenseChecker
@@ -25,8 +27,11 @@ import java.awt.BorderLayout
 import java.awt.CardLayout
 import java.awt.Color
 import java.awt.Component
+import java.awt.Cursor
 import java.awt.Dimension
 import java.awt.FlowLayout
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
 import java.io.File
 import javax.swing.ButtonGroup
 import javax.swing.Icon
@@ -36,6 +41,7 @@ import javax.swing.JRadioButton
 import javax.swing.JTable
 import javax.swing.ListSelectionModel
 import javax.swing.SwingConstants
+import javax.swing.SwingUtilities
 import javax.swing.table.DefaultTableCellRenderer
 import javax.swing.table.TableModel
 
@@ -92,7 +98,23 @@ class OverridesGroupBuilder {
 
         val licensed = LicenseChecker.isLicensedOrGrace()
 
-        val segmentedBar = buildSegmentedBar()
+        val projectsRadio = JRadioButton("Projects", true)
+        val languagesRadio = JRadioButton("Languages", false)
+        val segmentedButtonGroup =
+            ButtonGroup().apply {
+                add(projectsRadio)
+                add(languagesRadio)
+            }
+        projectsRadio.addActionListener { (cardPanel.layout as CardLayout).show(cardPanel, CARD_PROJECTS) }
+        languagesRadio.addActionListener { (cardPanel.layout as CardLayout).show(cardPanel, CARD_LANGUAGES) }
+        val segmentedBar =
+            JPanel(FlowLayout(FlowLayout.LEADING, BAR_HORIZONTAL_GAP, BAR_VERTICAL_GAP)).apply {
+                isOpaque = false
+                add(projectsRadio)
+                add(languagesRadio)
+                // Retain strong reference so actions survive focus changes.
+                putClientProperty("ayu.overrides.group", segmentedButtonGroup)
+            }
         cardPanel.add(decorateTable(projectTable, projectActions(licensed)), CARD_PROJECTS)
         cardPanel.add(decorateTable(languageTable, languageActions(licensed)), CARD_LANGUAGES)
         // No fixed preferredSize: the AutoSizingTable drives height via
@@ -139,11 +161,32 @@ class OverridesGroupBuilder {
         collapsible.addExpandedListener { expanded ->
             settings.state.overridesGroupExpanded = expanded
         }
-        // Keep the proportions status line in sync with the pending-change surface so
-        // any override add / edit / delete re-reads from the detector cache. Phase 29's
-        // rescan action will reuse this same channel (invalidate + fireChanged) without
-        // introducing a new MessageBus Topic.
+        // Two independent refresh channels share one repopulate helper:
+        //  - Pending-change listener: Settings-local edits (add / edit / delete a row)
+        //    fire `fireChanged()` synchronously on EDT, which re-reads the warm cache.
+        //  - Detection Topic: async scan completions (startup warmup, `ModuleRootListener`
+        //    content-root change, user-triggered rescan) fire
+        //    `ProjectLanguageDetectionListener.scanCompleted` on EDT — the only signal
+        //    the row has to exit a stale winner state without a settings edit.
         addPendingChangeListener { proportionsPanel?.let { populateProportionsPanel(it) } }
+        // Lifetime of the Topic subscription is tied to the project's MessageBus
+        // (auto-cleared on project close); the panel-displayable guard below
+        // covers the window where Settings has been closed but the project is
+        // still alive — `populateProportionsPanel` on a detached panel would
+        // paint into nothing and waste EDT budget.
+        contextProject?.let { project ->
+            val connection = project.messageBus.connect()
+            connection.subscribe(
+                ProjectLanguageDetectionListener.TOPIC,
+                ProjectLanguageDetectionListener {
+                    SwingUtilities.invokeLater {
+                        val panel = proportionsPanel ?: return@invokeLater
+                        if (!panel.isDisplayable) return@invokeLater
+                        populateProportionsPanel(panel)
+                    }
+                },
+            )
+        }
     }
 
     // Settings panel lifecycle (isModified / apply / reset)
@@ -378,39 +421,99 @@ class OverridesGroupBuilder {
                     foreground = subdued
                 },
             )
-            return
-        }
-        panel.add(JBLabel(PROPORTIONS_PREFIX).apply { foreground = subdued })
-        entries.forEachIndexed { index, entry ->
-            if (index > 0) {
-                panel.add(JBLabel(PROPORTIONS_SEPARATOR.toString()).apply { foreground = subdued })
-            }
-            val icon = entry.id?.let { LanguageDetectionRules.iconForLanguageId(it) }
-            // Named entries render as icon + percent only (icon identifies the
-            // language). The "other" bucket has no icon and no single language —
-            // render its literal "other" label before the percent so the row
-            // still reads as a unit instead of a dangling bare percent that
-            // looks like a rendering glitch.
-            val text =
-                if (entry.id == null) {
-                    "${entry.label} ${entry.percent}%"
-                } else {
-                    "${entry.percent}%"
+        } else {
+            panel.add(JBLabel(PROPORTIONS_PREFIX).apply { foreground = subdued })
+            entries.forEachIndexed { index, entry ->
+                if (index > 0) {
+                    panel.add(JBLabel(PROPORTIONS_SEPARATOR.toString()).apply { foreground = subdued })
                 }
-            panel.add(
-                JBLabel(text, icon, SwingConstants.LEADING).apply {
-                    foreground = subdued
-                    // Hover affordance: icon alone can be unfamiliar for less-common
-                    // languages, so the display name surfaces in the tooltip.
-                    // toolTipText is plain-text unless it starts with <html>, so
-                    // any pathological Language.displayName renders literally —
-                    // no HTML interpretation, consistent with the label-text
-                    // safety story.
-                    toolTipText = entry.label
+                val icon = entry.id?.let { LanguageDetectionRules.iconForLanguageId(it) }
+                // Named entries render as icon + percent only (icon identifies the
+                // language). The "other" bucket has no icon and no single language —
+                // render its literal "other" label before the percent so the row
+                // still reads as a unit instead of a dangling bare percent that
+                // looks like a rendering glitch.
+                val text =
+                    if (entry.id == null) {
+                        "${entry.label} ${entry.percent}%"
+                    } else {
+                        "${entry.percent}%"
+                    }
+                panel.add(
+                    JBLabel(text, icon, SwingConstants.LEADING).apply {
+                        foreground = subdued
+                        // Hover affordance: icon alone can be unfamiliar for less-common
+                        // languages, so the display name surfaces in the tooltip.
+                        // toolTipText is plain-text unless it starts with <html>, so
+                        // any pathological Language.displayName renders literally —
+                        // no HTML interpretation, consistent with the label-text
+                        // safety story.
+                        toolTipText = entry.label
+                    },
+                )
+            }
+        }
+        // Trailing Rescan affordance appended in BOTH paths (normal + polyglot)
+        // so the user is never stuck on a stale verdict without an escape hatch.
+        // Skipped when project is null (Settings opened without a focused project):
+        // `ProjectLanguageDetector.rescan` would have nowhere to dispatch.
+        if (project != null) {
+            panel.add(JBLabel(PROPORTIONS_SEPARATOR.toString()).apply { foreground = subdued })
+            panel.add(buildRescanAffordanceLabel(project, subdued))
+        }
+    }
+
+    /**
+     * Build the clickable "Rescan" label at the trailing end of the proportions row.
+     *
+     * Behavior contract (muted-by-default, accent-on-hover, click-to-rescan):
+     *  - Foreground starts at `subdued` so the label blends with the row.
+     *  - `mouseEntered` re-resolves the currently-applied accent live (NOT
+     *    captured at build time) so a mid-session accent change surfaces on
+     *    the next hover. `runCatchingPreservingCancellation` contains any
+     *    platform-API throw — this runs on every hover tick and an uncaught
+     *    EDT exception would break the entire Settings row.
+     *  - `mouseExited` restores `subdued`.
+     *  - `mouseClicked` calls [ProjectLanguageDetector.rescan]; the
+     *    invalidate + schedule + publish chain lives in the detector so the
+     *    click inherits dedup-gate coalescing for free.
+     *
+     * Extracted out of [renderProportionsInto] so the outer function stays
+     * inside detekt's cyclomatic budget now that the trailing affordance adds
+     * its own conditional branches.
+     */
+    private fun buildRescanAffordanceLabel(
+        project: Project,
+        subdued: Color,
+    ): JBLabel =
+        JBLabel(RESCAN_LABEL).apply {
+            foreground = subdued
+            toolTipText = RESCAN_TOOLTIP
+            cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+            addMouseListener(
+                object : MouseAdapter() {
+                    override fun mouseEntered(event: MouseEvent) {
+                        foreground =
+                            runCatchingPreservingCancellation {
+                                val variant =
+                                    AyuVariant.detect()
+                                        ?: return@runCatchingPreservingCancellation subdued
+                                ColorUtil.fromHex(AccentResolver.resolve(project, variant))
+                            }.getOrDefault(subdued)
+                        repaint()
+                    }
+
+                    override fun mouseExited(event: MouseEvent) {
+                        foreground = subdued
+                        repaint()
+                    }
+
+                    override fun mouseClicked(event: MouseEvent) {
+                        ProjectLanguageDetector.rescan(project)
+                    }
                 },
             )
         }
-    }
 
     /**
      * Builder-level `@TestOnly` seam that binds a focused project without
@@ -516,28 +619,6 @@ class OverridesGroupBuilder {
     }
 
     private val fireChanged: () -> Unit = { listeners.forEach { it.run() } }
-
-    private fun buildSegmentedBar(): JComponent {
-        val projectsRadio = JRadioButton("Projects", true)
-        val languagesRadio = JRadioButton("Languages", false)
-        val group =
-            ButtonGroup().apply {
-                add(projectsRadio)
-                add(languagesRadio)
-            }
-        projectsRadio.addActionListener { (cardPanel.layout as CardLayout).show(cardPanel, CARD_PROJECTS) }
-        languagesRadio.addActionListener { (cardPanel.layout as CardLayout).show(cardPanel, CARD_LANGUAGES) }
-
-        val bar =
-            JPanel(FlowLayout(FlowLayout.LEADING, BAR_HORIZONTAL_GAP, BAR_VERTICAL_GAP)).apply {
-                isOpaque = false
-                add(projectsRadio)
-                add(languagesRadio)
-            }
-        // Retain strong reference so actions survive focus changes
-        bar.putClientProperty("ayu.overrides.group", group)
-        return bar
-    }
 
     private fun configureTables() {
         for (table in listOf(projectTable, languageTable)) {
@@ -778,6 +859,21 @@ class OverridesGroupBuilder {
          * panel (e.g. `Maple Mono · 14pt · Regular · 1.0× · ligatures`).
          */
         const val PROPORTIONS_SEPARATOR: Char = '·'
+
+        /**
+         * Literal text of the inline clickable "Rescan" affordance at the
+         * trailing end of the proportions row. Kept short so it doesn't
+         * dominate the muted status line — the cursor change + hover-accent
+         * already signal interactivity.
+         */
+        const val RESCAN_LABEL: String = "Rescan"
+
+        /**
+         * Tooltip for the inline Rescan label. Clarifies what will happen
+         * without bloating the visible text — hover discoverability.
+         */
+        const val RESCAN_TOOLTIP: String =
+            "Re-detect the dominant language of this project"
     }
 
     /**

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -93,14 +93,38 @@ class OverridesGroupBuilder {
     private var detectionConnection: MessageBusConnection? = null
 
     /**
-     * Snapshot of the focused project captured at [buildGroup] time, nulled
-     * out when the user is unlicensed so the rescan affordance is suppressed
-     * without an inline `&&` check inside [renderProportionsInto]. Rescan is
-     * a Pro feature by project policy (all new features premium by default)
-     * and reading the license once in [buildGroup] keeps the hot render path
-     * under the detekt cyclomatic budget.
+     * License-gate snapshot for the rescan affordance, captured once at
+     * [buildGroup] time from `LicenseChecker.isLicensedOrGrace()`. Kept as a
+     * dedicated boolean (rather than folding into the `parentProject`
+     * nullability) so the two "Rescan hidden" reasons stay distinguishable
+     * at debug time:
+     *   - `parentProject == null` → Settings opened without a focused project.
+     *   - `parentProject != null && !rescanLicensed` → unlicensed user.
+     *
+     * Rescan is a Pro feature by project policy (all new features premium
+     * by default). Reading the license once in [buildGroup] keeps the hot
+     * render path ([renderProportionsInto]) out of a repeated
+     * `LicenseChecker.isLicensedOrGrace()` call and avoids a cyclomatic-
+     * budget bump from an inline `&&`.
+     *
+     * [buildRescanAffordanceLabel]'s `mouseClicked` defence-in-depth
+     * re-reads `LicenseChecker.isLicensedOrGrace()` live on click so a
+     * license that expires while Settings is open can't still fire a rescan
+     * from a stale panel.
      */
-    private var rescanAffordanceProject: Project? = null
+    private var rescanLicensed: Boolean = false
+
+    /**
+     * Derived rescan-eligibility: non-null iff a focused project is
+     * present AND the license snapshot permits the Pro affordance. Kept
+     * as a computed property (property getters don't count toward
+     * detekt's `TooManyFunctions` budget) so the single read in
+     * [renderProportionsInto] reduces to one `?.let` branch. The two
+     * reasons for null remain debuggable independently via
+     * [parentProject] and [rescanLicensed].
+     */
+    private val rescanEligibleProject: Project?
+        get() = parentProject?.takeIf { rescanLicensed }
 
     init {
         for (table in listOf(projectTable, languageTable)) {
@@ -125,10 +149,11 @@ class OverridesGroupBuilder {
     /**
      * Tear down the detection-Topic subscription. Called from
      * [dev.ayuislands.settings.AyuIslandsConfigurable.disposeUIResources]
-     * (which reaches the builder through the `internal val overrides` field
-     * exposed by [dev.ayuislands.settings.AyuIslandsAccentPanel]) so the
-     * live subscriber count doesn't grow by one per Settings open. Safe to
-     * call multiple times; no-op when the builder was never wired up.
+     * via the `dispose()` override on
+     * [dev.ayuislands.settings.AyuIslandsAccentPanel] (through the
+     * `AyuIslandsSettingsPanel.dispose()` interface method). Without this
+     * call the live subscriber count grows by one per Settings open. Safe
+     * to call multiple times; no-op when the builder was never wired up.
      */
     fun dispose() {
         detectionConnection?.disconnect()
@@ -151,11 +176,11 @@ class OverridesGroupBuilder {
         loadFromState()
 
         val licensed = LicenseChecker.isLicensedOrGrace()
-        // Capture the rescan-eligible project up front so the render hot path
-        // (`renderProportionsInto`) stays under the detekt cyclomatic budget;
-        // see `rescanAffordanceProject` KDoc for why the license check lives
-        // here rather than inline.
-        rescanAffordanceProject = contextProject?.takeIf { licensed }
+        // Capture the license snapshot up front so `renderProportionsInto`
+        // reads one boolean + one nullable without bumping its cyclomatic
+        // count. See `rescanLicensed` KDoc for why license and project
+        // eligibility live in separate fields.
+        rescanLicensed = licensed
 
         val projectsRadio = JRadioButton("Projects", true)
         val languagesRadio = JRadioButton("Languages", false)
@@ -236,9 +261,10 @@ class OverridesGroupBuilder {
         // firing, the connection still drops when the project closes.
         detectionConnection?.disconnect()
         detectionConnection = null
-        // The panel-displayable guard below covers the window where Settings has
-        // been closed but dispose hasn't fired yet — `populateProportionsPanel`
-        // paint into nothing and waste EDT budget.
+        // The `panel.isDisplayable` guard inside invokeLater below covers
+        // the window where Settings has been closed but dispose hasn't
+        // fired yet — without it, `populateProportionsPanel` would paint
+        // into a detached panel and waste EDT budget.
         contextProject?.let { project ->
             val connection = project.messageBus.connect()
             detectionConnection = connection
@@ -521,12 +547,13 @@ class OverridesGroupBuilder {
         }
         // Trailing Rescan affordance appended in BOTH paths (normal + polyglot)
         // so the user is never stuck on a stale verdict without an escape hatch.
-        // Source of truth: [rescanAffordanceProject] — null when there is no
-        // focused project OR when the user is unlicensed (see its KDoc).
-        // Reading it here as a single `?.let` keeps this method inside detekt's
-        // cyclomatic budget now that Rescan is behind a Pro-feature license
-        // gate.
-        rescanAffordanceProject?.let { rescanProject ->
+        // Source of truth: [rescanEligibleProject] — null when there is no
+        // focused project OR when the user is unlicensed (see
+        // `rescanLicensed` KDoc). Reading it as a single `?.let` keeps this
+        // method under detekt's cyclomatic budget. `mouseClicked` re-reads
+        // the live license as defence-in-depth against a license that
+        // expires while Settings is open.
+        rescanEligibleProject?.let { rescanProject ->
             panel.add(JBLabel(PROPORTIONS_SEPARATOR.toString()).apply { foreground = subdued })
             panel.add(buildRescanAffordanceLabel(rescanProject, subdued))
         }
@@ -578,6 +605,14 @@ class OverridesGroupBuilder {
                     }
 
                     override fun mouseClicked(event: MouseEvent) {
+                        // Defence-in-depth license re-check: the
+                        // `rescanLicensed` field was snapshotted at
+                        // `buildGroup` time. If the license expired while
+                        // Settings was open (grace roll-off, revocation via
+                        // LicensingFacade), the label is still visible but
+                        // the click must NOT fire a rescan. Matches the
+                        // `actionPerformed` gate in RescanLanguageAction.
+                        if (!LicenseChecker.isLicensedOrGrace()) return
                         ProjectLanguageDetector.rescan(project)
                     }
                 },
@@ -596,16 +631,16 @@ class OverridesGroupBuilder {
         licensed: Boolean = true,
     ) {
         parentProject = project
-        // Tests bypass `buildGroup`, so `rescanAffordanceProject` would
-        // otherwise stay null and the inline Rescan affordance would never
-        // appear under test. The `licensed` parameter mirrors the gate that
+        // Tests bypass `buildGroup`, so `rescanLicensed` would otherwise
+        // stay false and the inline Rescan affordance would never appear
+        // under test. The `licensed` parameter mirrors the gate that
         // `buildGroup` reads from `LicenseChecker.isLicensedOrGrace()` in
         // production — default `true` keeps every existing test driving the
         // rescan-affordance-visible path without having to stand up the
         // platform `ApplicationManager` service graph just to mock
         // `LicenseChecker`. A dedicated unlicensed-suppression spec passes
         // `licensed = false` to lock the inverse contract.
-        rescanAffordanceProject = project?.takeIf { licensed }
+        rescanLicensed = licensed
     }
 
     /**

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -85,6 +85,10 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>2.6.0</h3>
+    <ul>
+      <li>[Paid] Rescan project language on demand — new "Rescan" link in the Overrides proportions row and "Tools → Ayu Islands → Rescan Project Language" menu action, for when you want the detected breakdown to refresh without waiting for the next Gradle sync</li>
+    </ul>
     <h3>2.5.2</h3>
     <ul>
       <li>[Paid] Per-Language Accent Pins now show a live breakdown of the detected languages in your project (e.g. "Detected: Kotlin 78% • Java 15% • other 7%") or a clear "polyglot" notice when no single language dominates</li>
@@ -302,5 +306,16 @@
                 description="Reopen the latest Ayu Islands release showcase">
             <add-to-group group-id="ToolsMenu" anchor="last"/>
         </action>
+
+        <group id="AyuIslands.ToolsGroup"
+               popup="true"
+               text="Ayu Islands"
+               description="Ayu Islands theme actions">
+            <add-to-group group-id="ToolsMenu" anchor="last"/>
+            <action id="AyuIslands.RescanLanguage"
+                    class="dev.ayuislands.actions.RescanLanguageAction"
+                    text="Rescan Project Language"
+                    description="Invalidate the cache and re-detect the dominant project language"/>
+        </group>
     </actions>
 </idea-plugin>

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
@@ -829,6 +829,192 @@ class ProjectLanguageDetectorTest {
         verify(exactly = 0) { AccentApplicator.apply(any()) }
     }
 
+    // ── rescan (Phase 29) ─────────────────────────────────────────────────────
+
+    @Test
+    fun `rescan clears both caches so proportions returns null immediately`() {
+        // Baseline: warm both caches via dominant(). Then mock the scheduler
+        // so the post-invalidate scan never actually runs; this proves
+        // rescan()'s invalidate happens synchronously before the async
+        // scheduler is consulted.
+        val project = stubProject("/tmp/rescan-clears-${System.nanoTime()}")
+        every { ProjectLanguageScanner.scan(project) } returns mapOf("kotlin" to 900L, "java" to 100L)
+        wireProjectRootManager(project, sdkName = null)
+        wireModuleManager(project, moduleNames = emptyList())
+        ProjectLanguageDetector.dominant(project)
+        assertEquals(
+            mapOf("kotlin" to 900L, "java" to 100L),
+            ProjectLanguageDetector.proportions(project),
+        )
+
+        stubDumbServiceSmart(project)
+        mockkObject(ProjectLanguageScanAsync)
+        every { ProjectLanguageScanAsync.schedule(any(), any()) } returns true
+
+        ProjectLanguageDetector.rescan(project)
+
+        assertNull(
+            ProjectLanguageDetector.proportions(project),
+            "rescan MUST evict the weights cache synchronously — a stale breakdown " +
+                "served while the scan is still running would misrepresent the in-progress state",
+        )
+    }
+
+    @Test
+    fun `rescan forwards to scheduler keyed by the canonical project path`() {
+        // The dedup gate in ProjectLanguageScanAsync keys on the canonical
+        // project path — rescan MUST use the same key so rapid-fire Rescan
+        // clicks coalesce into a single scan run.
+        val project = stubProject("/tmp/rescan-schedules-${System.nanoTime()}")
+        every { ProjectLanguageScanner.scan(project) } returns emptyMap()
+        wireProjectRootManager(project, sdkName = null)
+        wireModuleManager(project, moduleNames = emptyList())
+
+        stubDumbServiceSmart(project)
+        mockkObject(ProjectLanguageScanAsync)
+        val capturedKey = io.mockk.slot<String>()
+        every { ProjectLanguageScanAsync.schedule(capture(capturedKey), any()) } returns true
+
+        ProjectLanguageDetector.rescan(project)
+
+        assertEquals(
+            AccentResolver.projectKey(project),
+            capturedKey.captured,
+            "rescan forwards the scheduler key so the dedup gate can coalesce concurrent requests",
+        )
+    }
+
+    @Test
+    fun `rescan on a project with no canonical path is a no-op`() {
+        // AccentResolver.projectKey returns null for a disposal race / default
+        // project. rescan must bail out without touching caches or scheduling.
+        val project = mockk<Project>()
+        every { project.basePath } returns null
+        every { project.isDefault } returns false
+        every { project.isDisposed } returns false
+
+        stubDumbServiceSmart(project)
+        mockkObject(ProjectLanguageScanAsync)
+
+        ProjectLanguageDetector.rescan(project)
+
+        verify(exactly = 0) { ProjectLanguageScanAsync.schedule(any(), any()) }
+    }
+
+    @Test
+    fun `rescan runs detectInternal and publishes scanCompleted with the winning id`() {
+        // End-to-end happy path: rescan → scheduler runs task inline →
+        // detectAndCache writes both caches → publishScanCompleted fires on
+        // EDT with the detected id. Verified by capturing the MessageBus
+        // subscriber and asserting scanCompleted was called with "python".
+        val project = stubProject("/tmp/rescan-publish-hit-${System.nanoTime()}")
+        every { ProjectLanguageScanner.scan(project) } returns mapOf("python" to 900L, "yaml" to 100L)
+        wireProjectRootManager(project, sdkName = null)
+        wireModuleManager(project, moduleNames = emptyList())
+
+        stubDumbServiceSmart(project)
+        val listener = mockk<ProjectLanguageDetectionListener>(relaxed = true)
+        wireMessageBus(project, listener)
+        runInvokeLaterInline()
+        runSchedulerInline()
+
+        ProjectLanguageDetector.rescan(project)
+
+        verify(exactly = 1) { listener.scanCompleted("python") }
+    }
+
+    @Test
+    fun `rescan publishes scanCompleted with null on polyglot no-winner verdict`() {
+        // 50/50 split with no SDK hint → scan returns null winner → detector
+        // caches the null verdict → publishScanCompleted fires with null so
+        // subscribers (Settings row, Rescan balloon) can render the polyglot
+        // copy without relying on detector state inspection.
+        val project = stubProject("/tmp/rescan-publish-polyglot-${System.nanoTime()}")
+        every { ProjectLanguageScanner.scan(project) } returns mapOf("kotlin" to 500L, "java" to 500L)
+        wireProjectRootManager(project, sdkName = null)
+        wireModuleManager(project, moduleNames = emptyList())
+
+        stubDumbServiceSmart(project)
+        val listener = mockk<ProjectLanguageDetectionListener>(relaxed = true)
+        wireMessageBus(project, listener)
+        runInvokeLaterInline()
+        runSchedulerInline()
+
+        ProjectLanguageDetector.rescan(project)
+
+        verify(exactly = 1) { listener.scanCompleted(null) }
+    }
+
+    @Test
+    fun `rescan skips publish entirely when project disposes before scan completes`() {
+        // Dispose-between-schedule-and-completion race: the scheduler's
+        // executor thread checks isDisposed before calling detectAndCache AND
+        // before publishScanCompleted invokeLater. A bug that dropped the
+        // second guard would publish on EDT after project disposal → stale
+        // MessageBus. Simulate by flipping isDisposed true between schedule
+        // and task execution.
+        val project = stubProject("/tmp/rescan-disposed-${System.nanoTime()}")
+        every { ProjectLanguageScanner.scan(project) } returns mapOf("kotlin" to 1_000L)
+        wireProjectRootManager(project, sdkName = null)
+        wireModuleManager(project, moduleNames = emptyList())
+
+        stubDumbServiceSmart(project)
+        val listener = mockk<ProjectLanguageDetectionListener>(relaxed = true)
+        wireMessageBus(project, listener)
+        runInvokeLaterInline()
+
+        // Custom scheduler: flips disposed right before running the task.
+        mockkObject(ProjectLanguageScanAsync)
+        every { ProjectLanguageScanAsync.schedule(any(), any()) } answers {
+            every { project.isDisposed } returns true
+            val task = secondArg<() -> Unit>()
+            task()
+            true
+        }
+
+        ProjectLanguageDetector.rescan(project)
+
+        verify(exactly = 0) { listener.scanCompleted(any()) }
+    }
+
+    // Helpers for rescan tests — shared across the five specs above.
+
+    private fun stubDumbServiceSmart(project: Project) {
+        // scheduleBackgroundDetection gates on DumbService.isDumb(project) —
+        // which resolves to `project.getService(DumbService::class).isDumb`
+        // (the companion @JvmStatic delegates to getInstance → getService).
+        // mockkStatic on DumbService does NOT intercept the companion call,
+        // so we wire the service lookup directly on the mock Project instead.
+        val dumbService = mockk<com.intellij.openapi.project.DumbService>()
+        every { dumbService.isDumb } returns false
+        every { project.getService(com.intellij.openapi.project.DumbService::class.java) } returns dumbService
+    }
+
+    private fun wireMessageBus(
+        project: Project,
+        listener: ProjectLanguageDetectionListener,
+    ) {
+        val bus = mockk<com.intellij.util.messages.MessageBus>()
+        every { project.messageBus } returns bus
+        every { bus.syncPublisher(ProjectLanguageDetectionListener.TOPIC) } returns listener
+    }
+
+    private fun runInvokeLaterInline() {
+        mockkStatic(javax.swing.SwingUtilities::class)
+        every { javax.swing.SwingUtilities.invokeLater(any()) } answers {
+            firstArg<Runnable>().run()
+        }
+    }
+
+    private fun runSchedulerInline() {
+        mockkObject(ProjectLanguageScanAsync)
+        every { ProjectLanguageScanAsync.schedule(any(), any()) } answers {
+            val task = secondArg<() -> Unit>()
+            task()
+            true
+        }
+    }
+
     private fun assertModuleDetects(
         moduleNames: List<String>,
         expected: String,

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
@@ -977,6 +977,58 @@ class ProjectLanguageDetectorTest {
         verify(exactly = 0) { listener.scanCompleted(any()) }
     }
 
+    @Test
+    fun `rescan on null project key publishes null scanCompleted`() {
+        // User-facing symptom guard: `AccentResolver.projectKey` can
+        // return null for a disposal race or canonicalization failure on
+        // a live project. Before the fix, `rescan` returned silently,
+        // orphaning the one-shot subscriber installed by
+        // `RescanLanguageAction.subscribeOnceForBalloon` — user clicks
+        // Rescan, gets no balloon, subscription leaks until project
+        // close. The fix publishes `scanCompleted(null)` so subscribers
+        // fire the polyglot-copy balloon and disconnect.
+        val project = mockk<Project>()
+        every { project.basePath } returns null
+        every { project.isDefault } returns false
+        every { project.isDisposed } returns false
+
+        val listener = mockk<ProjectLanguageDetectionListener>(relaxed = true)
+        wireMessageBus(project, listener)
+        runInvokeLaterInline()
+        mockkObject(ProjectLanguageScanAsync)
+
+        ProjectLanguageDetector.rescan(project)
+
+        verify(exactly = 1) { listener.scanCompleted(null) }
+        verify(exactly = 0) { ProjectLanguageScanAsync.schedule(any(), any()) }
+    }
+
+    @Test
+    fun `publishScanCompleted swallows a throwing subscriber without rethrow`() {
+        // Defensive lock on the runCatchingPreservingCancellation wrap
+        // inside publishScanCompleted. A rogue subscriber whose
+        // scanCompleted handler throws must not propagate into the EDT
+        // invokeLater callback — that becomes an uncaught EDT exception.
+        val project = stubProject("/tmp/rescan-publish-throw-${System.nanoTime()}")
+        every { ProjectLanguageScanner.scan(project) } returns mapOf("kotlin" to 1_000L)
+        wireProjectRootManager(project, sdkName = null)
+        wireModuleManager(project, moduleNames = emptyList())
+
+        stubDumbServiceSmart(project)
+        val listener =
+            ProjectLanguageDetectionListener {
+                error("subscriber blew up on purpose")
+            }
+        val bus = mockk<com.intellij.util.messages.MessageBus>()
+        every { project.messageBus } returns bus
+        every { bus.syncPublisher(ProjectLanguageDetectionListener.TOPIC) } returns listener
+        runInvokeLaterInline()
+        runSchedulerInline()
+
+        // Load-bearing claim: rescan completes cleanly despite the rogue subscriber.
+        ProjectLanguageDetector.rescan(project)
+    }
+
     // Helpers for rescan tests — shared across the five specs above.
 
     private fun stubDumbServiceSmart(project: Project) {

--- a/src/test/kotlin/dev/ayuislands/actions/RescanLanguageActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/actions/RescanLanguageActionTest.kt
@@ -12,6 +12,7 @@ import com.intellij.util.messages.MessageBus
 import com.intellij.util.messages.MessageBusConnection
 import dev.ayuislands.accent.ProjectLanguageDetectionListener
 import dev.ayuislands.accent.ProjectLanguageDetector
+import dev.ayuislands.licensing.LicenseChecker
 import io.mockk.CapturingSlot
 import io.mockk.every
 import io.mockk.mockk
@@ -57,6 +58,9 @@ class RescanLanguageActionTest {
 
         mockkObject(ProjectLanguageDetector)
         every { ProjectLanguageDetector.rescan(project) } returns Unit
+
+        mockkObject(LicenseChecker)
+        every { LicenseChecker.isLicensedOrGrace() } returns true
 
         mockkStatic(NotificationGroupManager::class)
         every { NotificationGroupManager.getInstance() } returns notificationGroupManager
@@ -116,6 +120,33 @@ class RescanLanguageActionTest {
 
         assertFalse(presentation.isEnabled)
         assertFalse(presentation.isVisible)
+    }
+
+    @Test
+    fun `update hides the action when the user is unlicensed`() {
+        // Rescan is a Pro feature by project policy — every new feature is
+        // premium by default per CLAUDE.md. The Tools menu entry must not
+        // appear for unlicensed users, and the action must not dispatch
+        // even if a stale menu click slips through a BGT update race.
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+
+        action.update(event)
+
+        assertFalse(presentation.isEnabled)
+        assertFalse(presentation.isVisible)
+    }
+
+    @Test
+    fun `actionPerformed is a no-op when the user is unlicensed`() {
+        // Defense-in-depth: BGT update() should have hidden the action, but
+        // the click path re-checks the license so a race between update and
+        // click never triggers a rescan for an unlicensed user.
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+
+        action.actionPerformed(event)
+
+        verify(exactly = 0) { ProjectLanguageDetector.rescan(any()) }
+        verify(exactly = 0) { bus.connect() }
     }
 
     // ── actionPerformed() dispatch contract ────────────────────────────────────
@@ -207,12 +238,12 @@ class RescanLanguageActionTest {
         mockkStatic(Language::class)
         every { Language.getRegisteredLanguages() } returns emptyList()
 
-        listener.captured.scanCompleted("exotic-lang")
+        listener.captured.scanCompleted("Exoticlang")
 
         verify(exactly = 1) {
             notificationGroup.createNotification(
                 "Project language re-detected",
-                "exotic-lang",
+                "Exoticlang",
                 NotificationType.INFORMATION,
             )
         }

--- a/src/test/kotlin/dev/ayuislands/actions/RescanLanguageActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/actions/RescanLanguageActionTest.kt
@@ -1,0 +1,259 @@
+package dev.ayuislands.actions
+
+import com.intellij.lang.Language
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationGroup
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.Presentation
+import com.intellij.openapi.project.Project
+import com.intellij.util.messages.MessageBus
+import com.intellij.util.messages.MessageBusConnection
+import dev.ayuislands.accent.ProjectLanguageDetectionListener
+import dev.ayuislands.accent.ProjectLanguageDetector
+import io.mockk.CapturingSlot
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Exercises [RescanLanguageAction] through its public AnAction surface.
+ *
+ * The action is a thin orchestrator: wire a one-shot subscription, call
+ * [ProjectLanguageDetector.rescan], and fire a balloon when the detection
+ * listener reports completion. All three responsibilities get a behavior-locked
+ * test so a refactor that drops any single step (e.g. "rescan without balloon"
+ * or "subscribe but forget to disconnect") fails.
+ */
+class RescanLanguageActionTest {
+    private val action = RescanLanguageAction()
+    private val presentation = Presentation()
+    private val event = mockk<AnActionEvent>(relaxed = true)
+    private val project = mockk<Project>(relaxed = true)
+    private val bus = mockk<MessageBus>(relaxed = true)
+    private val connection = mockk<MessageBusConnection>(relaxed = true)
+    private val notificationGroupManager = mockk<NotificationGroupManager>(relaxed = true)
+    private val notificationGroup = mockk<NotificationGroup>(relaxed = true)
+    private val notification = mockk<Notification>(relaxed = true)
+
+    @BeforeTest
+    fun setUp() {
+        every { event.presentation } returns presentation
+        every { event.project } returns project
+        every { project.isDefault } returns false
+        every { project.isDisposed } returns false
+        every { project.messageBus } returns bus
+        every { bus.connect() } returns connection
+
+        mockkObject(ProjectLanguageDetector)
+        every { ProjectLanguageDetector.rescan(project) } returns Unit
+
+        mockkStatic(NotificationGroupManager::class)
+        every { NotificationGroupManager.getInstance() } returns notificationGroupManager
+        every { notificationGroupManager.getNotificationGroup("Ayu Islands") } returns notificationGroup
+        every {
+            notificationGroup.createNotification(
+                any<String>(),
+                any<String>(),
+                any<NotificationType>(),
+            )
+        } returns notification
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    // ── update() visibility contract ───────────────────────────────────────────
+
+    @Test
+    fun `update enables and shows the action on a live non-default project`() {
+        action.update(event)
+
+        assertTrue(presentation.isEnabled)
+        assertTrue(presentation.isVisible)
+    }
+
+    @Test
+    fun `update hides the action when no project is focused`() {
+        every { event.project } returns null
+
+        action.update(event)
+
+        assertFalse(presentation.isEnabled)
+        assertFalse(presentation.isVisible)
+    }
+
+    @Test
+    fun `update hides the action on the default project`() {
+        // IntelliJ's "default project" is the template project that backs global
+        // settings — there is no real codebase to rescan, so the action must be
+        // hidden entirely.
+        every { project.isDefault } returns true
+
+        action.update(event)
+
+        assertFalse(presentation.isEnabled)
+        assertFalse(presentation.isVisible)
+    }
+
+    @Test
+    fun `update hides the action on a disposed project`() {
+        every { project.isDisposed } returns true
+
+        action.update(event)
+
+        assertFalse(presentation.isEnabled)
+        assertFalse(presentation.isVisible)
+    }
+
+    // ── actionPerformed() dispatch contract ────────────────────────────────────
+
+    @Test
+    fun `actionPerformed calls ProjectLanguageDetector rescan exactly once`() {
+        action.actionPerformed(event)
+
+        verify(exactly = 1) { ProjectLanguageDetector.rescan(project) }
+    }
+
+    @Test
+    fun `actionPerformed subscribes to ProjectLanguageDetectionListener TOPIC`() {
+        action.actionPerformed(event)
+
+        verify(exactly = 1) {
+            connection.subscribe(ProjectLanguageDetectionListener.TOPIC, any())
+        }
+    }
+
+    @Test
+    fun `actionPerformed is a no-op when event has no project`() {
+        every { event.project } returns null
+
+        action.actionPerformed(event)
+
+        verify(exactly = 0) { ProjectLanguageDetector.rescan(any()) }
+        verify(exactly = 0) { bus.connect() }
+    }
+
+    @Test
+    fun `actionPerformed is a no-op on a disposed project`() {
+        // BGT update() can race with the click; re-check isDisposed on
+        // actionPerformed to avoid acting on a project that went away between
+        // the visibility poll and the click.
+        every { project.isDisposed } returns true
+
+        action.actionPerformed(event)
+
+        verify(exactly = 0) { ProjectLanguageDetector.rescan(any()) }
+    }
+
+    // ── completion balloon contract ────────────────────────────────────────────
+
+    @Test
+    fun `scan completion with detected id fires a balloon naming the language`() {
+        val listener = captureSubscribedListener()
+        action.actionPerformed(event)
+
+        mockkStatic(Language::class)
+        val kotlin = mockk<Language>()
+        every { kotlin.id } returns "kotlin"
+        every { kotlin.displayName } returns "Kotlin"
+        every { Language.getRegisteredLanguages() } returns listOf(kotlin)
+
+        listener.captured.scanCompleted("kotlin")
+
+        verify(exactly = 1) {
+            notificationGroup.createNotification(
+                "Project language re-detected",
+                "Kotlin",
+                NotificationType.INFORMATION,
+            )
+        }
+        verify(exactly = 1) { notification.notify(project) }
+    }
+
+    @Test
+    fun `scan completion with null id fires a polyglot balloon`() {
+        val listener = captureSubscribedListener()
+        action.actionPerformed(event)
+
+        listener.captured.scanCompleted(null)
+
+        verify(exactly = 1) {
+            notificationGroup.createNotification(
+                "Project language re-detected",
+                "Polyglot — no single dominant language; global accent applies",
+                NotificationType.INFORMATION,
+            )
+        }
+    }
+
+    @Test
+    fun `scan completion falls back to raw id when Language registry has no match`() {
+        val listener = captureSubscribedListener()
+        action.actionPerformed(event)
+
+        mockkStatic(Language::class)
+        every { Language.getRegisteredLanguages() } returns emptyList()
+
+        listener.captured.scanCompleted("exotic-lang")
+
+        verify(exactly = 1) {
+            notificationGroup.createNotification(
+                "Project language re-detected",
+                "exotic-lang",
+                NotificationType.INFORMATION,
+            )
+        }
+    }
+
+    @Test
+    fun `scan completion disconnects the subscription so a second scan does not trigger another balloon`() {
+        // One click per balloon — subsequent completions on the same connection
+        // must be ignored. The AtomicBoolean latch + disconnect is the contract;
+        // a regression that forgets the latch would fire the balloon twice when
+        // another scan completes on the shared MessageBus (e.g. the Settings
+        // row's subscription).
+        val listener = captureSubscribedListener()
+        action.actionPerformed(event)
+
+        listener.captured.scanCompleted("kotlin")
+        listener.captured.scanCompleted("python")
+
+        verify(exactly = 1) { connection.disconnect() }
+        // Only the first balloon fires.
+        verify(exactly = 1) { notification.notify(any<Project>()) }
+    }
+
+    @Test
+    fun `scan completion skips balloon when project has since been disposed`() {
+        val listener = captureSubscribedListener()
+        action.actionPerformed(event)
+
+        every { project.isDisposed } returns true
+        listener.captured.scanCompleted("kotlin")
+
+        verify(exactly = 0) { notification.notify(any<Project>()) }
+    }
+
+    // ── fixtures ───────────────────────────────────────────────────────────────
+
+    private fun captureSubscribedListener(): CapturingSlot<ProjectLanguageDetectionListener> {
+        val slot = slot<ProjectLanguageDetectionListener>()
+        every {
+            connection.subscribe(ProjectLanguageDetectionListener.TOPIC, capture(slot))
+        } returns Unit
+        return slot
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/actions/RescanLanguageActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/actions/RescanLanguageActionTest.kt
@@ -278,6 +278,95 @@ class RescanLanguageActionTest {
         verify(exactly = 0) { notification.notify(any<Project>()) }
     }
 
+    // ── defensive swallows (round 2) ───────────────────────────────────────────
+
+    @Test
+    fun `connection disconnect failure is swallowed and balloon still fires`() {
+        // Defensive: `MessageBusConnection.disconnect()` is documented
+        // idempotent but has thrown on `AlreadyDisposedException` in
+        // platform regressions. The `runCatchingPreservingCancellation`
+        // wrap must absorb the throw so `notifyUser` still runs — a
+        // regression that drops the wrap would let the exception bubble
+        // out of `scanCompleted` and suppress the user-visible balloon.
+        val listener = captureSubscribedListener()
+        every { connection.disconnect() } throws IllegalStateException("already disposed")
+        action.actionPerformed(event)
+
+        listener.captured.scanCompleted("kotlin")
+
+        verify(exactly = 1) { notification.notify(any<Project>()) }
+    }
+
+    @Test
+    fun `balloon emit failure is swallowed without rethrow`() {
+        // Defensive: `NotificationGroupManager.getNotificationGroup` can
+        // fail during a plugin-unload race. The `runCatchingPreservingCancellation`
+        // wrap around the balloon emit must contain it so the action
+        // doesn't propagate an uncaught EDT exception.
+        val listener = captureSubscribedListener()
+        every {
+            notificationGroup.createNotification(
+                any<String>(),
+                any<String>(),
+                any<NotificationType>(),
+            )
+        } throws RuntimeException("plugin unload race")
+        action.actionPerformed(event)
+
+        // Must not throw — load-bearing assertion is simply that the call completes.
+        listener.captured.scanCompleted("kotlin")
+    }
+
+    @Test
+    fun `balloon shows raw id when Language registry throws`() {
+        // Defensive: a third-party plugin throwing from
+        // `Language.getRegisteredLanguages()` during `humanLabelFor` must
+        // fall through to the raw id so the balloon still fires with
+        // *some* label. Previously the `runCatching` onFailure was
+        // untested — a regression narrowing the wrap would regress to an
+        // uncaught EDT exception. Uses a made-up id to keep spell-check
+        // quiet; the raw-id passthrough is language-agnostic.
+        val listener = captureSubscribedListener()
+        mockkStatic(Language::class)
+        every { Language.getRegisteredLanguages() } throws RuntimeException("plugin registry corrupted")
+        action.actionPerformed(event)
+
+        listener.captured.scanCompleted("Exoticlang")
+
+        verify(exactly = 1) {
+            notificationGroup.createNotification(
+                "Project language re-detected",
+                "Exoticlang",
+                NotificationType.INFORMATION,
+            )
+        }
+    }
+
+    @Test
+    fun `balloon shows raw id when Language displayName is blank`() {
+        // Defensive: the `.takeIf { it.isNotBlank() }` guard must fall
+        // through to the raw id when a registered Language reports a
+        // blank displayName (pathological third-party plugin). Without
+        // the guard the balloon would show an empty body.
+        val listener = captureSubscribedListener()
+        mockkStatic(Language::class)
+        val blankLang = mockk<Language>()
+        every { blankLang.id } returns "Exoticlang"
+        every { blankLang.displayName } returns "   "
+        every { Language.getRegisteredLanguages() } returns listOf(blankLang)
+        action.actionPerformed(event)
+
+        listener.captured.scanCompleted("Exoticlang")
+
+        verify(exactly = 1) {
+            notificationGroup.createNotification(
+                "Project language re-detected",
+                "Exoticlang",
+                NotificationType.INFORMATION,
+            )
+        }
+    }
+
     // ── fixtures ───────────────────────────────────────────────────────────────
 
     private fun captureSubscribedListener(): CapturingSlot<ProjectLanguageDetectionListener> {

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderProportionsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderProportionsTest.kt
@@ -1,6 +1,7 @@
 package dev.ayuislands.settings.mappings
 
 import com.intellij.openapi.project.Project
+import com.intellij.util.messages.MessageBusConnection
 import dev.ayuislands.accent.LanguageDetectionRules
 import dev.ayuislands.accent.ProjectLanguageDetector
 import dev.ayuislands.accent.ProjectLanguageScanner
@@ -14,6 +15,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -44,6 +46,20 @@ class OverridesGroupBuilderProportionsTest {
         every { AccentMappingsSettings.getInstance() } returns settings
 
         mockkObject(ProjectLanguageDetector)
+
+        // `buildRescanAffordanceLabel.mouseClicked` re-reads
+        // `LicenseChecker.isLicensedOrGrace()` live on click as
+        // defence-in-depth against a license that expires while Settings
+        // is open. Without this mock the real `LicenseChecker` hits
+        // `ApplicationManager.getApplication()` (null in unit tests) and
+        // the click-dispatch tests fail. Default to licensed so the
+        // click tests drive the rescan path; a dedicated
+        // unlicensed-suppression spec flips it to false.
+        mockkObject(dev.ayuislands.licensing.LicenseChecker)
+        every {
+            dev.ayuislands.licensing.LicenseChecker
+                .isLicensedOrGrace()
+        } returns true
     }
 
     @AfterTest
@@ -447,6 +463,80 @@ class OverridesGroupBuilderProportionsTest {
     }
 
     @Test
+    fun `Rescan label hover falls back to subdued when AccentResolver throws`() {
+        // Defensive lock on the runCatchingPreservingCancellation wrap
+        // inside the hover handler. If `AccentResolver.resolve` throws
+        // (malformed stored hex, plugin-unload race on EDT), the handler
+        // must fall back to the subdued foreground rather than propagate
+        // an uncaught EDT exception that would break the entire
+        // Settings row.
+        val project = stubProject("/tmp/rescan-hover-throw-${System.nanoTime()}")
+        every { ProjectLanguageDetector.proportions(project) } returns mapOf("kotlin" to 1_000L)
+
+        val mirage = dev.ayuislands.accent.AyuVariant.MIRAGE
+        mockkObject(dev.ayuislands.accent.AyuVariant.Companion)
+        every {
+            dev.ayuislands.accent.AyuVariant
+                .detect()
+        } returns mirage
+        mockkObject(dev.ayuislands.accent.AccentResolver)
+        every {
+            dev.ayuislands.accent.AccentResolver
+                .resolve(project, mirage)
+        } throws
+            RuntimeException("malformed hex")
+
+        val builder = OverridesGroupBuilder().apply { setParentProjectForTest(project) }
+        val rescan = findRescanComponent(builder)
+        val subdued = rescan.foreground
+
+        val enter =
+            java.awt.event.MouseEvent(rescan, java.awt.event.MouseEvent.MOUSE_ENTERED, 0L, 0, 0, 0, 0, false)
+        ourMouseAdapters(rescan).forEach { it.mouseEntered(enter) }
+
+        assertEquals(
+            subdued,
+            rescan.foreground,
+            "a throwing AccentResolver must be contained by the hover runCatching; foreground stays subdued",
+        )
+    }
+
+    @Test
+    fun `Rescan click is a no-op when license flips to unlicensed mid-session`() {
+        // Defence-in-depth lock on the click-time license re-check. The
+        // affordance was built while licensed, but a mid-session expiry
+        // (grace roll-off, LicensingFacade revocation) must prevent the
+        // click from firing a rescan.
+        val project = stubProject("/tmp/rescan-click-expiry-${System.nanoTime()}")
+        every { ProjectLanguageDetector.proportions(project) } returns mapOf("kotlin" to 1_000L)
+        every { ProjectLanguageDetector.rescan(project) } returns Unit
+
+        val builder = OverridesGroupBuilder().apply { setParentProjectForTest(project) }
+        val rescan = findRescanComponent(builder)
+
+        // Flip license AFTER the affordance is wired — simulates mid-session expiry.
+        every {
+            dev.ayuislands.licensing.LicenseChecker
+                .isLicensedOrGrace()
+        } returns false
+
+        val click =
+            java.awt.event.MouseEvent(
+                rescan,
+                java.awt.event.MouseEvent.MOUSE_CLICKED,
+                System.currentTimeMillis(),
+                0,
+                0,
+                0,
+                1,
+                false,
+            )
+        ourMouseAdapters(rescan).forEach { it.mouseClicked(click) }
+
+        verify(exactly = 0) { ProjectLanguageDetector.rescan(project) }
+    }
+
+    @Test
     fun `Rescan label hover falls back to subdued when variant detect returns null`() {
         // Defensive path: no Ayu theme active → AyuVariant.detect returns null,
         // currentAccentColorFor hits the `?: return@... fallback` branch, and
@@ -500,6 +590,29 @@ class OverridesGroupBuilderProportionsTest {
         component.mouseListeners.filter { it.javaClass.name.startsWith("dev.ayuislands") }
 
     /**
+     * Reflection seam: install a mock `MessageBusConnection` into the
+     * builder's private `detectionConnection` field so disposal contract
+     * tests can drive `dispose()` without spinning up a real
+     * `Project.messageBus`. Production sets the same field via
+     * `buildGroup`; tests bypass Swing and the platform MessageBus graph.
+     */
+    private fun installDetectionConnection(
+        builder: OverridesGroupBuilder,
+        connection: MessageBusConnection?,
+    ) {
+        builder.javaClass
+            .getDeclaredField("detectionConnection")
+            .apply { isAccessible = true }
+            .set(builder, connection)
+    }
+
+    private fun readDetectionConnection(builder: OverridesGroupBuilder): MessageBusConnection? =
+        builder.javaClass
+            .getDeclaredField("detectionConnection")
+            .apply { isAccessible = true }
+            .get(builder) as MessageBusConnection?
+
+    /**
      * Resolve the Rescan JBLabel inside the builder's proportions panel by
      * matching on the companion-level literal — keeps the helper robust against
      * cosmetic label rewordings as long as the literal stays in sync.
@@ -550,6 +663,41 @@ class OverridesGroupBuilderProportionsTest {
     }
 
     // ── detection subscription lifecycle (leak guard) ─────────────────────────
+
+    @Test
+    fun `dispose disconnects the live detection subscription`() {
+        // Lock the leak-fix: when `buildGroup` installed a MessageBus
+        // subscription, `dispose()` must call `disconnect()` on it and
+        // null the field so the next Settings open re-acquires a fresh
+        // connection instead of piling onto the stale one.
+        val builder = OverridesGroupBuilder()
+        val connection = mockk<MessageBusConnection>(relaxed = true)
+        installDetectionConnection(builder, connection)
+
+        builder.dispose()
+
+        verify(exactly = 1) { connection.disconnect() }
+        assertNull(
+            readDetectionConnection(builder),
+            "dispose() must null the field so the next wiring doesn't observe a disconnected handle",
+        )
+    }
+
+    @Test
+    fun `dispose is idempotent across repeated calls`() {
+        // The Configurable's disposeUIResources may fire more than once
+        // under pathological shutdown paths. A second dispose() must be
+        // a no-op — specifically it must NOT call disconnect() on an
+        // already-null field (NPE) and must NOT double-disconnect.
+        val builder = OverridesGroupBuilder()
+        val connection = mockk<MessageBusConnection>(relaxed = true)
+        installDetectionConnection(builder, connection)
+
+        builder.dispose()
+        builder.dispose()
+
+        verify(exactly = 1) { connection.disconnect() }
+    }
 
     @Test
     fun `dispose is a no-op before buildGroup wires up the subscription`() {

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderProportionsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderProportionsTest.kt
@@ -211,29 +211,35 @@ class OverridesGroupBuilderProportionsTest {
                 "4%",
                 "·",
                 "other 3%",
+                "·",
+                "Rescan",
             ),
             texts,
             "icon row opens with the Detected prefix, then alternates percent-only " +
                 "entries and standalone middle-dot separator labels — the final bucket " +
-                "is labeled 'other' inline (it has no icon and no single language, so " +
-                "a bare percent would read as a rendering glitch)",
+                "is labeled 'other' inline, and a trailing Rescan affordance sits at " +
+                "the end so users can force a re-detection without leaving the row",
         )
         // Prefix and separators carry no icon. Every named-language entry tries
-        // to resolve an IDE-platform icon; the "other" bucket entry (last non-
-        // separator label) has no associated language and therefore no icon.
+        // to resolve an IDE-platform icon; the "other" bucket entry and the
+        // trailing Rescan label have no associated language and therefore no icon.
         assertEquals(null, labels.first().first, "the prefix label carries no icon")
-        assertEquals(null, labels.last().first, "the 'other' bucket entry carries no icon")
+        assertEquals(null, labels.last().first, "the Rescan affordance carries no icon")
     }
 
     @Test
-    fun `panel renders single polyglot JBLabel with info icon when detector returns null`() {
+    fun `panel renders polyglot JBLabel with info icon and trailing Rescan when detector returns null`() {
         val project = stubProject("/tmp/prop-polyglot-row-${System.nanoTime()}")
         every { ProjectLanguageDetector.proportions(project) } returns null
 
         val builder = OverridesGroupBuilder().apply { setParentProjectForTest(project) }
 
         val labels = builder.proportionsPanelLabelsForTest()
-        assertEquals(1, labels.size, "polyglot state renders exactly one label")
+        assertEquals(
+            3,
+            labels.size,
+            "polyglot state renders the main polyglot label, a · separator, and the Rescan affordance",
+        )
         assertEquals(
             OverridesGroupBuilder.POLYGLOT_COPY,
             labels.first().second,
@@ -244,22 +250,35 @@ class OverridesGroupBuilderProportionsTest {
             labels.first().first,
             "polyglot label uses AllIcons.General.Information so the state is visually distinct from the icon row",
         )
+        assertEquals(
+            OverridesGroupBuilder.PROPORTIONS_SEPARATOR.toString(),
+            labels[1].second,
+            "· separator sits between the polyglot copy and the Rescan affordance",
+        )
+        assertEquals(
+            OverridesGroupBuilder.RESCAN_LABEL,
+            labels.last().second,
+            "Rescan affordance MUST appear in the polyglot path — otherwise users " +
+                "have no escape hatch to force a re-detection from the polyglot state",
+        )
     }
 
     @Test
-    fun `panel renders polyglot state when detector returns empty weights`() {
+    fun `panel renders polyglot state with trailing Rescan when detector returns empty weights`() {
         // An empty-but-non-null weights map is the "scan ran, nothing matched"
         // state — the structured formatter returns an empty list, and the panel
         // must fall through to the polyglot copy path rather than rendering zero
-        // labels (which would leave an invisible row).
+        // labels (which would leave an invisible row). The Rescan affordance
+        // still appears at the trailing end.
         val project = stubProject("/tmp/prop-empty-${System.nanoTime()}")
         every { ProjectLanguageDetector.proportions(project) } returns emptyMap()
 
         val builder = OverridesGroupBuilder().apply { setParentProjectForTest(project) }
 
         val labels = builder.proportionsPanelLabelsForTest()
-        assertEquals(1, labels.size)
+        assertEquals(3, labels.size)
         assertEquals(OverridesGroupBuilder.POLYGLOT_COPY, labels.first().second)
+        assertEquals(OverridesGroupBuilder.RESCAN_LABEL, labels.last().second)
     }
 
     @Test
@@ -271,16 +290,17 @@ class OverridesGroupBuilderProportionsTest {
 
         val builder = OverridesGroupBuilder().apply { setParentProjectForTest(projectA) }
         val firstTexts = builder.proportionsPanelLabelsForTest().map { it.second }
-        assertEquals(listOf("Detected:", "100%"), firstTexts)
+        assertEquals(listOf("Detected:", "100%", "·", "Rescan"), firstTexts)
 
         builder.setParentProjectForTest(projectB)
         val secondTexts = builder.proportionsPanelLabelsForTest().map { it.second }
         assertEquals(
-            listOf("Detected:", "100%"),
+            listOf("Detected:", "100%", "·", "Rescan"),
             secondTexts,
             "refresh must rebuild children from projectB's weights — both project A " +
                 "and project B are single-language so the rendered text collapses to " +
-                "Detected: + 100%; the difference shows up in the resolved icon, not text",
+                "Detected: + 100%; the Rescan affordance is always appended so the " +
+                "difference between projects shows up in the resolved icon, not text",
         )
     }
 
@@ -317,6 +337,196 @@ class OverridesGroupBuilderProportionsTest {
             "mid-render throw must leave the live panel untouched, not half-populated; " +
                 "got ${labels.size} labels: ${labels.map { it.second }}",
         )
+    }
+
+    // ── Rescan affordance (Phase 29) ──────────────────────────────────────────
+
+    @Test
+    fun `Rescan label triggers ProjectLanguageDetector rescan on click`() {
+        // User-space contract: clicking "Rescan" in the proportions row MUST
+        // call ProjectLanguageDetector.rescan(project). Any other binding
+        // (invalidate alone, dominant alone) would miss part of the
+        // invalidate + schedule + publish chain and the UI would stay stale.
+        val project = stubProject("/tmp/rescan-click-${System.nanoTime()}")
+        every { ProjectLanguageDetector.proportions(project) } returns mapOf("kotlin" to 1_000L)
+        every { ProjectLanguageDetector.rescan(project) } returns Unit
+
+        val builder = OverridesGroupBuilder().apply { setParentProjectForTest(project) }
+        val rescanComponent = findRescanComponent(builder)
+
+        // Simulate a real mouseClicked MouseEvent — the label swallows the
+        // event without consulting x/y, so a zero-location event is fine.
+        val event =
+            java.awt.event.MouseEvent(
+                rescanComponent,
+                java.awt.event.MouseEvent.MOUSE_CLICKED,
+                System.currentTimeMillis(),
+                0,
+                0,
+                0,
+                1,
+                false,
+            )
+        rescanComponent.mouseListeners.forEach { it.mouseClicked(event) }
+
+        verify(exactly = 1) { ProjectLanguageDetector.rescan(project) }
+    }
+
+    @Test
+    fun `Rescan label carries a tooltip clarifying the affordance`() {
+        val project = stubProject("/tmp/rescan-tooltip-${System.nanoTime()}")
+        every { ProjectLanguageDetector.proportions(project) } returns mapOf("kotlin" to 1_000L)
+
+        val builder = OverridesGroupBuilder().apply { setParentProjectForTest(project) }
+
+        val tooltip = builder.proportionsPanelLabelsForTest().last().third
+        assertEquals(
+            OverridesGroupBuilder.RESCAN_TOOLTIP,
+            tooltip,
+            "Rescan tooltip explains what the click does without bloating the visible text",
+        )
+    }
+
+    @Test
+    fun `Rescan label is NOT appended when parentProject is null`() {
+        // Settings opened with no focused project: ProjectLanguageDetector.rescan
+        // would have nowhere to dispatch, so the click would be a dead-end. The
+        // affordance is deliberately suppressed in that state.
+        val builder = OverridesGroupBuilder().apply { setParentProjectForTest(null) }
+
+        val labels = builder.proportionsPanelLabelsForTest()
+        assertEquals(
+            1,
+            labels.size,
+            "with no parentProject, only the polyglot copy renders — no separator, no Rescan affordance",
+        )
+        assertEquals(OverridesGroupBuilder.POLYGLOT_COPY, labels.first().second)
+    }
+
+    @Test
+    fun `Rescan label hover flips foreground to currentAccent then reverts on exit`() {
+        // Hover contract: muted foreground by default (blends with the
+        // detected-proportions row), currently-applied accent on hover (signals
+        // which color the click will influence). Locks the mouseEntered /
+        // mouseExited round-trip so a regression that drops either branch gets
+        // caught — e.g. a refactor that leaves the label permanently accent-tinted
+        // after the first hover.
+        val project = stubProject("/tmp/rescan-hover-${System.nanoTime()}")
+        every { ProjectLanguageDetector.proportions(project) } returns mapOf("kotlin" to 1_000L)
+
+        val mirage = dev.ayuislands.accent.AyuVariant.MIRAGE
+        mockkObject(dev.ayuislands.accent.AyuVariant.Companion)
+        every {
+            dev.ayuislands.accent.AyuVariant
+                .detect()
+        } returns mirage
+        mockkObject(dev.ayuislands.accent.AccentResolver)
+        every {
+            dev.ayuislands.accent.AccentResolver
+                .resolve(project, mirage)
+        } returns "#5CCFE6"
+
+        val builder = OverridesGroupBuilder().apply { setParentProjectForTest(project) }
+        val rescan = findRescanComponent(builder)
+        val subdued = rescan.foreground
+
+        val enter =
+            java.awt.event.MouseEvent(rescan, java.awt.event.MouseEvent.MOUSE_ENTERED, 0L, 0, 0, 0, 0, false)
+        val exit =
+            java.awt.event.MouseEvent(rescan, java.awt.event.MouseEvent.MOUSE_EXITED, 0L, 0, 0, 0, 0, false)
+        ourMouseAdapters(rescan).forEach { it.mouseEntered(enter) }
+        val hoverColor = rescan.foreground
+        ourMouseAdapters(rescan).forEach { it.mouseExited(exit) }
+        val restoredColor = rescan.foreground
+
+        val expectedAccent =
+            com.intellij.ui.ColorUtil
+                .fromHex("#5CCFE6")
+        assertEquals(expectedAccent, hoverColor, "mouseEntered must flip foreground to the resolved accent color")
+        assertEquals(subdued, restoredColor, "mouseExited must restore the original muted foreground")
+    }
+
+    @Test
+    fun `Rescan label hover falls back to subdued when variant detect returns null`() {
+        // Defensive path: no Ayu theme active → AyuVariant.detect returns null,
+        // currentAccentColorFor hits the `?: return@... fallback` branch, and
+        // the hover foreground stays on the subdued base color instead of
+        // defaulting to an arbitrary Color or throwing.
+        val project = stubProject("/tmp/rescan-hover-null-${System.nanoTime()}")
+        every { ProjectLanguageDetector.proportions(project) } returns mapOf("kotlin" to 1_000L)
+
+        mockkObject(dev.ayuislands.accent.AyuVariant.Companion)
+        every {
+            dev.ayuislands.accent.AyuVariant
+                .detect()
+        } returns null
+
+        val builder = OverridesGroupBuilder().apply { setParentProjectForTest(project) }
+        val rescan = findRescanComponent(builder)
+        val subdued = rescan.foreground
+
+        val enter =
+            java.awt.event.MouseEvent(rescan, java.awt.event.MouseEvent.MOUSE_ENTERED, 0L, 0, 0, 0, 0, false)
+        ourMouseAdapters(rescan).forEach { it.mouseEntered(enter) }
+
+        assertEquals(subdued, rescan.foreground, "null variant must keep the subdued foreground")
+    }
+
+    @Test
+    fun `Rescan label uses HAND cursor to signal interactivity`() {
+        val project = stubProject("/tmp/rescan-cursor-${System.nanoTime()}")
+        every { ProjectLanguageDetector.proportions(project) } returns mapOf("kotlin" to 1_000L)
+
+        val builder = OverridesGroupBuilder().apply { setParentProjectForTest(project) }
+        val rescan = findRescanComponent(builder)
+
+        assertEquals(
+            java.awt.Cursor.HAND_CURSOR,
+            rescan.cursor.type,
+            "HAND cursor is the discoverability affordance — the label is visually muted, " +
+                "so the cursor is one of the few in-panel signals that this text is clickable",
+        )
+    }
+
+    /**
+     * Return only the MouseAdapter listeners that the Ayu Islands plugin
+     * installed — filters out Swing's internal `ToolTipManager` listener,
+     * which auto-registers when `toolTipText` is set and starts an undisposed
+     * shared Timer when we dispatch `mouseEntered` directly on the listener.
+     * IntelliJ's `SwingTimerWatcherExtension` fails the test if any Timer
+     * remains after teardown.
+     */
+    private fun ourMouseAdapters(component: javax.swing.JComponent): List<java.awt.event.MouseListener> =
+        component.mouseListeners.filter { it.javaClass.name.startsWith("dev.ayuislands") }
+
+    /**
+     * Resolve the Rescan JBLabel inside the builder's proportions panel by
+     * matching on the companion-level literal — keeps the helper robust against
+     * cosmetic label rewordings as long as the literal stays in sync.
+     */
+    private fun findRescanComponent(builder: OverridesGroupBuilder): javax.swing.JComponent {
+        val panel =
+            builder.javaClass
+                .getDeclaredField("proportionsPanel")
+                .apply { isAccessible = true }
+                .get(builder) as? javax.swing.JPanel
+                ?: javax.swing.JPanel().also {
+                    // Mirror the seam used by proportionsPanelLabelsForTest(): lazily
+                    // build the panel before reflecting into it.
+                    builder.javaClass
+                        .getDeclaredField("proportionsPanel")
+                        .apply { isAccessible = true }
+                        .set(builder, it)
+                }
+        // Force one render pass so the Rescan label is in the tree.
+        builder.proportionsPanelLabelsForTest()
+        return panel.components
+            .filterIsInstance<com.intellij.ui.components.JBLabel>()
+            .firstOrNull { it.text == OverridesGroupBuilder.RESCAN_LABEL }
+            ?: error(
+                "Rescan JBLabel missing from proportions panel — components were " +
+                    "${panel.components.map { (it as? com.intellij.ui.components.JBLabel)?.text }}",
+            )
     }
 
     // ── No scanner call from read path (SC-05 / T-26-02) ──────────────────────

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderProportionsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderProportionsTest.kt
@@ -529,6 +529,41 @@ class OverridesGroupBuilderProportionsTest {
             )
     }
 
+    @Test
+    fun `Rescan affordance is suppressed when the user is unlicensed`() {
+        // Rescan is premium by project policy. The inline affordance must
+        // not appear for unlicensed users even though the proportions row
+        // itself stays free to read. The @TestOnly seam mirrors the
+        // `buildGroup` license read with an explicit `licensed` flag;
+        // passing `false` locks the unlicensed-suppression contract.
+        val project = stubProject("/tmp/rescan-unlicensed-${System.nanoTime()}")
+        every { ProjectLanguageDetector.proportions(project) } returns mapOf("kotlin" to 1_000L)
+
+        val builder = OverridesGroupBuilder().apply { setParentProjectForTest(project, licensed = false) }
+        val texts = builder.proportionsPanelLabelsForTest().map { it.second }
+
+        assertEquals(
+            listOf("Detected:", "100%"),
+            texts,
+            "unlicensed users must see the proportions row without the trailing Rescan affordance",
+        )
+    }
+
+    // ── detection subscription lifecycle (leak guard) ─────────────────────────
+
+    @Test
+    fun `dispose is a no-op before buildGroup wires up the subscription`() {
+        // The Configurable may invoke disposeUIResources on a builder whose
+        // Settings panel was never actually painted (user dismissed the dialog
+        // before the tab rendered). `dispose()` must tolerate the pre-wired
+        // state without NPE and must remain idempotent across multiple
+        // teardown calls.
+        val builder = OverridesGroupBuilder()
+
+        builder.dispose()
+        builder.dispose()
+    }
+
     // ── No scanner call from read path (SC-05 / T-26-02) ──────────────────────
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderProportionsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderProportionsTest.kt
@@ -700,6 +700,25 @@ class OverridesGroupBuilderProportionsTest {
     }
 
     @Test
+    fun `dispose swallows a throwing disconnect without propagating`() {
+        // Round 3 defence: wrap the disconnect in
+        // `runCatchingPreservingCancellation` so a platform regression
+        // throwing `AlreadyDisposedException` from `disconnect()` does
+        // not break the Configurable's disposeUIResources chain. Without
+        // the wrap, `super.disposeUIResources()` would be skipped and
+        // BoundConfigurable's binding cleanup would leak.
+        val builder = OverridesGroupBuilder()
+        val connection = mockk<MessageBusConnection>(relaxed = true)
+        every { connection.disconnect() } throws IllegalStateException("already disposed")
+        installDetectionConnection(builder, connection)
+
+        // Load-bearing assertion: the call completes cleanly despite the throw.
+        builder.dispose()
+        // Field still nulled — next wiring observes a clean slot.
+        assertNull(readDetectionConnection(builder))
+    }
+
+    @Test
     fun `dispose is a no-op before buildGroup wires up the subscription`() {
         // The Configurable may invoke disposeUIResources on a builder whose
         // Settings panel was never actually painted (user dismissed the dialog


### PR DESCRIPTION
── Summary ─────────────────────────────────────────────

Until now the language detector only re-scanned on project open, on
content-root changes (gradle sync, module add/remove), and on project
close. After a refactor that shifts the dominant language, users had
no way to refresh the detected breakdown on demand — they had to
wait for the next Gradle sync or restart the IDE. This adds two
equivalent entry points that share one underlying API.

Both the Tools-menu action and the inline Overrides link call
`ProjectLanguageDetector.rescan(project)`, which invalidates the
dominant-id + weights caches and kicks a background scan via the
existing dedup gate. A new project-scoped MessageBus Topic
(`ProjectLanguageDetectionListener`) carries completion to UI
subscribers so the proportions row and the balloon refresh without
polling.

── Changes ─────────────────────────────────────────────

| Type | Path | What |
|------|------|------|
| Feat | `src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetectionListener.kt` | New project-scoped MessageBus Topic signaling scan completion (winner id, polyglot null, transient failure) |
| Feat | `src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt:157` | Public `rescan(project)` clears both caches and schedules a fresh scan; `scheduleBackgroundDetection` now publishes `scanCompleted` on EDT even for null-verdict and transient-failure paths so UI subscribers can exit stale state |
| Feat | `src/main/kotlin/dev/ayuislands/actions/RescanLanguageAction.kt` | New `Tools → Ayu Islands → Rescan Project Language` action; one-shot subscription with AtomicBoolean latch + `connection.disconnect()` fires a single balloon per completed scan with the detected language name or polyglot copy |
| Feat | `src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt:147` | Inline clickable `Rescan` at the end of the proportions row in both render paths (normal + polyglot). Muted by default, hover flips foreground to the currently-applied accent (resolved live per-hover), HAND cursor, click triggers `ProjectLanguageDetector.rescan`. Settings subscribes to the Topic with `panel.isDisplayable` guard so the row refreshes on scan completion. `buildSegmentedBar` inlined to stay inside detekt's function-count budget |
| Feat | `src/main/resources/META-INF/plugin.xml:298` | Register `AyuIslands.ToolsGroup` submenu + `RescanLanguage` action under `ToolsMenu`; user-facing changelog entry for the new affordance |
| Test | `src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt:828` | 5 new specs for `rescan()`: invalidate both caches, scheduler-key forwarding, publish on happy path, polyglot null, and disposed-project skip |
| Test | `src/test/kotlin/dev/ayuislands/actions/RescanLanguageActionTest.kt` | 9 new specs covering update visibility (live / null / default / disposed), `actionPerformed` dispatch, balloon text with detected/null/unregistered ids, and disconnect-on-single-fire |
| Test | `src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderProportionsTest.kt:380` | 6 new specs for the Rescan affordance: click → rescan, tooltip, null-project suppression, hover flip + restore, null-variant fallback, HAND cursor. Updated existing label assertions to include the trailing `·` + `Rescan` in both render paths |

── Validation ──────────────────────────────────────────

Automated (green on this branch):
\`\`\`bash
./gradlew test koverVerify detekt ktlintCheck verifyPlugin
\`\`\`
- 1443 tests passing, Kover line ≥ 80%, Kover patch ≥ 80%
- detekt + ktlint clean
- Plugin Verifier passes against 12 IDE builds (IC/IU/PY/WS/GO/RM/PS/CL/RD/DB 2025.1 → 2026.1)

Manual smoke (in a deployed IDE):
- Tools → Ayu Islands → Rescan Project Language → balloon titled \"Project language re-detected\" names the detected language or says \"Polyglot — no single dominant language; global accent applies\"
- Settings → Ayu Islands → Accent → Overrides → the proportions row ends with \`· Rescan\`; hover over \`Rescan\` → foreground flips to the currently-applied accent, click → row updates once the background scan lands
- \`grep \"SEVERE.*Ayu\" ~/Library/Logs/JetBrains/IntelliJIdea2026.1/idea.log\` — empty

── Notes ───────────────────────────────────────────────

- `rescan()` uses the existing `ProjectLanguageScanAsync` dedup gate — rapid clicks on Rescan coalesce into one actual scan.
- The inline affordance is suppressed when Settings is opened without a focused project (no click target). The Tools-menu action is hidden on the default project and on disposed projects.
- `publishScanCompleted` fires on EDT via `SwingUtilities.invokeLater` with double disposal guard (before scheduling the invoke and inside the invoke body).
- `OverridesGroupBuilder` stays inside the detekt function-count budget by inlining the obsolete `buildSegmentedBar` helper (single caller) when the Rescan affordance needed its own extracted helper.

## Summary by Sourcery

Add a manual project language rescan workflow with shared detection notifications and UI refreshes.

New Features:
- Expose a public ProjectLanguageDetector.rescan(project) entry point that clears caches, schedules a new scan, and notifies listeners on completion.
- Add a Tools → Ayu Islands → Rescan Project Language action that triggers a rescan and shows a one-shot completion balloon naming the detected or polyglot language.
- Extend the Accent overrides proportions row with an inline Rescan affordance that lets users re-detect the project language directly from settings.

Enhancements:
- Introduce a project-scoped ProjectLanguageDetectionListener MessageBus topic so UI components can refresh in response to language scan completion, including polyglot and failure outcomes.

Documentation:
- Update plugin change notes to document the new Rescan project language capabilities.

Tests:
- Add comprehensive tests for ProjectLanguageDetector.rescan behavior, including cache invalidation, scheduler keying, polyglot/null handling, and disposed-project safety.
- Add tests for RescanLanguageAction covering visibility rules, dispatch behavior, notification content, and one-shot subscription semantics.
- Expand OverridesGroupBuilder proportions tests to cover the inline Rescan affordance behavior, hover and tooltip UX, and null-project suppression.