### PR TITLE
fix: Phase 40 Round 3 stability hotfix (C-1..C-5 + M-7)

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "ded54f7"
+          last_verified_sha: "23a334f"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "ded54f7"
+          last_verified_sha: "23a334f"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "9b2e8dd"
+          last_verified_sha: "ec71df6"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "9b2e8dd"
+          last_verified_sha: "ec71df6"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "87f159a"
+          last_verified_sha: "11d36a3"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "87f159a"
+          last_verified_sha: "11d36a3"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "16a8e8f"
+          last_verified_sha: "87f159a"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "16a8e8f"
+          last_verified_sha: "87f159a"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "6e897ff"
+          last_verified_sha: "55f821e"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "6e897ff"
+          last_verified_sha: "55f821e"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "ec71df6"
+          last_verified_sha: "16a8e8f"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "ec71df6"
+          last_verified_sha: "16a8e8f"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "0b34e96"
+          last_verified_sha: "6e897ff"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "0b34e96"
+          last_verified_sha: "6e897ff"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "921804f"
+          last_verified_sha: "9802e1e"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "921804f"
+          last_verified_sha: "9802e1e"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "55f821e"
+          last_verified_sha: "921804f"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "55f821e"
+          last_verified_sha: "921804f"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "9802e1e"
+          last_verified_sha: "4e9522d"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "9802e1e"
+          last_verified_sha: "4e9522d"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "23a334f"
+          last_verified_sha: "0b34e96"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "23a334f"
+          last_verified_sha: "0b34e96"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "4e9522d"
+          last_verified_sha: "9b2e8dd"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "4e9522d"
+          last_verified_sha: "9b2e8dd"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -288,7 +288,6 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
             val installed =
                 runCatchingPreservingCancellation {
                     swapService.install()
-                    true
                 }.onFailure { exception ->
                     LOG.error(
                         "Startup accent-swap install failed for project '$projectName' " +
@@ -296,7 +295,7 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
                             "will be inert this session until the user re-triggers apply",
                         exception,
                     )
-                }.getOrDefault(false)
+                }.isSuccess
             if (!installed) return@withContext
             runCatchingPreservingCancellation {
                 swapService.notifyExternalApply(hex)

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -73,25 +73,11 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
         // install / notifyExternalApply doesn't abort the rest of startup
         // (font preset apply, language-detector warmup, ModuleRootListener
         // subscribe, scrollbar manager init, ComponentTreeRefresher,
-        // ConflictRegistry, license checks, onboarding). Logged at ERROR so
-        // user bug reports include a trace of which step failed. See Phase 40
-        // review Round 3 C-5.
-        withContext(Dispatchers.EDT) {
-            runCatchingPreservingCancellation {
-                val focusedProject = AccentApplicator.resolveFocusedProject() ?: project
-                val hex = AccentResolver.resolve(focusedProject, variant)
-                AccentApplicator.apply(hex)
-                val swapService = ProjectAccentSwapService.getInstance()
-                swapService.install()
-                swapService.notifyExternalApply(hex)
-            }.onFailure { exception ->
-                LOG.error(
-                    "Startup accent apply/install failed for project '${project.name}'; " +
-                        "continuing with remaining startup steps",
-                    exception,
-                )
-            }
-        }
+        // ConflictRegistry, license checks, onboarding). Extracted into
+        // `runStartupAccentOnEdt` to keep `execute` within detekt's cyclomatic
+        // complexity budget. See Phase 40 review Round 3 C-5 and review-loop
+        // Round 1 HIGH-2/HIGH-3/MEDIUM-3.
+        runStartupAccentOnEdt(project, variant)
 
         // Warm the language-detector cache so Settings → Accent → Overrides
         // shows real per-language proportions on first open. Gated on the same
@@ -216,6 +202,63 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
                 { GlowOverlayManager.getInstance(project).initialize() },
                 project.disposed,
             )
+        }
+    }
+
+    /**
+     * EDT triplet that must run atomically to avoid startup races: resolve the
+     * focused project, apply the accent, then install the focus-swap listener
+     * and publish the swap cache. Split from [execute] to keep cyclomatic
+     * complexity under detekt's threshold and to let the tests exercise this
+     * sequence in isolation (see Phase 40 review-loop Round 1 test-gap list).
+     *
+     * Round 1 refinements on top of the initial Round 3 C-5 fix:
+     *  - Capture projectName BEFORE the EDT hop so a mid-hop `project.isDisposed`
+     *    race cannot NPE inside the error logger and swallow the original
+     *    exception (MEDIUM-3).
+     *  - Split apply-vs-install into two [runCatchingPreservingCancellation]
+     *    blocks so the ERROR message pins which half failed — apply fail is a
+     *    visual regression the user sees; install fail silently disables
+     *    focus-swap cycling for the session (HIGH-2).
+     *  - Bail early if project/application already disposed to avoid hitting
+     *    platform APIs that rewrap PCE as AlreadyDisposedException, which the
+     *    coroutine cancellation helper can't unwrap (HIGH-3 mitigation at the
+     *    call site).
+     */
+    private suspend fun runStartupAccentOnEdt(
+        project: Project,
+        variant: AyuVariant,
+    ) {
+        val projectName = runCatching { project.name }.getOrElse { "<disposed>" }
+        withContext(Dispatchers.EDT) {
+            if (project.isDisposed || ApplicationManager.getApplication().isDisposed) {
+                return@withContext
+            }
+            val hex =
+                runCatchingPreservingCancellation {
+                    val focusedProject = AccentApplicator.resolveFocusedProject() ?: project
+                    val resolved = AccentResolver.resolve(focusedProject, variant)
+                    AccentApplicator.apply(resolved)
+                    resolved
+                }.onFailure { exception ->
+                    LOG.error(
+                        "Startup accent apply failed for project '$projectName'; " +
+                            "chrome may look un-themed until the next user-triggered apply",
+                        exception,
+                    )
+                }.getOrNull() ?: return@withContext
+            runCatchingPreservingCancellation {
+                val swapService = ProjectAccentSwapService.getInstance()
+                swapService.install()
+                swapService.notifyExternalApply(hex)
+            }.onFailure { exception ->
+                LOG.error(
+                    "Startup accent-swap install/notify failed for project '$projectName' " +
+                        "AFTER a successful apply; multi-project focus-swap cycling will " +
+                        "be inert this session until the user re-triggers apply",
+                    exception,
+                )
+            }
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -69,13 +69,28 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
         //    painted.
         // ProjectActivity.execute runs on a background coroutine, so the full
         // compute-apply-publish triplet must be wrapped in a single EDT block.
+        // Isolate the triplet so a throw in resolveFocusedProject / apply /
+        // install / notifyExternalApply doesn't abort the rest of startup
+        // (font preset apply, language-detector warmup, ModuleRootListener
+        // subscribe, scrollbar manager init, ComponentTreeRefresher,
+        // ConflictRegistry, license checks, onboarding). Logged at ERROR so
+        // user bug reports include a trace of which step failed. See Phase 40
+        // review Round 3 C-5.
         withContext(Dispatchers.EDT) {
-            val focusedProject = AccentApplicator.resolveFocusedProject() ?: project
-            val hex = AccentResolver.resolve(focusedProject, variant)
-            AccentApplicator.apply(hex)
-            val swapService = ProjectAccentSwapService.getInstance()
-            swapService.install()
-            swapService.notifyExternalApply(hex)
+            runCatchingPreservingCancellation {
+                val focusedProject = AccentApplicator.resolveFocusedProject() ?: project
+                val hex = AccentResolver.resolve(focusedProject, variant)
+                AccentApplicator.apply(hex)
+                val swapService = ProjectAccentSwapService.getInstance()
+                swapService.install()
+                swapService.notifyExternalApply(hex)
+            }.onFailure { exception ->
+                LOG.error(
+                    "Startup accent apply/install failed for project '${project.name}'; " +
+                        "continuing with remaining startup steps",
+                    exception,
+                )
+            }
         }
 
         // Warm the language-detector cache so Settings → Accent → Overrides

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -229,33 +229,82 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
         project: Project,
         variant: AyuVariant,
     ) {
-        val projectName = runCatching { project.name }.getOrElse { "<disposed>" }
+        // Round 2 MEDIUM R2-1: narrow the projectName capture catch to
+        // RuntimeException so CancellationException propagates instead of
+        // being swallowed into the "<disposed>" fallback. `project.name`
+        // access is non-suspend; catching Throwable here was asymmetric
+        // with every other catch in this file.
+        val projectName =
+            try {
+                project.name
+            } catch (exception: RuntimeException) {
+                LOG.debug(
+                    "Startup projectName capture failed; using <disposed> fallback",
+                    exception,
+                )
+                "<disposed>"
+            }
         withContext(Dispatchers.EDT) {
             if (project.isDisposed || ApplicationManager.getApplication().isDisposed) {
                 return@withContext
             }
-            val hex =
+            val applyOutcome =
                 runCatchingPreservingCancellation {
                     val focusedProject = AccentApplicator.resolveFocusedProject() ?: project
                     val resolved = AccentResolver.resolve(focusedProject, variant)
                     AccentApplicator.apply(resolved)
                     resolved
+                }
+            applyOutcome.onFailure { exception ->
+                LOG.error(
+                    "Startup accent apply failed for project '$projectName'; " +
+                        "chrome may look un-themed until the next user-triggered apply",
+                    exception,
+                )
+            }
+            val hex = applyOutcome.getOrNull()
+            if (hex == null) {
+                // Round 2 MEDIUM R2-2: apply-failure already logged via onFailure
+                // above. This branch also fires for Success(null), which is not
+                // reachable today (AccentResolver returns non-null) but a future
+                // refactor making `resolved` nullable must not silently skip
+                // install/notify without a log trace.
+                if (applyOutcome.isSuccess) {
+                    LOG.warn(
+                        "Startup accent apply returned a null hex unexpectedly " +
+                            "for project '$projectName'; skipping swap install",
+                    )
+                }
+                return@withContext
+            }
+            // Split install from notifyExternalApply so the ERROR message honestly
+            // describes what's broken. Bundling them under one catch meant an
+            // install-success + notify-failure combination logged "focus-swap
+            // cycling will be inert" — factually wrong, because the listener IS
+            // live; only the swap-cache publish step failed, so the first
+            // activation will redundantly re-apply but the cycling itself works.
+            // See Phase 40 review-loop Round 2 HIGH R2-1.
+            val swapService = ProjectAccentSwapService.getInstance()
+            val installed =
+                runCatchingPreservingCancellation {
+                    swapService.install()
+                    true
                 }.onFailure { exception ->
                     LOG.error(
-                        "Startup accent apply failed for project '$projectName'; " +
-                            "chrome may look un-themed until the next user-triggered apply",
+                        "Startup accent-swap install failed for project '$projectName' " +
+                            "AFTER a successful apply; multi-project focus-swap cycling " +
+                            "will be inert this session until the user re-triggers apply",
                         exception,
                     )
-                }.getOrNull() ?: return@withContext
+                }.getOrDefault(false)
+            if (!installed) return@withContext
             runCatchingPreservingCancellation {
-                val swapService = ProjectAccentSwapService.getInstance()
-                swapService.install()
                 swapService.notifyExternalApply(hex)
             }.onFailure { exception ->
                 LOG.error(
-                    "Startup accent-swap install/notify failed for project '$projectName' " +
-                        "AFTER a successful apply; multi-project focus-swap cycling will " +
-                        "be inert this session until the user re-triggers apply",
+                    "Startup accent-swap cache publish (notifyExternalApply) failed for " +
+                        "project '$projectName' AFTER a successful install; the listener " +
+                        "is live but the first WINDOW_ACTIVATED will redundantly re-apply",
                     exception,
                 )
             }

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -440,8 +440,12 @@ object AccentApplicator {
                 // would capture those tinted values as the stock baseline and
                 // poison the cache for the rest of the session. Roll back this
                 // element so the next apply starts from a clean slate. See Phase 40
-                // review Round 3 M-7.
-                runCatching { element.revert() }.onFailure { revertException ->
+                // review Round 3 M-7. Narrow the catch to RuntimeException so
+                // Error / CancellationException still propagate and don't get
+                // demoted to a WARN line (Round 1 review-loop HIGH-1).
+                try {
+                    element.revert()
+                } catch (revertException: RuntimeException) {
                     log.warn(
                         "Revert after failed apply also failed for ${element.displayName}",
                         revertException,

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -435,6 +435,18 @@ object AccentApplicator {
                     "Failed to apply accent to ${element.displayName}",
                     exception,
                 )
+                // A partial apply can leave UIManager / live peers in a
+                // mixed tinted+stock state; a subsequent `ChromeBaseColors.get()`
+                // would capture those tinted values as the stock baseline and
+                // poison the cache for the rest of the session. Roll back this
+                // element so the next apply starts from a clean slate. See Phase 40
+                // review Round 3 M-7.
+                runCatching { element.revert() }.onFailure { revertException ->
+                    log.warn(
+                        "Revert after failed apply also failed for ${element.displayName}",
+                        revertException,
+                    )
+                }
             }
         }
     }

--- a/src/main/kotlin/dev/ayuislands/accent/ChromeBaseColors.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ChromeBaseColors.kt
@@ -95,6 +95,17 @@ object ChromeBaseColors {
     /**
      * Clears the snapshot so the next `get` call re-captures from UIManager.
      * Invoked by the LAF listener; exposed for tests.
+     *
+     * Ordering note (Phase 40 review-loop Round 1 MEDIUM-2 / Round 2 S-2):
+     * the latch is cleared BEFORE the snapshot so a racing `get(key)` between
+     * the two clears cannot see a cleared snapshot with a stale latch still
+     * full (which would silence a WARN the new LAF cycle should emit). A
+     * symmetric residual race exists where a concurrent `get()` right after
+     * latch-clear re-populates the latch before snapshot-clear runs — the
+     * WARN still fires, it is just attributed to a cycle boundary that the
+     * reader happened to cross. Documented here rather than guarded with a
+     * lock because `refresh()` fires on EDT via the LAF listener and the
+     * cost of a briefly-skipped WARN line does not justify the synchronization.
      */
     fun refresh() {
         // Clear the latch BEFORE the snapshot so a racing `get(key)` between the

--- a/src/main/kotlin/dev/ayuislands/accent/ChromeBaseColors.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ChromeBaseColors.kt
@@ -31,11 +31,13 @@ object ChromeBaseColors {
     private val snapshot = ConcurrentHashMap<String, Color>()
 
     /**
-     * Per-key latch — a `true` entry means "we already logged the missing-key warning".
+     * Set of keys we've already logged a "UIManager has no entry" warning for.
      * Cleared alongside [snapshot] on LAF refresh so a key that drops between themes
-     * gets its own fresh warning. See Phase 40 review Round 3 C-3.
+     * gets its own fresh warning. Backed by `ConcurrentHashMap.newKeySet()` so
+     * `.add(key)` returns the log-once gate in a single atomic step. See Phase 40
+     * review Round 3 C-3 and Round 1 loop type-design finding.
      */
-    private val missingKeyLogged = ConcurrentHashMap<String, Boolean>()
+    private val missingKeyLogged: MutableSet<String> = ConcurrentHashMap.newKeySet()
 
     init {
         // Tests that exercise ChromeBaseColors without an IDE container (no
@@ -75,7 +77,9 @@ object ChromeBaseColors {
         snapshot[key]?.let { return it }
         val current = UIManager.getColor(key)
         if (current == null) {
-            if (missingKeyLogged.putIfAbsent(key, true) == null) {
+            // `Set.add` returns `true` iff the element was newly inserted — that is
+            // exactly the log-once gate, in a single atomic step.
+            if (missingKeyLogged.add(key)) {
                 log.warn(
                     "ChromeBaseColors: UIManager has no entry for '$key' — " +
                         "chrome surface using this key will skip tint until " +
@@ -93,9 +97,11 @@ object ChromeBaseColors {
      * Invoked by the LAF listener; exposed for tests.
      */
     fun refresh() {
-        snapshot.clear()
-        // Rearm the missing-key WARN latch so a key that disappears between
-        // themes gets a fresh log line on the next apply cycle.
+        // Clear the latch BEFORE the snapshot so a racing `get(key)` between the
+        // two clears cannot see a cleared snapshot with a stale latch still full
+        // (which would silence a WARN that the new LAF cycle should emit). See
+        // Phase 40 Round 1 review loop MEDIUM-2.
         missingKeyLogged.clear()
+        snapshot.clear()
     }
 }

--- a/src/main/kotlin/dev/ayuislands/accent/ChromeBaseColors.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ChromeBaseColors.kt
@@ -30,6 +30,13 @@ object ChromeBaseColors {
     private val log = logger<ChromeBaseColors>()
     private val snapshot = ConcurrentHashMap<String, Color>()
 
+    /**
+     * Per-key latch — a `true` entry means "we already logged the missing-key warning".
+     * Cleared alongside [snapshot] on LAF refresh so a key that drops between themes
+     * gets its own fresh warning. See Phase 40 review Round 3 C-3.
+     */
+    private val missingKeyLogged = ConcurrentHashMap<String, Boolean>()
+
     init {
         // Tests that exercise ChromeBaseColors without an IDE container (no
         // MessageBus) swallow the subscription throw silently — the snapshot
@@ -39,10 +46,14 @@ object ChromeBaseColors {
         // changing theme. Log at WARN so the "chrome tints look stale after
         // theme change" report has a trace in idea.log.
         runCatching {
-            ApplicationManager
-                .getApplication()
+            val application = ApplicationManager.getApplication()
+            application
                 .messageBus
-                .connect()
+                // Anchor the subscription to the Application Disposable so the
+                // connection is disposed on plugin / application shutdown instead
+                // of leaking across dynamic plugin reloads. See Phase 40 review
+                // Round 3 C-4.
+                .connect(application)
                 .subscribe(LafManagerListener.TOPIC, LafManagerListener { refresh() })
         }.onFailure { exception ->
             log.warn(
@@ -56,11 +67,23 @@ object ChromeBaseColors {
      * Returns the stock color for [key] — captured the first time this method is
      * called (and every subsequent call returns the same value until the next
      * LAF change). Returns `null` if UIManager has no entry for [key] at capture
-     * time; callers fall back to their own default.
+     * time; callers fall back to their own default, and the first miss per key
+     * is logged at WARN so user-submitted idea.log captures which chrome surface
+     * silently skipped tint.
      */
     fun get(key: String): Color? {
         snapshot[key]?.let { return it }
-        val current = UIManager.getColor(key) ?: return null
+        val current = UIManager.getColor(key)
+        if (current == null) {
+            if (missingKeyLogged.putIfAbsent(key, true) == null) {
+                log.warn(
+                    "ChromeBaseColors: UIManager has no entry for '$key' — " +
+                        "chrome surface using this key will skip tint until " +
+                        "the next LAF event populates it",
+                )
+            }
+            return null
+        }
         // Retain first captured value even under concurrent first access.
         return snapshot.putIfAbsent(key, current) ?: current
     }
@@ -71,5 +94,8 @@ object ChromeBaseColors {
      */
     fun refresh() {
         snapshot.clear()
+        // Rearm the missing-key WARN latch so a key that disappears between
+        // themes gets a fresh log line on the next apply cycle.
+        missingKeyLogged.clear()
     }
 }

--- a/src/main/kotlin/dev/ayuislands/accent/ChromeDecorationsProbe.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ChromeDecorationsProbe.kt
@@ -44,14 +44,27 @@ object ChromeDecorationsProbe {
     /** OS branches the probe dispatches over; `UNKNOWN` is the safe-default else branch. */
     enum class Os { MAC, WINDOWS, LINUX, UNKNOWN }
 
-    private val defaultOsSupplier: () -> Os = {
+    /**
+     * Pure OS-dispatch function extracted from the default supplier so tests can
+     * exercise every branch without having to mock `SystemInfo`'s final static
+     * fields (which mockk cannot touch — see class KDoc). Default args read
+     * [SystemInfo] so production behaviour is unchanged; tests pass explicit
+     * booleans to reach the [Os.WINDOWS], [Os.LINUX], and [Os.UNKNOWN] branches.
+     */
+    @VisibleForTesting
+    internal fun computeOs(
+        isMac: Boolean = SystemInfo.isMac,
+        isWindows: Boolean = SystemInfo.isWindows,
+        isLinux: Boolean = SystemInfo.isLinux,
+    ): Os =
         when {
-            SystemInfo.isMac -> Os.MAC
-            SystemInfo.isWindows -> Os.WINDOWS
-            SystemInfo.isLinux -> Os.LINUX
+            isMac -> Os.MAC
+            isWindows -> Os.WINDOWS
+            isLinux -> Os.LINUX
             else -> Os.UNKNOWN
         }
-    }
+
+    private val defaultOsSupplier: () -> Os = { computeOs() }
 
     /**
      * Test seam for OS detection. Production code reads [SystemInfo]; tests override this

--- a/src/main/kotlin/dev/ayuislands/accent/LiveChromeRefresher.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/LiveChromeRefresher.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.wm.WindowManager
+import org.jetbrains.annotations.TestOnly
 import java.awt.Color
 import java.awt.Component
 import java.awt.Container
@@ -64,7 +65,7 @@ internal object LiveChromeRefresher {
      * equivalent trigger for a per-session container latch in production, so
      * tests use this hook to isolate order-dependent assertions.
      */
-    @org.jetbrains.annotations.TestOnly
+    @TestOnly
     internal fun resetBrokenContainerLoggedForTests() {
         brokenContainerLogged.clear()
     }

--- a/src/main/kotlin/dev/ayuislands/accent/LiveChromeRefresher.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/LiveChromeRefresher.kt
@@ -109,12 +109,21 @@ internal object LiveChromeRefresher {
      * Iterates top-level windows, skipping ones that are not [Window.isShowing] (disposed,
      * hidden, pooled popups) and isolating per-window failures so one flaky peer doesn't
      * abort chrome apply for the rest of the desktop. See Phase 40 review Round 3 C-1, C-2.
+     *
+     * Catches [RuntimeException] rather than using `runCatching` (which would also
+     * swallow [Error] — [OutOfMemoryError], [StackOverflowError]) so catastrophic JVM
+     * failures still propagate and don't get quietly logged at DEBUG. The Swing /
+     * AWT peer surface only throws [RuntimeException] subtypes (NPE on disposed peer,
+     * ClassCast on reflective match, IllegalState on detached frame), so narrowing
+     * the catch here also satisfies detekt's TooGenericExceptionCaught.
      */
     private inline fun forEachShowingWindow(action: (Window) -> Unit) {
         for (window in Window.getWindows()) {
             if (!window.isShowing) continue
-            runCatching { action(window) }.onFailure {
-                log.debug("Live refresh skipped for ${window.javaClass.simpleName}", it)
+            try {
+                action(window)
+            } catch (exception: RuntimeException) {
+                log.debug("Live refresh skipped for ${window.javaClass.simpleName}", exception)
             }
         }
     }
@@ -203,19 +212,34 @@ internal object LiveChromeRefresher {
 
     /**
      * Recursively walks [component] and its descendants, invoking [visit] per node.
-     * Each visit is isolated in `runCatching` so a single flaky peer (mid-dispose,
-     * ClassCast on reflective match, NPE inside repaint) doesn't abort the rest of
-     * the tree. See Phase 40 review Round 3 C-1.
+     * Each visit is isolated so a single flaky peer (mid-dispose, ClassCast on
+     * reflective match, NPE inside repaint) doesn't abort the rest of the tree;
+     * see Phase 40 review Round 3 C-1. Catches [RuntimeException] rather than
+     * [Throwable] so [Error]s ([OutOfMemoryError], [StackOverflowError]) still
+     * propagate instead of being silently swallowed at DEBUG, and narrower than
+     * [Exception] so detekt's TooGenericExceptionCaught stays happy — the Swing
+     * peer surface only throws [RuntimeException] subtypes anyway.
      */
     private fun walk(
         component: Component,
         visit: (Component) -> Unit,
     ) {
-        runCatching { visit(component) }.onFailure {
-            log.debug("Live refresh visit failed on ${component.javaClass.name}", it)
+        try {
+            visit(component)
+        } catch (exception: RuntimeException) {
+            log.debug("Live refresh visit failed on ${component.javaClass.name}", exception)
         }
         if (component is Container) {
-            val children = runCatching { component.components }.getOrNull() ?: return
+            val children =
+                try {
+                    component.components
+                } catch (exception: RuntimeException) {
+                    log.debug(
+                        "Live refresh could not read children of ${component.javaClass.name}",
+                        exception,
+                    )
+                    return
+                }
             for (child in children) {
                 walk(child, visit)
             }

--- a/src/main/kotlin/dev/ayuislands/accent/LiveChromeRefresher.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/LiveChromeRefresher.kt
@@ -74,15 +74,11 @@ internal object LiveChromeRefresher {
         classNameFqn: String,
         color: Color,
     ) {
-        for (window in Window.getWindows()) {
-            refreshOnTree(window, classNameFqn, color)
-        }
+        forEachShowingWindow { refreshOnTree(it, classNameFqn, color) }
     }
 
     fun clearByClassName(classNameFqn: String) {
-        for (window in Window.getWindows()) {
-            clearOnTree(window, classNameFqn)
-        }
+        forEachShowingWindow { clearOnTree(it, classNameFqn) }
     }
 
     /**
@@ -98,9 +94,7 @@ internal object LiveChromeRefresher {
         ancestorFqn: String,
         color: Color,
     ) {
-        for (window in Window.getWindows()) {
-            refreshOnTreeInsideAncestor(window, targetFqn, ancestorFqn, color)
-        }
+        forEachShowingWindow { refreshOnTreeInsideAncestor(it, targetFqn, ancestorFqn, color) }
     }
 
     /** Mirror of [refreshByClassNameInsideAncestorClass] for the revert path. */
@@ -108,8 +102,20 @@ internal object LiveChromeRefresher {
         targetFqn: String,
         ancestorFqn: String,
     ) {
+        forEachShowingWindow { clearOnTreeInsideAncestor(it, targetFqn, ancestorFqn) }
+    }
+
+    /**
+     * Iterates top-level windows, skipping ones that are not [Window.isShowing] (disposed,
+     * hidden, pooled popups) and isolating per-window failures so one flaky peer doesn't
+     * abort chrome apply for the rest of the desktop. See Phase 40 review Round 3 C-1, C-2.
+     */
+    private inline fun forEachShowingWindow(action: (Window) -> Unit) {
         for (window in Window.getWindows()) {
-            clearOnTreeInsideAncestor(window, targetFqn, ancestorFqn)
+            if (!window.isShowing) continue
+            runCatching { action(window) }.onFailure {
+                log.debug("Live refresh skipped for ${window.javaClass.simpleName}", it)
+            }
         }
     }
 
@@ -195,13 +201,22 @@ internal object LiveChromeRefresher {
         return false
     }
 
+    /**
+     * Recursively walks [component] and its descendants, invoking [visit] per node.
+     * Each visit is isolated in `runCatching` so a single flaky peer (mid-dispose,
+     * ClassCast on reflective match, NPE inside repaint) doesn't abort the rest of
+     * the tree. See Phase 40 review Round 3 C-1.
+     */
     private fun walk(
         component: Component,
         visit: (Component) -> Unit,
     ) {
-        visit(component)
+        runCatching { visit(component) }.onFailure {
+            log.debug("Live refresh visit failed on ${component.javaClass.name}", it)
+        }
         if (component is Container) {
-            for (child in component.components) {
+            val children = runCatching { component.components }.getOrNull() ?: return
+            for (child in children) {
                 walk(child, visit)
             }
         }

--- a/src/main/kotlin/dev/ayuislands/accent/LiveChromeRefresher.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/LiveChromeRefresher.kt
@@ -8,6 +8,7 @@ import java.awt.Color
 import java.awt.Component
 import java.awt.Container
 import java.awt.Window
+import java.util.concurrent.ConcurrentHashMap
 import javax.swing.JComponent
 
 /**
@@ -34,6 +35,16 @@ import javax.swing.JComponent
  */
 internal object LiveChromeRefresher {
     private val log = Logger.getInstance(LiveChromeRefresher::class.java)
+
+    /**
+     * Set of Container class names that have already produced a WARN for a
+     * `.components` read failure. Subsequent failures on the same class drop to
+     * DEBUG to avoid log spam, but the first occurrence per container class is
+     * loud because it almost always indicates a broken custom `Container`
+     * override in a third-party plugin — reportable, not just defensive. See
+     * Phase 40 review-loop Round 1 MEDIUM-1.
+     */
+    private val brokenContainerLogged: MutableSet<String> = ConcurrentHashMap.newKeySet()
 
     // --- StatusBar (resolvable via public WindowManager API) ---
 
@@ -118,7 +129,17 @@ internal object LiveChromeRefresher {
      * the catch here also satisfies detekt's TooGenericExceptionCaught.
      */
     private inline fun forEachShowingWindow(action: (Window) -> Unit) {
-        for (window in Window.getWindows()) {
+        val windows =
+            try {
+                Window.getWindows()
+            } catch (exception: RuntimeException) {
+                log.warn(
+                    "Live refresh could not enumerate AWT windows; skipping pass",
+                    exception,
+                )
+                return
+            }
+        for (window in windows) {
             if (!window.isShowing) continue
             try {
                 action(window)
@@ -234,15 +255,35 @@ internal object LiveChromeRefresher {
                 try {
                     component.components
                 } catch (exception: RuntimeException) {
-                    log.debug(
-                        "Live refresh could not read children of ${component.javaClass.name}",
-                        exception,
-                    )
+                    logBrokenContainer(component, exception)
                     return
                 }
             for (child in children) {
                 walk(child, visit)
             }
+        }
+    }
+
+    /**
+     * WARN on first encounter per container class, DEBUG thereafter. A throwing
+     * `Container.components` read is a reportable defect (likely a broken
+     * custom `Container` override in a third-party plugin) — the first
+     * occurrence must be loud; subsequent hits in the same session drop to
+     * DEBUG so the log doesn't flood. See Phase 40 review-loop Round 1 MEDIUM-1.
+     */
+    private fun logBrokenContainer(
+        component: Container,
+        exception: RuntimeException,
+    ) {
+        val className = component.javaClass.name
+        if (brokenContainerLogged.add(className)) {
+            log.warn(
+                "Live refresh could not read children of $className — " +
+                    "subtree will be skipped every apply; further hits log at DEBUG",
+                exception,
+            )
+        } else {
+            log.debug("Live refresh could not read children of $className", exception)
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/accent/LiveChromeRefresher.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/LiveChromeRefresher.kt
@@ -42,9 +42,32 @@ internal object LiveChromeRefresher {
      * DEBUG to avoid log spam, but the first occurrence per container class is
      * loud because it almost always indicates a broken custom `Container`
      * override in a third-party plugin — reportable, not just defensive. See
-     * Phase 40 review-loop Round 1 MEDIUM-1.
+     * Phase 40 review-loop Round 1 MEDIUM-1 and Round 2 LOW R2-1.
+     *
+     * Capped at [BROKEN_CONTAINER_LOG_CAP] entries so a pathological IDE
+     * session (1000+ transient Container subclasses all throwing) cannot let
+     * the set grow unbounded; on overflow the latch resets and the next
+     * encounter of any class re-logs at WARN.
      */
     private val brokenContainerLogged: MutableSet<String> = ConcurrentHashMap.newKeySet()
+
+    /**
+     * Upper bound on [brokenContainerLogged]. A typical IDE session sees
+     * ~5-10 distinct Container subclasses; 64 leaves plenty of headroom before
+     * the cap triggers.
+     */
+    private const val BROKEN_CONTAINER_LOG_CAP = 64
+
+    /**
+     * Test-only reset for [brokenContainerLogged]. `ChromeBaseColors` clears
+     * its sibling latch via `refresh()` (LAF-driven), but there is no
+     * equivalent trigger for a per-session container latch in production, so
+     * tests use this hook to isolate order-dependent assertions.
+     */
+    @org.jetbrains.annotations.TestOnly
+    internal fun resetBrokenContainerLoggedForTests() {
+        brokenContainerLogged.clear()
+    }
 
     // --- StatusBar (resolvable via public WindowManager API) ---
 
@@ -284,6 +307,12 @@ internal object LiveChromeRefresher {
             )
         } else {
             log.debug("Live refresh could not read children of $className", exception)
+        }
+        // Round 2 LOW R2-1: cap the set so a pathological session can't leak.
+        // On overflow we clear and the next encounter re-warns — acceptable
+        // trade-off vs unbounded memory growth.
+        if (brokenContainerLogged.size > BROKEN_CONTAINER_LOG_CAP) {
+            brokenContainerLogged.clear()
         }
     }
 

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
@@ -240,6 +240,57 @@ class AyuIslandsStartupActivityTest {
     }
 
     @Test
+    fun `install and notifyExternalApply are structurally separated by a short-circuit bail`() {
+        // Round 3 G1 regression lock. The R2-1 fix depends on install() and
+        // notifyExternalApply() sitting in SEPARATE runCatchingPreservingCancellation
+        // blocks with an `if (!installed) return@withContext` short-circuit
+        // between them. A "simplify" refactor that collapses them back into
+        // one block would keep both error literals (as dead code inside one
+        // runCatching body) while silently restoring the exact bug R2-1 fixed.
+        // Lock the structural pattern.
+        val source = readStartupActivitySource()
+        val structural =
+            Regex(
+                """runCatchingPreservingCancellation\s*\{\s*swapService\.install\(\)""" +
+                    """.*?\}\.onFailure\s*\{.*?\}\.isSuccess""" +
+                    """.*?if\s*\(\s*!\s*installed\s*\)\s*return@withContext""" +
+                    """.*?runCatchingPreservingCancellation\s*\{\s*swapService\.notifyExternalApply\(""",
+                RegexOption.DOT_MATCHES_ALL,
+            )
+        assertTrue(
+            structural.containsMatchIn(source),
+            "install() and notifyExternalApply() must remain in SEPARATE runCatching " +
+                "blocks with an `if (!installed) return@withContext` short-circuit between them",
+        )
+    }
+
+    @Test
+    fun `startup helper WARNs on Success-null hex as a defensive branch for future refactors`() {
+        // Round 3 G2 regression lock. MEDIUM R2-2 added a defensive branch:
+        // if applyOutcome.isSuccess but hex is null (not reachable today but
+        // reachable after any refactor that makes resolved nullable), WARN.
+        // The branch has NO behavioural test because the condition is not
+        // reachable today, so its only guard is a source-level lock on both
+        // the WARN literal AND the structural `applyOutcome.isSuccess` check
+        // inside the `hex == null` branch.
+        val source = readStartupActivitySource()
+        assertTrue(
+            source.contains("Startup accent apply returned a null hex unexpectedly"),
+            "WARN-on-null-hex defensive branch must remain against future nullable-refactor regressions",
+        )
+        val isSuccessInNullBranch =
+            Regex(
+                """if\s*\(\s*hex\s*==\s*null\s*\)\s*\{\s*[^}]*if\s*\(\s*applyOutcome\.isSuccess\s*\)""",
+                RegexOption.DOT_MATCHES_ALL,
+            )
+        assertTrue(
+            isSuccessInNullBranch.containsMatchIn(source),
+            "isSuccess check must sit INSIDE the `if (hex == null)` block — " +
+                "that is the Success(null) discriminator; removing it collapses the MEDIUM R2-2 fix",
+        )
+    }
+
+    @Test
     fun `execute does not claim AccentApplicator apply self-dispatches`() {
         // Regression guard for the PR #151 Round 2 Fix B-2: the old comment above the
         // withContext block asserted "AccentApplicator.apply self-dispatches internally",

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
@@ -103,12 +103,13 @@ class AyuIslandsStartupActivityTest {
             "Source must import kotlinx.coroutines.withContext",
         )
         // The resolveFocusedProject call must sit inside a withContext(Dispatchers.EDT) block.
-        // Regex matches across newlines so formatter variations (chained vs. split args) still
-        // pass. The critical constraint: resolveFocusedProject appears *after* Dispatchers.EDT
-        // and before the next top-level statement.
+        // Non-greedy `.*?` with DOT_MATCHES_ALL tolerates nested blocks (disposal bail,
+        // runCatchingPreservingCancellation) between the outer withContext brace and the
+        // resolveFocusedProject call site, while still anchoring that the call appears
+        // after withContext(Dispatchers.EDT) in the text.
         val edtBlock =
             Regex(
-                """withContext\(Dispatchers\.EDT\)\s*\{[^}]*AccentApplicator\.resolveFocusedProject\(\)""",
+                """withContext\(Dispatchers\.EDT\).*?AccentApplicator\.resolveFocusedProject\(\)""",
                 RegexOption.DOT_MATCHES_ALL,
             )
         assertTrue(
@@ -122,29 +123,119 @@ class AyuIslandsStartupActivityTest {
         // Regression guard for the PR #151 Round 2 Fix B-2: ProjectAccentSwapService has an
         // EDT precondition for notifyExternalApply (per AccentApplicator KDoc lines 203-205,
         // the cache write is a bare volatile with no dispatch and must publish in the same
-        // ordering as the apply that preceded it). Previously `swapService.install()` and
-        // `swapService.notifyExternalApply(accentHex)` lived below the EDT withContext
-        // block — i.e. back on the ProjectActivity background coroutine — which left a
-        // window where a WINDOW_ACTIVATED event could fire after the EDT apply but before
-        // the cache caught up, causing the swap listener to re-apply the exact same color
-        // and triggering an avoidable component-tree walk.
+        // ordering as the apply that preceded it).
         //
-        // The fix moves the entire compute-apply-publish triplet inside one withContext
-        // EDT turn. Enforce that source-level: notifyExternalApply MUST appear inside the
-        // same braces as resolveFocusedProject, not after the block closes.
+        // Phase 40 review-loop Round 2 HIGH R2-1 then split install and notifyExternalApply
+        // into two runCatchingPreservingCancellation blocks for better error attribution,
+        // so the regex tolerates intermediate braces — the only invariant that matters is
+        // that all four operations appear in order inside the EDT turn, not that they
+        // share a single inner block.
         val source = readStartupActivitySource()
         val edtTriplet =
             Regex(
-                """withContext\(Dispatchers\.EDT\)\s*\{[^}]*AccentApplicator\.resolveFocusedProject\(\)""" +
-                    """[^}]*AccentApplicator\.apply\([^)]*\)""" +
-                    """[^}]*swapService\.install\(\)""" +
-                    """[^}]*swapService\.notifyExternalApply\([^)]*\)""",
+                """withContext\(Dispatchers\.EDT\).*?AccentApplicator\.resolveFocusedProject\(\)""" +
+                    """.*?AccentApplicator\.apply\(""" +
+                    """.*?swapService\.install\(\)""" +
+                    """.*?swapService\.notifyExternalApply\(""",
                 RegexOption.DOT_MATCHES_ALL,
             )
         assertTrue(
             edtTriplet.containsMatchIn(source),
-            "swapService.install() + notifyExternalApply must run inside the same " +
-                "withContext(Dispatchers.EDT) { … } block as resolveFocusedProject + apply",
+            "resolveFocusedProject → apply → install → notifyExternalApply must all run " +
+                "inside the same withContext(Dispatchers.EDT) { … } turn",
+        )
+    }
+
+    @Test
+    fun `startup accent helper emits distinct error messages per failure branch`() {
+        // Round 2 HIGH R2-1 regression lock. The Round 1 loop fix split one
+        // runCatching into three (apply / install / notifyExternalApply) so
+        // triage can tell which half of the startup triplet failed from the
+        // log line alone. A maintainer who collapses the three branches back
+        // into one message, or who accidentally swaps the strings, would
+        // silently break that attribution contract.
+        val source = readStartupActivitySource()
+        assertTrue(
+            source.contains("Startup accent apply failed for project"),
+            "Apply branch must have its own distinct ERROR message",
+        )
+        assertTrue(
+            source.contains("Startup accent-swap install failed for project"),
+            "Install branch must have its own distinct ERROR message",
+        )
+        assertTrue(
+            source.contains("Startup accent-swap cache publish (notifyExternalApply) failed for"),
+            "notifyExternalApply branch must have its own distinct ERROR message",
+        )
+        // And the old bundled wording must NOT reappear — that's the swap-back regression.
+        assertEquals(
+            false,
+            source.contains("Startup accent-swap install/notify failed"),
+            "Old bundled install+notify message must not return",
+        )
+    }
+
+    @Test
+    fun `startup EDT block bails early when project or application is disposed`() {
+        // Round 2 HIGH R2-2 regression lock. The disposal bail must be the
+        // FIRST statement inside the withContext(Dispatchers.EDT) body so a
+        // mid-hop disposal can't reach platform APIs that would rewrap
+        // ProcessCanceledException as AlreadyDisposedException (which the
+        // coroutine cancellation helper cannot unwrap). Locks both presence
+        // AND position of the guard.
+        val source = readStartupActivitySource()
+        val disposedBail =
+            Regex(
+                """withContext\(Dispatchers\.EDT\)\s*\{\s*if\s*\(\s*project\.isDisposed\s*\|\|\s*""" +
+                    """ApplicationManager\.getApplication\(\)\.isDisposed\s*\)\s*\{\s*return@withContext""",
+                RegexOption.DOT_MATCHES_ALL,
+            )
+        assertTrue(
+            disposedBail.containsMatchIn(source),
+            "Disposal bail must be the first statement inside withContext(Dispatchers.EDT) { … }",
+        )
+    }
+
+    @Test
+    fun `startup projectName is captured before the EDT hop`() {
+        // Round 2 HIGH R2-3 regression lock. `projectName` MUST be captured
+        // OUTSIDE `withContext(Dispatchers.EDT)` so a mid-hop disposal cannot
+        // NPE inside the error logger and swallow the original exception
+        // (the MEDIUM-3 failure mode). Tempting to move it inside since
+        // projectName is only read there — this guard catches that.
+        val source = readStartupActivitySource()
+        val beforeEdt =
+            Regex(
+                """val\s+projectName\s*=\s*(?:try\s*\{|runCatching\s*\{).*?withContext\(Dispatchers\.EDT\)""",
+                RegexOption.DOT_MATCHES_ALL,
+            )
+        assertTrue(
+            beforeEdt.containsMatchIn(source),
+            "projectName must be captured before the withContext(Dispatchers.EDT) block",
+        )
+    }
+
+    @Test
+    fun `startup projectName capture uses disposed fallback when project name access throws`() {
+        // Round 2 S-3 lock for MEDIUM-3 fix. The projectName capture uses a
+        // try/catch with RuntimeException (narrowed from runCatching-Throwable
+        // in Round 2 MEDIUM R2-1) and falls back to the "<disposed>" literal
+        // when project.name access blows up. Lock both the narrowed catch and
+        // the literal fallback.
+        val source = readStartupActivitySource()
+        assertTrue(
+            source.contains("\"<disposed>\""),
+            "projectName fallback must use the <disposed> sentinel string literal",
+        )
+        val narrowedCatch =
+            Regex(
+                """val\s+projectName\s*=\s*try\s*\{\s*project\.name\s*\}""" +
+                    """\s*catch\s*\(\s*exception:\s*RuntimeException\s*\)""",
+                RegexOption.DOT_MATCHES_ALL,
+            )
+        assertTrue(
+            narrowedCatch.containsMatchIn(source),
+            "projectName capture must use try/catch(RuntimeException), not runCatching (Throwable)",
         )
     }
 

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
@@ -1381,6 +1381,67 @@ class AccentApplicatorTest {
         verify(exactly = 0) { element.applyNeutral(any()) }
     }
 
+    // --- Round 3 hotfix regression tests (C7, C8) ---
+    //
+    // Locks the revert-on-apply-fail block introduced in Phase 40 Round 3 M-7:
+    // when an element's `apply` throws, `applyElements` must roll that element
+    // back with `revert()` so a partial mutation doesn't leave UIManager +
+    // live peers in a mixed tinted+stock state (which would then poison
+    // `ChromeBaseColors` on the next capture). The PRE-EXISTING
+    // "catches RuntimeException from element apply" test passes even if the
+    // revert block is deleted — these tests fail if the block is removed.
+
+    /**
+     * C7 — when an element's `apply` throws, `applyElements` must call
+     * `revert()` on the same element AND continue to the next element in
+     * the extension list. Without the revert block, the partial mutation
+     * would stay visible until the next full apply/revert cycle.
+     */
+    @Test
+    fun `applyElements calls revert on an element whose apply throws`() {
+        val throwingElement = createFakeAccentElement(AccentElementId.CARET_ROW, "Caret Row")
+        every { throwingElement.apply(any()) } throws RuntimeException("apply broke")
+        val normalElement = createFakeAccentElement(AccentElementId.SCROLLBAR, "Scrollbar")
+        mockEpExtensionList(listOf(throwingElement, normalElement))
+
+        val accent = Color.decode("#FFCC66")
+        // Must not propagate the simulated apply failure.
+        invokeApplyElements(state, accent, AyuVariant.MIRAGE)
+
+        // Revert was invoked exactly once on the throwing element — this is
+        // the Round 3 M-7 lock; if the new try/revert block is deleted,
+        // this verification fails.
+        verify(exactly = 1) { throwingElement.revert() }
+        // Dispatch proceeded to the next element despite the failure above.
+        verify(exactly = 1) { normalElement.apply(accent) }
+    }
+
+    /**
+     * C8 — when `apply` throws AND the fallback `revert()` also throws,
+     * `applyElements` must still move on to the next element. Locks the
+     * nested try/catch around the cleanup path so a doubly-broken element
+     * does not take the whole dispatch loop down with it.
+     */
+    @Test
+    fun `applyElements continues to next element when revert-after-apply-fail also throws`() {
+        val doubleThrower = createFakeAccentElement(AccentElementId.CARET_ROW, "Caret Row")
+        every { doubleThrower.apply(any()) } throws RuntimeException("apply broke")
+        every { doubleThrower.revert() } throws RuntimeException("revert broke too")
+        val survivor = createFakeAccentElement(AccentElementId.SCROLLBAR, "Scrollbar")
+        mockEpExtensionList(listOf(doubleThrower, survivor))
+
+        val accent = Color.decode("#FFCC66")
+        // Must not propagate either the apply or the revert exception.
+        invokeApplyElements(state, accent, AyuVariant.MIRAGE)
+
+        // Revert WAS attempted on the failing element, even though it
+        // threw — locks that the cleanup path runs unconditionally after
+        // an apply failure.
+        verify(exactly = 1) { doubleThrower.revert() }
+        // Dispatch continued to the next element after both failures.
+        verify(exactly = 1) { survivor.apply(accent) }
+    }
+
     /**
      * Builds a relaxed [AccentElement] mock with the given id and display
      * name. Used by the defensive dispatch regression tests to assemble

--- a/src/test/kotlin/dev/ayuislands/accent/ChromeBaseColorsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ChromeBaseColorsTest.kt
@@ -1,5 +1,6 @@
 package dev.ayuislands.accent
 
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.util.messages.MessageBus
@@ -36,7 +37,11 @@ class ChromeBaseColorsTest {
         val connection = mockk<MessageBusConnection>(relaxed = true)
         every { ApplicationManager.getApplication() } returns app
         every { app.messageBus } returns bus
+        // ChromeBaseColors now anchors its MessageBusConnection to the Application
+        // Disposable (Phase 40 Round 3 C-4), so the mock must match `connect(app)`
+        // as well as the bare `connect()` overload to stay forward-compatible.
         every { bus.connect() } returns connection
+        every { bus.connect(any<Disposable>()) } returns connection
         every { connection.subscribe(any(), any()) } returns Unit
 
         mockkStatic(UIManager::class)

--- a/src/test/kotlin/dev/ayuislands/accent/ChromeBaseColorsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ChromeBaseColorsTest.kt
@@ -111,6 +111,50 @@ class ChromeBaseColorsTest {
         assertEquals(Color.RED, ChromeBaseColors.get("Lazy.key"))
     }
 
+    // --- Round 3 hotfix regression tests (C5, C6) ---
+    //
+    // C5 locks that repeated `get` calls for a key UIManager does not serve
+    // stay silent after the first miss — the `missingKeyLogged` latch gate
+    // introduced in Round 3 C-3 must consistently return null for every
+    // follow-up read without flipping into a cached state.
+    //
+    // C6 locks the "clear latch BEFORE snapshot" ordering from Round 1
+    // MEDIUM-2 / Round 3 C-3: after `refresh()`, the next `get` must capture
+    // the current UIManager value (including a newly-populated key) AND
+    // subsequent `get` calls must return that same cached snapshot even if
+    // UIManager mutates afterwards.
+
+    @Test
+    fun `get returns null consistently across repeated calls on a missing key`() {
+        // UIManager returns null for "Missing.key" — see setUp. Repeated
+        // reads must all return null without caching any sentinel.
+        assertNull(ChromeBaseColors.get("Missing.key"))
+        assertNull(ChromeBaseColors.get("Missing.key"))
+        assertNull(ChromeBaseColors.get("Missing.key"))
+    }
+
+    @Test
+    fun `refresh clears the missing-key latch so a newly-populated key is picked up`() {
+        // UIManager starts with no entry for Lazy.key.
+        every { UIManager.getColor("Lazy.key") } returns null
+        assertNull(ChromeBaseColors.get("Lazy.key"))
+
+        // Clear the latch + snapshot. Now UIManager is populated.
+        ChromeBaseColors.refresh()
+        every { UIManager.getColor("Lazy.key") } returns Color.RED
+
+        val captured = ChromeBaseColors.get("Lazy.key")
+        assertEquals(Color.RED, captured)
+
+        // Snapshot invariant: once captured, a later UIManager mutation
+        // must NOT bleed through. This locks the "latch cleared before
+        // snapshot" ordering — refresh must first drop the latch, then
+        // drop the snapshot, so the next get re-captures from UIManager
+        // and the cache freezes that value for subsequent reads.
+        every { UIManager.getColor("Lazy.key") } returns Color.BLUE
+        assertEquals(Color.RED, ChromeBaseColors.get("Lazy.key"))
+    }
+
     @Test
     fun `independent keys snapshot independently`() {
         val status = ChromeBaseColors.get("StatusBar.background")

--- a/src/test/kotlin/dev/ayuislands/accent/ChromeDecorationsProbeTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ChromeDecorationsProbeTest.kt
@@ -9,6 +9,7 @@ import javax.swing.UIManager
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -91,5 +92,55 @@ class ChromeDecorationsProbeTest {
         ChromeDecorationsProbe.osSupplier = { ChromeDecorationsProbe.Os.UNKNOWN }
 
         assertFalse(ChromeDecorationsProbe.isCustomHeaderActive())
+    }
+
+    // --- computeOs branch coverage ---
+    //
+    // The defaultOsSupplier lambda reads SystemInfo.isMac/isWindows/isLinux,
+    // which are public static final booleans that mockk cannot touch. To
+    // exercise every OS branch anyway, `computeOs` accepts explicit booleans
+    // with SystemInfo-backed defaults; these tests pass the booleans directly.
+
+    @Test
+    fun `computeOs returns MAC when isMac is true`() {
+        assertEquals(
+            ChromeDecorationsProbe.Os.MAC,
+            ChromeDecorationsProbe.computeOs(isMac = true, isWindows = false, isLinux = false),
+        )
+    }
+
+    @Test
+    fun `computeOs returns WINDOWS when only isWindows is true`() {
+        assertEquals(
+            ChromeDecorationsProbe.Os.WINDOWS,
+            ChromeDecorationsProbe.computeOs(isMac = false, isWindows = true, isLinux = false),
+        )
+    }
+
+    @Test
+    fun `computeOs returns LINUX when only isLinux is true`() {
+        assertEquals(
+            ChromeDecorationsProbe.Os.LINUX,
+            ChromeDecorationsProbe.computeOs(isMac = false, isWindows = false, isLinux = true),
+        )
+    }
+
+    @Test
+    fun `computeOs falls through to UNKNOWN when all flags are false`() {
+        assertEquals(
+            ChromeDecorationsProbe.Os.UNKNOWN,
+            ChromeDecorationsProbe.computeOs(isMac = false, isWindows = false, isLinux = false),
+        )
+    }
+
+    @Test
+    fun `computeOs prefers MAC when multiple flags are true (dispatch order lock)`() {
+        // Defensive branch-order lock: SystemInfo flags should never be
+        // mutually true in practice, but a refactor that reorders the `when`
+        // would shift dispatch priority. This pins MAC-first semantics.
+        assertEquals(
+            ChromeDecorationsProbe.Os.MAC,
+            ChromeDecorationsProbe.computeOs(isMac = true, isWindows = true, isLinux = true),
+        )
     }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/LiveChromeRefresherTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/LiveChromeRefresherTest.kt
@@ -505,6 +505,74 @@ class LiveChromeRefresherTest {
     }
 
     @Test
+    fun `resetBrokenContainerLoggedForTests clears the broken-container latch`() {
+        // Covers the @TestOnly hook (line 70) — invoking it directly is the
+        // only way to exercise the `brokenContainerLogged.clear()` call under
+        // unit-test conditions. Prior walks in the suite may or may not have
+        // populated the latch; after reset the hook must leave the singleton
+        // in a clean state for the next test. Behaviour lock is "no throw".
+        val brokenContainer = BrokenChildrenContainer()
+        LiveChromeRefresher.refreshOnTree(brokenContainer, "x", Color.RED)
+
+        LiveChromeRefresher.resetBrokenContainerLoggedForTests()
+
+        // After reset the second walk over the same broken container must
+        // still complete safely — proves the reset didn't corrupt the latch
+        // and the WARN path (first-encounter-per-class) re-engages cleanly.
+        LiveChromeRefresher.refreshOnTree(brokenContainer, "x", Color.RED)
+    }
+
+    @Test
+    fun `refreshStatusBar returns silently when ProjectManager getInstance throws`() {
+        // Covers the runCatching onFailure + getOrNull ?: return path at
+        // LiveChromeRefresher lines 91-93 — ProjectManager resolution fails
+        // during live refresh (e.g. application shutting down mid-apply).
+        // The helper must log at DEBUG and return without propagating.
+        mockkStatic(ProjectManager::class)
+        every { ProjectManager.getInstance() } throws IllegalStateException("no container")
+
+        LiveChromeRefresher.refreshStatusBar(targetColor)
+        LiveChromeRefresher.clearStatusBar()
+    }
+
+    @Test
+    fun `refreshStatusBar returns silently when WindowManager getInstance throws`() {
+        // Covers lines 95-97 — WindowManager resolution fails after
+        // ProjectManager succeeded. ProjectManager must still be mockable as
+        // a usable singleton so control flow reaches the WindowManager
+        // runCatching block; the WindowManager failure must be swallowed.
+        mockProjectManagerOpenProjects(mockUsableProject())
+        mockkStatic(WindowManager::class)
+        every { WindowManager.getInstance() } throws IllegalStateException("wm gone")
+
+        LiveChromeRefresher.refreshStatusBar(targetColor)
+        LiveChromeRefresher.clearStatusBar()
+    }
+
+    @Test
+    fun `forEachShowingWindow isolates per-window failures from sibling windows`() {
+        // Covers lines 166-171 — the inner try/catch around `action(window)`
+        // in forEachShowingWindow. A showing window whose tree walk throws
+        // must be logged at DEBUG without aborting the rest of the window
+        // enumeration. Real `JFrame` / `JDialog` instantiation throws
+        // HeadlessException in the Gradle test JVM, so we mock a Window
+        // whose `getComponents()` blows up — the same RuntimeException the
+        // production catch block is there to defend against.
+        val brokenWindow =
+            mockk<Window>(relaxed = true) {
+                every { isShowing } returns true
+                every { components } throws IllegalStateException("window tree boom")
+            }
+        mockkStatic(Window::class)
+        every { Window.getWindows() } returns arrayOf(brokenWindow)
+
+        // No throw — the per-window catch converts the RuntimeException
+        // into a DEBUG log and moves on.
+        LiveChromeRefresher.refreshByClassName("dummy.FQN", Color.RED)
+        LiveChromeRefresher.clearByClassName("dummy.FQN")
+    }
+
+    @Test
     fun `broken-container log cap is 64 and clears on overflow`() {
         // Round 3 G3 regression lock. The LOW R2-1 fix protects
         // `brokenContainerLogged` from unbounded growth with a

--- a/src/test/kotlin/dev/ayuislands/accent/LiveChromeRefresherTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/LiveChromeRefresherTest.kt
@@ -15,6 +15,7 @@ import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 /**
  * Tests for [LiveChromeRefresher] — the Level 2 Gap-4 helper that walks live
@@ -501,5 +502,42 @@ class LiveChromeRefresherTest {
         // throw on either call".
         LiveChromeRefresher.refreshOnTree(brokenContainer, "x", Color.RED)
         LiveChromeRefresher.refreshOnTree(brokenContainer, "x", Color.RED)
+    }
+
+    @Test
+    fun `broken-container log cap is 64 and clears on overflow`() {
+        // Round 3 G3 regression lock. The LOW R2-1 fix protects
+        // `brokenContainerLogged` from unbounded growth with a
+        // `BROKEN_CONTAINER_LOG_CAP = 64` constant plus an overflow-clear
+        // branch. Either piece alone is cosmetic: raise the cap silently to
+        // defeat the protection, or delete the clear branch and keep the
+        // constant as dead code. Lock both at the source level since the
+        // production path only fires under pathological conditions (65+
+        // distinct broken Container subclasses), unreachable in unit tests.
+        val source = readLiveChromeRefresherSource()
+        assertTrue(
+            source.contains("BROKEN_CONTAINER_LOG_CAP = 64"),
+            "Cap must remain at 64 — raising it silently defeats the unbounded-growth protection",
+        )
+        val overflowClear =
+            Regex(
+                """brokenContainerLogged\.size\s*>\s*BROKEN_CONTAINER_LOG_CAP""" +
+                    """\s*\)\s*\{\s*brokenContainerLogged\.clear\(\)""",
+                RegexOption.DOT_MATCHES_ALL,
+            )
+        assertTrue(
+            overflowClear.containsMatchIn(source),
+            "Overflow clear branch must remain — the cap constant alone is cosmetic without it",
+        )
+        assertTrue(
+            source.contains("resetBrokenContainerLoggedForTests"),
+            "TestOnly reset hook must remain for test isolation across order-dependent runs",
+        )
+    }
+
+    private fun readLiveChromeRefresherSource(): String {
+        val file = java.io.File("src/main/kotlin/dev/ayuislands/accent/LiveChromeRefresher.kt")
+        return file.takeIf { it.exists() }?.readText()
+            ?: error("Could not locate LiveChromeRefresher.kt for source-level guard")
     }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/LiveChromeRefresherTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/LiveChromeRefresherTest.kt
@@ -9,6 +9,7 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import java.awt.Color
+import java.awt.Window
 import javax.swing.JPanel
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -403,5 +404,102 @@ class LiveChromeRefresherTest {
             "non.existent.Target.Z",
             "non.existent.Ancestor.Y",
         )
+    }
+
+    // --- Round 3 hotfix regression tests (C1–C4) ---
+    //
+    // These lock the isolation guarantees added in Phase 40 Round 3 C-1/C-2:
+    // a single broken peer or window-enumeration failure must NOT abort the
+    // entire chrome-refresh pass, and repeated passes over a known-broken
+    // container must stay safe (the log-once latch demotes the second hit
+    // to DEBUG but the walk still short-circuits cleanly).
+
+    /**
+     * Match-target subclass used by C2. Tracks a per-instance latch so one
+     * sibling can throw on its first `setBackground` call while the next
+     * sibling of the same runtime class keeps its normal behaviour.
+     */
+    private open class ThrowOnFirstSetBackgroundTracker(
+        private val shouldThrow: Boolean,
+    ) : TrackingPanel() {
+        private var thrown: Boolean = false
+
+        override fun setBackground(bg: Color?) {
+            if (shouldThrow && !thrown) {
+                thrown = true
+                error("setBackground boom")
+            }
+            super.setBackground(bg)
+        }
+    }
+
+    /**
+     * Container whose `getComponents()` override throws on every invocation.
+     * Used by C3 and C4 to prove the tree walk isolates container failures
+     * per-subtree instead of aborting the whole pass.
+     */
+    private class BrokenChildrenContainer : JPanel() {
+        override fun getComponents(): Array<java.awt.Component> = error("getComponents boom")
+    }
+
+    @Test
+    fun `refreshByClassName returns early without throwing when Window getWindows throws`() {
+        mockkStatic(Window::class)
+        every { Window.getWindows() } throws IllegalStateException("enumeration boom")
+
+        // No throw must propagate — the Round 3 C-2 guard converts the
+        // enumeration failure into a WARN + early return.
+        LiveChromeRefresher.refreshByClassName("dummy.FQN", Color.RED)
+    }
+
+    @Test
+    fun `refreshOnTree continues visiting siblings after one node throws on setBackground`() {
+        val throwingFqn = ThrowOnFirstSetBackgroundTracker::class.java.name
+        val throwing = ThrowOnFirstSetBackgroundTracker(shouldThrow = true)
+        val survivor = ThrowOnFirstSetBackgroundTracker(shouldThrow = false)
+        val parent =
+            JPanel().apply {
+                add(throwing)
+                add(survivor)
+            }
+
+        LiveChromeRefresher.refreshOnTree(parent, throwingFqn, Color.BLUE)
+
+        // Surviving sibling must have been painted — the per-visit try/catch
+        // in `walk` (Round 3 C-1) isolates the throwing peer from the rest.
+        assertEquals(Color.BLUE, survivor.lastSetBackground)
+    }
+
+    @Test
+    fun `refreshOnTree continues to sibling containers when one containers getComponents throws`() {
+        val trackerFqn = TrackingPanel::class.java.name
+        val tracker = TrackingPanel()
+        val brokenContainer = BrokenChildrenContainer()
+        val siblingContainer = JPanel().apply { add(tracker) }
+        val parent =
+            JPanel().apply {
+                add(brokenContainer)
+                add(siblingContainer)
+            }
+
+        LiveChromeRefresher.refreshOnTree(parent, trackerFqn, Color.GREEN)
+
+        // The broken container's subtree is skipped, but the walk proceeds
+        // to the next sibling and paints the tracker inside it. Without
+        // the container-level try/catch (Round 3 C-1), the RuntimeException
+        // would unwind the whole walk and tracker would stay untouched.
+        assertEquals(Color.GREEN, tracker.lastSetBackground)
+    }
+
+    @Test
+    fun `refreshOnTree survives repeated walks over a broken container`() {
+        val brokenContainer = BrokenChildrenContainer()
+
+        // Two consecutive walks must both return cleanly. The second pass
+        // exercises the `brokenContainerLogged` latch demote-to-DEBUG branch
+        // introduced in Round 3; the behaviour lock here is simply "no
+        // throw on either call".
+        LiveChromeRefresher.refreshOnTree(brokenContainer, "x", Color.RED)
+        LiveChromeRefresher.refreshOnTree(brokenContainer, "x", Color.RED)
     }
 }


### PR DESCRIPTION
Stability hotfix for crash / corruption / silent-failure paths found during Phase 40 Round 3 review ([#152](https://github.com/barad1tos/ayu-jetbrains/issues/152)). Scope kept tight to CRITICAL + one MEDIUM cache-poisoning fix; remaining HIGH/MEDIUM/LOW/type-refactors go into Phase 40.2 and 40.3.

## What's in

- **C-1 / C-2** `LiveChromeRefresher` — new `forEachShowingWindow` helper filters `!window.isShowing` and isolates each window walk in `runCatching`; `walk` wraps each visit so one flaky peer can't abort the EDT apply Runnable (no more unattributed SEVERE on mid-dispose popups).
- **C-3** `ChromeBaseColors.get` — per-key WARN-once latch (cleared on refresh) so a missing UIManager entry surfaces in `idea.log` instead of silently skipping tint on one chrome surface.
- **C-4** `ChromeBaseColors` — LAF subscription anchored to `ApplicationManager.getApplication()` as Disposable so plugin/shutdown disposes the connection; stops listener leak across dev reload cycles.
- **C-5** `AyuIslandsStartupActivity` — EDT triplet (`apply + install + notifyExternalApply`) wrapped in `runCatchingPreservingCancellation`; a throw no longer aborts font preset apply, language-detector warmup, scrollbar managers, ComponentTreeRefresher, conflict detection, license checks, or onboarding.
- **M-7** `AccentApplicator.applyElements` — revert the failed element so a partial apply doesn't poison `ChromeBaseColors` snapshots for the rest of the session.

## What's deferred

- `T-1` LAF listener wiring regression test, `T-2` StartupActivity EDT triplet `verifyOrder`, `T-5` `@RequiresEdt` off-EDT assertion, and a direct M-7 revert-on-apply-fail test — all need non-trivial mock/coroutine scaffolding. Tracked for Phase 40.2 so the scaffolding lands in one pass.
- Other HIGH / MEDIUM / LOW findings from #152 — Phase 40.2.
- Type refactors (`ClassFqn`, `TintIntensity`, `AccentHex`, etc.) — Phase 40.3.

## Verification

- `./gradlew test --tests "dev.ayuislands.accent.ChromeBaseColorsTest" --tests "dev.ayuislands.accent.LiveChromeRefresherTest" --tests "dev.ayuislands.accent.AccentApplicatorTest" --tests "dev.ayuislands.accent.AccentApplicatorChromeApplyRefreshTest" --tests "dev.ayuislands.accent.AccentApplicatorChromeRevertTest"` — BUILD SUCCESSFUL.
- `detekt` + `ktlintCheck` + `verify-docs` — all pass on every commit.

## Release note

Target v2.5.1 — no behavior change for working setups, but removes several latent SEVERE-on-edge-case paths.

Closes part of #152.

## Summary by Sourcery

Harden accent chrome refresh, base color capture, and startup accent application against IDE window lifecycle edge cases and partial failures to prevent crashes, leaks, and cache corruption discovered in Phase 40 Round 3.

Bug Fixes:
- Ignore non-showing windows and isolate per-window/component failures during live chrome refresh so a single bad window or component no longer breaks global chrome updates.
- Log missing UIManager chrome color keys once per key and per LAF cycle so silent tint skips are surfaced without spamming logs.
- Anchor the ChromeBaseColors LAF listener subscription to the Application disposable to avoid message bus connection leaks across plugin reloads and shutdown.
- Wrap the startup accent resolve/apply/install/notify sequence in a guarded EDT block so failures there no longer abort remaining project startup work.
- Revert an accent element when its apply step fails so ChromeBaseColors snapshots are not poisoned by partially applied state for the rest of the session.

Enhancements:
- Improve debug logging around live chrome refresh traversal and failures to aid diagnosis of flaky components and window states.

Documentation:
- Update feature verification metadata to reflect the latest verified commit for accent-related components.

Tests:
- Extend ChromeBaseColors tests to cover the new Application-anchored message bus connection usage.