### PR TITLE
Clock-seam helper + XML parser hardening (Sourcery follow-up)

### DIFF
--- a/src/test/kotlin/dev/ayuislands/licensing/FreeTierLockdownTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/FreeTierLockdownTest.kt
@@ -23,6 +23,7 @@ import io.mockk.runs
 import io.mockk.unmockkAll
 import io.mockk.verify
 import org.w3c.dom.Element
+import javax.xml.XMLConstants
 import javax.xml.parsers.DocumentBuilderFactory
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -195,11 +196,18 @@ class FreeTierLockdownTest {
         // `<themeProvider` would miscount if a theme provider ever got commented out
         // or another element's name starts with the same prefix. DOM ignores comments
         // and returns only live nodes.
+        //
+        // Hardened against malicious manifests: secure-processing on, DOCTYPE
+        // declarations rejected outright, both external-entity flags off. The plugin's
+        // own plugin.xml has no DOCTYPE, so flipping disallow-doctype-decl to true
+        // costs nothing and prevents DTD-based attacks if the test classpath is ever
+        // swapped for a tampered manifest.
         val factory =
             DocumentBuilderFactory.newInstance().apply {
                 isNamespaceAware = false
                 isValidating = false
-                setFeature("http://apache.org/xml/features/disallow-doctype-decl", false)
+                setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true)
+                setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
                 setFeature("http://xml.org/sax/features/external-general-entities", false)
                 setFeature("http://xml.org/sax/features/external-parameter-entities", false)
             }

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerAntiCheatTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerAntiCheatTest.kt
@@ -59,19 +59,17 @@ class LicenseCheckerAntiCheatTest {
         mockkStatic(PluginManagerCore::class)
         every { PluginManagerCore.getPlugin(any<PluginId>()) } returns null
 
-        // Pin the clock through the public test seam instead of mocking
-        // System.currentTimeMillis — the latter kept Gradle test-executor shutdown
-        // hooks alive and timed out CI. A stable anchor removes boundary-test
-        // flakiness caused by real-clock jitter during the `isLicensedOrGrace` call.
+        // Pin the clock through LicenseCheckerClockSeam so restore stays centralized
+        // and the production defaults come back from exactly one place in tearDown.
         fixedNow = 1_700_000_000_000L // 2023-11-14, arbitrary but stable
-        LicenseChecker.nowMsSupplier = { fixedNow }
+        LicenseCheckerClockSeam.pinNow(fixedNow)
 
         System.clearProperty("ayu.islands.dev")
     }
 
     @AfterTest
     fun tearDown() {
-        LicenseChecker.nowMsSupplier = System::currentTimeMillis
+        LicenseCheckerClockSeam.restore()
         System.clearProperty("ayu.islands.dev")
         unmockkAll()
     }

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerClockSeam.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerClockSeam.kt
@@ -1,0 +1,75 @@
+package dev.ayuislands.licensing
+
+import java.time.LocalDate
+import java.time.ZoneId
+
+/**
+ * Scoped override for the [LicenseChecker] time seams.
+ *
+ * [LicenseChecker.nowMsSupplier] and [LicenseChecker.todayUtcSupplier] are object-scoped
+ * `var`s — convenient for test determinism, dangerous if a test forgets to restore them.
+ * This helper centralizes the pin/restore dance so every time-sensitive test uses the
+ * same idiom, and the production defaults are re-installed from exactly one place.
+ *
+ * Typical usage in per-class test state:
+ * ```
+ * @BeforeTest fun setUp() {
+ *     LicenseCheckerClockSeam.pinNow { fakeNowMs }
+ *     LicenseCheckerClockSeam.pinToday { fakeTodayUtc }
+ * }
+ *
+ * @AfterTest fun tearDown() {
+ *     LicenseCheckerClockSeam.restore()
+ * }
+ * ```
+ *
+ * For one-off boundary cases that should not leak their pinned clock to sibling tests:
+ * ```
+ * LicenseCheckerClockSeam.withFixedNow(fixedNowMs) {
+ *     assertFalse(LicenseChecker.isLicensedOrGrace())
+ * }
+ * ```
+ */
+internal object LicenseCheckerClockSeam {
+    /** Pin the millisecond clock to a constant value. */
+    fun pinNow(fixedNowMs: Long) {
+        LicenseChecker.nowMsSupplier = { fixedNowMs }
+    }
+
+    /** Pin the millisecond clock to a dynamic supplier (e.g. a `var` that tests advance). */
+    fun pinNow(supplier: () -> Long) {
+        LicenseChecker.nowMsSupplier = supplier
+    }
+
+    /** Pin the UTC "today" date to a constant value. */
+    fun pinToday(fixedToday: LocalDate) {
+        LicenseChecker.todayUtcSupplier = { fixedToday }
+    }
+
+    /** Pin the UTC "today" date to a dynamic supplier. */
+    fun pinToday(supplier: () -> LocalDate) {
+        LicenseChecker.todayUtcSupplier = supplier
+    }
+
+    /** Reset both seams to their production defaults. Safe to call multiple times. */
+    fun restore() {
+        LicenseChecker.nowMsSupplier = System::currentTimeMillis
+        LicenseChecker.todayUtcSupplier = { LocalDate.now(ZoneId.of("UTC")) }
+    }
+
+    /**
+     * Pin [LicenseChecker.nowMsSupplier] to [fixedNowMs] for the duration of [block],
+     * always restoring the default afterwards — even on exception.
+     */
+    inline fun <R> withFixedNow(
+        fixedNowMs: Long,
+        block: () -> R,
+    ): R {
+        pinNow(fixedNowMs)
+        return try {
+            block()
+        } finally {
+            restore()
+        }
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerTest.kt
@@ -157,11 +157,10 @@ class LicenseCheckerTest {
 
     // ---------- Grace-window boundary tests ----------
     //
-    // Each boundary case pins the clock through LicenseChecker.nowMsSupplier so
-    // real-clock jitter during the `isLicensedOrGrace` call cannot cross the
-    // 48 h threshold mid-test. Restore the default supplier in AfterTest via
-    // `unmockkAll` + a fresh setUp is not enough — nowMsSupplier is a top-level
-    // var on the object and survives mockk resets.
+    // Each case uses LicenseCheckerClockSeam so the pin/restore pair is uniform and the
+    // production defaults come back from one place. Restore runs in `finally` via
+    // withFixedNow / explicit `restore()`, so a failing assertion can never leak the
+    // fake clock to a sibling test.
 
     @Test
     fun `isLicensedOrGrace returns true within 47h 59m of last licensed check`() {
@@ -176,12 +175,9 @@ class LicenseCheckerTest {
 
         val msPerHour = 3_600_000L
         val fixedNow = 1_700_000_000_000L
-        LicenseChecker.nowMsSupplier = { fixedNow }
-        try {
+        LicenseCheckerClockSeam.withFixedNow(fixedNow) {
             realState.lastKnownLicensedMs = fixedNow - (47L * msPerHour) - (59L * 60_000L)
             assertTrue(LicenseChecker.isLicensedOrGrace(), "47h 59m must still be inside grace window")
-        } finally {
-            LicenseChecker.nowMsSupplier = System::currentTimeMillis
         }
     }
 
@@ -198,12 +194,9 @@ class LicenseCheckerTest {
 
         val msPerHour = 3_600_000L
         val fixedNow = 1_700_000_000_000L
-        LicenseChecker.nowMsSupplier = { fixedNow }
-        try {
+        LicenseCheckerClockSeam.withFixedNow(fixedNow) {
             realState.lastKnownLicensedMs = fixedNow - (48L * msPerHour)
             assertFalse(LicenseChecker.isLicensedOrGrace(), "Exactly 48h must be outside grace window (strict <)")
-        } finally {
-            LicenseChecker.nowMsSupplier = System::currentTimeMillis
         }
     }
 
@@ -219,7 +212,7 @@ class LicenseCheckerTest {
         every { facade.getConfirmationStamp(LicenseChecker.PRODUCT_CODE) } returns "eval:1"
 
         var nowTick = 1_700_000_000_000L
-        LicenseChecker.nowMsSupplier = { nowTick }
+        LicenseCheckerClockSeam.pinNow { nowTick }
         try {
             realState.lastKnownLicensedMs = 0L
             LicenseChecker.isLicensedOrGrace()
@@ -231,7 +224,7 @@ class LicenseCheckerTest {
             LicenseChecker.isLicensedOrGrace()
             assertEquals(nowTick, realState.lastKnownLicensedMs, "Stamp must move forward with the clock")
         } finally {
-            LicenseChecker.nowMsSupplier = System::currentTimeMillis
+            LicenseCheckerClockSeam.restore()
         }
     }
 

--- a/src/test/kotlin/dev/ayuislands/licensing/TrialLifecycleIntegrationTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/TrialLifecycleIntegrationTest.kt
@@ -84,10 +84,12 @@ class TrialLifecycleIntegrationTest {
         // arithmetic are fully deterministic. fakeNowMs mirrors the same moment
         // (midnight UTC on the anchor day), which lets grace-window assertions
         // derive from the same reference frame as the expiration helper.
+        // Dynamic suppliers read the latest `var` value on every call so the
+        // lifecycle simulation can advance the clock between checks.
         fakeTodayUtc = LocalDate.of(2026, 4, 20)
         fakeNowMs = fakeTodayUtc.atStartOfDay(ZoneId.of("UTC")).toInstant().toEpochMilli()
-        LicenseChecker.nowMsSupplier = { fakeNowMs }
-        LicenseChecker.todayUtcSupplier = { fakeTodayUtc }
+        LicenseCheckerClockSeam.pinNow { fakeNowMs }
+        LicenseCheckerClockSeam.pinToday { fakeTodayUtc }
 
         System.clearProperty("ayu.islands.dev")
 
@@ -117,8 +119,7 @@ class TrialLifecycleIntegrationTest {
 
     @AfterTest
     fun tearDown() {
-        LicenseChecker.nowMsSupplier = System::currentTimeMillis
-        LicenseChecker.todayUtcSupplier = { LocalDate.now(ZoneId.of("UTC")) }
+        LicenseCheckerClockSeam.restore()
         unmockkAll()
     }
 


### PR DESCRIPTION
## Summary

Sourcery left two high-level comments on #145:

1. **XML parser wasn't actually hardened.** The DocumentBuilderFactory set `disallow-doctype-decl` to `false` — opposite of what the argument name implies. Flipped to `true` and added `XMLConstants.FEATURE_SECURE_PROCESSING`. The plugin's own `plugin.xml` has no DOCTYPE, so there's no compatibility cost.
2. **Every test manually restored the clock seam in `@AfterTest` / `finally`.** One forgotten `restore` would leak a fake clock into the next test. Extracted `LicenseCheckerClockSeam` — `pinNow(Long)` / `pinNow(() -> Long)` / `pinToday(...)` / `restore()` / `withFixedNow(block)`. Every time-sensitive test now uses it.

Both asks are test-only; no production change.

## What changed

- **New** `LicenseCheckerClockSeam.kt` — scoped helper with pin/restore + `withFixedNow` inline wrapper for one-off boundary cases.
- `LicenseCheckerAntiCheatTest.kt` — `setUp` calls `pinNow(fixedNow)`, `tearDown` calls `restore()`. No direct supplier assignment.
- `LicenseCheckerTest.kt` — the three grace-boundary cases now wrap their pinned block in `withFixedNow(...)` / `pinNow { nowTick } + restore()` instead of inline try/finally.
- `TrialLifecycleIntegrationTest.kt` — `setUp` pins both suppliers via the helper with dynamic `() -> Long` / `() -> LocalDate` closures that read the mutable `fakeNowMs` / `fakeTodayUtc` on each call; `tearDown` is a single `restore()`.
- `FreeTierLockdownTest.kt` — `DocumentBuilderFactory` now turns on `FEATURE_SECURE_PROCESSING` and sets `disallow-doctype-decl` to `true`.

## Test plan

- [x] `./gradlew compileTestKotlin` — clean
- [x] `./gradlew ktlintTestSourceSetCheck` — green
- [ ] CI `./gradlew test` — full suite

## Notes

Behavior is identical — the seam still reads from the production suppliers by default, and the XML still accepts the current manifest. `restore()` is idempotent and documented as safe to call multiple times, so a helper that re-invokes it during teardown doesn't fight the inline cleanup in `withFixedNow`.

## Summary by Sourcery

Introduce a centralized clock seam helper for LicenseChecker tests and harden XML parsing in test-only manifest loading.

New Features:
- Add LicenseCheckerClockSeam test helper to centralize pinning and restoring LicenseChecker time suppliers, including a withFixedNow wrapper for scoped overrides.

Bug Fixes:
- Correct the XML parser configuration in FreeTierLockdownTest to enable secure processing, disallow DOCTYPE declarations, and keep external entities disabled to prevent DTD-based attacks.

Tests:
- Refactor LicenseCheckerTest, LicenseCheckerAntiCheatTest, and TrialLifecycleIntegrationTest to use LicenseCheckerClockSeam for deterministic, leak-free time-based testing.