### PR TITLE
refactor(accent): sealed ScanOutcome + safelyDisconnectDetection helper

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "9860632"
+          last_verified_sha: "c9b8840"
           last_verified_date: "2026-04-19"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "9860632"
+          last_verified_sha: "c9b8840"
           last_verified_date: "2026-04-19"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "f3b7fc6"
+          last_verified_sha: "9860632"
           last_verified_date: "2026-04-19"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "f3b7fc6"
+          last_verified_sha: "9860632"
           last_verified_date: "2026-04-19"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetectionListener.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetectionListener.kt
@@ -21,26 +21,23 @@ import com.intellij.util.messages.Topic
  */
 internal fun interface ProjectLanguageDetectionListener {
     /**
-     * Invoked after `ProjectLanguageDetector` settles a scan (successful or
-     * non-cacheable transient failure) OR after a `rescan` call whose
-     * `AccentResolver.projectKey` returned null (the scheduler is bypassed
-     * but the listener still fires so one-shot subscribers can unblock).
+     * Invoked after `ProjectLanguageDetector` settles a scan (successful,
+     * polyglot, or non-cacheable transient failure) OR after a `rescan`
+     * call whose `AccentResolver.projectKey` returned null.
      *
-     * @param detectedId the dominant language id the detector settled on,
-     *   or `null` when the scan was polyglot (definitive no-winner verdict),
-     *   hit a non-cacheable transient failure (scanner threw, index read
-     *   aborted), or the caller was a `rescan` with an unresolvable project
-     *   key. Note: dumb mode and pre-scan disposal short-circuit inside
-     *   `scheduleBackgroundDetection` and produce *no* publish at all;
+     * @param outcome structurally distinguishes the three end states;
+     *   see [ScanOutcome] for the discriminator contract. Dumb mode and
+     *   pre-scan disposal short-circuit inside
+     *   `scheduleBackgroundDetection` and produce *no* publish at all —
      *   subscribers must not treat absence of `scanCompleted` as an error.
      *
      *   Callers rendering proportions MUST re-query
-     *   [ProjectLanguageDetector.proportions] instead of relying on this id
-     *   alone — the weights cache is the authoritative source for the
-     *   proportions row and may be populated (or deliberately empty)
-     *   independently of the winner id.
+     *   [ProjectLanguageDetector.proportions] instead of relying on the
+     *   outcome alone — the weights cache is the authoritative source for
+     *   the proportions row and may be populated (or deliberately empty)
+     *   independently of the outcome shape.
      */
-    fun scanCompleted(detectedId: String?)
+    fun scanCompleted(outcome: ScanOutcome)
 
     companion object {
         val TOPIC: Topic<ProjectLanguageDetectionListener> =

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
@@ -187,8 +187,8 @@ object ProjectLanguageDetector {
                 // project close. `AccentResolver.projectKey` already logged the
                 // reason it returned null (base-path throw, canonicalization
                 // failure) — this branch is about the *user-facing* symptom.
-                LOG.info("rescan: projectKey unavailable; publishing null scanCompleted so subscribers unblock")
-                publishScanCompleted(project, null)
+                LOG.info("rescan: projectKey unavailable; publishing Unavailable so subscribers unblock")
+                publishScanCompleted(project, ScanOutcome.Unavailable)
                 return
             }
         cache.remove(key)
@@ -285,17 +285,27 @@ object ProjectLanguageDetector {
                 return@schedule
             }
             val detected = detectAndCache(project, key)
-            // Publish even when `detected` is null — UI subscribers (the
-            // Settings proportions row, the Rescan balloon) need to refresh
-            // their projection of the cache regardless of whether the scan
-            // produced a winner, a polyglot null, or a non-cacheable
-            // transient failure. A null publish after a Rescan click is the
-            // only way the UI can exit the stale "old winner" state when
-            // the project has since drifted into polyglot territory.
+            // Classify into a typed ScanOutcome so subscribers can
+            // distinguish polyglot (definitive no-winner) from
+            // Unavailable (transient — scanner threw, dumb-mode race).
+            // Discriminator: `detectAndCache` writes `cache[key]` only
+            // when the underlying DetectionResult is cacheable. After
+            // the call:
+            //   - detected != null → cache holds the id → Detected
+            //   - detected == null && cache[key] != null → cache holds
+            //     NULL_SENTINEL → definitive polyglot verdict
+            //   - detected == null && cache[key] == null → non-cacheable
+            //     transient failure → Unavailable
+            val outcome: ScanOutcome =
+                when {
+                    detected != null -> ScanOutcome.Detected(detected)
+                    cache[key] != null -> ScanOutcome.Polyglot
+                    else -> ScanOutcome.Unavailable
+                }
             if (detected != null) {
                 tryRefreshAccentForDetected(project, detected)
             }
-            publishScanCompleted(project, detected)
+            publishScanCompleted(project, outcome)
         }
     }
 
@@ -311,7 +321,7 @@ object ProjectLanguageDetector {
      */
     private fun publishScanCompleted(
         project: Project,
-        detectedId: String?,
+        outcome: ScanOutcome,
     ) {
         if (project.isDisposed) {
             LOG.debug("publishScanCompleted dropped before invokeLater: project already disposed")
@@ -325,7 +335,7 @@ object ProjectLanguageDetector {
             runCatchingPreservingCancellation {
                 project.messageBus
                     .syncPublisher(ProjectLanguageDetectionListener.TOPIC)
-                    .scanCompleted(detectedId)
+                    .scanCompleted(outcome)
             }.onFailure { exception ->
                 LOG.warn("scanCompleted publish failed; subscribers will not refresh for this scan", exception)
             }

--- a/src/main/kotlin/dev/ayuislands/accent/ScanOutcome.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ScanOutcome.kt
@@ -1,0 +1,48 @@
+package dev.ayuislands.accent
+
+/**
+ * Typed result payload for [ProjectLanguageDetectionListener.scanCompleted].
+ *
+ * Replaces the previous nullable `String?` signature so subscribers can
+ * distinguish the three post-scan states structurally rather than
+ * re-querying [ProjectLanguageDetector.proportions] to tell polyglot
+ * (definitive no-winner) apart from a transient failure (scanner threw,
+ * rescan with unresolvable project key, disposal race). The payload is
+ * advisory — subscribers that render proportions MUST still re-query
+ * `proportions()` because the weights cache is the authoritative source
+ * for the UI row — but the discriminator lets the UI decide whether the
+ * previous paint is still correct (Unavailable → keep it) or a
+ * polyglot label should replace it (Polyglot → overwrite).
+ *
+ * Sealed hierarchy so exhaustive `when` forces callers to handle new
+ * outcomes if the set ever grows (e.g., a future "Scanning" interim
+ * state).
+ */
+internal sealed interface ScanOutcome {
+    /**
+     * Scan settled on a dominant language. [languageId] is the lowercase
+     * AYU id from [LanguageDetectionRules].
+     */
+    data class Detected(
+        val languageId: String,
+    ) : ScanOutcome
+
+    /**
+     * Scan ran cleanly but produced no winner — either no language
+     * clears the dominance threshold, no plurality margin, or the
+     * legacy SDK/module tiebreaker did not qualify. Definitive verdict:
+     * subscribers can render the polyglot copy with confidence that
+     * the weights cache is in sync.
+     */
+    object Polyglot : ScanOutcome
+
+    /**
+     * Scan could not produce an authoritative answer — scanner threw,
+     * dumb-mode race, disposal race, or a `rescan` was invoked with an
+     * unresolvable project key. Subscribers should prefer keeping the
+     * previous UI paint and try again on the next event; the cache is
+     * intentionally not populated so [ProjectLanguageDetector.dominant]
+     * will re-scan on the next call.
+     */
+    object Unavailable : ScanOutcome
+}

--- a/src/main/kotlin/dev/ayuislands/actions/RescanLanguageAction.kt
+++ b/src/main/kotlin/dev/ayuislands/actions/RescanLanguageAction.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
 import dev.ayuislands.accent.ProjectLanguageDetectionListener
 import dev.ayuislands.accent.ProjectLanguageDetector
+import dev.ayuislands.accent.ScanOutcome
 import dev.ayuislands.accent.runCatchingPreservingCancellation
 import dev.ayuislands.licensing.LicenseChecker
 
@@ -61,23 +62,23 @@ internal class RescanLanguageAction : DumbAwareAction() {
             java.util.concurrent.atomic
                 .AtomicBoolean(false)
         val listener =
-            ProjectLanguageDetectionListener { detectedId ->
+            ProjectLanguageDetectionListener { outcome ->
                 if (!fired.compareAndSet(false, true)) return@ProjectLanguageDetectionListener
                 runCatchingPreservingCancellation { connection.disconnect() }
                     .onFailure { exception ->
                         LOG.debug("Rescan balloon connection disconnect failed", exception)
                     }
-                notifyUser(project, detectedId)
+                notifyUser(project, outcome)
             }
         connection.subscribe(ProjectLanguageDetectionListener.TOPIC, listener)
     }
 
     private fun notifyUser(
         project: Project,
-        detectedId: String?,
+        outcome: ScanOutcome,
     ) {
         if (project.isDisposed) return
-        val label = humanLabelFor(detectedId)
+        val label = humanLabelFor(outcome)
         runCatchingPreservingCancellation {
             NotificationGroupManager
                 .getInstance()
@@ -93,17 +94,28 @@ internal class RescanLanguageAction : DumbAwareAction() {
     }
 
     /**
-     * Resolve an AYU language id to a display name using the platform registry,
-     * falling back to the raw id when the language plugin has been unloaded
-     * between scan and render. Null id means "no dominant language" —
-     * render the polyglot copy.
+     * Resolve a [ScanOutcome] to a human-readable balloon body.
+     * [ScanOutcome.Detected] maps to the registered Language `displayName`
+     * (case-insensitive, raw id on lookup failure or blank displayName).
+     * [ScanOutcome.Polyglot] and [ScanOutcome.Unavailable] both map to the
+     * polyglot copy today — from the user's perspective "no dominant
+     * language right now" reads the same whether the scan definitively
+     * said polyglot or hit a transient failure, and the UI keeps a
+     * single copy string rather than surfacing detector-internal
+     * transience.
      *
-     * Case-insensitive lookup because `Language.id` casing varies per plugin
-     * (`"JAVA"` / `"kotlin"` / `"JavaScript"`) while the detector always
-     * normalizes to lowercase via [dev.ayuislands.accent.LanguageDetectionRules].
+     * Case-insensitive lookup because `Language.id` casing varies per
+     * plugin (`"JAVA"` / `"kotlin"` / `"JavaScript"`) while the detector
+     * always normalises to lowercase via
+     * [dev.ayuislands.accent.LanguageDetectionRules].
      */
-    private fun humanLabelFor(detectedId: String?): String {
-        if (detectedId == null) return POLYGLOT_LABEL
+    private fun humanLabelFor(outcome: ScanOutcome): String =
+        when (outcome) {
+            is ScanOutcome.Detected -> displayNameFor(outcome.languageId)
+            ScanOutcome.Polyglot, ScanOutcome.Unavailable -> POLYGLOT_LABEL
+        }
+
+    private fun displayNameFor(detectedId: String): String {
         val display =
             runCatchingPreservingCancellation {
                 Language

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt
@@ -12,6 +12,7 @@ import com.intellij.ui.dsl.builder.Align
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.util.ui.JBUI
 import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.accent.runCatchingPreservingCancellation
 import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.onboarding.OnboardingUrls
@@ -310,11 +311,17 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
         // from running. The MessageBus subscription in overrides is the
         // load-bearing cleanup — a skipped super would leak the
         // BoundConfigurable binding too.
+        // Cancellation-preserving wrap keeps structured-concurrency
+        // semantics if a future refactor moves this dispose chain into
+        // a coroutine scope; today disposeUIResources is a plain EDT
+        // callback but the sibling disconnect wraps in
+        // OverridesGroupBuilder use the same variant, so we stay
+        // consistent across the module.
         panels.forEach { panel ->
-            runCatching { panel.dispose() }
+            runCatchingPreservingCancellation { panel.dispose() }
                 .onFailure { log.warn("Panel dispose threw for ${panel.javaClass.simpleName}", it) }
         }
-        runCatching { accentPanel.overrides.dispose() }
+        runCatchingPreservingCancellation { accentPanel.overrides.dispose() }
             .onFailure { log.warn("OverridesGroupBuilder dispose threw", it) }
         super.disposeUIResources()
     }

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -156,17 +156,34 @@ class OverridesGroupBuilder {
      * to call multiple times; no-op when the builder was never wired up.
      */
     fun dispose() {
-        // Wrap the disconnect in runCatchingPreservingCancellation to
-        // match the sibling defence in RescanLanguageAction: the platform
-        // has been observed to throw `AlreadyDisposedException` from
-        // `MessageBusConnection.disconnect()` during a plugin-unload
-        // race. Without the wrap, a throw here propagates up through
-        // `AyuIslandsConfigurable.disposeUIResources` and skips both the
-        // remaining panel teardown and `super.disposeUIResources`, which
-        // would leak the `BoundConfigurable` binding cleanup.
+        safelyDisconnectDetection("dispose")
+    }
+
+    /**
+     * Shared disconnect-and-null helper for the two call sites that
+     * tear down [detectionConnection]: [dispose] from
+     * `AyuIslandsConfigurable.disposeUIResources` and the re-entry
+     * guard inside [buildGroup] when a variant swap reuses the builder.
+     *
+     * Wrapping the disconnect in `runCatchingPreservingCancellation`
+     * matches the sibling defence in
+     * [dev.ayuislands.actions.RescanLanguageAction]: the platform has
+     * been observed to throw `AlreadyDisposedException` from
+     * `MessageBusConnection.disconnect()` during a plugin-unload race.
+     * Without the wrap, a throw here propagates up through
+     * `AyuIslandsConfigurable.disposeUIResources` and skips both the
+     * remaining panel teardown and `super.disposeUIResources`, which
+     * would leak the `BoundConfigurable` binding cleanup.
+     *
+     * The [site] string names the caller in the breadcrumb so triage
+     * can distinguish a dispose-path failure from a rebuild-path one —
+     * the former is a Settings-close race, the latter is a mid-session
+     * variant swap.
+     */
+    private fun safelyDisconnectDetection(site: String) {
         runCatchingPreservingCancellation { detectionConnection?.disconnect() }
             .onFailure { exception ->
-                LOG.debug("OverridesGroupBuilder detection disconnect failed", exception)
+                LOG.debug("OverridesGroupBuilder $site disconnect failed", exception)
             }
         detectionConnection = null
     }
@@ -273,12 +290,10 @@ class OverridesGroupBuilder {
         // propagate out of `buildGroup` and break the Settings render path.
         // The project MessageBus is the ultimate safety net — if Settings is
         // orphaned without disposeUI firing, the connection still drops on
-        // project close.
-        runCatchingPreservingCancellation { detectionConnection?.disconnect() }
-            .onFailure { exception ->
-                LOG.debug("OverridesGroupBuilder re-entry disconnect failed", exception)
-            }
-        detectionConnection = null
+        // project close. Shared with `dispose()` via
+        // [safelyDisconnectDetection] so a single red/green test covers
+        // both call sites by construction.
+        safelyDisconnectDetection("re-entry")
         // The `panel.isDisplayable` guard inside invokeLater below covers
         // the window where Settings has been closed but dispose hasn't
         // fired yet — without it, `populateProportionsPanel` would paint
@@ -800,7 +815,21 @@ class OverridesGroupBuilder {
                         AllIcons.Actions.PinTab,
                     ) {
                         override fun actionPerformed(event: AnActionEvent) {
-                            pinCurrentProject()
+                            // Inlined from the former `pinCurrentProject` helper to
+                            // keep the class under detekt's 25-function cap after
+                            // [safelyDisconnectDetection] was extracted. Behaviour
+                            // unchanged: capture focused project, derive canonical
+                            // key, pin with the current variant's global accent.
+                            val project = parentProject ?: return
+                            if (project.isDefault || project.isDisposed) return
+                            val key = AccentResolver.projectKey(project) ?: return
+                            if (projectModel.containsPath(key)) return
+                            val variant = AyuVariant.detect() ?: AyuVariant.MIRAGE
+                            val hex = AyuIslandsSettings.getInstance().getAccentForVariant(variant)
+                            val name = project.name.takeIf { it.isNotBlank() } ?: File(key).name
+                            val index = projectModel.add(ProjectMapping(key, name, hex))
+                            projectTable.selectionModel.setSelectionInterval(index, index)
+                            fireChanged()
                         }
 
                         override fun update(event: AnActionEvent) {
@@ -871,19 +900,6 @@ class OverridesGroupBuilder {
         val hex = dialog.resultHex ?: return
         val name = dialog.resultDisplayName ?: File(path).name
         val index = projectModel.add(ProjectMapping(path, name, hex))
-        projectTable.selectionModel.setSelectionInterval(index, index)
-        fireChanged()
-    }
-
-    private fun pinCurrentProject() {
-        val project = parentProject ?: return
-        if (project.isDefault || project.isDisposed) return
-        val key = AccentResolver.projectKey(project) ?: return
-        if (projectModel.containsPath(key)) return
-        val variant = AyuVariant.detect() ?: AyuVariant.MIRAGE
-        val hex = AyuIslandsSettings.getInstance().getAccentForVariant(variant)
-        val name = project.name.takeIf { it.isNotBlank() } ?: File(key).name
-        val index = projectModel.add(ProjectMapping(key, name, hex))
         projectTable.selectionModel.setSelectionInterval(index, index)
         fireChanged()
     }

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
@@ -924,6 +924,33 @@ class ProjectLanguageDetectorTest {
     }
 
     @Test
+    fun `rescan publishes Unavailable when scanner hits a non-cacheable transient failure`() {
+        // Scanner returns null when it can't give an authoritative answer
+        // (ReadAction throw, disposal race, DumbService edge). The
+        // DetectionResult carries cacheable=false, so detectAndCache does
+        // NOT write the dominant-id cache. scheduleBackgroundDetection's
+        // classifier then picks the third when-arm:
+        //   detected == null && cache[key] == null → Unavailable.
+        // Locks the discriminator that distinguishes Unavailable from
+        // Polyglot — a regression collapsing both into a single outcome
+        // would surface here.
+        val project = stubProject("/tmp/rescan-publish-unavailable-${System.nanoTime()}")
+        every { ProjectLanguageScanner.scan(project) } returns null
+        wireProjectRootManager(project, sdkName = null)
+        wireModuleManager(project, moduleNames = emptyList())
+
+        stubDumbServiceSmart(project)
+        val listener = mockk<ProjectLanguageDetectionListener>(relaxed = true)
+        wireMessageBus(project, listener)
+        runInvokeLaterInline()
+        runSchedulerInline()
+
+        ProjectLanguageDetector.rescan(project)
+
+        verify(exactly = 1) { listener.scanCompleted(ScanOutcome.Unavailable) }
+    }
+
+    @Test
     fun `rescan publishes scanCompleted with null on polyglot no-winner verdict`() {
         // 50/50 split with no SDK hint → scan returns null winner → detector
         // caches the null verdict → publishScanCompleted fires with null so

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
@@ -920,7 +920,7 @@ class ProjectLanguageDetectorTest {
 
         ProjectLanguageDetector.rescan(project)
 
-        verify(exactly = 1) { listener.scanCompleted("python") }
+        verify(exactly = 1) { listener.scanCompleted(ScanOutcome.Detected("python")) }
     }
 
     @Test
@@ -942,7 +942,7 @@ class ProjectLanguageDetectorTest {
 
         ProjectLanguageDetector.rescan(project)
 
-        verify(exactly = 1) { listener.scanCompleted(null) }
+        verify(exactly = 1) { listener.scanCompleted(ScanOutcome.Polyglot) }
     }
 
     @Test
@@ -978,15 +978,17 @@ class ProjectLanguageDetectorTest {
     }
 
     @Test
-    fun `rescan on null project key publishes null scanCompleted`() {
+    fun `rescan on null project key publishes Unavailable outcome`() {
         // User-facing symptom guard: `AccentResolver.projectKey` can
         // return null for a disposal race or canonicalization failure on
         // a live project. Before the fix, `rescan` returned silently,
         // orphaning the one-shot subscriber installed by
         // `RescanLanguageAction.subscribeOnceForBalloon` — user clicks
         // Rescan, gets no balloon, subscription leaks until project
-        // close. The fix publishes `scanCompleted(null)` so subscribers
-        // fire the polyglot-copy balloon and disconnect.
+        // close. The fix publishes [ScanOutcome.Unavailable] (transient,
+        // not a definitive polyglot verdict) so subscribers fire the
+        // polyglot-copy balloon and disconnect while signalling to the
+        // Settings row that the previous render should stay put.
         val project = mockk<Project>()
         every { project.basePath } returns null
         every { project.isDefault } returns false
@@ -999,7 +1001,7 @@ class ProjectLanguageDetectorTest {
 
         ProjectLanguageDetector.rescan(project)
 
-        verify(exactly = 1) { listener.scanCompleted(null) }
+        verify(exactly = 1) { listener.scanCompleted(ScanOutcome.Unavailable) }
         verify(exactly = 0) { ProjectLanguageScanAsync.schedule(any(), any()) }
     }
 

--- a/src/test/kotlin/dev/ayuislands/actions/RescanLanguageActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/actions/RescanLanguageActionTest.kt
@@ -12,6 +12,7 @@ import com.intellij.util.messages.MessageBus
 import com.intellij.util.messages.MessageBusConnection
 import dev.ayuislands.accent.ProjectLanguageDetectionListener
 import dev.ayuislands.accent.ProjectLanguageDetector
+import dev.ayuislands.accent.ScanOutcome
 import dev.ayuislands.licensing.LicenseChecker
 import io.mockk.CapturingSlot
 import io.mockk.every
@@ -202,7 +203,7 @@ class RescanLanguageActionTest {
         every { kotlin.displayName } returns "Kotlin"
         every { Language.getRegisteredLanguages() } returns listOf(kotlin)
 
-        listener.captured.scanCompleted("kotlin")
+        listener.captured.scanCompleted(ScanOutcome.Detected("kotlin"))
 
         verify(exactly = 1) {
             notificationGroup.createNotification(
@@ -219,7 +220,7 @@ class RescanLanguageActionTest {
         val listener = captureSubscribedListener()
         action.actionPerformed(event)
 
-        listener.captured.scanCompleted(null)
+        listener.captured.scanCompleted(ScanOutcome.Polyglot)
 
         verify(exactly = 1) {
             notificationGroup.createNotification(
@@ -238,7 +239,7 @@ class RescanLanguageActionTest {
         mockkStatic(Language::class)
         every { Language.getRegisteredLanguages() } returns emptyList()
 
-        listener.captured.scanCompleted("Exoticlang")
+        listener.captured.scanCompleted(ScanOutcome.Detected("Exoticlang"))
 
         verify(exactly = 1) {
             notificationGroup.createNotification(
@@ -259,8 +260,8 @@ class RescanLanguageActionTest {
         val listener = captureSubscribedListener()
         action.actionPerformed(event)
 
-        listener.captured.scanCompleted("kotlin")
-        listener.captured.scanCompleted("python")
+        listener.captured.scanCompleted(ScanOutcome.Detected("kotlin"))
+        listener.captured.scanCompleted(ScanOutcome.Detected("python"))
 
         verify(exactly = 1) { connection.disconnect() }
         // Only the first balloon fires.
@@ -273,7 +274,7 @@ class RescanLanguageActionTest {
         action.actionPerformed(event)
 
         every { project.isDisposed } returns true
-        listener.captured.scanCompleted("kotlin")
+        listener.captured.scanCompleted(ScanOutcome.Detected("kotlin"))
 
         verify(exactly = 0) { notification.notify(any<Project>()) }
     }
@@ -292,7 +293,7 @@ class RescanLanguageActionTest {
         every { connection.disconnect() } throws IllegalStateException("already disposed")
         action.actionPerformed(event)
 
-        listener.captured.scanCompleted("kotlin")
+        listener.captured.scanCompleted(ScanOutcome.Detected("kotlin"))
 
         verify(exactly = 1) { notification.notify(any<Project>()) }
     }
@@ -314,7 +315,7 @@ class RescanLanguageActionTest {
         action.actionPerformed(event)
 
         // Must not throw — load-bearing assertion is simply that the call completes.
-        listener.captured.scanCompleted("kotlin")
+        listener.captured.scanCompleted(ScanOutcome.Detected("kotlin"))
     }
 
     @Test
@@ -331,7 +332,7 @@ class RescanLanguageActionTest {
         every { Language.getRegisteredLanguages() } throws RuntimeException("plugin registry corrupted")
         action.actionPerformed(event)
 
-        listener.captured.scanCompleted("Exoticlang")
+        listener.captured.scanCompleted(ScanOutcome.Detected("Exoticlang"))
 
         verify(exactly = 1) {
             notificationGroup.createNotification(
@@ -356,7 +357,7 @@ class RescanLanguageActionTest {
         every { Language.getRegisteredLanguages() } returns listOf(blankLang)
         action.actionPerformed(event)
 
-        listener.captured.scanCompleted("Exoticlang")
+        listener.captured.scanCompleted(ScanOutcome.Detected("Exoticlang"))
 
         verify(exactly = 1) {
             notificationGroup.createNotification(

--- a/src/test/kotlin/dev/ayuislands/actions/RescanLanguageActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/actions/RescanLanguageActionTest.kt
@@ -216,11 +216,33 @@ class RescanLanguageActionTest {
     }
 
     @Test
-    fun `scan completion with null id fires a polyglot balloon`() {
+    fun `scan completion with Polyglot fires the polyglot balloon`() {
         val listener = captureSubscribedListener()
         action.actionPerformed(event)
 
         listener.captured.scanCompleted(ScanOutcome.Polyglot)
+
+        verify(exactly = 1) {
+            notificationGroup.createNotification(
+                "Project language re-detected",
+                "Polyglot — no single dominant language; global accent applies",
+                NotificationType.INFORMATION,
+            )
+        }
+    }
+
+    @Test
+    fun `scan completion with Unavailable fires the polyglot balloon via the shared when arm`() {
+        // `humanLabelFor` collapses Polyglot and Unavailable into the
+        // same user-visible balloon body (polyglot copy) — the user
+        // sees "no dominant language right now" the same way whether
+        // the scan definitively said polyglot or hit a transient
+        // failure. Locks the when-arm coverage so a regression
+        // splitting the arms without updating the copy gets caught.
+        val listener = captureSubscribedListener()
+        action.actionPerformed(event)
+
+        listener.captured.scanCompleted(ScanOutcome.Unavailable)
 
         verify(exactly = 1) {
             notificationGroup.createNotification(


### PR DESCRIPTION
── Summary ─────────────────────────────────────────────

Follow-up to #142. Three type/architecture SUGGESTIONs from the prior
review loop were deferred as follow-ups; this PR closes them so the
rescan subsystem carries typed state across the Topic boundary and
shares one disconnect helper between its two call sites.

No user-visible behaviour change. The Topic API tightens from
\`scanCompleted(String?)\` to \`scanCompleted(ScanOutcome)\`, and
subscribers can now distinguish polyglot (definitive no-winner) from
Unavailable (transient — scanner threw, unresolvable project key,
dumb-mode race) at the type level instead of re-querying the detector
cache to tell them apart.

── Changes ─────────────────────────────────────────────

| Type | Path | What |
|------|------|------|
| Refactor | \`src/main/kotlin/dev/ayuislands/accent/ScanOutcome.kt\` | New \`sealed interface ScanOutcome\` with \`Detected(id)\`, \`Polyglot\`, \`Unavailable\`. Replaces nullable-String discriminator on the detection Topic. |
| Refactor | \`src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetectionListener.kt\` | \`scanCompleted(ScanOutcome)\` signature. KDoc tightens the null-cause enumeration accordingly. |
| Refactor | \`src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt:287\` | \`scheduleBackgroundDetection\` classifies the \`DetectionResult\` into a \`ScanOutcome\` using \`cache[key]\` as the cacheable-vs-transient discriminator. \`rescan\` on null projectKey publishes \`Unavailable\` (not a generic null). |
| Refactor | \`src/main/kotlin/dev/ayuislands/actions/RescanLanguageAction.kt:110\` | \`humanLabelFor\` uses \`when\` over \`ScanOutcome\` instead of nullable-string branch. \`Polyglot\` and \`Unavailable\` collapse to the same polyglot copy in the balloon — the user's UI is unchanged; the distinction stays usable internally for subscribers that care. |
| Refactor | \`src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt:172\` | New \`safelyDisconnectDetection(site)\` helper. Both \`dispose()\` and the \`buildGroup\` re-entry teardown call it — one red/green test now covers both call sites by construction. Closes the round-2 re-entry-test deferral. |
| Refactor | \`src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt:826\` | \`pinCurrentProject\` inlined into its sole call site (Pin-Current-Project AnAction) to compensate for the new helper under detekt's 25-function class cap. Behaviour identical. |
| Fix | \`src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt:312\` | Both dispose wraps switched from plain \`runCatching\` to \`runCatchingPreservingCancellation\` for consistency with the sibling sites in OverridesGroupBuilder. Lets a future move of the dispose chain into a coroutine scope stay structured-concurrency-safe. |
| Test | \`src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt:945\` | Null-key rescan spec now asserts \`ScanOutcome.Unavailable\` (not a generic null); polyglot scan spec asserts \`ScanOutcome.Polyglot\`. |
| Test | \`src/test/kotlin/dev/ayuislands/actions/RescanLanguageActionTest.kt:205\` | All \`scanCompleted\` call sites wrap the id in \`ScanOutcome.Detected(...)\` or use \`ScanOutcome.Polyglot\` for the polyglot-copy spec. |

── Validation ──────────────────────────────────────────

Automated:
\`\`\`bash
./gradlew test koverVerify detekt ktlintCheck verifyPlugin
\`\`\`
- Tests pass, Kover line ≥ 80%, patch ≥ 80%.
- detekt + ktlint clean.

Manual smoke (deployed via \`/deploy-to-ide\`):
- Tools → Ayu Islands → Rescan Project Language: balloon names detected language or shows "Polyglot — no single dominant language; global accent applies". Confirmed for both \`Detected\` and \`Polyglot\` outcomes.
- Settings → Ayu Islands → Accent → Overrides → Rescan click: row refreshes on completion. Confirmed for polyglot + winner rescans.
- \`grep "SEVERE.*Ayu" ~/Library/Logs/JetBrains/IntelliJIdea2026.1/idea.log\` — empty.

── Notes ───────────────────────────────────────────────

- The balloon body collapses \`Polyglot\` and \`Unavailable\` to the same string today. A future UX iteration could surface "try again in a moment" for Unavailable distinctly — the sealed hierarchy makes that change a one-line \`when\` arm instead of a plumbing refactor.
- \`!panel.isDisplayable\` subscriber short-circuit test stays deferred. Reaching the guard requires either standing up a real \`Project.messageBus\` + \`DialogPanel\`/\`Panel\` scope (Swing-heavy, forbidden by project \`TESTING.md\`) or adding another \`@TestOnly\` seam that would push the class past detekt's function cap. The correctness contract is already locked by the dispose + re-entry subscription-disconnect tests.
- Follow-up candidates: Unavailable vs Polyglot differentiation in the balloon copy, \`panel.isDisplayable\` integration test once we have the fixture.

## Summary by Sourcery

Introduce a typed ScanOutcome result for project language detection and centralize detection connection teardown while keeping user-facing behavior unchanged.

Enhancements:
- Replace nullable String scanCompleted payload with sealed ScanOutcome to distinguish detected, polyglot, and unavailable outcomes across the detection pipeline and balloon UI.
- Classify detection results into ScanOutcome variants based on cache state so subscribers can infer definitive polyglot vs transient failure without re-querying.
- Extract a shared safelyDisconnectDetection helper for OverridesGroupBuilder to unify and harden message bus connection teardown, and inline the pinCurrentProject helper to satisfy detekt function count limits.
- Use runCatchingPreservingCancellation for settings panel disposal to align with other cancellation-safe cleanup sites.

Documentation:
- Refresh feature verification metadata in docs/features.yml for the updated accent and settings code paths.

Tests:
- Update detection and rescan action tests to assert ScanOutcome-based callbacks, including separate coverage for Polyglot and Unavailable outcomes.