### PR TITLE
Snapshot clock seams + preserve nested overrides (Sourcery #2)

### DIFF
--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerClockSeam.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerClockSeam.kt
@@ -1,7 +1,6 @@
 package dev.ayuislands.licensing
 
 import java.time.LocalDate
-import java.time.ZoneId
 
 /**
  * Scoped override for the [LicenseChecker] time seams.
@@ -10,6 +9,13 @@ import java.time.ZoneId
  * `var`s — convenient for test determinism, dangerous if a test forgets to restore them.
  * This helper centralizes the pin/restore dance so every time-sensitive test uses the
  * same idiom, and the production defaults are re-installed from exactly one place.
+ *
+ * **Snapshot at class init, not hardcoded.** The first time this object is touched it
+ * captures whatever suppliers [LicenseChecker] currently holds — typically the production
+ * defaults (`System::currentTimeMillis`, `LocalDate.now(UTC)`). [restore] hands those
+ * original references back, so the helper stays correct even if the production defaults
+ * ever change inside [LicenseChecker]. The capture happens before any test can pin a
+ * supplier because Kotlin `object` initialization is eager on first access.
  *
  * Typical usage in per-class test state:
  * ```
@@ -29,8 +35,15 @@ import java.time.ZoneId
  *     assertFalse(LicenseChecker.isLicensedOrGrace())
  * }
  * ```
+ *
+ * [withFixedNow] captures the currently-installed supplier before pinning and reinstalls
+ * that exact reference in `finally`, so a setUp-level pin survives an inner boundary
+ * test's block without being hard-reset to the production default.
  */
 internal object LicenseCheckerClockSeam {
+    private val originalNowMsSupplier: () -> Long = LicenseChecker.nowMsSupplier
+    private val originalTodayUtcSupplier: () -> LocalDate = LicenseChecker.todayUtcSupplier
+
     /** Pin the millisecond clock to a constant value. */
     fun pinNow(fixedNowMs: Long) {
         LicenseChecker.nowMsSupplier = { fixedNowMs }
@@ -51,25 +64,34 @@ internal object LicenseCheckerClockSeam {
         LicenseChecker.todayUtcSupplier = supplier
     }
 
-    /** Reset both seams to their production defaults. Safe to call multiple times. */
+    /**
+     * Reset both seams to the suppliers that [LicenseChecker] held when this helper was
+     * first touched. Typically the production defaults, but the snapshot keeps the helper
+     * correct even if those defaults ever move. Safe to call multiple times.
+     */
     fun restore() {
-        LicenseChecker.nowMsSupplier = System::currentTimeMillis
-        LicenseChecker.todayUtcSupplier = { LocalDate.now(ZoneId.of("UTC")) }
+        LicenseChecker.nowMsSupplier = originalNowMsSupplier
+        LicenseChecker.todayUtcSupplier = originalTodayUtcSupplier
     }
 
     /**
      * Pin [LicenseChecker.nowMsSupplier] to [fixedNowMs] for the duration of [block],
-     * always restoring the default afterwards — even on exception.
+     * always restoring the *previously-installed* supplier afterwards — even on exception.
+     *
+     * Preserves a caller-level pin (e.g. a `@BeforeTest` pin that wraps a whole class)
+     * so a nested boundary test can override the clock for a single assertion without
+     * clobbering the outer override.
      */
     inline fun <R> withFixedNow(
         fixedNowMs: Long,
         block: () -> R,
     ): R {
-        pinNow(fixedNowMs)
+        val previous = LicenseChecker.nowMsSupplier
+        LicenseChecker.nowMsSupplier = { fixedNowMs }
         return try {
             block()
         } finally {
-            restore()
+            LicenseChecker.nowMsSupplier = previous
         }
     }
 }


### PR DESCRIPTION
## Summary

Two more Sourcery asks on [#146](https://github.com/barad1tos/ayu-jetbrains/pull/146), both land on the clock-seam helper:

1. **`withFixedNow` hard-reset to production defaults.** A setUp-level pin on `nowMsSupplier` (e.g. a `{ fakeNowMs }` closure in `TrialLifecycleIntegrationTest`) would be clobbered the moment an inner `withFixedNow { ... }` block finished, because `withFixedNow` called `restore()`, not the supplier it saw on entry. Now it stashes `LicenseChecker.nowMsSupplier` before pinning and reinstalls that exact reference in `finally`.
2. **`restore()` hardcoded the production defaults** (`System::currentTimeMillis`, `LocalDate.now(UTC)`). If production ever swaps in a different supplier (say, a time-zone-aware clock or a `ThreadLocal`-indexed one for tests), the hardcoded strings drift out of sync. Capture the originals at object init (`private val originalNowMsSupplier = LicenseChecker.nowMsSupplier`) and hand those references back.

Both are test-only. No production behavior change.

## What changed

- `LicenseCheckerClockSeam.kt`:
  - Added `private val originalNowMsSupplier` + `originalTodayUtcSupplier` — snapshot at first access.
  - `restore()` now reads from those snapshots instead of referencing `System::currentTimeMillis` / `LocalDate.now(UTC)` directly.
  - `withFixedNow` captures `LicenseChecker.nowMsSupplier` into a local, pins the parameter, and restores the local in `finally`. No `restore()` call inside.
  - Expanded KDoc to explain the init-time capture and the nested-preserve contract.

## Test plan

- [x] `./gradlew compileTestKotlin` — clean
- [x] `./gradlew ktlintTestSourceSetCheck` — green
- [ ] CI `./gradlew test` — full suite (TrialLifecycleIntegrationTest is the main beneficiary; its setUp pins both suppliers via dynamic closures, and no inner block uses `withFixedNow`, so the change is a defensive cleanup the current tests don't directly exercise yet)

## Summary by Sourcery

Adjust test-only LicenseChecker clock seam helper to snapshot original time suppliers and preserve nested overrides when temporarily pinning the clock.

Enhancements:
- Snapshot LicenseChecker's original time suppliers at helper initialization and use them for restoring instead of hardcoded production defaults.
- Update withFixedNow to restore the previously installed clock supplier after the block, allowing nested overrides without losing outer pins.
- Expand KDoc for the clock seam helper to document snapshot behavior and nested override semantics.