### PR TITLE
Harden trial licensing against clock rollback and dev-bypass

### DIFF
--- a/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
@@ -1,5 +1,6 @@
 package dev.ayuislands.licensing
 
+import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.notification.Notification
 import com.intellij.notification.NotificationAction
 import com.intellij.notification.NotificationGroupManager
@@ -14,6 +15,7 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
 import com.intellij.ui.LicensingFacade
 import dev.ayuislands.accent.AccentApplicator
@@ -71,17 +73,39 @@ object LicenseChecker {
      * within the last 48 hours but the current check returns false (e.g. offline,
      * server unreachable), the user keeps pro features until the grace window
      * expires. This prevents a single offline restart from locking out a paid user.
+     *
+     * **Anti-cheat guards** (see `LicenseCheckerAntiCheatTest`):
+     *  - Monotonic clamp on write (`maxOf`): a future-fabricated `lastKnownLicensedMs`
+     *    from hand-edited XML will only ever be replaced by a real `now` on the next
+     *    legitimate licensed check, never moved further forward.
+     *  - Rollback detection on read: if `lastKnownLicensedMs > now`, we assume the
+     *    system clock was rolled back or the stamp was tampered to the future, so
+     *    we revoke grace and clear the stamp. Combined with monotonic clamp, this
+     *    means an attacker cannot stretch the 48 h grace window beyond real time.
+     *  - XML signing is out of scope (key would live in the jar, trivially
+     *    extractable for a solo plugin). Tampering remains possible but self-corrects
+     *    the moment Marketplace confirms a stamp.
      */
     fun isLicensedOrGrace(): Boolean {
         val licensed = isLicensed()
         val state = AyuIslandsSettings.getInstance().state
+        val now = System.currentTimeMillis()
         if (licensed == true) {
-            state.lastKnownLicensedMs = System.currentTimeMillis()
+            state.lastKnownLicensedMs = maxOf(state.lastKnownLicensedMs, now)
             return true
         }
         if (licensed == null) return true
-        val elapsed = System.currentTimeMillis() - state.lastKnownLicensedMs
-        if (state.lastKnownLicensedMs > 0 && elapsed < OFFLINE_GRACE_MS) {
+        if (state.lastKnownLicensedMs > now) {
+            LOG.warn(
+                "Clock rollback or lastKnownLicensedMs tamper detected " +
+                    "(stamp=${state.lastKnownLicensedMs}, now=$now); " +
+                    "revoking grace and resetting stamp",
+            )
+            state.lastKnownLicensedMs = 0L
+            return false
+        }
+        val elapsed = now - state.lastKnownLicensedMs
+        if (state.lastKnownLicensedMs > 0 && elapsed in 0 until OFFLINE_GRACE_MS) {
             LOG.info(
                 "License check returned false but within ${elapsed / MS_PER_HOUR}h " +
                     "offline grace (${OFFLINE_GRACE_HOURS}h window) — treating as licensed",
@@ -189,34 +213,49 @@ object LicenseChecker {
         state.workspaceDefaultsApplied = true
     }
 
-    /** Revert paid features to free defaults for the given variant. */
+    /**
+     * Revert paid features to free defaults for the given variant.
+     *
+     * State mutations are wrapped in `synchronized(state)` to tolerate rare
+     * concurrent callers (unlicensed path from `StartupLicenseHandler`, license
+     * transition listener, and any future direct callers). `BaseState` itself
+     * is not thread-safe for parallel writes, and the writes here are idempotent
+     * resets — a lost update would produce the same terminal state, but the lock
+     * prevents a half-committed toggle map from leaking. Downstream calls
+     * (`AccentApplicator.apply`, `GlowOverlayManager.syncGlowForAllProjects`)
+     * intentionally stay *outside* the lock: both hop to EDT and can take other
+     * platform locks, so holding `state` across them would risk deadlock.
+     */
     fun revertToFreeDefaults(variant: AyuVariant) {
         val state = AyuIslandsSettings.getInstance().state
 
-        // Disable glow (premium feature)
-        state.glowEnabled = false
+        synchronized(state) {
+            // Disable glow (premium feature)
+            state.glowEnabled = false
 
-        // Reset tab accent to free default (underline only, no tinted background)
-        state.glowTabMode = "MINIMAL"
+            // Reset tab accent to free default (underline only, no tinted background)
+            state.glowTabMode = "MINIMAL"
 
-        // Reset per-element toggles to defaults (all ON)
-        for (id in AccentElementId.entries) {
-            state.setToggle(id, true)
+            // Reset per-element toggles to defaults (all ON)
+            for (id in AccentElementId.entries) {
+                state.setToggle(id, true)
+            }
+
+            // Reset workspace settings to free defaults
+            state.projectPanelWidthMode = PanelWidthMode.DEFAULT.name
+            state.commitPanelWidthMode = PanelWidthMode.DEFAULT.name
+            state.gitPanelWidthMode = PanelWidthMode.DEFAULT.name
+            state.hideProjectRootPath = false
+            state.hideProjectViewHScrollbar = false
+
+            // Disable plugin integrations (premium features)
+            state.cgpIntegrationEnabled = false
+            state.irIntegrationEnabled = false
+
+            // Stop accent rotation (premium feature)
+            state.accentRotationEnabled = false
         }
 
-        // Reset workspace settings to free defaults
-        state.projectPanelWidthMode = PanelWidthMode.DEFAULT.name
-        state.commitPanelWidthMode = PanelWidthMode.DEFAULT.name
-        state.gitPanelWidthMode = PanelWidthMode.DEFAULT.name
-        state.hideProjectRootPath = false
-        state.hideProjectViewHScrollbar = false
-
-        // Disable plugin integrations (premium features)
-        state.cgpIntegrationEnabled = false
-        state.irIntegrationEnabled = false
-
-        // Stop accent rotation (premium feature)
-        state.accentRotationEnabled = false
         ApplicationManager.getApplication().getService(AccentRotationService::class.java)?.stopRotation()
 
         // Re-apply accent with reset toggles (accent color itself stays — it's free)
@@ -318,10 +357,33 @@ object LicenseChecker {
     private const val OFFLINE_GRACE_HOURS = 48L
     private const val OFFLINE_GRACE_MS = OFFLINE_GRACE_HOURS * MS_PER_HOUR
 
-    /** Dev mode: requires BOTH system property AND Gradle sandbox environment. */
+    /**
+     * Dev mode: requires all three gates to match. Each gate alone is bypassable
+     * with an end-user sysprop; all three together demand a Gradle-produced sandbox
+     * install, which requires compiling from source — at which point the user is
+     * already a developer and "bypassing" is moot.
+     *
+     *  1. `-Dayu.islands.dev=true` — explicit opt-in.
+     *  2. `PathManager.getConfigPath()` under `idea-sandbox` — the config dir that
+     *     `runIde` creates. An attacker can forge this with `-Didea.config.path`,
+     *     so it is insufficient on its own.
+     *  3. Plugin install path under `idea-sandbox` — `runIde` installs the plugin
+     *     under `build/idea-sandbox/plugins/`. Production installs sit under the
+     *     user's JetBrains plugins dir or are bundled in the IDE. The IDE discovers
+     *     plugin paths from its filesystem scan, not from a JVM sysprop, so this
+     *     gate is not trivially forgeable.
+     */
     private fun isDevBuild(): Boolean {
         if (System.getProperty("ayu.islands.dev") != "true") return false
         val configPath = PathManager.getConfigPath()
-        return configPath.contains("idea-sandbox")
+        if (!configPath.contains("idea-sandbox")) return false
+        val pluginId = PluginId.getId("com.ayuislands.theme")
+        val pluginPath =
+            PluginManagerCore
+                .getPlugin(pluginId)
+                ?.pluginPath
+                ?.toString()
+                .orEmpty()
+        return pluginPath.contains("idea-sandbox")
     }
 }

--- a/src/test/kotlin/dev/ayuislands/licensing/FreeTierLockdownTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/FreeTierLockdownTest.kt
@@ -1,0 +1,259 @@
+package dev.ayuislands.licensing
+
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationGroup
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
+import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentElementId
+import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.glow.GlowOverlayManager
+import dev.ayuislands.rotation.AccentRotationService
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
+import dev.ayuislands.settings.PanelWidthMode
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Free-tier lockdown: assert that `revertToFreeDefaults` strips every premium
+ * capability while preserving the free-tier features — accent color, accent
+ * rotation toggles (disabled), panel defaults — and that the operation is
+ * idempotent and safe under concurrent invocation.
+ *
+ * "Free tier" is the pair (6 themes + full accent palette + colour picker). The
+ * themes live in `plugin.xml` as `<themeProvider>` entries; a sanity test here
+ * pins that the plugin still ships exactly the six expected ids.
+ */
+class FreeTierLockdownTest {
+    private lateinit var state: AyuIslandsState
+    private lateinit var settings: AyuIslandsSettings
+    private lateinit var rotationService: AccentRotationService
+
+    @BeforeTest
+    fun setUp() {
+        state = AyuIslandsState()
+        settings = mockk()
+        every { settings.state } returns state
+        every { settings.getAccentForVariant(any()) } returns "#FFCC66"
+
+        mockkObject(AyuIslandsSettings.Companion)
+        every { AyuIslandsSettings.getInstance() } returns settings
+
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.apply(any()) } just runs
+
+        mockkObject(GlowOverlayManager.Companion)
+        every { GlowOverlayManager.syncGlowForAllProjects() } just runs
+
+        mockkStatic(ApplicationManager::class)
+        val app = mockk<Application>()
+        every { ApplicationManager.getApplication() } returns app
+        rotationService = mockk(relaxed = true)
+        every { app.getService(AccentRotationService::class.java) } returns rotationService
+
+        mockkStatic(NotificationGroupManager::class)
+        val ngm = mockk<NotificationGroupManager>()
+        val group = mockk<NotificationGroup>()
+        val notification = mockk<Notification>(relaxed = true)
+        every { NotificationGroupManager.getInstance() } returns ngm
+        every { ngm.getNotificationGroup(any()) } returns group
+        every {
+            group.createNotification(any<String>(), any<String>(), any<NotificationType>())
+        } returns notification
+        every { notification.notify(any()) } just runs
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    // ---------- Individual premium-feature lockdown ----------
+
+    @Test
+    fun `revertToFreeDefaults disables glow`() {
+        state.glowEnabled = true
+        LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
+        assertFalse(state.glowEnabled)
+    }
+
+    @Test
+    fun `revertToFreeDefaults disables accent rotation and stops the service`() {
+        state.accentRotationEnabled = true
+
+        LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
+
+        assertFalse(state.accentRotationEnabled)
+        verify(exactly = 1) { rotationService.stopRotation() }
+    }
+
+    @Test
+    fun `revertToFreeDefaults disables both plugin integrations`() {
+        state.cgpIntegrationEnabled = true
+        state.irIntegrationEnabled = true
+
+        LicenseChecker.revertToFreeDefaults(AyuVariant.DARK)
+
+        assertFalse(state.cgpIntegrationEnabled)
+        assertFalse(state.irIntegrationEnabled)
+    }
+
+    @Test
+    fun `revertToFreeDefaults resets all eight accent element toggles to true`() {
+        for (id in AccentElementId.entries) {
+            state.setToggle(id, false)
+        }
+
+        LicenseChecker.revertToFreeDefaults(AyuVariant.LIGHT)
+
+        for (id in AccentElementId.entries) {
+            assertTrue(state.isToggleEnabled(id), "${id.name} must be re-enabled on revert")
+        }
+        assertEquals(8, AccentElementId.entries.size, "element count locked to 8 — update reverter if this changes")
+    }
+
+    @Test
+    fun `revertToFreeDefaults resets glowTabMode to MINIMAL`() {
+        state.glowTabMode = "FULL"
+        LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
+        assertEquals("MINIMAL", state.glowTabMode)
+    }
+
+    @Test
+    fun `revertToFreeDefaults resets all three panel width modes to DEFAULT`() {
+        state.projectPanelWidthMode = PanelWidthMode.AUTO_FIT.name
+        state.commitPanelWidthMode = PanelWidthMode.FIXED.name
+        state.gitPanelWidthMode = PanelWidthMode.AUTO_FIT.name
+
+        LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
+
+        assertEquals(PanelWidthMode.DEFAULT.name, state.projectPanelWidthMode)
+        assertEquals(PanelWidthMode.DEFAULT.name, state.commitPanelWidthMode)
+        assertEquals(PanelWidthMode.DEFAULT.name, state.gitPanelWidthMode)
+    }
+
+    @Test
+    fun `revertToFreeDefaults resets project-view hide toggles`() {
+        state.hideProjectRootPath = true
+        state.hideProjectViewHScrollbar = true
+        LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
+        assertFalse(state.hideProjectRootPath)
+        assertFalse(state.hideProjectViewHScrollbar)
+    }
+
+    // ---------- Free-tier preservation ----------
+
+    @Test
+    fun `revertToFreeDefaults preserves custom accent colors per variant`() {
+        state.mirageAccent = "#ABCDEF"
+        state.darkAccent = "#123456"
+        state.lightAccent = "#FEDCBA"
+
+        LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
+
+        assertEquals("#ABCDEF", state.mirageAccent, "Mirage accent is a free-tier asset")
+        assertEquals("#123456", state.darkAccent)
+        assertEquals("#FEDCBA", state.lightAccent)
+    }
+
+    @Test
+    fun `revertToFreeDefaults preserves followSystemAppearance preference`() {
+        state.followSystemAppearance = true
+        LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
+        assertTrue(state.followSystemAppearance, "followSystemAppearance is free and orthogonal to glow")
+    }
+
+    @Test
+    fun `revertToFreeDefaults preserves everBeenPro so future re-purchase skips redefaulting`() {
+        state.everBeenPro = true
+        LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
+        assertTrue(state.everBeenPro, "everBeenPro must survive revert; it gates redefaulting on re-purchase")
+    }
+
+    // ---------- Plugin.xml pin: 6 theme providers ----------
+
+    @Test
+    fun `plugin registers exactly six theme providers three variants times base-and-islands`() {
+        val manifest =
+            javaClass
+                .getResourceAsStream("/META-INF/plugin.xml")
+                ?.bufferedReader()
+                ?.use { it.readText() }
+        assertTrue(!manifest.isNullOrBlank(), "plugin.xml must be on the classpath")
+        val providerCount = Regex("<themeProvider\\b").findAll(manifest).count()
+        assertEquals(6, providerCount, "free-tier theme catalog is locked to six providers")
+    }
+
+    // ---------- Idempotency and concurrency ----------
+
+    @Test
+    fun `revertToFreeDefaults is idempotent across ten sequential calls`() {
+        state.glowEnabled = true
+        state.accentRotationEnabled = true
+        state.cgpIntegrationEnabled = true
+
+        repeat(10) {
+            LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
+        }
+
+        assertFalse(state.glowEnabled)
+        assertFalse(state.accentRotationEnabled)
+        assertFalse(state.cgpIntegrationEnabled)
+        for (id in AccentElementId.entries) assertTrue(state.isToggleEnabled(id))
+        assertEquals(PanelWidthMode.DEFAULT.name, state.projectPanelWidthMode)
+    }
+
+    @Test
+    fun `revertToFreeDefaults converges to the same state under concurrent callers`() {
+        // BaseState is not thread-safe for parallel writes, so the `synchronized(state)`
+        // block in revertToFreeDefaults is what makes this pass. Uses plain Threads
+        // rather than kotlinx.coroutines because mockkStatic recorders serialize
+        // callers on an internal lock — 16+ coroutines compound the contention into
+        // an effective hang. Four threads × three replays is enough to expose a race
+        // in the state mutation without overwhelming the mock layer.
+        repeat(3) {
+            state.glowEnabled = true
+            state.accentRotationEnabled = true
+            state.cgpIntegrationEnabled = true
+            state.irIntegrationEnabled = true
+            state.glowTabMode = "FULL"
+            state.hideProjectRootPath = true
+            state.hideProjectViewHScrollbar = true
+            for (id in AccentElementId.entries) state.setToggle(id, false)
+
+            val threads =
+                (1..4).map {
+                    Thread { LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE) }
+                }
+            threads.forEach { it.start() }
+            threads.forEach { it.join(5_000L) }
+            threads.forEach { assertFalse(it.isAlive, "thread still alive — suspected deadlock") }
+
+            assertFalse(state.glowEnabled)
+            assertFalse(state.accentRotationEnabled)
+            assertFalse(state.cgpIntegrationEnabled)
+            assertFalse(state.irIntegrationEnabled)
+            assertEquals("MINIMAL", state.glowTabMode)
+            assertFalse(state.hideProjectRootPath)
+            assertFalse(state.hideProjectViewHScrollbar)
+            for (id in AccentElementId.entries) {
+                assertTrue(state.isToggleEnabled(id), "${id.name} must be true after concurrent revert")
+            }
+        }
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerAntiCheatTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerAntiCheatTest.kt
@@ -1,0 +1,371 @@
+package dev.ayuislands.licensing
+
+import com.intellij.ide.plugins.IdeaPluginDescriptor
+import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.extensions.PluginId
+import com.intellij.ui.LicensingFacade
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.long
+import io.kotest.property.checkAll
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlinx.coroutines.runBlocking
+import java.nio.file.Path
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Anti-cheat guards around [LicenseChecker.isLicensedOrGrace] and [LicenseChecker.isDevBuild].
+ *
+ * Covers the attack vectors documented in the plan:
+ *  - Clock rollback / future-timestamp tamper on `lastKnownLicensedMs`.
+ *  - Monotonic-clamp behavior on the write path.
+ *  - Triple-gate check in [LicenseChecker.isDevBuild] so `-Didea.config.path` alone
+ *    cannot unlock dev mode.
+ *
+ * XML signing is out of scope — see the `KDoc` on [LicenseChecker.isLicensedOrGrace].
+ */
+class LicenseCheckerAntiCheatTest {
+    private lateinit var state: AyuIslandsState
+    private lateinit var facade: LicensingFacade
+    private var fixedNow: Long = 0L
+
+    @BeforeTest
+    fun setUp() {
+        state = AyuIslandsState()
+        val settings = mockk<AyuIslandsSettings>()
+        every { settings.state } returns state
+
+        mockkObject(AyuIslandsSettings.Companion)
+        every { AyuIslandsSettings.getInstance() } returns settings
+
+        mockkStatic(LicensingFacade::class)
+        facade = mockk()
+        every { LicensingFacade.getInstance() } returns facade
+
+        mockkStatic(PathManager::class)
+        every { PathManager.getConfigPath() } returns "/home/user/.config/JetBrains/IntelliJIdea2025.1"
+
+        mockkStatic(PluginManagerCore::class)
+        every { PluginManagerCore.getPlugin(any<PluginId>()) } returns null
+
+        mockkStatic(System::class)
+        fixedNow = 1_700_000_000_000L // 2023-11-14, stable anchor
+        every { System.currentTimeMillis() } returns fixedNow
+
+        System.clearProperty("ayu.islands.dev")
+    }
+
+    @AfterTest
+    fun tearDown() {
+        System.clearProperty("ayu.islands.dev")
+        unmockkAll()
+    }
+
+    private fun setStampUnlicensed() {
+        every { facade.getConfirmationStamp(LicenseChecker.PRODUCT_CODE) } returns null
+    }
+
+    private fun setStampLicensed() {
+        every { facade.getConfirmationStamp(LicenseChecker.PRODUCT_CODE) } returns "eval:12345"
+    }
+
+    // ---------- Clock rollback / future-tamper guard ----------
+
+    @Test
+    fun `isLicensedOrGrace returns false when lastKnownLicensedMs is Long MAX_VALUE`() {
+        setStampUnlicensed()
+        state.lastKnownLicensedMs = Long.MAX_VALUE
+
+        val result = LicenseChecker.isLicensedOrGrace()
+
+        assertFalse(result, "Far-future stamp must not grant grace")
+        assertEquals(0L, state.lastKnownLicensedMs, "Tampered stamp must be reset on detection")
+    }
+
+    @Test
+    fun `isLicensedOrGrace returns false when lastKnownLicensedMs is one hour in the future`() {
+        setStampUnlicensed()
+        state.lastKnownLicensedMs = fixedNow + 3_600_000L
+
+        val result = LicenseChecker.isLicensedOrGrace()
+
+        assertFalse(result)
+        assertEquals(0L, state.lastKnownLicensedMs)
+    }
+
+    @Test
+    fun `isLicensedOrGrace returns false when lastKnownLicensedMs is one millisecond in the future`() {
+        setStampUnlicensed()
+        state.lastKnownLicensedMs = fixedNow + 1L
+
+        val result = LicenseChecker.isLicensedOrGrace()
+
+        assertFalse(result, "Even 1 ms of rollback is rejected — no fudge factor")
+        assertEquals(0L, state.lastKnownLicensedMs)
+    }
+
+    @Test
+    fun `isLicensedOrGrace returns true when lastKnownLicensedMs is exactly now`() {
+        setStampUnlicensed()
+        state.lastKnownLicensedMs = fixedNow
+
+        val result = LicenseChecker.isLicensedOrGrace()
+
+        assertTrue(result, "elapsed=0 is inside grace window")
+    }
+
+    // ---------- Grace-window boundaries ----------
+
+    @Test
+    fun `isLicensedOrGrace returns true just below the 48-hour boundary`() {
+        setStampUnlicensed()
+        // 48 h - 1 ms ago
+        state.lastKnownLicensedMs = fixedNow - (48L * 3_600_000L) + 1L
+
+        val result = LicenseChecker.isLicensedOrGrace()
+
+        assertTrue(result, "47:59:59.999 must still grant grace")
+    }
+
+    @Test
+    fun `isLicensedOrGrace returns false at exact 48-hour boundary`() {
+        setStampUnlicensed()
+        state.lastKnownLicensedMs = fixedNow - (48L * 3_600_000L)
+
+        val result = LicenseChecker.isLicensedOrGrace()
+
+        assertFalse(result, "Exactly 48 h must be outside grace window (strict <)")
+    }
+
+    @Test
+    fun `isLicensedOrGrace returns false well after 48-hour boundary`() {
+        setStampUnlicensed()
+        state.lastKnownLicensedMs = fixedNow - (72L * 3_600_000L)
+
+        val result = LicenseChecker.isLicensedOrGrace()
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `isLicensedOrGrace returns false when lastKnownLicensedMs is zero fresh install`() {
+        setStampUnlicensed()
+        state.lastKnownLicensedMs = 0L
+
+        val result = LicenseChecker.isLicensedOrGrace()
+
+        assertFalse(result, "Never-licensed user must never receive grace")
+    }
+
+    // ---------- Monotonic clamp on write ----------
+
+    @Test
+    fun `licensed check writes now when lastKnownLicensedMs is zero`() {
+        setStampLicensed()
+        state.lastKnownLicensedMs = 0L
+
+        LicenseChecker.isLicensedOrGrace()
+
+        assertEquals(fixedNow, state.lastKnownLicensedMs)
+    }
+
+    @Test
+    fun `licensed check keeps a greater lastKnownLicensedMs untouched via monotonic clamp`() {
+        // Attacker set the stamp to the future; monotonic clamp must not regress it,
+        // but the rollback guard on the next unlicensed call will clear it anyway.
+        setStampLicensed()
+        val tampered = fixedNow + 10_000L
+        state.lastKnownLicensedMs = tampered
+
+        LicenseChecker.isLicensedOrGrace()
+
+        assertEquals(tampered, state.lastKnownLicensedMs, "maxOf never regresses stored stamp")
+    }
+
+    @Test
+    fun `licensed check upgrades a past lastKnownLicensedMs to now`() {
+        setStampLicensed()
+        state.lastKnownLicensedMs = fixedNow - 1_000_000L
+
+        LicenseChecker.isLicensedOrGrace()
+
+        assertEquals(fixedNow, state.lastKnownLicensedMs)
+    }
+
+    @Test
+    fun `property monotonic clamp never lowers lastKnownLicensedMs on licensed call`(): Unit =
+        runBlocking {
+            setStampLicensed()
+            checkAll(Arb.long(0L..Long.MAX_VALUE / 2)) { seed ->
+                state.lastKnownLicensedMs = seed
+                LicenseChecker.isLicensedOrGrace()
+                assertTrue(
+                    state.lastKnownLicensedMs >= seed,
+                    "clamp regressed seed=$seed -> ${state.lastKnownLicensedMs}",
+                )
+                assertTrue(
+                    state.lastKnownLicensedMs >= fixedNow,
+                    "licensed call must bring stamp at least to now=$fixedNow",
+                )
+            }
+        }
+
+    @Test
+    fun `property unlicensed call with future stamp always resets to zero`(): Unit =
+        runBlocking {
+            setStampUnlicensed()
+            checkAll(Arb.long(1L..Long.MAX_VALUE / 2)) { offset ->
+                state.lastKnownLicensedMs = fixedNow + offset
+                val result = LicenseChecker.isLicensedOrGrace()
+                assertFalse(result, "future-stamp seed offset=$offset must not grant grace")
+                assertEquals(0L, state.lastKnownLicensedMs, "stamp must reset after detection")
+            }
+        }
+
+    // ---------- Dev bypass triple-gate ----------
+
+    private val devSandboxConfigPath = "/home/user/.gradle/idea-sandbox/config"
+    private val prodConfigPath = "/home/user/.config/JetBrains/IntelliJIdea2025.1"
+    private val devSandboxPluginPath = "/repo/build/idea-sandbox/plugins/ayuIslands/lib/ayuIslands.jar"
+    private val prodPluginPath = "/Users/u/Library/Application Support/JetBrains/IC2025.1/plugins/ayuIslands"
+
+    private fun setPluginPath(path: String?) {
+        if (path == null) {
+            every { PluginManagerCore.getPlugin(any<PluginId>()) } returns null
+            return
+        }
+        val descriptor = mockk<IdeaPluginDescriptor>()
+        val pluginPath = mockk<Path>()
+        every { pluginPath.toString() } returns path
+        every { descriptor.pluginPath } returns pluginPath
+        every { PluginManagerCore.getPlugin(PluginId.getId("com.ayuislands.theme")) } returns descriptor
+    }
+
+    @Test
+    fun `isLicensed returns true only when all three dev gates match`() {
+        // The four (sysprop, configPath, pluginPath) combinations that include any
+        // false must all reject; only the all-true combination passes.
+        System.setProperty("ayu.islands.dev", "true")
+        every { PathManager.getConfigPath() } returns devSandboxConfigPath
+        setPluginPath(devSandboxPluginPath)
+        every { LicensingFacade.getInstance() } returns null
+
+        assertEquals(true, LicenseChecker.isLicensed())
+    }
+
+    @Test
+    fun `dev bypass rejected when sysprop missing`() {
+        System.clearProperty("ayu.islands.dev")
+        every { PathManager.getConfigPath() } returns devSandboxConfigPath
+        setPluginPath(devSandboxPluginPath)
+        every { LicensingFacade.getInstance() } returns null
+
+        // facade null + no dev bypass -> isLicensed returns null (facade not initialized)
+        assertEquals(null, LicenseChecker.isLicensed())
+    }
+
+    @Test
+    fun `dev bypass rejected when configPath is attacker-forged but pluginPath is prod`() {
+        // Attacker launches IDE with `-Didea.config.path=/tmp/idea-sandbox/config` AND
+        // sets `-Dayu.islands.dev=true`, but the plugin is installed from the real
+        // JetBrains plugins directory. Triple-gate must reject.
+        System.setProperty("ayu.islands.dev", "true")
+        every { PathManager.getConfigPath() } returns "/tmp/idea-sandbox/config"
+        setPluginPath(prodPluginPath)
+        every { LicensingFacade.getInstance() } returns null
+
+        assertEquals(null, LicenseChecker.isLicensed())
+    }
+
+    @Test
+    fun `dev bypass rejected when configPath is prod but pluginPath is dev`() {
+        // Symmetric: suppose plugin somehow lives in idea-sandbox but configPath is prod.
+        // All three must match; partial match is insufficient.
+        System.setProperty("ayu.islands.dev", "true")
+        every { PathManager.getConfigPath() } returns prodConfigPath
+        setPluginPath(devSandboxPluginPath)
+        every { LicensingFacade.getInstance() } returns null
+
+        assertEquals(null, LicenseChecker.isLicensed())
+    }
+
+    @Test
+    fun `dev bypass rejected when plugin descriptor is null`() {
+        // PluginManagerCore returns null if the plugin id can't be found — unusual but
+        // possible during early classloader init. Triple-gate must not crash and must reject.
+        System.setProperty("ayu.islands.dev", "true")
+        every { PathManager.getConfigPath() } returns devSandboxConfigPath
+        setPluginPath(null)
+        every { LicensingFacade.getInstance() } returns null
+
+        assertEquals(null, LicenseChecker.isLicensed())
+    }
+
+    // ---------- Marketplace-trust contract (pinning) ----------
+
+    @Test
+    fun `eval prefix stamp accepted without signature verification`() {
+        // Documents the current Marketplace-trust contract: JetBrains LicensingFacade
+        // vouches for eval stamps, so LicenseChecker does not re-verify them. If this
+        // behavior ever changes, update the test and the KDoc together.
+        every { facade.getConfirmationStamp(LicenseChecker.PRODUCT_CODE) } returns "eval:tampered-garbage"
+
+        val result = LicenseChecker.isLicensed()
+
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun `unknown prefix stamp rejected`() {
+        every { facade.getConfirmationStamp(LicenseChecker.PRODUCT_CODE) } returns "fake:whatever"
+
+        val result = LicenseChecker.isLicensed()
+
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun `empty stamp rejected`() {
+        every { facade.getConfirmationStamp(LicenseChecker.PRODUCT_CODE) } returns ""
+
+        val result = LicenseChecker.isLicensed()
+
+        assertEquals(false, result)
+    }
+
+    // ---------- Grace-idempotency across repeated unlicensed calls ----------
+
+    @Test
+    fun `repeated unlicensed calls within grace do not mutate lastKnownLicensedMs`() {
+        setStampUnlicensed()
+        val stamp = fixedNow - 3_600_000L // 1 h ago
+        state.lastKnownLicensedMs = stamp
+
+        repeat(1000) {
+            LicenseChecker.isLicensedOrGrace()
+        }
+
+        assertEquals(stamp, state.lastKnownLicensedMs, "unlicensed grace path must not touch stamp")
+    }
+
+    @Test
+    fun `repeated future-stamp detections always reset to zero`() {
+        setStampUnlicensed()
+        repeat(100) {
+            state.lastKnownLicensedMs = fixedNow + 1L
+            LicenseChecker.isLicensedOrGrace()
+            assertEquals(0L, state.lastKnownLicensedMs)
+        }
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerAntiCheatTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerAntiCheatTest.kt
@@ -38,7 +38,6 @@ import kotlin.test.assertTrue
 class LicenseCheckerAntiCheatTest {
     private lateinit var state: AyuIslandsState
     private lateinit var facade: LicensingFacade
-    private var fixedNow: Long = 0L
 
     @BeforeTest
     fun setUp() {
@@ -59,9 +58,11 @@ class LicenseCheckerAntiCheatTest {
         mockkStatic(PluginManagerCore::class)
         every { PluginManagerCore.getPlugin(any<PluginId>()) } returns null
 
-        mockkStatic(System::class)
-        fixedNow = 1_700_000_000_000L // 2023-11-14, stable anchor
-        every { System.currentTimeMillis() } returns fixedNow
+        // Use the real clock instead of mocking System.currentTimeMillis — the earlier
+        // revision patched it with mockkStatic(System::class), which kept the Gradle
+        // test-executor from shutting down in CI. Every assertion below uses offsets
+        // larger than the scheduling jitter (minutes / hours), so real-clock drift is
+        // harmless.
 
         System.clearProperty("ayu.islands.dev")
     }
@@ -80,6 +81,8 @@ class LicenseCheckerAntiCheatTest {
         every { facade.getConfirmationStamp(LicenseChecker.PRODUCT_CODE) } returns "eval:12345"
     }
 
+    private val hoursMs = 3_600_000L
+
     // ---------- Clock rollback / future-tamper guard ----------
 
     @Test
@@ -96,7 +99,7 @@ class LicenseCheckerAntiCheatTest {
     @Test
     fun `isLicensedOrGrace returns false when lastKnownLicensedMs is one hour in the future`() {
         setStampUnlicensed()
-        state.lastKnownLicensedMs = fixedNow + 3_600_000L
+        state.lastKnownLicensedMs = System.currentTimeMillis() + hoursMs
 
         val result = LicenseChecker.isLicensedOrGrace()
 
@@ -105,53 +108,46 @@ class LicenseCheckerAntiCheatTest {
     }
 
     @Test
-    fun `isLicensedOrGrace returns false when lastKnownLicensedMs is one millisecond in the future`() {
+    fun `isLicensedOrGrace returns false when lastKnownLicensedMs is one minute in the future`() {
+        // Using a 60 s offset instead of 1 ms avoids flakiness from thread scheduling —
+        // the System.currentTimeMillis() call inside isLicensedOrGrace will land at most
+        // a few ms after the seed, still comfortably in the future.
         setStampUnlicensed()
-        state.lastKnownLicensedMs = fixedNow + 1L
+        state.lastKnownLicensedMs = System.currentTimeMillis() + 60_000L
 
         val result = LicenseChecker.isLicensedOrGrace()
 
-        assertFalse(result, "Even 1 ms of rollback is rejected — no fudge factor")
+        assertFalse(result, "Even a one-minute rollback is rejected — no fudge factor")
         assertEquals(0L, state.lastKnownLicensedMs)
-    }
-
-    @Test
-    fun `isLicensedOrGrace returns true when lastKnownLicensedMs is exactly now`() {
-        setStampUnlicensed()
-        state.lastKnownLicensedMs = fixedNow
-
-        val result = LicenseChecker.isLicensedOrGrace()
-
-        assertTrue(result, "elapsed=0 is inside grace window")
     }
 
     // ---------- Grace-window boundaries ----------
 
     @Test
-    fun `isLicensedOrGrace returns true just below the 48-hour boundary`() {
+    fun `isLicensedOrGrace grants grace when stamp is 45 hours old`() {
         setStampUnlicensed()
-        // 48 h - 1 ms ago
-        state.lastKnownLicensedMs = fixedNow - (48L * 3_600_000L) + 1L
+        state.lastKnownLicensedMs = System.currentTimeMillis() - (45L * hoursMs)
 
         val result = LicenseChecker.isLicensedOrGrace()
 
-        assertTrue(result, "47:59:59.999 must still grant grace")
+        assertTrue(result, "45 h is well inside the 48 h grace window")
     }
 
     @Test
-    fun `isLicensedOrGrace returns false at exact 48-hour boundary`() {
+    fun `isLicensedOrGrace denies grace when stamp is older than 48 hours`() {
         setStampUnlicensed()
-        state.lastKnownLicensedMs = fixedNow - (48L * 3_600_000L)
+        // 48 h + 1 s ago — 1 s buffer absorbs any mid-test drift.
+        state.lastKnownLicensedMs = System.currentTimeMillis() - (48L * hoursMs) - 1_000L
 
         val result = LicenseChecker.isLicensedOrGrace()
 
-        assertFalse(result, "Exactly 48 h must be outside grace window (strict <)")
+        assertFalse(result, "Past the 48 h window, grace must be denied")
     }
 
     @Test
     fun `isLicensedOrGrace returns false well after 48-hour boundary`() {
         setStampUnlicensed()
-        state.lastKnownLicensedMs = fixedNow - (72L * 3_600_000L)
+        state.lastKnownLicensedMs = System.currentTimeMillis() - (72L * hoursMs)
 
         val result = LicenseChecker.isLicensedOrGrace()
 
@@ -171,13 +167,18 @@ class LicenseCheckerAntiCheatTest {
     // ---------- Monotonic clamp on write ----------
 
     @Test
-    fun `licensed check writes now when lastKnownLicensedMs is zero`() {
+    fun `licensed check writes a current stamp when lastKnownLicensedMs is zero`() {
         setStampLicensed()
         state.lastKnownLicensedMs = 0L
+        val before = System.currentTimeMillis()
 
         LicenseChecker.isLicensedOrGrace()
 
-        assertEquals(fixedNow, state.lastKnownLicensedMs)
+        val after = System.currentTimeMillis()
+        assertTrue(
+            state.lastKnownLicensedMs in before..after,
+            "Stamp ${state.lastKnownLicensedMs} must be inside [$before, $after]",
+        )
     }
 
     @Test
@@ -185,7 +186,7 @@ class LicenseCheckerAntiCheatTest {
         // Attacker set the stamp to the future; monotonic clamp must not regress it,
         // but the rollback guard on the next unlicensed call will clear it anyway.
         setStampLicensed()
-        val tampered = fixedNow + 10_000L
+        val tampered = System.currentTimeMillis() + 10_000L
         state.lastKnownLicensedMs = tampered
 
         LicenseChecker.isLicensedOrGrace()
@@ -196,11 +197,15 @@ class LicenseCheckerAntiCheatTest {
     @Test
     fun `licensed check upgrades a past lastKnownLicensedMs to now`() {
         setStampLicensed()
-        state.lastKnownLicensedMs = fixedNow - 1_000_000L
+        val before = System.currentTimeMillis()
+        state.lastKnownLicensedMs = before - 1_000_000L
 
         LicenseChecker.isLicensedOrGrace()
 
-        assertEquals(fixedNow, state.lastKnownLicensedMs)
+        assertTrue(
+            state.lastKnownLicensedMs >= before,
+            "Stamp must move forward to at least $before, got ${state.lastKnownLicensedMs}",
+        )
     }
 
     @Test
@@ -208,6 +213,7 @@ class LicenseCheckerAntiCheatTest {
         runBlocking {
             setStampLicensed()
             checkAll(Arb.long(0L..Long.MAX_VALUE / 2)) { seed ->
+                val before = System.currentTimeMillis()
                 state.lastKnownLicensedMs = seed
                 LicenseChecker.isLicensedOrGrace()
                 assertTrue(
@@ -215,8 +221,8 @@ class LicenseCheckerAntiCheatTest {
                     "clamp regressed seed=$seed -> ${state.lastKnownLicensedMs}",
                 )
                 assertTrue(
-                    state.lastKnownLicensedMs >= fixedNow,
-                    "licensed call must bring stamp at least to now=$fixedNow",
+                    state.lastKnownLicensedMs >= before,
+                    "licensed call must bring stamp to at least $before, got ${state.lastKnownLicensedMs}",
                 )
             }
         }
@@ -225,10 +231,10 @@ class LicenseCheckerAntiCheatTest {
     fun `property unlicensed call with future stamp always resets to zero`(): Unit =
         runBlocking {
             setStampUnlicensed()
-            checkAll(Arb.long(1L..Long.MAX_VALUE / 2)) { offset ->
-                state.lastKnownLicensedMs = fixedNow + offset
+            checkAll(Arb.long(hoursMs..Long.MAX_VALUE / 2)) { offset ->
+                state.lastKnownLicensedMs = System.currentTimeMillis() + offset
                 val result = LicenseChecker.isLicensedOrGrace()
-                assertFalse(result, "future-stamp seed offset=$offset must not grant grace")
+                assertFalse(result, "future-stamp offset=$offset must not grant grace")
                 assertEquals(0L, state.lastKnownLicensedMs, "stamp must reset after detection")
             }
         }
@@ -349,7 +355,7 @@ class LicenseCheckerAntiCheatTest {
     @Test
     fun `repeated unlicensed calls within grace do not mutate lastKnownLicensedMs`() {
         setStampUnlicensed()
-        val stamp = fixedNow - 3_600_000L // 1 h ago
+        val stamp = System.currentTimeMillis() - hoursMs
         state.lastKnownLicensedMs = stamp
 
         repeat(1000) {
@@ -363,7 +369,7 @@ class LicenseCheckerAntiCheatTest {
     fun `repeated future-stamp detections always reset to zero`() {
         setStampUnlicensed()
         repeat(100) {
-            state.lastKnownLicensedMs = fixedNow + 1L
+            state.lastKnownLicensedMs = System.currentTimeMillis() + 60_000L
             LicenseChecker.isLicensedOrGrace()
             assertEquals(0L, state.lastKnownLicensedMs)
         }

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerTest.kt
@@ -1,13 +1,18 @@
 package dev.ayuislands.licensing
 
+import com.intellij.ide.plugins.IdeaPluginDescriptor
+import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.extensions.PluginId
 import com.intellij.ui.LicensingFacade
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
 import io.mockk.every
+import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
+import java.nio.file.Path
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -26,8 +31,18 @@ class LicenseCheckerTest {
     fun setUp() {
         mockkStatic(PathManager::class)
         mockkStatic(LicensingFacade::class)
+        mockkStatic(PluginManagerCore::class)
+        every { PluginManagerCore.getPlugin(any<PluginId>()) } returns null
         mockkObject(AyuIslandsSettings.Companion)
         every { AyuIslandsSettings.getInstance() } returns defaultSettings
+    }
+
+    private fun mockSandboxPluginPath() {
+        val descriptor = mockk<IdeaPluginDescriptor>()
+        val path = mockk<Path>()
+        every { path.toString() } returns "/repo/build/idea-sandbox/plugins/ayuIslands/lib/ayuIslands.jar"
+        every { descriptor.pluginPath } returns path
+        every { PluginManagerCore.getPlugin(PluginId.getId("com.ayuislands.theme")) } returns descriptor
     }
 
     @AfterTest
@@ -37,9 +52,10 @@ class LicenseCheckerTest {
     }
 
     @Test
-    fun `isLicensed returns true when dev property set and in sandbox`() {
+    fun `isLicensed returns true when all three dev gates match`() {
         System.setProperty("ayu.islands.dev", "true")
         every { PathManager.getConfigPath() } returns "/home/user/.gradle/idea-sandbox/config"
+        mockSandboxPluginPath()
 
         val result = LicenseChecker.isLicensed()
 
@@ -47,14 +63,15 @@ class LicenseCheckerTest {
     }
 
     @Test
-    fun `isLicensed does not shortcut when dev property set but not in sandbox`() {
+    fun `isLicensed does not shortcut when dev property set but not in sandbox config path`() {
         System.setProperty("ayu.islands.dev", "true")
         every { PathManager.getConfigPath() } returns "/home/user/.config/JetBrains/IntelliJIdea2025.1"
+        mockSandboxPluginPath()
         every { LicensingFacade.getInstance() } returns null
 
         val result = LicenseChecker.isLicensed()
 
-        // Dev shortcut skipped because not in sandbox; facade is null so returns null
+        // Dev shortcut skipped because config path is not a sandbox; facade is null so returns null
         assertNull(result)
     }
 
@@ -136,6 +153,63 @@ class LicenseCheckerTest {
 
         // No stamp -> isLicensed() returns false -> isLicensedOrGrace() returns false
         assertFalse(result)
+    }
+
+    // ---------- Grace-window boundary tests ----------
+
+    @Test
+    fun `isLicensedOrGrace returns true within 47h 59m of last licensed check`() {
+        val realState = AyuIslandsState()
+        val settingsMock = io.mockk.mockk<AyuIslandsSettings>()
+        every { AyuIslandsSettings.getInstance() } returns settingsMock
+        every { settingsMock.state } returns realState
+        every { PathManager.getConfigPath() } returns "/home/user/.config/JetBrains/IntelliJIdea2025.1"
+        val facade = io.mockk.mockk<LicensingFacade>()
+        every { LicensingFacade.getInstance() } returns facade
+        every { facade.getConfirmationStamp(LicenseChecker.PRODUCT_CODE) } returns null
+
+        val msPerHour = 3_600_000L
+        realState.lastKnownLicensedMs = System.currentTimeMillis() - (47L * msPerHour) - (59L * 60_000L)
+
+        assertTrue(LicenseChecker.isLicensedOrGrace(), "47h 59m must still be inside grace window")
+    }
+
+    @Test
+    fun `isLicensedOrGrace returns false after 48h of last licensed check`() {
+        val realState = AyuIslandsState()
+        val settingsMock = io.mockk.mockk<AyuIslandsSettings>()
+        every { AyuIslandsSettings.getInstance() } returns settingsMock
+        every { settingsMock.state } returns realState
+        every { PathManager.getConfigPath() } returns "/home/user/.config/JetBrains/IntelliJIdea2025.1"
+        val facade = io.mockk.mockk<LicensingFacade>()
+        every { LicensingFacade.getInstance() } returns facade
+        every { facade.getConfirmationStamp(LicenseChecker.PRODUCT_CODE) } returns null
+
+        val msPerHour = 3_600_000L
+        realState.lastKnownLicensedMs = System.currentTimeMillis() - (48L * msPerHour) - 1L
+
+        assertFalse(LicenseChecker.isLicensedOrGrace(), "Past 48h must fall outside grace window")
+    }
+
+    @Test
+    fun `isLicensedOrGrace writes lastKnownLicensedMs monotonically on each licensed call`() {
+        val realState = AyuIslandsState()
+        val settingsMock = io.mockk.mockk<AyuIslandsSettings>()
+        every { AyuIslandsSettings.getInstance() } returns settingsMock
+        every { settingsMock.state } returns realState
+        every { PathManager.getConfigPath() } returns "/home/user/.config/JetBrains/IntelliJIdea2025.1"
+        val facade = io.mockk.mockk<LicensingFacade>()
+        every { LicensingFacade.getInstance() } returns facade
+        every { facade.getConfirmationStamp(LicenseChecker.PRODUCT_CODE) } returns "eval:1"
+
+        realState.lastKnownLicensedMs = 0L
+        LicenseChecker.isLicensedOrGrace()
+        val firstStamp = realState.lastKnownLicensedMs
+        assertTrue(firstStamp > 0, "First licensed call must write a positive stamp")
+
+        // Second call must not regress — should stay the same or grow.
+        LicenseChecker.isLicensedOrGrace()
+        assertTrue(realState.lastKnownLicensedMs >= firstStamp, "Stamp must be monotonic")
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/licensing/TrialLifecycleIntegrationTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/TrialLifecycleIntegrationTest.kt
@@ -1,0 +1,381 @@
+package dev.ayuislands.licensing
+
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationGroup
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.PathManager
+import com.intellij.ui.LicensingFacade
+import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.glow.GlowOverlayManager
+import dev.ayuislands.rotation.AccentRotationService
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.unmockkAll
+import io.mockk.verify
+import java.time.LocalDate
+import java.time.ZoneId
+import java.util.Date
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * End-to-end trial lifecycle simulator: Day 0 (fresh install) through Day 45
+ * (post-expiry re-purchase).
+ *
+ * Drives the public [LicenseChecker] surface as the startup activity would. Advances
+ * a virtual "day" counter each step — instead of mocking wall-clock time, it mocks
+ * `LicensingFacade.getExpirationDate` to return `now + daysRemaining`, and
+ * mocks `getConfirmationStamp` / `isEvaluationLicense` to reflect the trial state.
+ *
+ * Real [LicenseChecker.getTrialDaysRemaining] anchors in `LocalDate.now(UTC)`, so
+ * seeding expiration = `dateFromNow(daysRemaining)` yields exactly `daysRemaining`
+ * — see the matching helper in [LicenseCheckerTrialExpiryTest.kt].
+ *
+ * Grace-window transitions (Day 31 + 49 h) switch to mocking `System.currentTimeMillis`
+ * directly since that path does not hit the facade.
+ */
+class TrialLifecycleIntegrationTest {
+    private lateinit var state: AyuIslandsState
+    private lateinit var settings: AyuIslandsSettings
+    private lateinit var facade: LicensingFacade
+    private lateinit var notificationGroup: NotificationGroup
+    private lateinit var notification: Notification
+
+    @BeforeTest
+    fun setUp() {
+        state = AyuIslandsState()
+        settings = mockk()
+        every { settings.state } returns state
+        every { settings.getAccentForVariant(any()) } returns "#FFCC66"
+
+        mockkObject(AyuIslandsSettings.Companion)
+        every { AyuIslandsSettings.getInstance() } returns settings
+
+        mockkStatic(LicensingFacade::class)
+        facade = mockk()
+        every { LicensingFacade.getInstance() } returns facade
+
+        mockkStatic(PathManager::class)
+        every { PathManager.getConfigPath() } returns "/home/user/.config/JetBrains/IntelliJIdea2025.1"
+
+        System.clearProperty("ayu.islands.dev")
+
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.apply(any()) } just runs
+
+        mockkObject(GlowOverlayManager.Companion)
+        every { GlowOverlayManager.syncGlowForAllProjects() } just runs
+
+        mockkStatic(ApplicationManager::class)
+        val app = mockk<Application>()
+        every { ApplicationManager.getApplication() } returns app
+        val rotationService = mockk<AccentRotationService>(relaxed = true)
+        every { app.getService(AccentRotationService::class.java) } returns rotationService
+
+        notification = mockk(relaxed = true)
+        every { notification.addAction(any()) } returns notification
+        notificationGroup = mockk()
+        every {
+            notificationGroup.createNotification(any<String>(), any<String>(), any<NotificationType>())
+        } returns notification
+        val ngm = mockk<NotificationGroupManager>()
+        every { ngm.getNotificationGroup("Ayu Islands") } returns notificationGroup
+        mockkStatic(NotificationGroupManager::class)
+        every { NotificationGroupManager.getInstance() } returns ngm
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    private fun dateFromNow(offsetDays: Long): Date {
+        val localDate = LocalDate.now(ZoneId.of("UTC")).plusDays(offsetDays)
+        return Date.from(localDate.atStartOfDay(ZoneId.of("UTC")).toInstant())
+    }
+
+    /** Advance to [day] of a 30-day trial. Day 0 = fresh install, Day 30 = expires today. */
+    private fun advanceToTrialDay(day: Int) {
+        val daysRemaining = (30 - day).toLong()
+        every { facade.isEvaluationLicense } returns true
+        every { facade.getConfirmationStamp(LicenseChecker.PRODUCT_CODE) } returns "eval:session-$day"
+        every { facade.getExpirationDate(LicenseChecker.PRODUCT_CODE) } returns
+            if (daysRemaining >= 0) dateFromNow(daysRemaining) else null
+    }
+
+    private fun advanceToPostTrial() {
+        // Marketplace stops returning eval stamp; facade still reachable.
+        every { facade.isEvaluationLicense } returns false
+        every { facade.getConfirmationStamp(LicenseChecker.PRODUCT_CODE) } returns null
+        every { facade.getExpirationDate(LicenseChecker.PRODUCT_CODE) } returns null
+    }
+
+    private fun advanceToLicensed() {
+        every { facade.isEvaluationLicense } returns false
+        every { facade.getConfirmationStamp(LicenseChecker.PRODUCT_CODE) } returns "eval:purchased-stamp"
+        every { facade.getExpirationDate(LicenseChecker.PRODUCT_CODE) } returns null
+    }
+
+    // ---------- Full lifecycle simulation ----------
+
+    @Test
+    fun `full trial lifecycle from day 0 through post-expiry re-purchase`() {
+        // Day 0: fresh install. Marketplace issues eval stamp. First licensed
+        // check writes `lastKnownLicensedMs`, StartupLicenseHandler calls
+        // enableProDefaults(). User gets Pro experience out of the box.
+        advanceToTrialDay(0)
+        assertTrue(LicenseChecker.isLicensedOrGrace(), "Day 0: eval stamp must be treated as licensed")
+        assertEquals(30L, LicenseChecker.getTrialDaysRemaining())
+        assertTrue(state.lastKnownLicensedMs > 0, "Day 0: licensed check must stamp lastKnownLicensedMs")
+
+        LicenseChecker.enableProDefaults()
+        assertTrue(state.everBeenPro, "Day 0: Pro activation must set everBeenPro latch")
+        assertTrue(state.proDefaultsApplied)
+        assertTrue(state.glowEnabled)
+        assertEquals(100, state.sharpNeonIntensity)
+
+        // Day 1..22: trial active, nothing notable. checkTrialExpiryWarning
+        // must stay silent outside the 7-day window.
+        for (day in listOf(1, 10, 15, 22)) {
+            advanceToTrialDay(day)
+            LicenseChecker.checkTrialExpiryWarning(null)
+        }
+        verify(exactly = 0) {
+            notificationGroup.createNotification(any<String>(), any<String>(), any<NotificationType>())
+        }
+        assertFalse(state.trialExpiryWarningShown, "No warning before 7-day threshold")
+
+        // Day 10: user disables glow manually (mid-trial customization).
+        state.glowEnabled = false
+
+        // Day 23: 7 days remaining. First warning fires and latches.
+        advanceToTrialDay(23)
+        assertEquals(7L, LicenseChecker.getTrialDaysRemaining())
+        LicenseChecker.checkTrialExpiryWarning(null)
+        assertTrue(state.trialExpiryWarningShown)
+        verify(exactly = 1) {
+            notificationGroup.createNotification(
+                match { it.contains("7 days remaining") },
+                any<String>(),
+                NotificationType.INFORMATION,
+            )
+        }
+
+        // Day 24-26: still within 7-day window but latch silences further warnings.
+        for (day in listOf(24, 25, 26)) {
+            advanceToTrialDay(day)
+            LicenseChecker.checkTrialExpiryWarning(null)
+        }
+        // Still exactly one notification so far.
+        verify(exactly = 1) {
+            notificationGroup.createNotification(any<String>(), any<String>(), any<NotificationType>())
+        }
+
+        // Day 27: 3 days remaining, second warning fires.
+        advanceToTrialDay(27)
+        LicenseChecker.checkTrialExpiryWarning(null)
+        assertTrue(state.trialExpiry3DayWarningShown)
+        verify(exactly = 1) {
+            notificationGroup.createNotification(
+                match { it.contains("3 days remaining") },
+                any<String>(),
+                NotificationType.INFORMATION,
+            )
+        }
+
+        // Day 28-29: both latched, silence.
+        for (day in listOf(28, 29)) {
+            advanceToTrialDay(day)
+            LicenseChecker.checkTrialExpiryWarning(null)
+        }
+        verify(exactly = 2) {
+            notificationGroup.createNotification(any<String>(), any<String>(), any<NotificationType>())
+        }
+
+        // Day 30: expires today. Marketplace still honors the stamp.
+        advanceToTrialDay(30)
+        assertEquals(0L, LicenseChecker.getTrialDaysRemaining())
+        assertTrue(LicenseChecker.isLicensedOrGrace())
+
+        // Day 31: eval stamp gone, facade still reachable. The 48 h offline
+        // grace carries the user from their last licensed check on Day 30 into
+        // a brief bonus window — they won't notice a lockout if they restart
+        // the IDE the same day the stamp expires.
+        advanceToPostTrial()
+        val lastLicensedStamp = state.lastKnownLicensedMs
+        assertTrue(lastLicensedStamp > 0)
+        assertTrue(
+            LicenseChecker.isLicensedOrGrace(),
+            "Day 31 within 48 h grace: user must still see Pro",
+        )
+
+        // Day 31 + 49 h: grace expired. Simulate by moving the stored stamp
+        // into the past rather than mocking System clock — equivalent result
+        // from isLicensedOrGrace's perspective.
+        state.lastKnownLicensedMs = System.currentTimeMillis() - 49L * 3_600_000L
+        assertFalse(
+            LicenseChecker.isLicensedOrGrace(),
+            "Day 31 + 49 h: grace window must close",
+        )
+
+        // StartupLicenseHandler would now invoke revertToFreeDefaults +
+        // notifyTrialExpired. Simulate that.
+        LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
+        assertFalse(state.glowEnabled, "revert keeps glow off")
+        assertFalse(state.accentRotationEnabled)
+        assertFalse(state.cgpIntegrationEnabled)
+        LicenseChecker.notifyTrialExpired(null)
+        state.trialExpiredNotified = true
+
+        // Day 32 (restart same day): trialExpiredNotified latched → no duplicate
+        // notification even if the startup handler is re-invoked.
+        val notifyCountAfterDay31 = 3 // 7-day + 3-day + trial-expired = 3
+        verify(exactly = notifyCountAfterDay31) {
+            notificationGroup.createNotification(any<String>(), any<String>(), any<NotificationType>())
+        }
+
+        // Day 45: user purchases. We simulate what StartupLicenseHandler.applyLicensedDefaults
+        // does — reset trialExpiredNotified + proDefaultsApplied, then enableProDefaults().
+        advanceToLicensed()
+        assertTrue(LicenseChecker.isLicensedOrGrace())
+        state.trialExpiredNotified = false
+        state.proDefaultsApplied = false
+        state.premiumOnboardingShown = false
+        LicenseChecker.enableProDefaults()
+
+        // `everBeenPro` guard means enableProDefaults is a no-op for
+        // customizations — glow stays off as it was at revert / Day 10.
+        assertFalse(
+            state.glowEnabled,
+            "Re-purchase must not resurrect glow; everBeenPro gate preserves the revert outcome",
+        )
+        assertTrue(state.proDefaultsApplied, "enableProDefaults still sets the applied latch")
+        assertTrue(state.everBeenPro)
+    }
+
+    // ---------- Focused per-step assertions ----------
+
+    @Test
+    fun `getTrialDaysRemaining returns 30 at the start of the trial`() {
+        advanceToTrialDay(0)
+        assertEquals(30L, LicenseChecker.getTrialDaysRemaining())
+    }
+
+    @Test
+    fun `getTrialDaysRemaining returns zero on expiry day`() {
+        advanceToTrialDay(30)
+        assertEquals(0L, LicenseChecker.getTrialDaysRemaining())
+    }
+
+    @Test
+    fun `post-trial stamp absence yields null trial days`() {
+        advanceToPostTrial()
+        assertNull(LicenseChecker.getTrialDaysRemaining())
+    }
+
+    @Test
+    fun `seven-day warning fires exactly once even across many same-day checks`() {
+        advanceToTrialDay(23) // 7 days remaining
+        repeat(100) { LicenseChecker.checkTrialExpiryWarning(null) }
+        verify(exactly = 1) {
+            notificationGroup.createNotification(any<String>(), any<String>(), any<NotificationType>())
+        }
+    }
+
+    @Test
+    fun `three-day warning fires even if seven-day warning latched in a previous session`() {
+        // Simulate a returning user who already saw the 7-day warning in a prior session.
+        state.trialExpiryWarningShown = true
+        advanceToTrialDay(27) // 3 days remaining
+        LicenseChecker.checkTrialExpiryWarning(null)
+        assertTrue(state.trialExpiry3DayWarningShown)
+        verify(exactly = 1) {
+            notificationGroup.createNotification(
+                match { it.contains("3 days remaining") },
+                any<String>(),
+                NotificationType.INFORMATION,
+            )
+        }
+    }
+
+    @Test
+    fun `isLicensedOrGrace stays true throughout the 30-day eval window`() {
+        for (day in 0..30) {
+            advanceToTrialDay(day)
+            assertTrue(
+                LicenseChecker.isLicensedOrGrace(),
+                "Day $day: user must have Pro access throughout the trial",
+            )
+        }
+    }
+
+    @Test
+    fun `lastKnownLicensedMs advances monotonically across consecutive licensed checks`() {
+        advanceToTrialDay(0)
+        LicenseChecker.isLicensedOrGrace()
+        val first = state.lastKnownLicensedMs
+        assertTrue(first > 0)
+        Thread.sleep(5L)
+        advanceToTrialDay(1)
+        LicenseChecker.isLicensedOrGrace()
+        val second = state.lastKnownLicensedMs
+        assertTrue(second >= first, "Stamp must never regress across sessions")
+    }
+
+    @Test
+    fun `trial warning reuses the same state object across simulated sessions`() {
+        // Day 23: 7-day warning.
+        advanceToTrialDay(23)
+        LicenseChecker.checkTrialExpiryWarning(null)
+        val afterSession1 = state.trialExpiryWarningShown
+
+        // Day 24 (new "session"): same state instance, latch persisted.
+        advanceToTrialDay(24)
+        LicenseChecker.checkTrialExpiryWarning(null)
+
+        assertTrue(afterSession1, "Session 1 must latch the 7-day warning")
+        assertTrue(state.trialExpiryWarningShown, "Session 2 must see the persisted latch")
+    }
+
+    @Test
+    fun `re-purchase after grace expiry restores isLicensedOrGrace`() {
+        advanceToTrialDay(0)
+        LicenseChecker.isLicensedOrGrace()
+        state.everBeenPro = true
+
+        advanceToPostTrial()
+        state.lastKnownLicensedMs = System.currentTimeMillis() - 49L * 3_600_000L
+        assertFalse(LicenseChecker.isLicensedOrGrace())
+
+        advanceToLicensed()
+        assertTrue(
+            LicenseChecker.isLicensedOrGrace(),
+            "Re-purchase must immediately restore licensed state",
+        )
+    }
+
+    @Test
+    fun `first licensed check on fresh install stamps lastKnownLicensedMs to a positive value`() {
+        advanceToTrialDay(0)
+        assertEquals(0L, state.lastKnownLicensedMs, "Precondition: fresh install has no stamp")
+        LicenseChecker.isLicensedOrGrace()
+        assertTrue(state.lastKnownLicensedMs > 0, "First licensed check writes a real timestamp")
+        assertNotNull(LicenseChecker.getTrialDaysRemaining())
+    }
+}


### PR DESCRIPTION
## Summary

Three anti-cheat holes + the test scaffolding to keep them closed.

**Clock rollback.** `isLicensedOrGrace()` compared `System.currentTimeMillis() - state.lastKnownLicensedMs` and granted grace whenever `elapsed < OFFLINE_GRACE_MS`. A user who rolled the clock back or hand-edited `lastKnownLicensedMs = Long.MAX_VALUE` in `ayuIslands.xml` got `elapsed < 0`, which passed the check → permanent grace. The rewrite: monotonic clamp on write (`maxOf`), explicit rollback detection on read (resets the stamp to 0, logs a warning, returns false), and a tightened window check (`elapsed in 0 until OFFLINE_GRACE_MS`).

**Dev bypass via `-Didea.config.path`.** `isDevBuild()` needed `ayu.islands.dev=true` plus `configPath.contains("idea-sandbox")`. Both are user-controllable. Added a third gate that checks the plugin's own install path via `PluginManagerCore.getPlugin(…)?.pluginPath` — Gradle's `runIde` plants the plugin under `build/idea-sandbox/…` and the IDE's plugin-path discovery is not sysprop-driven, so forging this requires compiling from source (at which point the user is already a dev).

**Thread-safety of revert.** `revertToFreeDefaults` mutates `BaseState` from background coroutines (`StartupLicenseHandler`, `LicenseTransitionListener`). `BaseState` isn't thread-safe for parallel writes. Wrapped the mutation block in `synchronized(state)`; kept the downstream `AccentApplicator.apply()` / `GlowOverlayManager.syncGlowForAllProjects()` calls outside the lock because they hop to EDT and can take other platform locks.

## Tests

- `LicenseCheckerAntiCheatTest` — Long.MAX_VALUE tamper, 1 ms rollback, exact 48-hour boundary (inside/outside), monotonic-clamp property test over `Arb.long()`, 2³ matrix for the triple dev gate, Marketplace-trust pinning (`eval:` stamp still accepted without re-verification).
- `TrialLifecycleIntegrationTest` — Day 0 → Day 45 simulator: Pro activation → mid-trial custom glow off → 7-day warning → 3-day warning → expiry → 48-hour grace → post-grace revert → re-purchase. Asserts `everBeenPro` guard preserves user customizations after re-license.
- `FreeTierLockdownTest` — pins the six-theme catalog in `plugin.xml`, asserts every premium toggle flips off on revert, preserves accent colors, and exercises `synchronized(state)` with 4 concurrent `Thread`s × 3 replays + 5 s join-timeout deadlock detection.
- `LicenseCheckerTest` — grace-boundary cases (47 h 59 m inside, 48 h outside) and a monotonic-stamp assertion; updated the existing dev-bypass case to mock the plugin path too.

## Why this matters

JetBrains Marketplace vouches for the 30-day eval license via `LicensingFacade` — that part we trust. The vulnerable surface is the 48-hour offline grace that keeps paying users unlocked when the license server is unreachable. Without this fix, a user never has to connect again after the first legitimate licensed check.

## Test plan

- [x] `./gradlew compileTestKotlin` — compiles clean
- [x] `./gradlew ktlintTestSourceSetCheck ktlintMainSourceSetCheck` — green
- [ ] CI `./gradlew test` — full suite (locally the IDE sandbox test-executor hung in teardown; the existing 537-line `StartupLicenseStateTest` already passed on the untouched prod paths before these changes landed, so regressions should surface on CI only on new files)
- [ ] Optional manual smoke in sandbox: roll system clock +60 days → trial locks; roll −10 days → rollback guard fires, `idea.log` shows `"Clock rollback or lastKnownLicensedMs tamper detected"`

## Notes for reviewer

XML signing / HMAC was considered and rejected — for a solo plugin the key would live in the jar. Accepted risk, documented inline. The wall-clock guard above covers the worst attack vector (stretching grace indefinitely); hand-editing a random future value now self-corrects on the next unlicensed check.

## Summary by Sourcery

Strengthen trial licensing and free-tier reversion logic against tampering and race conditions, and expand tests to cover trial lifecycle, anti-cheat behavior, and free-tier lockdown.

Bug Fixes:
- Prevent indefinite offline grace by clamping last-known licensed timestamps monotonically, rejecting clock rollbacks and future tampering, and tightening the 48-hour grace window check.
- Eliminate a dev-mode licensing bypass by requiring a triple gate of dev property, sandbox config path, and sandbox plugin install path.
- Avoid concurrent state corruption when reverting to free defaults by synchronizing configuration mutations while keeping UI updates outside the lock.

Enhancements:
- Document anti-cheat and dev-mode behavior directly in licensing KDoc for future maintainability.

Tests:
- Add comprehensive anti-cheat tests for clock rollback, grace-window boundaries, monotonic timestamp behavior, dev-mode triple gate, and Marketplace stamp trust.
- Add an end-to-end trial lifecycle integration test from fresh install through expiry, grace, revert, and re-purchase, including trial warning notifications and state latching.
- Add free-tier lockdown tests to ensure revert-to-free disables all premium features, preserves free-tier settings, validates the theme catalog, and remains idempotent under concurrency.
- Extend existing licensing tests with additional grace-window boundary checks and a monotonic timestamp assertion, plus plugin-path mocking for dev-mode behavior.