### PR TITLE
feat: Phase 40.2-40.4 — close Round 3 review-loop, type refactors, polish (v2.5.3)

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "ba67734"
+          last_verified_sha: "1e0bf37"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "ba67734"
+          last_verified_sha: "1e0bf37"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "0519a93"
+          last_verified_sha: "1079f7a"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "0519a93"
+          last_verified_sha: "1079f7a"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "2c62fa5"
+          last_verified_sha: "c1cc40a"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "2c62fa5"
+          last_verified_sha: "c1cc40a"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "327fec7"
+          last_verified_sha: "8bbd351"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "327fec7"
+          last_verified_sha: "8bbd351"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "da259b9"
+          last_verified_sha: "fb52bef"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "da259b9"
+          last_verified_sha: "fb52bef"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "1079f7a"
+          last_verified_sha: "9a63366"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "1079f7a"
+          last_verified_sha: "9a63366"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "2433175"
+          last_verified_sha: "2c62fa5"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "2433175"
+          last_verified_sha: "2c62fa5"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "85858dd"
+          last_verified_sha: "b3282b8"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "85858dd"
+          last_verified_sha: "b3282b8"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "0748c16"
+          last_verified_sha: "da259b9"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "0748c16"
+          last_verified_sha: "da259b9"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "4d52330"
+          last_verified_sha: "156a823"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "4d52330"
+          last_verified_sha: "156a823"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "2dfcd07"
+          last_verified_sha: "0748c16"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "2dfcd07"
+          last_verified_sha: "0748c16"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "1e0bf37"
+          last_verified_sha: "85858dd"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "1e0bf37"
+          last_verified_sha: "85858dd"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "5a7e430"
+          last_verified_sha: "0519a93"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "5a7e430"
+          last_verified_sha: "0519a93"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "c1cc40a"
+          last_verified_sha: "327fec7"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "c1cc40a"
+          last_verified_sha: "327fec7"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "600f94d"
+          last_verified_sha: "9dfa9f0"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "600f94d"
+          last_verified_sha: "9dfa9f0"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "1399273"
+          last_verified_sha: "ff11dc7"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "1399273"
+          last_verified_sha: "ff11dc7"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "b3282b8"
+          last_verified_sha: "600f94d"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "b3282b8"
+          last_verified_sha: "600f94d"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "ff11dc7"
+          last_verified_sha: "5a7e430"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "ff11dc7"
+          last_verified_sha: "5a7e430"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "9dfa9f0"
+          last_verified_sha: "2433175"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "9dfa9f0"
+          last_verified_sha: "2433175"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "9a63366"
+          last_verified_sha: "ba67734"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "9a63366"
+          last_verified_sha: "ba67734"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "8bbd351"
+          last_verified_sha: "2dfcd07"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "8bbd351"
+          last_verified_sha: "2dfcd07"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "fb52bef"
+          last_verified_sha: "4d52330"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "fb52bef"
+          last_verified_sha: "4d52330"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "11d36a3"
+          last_verified_sha: "1399273"
           last_verified_date: "2026-04-23"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "11d36a3"
+          last_verified_sha: "1399273"
           last_verified_date: "2026-04-23"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsAppListener.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsAppListener.kt
@@ -41,14 +41,24 @@ internal class AyuIslandsAppListener : AppLifecycleListener {
         // resolver rather than re-paint against a torn half-apply.
         val trustedCached = validCached?.takeIf { cleanCache }
         val accentHex = trustedCached?.value ?: AccentResolver.resolve(null, variant)
-        AccentApplicator.applyFromHexString(accentHex)
+        val applied = AccentApplicator.applyFromHexString(accentHex)
         val source =
             when {
                 trustedCached != null -> "cached"
                 validCached != null -> "cached-untrusted"
                 else -> "resolved"
             }
-        LOG.info("Ayu Islands accent pre-applied in appFrameCreated ($source): $accentHex for ${variant.name}")
+        if (applied) {
+            LOG.info(
+                "Ayu Islands accent applied in appFrameCreated " +
+                    "(source=$source, hex='$accentHex') for ${variant.name}",
+            )
+        } else {
+            LOG.warn(
+                "Ayu Islands accent rejected in appFrameCreated " +
+                    "(source=$source, hex='$accentHex') for ${variant.name}",
+            )
+        }
     }
 
     companion object {

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsAppListener.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsAppListener.kt
@@ -29,14 +29,25 @@ internal class AyuIslandsAppListener : AppLifecycleListener {
         // through to the resolver path just like a fresh install.
         val settings = AyuIslandsSettings.getInstance()
         val cached = settings.state.lastAppliedAccentHex
+        val cleanCache = settings.state.lastApplyOk
         val validCached = cached?.takeIf { AccentApplicator.HEX_COLOR_PATTERN.matches(it) }
         if (cached != null && validCached == null) {
             LOG.warn("AyuIslandsAppListener: invalid cached hex '$cached'; clearing and re-resolving")
             settings.state.lastAppliedAccentHex = null
         }
-        val accentHex = validCached ?: AccentResolver.resolve(null, variant)
+        // Phase 40.2 H-2: trust the cached hex only when the previous session's
+        // apply finished cleanly (lastApplyOk=true). A mid-EP throw leaves the
+        // hex persisted without the clean flag, so we must fall back to the
+        // resolver rather than re-paint against a torn half-apply.
+        val trustedCached = validCached?.takeIf { cleanCache }
+        val accentHex = trustedCached ?: AccentResolver.resolve(null, variant)
         AccentApplicator.apply(accentHex)
-        val source = if (validCached != null) "cached" else "resolved"
+        val source =
+            when {
+                trustedCached != null -> "cached"
+                validCached != null -> "cached-untrusted"
+                else -> "resolved"
+            }
         LOG.info("Ayu Islands accent pre-applied in appFrameCreated ($source): $accentHex for ${variant.name}")
     }
 

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsAppListener.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsAppListener.kt
@@ -3,7 +3,6 @@ package dev.ayuislands
 import com.intellij.ide.AppLifecycleListener
 import com.intellij.openapi.diagnostic.logger
 import dev.ayuislands.accent.AccentApplicator
-import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.settings.AyuIslandsSettings
@@ -31,7 +30,7 @@ internal class AyuIslandsAppListener : AppLifecycleListener {
         val settings = AyuIslandsSettings.getInstance()
         val cached = settings.state.lastAppliedAccentHex
         val cleanCache = settings.state.lastApplyOk
-        val validCached = AccentHex.of(cached)
+        val validCached = settings.state.effectiveLastAppliedAccentHex()
         if (cached != null && validCached == null) {
             LOG.warn("AyuIslandsAppListener: invalid cached hex '$cached'; clearing and re-resolving")
             settings.state.lastAppliedAccentHex = null

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsAppListener.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsAppListener.kt
@@ -3,6 +3,7 @@ package dev.ayuislands
 import com.intellij.ide.AppLifecycleListener
 import com.intellij.openapi.diagnostic.logger
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.settings.AyuIslandsSettings
@@ -30,7 +31,7 @@ internal class AyuIslandsAppListener : AppLifecycleListener {
         val settings = AyuIslandsSettings.getInstance()
         val cached = settings.state.lastAppliedAccentHex
         val cleanCache = settings.state.lastApplyOk
-        val validCached = cached?.takeIf { AccentApplicator.HEX_COLOR_PATTERN.matches(it) }
+        val validCached = AccentHex.of(cached)
         if (cached != null && validCached == null) {
             LOG.warn("AyuIslandsAppListener: invalid cached hex '$cached'; clearing and re-resolving")
             settings.state.lastAppliedAccentHex = null
@@ -40,8 +41,8 @@ internal class AyuIslandsAppListener : AppLifecycleListener {
         // hex persisted without the clean flag, so we must fall back to the
         // resolver rather than re-paint against a torn half-apply.
         val trustedCached = validCached?.takeIf { cleanCache }
-        val accentHex = trustedCached ?: AccentResolver.resolve(null, variant)
-        AccentApplicator.apply(accentHex)
+        val accentHex = trustedCached?.value ?: AccentResolver.resolve(null, variant)
+        AccentApplicator.applyFromHexString(accentHex)
         val source =
             when {
                 trustedCached != null -> "cached"

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -252,7 +252,7 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
                 runCatchingPreservingCancellation {
                     val focusedProject = AccentApplicator.resolveFocusedProject() ?: project
                     val resolved = AccentResolver.resolve(focusedProject, variant)
-                    AccentApplicator.apply(resolved)
+                    AccentApplicator.applyFromHexString(resolved)
                     resolved
                 }
             applyOutcome.onFailure { exception ->

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -252,8 +252,8 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
                 runCatchingPreservingCancellation {
                     val focusedProject = AccentApplicator.resolveFocusedProject() ?: project
                     val resolved = AccentResolver.resolve(focusedProject, variant)
-                    AccentApplicator.applyFromHexString(resolved)
-                    resolved
+                    val applied = AccentApplicator.applyFromHexString(resolved)
+                    if (applied) resolved else null
                 }
             applyOutcome.onFailure { exception ->
                 LOG.error(
@@ -265,14 +265,15 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
             val hex = applyOutcome.getOrNull()
             if (hex == null) {
                 // Round 2 MEDIUM R2-2: apply-failure already logged via onFailure
-                // above. This branch also fires for Success(null), which is not
-                // reachable today (AccentResolver returns non-null) but a future
-                // refactor making `resolved` nullable must not silently skip
-                // install/notify without a log trace.
+                // above. Hex is null in two cases: (a) the runCatching caught an
+                // exception, (b) applyFromHexString returned false (rejected
+                // hex — the user-facing notification already fired inside the
+                // applicator). In (b), suppress the install+notify because
+                // there's no applied color to publish to the swap cache.
                 if (applyOutcome.isSuccess) {
                     LOG.warn(
-                        "Startup accent apply returned a null hex unexpectedly " +
-                            "for project '$projectName'; skipping swap install",
+                        "Startup accent apply was rejected by applyFromHexString " +
+                            "for project '$projectName'; skipping swap install/notify",
                     )
                 }
                 return@withContext

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -346,7 +346,12 @@ object AccentApplicator {
             var probedName: String? = null
             try {
                 val project = frame.project ?: continue
-                probedName = runCatching { project.name }.getOrNull()
+                // Platform contract: `Project.getName()` is a safe bookmarked-name
+                // accessor that does not throw even on a mid-dispose instance. A
+                // prior `runCatching { project.name }.getOrNull()` here swallowed
+                // the entire [Throwable] surface (Pattern B) for no defensive
+                // benefit — drop the wrapper and read the property directly.
+                probedName = project.name
                 if (!project.isUsable()) continue
                 val window = SwingUtilities.getWindowAncestor(frame.component) ?: continue
                 if (window.isActive) return project

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -1,6 +1,9 @@
 package dev.ayuislands.accent
 
 import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationType
+import com.intellij.notification.Notifications
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.ReadAction
@@ -40,8 +43,17 @@ object AccentApplicator {
      * XML, truncated writes, rare partial-persist under IDE crash) before they reach the
      * decoder. Without this gate a single bad hex in `ayu-islands.xml` would abort the
      * very first frame paint and leave the plugin silently inert for the session.
+     *
+     * Phase 40.2 M-2: leading/trailing whitespace is tolerated in the match but callers
+     * MUST `.trim()` the input before handing it to [Color.decode] (the decoder itself
+     * does not accept padding). Shorthand `#RGB` is intentionally NOT accepted — every
+     * persisted value in `ayu-islands.xml` is emitted as `#RRGGBB` and expanding the
+     * pattern would silently forgive a new corruption mode.
      */
-    val HEX_COLOR_PATTERN = Regex("^#[0-9A-Fa-f]{6}$")
+    val HEX_COLOR_PATTERN = Regex("^\\s*#[0-9A-Fa-f]{6}\\s*$")
+
+    /** Notification group ID declared in plugin.xml — shared with [dev.ayuislands.rotation.AccentRotationService]. */
+    private const val NOTIFICATION_GROUP_ID = "Ayu Islands"
 
     private val EP_NAME =
         ExtensionPointName<AccentElement>(
@@ -140,21 +152,66 @@ object AccentApplicator {
             AttrOverride("WARNING_ATTRIBUTES", effectColor = true, errorStripe = true),
         )
 
-    fun apply(accentHex: String) {
+    /**
+     * Applies [accentHex] across UIManager, editor keys, and the EP chain.
+     *
+     * Phase 40.2 H-3 changed the return type to [Boolean]: `false` signals that the
+     * caller-provided hex failed shape validation and no apply work ran. Callers MUST
+     * surface a user-visible notification so settings-panel Apply, rotation ticks, and
+     * manual accent picks do not silently swallow corruption. `true` means the hex
+     * passed validation and the EP dispatch was scheduled (actual EP work may still
+     * happen asynchronously if the caller is off-EDT — the Boolean reports
+     * validation + scheduling, not end-to-end paint completion).
+     *
+     * Phase 40.2 H-2: [AyuIslandsState.lastAppliedAccentHex] is written BEFORE the EP
+     * iteration runs, not after — a mid-EP throw would otherwise drop the anti-flicker
+     * cache and re-flash Gold on the next startup. The paired
+     * [AyuIslandsState.lastApplyOk] flag is reset to `false` before EP iteration and
+     * flipped to `true` only after the full sequence completes, so the startup listener
+     * can distinguish "cached hex from a clean apply" from "cached hex from a torn
+     * apply" and fall back to the resolver in the torn case.
+     */
+    fun apply(accentHex: String): Boolean {
         // Reject garbage before it reaches [Color.decode], which throws
         // [NumberFormatException] on anything outside the `#RRGGBB` form. Callers
         // include [dev.ayuislands.AyuIslandsAppListener.appFrameCreated] feeding the
         // persisted `lastAppliedAccentHex` straight from XML — a corrupted or
         // hand-edited value must not abort the first frame paint. Warn so user-submitted
-        // idea.log captures the offending value for diagnosis, then bail; the next
-        // resolver-driven apply (StartupActivity) will write a clean hex.
+        // idea.log captures the offending value for diagnosis, surface a user-facing
+        // notification (Phase 40.2 H-3), then bail; the next resolver-driven apply
+        // (StartupActivity) will write a clean hex.
         if (!HEX_COLOR_PATTERN.matches(accentHex)) {
             log.warn("AccentApplicator.apply: invalid hex '$accentHex' — skipping apply")
-            return
+            // Phase 40.2 H-3: user-visible notification for the rejected hex so
+            // per-project XML corruption, manual edits, and rotation palette
+            // bugs do not silently turn chrome tinting off. Wrapped in
+            // runCatching so a notification subsystem hiccup cannot cascade
+            // into the caller (settings panel, rotation tick, startup).
+            runCatching {
+                Notifications.Bus.notify(
+                    Notification(
+                        NOTIFICATION_GROUP_ID,
+                        "Ayu Islands",
+                        "Ayu accent rejected — hex '$accentHex' is not a valid #RRGGBB.",
+                        NotificationType.WARNING,
+                    ),
+                )
+            }.onFailure { exception ->
+                log.debug("AccentApplicator invalid-hex notification failed to post", exception)
+            }
+            return false
         }
-        val accent = Color.decode(accentHex)
+        val trimmedHex = accentHex.trim()
+        val accent = Color.decode(trimmedHex)
         val state = AyuIslandsSettings.getInstance().state
         val variant = AyuVariant.detect()
+
+        // H-2: persist BEFORE the EP iteration so the cache survives a mid-EP
+        // throw. Clear the clean-apply flag here and only set it true after the
+        // full sequence completes — the startup listener reads the pair and
+        // falls through to the resolver when the flag is false.
+        state.lastAppliedAccentHex = trimmedHex
+        state.lastApplyOk = false
 
         // All work batched into a single EDT dispatch (UIManager.put is not
         // thread-safe, and elements previously posted their own invokeLater)
@@ -163,9 +220,9 @@ object AccentApplicator {
                 applyAlwaysOnUiKeys(accent)
 
                 applyElements(state, accent, variant)
-                syncCodeGlanceProViewport(accentHex)
+                syncCodeGlanceProViewport(trimmedHex)
                 if (variant != null) {
-                    IndentRainbowSync.apply(variant, accentHex)
+                    IndentRainbowSync.apply(variant, trimmedHex)
                 }
                 applyAlwaysOnEditorKeys(accent)
                 overrideTabUnderlineForOffMode(state, variant)
@@ -188,12 +245,12 @@ object AccentApplicator {
 
                 repaintAllWindows(Window.getWindows())
 
-                // Persist for next-startup anti-flicker: AyuIslandsAppListener.appFrameCreated
-                // reads this hex and applies it before any project context exists, so the first
-                // painted frame after IDE restart matches the eventual resolver output. Without
-                // this, multi-window setups flash the GLOBAL accent before each project's
-                // StartupActivity runs.
-                state.lastAppliedAccentHex = accentHex
+                // H-2: mark the apply clean only after the full EP sequence
+                // succeeded. A throw earlier leaves the flag false and the
+                // startup listener (AyuIslandsAppListener.appFrameCreated)
+                // will fall through to the resolver rather than trust the
+                // cached hex.
+                state.lastApplyOk = true
             }
 
         if (SwingUtilities.isEventDispatchThread()) {
@@ -201,9 +258,10 @@ object AccentApplicator {
         } else {
             invokeLaterSafe(work)
         }
+        return true
     }
 
-    /**
+/**
      * Convenience wrapper around [AccentResolver.resolve] + [apply] for the "currently focused
      * project" use case. Called from the settings panels (Accent / Elements / Plugins), the
      * LAF listener, and the rotation tick. Pre-helper, those sites hand-wired variants of
@@ -230,8 +288,15 @@ object AccentApplicator {
     fun applyForFocusedProject(variant: AyuVariant): String {
         val focusedProject = resolveFocusedProject()
         val hex = AccentResolver.resolve(focusedProject, variant)
-        apply(hex)
-        ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
+        // Phase 40.2 H-3: apply now returns a validation flag. If the resolver hands
+        // back a hex that fails shape validation (corrupted per-project override,
+        // manual XML edit, future resolver bug), skip the swap-cache publish so the
+        // cache does not drift to a hex that was never actually painted. The apply
+        // call itself already surfaces the user-visible notification.
+        val applied = apply(hex)
+        if (applied) {
+            ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
+        }
         return hex
     }
 
@@ -590,7 +655,15 @@ object AccentApplicator {
     }
 
     private fun repaintAllWindows(windows: Array<Window>) {
+        // Phase 40.2 M-8: filter by isDisplayable before repaint, mirroring
+        // LiveChromeRefresher.forEachShowingWindow. A disposed/undisplayed window still
+        // lingers in Window.getWindows() briefly during shutdown races; calling
+        // repaint() on it is a no-op at best and throws on some LAFs at worst. The
+        // isShowing check is stricter than we need here (pooled popups are fine to
+        // skip-repaint anyway), so isDisplayable captures the bare "not-yet-disposed"
+        // predicate for this write-side pass.
         for (window in windows) {
+            if (!window.isDisplayable) continue
             window.repaint()
         }
     }

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -157,6 +157,19 @@ object AccentApplicator {
      * flipped to `true` only after the full sequence completes, so the startup listener
      * can distinguish "cached hex from a clean apply" from "cached hex from a torn
      * apply" and fall back to the resolver in the torn case.
+     *
+     * ### Threading contract
+     *
+     * Synchronous when called on the EDT; posts the full Runnable via
+     * [invokeLaterSafe] when called off-EDT. The ordering invariant —
+     * applyElements / editor keys / repaint all happen BEFORE the method
+     * returns on EDT — is load-bearing for callers that publish follow-on
+     * cache state (for example [ProjectAccentSwapService.notifyExternalApply]
+     * reached via [applyForFocusedProject]): those callers MUST already be on
+     * the EDT so their cache write happens after the full apply sequence.
+     * Off-EDT callers get Boolean "validation + scheduling" semantics only —
+     * paint completion is asynchronous, and the [lastApplyOk] flag is the
+     * correct signal for "apply finished cleanly" in those flows.
      */
     fun apply(accentHex: AccentHex): Boolean {
         val trimmedHex = accentHex.value
@@ -175,7 +188,7 @@ object AccentApplicator {
         // thread-safe, and elements previously posted their own invokeLater)
         val work =
             Runnable {
-                applyAlwaysOnUiKeys(accent)
+                applyAlwaysOnUiKeys(state, accent)
 
                 applyElements(state, accent, variant)
                 syncCodeGlanceProViewport(trimmedHex)
@@ -478,7 +491,16 @@ object AccentApplicator {
         }
     }
 
-    private fun applyAlwaysOnUiKeys(accent: Color) {
+    /**
+     * Thread [state] in from the outer [apply] capture rather than re-fetching via
+     * `AyuIslandsSettings.getInstance()`: the outer call already read state at the
+     * apply entry, so re-reading here risked observing a mid-apply settings mutation
+     * and splitting behaviour between the EP chain and the tab-mode resolution.
+     */
+    private fun applyAlwaysOnUiKeys(
+        state: AyuIslandsState,
+        accent: Color,
+    ) {
         for (key in ALWAYS_ON_UI_KEYS) {
             UIManager.put(key, accent)
         }
@@ -496,7 +518,6 @@ object AccentApplicator {
         UIManager.put("Button.default.endBorderColor", darkenedAccent)
 
         // Editor tab background tint (respects persisted tab mode, not gated by license)
-        val state = AyuIslandsSettings.getInstance().state
         val tabMode = GlowTabMode.fromName(state.glowTabMode ?: "MINIMAL")
         when (tabMode) {
             GlowTabMode.MINIMAL -> UIManager.put(KEY_TAB_BACKGROUND, Color(0, 0, 0, 0))
@@ -612,6 +633,11 @@ object AccentApplicator {
         }
     }
 
+    /**
+     * Pairs with [LiveChromeRefresher.forEachShowingWindow]'s `isShowing` filter —
+     * both paths must skip disposed/hidden peers so a future contributor doesn't
+     * regress one without the other.
+     */
     private fun repaintAllWindows(windows: Array<Window>) {
         // Phase 40.2 M-8: filter by isDisplayable before repaint, mirroring
         // LiveChromeRefresher.forEachShowingWindow. A disposed/undisplayed window still

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -265,6 +265,12 @@ object AccentApplicator {
         // cache does not drift to a hex that was never actually painted. The apply
         // call itself already surfaces the user-visible notification.
         val applied = applyFromHexString(hex)
+        // Pattern D — regression lock: if you remove this gate, the swap cache
+        // will publish hexes that `applyFromHexString` rejected (malformed XML,
+        // manual edits, rotation palette bug) and drift from the paint state.
+        // `AccentApplicatorFocusedProjectTest.applyForFocusedProject skips swap
+        // cache publish when applyFromHexString rejects the resolver output`
+        // must fail first if you touch this branch.
         if (applied) {
             ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
         }

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -35,23 +35,6 @@ import javax.swing.SwingUtilities
 import javax.swing.UIManager
 
 object AccentApplicator {
-    /**
-     * Shape check for persisted / caller-provided accent hex strings. `#` prefix + exactly
-     * six hex digits — the only form [Color.decode] can interpret without throwing on
-     * this path. Shared with [dev.ayuislands.AyuIslandsAppListener] so the cache read
-     * on startup and the apply entry point reject the same corrupted values (hand-edited
-     * XML, truncated writes, rare partial-persist under IDE crash) before they reach the
-     * decoder. Without this gate a single bad hex in `ayu-islands.xml` would abort the
-     * very first frame paint and leave the plugin silently inert for the session.
-     *
-     * Phase 40.2 M-2: leading/trailing whitespace is tolerated in the match but callers
-     * MUST `.trim()` the input before handing it to [Color.decode] (the decoder itself
-     * does not accept padding). Shorthand `#RGB` is intentionally NOT accepted — every
-     * persisted value in `ayu-islands.xml` is emitted as `#RRGGBB` and expanding the
-     * pattern would silently forgive a new corruption mode.
-     */
-    val HEX_COLOR_PATTERN = Regex("^\\s*#[0-9A-Fa-f]{6}\\s*$")
-
     /** Notification group ID declared in plugin.xml — shared with [dev.ayuislands.rotation.AccentRotationService]. */
     private const val NOTIFICATION_GROUP_ID = "Ayu Islands"
 
@@ -155,13 +138,17 @@ object AccentApplicator {
     /**
      * Applies [accentHex] across UIManager, editor keys, and the EP chain.
      *
-     * Phase 40.2 H-3 changed the return type to [Boolean]: `false` signals that the
-     * caller-provided hex failed shape validation and no apply work ran. Callers MUST
-     * surface a user-visible notification so settings-panel Apply, rotation ticks, and
-     * manual accent picks do not silently swallow corruption. `true` means the hex
-     * passed validation and the EP dispatch was scheduled (actual EP work may still
-     * happen asynchronously if the caller is off-EDT — the Boolean reports
-     * validation + scheduling, not end-to-end paint completion).
+     * Takes an [AccentHex] whose `#RRGGBB` shape is proven by construction —
+     * no internal regex, no `NumberFormatException` path through [Color.decode].
+     * Callers with a raw `String` from an untrusted boundary should use the
+     * top-level [applyFromHexString] helper which centralizes the Phase 40.2
+     * H-3 notification-on-bad-hex + `false` return contract.
+     *
+     * Phase 40.2 H-3 preserved: `true` means the hex passed validation and the
+     * EP dispatch was scheduled (actual EP work may still happen asynchronously
+     * if the caller is off-EDT — the Boolean reports validation + scheduling,
+     * not end-to-end paint completion). The return stays `Boolean` rather than
+     * `Unit` so the string-wrapper's `false` path can bubble up.
      *
      * Phase 40.2 H-2: [AyuIslandsState.lastAppliedAccentHex] is written BEFORE the EP
      * iteration runs, not after — a mid-EP throw would otherwise drop the anti-flicker
@@ -171,38 +158,9 @@ object AccentApplicator {
      * can distinguish "cached hex from a clean apply" from "cached hex from a torn
      * apply" and fall back to the resolver in the torn case.
      */
-    fun apply(accentHex: String): Boolean {
-        // Reject garbage before it reaches [Color.decode], which throws
-        // [NumberFormatException] on anything outside the `#RRGGBB` form. Callers
-        // include [dev.ayuislands.AyuIslandsAppListener.appFrameCreated] feeding the
-        // persisted `lastAppliedAccentHex` straight from XML — a corrupted or
-        // hand-edited value must not abort the first frame paint. Warn so user-submitted
-        // idea.log captures the offending value for diagnosis, surface a user-facing
-        // notification (Phase 40.2 H-3), then bail; the next resolver-driven apply
-        // (StartupActivity) will write a clean hex.
-        if (!HEX_COLOR_PATTERN.matches(accentHex)) {
-            log.warn("AccentApplicator.apply: invalid hex '$accentHex' — skipping apply")
-            // Phase 40.2 H-3: user-visible notification for the rejected hex so
-            // per-project XML corruption, manual edits, and rotation palette
-            // bugs do not silently turn chrome tinting off. Wrapped in
-            // runCatching so a notification subsystem hiccup cannot cascade
-            // into the caller (settings panel, rotation tick, startup).
-            runCatching {
-                Notifications.Bus.notify(
-                    Notification(
-                        NOTIFICATION_GROUP_ID,
-                        "Ayu Islands",
-                        "Ayu accent rejected — hex '$accentHex' is not a valid #RRGGBB.",
-                        NotificationType.WARNING,
-                    ),
-                )
-            }.onFailure { exception ->
-                log.debug("AccentApplicator invalid-hex notification failed to post", exception)
-            }
-            return false
-        }
-        val trimmedHex = accentHex.trim()
-        val accent = Color.decode(trimmedHex)
+    fun apply(accentHex: AccentHex): Boolean {
+        val trimmedHex = accentHex.value
+        val accent = accentHex.toColor()
         val state = AyuIslandsSettings.getInstance().state
         val variant = AyuVariant.detect()
 
@@ -293,7 +251,7 @@ object AccentApplicator {
         // manual XML edit, future resolver bug), skip the swap-cache publish so the
         // cache does not drift to a hex that was never actually painted. The apply
         // call itself already surfaces the user-visible notification.
-        val applied = apply(hex)
+        val applied = applyFromHexString(hex)
         if (applied) {
             ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
         }
@@ -696,9 +654,9 @@ object AccentApplicator {
             cgpSetViewportBorderColor = configClass.getMethod("setViewportBorderColor", String::class.java)
             cgpSetViewportBorderThickness = configClass.getMethod("setViewportBorderThickness", Int::class.java)
         } catch (exception: ReflectiveOperationException) {
-            logCgpWarning(CGP_RESOLUTION_FAILED, exception)
+            log.warn("CodeGlance Pro $CGP_RESOLUTION_FAILED: ${exception.javaClass.simpleName}: ${exception.message}")
         } catch (exception: RuntimeException) {
-            logCgpWarning(CGP_RESOLUTION_FAILED, exception)
+            log.warn("CodeGlance Pro $CGP_RESOLUTION_FAILED: ${exception.javaClass.simpleName}: ${exception.message}")
         }
     }
 
@@ -724,18 +682,50 @@ object AccentApplicator {
             // CGP panels repaint via globalSchemeChange notification (no manual walk needed)
             log.info("CodeGlance Pro viewport color synced to $hexWithoutHash")
         } catch (exception: java.lang.reflect.InvocationTargetException) {
-            logCgpWarning(CGP_SYNC_FAILED, exception.cause ?: exception)
+            val cause = exception.cause ?: exception
+            log.warn("CodeGlance Pro $CGP_SYNC_FAILED: ${cause.javaClass.simpleName}: ${cause.message}")
         } catch (exception: ReflectiveOperationException) {
-            logCgpWarning(CGP_SYNC_FAILED, exception)
+            log.warn("CodeGlance Pro $CGP_SYNC_FAILED: ${exception.javaClass.simpleName}: ${exception.message}")
         } catch (exception: RuntimeException) {
-            logCgpWarning(CGP_SYNC_FAILED, exception)
+            log.warn("CodeGlance Pro $CGP_SYNC_FAILED: ${exception.javaClass.simpleName}: ${exception.message}")
         }
     }
 
-    private fun logCgpWarning(
-        action: String,
-        exception: Throwable,
-    ) {
-        log.warn("CodeGlance Pro $action: ${exception.javaClass.simpleName}: ${exception.message}")
+    /**
+     * String-accepting entry point for callers that hold a raw hex from an
+     * untrusted boundary (persisted XML, settings-panel input, resolver
+     * output that is still `String` until Phase 40.3b migration completes).
+     * Validates the shape via [AccentHex.of], surfaces the Phase 40.2 H-3
+     * notification + returns `false` on rejection, and forwards to [apply]
+     * on success.
+     *
+     * Deliberately NOT named `apply(String)` — mockk's `every { apply(any()) }`
+     * can't resolve across overloads of the same name, so tests that lock in
+     * the cache-publish ordering against the apply path would all break.
+     */
+    fun applyFromHexString(accentHex: String): Boolean {
+        val accent =
+            AccentHex.of(accentHex) ?: run {
+                log.warn("AccentApplicator.apply: invalid hex '$accentHex' — skipping apply")
+                // Phase 40.2 H-3: user-visible notification for the rejected hex so
+                // per-project XML corruption, manual edits, and rotation palette
+                // bugs do not silently turn chrome tinting off. Wrapped in
+                // runCatching so a notification subsystem hiccup cannot cascade
+                // into the caller (settings panel, rotation tick, startup).
+                runCatching {
+                    Notifications.Bus.notify(
+                        Notification(
+                            NOTIFICATION_GROUP_ID,
+                            "Ayu Islands",
+                            "Ayu accent rejected — hex '$accentHex' is not a valid #RRGGBB.",
+                            NotificationType.WARNING,
+                        ),
+                    )
+                }.onFailure { exception ->
+                    log.debug("AccentApplicator invalid-hex notification failed to post", exception)
+                }
+                return false
+            }
+        return apply(accent)
     }
 }

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -740,10 +740,20 @@ object AccentApplicator {
                 log.warn("AccentApplicator.apply: invalid hex '$accentHex' — skipping apply")
                 // Phase 40.2 H-3: user-visible notification for the rejected hex so
                 // per-project XML corruption, manual edits, and rotation palette
-                // bugs do not silently turn chrome tinting off. Wrapped in
-                // runCatching so a notification subsystem hiccup cannot cascade
-                // into the caller (settings panel, rotation tick, startup).
-                runCatching {
+                // bugs do not silently turn chrome tinting off. Wrapped in a
+                // narrow try/catch so a notification subsystem hiccup cannot
+                // cascade into the caller (settings panel, rotation tick,
+                // startup).
+                //
+                // Pattern B + log-level escalation: narrow the catch to
+                // [RuntimeException] so [OutOfMemoryError] /
+                // [NoClassDefFoundError] propagate, and raise the fallback log
+                // from DEBUG to WARN — this is the user-visible fallback for
+                // per-project XML corruption / manual edits / rotation palette
+                // bugs. If THAT notification fails to post, the user sees a
+                // silent no-op; the WARN trace is the only thread to pull on
+                // during triage.
+                try {
                     Notifications.Bus.notify(
                         Notification(
                             NOTIFICATION_GROUP_ID,
@@ -752,8 +762,8 @@ object AccentApplicator {
                             NotificationType.WARNING,
                         ),
                     )
-                }.onFailure { exception ->
-                    log.debug("AccentApplicator invalid-hex notification failed to post", exception)
+                } catch (exception: RuntimeException) {
+                    log.warn("AccentApplicator invalid-hex notification failed to post", exception)
                 }
                 return false
             }

--- a/src/main/kotlin/dev/ayuislands/accent/AccentHex.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentHex.kt
@@ -1,0 +1,77 @@
+package dev.ayuislands.accent
+
+import java.awt.Color
+
+/**
+ * Typed wrapper for a validated `#RRGGBB` accent color string.
+ *
+ * ### Why a value class
+ *
+ * Accent hex strings flow through many call sites (settings panels,
+ * rotation, LAF listener, startup, applicator, resolver) as raw `String`.
+ * Phase 40.2 M-2 introduced a single shape check at the
+ * [AccentApplicator.apply] boundary — but every other caller still had
+ * to remember to respect the same contract. A single bad hex reaching
+ * [Color.decode] throws [NumberFormatException] and aborts the first
+ * painted frame.
+ *
+ * Lifting the validation into the type means [AccentHex] can only be
+ * constructed through [of] (validated) or [ofTrusted] (explicit trust for
+ * compile-time literals like [AyuVariant.defaultAccent] / [AccentColor.hex]).
+ * The applicator's [toColor] is then total: there is no way to build an
+ * `AccentHex` whose [value] fails `Color.decode`.
+ *
+ * ### Persistence
+ *
+ * The wrapper deliberately does NOT replace persisted `String` fields on
+ * [dev.ayuislands.settings.AyuIslandsState]. `BaseState` requires `String`
+ * property delegates for XML serialization; changing the stored type
+ * would break forward/backward compat. Read-time wrappers
+ * (e.g. [dev.ayuislands.settings.AyuIslandsState.effectiveLastAppliedAccentHex])
+ * bridge the raw field to the typed accent surface.
+ *
+ * ### Validation
+ *
+ * The accepted shape is `#` + exactly six hex digits, with optional
+ * leading/trailing whitespace (trimmed by [of]). Shorthand `#RGB` is
+ * intentionally NOT accepted — every persisted value in `ayu-islands.xml`
+ * is emitted as `#RRGGBB`, so expanding the pattern would silently forgive
+ * a new corruption mode.
+ */
+@JvmInline
+value class AccentHex private constructor(
+    val value: String,
+) {
+    /** Decodes [value] into an AWT [Color]. Total by construction. */
+    fun toColor(): Color = Color.decode(value)
+
+    companion object {
+        /**
+         * Accepted shape: `#` + exactly six hex digits. Leading/trailing
+         * whitespace is tolerated per the Phase 40.2 M-2 fix; [of] trims
+         * before matching.
+         */
+        private val PATTERN = Regex("^\\s*#[0-9A-Fa-f]{6}\\s*$")
+
+        /**
+         * Returns an [AccentHex] for valid input (after `trim`), or `null`
+         * when [raw] is null, empty, malformed, or contains non-hex chars.
+         */
+        fun of(raw: String?): AccentHex? = raw?.trim()?.takeIf { PATTERN.matches(it) }?.let(::AccentHex)
+
+        /**
+         * Throws [IllegalArgumentException] on invalid input. Prefer [of]
+         * for user-provided / persisted values; use this for invariants
+         * proven by a preceding validation step.
+         */
+        fun require(raw: String?): AccentHex = of(raw) ?: error("Invalid accent hex: '$raw' (expected #RRGGBB)")
+
+        /**
+         * Wraps a known-good literal (e.g. [AyuVariant.defaultAccent] or
+         * an entry from [AYU_ACCENT_PRESETS]) without re-running validation.
+         * Callers assert the input is a compile-time constant `#RRGGBB` —
+         * use [of] for any runtime-sourced value.
+         */
+        fun ofTrusted(raw: String): AccentHex = AccentHex(raw.trim())
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/accent/AccentHex.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentHex.kt
@@ -16,7 +16,7 @@ import java.awt.Color
  * painted frame.
  *
  * Lifting the validation into the type means [AccentHex] can only be
- * constructed through [of] (validated) or [ofTrusted] (explicit trust for
+ * constructed through [of] (validated) or [unsafeOf] (explicit trust for
  * compile-time literals like [AyuVariant.defaultAccent] / [AccentColor.hex]).
  * The applicator's [toColor] is then total: there is no way to build an
  * `AccentHex` whose [value] fails `Color.decode`.
@@ -67,11 +67,13 @@ value class AccentHex private constructor(
         fun require(raw: String?): AccentHex = of(raw) ?: error("Invalid accent hex: '$raw' (expected #RRGGBB)")
 
         /**
-         * Wraps a known-good literal (e.g. [AyuVariant.defaultAccent] or
-         * an entry from [AYU_ACCENT_PRESETS]) without re-running validation.
-         * Callers assert the input is a compile-time constant `#RRGGBB` —
-         * use [of] for any runtime-sourced value.
+         * Escape-hatch wrapper for known-good literals (e.g. [AyuVariant.defaultAccent]
+         * or an entry from `AYU_ACCENT_PRESETS`). Skips validation — callers
+         * assert the input is a compile-time constant `#RRGGBB`. Prefixed
+         * `unsafe` per the Kotlin convention (`unsafeCast`, `unsafeLazy`) so
+         * IDE completion warns readers this is a bypass, not a sibling of [of].
+         * Use [of] for any runtime-sourced value.
          */
-        fun ofTrusted(raw: String): AccentHex = AccentHex(raw.trim())
+        fun unsafeOf(raw: String): AccentHex = AccentHex(raw.trim())
     }
 }

--- a/src/main/kotlin/dev/ayuislands/accent/ChromeBaseColors.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ChromeBaseColors.kt
@@ -28,6 +28,12 @@ import javax.swing.UIManager
  */
 object ChromeBaseColors {
     private val log = logger<ChromeBaseColors>()
+
+    // Bounded implicitly by the finite set of UIManager keys consumed by chrome
+    // elements (~20). No explicit cap needed — no caller feeds user-controlled
+    // keys in, and a LAF refresh() clears the whole map anyway. Do not introduce
+    // a TTL or LRU cache here speculatively; the growth ceiling is the key list
+    // above, not user activity.
     private val snapshot = ConcurrentHashMap<String, Color>()
 
     /**

--- a/src/main/kotlin/dev/ayuislands/accent/ChromeBaseColors.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ChromeBaseColors.kt
@@ -53,7 +53,14 @@ object ChromeBaseColors {
         // on theme switch, so the user would see wrong base colors after
         // changing theme. Log at WARN so the "chrome tints look stale after
         // theme change" report has a trace in idea.log.
-        runCatching {
+        //
+        // Pattern B: narrow the catch to [RuntimeException] so catastrophic
+        // JVM signals ([OutOfMemoryError], [NoClassDefFoundError],
+        // [StackOverflowError]) still propagate during plugin init instead
+        // of being demoted to a single WARN line. The MessageBus / LAF
+        // subscription surface throws only [RuntimeException] subtypes
+        // (NPE on null service, IllegalState on torn-down app).
+        try {
             val application = ApplicationManager.getApplication()
             application
                 .messageBus
@@ -63,7 +70,7 @@ object ChromeBaseColors {
                 // Round 3 C-4.
                 .connect(application)
                 .subscribe(LafManagerListener.TOPIC, LafManagerListener { refresh() })
-        }.onFailure { exception ->
+        } catch (exception: RuntimeException) {
             log.warn(
                 "ChromeBaseColors LAF listener wiring failed; cache will not auto-refresh on theme change",
                 exception,

--- a/src/main/kotlin/dev/ayuislands/accent/ChromeBaseColors.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ChromeBaseColors.kt
@@ -72,47 +72,62 @@ object ChromeBaseColors {
      * time; callers fall back to their own default, and the first miss per key
      * is logged at WARN so user-submitted idea.log captures which chrome surface
      * silently skipped tint.
+     *
+     * Phase 40.2 M-6: the fast-path `snapshot[key]?.let { return it }` stays
+     * outside the lock (already thread-safe via [ConcurrentHashMap]) so repeat
+     * reads — the common case — hit no contention. The composite read-UIManager
+     * -putIfAbsent for first capture runs inside `synchronized(snapshot)` so
+     * [refresh] cannot interleave between the UIManager read and the snapshot
+     * write. Without this, a racing `refresh()` between those two lines would
+     * let a stale pre-LAF color land in the post-LAF snapshot.
      */
     fun get(key: String): Color? {
         snapshot[key]?.let { return it }
-        val current = UIManager.getColor(key)
-        if (current == null) {
-            // `Set.add` returns `true` iff the element was newly inserted — that is
-            // exactly the log-once gate, in a single atomic step.
-            if (missingKeyLogged.add(key)) {
-                log.warn(
-                    "ChromeBaseColors: UIManager has no entry for '$key' — " +
-                        "chrome surface using this key will skip tint until " +
-                        "the next LAF event populates it",
-                )
+        synchronized(snapshot) {
+            // Re-check under the lock: a concurrent writer may have populated
+            // between the outer fast-path check and acquiring the monitor.
+            snapshot[key]?.let { return it }
+            val current = UIManager.getColor(key)
+            if (current == null) {
+                // `Set.add` returns `true` iff the element was newly inserted — that is
+                // exactly the log-once gate, in a single atomic step.
+                if (missingKeyLogged.add(key)) {
+                    log.warn(
+                        "ChromeBaseColors: UIManager has no entry for '$key' — " +
+                            "chrome surface using this key will skip tint until " +
+                            "the next LAF event populates it",
+                    )
+                }
+                return null
             }
-            return null
+            // Retain first captured value even under concurrent first access.
+            return snapshot.putIfAbsent(key, current) ?: current
         }
-        // Retain first captured value even under concurrent first access.
-        return snapshot.putIfAbsent(key, current) ?: current
     }
 
     /**
      * Clears the snapshot so the next `get` call re-captures from UIManager.
      * Invoked by the LAF listener; exposed for tests.
      *
-     * Ordering note (Phase 40 review-loop Round 1 MEDIUM-2 / Round 2 S-2):
-     * the latch is cleared BEFORE the snapshot so a racing `get(key)` between
-     * the two clears cannot see a cleared snapshot with a stale latch still
-     * full (which would silence a WARN the new LAF cycle should emit). A
-     * symmetric residual race exists where a concurrent `get()` right after
-     * latch-clear re-populates the latch before snapshot-clear runs — the
-     * WARN still fires, it is just attributed to a cycle boundary that the
-     * reader happened to cross. Documented here rather than guarded with a
-     * lock because `refresh()` fires on EDT via the LAF listener and the
-     * cost of a briefly-skipped WARN line does not justify the synchronization.
+     * Phase 40.2 M-6: the clear pair now runs inside `synchronized(snapshot)`
+     * so a `get()` in first-capture mode cannot interleave its
+     * read-UIManager-putIfAbsent composite and land a pre-LAF color into the
+     * post-LAF snapshot. The prior in-flight-race note has been tightened
+     * accordingly: the latch is still cleared BEFORE the snapshot so a racing
+     * `get()` entering the lock just AFTER refresh's latch-clear but BEFORE
+     * its snapshot-clear still sees an empty latch and (re-)warns on the
+     * next miss. The "missed WARN attributed to cycle boundary" residual
+     * race documented in prior rounds is now impossible because both clears
+     * are visible to the next entrant atomically under the same monitor.
      */
     fun refresh() {
-        // Clear the latch BEFORE the snapshot so a racing `get(key)` between the
-        // two clears cannot see a cleared snapshot with a stale latch still full
-        // (which would silence a WARN that the new LAF cycle should emit). See
-        // Phase 40 Round 1 review loop MEDIUM-2.
-        missingKeyLogged.clear()
-        snapshot.clear()
+        synchronized(snapshot) {
+            // Clear the latch BEFORE the snapshot so a racing `get(key)` between the
+            // two clears cannot see a cleared snapshot with a stale latch still full
+            // (which would silence a WARN that the new LAF cycle should emit). See
+            // Phase 40 Round 1 review loop MEDIUM-2.
+            missingKeyLogged.clear()
+            snapshot.clear()
+        }
     }
 }

--- a/src/main/kotlin/dev/ayuislands/accent/ChromeDecorationsProbe.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ChromeDecorationsProbe.kt
@@ -36,7 +36,8 @@ import javax.swing.UIManager
  * probe therefore funnels OS detection through [osSupplier], an overridable seam in the
  * same shape as `LicenseChecker.nowMsSupplier`. Tests pin [osSupplier] to the desired
  * branch and must call [resetOsSupplierForTests] in `@AfterTest` to restore production
- * behavior.
+ * behavior. The override is held in a [ThreadLocal] so parallel JUnit workers cannot
+ * leak a pinned OS from one test into a concurrent sibling.
  */
 object ChromeDecorationsProbe {
     private const val MAC_UNIFIED_KEY = "TitlePane.unifiedBackground"
@@ -70,18 +71,43 @@ object ChromeDecorationsProbe {
     private val defaultOsSupplier: () -> Os = { computeOs() }
 
     /**
+     * Per-thread override storage for the OS-detection seam. `null` means "use the
+     * production supplier" — only tests ever write a non-null entry, and they must
+     * clear it in `@AfterTest` via [resetOsSupplierForTests].
+     *
+     * Why ThreadLocal rather than the prior `@Volatile var`? Gradle runs JUnit tests
+     * in parallel workers by default; a shared `@Volatile` supplier leaks a pinned
+     * OS from one test into a concurrent sibling's probe call, producing
+     * intermittent "looks like macOS in a Windows test" false negatives. The
+     * ThreadLocal isolates the override to the mutating test's own thread.
+     */
+    private val osSupplierOverride: ThreadLocal<(() -> Os)?> = ThreadLocal.withInitial { null }
+
+    /**
      * Test seam for OS detection. Production code reads [SystemInfo]; tests override this
      * supplier to exercise each branch. Always restore via [resetOsSupplierForTests] in
      * teardown to prevent leaking state across tests.
+     *
+     * Backed by a per-thread override ([osSupplierOverride]) so concurrent test
+     * workers cannot leak OS overrides into each other. The `var` shape with
+     * get/set accessors is preserved for test-API compatibility — `osSupplier = { ... }`
+     * on the mutating test's own thread writes into the thread-local; the read side
+     * falls back to [defaultOsSupplier] when the thread-local is null (production
+     * path and any thread that never set an override).
      */
-    @VisibleForTesting
-    @Volatile
-    internal var osSupplier: () -> Os = defaultOsSupplier
+    internal var osSupplier: () -> Os
+        @VisibleForTesting
+        get() = osSupplierOverride.get() ?: defaultOsSupplier
 
-    /** Restore the production [osSupplier]. Intended for test teardown. */
+        @VisibleForTesting
+        set(value) {
+            osSupplierOverride.set(value)
+        }
+
+    /** Restore the production [osSupplier] on the calling thread. Intended for test teardown. */
     @VisibleForTesting
     internal fun resetOsSupplierForTests() {
-        osSupplier = defaultOsSupplier
+        osSupplierOverride.remove()
     }
 
     private val log = logger<ChromeDecorationsProbe>()

--- a/src/main/kotlin/dev/ayuislands/accent/ChromeDecorationsProbe.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ChromeDecorationsProbe.kt
@@ -1,8 +1,11 @@
 package dev.ayuislands.accent
 
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.util.registry.Registry
+import org.jetbrains.annotations.TestOnly
 import org.jetbrains.annotations.VisibleForTesting
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.swing.UIManager
 
 /**
@@ -81,20 +84,52 @@ object ChromeDecorationsProbe {
         osSupplier = defaultOsSupplier
     }
 
+    private val log = logger<ChromeDecorationsProbe>()
+
+    /**
+     * One-shot gate for the per-session INFO diagnostic log (Phase 40.2 H-5). The
+     * first `isCustomHeaderActive()` call records which OS branch ran and which
+     * raw inputs fed the decision, so a user whose Main Toolbar row is disabled
+     * can point at their `idea.log` to see WHY the probe said no. Subsequent
+     * calls within the same session stay silent.
+     */
+    private val diagnosticLogged = AtomicBoolean(false)
+
     /**
      * Returns `true` when the IDE is currently painting a JBR custom window header for
      * the current OS. Never throws: a missing UIManager key resolves to `false`, and a
      * missing Registry key returns the supplied default (`false`).
      */
-    fun isCustomHeaderActive(): Boolean =
-        when (osSupplier()) {
-            Os.MAC -> macCustomHeader()
-            Os.WINDOWS -> UIManager.getBoolean(WINDOWS_HEADER_KEY)
-            Os.LINUX -> Registry.`is`(LINUX_REGISTRY_KEY, false)
-            Os.UNKNOWN -> false
+    fun isCustomHeaderActive(): Boolean {
+        val os = osSupplier()
+        val unified = UIManager.getBoolean(MAC_UNIFIED_KEY)
+        val tpab = Registry.`is`(MAC_REGISTRY_KEY, false)
+        val winHeader = UIManager.getBoolean(WINDOWS_HEADER_KEY)
+        val linuxReg = Registry.`is`(LINUX_REGISTRY_KEY, false)
+        val result =
+            when (os) {
+                Os.MAC -> unified || tpab
+                Os.WINDOWS -> winHeader
+                Os.LINUX -> linuxReg
+                Os.UNKNOWN -> false
+            }
+        // H-5: one-shot INFO diagnostic per session so users can see WHY the
+        // Main Toolbar toggle was disabled (or enabled) from idea.log alone.
+        // Gate with AtomicBoolean.compareAndSet so concurrent first calls from
+        // settings panel + MainToolbarElement.apply can race without duplicate
+        // log lines.
+        if (diagnosticLogged.compareAndSet(false, true)) {
+            log.info(
+                "ChromeDecorationsProbe: os=$os result=$result sources=[" +
+                    "unified=$unified,tpab=$tpab,winHeader=$winHeader,linuxReg=$linuxReg]",
+            )
         }
+        return result
+    }
 
-    private fun macCustomHeader(): Boolean =
-        UIManager.getBoolean(MAC_UNIFIED_KEY) ||
-            Registry.`is`(MAC_REGISTRY_KEY, false)
+    /** Test-only reset for the one-shot diagnostic gate. */
+    @TestOnly
+    internal fun resetDiagnosticLoggedForTests() {
+        diagnosticLogged.set(false)
+    }
 }

--- a/src/main/kotlin/dev/ayuislands/accent/ChromeDecorationsProbe.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ChromeDecorationsProbe.kt
@@ -96,22 +96,44 @@ object ChromeDecorationsProbe {
     private val diagnosticLogged = AtomicBoolean(false)
 
     /**
-     * Returns `true` when the IDE is currently painting a JBR custom window header for
-     * the current OS. Never throws: a missing UIManager key resolves to `false`, and a
-     * missing Registry key returns the supplied default (`false`).
+     * Returns a typed [ChromeSupport] result describing whether chrome tinting can
+     * reach the title bar and, when it cannot, why. Never throws: a missing UIManager
+     * key resolves to `false`, and a missing Registry key returns the supplied default.
+     *
+     * Phase 40.3c Refactor 3: introduced so the Settings UI can read the reason code
+     * straight from the probe instead of re-sampling `SystemInfo.isMac/isWindows/isLinux`
+     * on its own to build the "disabled" tooltip.
      */
-    fun isCustomHeaderActive(): Boolean {
+    fun probe(): ChromeSupport {
         val os = osSupplier()
         val unified = UIManager.getBoolean(MAC_UNIFIED_KEY)
         val tpab = Registry.`is`(MAC_REGISTRY_KEY, false)
         val winHeader = UIManager.getBoolean(WINDOWS_HEADER_KEY)
         val linuxReg = Registry.`is`(LINUX_REGISTRY_KEY, false)
-        val result =
+        val result: ChromeSupport =
             when (os) {
-                Os.MAC -> unified || tpab
-                Os.WINDOWS -> winHeader
-                Os.LINUX -> linuxReg
-                Os.UNKNOWN -> false
+                Os.MAC -> {
+                    if (unified || tpab) {
+                        ChromeSupport.Supported
+                    } else {
+                        ChromeSupport.Unsupported.NativeMacTitleBar
+                    }
+                }
+                Os.WINDOWS -> {
+                    if (winHeader) {
+                        ChromeSupport.Supported
+                    } else {
+                        ChromeSupport.Unsupported.WindowsNoCustomHeader
+                    }
+                }
+                Os.LINUX -> {
+                    if (linuxReg) {
+                        ChromeSupport.Supported
+                    } else {
+                        ChromeSupport.Unsupported.GnomeSsd
+                    }
+                }
+                Os.UNKNOWN -> ChromeSupport.Unsupported.UnknownOs
             }
         // H-5: one-shot INFO diagnostic per session so users can see WHY the
         // Main Toolbar toggle was disabled (or enabled) from idea.log alone.
@@ -126,6 +148,14 @@ object ChromeDecorationsProbe {
         }
         return result
     }
+
+    /**
+     * Back-compat boolean delegate — returns `true` iff [probe] reports [ChromeSupport.Supported].
+     * Call sites that only need the boolean answer (the Settings row `.enabledIf` predicate,
+     * MainToolbarElement's probe gate) keep using this method; [probe] is the typed entry for
+     * callers that also need the reason code.
+     */
+    fun isCustomHeaderActive(): Boolean = probe() is ChromeSupport.Supported
 
     /** Test-only reset for the one-shot diagnostic gate. */
     @TestOnly

--- a/src/main/kotlin/dev/ayuislands/accent/ChromeSupport.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ChromeSupport.kt
@@ -11,9 +11,11 @@ package dev.ayuislands.accent
  * that could easily drift from the probe's decision.
  *
  * Modeling the outcome as a sealed hierarchy gives the probe a single place
- * to distinguish *why* chrome tinting is unavailable, and lets callers
- * render a tailored message via [Unsupported.reason] without re-sampling
- * `SystemInfo` themselves.
+ * to distinguish *why* chrome tinting is unavailable. Phase 40.4 R-3 then
+ * lifted the user-visible display strings into the UI layer
+ * ([dev.ayuislands.settings.AyuIslandsChromePanel]) — a sealed `when` on
+ * the subtype is total, so the mapping is still compile-time exhaustive
+ * but the display copy lives next to the UI code that owns its wording.
  *
  * Back-compat: [ChromeDecorationsProbe.isCustomHeaderActive] is kept as a
  * thin delegate (`probe() is Supported`) for call sites that only need the
@@ -23,28 +25,22 @@ sealed interface ChromeSupport {
     /** JBR custom window decorations are active — chrome tinting will reach the title bar. */
     object Supported : ChromeSupport
 
-    /** Chrome tinting cannot reach the title bar; [reason] carries the user-visible explanation. */
+    /**
+     * Chrome tinting cannot reach the title bar. The subtype identity encodes
+     * *why*; the UI layer pattern-matches on it to render a user-visible
+     * message.
+     */
     sealed interface Unsupported : ChromeSupport {
-        val reason: String
-
         /** macOS is painting its native title bar (IDE 2026.1+ removed the unified-title toggle). */
-        object NativeMacTitleBar : Unsupported {
-            override val reason = "native macOS title bar"
-        }
+        object NativeMacTitleBar : Unsupported
 
         /** Linux with GNOME server-side decorations — the window manager paints the title bar. */
-        object GnomeSsd : Unsupported {
-            override val reason = "GNOME server-side decorations"
-        }
+        object GnomeSsd : Unsupported
 
         /** Windows without the CustomWindowHeader LAF entry — IDE is using the native frame. */
-        object WindowsNoCustomHeader : Unsupported {
-            override val reason = "Windows native header"
-        }
+        object WindowsNoCustomHeader : Unsupported
 
         /** Running on an OS the probe's dispatch enum does not cover. */
-        object UnknownOs : Unsupported {
-            override val reason = "unknown OS"
-        }
+        object UnknownOs : Unsupported
     }
 }

--- a/src/main/kotlin/dev/ayuislands/accent/ChromeSupport.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ChromeSupport.kt
@@ -1,0 +1,50 @@
+package dev.ayuislands.accent
+
+/**
+ * Result type for [ChromeDecorationsProbe.probe].
+ *
+ * Phase 40.3c Refactor 3 — the prior probe collapsed four OS / decoration
+ * branches (native macOS title bar, GNOME SSD, Windows native header,
+ * unknown OS) into a single boolean. Settings UI then had to re-derive the
+ * reason code with its own per-OS `when` (`SystemInfo.isMac/isWindows/isLinux`)
+ * to compose the user-visible "disabled" tooltip — a second source of truth
+ * that could easily drift from the probe's decision.
+ *
+ * Modeling the outcome as a sealed hierarchy gives the probe a single place
+ * to distinguish *why* chrome tinting is unavailable, and lets callers
+ * render a tailored message via [Unsupported.reason] without re-sampling
+ * `SystemInfo` themselves.
+ *
+ * Back-compat: [ChromeDecorationsProbe.isCustomHeaderActive] is kept as a
+ * thin delegate (`probe() is Supported`) for call sites that only need the
+ * boolean answer (the Settings row `.enabledIf` predicate).
+ */
+sealed interface ChromeSupport {
+    /** JBR custom window decorations are active — chrome tinting will reach the title bar. */
+    object Supported : ChromeSupport
+
+    /** Chrome tinting cannot reach the title bar; [reason] carries the user-visible explanation. */
+    sealed interface Unsupported : ChromeSupport {
+        val reason: String
+
+        /** macOS is painting its native title bar (IDE 2026.1+ removed the unified-title toggle). */
+        object NativeMacTitleBar : Unsupported {
+            override val reason = "native macOS title bar"
+        }
+
+        /** Linux with GNOME server-side decorations — the window manager paints the title bar. */
+        object GnomeSsd : Unsupported {
+            override val reason = "GNOME server-side decorations"
+        }
+
+        /** Windows without the CustomWindowHeader LAF entry — IDE is using the native frame. */
+        object WindowsNoCustomHeader : Unsupported {
+            override val reason = "Windows native header"
+        }
+
+        /** Running on an OS the probe's dispatch enum does not cover. */
+        object UnknownOs : Unsupported {
+            override val reason = "unknown OS"
+        }
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/accent/ChromeTarget.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ChromeTarget.kt
@@ -38,9 +38,31 @@ sealed interface ChromeTarget {
         val fqn: ClassFqn,
     ) : ChromeTarget
 
-    /** Ancestor-constrained class-name lookup — [target] must sit inside a [ancestor]. */
-    data class ByClassNameInside(
+    /**
+     * Ancestor-constrained class-name lookup — [target] must sit inside a [ancestor].
+     *
+     * **Private constructor — use the companion `invoke(target = ..., ancestor = ...)`
+     * factory and pass named arguments.** Both fields are [ClassFqn], so positional
+     * construction (`ByClassNameInside(foo, bar)`) silently compiles with `foo` and
+     * `bar` swapped — which would walk the wrong ancestor chain and either over-tint
+     * every matching component across the IDE or under-tint (never find ancestor).
+     * The private ctor forces all call sites through [Companion.invoke], and the
+     * named-arg convention there is our last line of defense.
+     */
+    data class ByClassNameInside private constructor(
         val target: ClassFqn,
         val ancestor: ClassFqn,
-    ) : ChromeTarget
+    ) : ChromeTarget {
+        companion object {
+            /**
+             * Factory requiring named arguments at the call site. The `data class`
+             * copy/equals/hashCode contract is unchanged — only `new` construction
+             * is routed through this factory.
+             */
+            operator fun invoke(
+                target: ClassFqn,
+                ancestor: ClassFqn,
+            ): ByClassNameInside = ByClassNameInside(target = target, ancestor = ancestor)
+        }
+    }
 }

--- a/src/main/kotlin/dev/ayuislands/accent/ChromeTarget.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ChromeTarget.kt
@@ -1,0 +1,46 @@
+package dev.ayuislands.accent
+
+/**
+ * Typed description of the live Swing peer a chrome element tints.
+ *
+ * Phase 40.3c Refactor 2 — before this type existed, [LiveChromeRefresher]
+ * exposed six flat entry points (`refreshStatusBar`, `clearStatusBar`,
+ * `refreshByClassName`, `clearByClassName`, `refreshByClassNameInsideAncestorClass`,
+ * `clearByClassNameInsideAncestorClass`). Every chrome element had to remember
+ * which of the six matched its peer topology and call it correctly.
+ *
+ * Modeling the target as a sealed type collapses the six-entry API into two
+ * (`refresh(target, color)` + `clear(target)`), forces call sites to name the
+ * peer strategy explicitly, and makes adding a new topology a compile-time
+ * pattern-match failure instead of a silent new overload.
+ *
+ * ### Variants
+ *
+ *  - [StatusBar] — resolved via the public [com.intellij.openapi.wm.WindowManager]
+ *    API per open [com.intellij.openapi.project.Project]. The only peer type not
+ *    looked up via runtime class-name string match.
+ *  - [ByClassName] — walks every showing AWT window and mutates any [javax.swing.JComponent]
+ *    whose runtime class name equals [ByClassName.fqn]. Used for package-private
+ *    platform peers (`com.intellij.toolWindow.Stripe`, internal `MainToolbar`,
+ *    `MyNavBarWrapperPanel`) whose types we cannot import.
+ *  - [ByClassNameInside] — ancestor-scoped variant. Mutates a matching [ByClassNameInside.target]
+ *    only when its container chain includes a component whose runtime class name equals
+ *    [ByClassNameInside.ancestor]. Used for `OnePixelDivider` (shared IDE-wide) so we don't
+ *    leak panel-border tinting into editor splitters, diff gutter, Settings dialog, etc.
+ *    See Phase 40 review Round 2 A-1.
+ */
+sealed interface ChromeTarget {
+    /** StatusBar peer resolved via public [com.intellij.openapi.wm.WindowManager] API. */
+    object StatusBar : ChromeTarget
+
+    /** Peer located by runtime class-name string match across every showing window. */
+    data class ByClassName(
+        val fqn: ClassFqn,
+    ) : ChromeTarget
+
+    /** Ancestor-constrained class-name lookup — [target] must sit inside a [ancestor]. */
+    data class ByClassNameInside(
+        val target: ClassFqn,
+        val ancestor: ClassFqn,
+    ) : ChromeTarget
+}

--- a/src/main/kotlin/dev/ayuislands/accent/ChromeTintBlender.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ChromeTintBlender.kt
@@ -64,7 +64,10 @@ object ChromeTintBlender {
      * Algorithm (VERIFICATION Gap 1, Phase 40-09) — HSB-space blend rather than
      * per-channel RGB lerp so every chrome surface receives the SAME accent
      * hue regardless of how its stock base hue drifts:
-     *  1. Clamp [intensityPercent] to `[0, 100]`.
+     *  1. Read `intensity.percent` — already clamped to the user-visible
+     *     slider range by the [TintIntensity] constructor. The blender still
+     *     coerces into `[0, 100]` as a math-safety floor in case the wrapper
+     *     cap ever widens past the blender's algorithmic range.
      *  2. Extract the accent's hue + saturation (`accent.H`, `accent.S`) and
      *     the base's hue + saturation + brightness (`base.H`, `base.S`,
      *     `base.B`) via [Color.RGBtoHSB].
@@ -89,15 +92,16 @@ object ChromeTintBlender {
      * @param baseColor stock theme color to tint — callers fetch this from
      *     [ChromeBaseColors] so repeated applies all blend from the true stock
      *     baseline instead of an already-tinted value
-     * @param intensityPercent 0-100 mix ratio; out-of-range values clamp without throwing
+     * @param intensity typed slider position — range invariant proven at
+     *     construction via [TintIntensity.of]
      * @return opaque [Color] sharing the accent hue at the requested blend ratio
      */
     fun blend(
         accent: Color,
         baseColor: Color,
-        intensityPercent: Int,
+        intensity: TintIntensity,
     ): Color {
-        val clamped = intensityPercent.coerceIn(MIN_INTENSITY, MAX_INTENSITY)
+        val clamped = intensity.percent.coerceIn(MIN_INTENSITY, MAX_INTENSITY)
 
         // Identity short-circuit at 0: return the base per-channel so callers
         // see the exact stock color when the slider is off. This preserves the

--- a/src/main/kotlin/dev/ayuislands/accent/ChromeTintBlender.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ChromeTintBlender.kt
@@ -124,6 +124,15 @@ object ChromeTintBlender {
             baseHsb[2] + (accentHsb[2] - baseHsb[2]) * ratio * BRIGHTNESS_PULL_RATIO
 
         // getHSBColor returns an opaque Color; no 4-arg ctor needed (D-05).
-        return Color.getHSBColor(outputHue, outputSaturation.coerceIn(0f, 1f), outputBrightness)
+        // Phase 40.2 M-5: clamp brightness to [0, 1] to mirror the saturation clamp
+        // above. `Color.getHSBColor` passes brightness unchanged into a linear ramp
+        // and then into byte-quantisation — out-of-range values from a future tweak
+        // to BRIGHTNESS_PULL_RATIO or a base-color extraction edge case would slide
+        // into negative/overflow RGB territory without this guard.
+        return Color.getHSBColor(
+            outputHue,
+            outputSaturation.coerceIn(0f, 1f),
+            outputBrightness.coerceIn(0f, 1f),
+        )
     }
 }

--- a/src/main/kotlin/dev/ayuislands/accent/ClassFqn.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ClassFqn.kt
@@ -1,0 +1,68 @@
+package dev.ayuislands.accent
+
+/**
+ * Typed wrapper for a Java/Kotlin fully-qualified class name used by [LiveChromeRefresher]
+ * to look up Swing peers at runtime via `Class.getName()` string match.
+ *
+ * ### Why a value class
+ *
+ * The refresher's ancestor-scoped entry points previously took two adjacent
+ * `String` parameters with identical type (`targetFqn`, `ancestorFqn`).
+ * Swapping them compiles, unit tests still pass (both sides are just string
+ * match + tree walk), but production silently over-tints the wrong peers —
+ * exactly the positional-arg footgun Phase 40.3 was chartered to kill.
+ * Wrapping the FQN in a dedicated type forces call sites to tag each
+ * argument, so a swap becomes a compile error.
+ *
+ * ### Factories vs raw construction
+ *
+ * The primary constructor is private — callers must go through [of] or
+ * [require] so an invalid string cannot enter the type:
+ *
+ *  - [of] returns `null` for blank / syntactically-invalid input; callers
+ *    that can tolerate missing data use this one.
+ *  - [require] throws [IllegalArgumentException] for invalid input; call
+ *    sites that hardcode an FQN (the `PEER_CLASS` constants in every
+ *    chrome element) use this one so a typo fails fast at class-init
+ *    time instead of silently matching nothing at runtime.
+ *
+ * ### FQN pattern
+ *
+ * Matches `^[a-zA-Z_][\w.$]*$` — a Java identifier start followed by any
+ * mix of identifier chars, dots, and `$` inner-class markers. Intentionally
+ * conservative: rejects leading dot, leading digit, and embedded whitespace.
+ * `\w` in Kotlin's regex engine is `[a-zA-Z0-9_]` and does NOT include `$`,
+ * so the class separator must be listed explicitly.
+ */
+@JvmInline
+value class ClassFqn private constructor(
+    val value: String,
+) {
+    companion object {
+        /**
+         * Java-identifier FQN pattern — start char is letter or underscore,
+         * remainder allows word chars (incl. `$` for inner classes) and dots.
+         * See class-level KDoc for the rationale behind each exclusion.
+         */
+        private val FQN_PATTERN = Regex("^[a-zA-Z_][\\w.$]*$")
+
+        /** Returns a [ClassFqn] when [raw] matches [FQN_PATTERN], otherwise `null`. */
+        fun of(raw: String): ClassFqn? {
+            val trimmed = raw.trim()
+            if (trimmed.isEmpty()) return null
+            if (!FQN_PATTERN.matches(trimmed)) return null
+            return ClassFqn(trimmed)
+        }
+
+        /**
+         * Returns a [ClassFqn] when [raw] matches [FQN_PATTERN], otherwise throws
+         * [IllegalArgumentException]. Used at hardcoded `PEER_CLASS` call sites so
+         * a typo surfaces at class-init time instead of as a silent no-match at
+         * runtime.
+         */
+        fun require(raw: String): ClassFqn =
+            of(raw) ?: throw IllegalArgumentException(
+                "Invalid class FQN: '$raw' — must match $FQN_PATTERN",
+            )
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/accent/LiveChromeRefresher.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/LiveChromeRefresher.kt
@@ -71,19 +71,48 @@ internal object LiveChromeRefresher {
         brokenContainerLogged.clear()
     }
 
-    // --- StatusBar (resolvable via public WindowManager API) ---
+    // --- Typed entry points (Phase 40.3c Refactor 2) ---
+    //
+    // Sealed [ChromeTarget] collapses the prior 6-entry API (refresh/clear × 3
+    // peer strategies) into two methods. Dispatch is exhaustive — adding a new
+    // ChromeTarget variant is a compile-time pattern-match failure, not a silent
+    // new overload. Internal helpers (refreshOnTree*, clearOnTree*) stay
+    // `internal` for the tree-walk tests that build synthetic Container trees.
 
-    fun refreshStatusBar(color: Color) {
-        forEachUsableStatusBarComponent { component ->
-            component.background = color
-            component.repaint()
+    /** Refreshes the live peer described by [target] with [color]. */
+    fun refresh(
+        target: ChromeTarget,
+        color: Color,
+    ) {
+        when (target) {
+            ChromeTarget.StatusBar ->
+                forEachUsableStatusBarComponent { component ->
+                    component.background = color
+                    component.repaint()
+                }
+            is ChromeTarget.ByClassName ->
+                forEachShowingWindow { refreshOnTree(it, target.fqn, color) }
+            is ChromeTarget.ByClassNameInside ->
+                forEachShowingWindow {
+                    refreshOnTreeInsideAncestor(it, target.target, target.ancestor, color)
+                }
         }
     }
 
-    fun clearStatusBar() {
-        forEachUsableStatusBarComponent { component ->
-            component.background = null
-            component.repaint()
+    /** D-14 symmetry mirror of [refresh] — hands [target]'s peer back to LAF default. */
+    fun clear(target: ChromeTarget) {
+        when (target) {
+            ChromeTarget.StatusBar ->
+                forEachUsableStatusBarComponent { component ->
+                    component.background = null
+                    component.repaint()
+                }
+            is ChromeTarget.ByClassName ->
+                forEachShowingWindow { clearOnTree(it, target.fqn) }
+            is ChromeTarget.ByClassNameInside ->
+                forEachShowingWindow {
+                    clearOnTreeInsideAncestor(it, target.target, target.ancestor)
+                }
         }
     }
 
@@ -102,43 +131,6 @@ internal object LiveChromeRefresher {
             val component = statusBar.component as? JComponent ?: continue
             action(component)
         }
-    }
-
-    // --- Class-name-based frame walk (internal platform peer types) ---
-
-    fun refreshByClassName(
-        classNameFqn: ClassFqn,
-        color: Color,
-    ) {
-        forEachShowingWindow { refreshOnTree(it, classNameFqn, color) }
-    }
-
-    fun clearByClassName(classNameFqn: ClassFqn) {
-        forEachShowingWindow { clearOnTree(it, classNameFqn) }
-    }
-
-    /**
-     * Ancestor-constrained variant of [refreshByClassName]. Mutates a matching [targetFqn]
-     * only when the component sits inside a container whose runtime class name equals
-     * [ancestorFqn]. Used for shared peer types (`OnePixelDivider`) whose instances live
-     * all over the IDE — tinting every one of them would leak panel-border styling into
-     * editor splitters, diff gutters, Settings dialog splitters, etc. See Phase 40
-     * review Round 2 A-1.
-     */
-    fun refreshByClassNameInsideAncestorClass(
-        targetFqn: ClassFqn,
-        ancestorFqn: ClassFqn,
-        color: Color,
-    ) {
-        forEachShowingWindow { refreshOnTreeInsideAncestor(it, targetFqn, ancestorFqn, color) }
-    }
-
-    /** Mirror of [refreshByClassNameInsideAncestorClass] for the revert path. */
-    fun clearByClassNameInsideAncestorClass(
-        targetFqn: ClassFqn,
-        ancestorFqn: ClassFqn,
-    ) {
-        forEachShowingWindow { clearOnTreeInsideAncestor(it, targetFqn, ancestorFqn) }
     }
 
     /**

--- a/src/main/kotlin/dev/ayuislands/accent/LiveChromeRefresher.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/LiveChromeRefresher.kt
@@ -107,13 +107,13 @@ internal object LiveChromeRefresher {
     // --- Class-name-based frame walk (internal platform peer types) ---
 
     fun refreshByClassName(
-        classNameFqn: String,
+        classNameFqn: ClassFqn,
         color: Color,
     ) {
         forEachShowingWindow { refreshOnTree(it, classNameFqn, color) }
     }
 
-    fun clearByClassName(classNameFqn: String) {
+    fun clearByClassName(classNameFqn: ClassFqn) {
         forEachShowingWindow { clearOnTree(it, classNameFqn) }
     }
 
@@ -126,8 +126,8 @@ internal object LiveChromeRefresher {
      * review Round 2 A-1.
      */
     fun refreshByClassNameInsideAncestorClass(
-        targetFqn: String,
-        ancestorFqn: String,
+        targetFqn: ClassFqn,
+        ancestorFqn: ClassFqn,
         color: Color,
     ) {
         forEachShowingWindow { refreshOnTreeInsideAncestor(it, targetFqn, ancestorFqn, color) }
@@ -135,8 +135,8 @@ internal object LiveChromeRefresher {
 
     /** Mirror of [refreshByClassNameInsideAncestorClass] for the revert path. */
     fun clearByClassNameInsideAncestorClass(
-        targetFqn: String,
-        ancestorFqn: String,
+        targetFqn: ClassFqn,
+        ancestorFqn: ClassFqn,
     ) {
         forEachShowingWindow { clearOnTreeInsideAncestor(it, targetFqn, ancestorFqn) }
     }
@@ -180,11 +180,11 @@ internal object LiveChromeRefresher {
      */
     internal fun refreshOnTree(
         root: Component,
-        classNameFqn: String,
+        classNameFqn: ClassFqn,
         color: Color,
     ) {
         walk(root) { component ->
-            if (component is JComponent && component.javaClass.name == classNameFqn) {
+            if (component is JComponent && component.javaClass.name == classNameFqn.value) {
                 component.background = color
                 component.repaint()
             }
@@ -194,10 +194,10 @@ internal object LiveChromeRefresher {
     /** Visible for tests — mirror of [refreshOnTree] for the revert path. */
     internal fun clearOnTree(
         root: Component,
-        classNameFqn: String,
+        classNameFqn: ClassFqn,
     ) {
         walk(root) { component ->
-            if (component is JComponent && component.javaClass.name == classNameFqn) {
+            if (component is JComponent && component.javaClass.name == classNameFqn.value) {
                 component.background = null
                 component.repaint()
             }
@@ -211,13 +211,13 @@ internal object LiveChromeRefresher {
      */
     internal fun refreshOnTreeInsideAncestor(
         root: Component,
-        targetFqn: String,
-        ancestorFqn: String,
+        targetFqn: ClassFqn,
+        ancestorFqn: ClassFqn,
         color: Color,
     ) {
         walk(root) { component ->
             if (component is JComponent &&
-                component.javaClass.name == targetFqn &&
+                component.javaClass.name == targetFqn.value &&
                 hasAncestorWithClassName(component, ancestorFqn)
             ) {
                 component.background = color
@@ -229,12 +229,12 @@ internal object LiveChromeRefresher {
     /** Visible for tests — mirror of [refreshOnTreeInsideAncestor] for the revert path. */
     internal fun clearOnTreeInsideAncestor(
         root: Component,
-        targetFqn: String,
-        ancestorFqn: String,
+        targetFqn: ClassFqn,
+        ancestorFqn: ClassFqn,
     ) {
         walk(root) { component ->
             if (component is JComponent &&
-                component.javaClass.name == targetFqn &&
+                component.javaClass.name == targetFqn.value &&
                 hasAncestorWithClassName(component, ancestorFqn)
             ) {
                 component.background = null
@@ -246,11 +246,11 @@ internal object LiveChromeRefresher {
     /** Walks the parent chain of [component] looking for a container whose runtime class name equals [ancestorFqn]. */
     private fun hasAncestorWithClassName(
         component: Component,
-        ancestorFqn: String,
+        ancestorFqn: ClassFqn,
     ): Boolean {
         var current: Container? = component.parent
         while (current != null) {
-            if (current.javaClass.name == ancestorFqn) return true
+            if (current.javaClass.name == ancestorFqn.value) return true
             current = current.parent
         }
         return false

--- a/src/main/kotlin/dev/ayuislands/accent/LiveChromeRefresher.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/LiveChromeRefresher.kt
@@ -117,14 +117,8 @@ internal object LiveChromeRefresher {
     }
 
     private inline fun forEachUsableStatusBarComponent(action: (JComponent) -> Unit) {
-        val projectManager =
-            runCatching { ProjectManager.getInstance() }
-                .onFailure { log.debug("ProjectManager unavailable during live refresh", it) }
-                .getOrNull() ?: return
-        val windowManager =
-            runCatching { WindowManager.getInstance() }
-                .onFailure { log.debug("WindowManager unavailable during live refresh", it) }
-                .getOrNull() ?: return
+        val projectManager = safeService("ProjectManager") { ProjectManager.getInstance() } ?: return
+        val windowManager = safeService("WindowManager") { WindowManager.getInstance() } ?: return
         for (project in projectManager.openProjects) {
             if (!project.isUsable()) continue
             val statusBar = windowManager.getStatusBar(project) ?: continue
@@ -132,6 +126,25 @@ internal object LiveChromeRefresher {
             action(component)
         }
     }
+
+    /**
+     * Pattern B: narrow the service-lookup catch to [RuntimeException] so
+     * [OutOfMemoryError] / [NoClassDefFoundError] during a shutdown race
+     * still propagate — the prior `runCatching { ... }.onFailure { log.debug(...) }`
+     * swallowed the full [Throwable] surface on the hot live-refresh path.
+     * The `?: return` on the callsite is expected during shutdown (both
+     * services can legitimately report null).
+     */
+    private inline fun <T : Any> safeService(
+        name: String,
+        crossinline lookup: () -> T?,
+    ): T? =
+        try {
+            lookup()
+        } catch (exception: RuntimeException) {
+            log.debug("$name unavailable during live refresh", exception)
+            null
+        }
 
     /**
      * Iterates top-level windows, skipping ones that are not [Window.isShowing] (disposed,

--- a/src/main/kotlin/dev/ayuislands/accent/LiveChromeRefresher.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/LiveChromeRefresher.kt
@@ -161,6 +161,15 @@ internal object LiveChromeRefresher {
      * AWT peer surface only throws [RuntimeException] subtypes (NPE on disposed peer,
      * ClassCast on reflective match, IllegalState on detached frame), so narrowing
      * the catch here also satisfies detekt's TooGenericExceptionCaught.
+     *
+     * The per-window catch around `action(window)` is defense-in-depth for callers
+     * that might pass an `action` lambda not wrapped in [walk]. Every current caller
+     * ([refreshOnTree], [clearOnTree], and the two `*InsideAncestor` variants)
+     * delegates to [walk], whose own per-component catch swallows broken peers
+     * before they can reach this layer — so the per-window catch is structurally
+     * unreachable today. Keep it: this is a `private inline fun` whose signature
+     * accepts an arbitrary `(Window) -> Unit`, and a future non-walk caller would
+     * otherwise regress the isolation guarantee.
      */
     private inline fun forEachShowingWindow(action: (Window) -> Unit) {
         val windows =

--- a/src/main/kotlin/dev/ayuislands/accent/LiveChromeRefresher.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/LiveChromeRefresher.kt
@@ -9,6 +9,7 @@ import java.awt.Color
 import java.awt.Component
 import java.awt.Container
 import java.awt.Window
+import java.util.ArrayDeque
 import java.util.concurrent.ConcurrentHashMap
 import javax.swing.JComponent
 
@@ -256,34 +257,47 @@ internal object LiveChromeRefresher {
     }
 
     /**
-     * Recursively walks [component] and its descendants, invoking [visit] per node.
+     * Iteratively walks [component] and its descendants, invoking [visit] per node.
+     * Phase 40.2 M-4 — converted from the prior recursive walk to an
+     * [ArrayDeque]-based BFS so a pathological deeply nested container tree
+     * cannot blow the JVM thread stack. The recursive version was capped only by
+     * whatever headroom the EDT happened to have and a malicious plugin could
+     * emit a container chain deep enough to trigger [StackOverflowError] mid-apply.
+     * Iterative traversal bounds growth to heap (orders of magnitude more slack)
+     * and keeps the per-visit try/catch + broken-container logging semantics
+     * exactly as before. See Phase 40 review Round 3 C-1.
+     *
      * Each visit is isolated so a single flaky peer (mid-dispose, ClassCast on
-     * reflective match, NPE inside repaint) doesn't abort the rest of the tree;
-     * see Phase 40 review Round 3 C-1. Catches [RuntimeException] rather than
-     * [Throwable] so [Error]s ([OutOfMemoryError], [StackOverflowError]) still
-     * propagate instead of being silently swallowed at DEBUG, and narrower than
-     * [Exception] so detekt's TooGenericExceptionCaught stays happy — the Swing
-     * peer surface only throws [RuntimeException] subtypes anyway.
+     * reflective match, NPE inside repaint) doesn't abort the rest of the tree.
+     * Catches [RuntimeException] rather than [Throwable] so [Error]s
+     * ([OutOfMemoryError], [StackOverflowError]) still propagate instead of being
+     * silently swallowed at DEBUG, and narrower than [Exception] so detekt's
+     * TooGenericExceptionCaught stays happy — the Swing peer surface only throws
+     * [RuntimeException] subtypes anyway.
      */
     private fun walk(
         component: Component,
         visit: (Component) -> Unit,
     ) {
-        try {
-            visit(component)
-        } catch (exception: RuntimeException) {
-            log.debug("Live refresh visit failed on ${component.javaClass.name}", exception)
-        }
-        if (component is Container) {
+        val queue: ArrayDeque<Component> = ArrayDeque()
+        queue.addLast(component)
+        while (queue.isNotEmpty()) {
+            val current = queue.removeFirst()
+            try {
+                visit(current)
+            } catch (exception: RuntimeException) {
+                log.debug("Live refresh visit failed on ${current.javaClass.name}", exception)
+            }
+            if (current !is Container) continue
             val children =
                 try {
-                    component.components
+                    current.components
                 } catch (exception: RuntimeException) {
-                    logBrokenContainer(component, exception)
-                    return
+                    logBrokenContainer(current, exception)
+                    continue
                 }
             for (child in children) {
-                walk(child, visit)
+                queue.addLast(child)
             }
         }
     }

--- a/src/main/kotlin/dev/ayuislands/accent/LiveChromeRefresher.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/LiveChromeRefresher.kt
@@ -138,6 +138,10 @@ internal object LiveChromeRefresher {
      * hidden, pooled popups) and isolating per-window failures so one flaky peer doesn't
      * abort chrome apply for the rest of the desktop. See Phase 40 review Round 3 C-1, C-2.
      *
+     * Uses [Window.getWindows] (broader than `WindowManager.allProjectFrames`) to catch
+     * pooled dialogs and detached popups that still cache stale chrome colors; the
+     * [Window.isShowing] filter keeps the walk safe by skipping disposed/hidden peers.
+     *
      * Catches [RuntimeException] rather than using `runCatching` (which would also
      * swallow [Error] — [OutOfMemoryError], [StackOverflowError]) so catastrophic JVM
      * failures still propagate and don't get quietly logged at DEBUG. The Swing /

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
@@ -397,8 +397,12 @@ object ProjectLanguageDetector {
             // exception and risking the UI.
             val variant = AyuVariant.detect() ?: return@runCatchingPreservingCancellation
             val hex = AccentResolver.resolve(project, variant)
-            AccentApplicator.applyFromHexString(hex)
-            ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
+            val applied = AccentApplicator.applyFromHexString(hex)
+            if (applied) {
+                ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
+            } else {
+                LOG.warn("Skipping swap publish: applyFromHexString rejected '$hex'")
+            }
         }.onFailure { exception ->
             LOG.warn("Post-scan accent refresh failed; cache is still warm", exception)
         }

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
@@ -397,7 +397,7 @@ object ProjectLanguageDetector {
             // exception and risking the UI.
             val variant = AyuVariant.detect() ?: return@runCatchingPreservingCancellation
             val hex = AccentResolver.resolve(project, variant)
-            AccentApplicator.apply(hex)
+            AccentApplicator.applyFromHexString(hex)
             ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
         }.onFailure { exception ->
             LOG.warn("Post-scan accent refresh failed; cache is still warm", exception)

--- a/src/main/kotlin/dev/ayuislands/accent/TintIntensity.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/TintIntensity.kt
@@ -1,0 +1,62 @@
+package dev.ayuislands.accent
+
+/**
+ * Typed wrapper for the chrome tint intensity percent fed into
+ * [ChromeTintBlender.blend].
+ *
+ * ### Why a value class
+ *
+ * [dev.ayuislands.settings.AyuIslandsState.chromeTintIntensity] is persisted
+ * as a raw `Int` and the valid range `[MIN, MAX]` was previously enforced
+ * at the read boundary via `effectiveChromeTintIntensity().coerceIn(...)`.
+ * Every caller had to remember to call the helper — easy to forget, and a
+ * future caller reaching the raw delegate gets an unchecked `Int` that may
+ * carry a corrupted out-of-range value straight into the HSB blender.
+ *
+ * Lifting the clamp into the type means the only way to construct a
+ * `TintIntensity` is through [of], which coerces at the boundary. The
+ * blender then reads `intensity.percent` with the range invariant already
+ * proven by construction.
+ *
+ * ### Persistence
+ *
+ * The wrapper deliberately does NOT replace the persisted field. `BaseState`
+ * requires `Int` property delegates for XML serialization; changing the
+ * stored type would break forward/backward compat. Callers resolve the
+ * wrapper at read time via
+ * [dev.ayuislands.settings.AyuIslandsState.effectiveChromeTintIntensity].
+ */
+@JvmInline
+value class TintIntensity private constructor(
+    val percent: Int,
+) {
+    companion object {
+        /** Lower bound for the slider-visible range (inclusive). */
+        const val MIN: Int = 0
+
+        /**
+         * Upper bound for the slider-visible range (inclusive). Mirrors
+         * [dev.ayuislands.settings.AyuIslandsState.MAX_CHROME_TINT_INTENSITY]
+         * — the user-visible cap — not the blender's internal 0-100 math-safety
+         * clamp. A persisted value above [MAX] (legacy pre-cap session, hand-edited
+         * XML) coerces down to [MAX] here so every live user observes the same
+         * ceiling the slider exposes.
+         */
+        const val MAX: Int = 50
+
+        /**
+         * Default intensity for newly-enabled chrome tinting — the Peacock-parity
+         * opening balance per Phase 40 `CONTEXT.md §specifics`. Matches the
+         * `DEFAULT_CHROME_TINT_INTENSITY` constant exposed on `AyuIslandsState`.
+         */
+        val DEFAULT: TintIntensity = of(40)
+
+        /**
+         * Coerces [raw] into `[MIN, MAX]` and wraps the result. Values outside the
+         * slider-visible range do not throw — they clamp, matching the defensive
+         * behaviour of the prior `coerceIn` read boundary so a corrupted persisted
+         * XML never desaturates or over-saturates chrome.
+         */
+        fun of(raw: Int): TintIntensity = TintIntensity(raw.coerceIn(MIN, MAX))
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/accent/elements/AbstractChromeElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/AbstractChromeElement.kt
@@ -1,0 +1,162 @@
+package dev.ayuislands.accent.elements
+
+import dev.ayuislands.accent.AccentElement
+import dev.ayuislands.accent.ChromeBaseColors
+import dev.ayuislands.accent.ChromeTarget
+import dev.ayuislands.accent.ChromeTintBlender
+import dev.ayuislands.accent.ClassFqn
+import dev.ayuislands.accent.LiveChromeRefresher
+import dev.ayuislands.accent.WcagForeground
+import dev.ayuislands.settings.AyuIslandsSettings
+import java.awt.Color
+import javax.swing.UIManager
+
+/**
+ * Base class for chrome tinting [AccentElement]s (Phase 40.3c Refactor 1).
+ *
+ * Before this extraction, `StatusBarElement`, `MainToolbarElement`, `NavBarElement`,
+ * `PanelBorderElement`, and `ToolWindowStripeElement` each replicated the same
+ * ~40-line recipe: read intensity → for each bg key → [ChromeBaseColors.get] →
+ * [ChromeTintBlender.blend] → [UIManager.put] → sample WCAG foreground → write to
+ * fg keys → push tinted background to the live peer via [LiveChromeRefresher].
+ * Revert mirrors it: null every key, clear the peer.
+ *
+ * Subclasses declare *what* to tint (keys, peer target) and the base handles *how*:
+ *
+ *  - [backgroundKeys] — every UIManager key that receives a tinted color on apply
+ *    and is nulled on revert.
+ *  - [foregroundKeys] — every UIManager key that receives a WCAG-picked contrast
+ *    color on apply and is nulled on revert. May be empty (e.g. panel borders).
+ *  - [foregroundTextTarget] — WCAG minimum-ratio band the picker must satisfy.
+ *    `PRIMARY_TEXT` for widget text (4.5:1), `ICON` for stripe buttons (3.0:1).
+ *  - [peerTarget] — typed description of the Swing peer to refresh. `null` means
+ *    no live peer walk (element only writes UIManager keys).
+ *  - [isEnabled] — optional gate. `MainToolbarElement` overrides this to short-circuit
+ *    `apply` when JBR custom decorations are inactive (D-13). `revert` ignores it so
+ *    keys written before the gate flipped are still cleaned up.
+ *
+ * Elements with split-fg pick requirements (StatusBar's normal vs hover fg from
+ * Phase 40.2 M-1; ToolWindowStripe's stripe vs selected fg from Round 2 A-2)
+ * override [writeForegrounds] to pick the contrast per sampling-bg; the default
+ * implementation picks one contrast color against the first tinted background
+ * key and writes it to every entry in [foregroundKeys].
+ *
+ * Elements with first-apply diagnostic logging (PanelBorder, ToolWindowStripe —
+ * Phase 40.2 M-3) stay in their own subclass because the one-shot gate is
+ * per-element state and the logged fields (keysSeen / keysMissed / walk target
+ * class) differ per element.
+ *
+ * EDT: callers are already on EDT (AccentApplicator dispatches through
+ * `invokeLaterSafe`), so [UIManager.put] + peer mutation are safe.
+ */
+abstract class AbstractChromeElement : AccentElement {
+    /** UIManager keys that receive a tinted color on apply, nulled on revert. */
+    protected abstract val backgroundKeys: List<String>
+
+    /** UIManager keys that receive a WCAG-picked contrast color on apply, nulled on revert. May be empty. */
+    protected abstract val foregroundKeys: List<String>
+
+    /** WCAG target band for the contrast pick. [foregroundKeys] empty → ignored. */
+    protected abstract val foregroundTextTarget: WcagForeground.TextTarget
+
+    /** Typed peer descriptor for [LiveChromeRefresher]. `null` skips the live peer walk. */
+    protected abstract val peerTarget: ChromeTarget?
+
+    /** Gate for `apply` (MainToolbar uses this for the probe). Always `true` by default. `revert` ignores it. */
+    protected open val isEnabled: Boolean
+        get() = true
+
+    override fun apply(color: Color) {
+        if (!isEnabled) return
+        val intensity = AyuIslandsSettings.getInstance().state.effectiveChromeTintIntensity()
+        val tintedBackgrounds = LinkedHashMap<String, Color>()
+        for (key in backgroundKeys) {
+            val baseColor = ChromeBaseColors.get(key) ?: continue
+            val tinted = ChromeTintBlender.blend(color, baseColor, intensity)
+            UIManager.put(key, tinted)
+            tintedBackgrounds[key] = tinted
+        }
+        onBackgroundsTinted(tintedBackgrounds)
+        writeForegrounds(tintedBackgrounds)
+        val samplingBg = tintedBackgrounds.values.firstOrNull()
+        if (samplingBg != null) {
+            refreshPeer(samplingBg)
+        }
+    }
+
+    override fun revert() {
+        for (key in backgroundKeys) {
+            UIManager.put(key, null)
+        }
+        for (key in foregroundKeys) {
+            UIManager.put(key, null)
+        }
+        clearPeer()
+    }
+
+    /**
+     * Hook for subclasses that need to observe which bg keys resolved vs missed
+     * without rewriting the whole apply template. Default no-op. PanelBorder and
+     * ToolWindowStripe use this for their first-apply M-3 diagnostic log.
+     */
+    protected open fun onBackgroundsTinted(tintedBackgrounds: Map<String, Color>) {
+        // default no-op
+    }
+
+    /**
+     * Default single-contrast fg write: samples [WcagForeground.pickForeground]
+     * against the first tinted background and writes that color to every entry
+     * in [foregroundKeys]. Subclasses with per-bg fg picks (StatusBar M-1,
+     * ToolWindowStripe A-2) override this.
+     */
+    protected open fun writeForegrounds(tintedBackgrounds: Map<String, Color>) {
+        if (foregroundKeys.isEmpty()) return
+        val samplingBg = tintedBackgrounds.values.firstOrNull() ?: return
+        val contrast = WcagForeground.pickForeground(samplingBg, foregroundTextTarget)
+        for (key in foregroundKeys) {
+            UIManager.put(key, contrast)
+        }
+    }
+
+    /**
+     * Dispatches the live peer refresh to [LiveChromeRefresher] per the typed
+     * [peerTarget]. Refactor 2 will collapse the six entry points into
+     * `LiveChromeRefresher.refresh(target, color)`; until then the base class
+     * performs the mapping so subclasses never touch the flat API surface.
+     */
+    private fun refreshPeer(color: Color) {
+        when (val target = peerTarget) {
+            null -> Unit
+            ChromeTarget.StatusBar -> LiveChromeRefresher.refreshStatusBar(color)
+            is ChromeTarget.ByClassName -> LiveChromeRefresher.refreshByClassName(target.fqn, color)
+            is ChromeTarget.ByClassNameInside ->
+                LiveChromeRefresher.refreshByClassNameInsideAncestorClass(
+                    target.target,
+                    target.ancestor,
+                    color,
+                )
+        }
+    }
+
+    /** D-14 symmetry mirror of [refreshPeer] — unconditional, ignores [isEnabled]. */
+    private fun clearPeer() {
+        when (val target = peerTarget) {
+            null -> Unit
+            ChromeTarget.StatusBar -> LiveChromeRefresher.clearStatusBar()
+            is ChromeTarget.ByClassName -> LiveChromeRefresher.clearByClassName(target.fqn)
+            is ChromeTarget.ByClassNameInside ->
+                LiveChromeRefresher.clearByClassNameInsideAncestorClass(
+                    target.target,
+                    target.ancestor,
+                )
+        }
+    }
+
+    /**
+     * Helper for subclasses that need to look up a [ClassFqn] for a constant peer
+     * class name. Exposed here so per-element code can keep its PEER_CLASS string
+     * constants collocated with the element's KDoc (where the javap verification
+     * reasoning lives) without each subclass having to re-import [ClassFqn].
+     */
+    protected fun classFqn(value: String): ClassFqn = ClassFqn.require(value)
+}

--- a/src/main/kotlin/dev/ayuislands/accent/elements/AbstractChromeElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/AbstractChromeElement.kt
@@ -120,36 +120,19 @@ abstract class AbstractChromeElement : AccentElement {
 
     /**
      * Dispatches the live peer refresh to [LiveChromeRefresher] per the typed
-     * [peerTarget]. Refactor 2 will collapse the six entry points into
-     * `LiveChromeRefresher.refresh(target, color)`; until then the base class
-     * performs the mapping so subclasses never touch the flat API surface.
+     * [peerTarget]. Phase 40.3c Refactor 2 collapsed the six entry points into
+     * `LiveChromeRefresher.refresh(target, color)`; subclasses never touch the
+     * LiveChromeRefresher surface directly.
      */
     private fun refreshPeer(color: Color) {
-        when (val target = peerTarget) {
-            null -> Unit
-            ChromeTarget.StatusBar -> LiveChromeRefresher.refreshStatusBar(color)
-            is ChromeTarget.ByClassName -> LiveChromeRefresher.refreshByClassName(target.fqn, color)
-            is ChromeTarget.ByClassNameInside ->
-                LiveChromeRefresher.refreshByClassNameInsideAncestorClass(
-                    target.target,
-                    target.ancestor,
-                    color,
-                )
-        }
+        val target = peerTarget ?: return
+        LiveChromeRefresher.refresh(target, color)
     }
 
     /** D-14 symmetry mirror of [refreshPeer] — unconditional, ignores [isEnabled]. */
     private fun clearPeer() {
-        when (val target = peerTarget) {
-            null -> Unit
-            ChromeTarget.StatusBar -> LiveChromeRefresher.clearStatusBar()
-            is ChromeTarget.ByClassName -> LiveChromeRefresher.clearByClassName(target.fqn)
-            is ChromeTarget.ByClassNameInside ->
-                LiveChromeRefresher.clearByClassNameInsideAncestorClass(
-                    target.target,
-                    target.ancestor,
-                )
-        }
+        val target = peerTarget ?: return
+        LiveChromeRefresher.clear(target)
     }
 
     /**

--- a/src/main/kotlin/dev/ayuislands/accent/elements/MainToolbarElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/MainToolbarElement.kt
@@ -1,31 +1,28 @@
 package dev.ayuislands.accent.elements
 
-import dev.ayuislands.accent.AccentElement
 import dev.ayuislands.accent.AccentElementId
-import dev.ayuislands.accent.ChromeBaseColors
 import dev.ayuislands.accent.ChromeDecorationsProbe
-import dev.ayuislands.accent.ChromeTintBlender
-import dev.ayuislands.accent.ClassFqn
-import dev.ayuislands.accent.LiveChromeRefresher
+import dev.ayuislands.accent.ChromeTarget
 import dev.ayuislands.accent.WcagForeground
-import dev.ayuislands.settings.AyuIslandsSettings
-import java.awt.Color
-import javax.swing.UIManager
 
 /**
  * Tints the main toolbar / title bar per CHROME-02.
  *
+ * Phase 40.3c Refactor 1: migrated to [AbstractChromeElement].
+ *
  * ### Probe gate (D-13)
  *
- * `apply` short-circuits with a silent no-op when [ChromeDecorationsProbe.isCustomHeaderActive]
- * returns `false` — native macOS title bar, GNOME SSD, Windows without custom-header. In those
- * setups the OS paints the chrome and our UIManager writes would be cosmetic-only against
- * invisible platform theme keys. The user-visible "disabled with tooltip" behavior is enforced
- * by the Settings row (CHROME-02, D-09); this class only owns the element-level contract.
+ * `apply` short-circuits via the [isEnabled] override when
+ * [ChromeDecorationsProbe.isCustomHeaderActive] returns `false` — native macOS title
+ * bar, GNOME SSD, Windows without custom-header. In those setups the OS paints the
+ * chrome and our UIManager writes would be cosmetic-only against invisible platform
+ * theme keys. The user-visible "disabled with tooltip" behavior is enforced by the
+ * Settings row (CHROME-02, D-09); this class only owns the element-level contract.
  *
- * `revert` stays **unconditional**: if the probe flips between apply and revert (user re-enables
- * unified title bar mid-session and then disables tinting), we still clean up every key so the
- * stock theme value re-resolves (CHROME-08).
+ * `revert` stays unconditional (inherited from the base): if the probe flips between
+ * apply and revert (user re-enables unified title bar mid-session and then disables
+ * tinting), we still clean up every key so the stock theme value re-resolves
+ * (CHROME-08).
  *
  * ### Key selection (javap-verified against platformVersion 2025.1)
  *
@@ -44,56 +41,29 @@ import javax.swing.UIManager
  *  - The per-project gradient palette under the Recent Projects feature's per-colour
  *    keys — owned by that feature, not chrome tinting.
  */
-class MainToolbarElement : AccentElement {
+class MainToolbarElement : AbstractChromeElement() {
     override val id = AccentElementId.MAIN_TOOLBAR
     override val displayName = "Main toolbar"
 
-    private val backgroundKeys =
+    override val backgroundKeys =
         listOf(
             "MainToolbar.background",
         )
 
-    private val foregroundKeys =
+    override val foregroundKeys =
         listOf(
             "MainToolbar.foreground",
         )
 
-    override fun apply(color: Color) {
-        if (!ChromeDecorationsProbe.isCustomHeaderActive()) return
-        val intensity = AyuIslandsSettings.getInstance().state.effectiveChromeTintIntensity()
-        var tintedBackground: Color? = null
-        for (key in backgroundKeys) {
-            val baseColor = ChromeBaseColors.get(key) ?: continue
-            val tinted = ChromeTintBlender.blend(color, baseColor, intensity)
-            UIManager.put(key, tinted)
-            if (key == BACKGROUND_KEY) tintedBackground = tinted
-        }
-        if (tintedBackground != null) {
-            val foreground =
-                WcagForeground.pickForeground(tintedBackground, WcagForeground.TextTarget.PRIMARY_TEXT)
-            for (key in foregroundKeys) {
-                UIManager.put(key, foreground)
-            }
-        }
-        // Level 2 Gap-4: push tinted bg to live MainToolbar peer. Probe-gated per D-13
-        // — we only walk when isCustomHeaderActive is true (early return above).
-        tintedBackground?.let { LiveChromeRefresher.refreshByClassName(ClassFqn.require(MAIN_TOOLBAR_PEER_CLASS), it) }
-    }
+    override val foregroundTextTarget = WcagForeground.TextTarget.PRIMARY_TEXT
 
-    override fun revert() {
-        for (key in backgroundKeys + foregroundKeys) {
-            UIManager.put(key, null)
-        }
-        // D-14 symmetry: hand the toolbar peer back to LAF default. Unconditional like
-        // the UIManager revert above — even if the probe flips between apply and revert,
-        // the peer's lingering explicit background must be cleared.
-        LiveChromeRefresher.clearByClassName(ClassFqn.require(MAIN_TOOLBAR_PEER_CLASS))
-    }
+    override val peerTarget: ChromeTarget = ChromeTarget.ByClassName(classFqn(MAIN_TOOLBAR_PEER_CLASS))
+
+    /** D-13 probe gate — evaluated per `apply` so a mid-session LAF flip is honoured. */
+    override val isEnabled: Boolean
+        get() = ChromeDecorationsProbe.isCustomHeaderActive()
 
     private companion object {
-        /** Reference key for the contrast-foreground sample; same as the only entry in [backgroundKeys]. */
-        const val BACKGROUND_KEY = "MainToolbar.background"
-
         /**
          * FQN of the internal main-toolbar peer — imported as a literal string because the
          * class is package-private (see 40-12 §B).

--- a/src/main/kotlin/dev/ayuislands/accent/elements/MainToolbarElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/MainToolbarElement.kt
@@ -5,6 +5,7 @@ import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.ChromeBaseColors
 import dev.ayuislands.accent.ChromeDecorationsProbe
 import dev.ayuislands.accent.ChromeTintBlender
+import dev.ayuislands.accent.ClassFqn
 import dev.ayuislands.accent.LiveChromeRefresher
 import dev.ayuislands.accent.WcagForeground
 import dev.ayuislands.settings.AyuIslandsSettings
@@ -76,7 +77,7 @@ class MainToolbarElement : AccentElement {
         }
         // Level 2 Gap-4: push tinted bg to live MainToolbar peer. Probe-gated per D-13
         // — we only walk when isCustomHeaderActive is true (early return above).
-        tintedBackground?.let { LiveChromeRefresher.refreshByClassName(MAIN_TOOLBAR_PEER_CLASS, it) }
+        tintedBackground?.let { LiveChromeRefresher.refreshByClassName(ClassFqn.require(MAIN_TOOLBAR_PEER_CLASS), it) }
     }
 
     override fun revert() {
@@ -86,7 +87,7 @@ class MainToolbarElement : AccentElement {
         // D-14 symmetry: hand the toolbar peer back to LAF default. Unconditional like
         // the UIManager revert above — even if the probe flips between apply and revert,
         // the peer's lingering explicit background must be cleared.
-        LiveChromeRefresher.clearByClassName(MAIN_TOOLBAR_PEER_CLASS)
+        LiveChromeRefresher.clearByClassName(ClassFqn.require(MAIN_TOOLBAR_PEER_CLASS))
     }
 
     private companion object {

--- a/src/main/kotlin/dev/ayuislands/accent/elements/NavBarElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/NavBarElement.kt
@@ -4,6 +4,7 @@ import dev.ayuislands.accent.AccentElement
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.ChromeBaseColors
 import dev.ayuislands.accent.ChromeTintBlender
+import dev.ayuislands.accent.ClassFqn
 import dev.ayuislands.accent.LiveChromeRefresher
 import dev.ayuislands.accent.WcagForeground
 import dev.ayuislands.settings.AyuIslandsSettings
@@ -54,7 +55,7 @@ class NavBarElement : AccentElement {
             }
         }
         // Level 2 Gap-4: push tinted bg to the live MyNavBarWrapperPanel peer.
-        tintedBackground?.let { LiveChromeRefresher.refreshByClassName(NAVBAR_PEER_CLASS, it) }
+        tintedBackground?.let { LiveChromeRefresher.refreshByClassName(ClassFqn.require(NAVBAR_PEER_CLASS), it) }
     }
 
     override fun revert() {
@@ -62,7 +63,7 @@ class NavBarElement : AccentElement {
             UIManager.put(key, null)
         }
         // D-14 symmetry: hand the navbar peer back to LAF default.
-        LiveChromeRefresher.clearByClassName(NAVBAR_PEER_CLASS)
+        LiveChromeRefresher.clearByClassName(ClassFqn.require(NAVBAR_PEER_CLASS))
     }
 
     private companion object {

--- a/src/main/kotlin/dev/ayuislands/accent/elements/NavBarElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/NavBarElement.kt
@@ -1,70 +1,43 @@
 package dev.ayuislands.accent.elements
 
-import dev.ayuislands.accent.AccentElement
 import dev.ayuislands.accent.AccentElementId
-import dev.ayuislands.accent.ChromeBaseColors
-import dev.ayuislands.accent.ChromeTintBlender
-import dev.ayuislands.accent.ClassFqn
-import dev.ayuislands.accent.LiveChromeRefresher
+import dev.ayuislands.accent.ChromeTarget
 import dev.ayuislands.accent.WcagForeground
-import dev.ayuislands.settings.AyuIslandsSettings
-import java.awt.Color
-import javax.swing.UIManager
 
 /**
  * Tints the Navigation Bar per CHROME-04.
  *
+ * Phase 40.3c Refactor 1: migrated to [AbstractChromeElement]. Subclass declares only
+ * the key lists + peer target; the base handles apply/revert.
+ *
  * Writes WCAG-picked foregrounds to `NavBar.foreground` +
  * `NavBar.selectedItemForeground` — closes VERIFICATION Gap 2 (navbar
  * breadcrumb text was unreadable at saturated accents + intensity >= 40%).
- * Intensity is read directly from [AyuIslandsSettings.state] per CONTEXT D-03.
+ * Intensity is read directly from [dev.ayuislands.settings.AyuIslandsSettings.state]
+ * per CONTEXT D-03.
  *
  * `revert()` nulls every touched key unconditionally so the LAF re-resolves
  * the stock theme value — CHROME-08 symmetry across bg + fg.
  */
-class NavBarElement : AccentElement {
+class NavBarElement : AbstractChromeElement() {
     override val id = AccentElementId.NAV_BAR
     override val displayName = "Navigation bar"
 
-    private val backgroundKeys =
+    override val backgroundKeys =
         listOf(
             "NavBar.background",
             "NavBar.borderColor",
         )
 
-    private val foregroundKeys =
+    override val foregroundKeys =
         listOf(
             "NavBar.foreground",
             "NavBar.selectedItemForeground",
         )
 
-    override fun apply(color: Color) {
-        val intensity = AyuIslandsSettings.getInstance().state.effectiveChromeTintIntensity()
-        var tintedBackground: Color? = null
-        for (key in backgroundKeys) {
-            val baseColor = ChromeBaseColors.get(key) ?: continue
-            val tinted = ChromeTintBlender.blend(color, baseColor, intensity)
-            UIManager.put(key, tinted)
-            if (key == "NavBar.background") tintedBackground = tinted
-        }
-        if (tintedBackground != null) {
-            val contrast =
-                WcagForeground.pickForeground(tintedBackground, WcagForeground.TextTarget.PRIMARY_TEXT)
-            for (key in foregroundKeys) {
-                UIManager.put(key, contrast)
-            }
-        }
-        // Level 2 Gap-4: push tinted bg to the live MyNavBarWrapperPanel peer.
-        tintedBackground?.let { LiveChromeRefresher.refreshByClassName(ClassFqn.require(NAVBAR_PEER_CLASS), it) }
-    }
+    override val foregroundTextTarget = WcagForeground.TextTarget.PRIMARY_TEXT
 
-    override fun revert() {
-        for (key in backgroundKeys + foregroundKeys) {
-            UIManager.put(key, null)
-        }
-        // D-14 symmetry: hand the navbar peer back to LAF default.
-        LiveChromeRefresher.clearByClassName(ClassFqn.require(NAVBAR_PEER_CLASS))
-    }
+    override val peerTarget: ChromeTarget = ChromeTarget.ByClassName(classFqn(NAVBAR_PEER_CLASS))
 
     private companion object {
         /**

--- a/src/main/kotlin/dev/ayuislands/accent/elements/PanelBorderElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/PanelBorderElement.kt
@@ -5,6 +5,7 @@ import dev.ayuislands.accent.AccentElement
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.ChromeBaseColors
 import dev.ayuislands.accent.ChromeTintBlender
+import dev.ayuislands.accent.ClassFqn
 import dev.ayuislands.accent.LiveChromeRefresher
 import dev.ayuislands.settings.AyuIslandsSettings
 import java.awt.Color
@@ -72,8 +73,8 @@ class PanelBorderElement : AccentElement {
         // which extends `JBPanel`, so `Container.getParent()` chain traversal is safe).
         tintedHeaderBorder?.let {
             LiveChromeRefresher.refreshByClassNameInsideAncestorClass(
-                DIVIDER_PEER_CLASS,
-                TOOL_WINDOW_ANCESTOR_CLASS,
+                ClassFqn.require(DIVIDER_PEER_CLASS),
+                ClassFqn.require(TOOL_WINDOW_ANCESTOR_CLASS),
                 it,
             )
         }
@@ -85,8 +86,8 @@ class PanelBorderElement : AccentElement {
         }
         // D-14 symmetry: hand the divider peer back to LAF default.
         LiveChromeRefresher.clearByClassNameInsideAncestorClass(
-            DIVIDER_PEER_CLASS,
-            TOOL_WINDOW_ANCESTOR_CLASS,
+            ClassFqn.require(DIVIDER_PEER_CLASS),
+            ClassFqn.require(TOOL_WINDOW_ANCESTOR_CLASS),
         )
     }
 

--- a/src/main/kotlin/dev/ayuislands/accent/elements/PanelBorderElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/PanelBorderElement.kt
@@ -1,5 +1,6 @@
 package dev.ayuislands.accent.elements
 
+import com.intellij.openapi.diagnostic.logger
 import dev.ayuislands.accent.AccentElement
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.ChromeBaseColors
@@ -7,6 +8,7 @@ import dev.ayuislands.accent.ChromeTintBlender
 import dev.ayuislands.accent.LiveChromeRefresher
 import dev.ayuislands.settings.AyuIslandsSettings
 import java.awt.Color
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.swing.UIManager
 
 /**
@@ -32,11 +34,29 @@ class PanelBorderElement : AccentElement {
     override fun apply(color: Color) {
         val intensity = AyuIslandsSettings.getInstance().state.effectiveChromeTintIntensity()
         var tintedHeaderBorder: Color? = null
+        val keysSeen = mutableListOf<String>()
+        val keysMissed = mutableListOf<String>()
         for (key in uiKeys) {
-            val baseColor = ChromeBaseColors.get(key) ?: continue
+            val baseColor = ChromeBaseColors.get(key)
+            if (baseColor == null) {
+                keysMissed.add(key)
+                continue
+            }
+            keysSeen.add(key)
             val tinted = ChromeTintBlender.blend(color, baseColor, intensity)
             UIManager.put(key, tinted)
             if (key == HEADER_BORDER_KEY) tintedHeaderBorder = tinted
+        }
+        // Phase 40.2 M-3: first-apply INFO diagnostic so a future platform FQN
+        // rename surfaces in idea.log. Includes the UIManager key matches/misses
+        // AND the peer-walk target classes we'll ask LiveChromeRefresher to
+        // find. Gated on a one-shot AtomicBoolean so repeated apply passes stay
+        // quiet.
+        if (firstApplyLogged.compareAndSet(false, true)) {
+            LOG.info(
+                "PanelBorderElement first apply: keysSeen=$keysSeen keysMissed=$keysMissed " +
+                    "walkTargets=[divider=$DIVIDER_PEER_CLASS,ancestor=$TOOL_WINDOW_ANCESTOR_CLASS]",
+            )
         }
         // Level 2 Gap-4: push tinted tool-window header border to the live OnePixelDivider
         // peer. The divider caches its color at construction and re-renders on repaint;
@@ -71,6 +91,16 @@ class PanelBorderElement : AccentElement {
     }
 
     private companion object {
+        private val LOG = logger<PanelBorderElement>()
+
+        /**
+         * One-shot gate for the per-session first-apply diagnostic log (Phase 40.2 M-3).
+         * Logs which UIManager keys resolved vs missed and which peer classes the
+         * refresher will walk for — so a future platform FQN rename surfaces in
+         * idea.log without needing a debugger attach.
+         */
+        private val firstApplyLogged = AtomicBoolean(false)
+
         const val HEADER_BORDER_KEY = "ToolWindow.Header.borderColor"
 
         /**

--- a/src/main/kotlin/dev/ayuislands/accent/elements/PanelBorderElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/PanelBorderElement.kt
@@ -1,94 +1,73 @@
 package dev.ayuislands.accent.elements
 
 import com.intellij.openapi.diagnostic.logger
-import dev.ayuislands.accent.AccentElement
 import dev.ayuislands.accent.AccentElementId
-import dev.ayuislands.accent.ChromeBaseColors
-import dev.ayuislands.accent.ChromeTintBlender
-import dev.ayuislands.accent.ClassFqn
-import dev.ayuislands.accent.LiveChromeRefresher
-import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.accent.ChromeTarget
+import dev.ayuislands.accent.WcagForeground
 import java.awt.Color
 import java.util.concurrent.atomic.AtomicBoolean
-import javax.swing.UIManager
 
 /**
  * Tints panel / tool-window borders per CHROME-05.
+ *
+ * Phase 40.3c Refactor 1: migrated to [AbstractChromeElement]. This element has no
+ * foreground — [foregroundKeys] is intentionally empty.
  *
  * NB: `OnePixelDivider.background` is deliberately excluded — it is already
  * managed by [dev.ayuislands.accent.AccentApplicator]'s `ALWAYS_ON_UI_KEYS`
  * list. Double-writing from two sources would make revert ambiguous (whose
  * null wins?), so this element owns only the tool-window-level border keys.
  *
- * Intensity is read directly from [AyuIslandsSettings.state] per CONTEXT D-03.
+ * Intensity is read directly from [dev.ayuislands.settings.AyuIslandsSettings.state]
+ * per CONTEXT D-03.
+ *
+ * Round 2 review A-1 (CRITICAL correctness): `OnePixelDivider` is used IDE-wide —
+ * editor splitters, Project/editor divider, Settings dialog splitters, diff gutter,
+ * Run/Debug splitter, file-chooser splitter. A blind class-name walk would tint every
+ * divider in every window, not just tool-window header borders. The [ChromeTarget.ByClassNameInside]
+ * variant constrains the walk to dividers whose ancestor chain contains the tool-window
+ * decorator (`com.intellij.toolWindow.InternalDecoratorImpl`, javap-verified against
+ * `intellij.platform.ide.impl.jar` in 2026.1).
  */
-class PanelBorderElement : AccentElement {
+class PanelBorderElement : AbstractChromeElement() {
     override val id = AccentElementId.PANEL_BORDER
     override val displayName = "Panel borders"
 
+    /** Exposed `internal` so PanelBorderElementTest can lock the ALWAYS_ON_UI_KEYS non-overlap invariant. */
     internal val uiKeys: List<String> =
         listOf(
             "ToolWindow.Header.borderColor",
             "ToolWindow.borderColor",
         )
 
-    override fun apply(color: Color) {
-        val intensity = AyuIslandsSettings.getInstance().state.effectiveChromeTintIntensity()
-        var tintedHeaderBorder: Color? = null
-        val keysSeen = mutableListOf<String>()
-        val keysMissed = mutableListOf<String>()
-        for (key in uiKeys) {
-            val baseColor = ChromeBaseColors.get(key)
-            if (baseColor == null) {
-                keysMissed.add(key)
-                continue
-            }
-            keysSeen.add(key)
-            val tinted = ChromeTintBlender.blend(color, baseColor, intensity)
-            UIManager.put(key, tinted)
-            if (key == HEADER_BORDER_KEY) tintedHeaderBorder = tinted
-        }
+    override val backgroundKeys: List<String> get() = uiKeys
+
+    /** No foregrounds — panel borders paint only their tinted background. */
+    override val foregroundKeys: List<String> = emptyList()
+
+    /** Unused (foregroundKeys is empty) but required by the base — declared for completeness. */
+    override val foregroundTextTarget: WcagForeground.TextTarget = WcagForeground.TextTarget.PRIMARY_TEXT
+
+    override val peerTarget: ChromeTarget =
+        ChromeTarget.ByClassNameInside(
+            target = classFqn(DIVIDER_PEER_CLASS),
+            ancestor = classFqn(TOOL_WINDOW_ANCESTOR_CLASS),
+        )
+
+    override fun onBackgroundsTinted(tintedBackgrounds: Map<String, Color>) {
         // Phase 40.2 M-3: first-apply INFO diagnostic so a future platform FQN
         // rename surfaces in idea.log. Includes the UIManager key matches/misses
         // AND the peer-walk target classes we'll ask LiveChromeRefresher to
         // find. Gated on a one-shot AtomicBoolean so repeated apply passes stay
         // quiet.
         if (firstApplyLogged.compareAndSet(false, true)) {
+            val keysSeen = tintedBackgrounds.keys.toList()
+            val keysMissed = backgroundKeys.filter { it !in tintedBackgrounds }
             LOG.info(
                 "PanelBorderElement first apply: keysSeen=$keysSeen keysMissed=$keysMissed " +
                     "walkTargets=[divider=$DIVIDER_PEER_CLASS,ancestor=$TOOL_WINDOW_ANCESTOR_CLASS]",
             )
         }
-        // Level 2 Gap-4: push tinted tool-window header border to the live OnePixelDivider
-        // peer. The divider caches its color at construction and re-renders on repaint;
-        // UIManager writes alone don't refresh it (see VERIFICATION Gap 4, CHROME-05).
-        //
-        // Round 2 review A-1 (CRITICAL correctness): `OnePixelDivider` is used IDE-wide —
-        // editor splitters, Project/editor divider, Settings dialog splitters, diff gutter,
-        // Run/Debug splitter, file-chooser splitter. A blind `refreshByClassName` walk
-        // would tint every divider in every window, not just tool-window header borders.
-        // Constrain the walk to dividers whose ancestor chain contains the tool-window
-        // decorator (`com.intellij.toolWindow.InternalDecoratorImpl`, javap-verified against
-        // `intellij.platform.ide.impl.jar` in 2026.1 — it extends `InternalDecorator`
-        // which extends `JBPanel`, so `Container.getParent()` chain traversal is safe).
-        tintedHeaderBorder?.let {
-            LiveChromeRefresher.refreshByClassNameInsideAncestorClass(
-                ClassFqn.require(DIVIDER_PEER_CLASS),
-                ClassFqn.require(TOOL_WINDOW_ANCESTOR_CLASS),
-                it,
-            )
-        }
-    }
-
-    override fun revert() {
-        for (key in uiKeys) {
-            UIManager.put(key, null)
-        }
-        // D-14 symmetry: hand the divider peer back to LAF default.
-        LiveChromeRefresher.clearByClassNameInsideAncestorClass(
-            ClassFqn.require(DIVIDER_PEER_CLASS),
-            ClassFqn.require(TOOL_WINDOW_ANCESTOR_CLASS),
-        )
     }
 
     private companion object {
@@ -101,8 +80,6 @@ class PanelBorderElement : AccentElement {
          * idea.log without needing a debugger attach.
          */
         private val firstApplyLogged = AtomicBoolean(false)
-
-        const val HEADER_BORDER_KEY = "ToolWindow.Header.borderColor"
 
         /**
          * FQN of the internal 1-pixel divider used for tool-window panel borders — package-private,

--- a/src/main/kotlin/dev/ayuislands/accent/elements/StatusBarElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/StatusBarElement.kt
@@ -1,46 +1,41 @@
 package dev.ayuislands.accent.elements
 
-import dev.ayuislands.accent.AccentElement
 import dev.ayuislands.accent.AccentElementId
-import dev.ayuislands.accent.ChromeBaseColors
-import dev.ayuislands.accent.ChromeTintBlender
-import dev.ayuislands.accent.LiveChromeRefresher
+import dev.ayuislands.accent.ChromeTarget
 import dev.ayuislands.accent.WcagForeground
-import dev.ayuislands.settings.AyuIslandsSettings
 import java.awt.Color
 import javax.swing.UIManager
 
 /**
  * Tints the status bar background, border, and widget hover per CHROME-01 / CHROME-07.
  *
- * Intensity is read directly from [AyuIslandsSettings.state] per CONTEXT D-03 — the
- * `apply(color)` signature does not carry it, so every Phase 40 chrome element pulls
- * the same live settings. WCAG-aware foreground contrast is always applied — the
- * earlier opt-out toggle was retired because saturated tints without readable
- * foregrounds failed the user-space quality bar.
+ * Phase 40.3c Refactor 1: migrated to [AbstractChromeElement]. [writeForegrounds] is
+ * overridden because StatusBar needs the Phase 40.2 M-1 split-fg pick — normal and
+ * hover foregrounds are sampled against their own tinted backgrounds rather than
+ * sharing a single contrast pick.
+ *
+ * Intensity is read directly from [dev.ayuislands.settings.AyuIslandsSettings.state]
+ * per CONTEXT D-03 — the `apply(color)` signature does not carry it, so every Phase
+ * 40 chrome element pulls the same live settings. WCAG-aware foreground contrast is
+ * always applied — the earlier opt-out toggle was retired because saturated tints
+ * without readable foregrounds failed the user-space quality bar.
  *
  * `revert()` nulls every touched UIManager key so the LAF re-resolves the stock
  * theme value (D-14 / CHROME-08). Both the background keys and the foreground keys
  * are nulled unconditionally so a previously-applied contrast color cannot leak
  * after the user disables chrome tinting.
  */
-class StatusBarElement : AccentElement {
+class StatusBarElement : AbstractChromeElement() {
     override val id = AccentElementId.STATUS_BAR
     override val displayName = "Status bar"
 
-    private val backgroundKeys =
+    override val backgroundKeys =
         listOf(
             STATUS_BAR_BG_KEY,
             "StatusBar.borderColor",
             STATUS_WIDGET_HOVER_BG_KEY,
         )
 
-    // Foreground keys receive the WcagForeground-picked contrast color sampled against
-    // the tinted StatusBar background. Breadcrumb foregrounds are included so the
-    // path breadcrumb ("project > build.gradle.kts") inherits the same contrast-aware
-    // colour as the rest of the status bar widget text — without them, breadcrumbs
-    // stayed LAF-grey and became unreadable once the status bar was tinted.
-    //
     // Phase 40.2 M-1: foregrounds split into two pairs sampled against their own bg.
     // Previously one contrast pick from StatusBar.background drove all four fg keys,
     // but Widget.hoverForeground sits on StatusBar.Widget.hoverBackground — a
@@ -52,13 +47,9 @@ class StatusBarElement : AccentElement {
     //                  vs StatusBar.Widget.hoverBackground
     //
     // Only keys confirmed present in IntelliJPlatform.themeMetadata.json for
-    // platformVersion 2026.1 (ide.impl/themes/metadata) are written. Verified via
-    // `unzip -p intellij.platform.ide.impl.jar themes/metadata/IntelliJPlatform.themeMetadata.json`
-    // on IDE 2026.1:
-    //   - StatusBar.Breadcrumbs.foreground       — PRESENT
-    //   - StatusBar.Breadcrumbs.hoverForeground  — PRESENT
-    // Keys that do NOT exist in 2026.1 metadata (do NOT add — silent writes to
-    // non-existent UIManager keys are dead bytes and lie to future readers):
+    // platformVersion 2026.1 (ide.impl/themes/metadata) are written. Keys that do NOT
+    // exist in 2026.1 metadata (do NOT add — silent writes to non-existent UIManager
+    // keys are dead bytes and lie to future readers):
     //   - Breadcrumbs.CurrentColor               — ABSENT in 2026.1
     //   - Breadcrumbs.InactiveColor              — ABSENT in 2026.1
     //   - Breadcrumbs.HoverColor                 — ABSENT in 2026.1
@@ -74,43 +65,33 @@ class StatusBarElement : AccentElement {
             "StatusBar.Breadcrumbs.hoverForeground",
         )
 
-    override fun apply(color: Color) {
-        val intensity = AyuIslandsSettings.getInstance().state.effectiveChromeTintIntensity()
-        var tintedBackground: Color? = null
-        var tintedHoverBackground: Color? = null
-        for (key in backgroundKeys) {
-            val baseColor = ChromeBaseColors.get(key) ?: continue
-            val tinted = ChromeTintBlender.blend(color, baseColor, intensity)
-            UIManager.put(key, tinted)
-            when (key) {
-                STATUS_BAR_BG_KEY -> tintedBackground = tinted
-                STATUS_WIDGET_HOVER_BG_KEY -> tintedHoverBackground = tinted
-            }
-        }
-        if (tintedBackground != null) {
-            val contrast = WcagForeground.pickForeground(tintedBackground, WcagForeground.TextTarget.PRIMARY_TEXT)
+    /** Flat aggregation used by the base class's revert(); writes happen via [writeForegrounds]. */
+    override val foregroundKeys: List<String> = normalForegroundKeys + hoverForegroundKeys
+
+    override val foregroundTextTarget = WcagForeground.TextTarget.PRIMARY_TEXT
+
+    override val peerTarget: ChromeTarget = ChromeTarget.StatusBar
+
+    /**
+     * M-1 split-fg pick: two independent contrast samples, one per tinted bg surface.
+     * Breadcrumb foregrounds are included so the path breadcrumb inherits the same
+     * contrast-aware color as the rest of the status bar widget text.
+     */
+    override fun writeForegrounds(tintedBackgrounds: Map<String, Color>) {
+        val tintedBg = tintedBackgrounds[STATUS_BAR_BG_KEY]
+        if (tintedBg != null) {
+            val contrast = WcagForeground.pickForeground(tintedBg, foregroundTextTarget)
             for (key in normalForegroundKeys) {
                 UIManager.put(key, contrast)
             }
         }
-        if (tintedHoverBackground != null) {
-            val hoverContrast =
-                WcagForeground.pickForeground(tintedHoverBackground, WcagForeground.TextTarget.PRIMARY_TEXT)
+        val tintedHoverBg = tintedBackgrounds[STATUS_WIDGET_HOVER_BG_KEY]
+        if (tintedHoverBg != null) {
+            val hoverContrast = WcagForeground.pickForeground(tintedHoverBg, foregroundTextTarget)
             for (key in hoverForegroundKeys) {
                 UIManager.put(key, hoverContrast)
             }
         }
-        // Level 2 Gap-4: push the tinted bg to the live IdeStatusBarImpl peer because
-        // UIManager writes don't propagate to already-rendered chrome (CHROME-07).
-        tintedBackground?.let { LiveChromeRefresher.refreshStatusBar(it) }
-    }
-
-    override fun revert() {
-        for (key in backgroundKeys + normalForegroundKeys + hoverForegroundKeys) {
-            UIManager.put(key, null)
-        }
-        // D-14 symmetry: hand the status bar peer back to LAF default.
-        LiveChromeRefresher.clearStatusBar()
     }
 
     private companion object {

--- a/src/main/kotlin/dev/ayuislands/accent/elements/StatusBarElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/StatusBarElement.kt
@@ -30,9 +30,9 @@ class StatusBarElement : AccentElement {
 
     private val backgroundKeys =
         listOf(
-            "StatusBar.background",
+            STATUS_BAR_BG_KEY,
             "StatusBar.borderColor",
-            "StatusBar.Widget.hoverBackground",
+            STATUS_WIDGET_HOVER_BG_KEY,
         )
 
     // Foreground keys receive the WcagForeground-picked contrast color sampled against
@@ -40,6 +40,16 @@ class StatusBarElement : AccentElement {
     // path breadcrumb ("project > build.gradle.kts") inherits the same contrast-aware
     // colour as the rest of the status bar widget text — without them, breadcrumbs
     // stayed LAF-grey and became unreadable once the status bar was tinted.
+    //
+    // Phase 40.2 M-1: foregrounds split into two pairs sampled against their own bg.
+    // Previously one contrast pick from StatusBar.background drove all four fg keys,
+    // but Widget.hoverForeground sits on StatusBar.Widget.hoverBackground — a
+    // different tinted surface. At non-trivial intensities the two bg tints diverge
+    // and a shared contrast pick can drop the hover foreground under the WCAG AA
+    // ratio. Mirrors the Round 2 A-2 split already applied in ToolWindowStripeElement.
+    //   - Normal pair: (Widget.foreground + Breadcrumbs.foreground) vs StatusBar.background
+    //   - Hover pair:  (Widget.hoverForeground + Breadcrumbs.hoverForeground)
+    //                  vs StatusBar.Widget.hoverBackground
     //
     // Only keys confirmed present in IntelliJPlatform.themeMetadata.json for
     // platformVersion 2026.1 (ide.impl/themes/metadata) are written. Verified via
@@ -52,27 +62,42 @@ class StatusBarElement : AccentElement {
     //   - Breadcrumbs.CurrentColor               — ABSENT in 2026.1
     //   - Breadcrumbs.InactiveColor              — ABSENT in 2026.1
     //   - Breadcrumbs.HoverColor                 — ABSENT in 2026.1
-    private val foregroundKeys =
+    private val normalForegroundKeys =
         listOf(
             "StatusBar.Widget.foreground",
-            "StatusBar.Widget.hoverForeground",
             "StatusBar.Breadcrumbs.foreground",
+        )
+
+    private val hoverForegroundKeys =
+        listOf(
+            "StatusBar.Widget.hoverForeground",
             "StatusBar.Breadcrumbs.hoverForeground",
         )
 
     override fun apply(color: Color) {
         val intensity = AyuIslandsSettings.getInstance().state.effectiveChromeTintIntensity()
         var tintedBackground: Color? = null
+        var tintedHoverBackground: Color? = null
         for (key in backgroundKeys) {
             val baseColor = ChromeBaseColors.get(key) ?: continue
             val tinted = ChromeTintBlender.blend(color, baseColor, intensity)
             UIManager.put(key, tinted)
-            if (key == "StatusBar.background") tintedBackground = tinted
+            when (key) {
+                STATUS_BAR_BG_KEY -> tintedBackground = tinted
+                STATUS_WIDGET_HOVER_BG_KEY -> tintedHoverBackground = tinted
+            }
         }
         if (tintedBackground != null) {
             val contrast = WcagForeground.pickForeground(tintedBackground, WcagForeground.TextTarget.PRIMARY_TEXT)
-            for (key in foregroundKeys) {
+            for (key in normalForegroundKeys) {
                 UIManager.put(key, contrast)
+            }
+        }
+        if (tintedHoverBackground != null) {
+            val hoverContrast =
+                WcagForeground.pickForeground(tintedHoverBackground, WcagForeground.TextTarget.PRIMARY_TEXT)
+            for (key in hoverForegroundKeys) {
+                UIManager.put(key, hoverContrast)
             }
         }
         // Level 2 Gap-4: push the tinted bg to the live IdeStatusBarImpl peer because
@@ -81,10 +106,15 @@ class StatusBarElement : AccentElement {
     }
 
     override fun revert() {
-        for (key in backgroundKeys + foregroundKeys) {
+        for (key in backgroundKeys + normalForegroundKeys + hoverForegroundKeys) {
             UIManager.put(key, null)
         }
         // D-14 symmetry: hand the status bar peer back to LAF default.
         LiveChromeRefresher.clearStatusBar()
+    }
+
+    private companion object {
+        const val STATUS_BAR_BG_KEY = "StatusBar.background"
+        const val STATUS_WIDGET_HOVER_BG_KEY = "StatusBar.Widget.hoverBackground"
     }
 }

--- a/src/main/kotlin/dev/ayuislands/accent/elements/ToolWindowStripeElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/ToolWindowStripeElement.kt
@@ -1,5 +1,6 @@
 package dev.ayuislands.accent.elements
 
+import com.intellij.openapi.diagnostic.logger
 import dev.ayuislands.accent.AccentElement
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.ChromeBaseColors
@@ -8,6 +9,7 @@ import dev.ayuislands.accent.LiveChromeRefresher
 import dev.ayuislands.accent.WcagForeground
 import dev.ayuislands.settings.AyuIslandsSettings
 import java.awt.Color
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.swing.UIManager
 
 /**
@@ -44,14 +46,30 @@ class ToolWindowStripeElement : AccentElement {
         val intensity = AyuIslandsSettings.getInstance().state.effectiveChromeTintIntensity()
         var tintedStripeBackground: Color? = null
         var tintedSelectedBackground: Color? = null
+        val keysSeen = mutableListOf<String>()
+        val keysMissed = mutableListOf<String>()
         for (key in backgroundKeys) {
-            val baseColor = ChromeBaseColors.get(key) ?: continue
+            val baseColor = ChromeBaseColors.get(key)
+            if (baseColor == null) {
+                keysMissed.add(key)
+                continue
+            }
+            keysSeen.add(key)
             val tinted = ChromeTintBlender.blend(color, baseColor, intensity)
             UIManager.put(key, tinted)
             when (key) {
                 STRIPE_BACKGROUND_KEY -> tintedStripeBackground = tinted
                 SELECTED_BACKGROUND_KEY -> tintedSelectedBackground = tinted
             }
+        }
+        // Phase 40.2 M-3: first-apply INFO diagnostic so a future platform FQN
+        // rename surfaces in idea.log (both the UIManager key resolution map
+        // and the live peer-walk target class).
+        if (firstApplyLogged.compareAndSet(false, true)) {
+            LOG.info(
+                "ToolWindowStripeElement first apply: keysSeen=$keysSeen keysMissed=$keysMissed " +
+                    "walkTargets=[stripe=$STRIPE_PEER_CLASS]",
+            )
         }
         // Round 2 review A-2 (CRITICAL correctness): stripe background and selected-button
         // background are DIFFERENT base colors — at non-trivial intensities their tinted
@@ -81,6 +99,15 @@ class ToolWindowStripeElement : AccentElement {
     }
 
     private companion object {
+        private val LOG = logger<ToolWindowStripeElement>()
+
+        /**
+         * One-shot gate for the per-session first-apply diagnostic log (Phase 40.2 M-3).
+         * Logs which UIManager keys resolved vs missed and the peer-walk target class
+         * so a future platform FQN rename is visible in idea.log.
+         */
+        private val firstApplyLogged = AtomicBoolean(false)
+
         /** Reference key for the selected-button contrast-foreground sample. */
         const val SELECTED_BACKGROUND_KEY = "ToolWindow.Button.selectedBackground"
         const val STRIPE_BACKGROUND_KEY = "ToolWindow.Stripe.background"

--- a/src/main/kotlin/dev/ayuislands/accent/elements/ToolWindowStripeElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/ToolWindowStripeElement.kt
@@ -1,14 +1,9 @@
 package dev.ayuislands.accent.elements
 
 import com.intellij.openapi.diagnostic.logger
-import dev.ayuislands.accent.AccentElement
 import dev.ayuislands.accent.AccentElementId
-import dev.ayuislands.accent.ChromeBaseColors
-import dev.ayuislands.accent.ChromeTintBlender
-import dev.ayuislands.accent.ClassFqn
-import dev.ayuislands.accent.LiveChromeRefresher
+import dev.ayuislands.accent.ChromeTarget
 import dev.ayuislands.accent.WcagForeground
-import dev.ayuislands.settings.AyuIslandsSettings
 import java.awt.Color
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.swing.UIManager
@@ -16,87 +11,75 @@ import javax.swing.UIManager
 /**
  * Tints the tool window stripe and its active/selected stripe button per CHROME-03.
  *
+ * Phase 40.3c Refactor 1: migrated to [AbstractChromeElement]. [writeForegrounds] is
+ * overridden to implement the Round 2 A-2 split-fg pick (stripe bg and selected
+ * bg sampled independently); [onBackgroundsTinted] wires the Phase 40.2 M-3
+ * first-apply diagnostic.
+ *
  * The three background keys are javap-verified against platformVersion 2025.1 — see
  * `40-06-SUMMARY.md` "Stripe Button Key Verification". `ToolWindow.Button.selectedBackground`
  * is the core New UI stripe-button key and is registered in the bundled
  * `IntelliJPlatform.themeMetadata.json` under `app-client.jar`, so every 2025.1 user has
  * a live LAF entry for it even when the project theme does not.
  *
- * Intensity is read from [AyuIslandsState.chromeTintIntensity] per D-03; the per-element
+ * Intensity is read from `AyuIslandsState.chromeTintIntensity` per D-03; the per-element
  * revert unconditionally nulls every key the element can write so a toggle flip leaves
  * the stock theme value to re-resolve (CHROME-08).
  */
-class ToolWindowStripeElement : AccentElement {
+class ToolWindowStripeElement : AbstractChromeElement() {
     override val id = AccentElementId.TOOL_WINDOW_STRIPE
     override val displayName = "Tool window stripe"
 
-    private val backgroundKeys =
+    override val backgroundKeys =
         listOf(
-            "ToolWindow.Stripe.background",
+            STRIPE_BACKGROUND_KEY,
             "ToolWindow.Stripe.borderColor",
-            "ToolWindow.Button.selectedBackground",
+            SELECTED_BACKGROUND_KEY,
         )
 
-    private val foregroundKeys =
+    override val foregroundKeys =
         listOf(
-            "ToolWindow.Button.selectedForeground",
-            "ToolWindow.Stripe.foreground",
+            SELECTED_FOREGROUND_KEY,
+            STRIPE_FOREGROUND_KEY,
         )
 
-    override fun apply(color: Color) {
-        val intensity = AyuIslandsSettings.getInstance().state.effectiveChromeTintIntensity()
-        var tintedStripeBackground: Color? = null
-        var tintedSelectedBackground: Color? = null
-        val keysSeen = mutableListOf<String>()
-        val keysMissed = mutableListOf<String>()
-        for (key in backgroundKeys) {
-            val baseColor = ChromeBaseColors.get(key)
-            if (baseColor == null) {
-                keysMissed.add(key)
-                continue
-            }
-            keysSeen.add(key)
-            val tinted = ChromeTintBlender.blend(color, baseColor, intensity)
-            UIManager.put(key, tinted)
-            when (key) {
-                STRIPE_BACKGROUND_KEY -> tintedStripeBackground = tinted
-                SELECTED_BACKGROUND_KEY -> tintedSelectedBackground = tinted
-            }
-        }
+    override val foregroundTextTarget = WcagForeground.TextTarget.ICON
+
+    override val peerTarget: ChromeTarget = ChromeTarget.ByClassName(classFqn(STRIPE_PEER_CLASS))
+
+    override fun onBackgroundsTinted(tintedBackgrounds: Map<String, Color>) {
         // Phase 40.2 M-3: first-apply INFO diagnostic so a future platform FQN
         // rename surfaces in idea.log (both the UIManager key resolution map
         // and the live peer-walk target class).
         if (firstApplyLogged.compareAndSet(false, true)) {
+            val keysSeen = tintedBackgrounds.keys.toList()
+            val keysMissed = backgroundKeys.filter { it !in tintedBackgrounds }
             LOG.info(
                 "ToolWindowStripeElement first apply: keysSeen=$keysSeen keysMissed=$keysMissed " +
                     "walkTargets=[stripe=$STRIPE_PEER_CLASS]",
             )
         }
-        // Round 2 review A-2 (CRITICAL correctness): stripe background and selected-button
-        // background are DIFFERENT base colors — at non-trivial intensities their tinted
-        // outputs diverge. Sampling the contrast foreground against only the selected-button
-        // bg and reusing that pick for the stripe foreground can drop non-selected stripe
-        // icons below the WCAG AA ratio. Pick each foreground against its own bg.
-        if (tintedSelectedBackground != null) {
-            val selectedForeground =
-                WcagForeground.pickForeground(tintedSelectedBackground, WcagForeground.TextTarget.ICON)
-            UIManager.put(SELECTED_FOREGROUND_KEY, selectedForeground)
-        }
-        if (tintedStripeBackground != null) {
-            val stripeForeground =
-                WcagForeground.pickForeground(tintedStripeBackground, WcagForeground.TextTarget.ICON)
-            UIManager.put(STRIPE_FOREGROUND_KEY, stripeForeground)
-        }
-        // Level 2 Gap-4: push stripe bg to the live com.intellij.toolWindow.Stripe peer.
-        tintedStripeBackground?.let { LiveChromeRefresher.refreshByClassName(ClassFqn.require(STRIPE_PEER_CLASS), it) }
     }
 
-    override fun revert() {
-        for (key in backgroundKeys + foregroundKeys) {
-            UIManager.put(key, null)
+    /**
+     * Round 2 A-2 split-fg pick: stripe background and selected-button background
+     * are DIFFERENT base colors — at non-trivial intensities their tinted outputs
+     * diverge. Sampling the contrast foreground against only one and reusing the
+     * pick for the other can drop non-selected stripe icons below WCAG AA.
+     */
+    override fun writeForegrounds(tintedBackgrounds: Map<String, Color>) {
+        val tintedSelectedBackground = tintedBackgrounds[SELECTED_BACKGROUND_KEY]
+        if (tintedSelectedBackground != null) {
+            val selectedForeground =
+                WcagForeground.pickForeground(tintedSelectedBackground, foregroundTextTarget)
+            UIManager.put(SELECTED_FOREGROUND_KEY, selectedForeground)
         }
-        // D-14 symmetry: hand the stripe peer back to LAF default.
-        LiveChromeRefresher.clearByClassName(ClassFqn.require(STRIPE_PEER_CLASS))
+        val tintedStripeBackground = tintedBackgrounds[STRIPE_BACKGROUND_KEY]
+        if (tintedStripeBackground != null) {
+            val stripeForeground =
+                WcagForeground.pickForeground(tintedStripeBackground, foregroundTextTarget)
+            UIManager.put(STRIPE_FOREGROUND_KEY, stripeForeground)
+        }
     }
 
     private companion object {

--- a/src/main/kotlin/dev/ayuislands/accent/elements/ToolWindowStripeElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/ToolWindowStripeElement.kt
@@ -5,6 +5,7 @@ import dev.ayuislands.accent.AccentElement
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.ChromeBaseColors
 import dev.ayuislands.accent.ChromeTintBlender
+import dev.ayuislands.accent.ClassFqn
 import dev.ayuislands.accent.LiveChromeRefresher
 import dev.ayuislands.accent.WcagForeground
 import dev.ayuislands.settings.AyuIslandsSettings
@@ -87,7 +88,7 @@ class ToolWindowStripeElement : AccentElement {
             UIManager.put(STRIPE_FOREGROUND_KEY, stripeForeground)
         }
         // Level 2 Gap-4: push stripe bg to the live com.intellij.toolWindow.Stripe peer.
-        tintedStripeBackground?.let { LiveChromeRefresher.refreshByClassName(STRIPE_PEER_CLASS, it) }
+        tintedStripeBackground?.let { LiveChromeRefresher.refreshByClassName(ClassFqn.require(STRIPE_PEER_CLASS), it) }
     }
 
     override fun revert() {
@@ -95,7 +96,7 @@ class ToolWindowStripeElement : AccentElement {
             UIManager.put(key, null)
         }
         // D-14 symmetry: hand the stripe peer back to LAF default.
-        LiveChromeRefresher.clearByClassName(STRIPE_PEER_CLASS)
+        LiveChromeRefresher.clearByClassName(ClassFqn.require(STRIPE_PEER_CLASS))
     }
 
     private companion object {

--- a/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
@@ -294,7 +294,13 @@ object LicenseChecker {
         // Re-apply accent with reset toggles (accent color itself stays — it's free)
         try {
             val accentHex = AyuIslandsSettings.getInstance().getAccentForVariant(variant)
-            AccentApplicator.applyFromHexString(accentHex)
+            val applied = AccentApplicator.applyFromHexString(accentHex)
+            if (!applied) {
+                LOG.warn(
+                    "Revert-to-free accent apply rejected (hex='$accentHex', variant=$variant); " +
+                        "visible accent left unchanged",
+                )
+            }
         } catch (exception: RuntimeException) {
             LOG.warn("Revert to free defaults failed", exception)
             NotificationGroupManager

--- a/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
@@ -294,7 +294,7 @@ object LicenseChecker {
         // Re-apply accent with reset toggles (accent color itself stays — it's free)
         try {
             val accentHex = AyuIslandsSettings.getInstance().getAccentForVariant(variant)
-            AccentApplicator.apply(accentHex)
+            AccentApplicator.applyFromHexString(accentHex)
         } catch (exception: RuntimeException) {
             LOG.warn("Revert to free defaults failed", exception)
             NotificationGroupManager

--- a/src/main/kotlin/dev/ayuislands/onboarding/FreeOnboardingPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/onboarding/FreeOnboardingPanel.kt
@@ -480,7 +480,7 @@ internal class FreeOnboardingPanel(
             updateTrialHeadline(fontPx)
         }
         ApplicationManager.getApplication().invokeLater {
-            AccentApplicator.apply(preset.hex)
+            AccentApplicator.applyFromHexString(preset.hex)
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/onboarding/FreeOnboardingPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/onboarding/FreeOnboardingPanel.kt
@@ -480,7 +480,10 @@ internal class FreeOnboardingPanel(
             updateTrialHeadline(fontPx)
         }
         ApplicationManager.getApplication().invokeLater {
-            AccentApplicator.applyFromHexString(preset.hex)
+            val applied = AccentApplicator.applyFromHexString(preset.hex)
+            if (!applied) {
+                LOG.warn("Onboarding preset apply rejected (hex='${preset.hex}')")
+            }
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -258,8 +258,12 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
     private fun applyRotationRespectingOverrides(currentVariant: AyuVariant) {
         val focusedProject = AccentApplicator.resolveFocusedProject()
         val resolvedHex = AccentResolver.resolve(focusedProject, currentVariant)
-        AccentApplicator.applyFromHexString(resolvedHex)
-        ProjectAccentSwapService.getInstance().notifyExternalApply(resolvedHex)
+        val applied = AccentApplicator.applyFromHexString(resolvedHex)
+        if (applied) {
+            ProjectAccentSwapService.getInstance().notifyExternalApply(resolvedHex)
+        } else {
+            LOG.warn("Skipping swap publish: applyFromHexString rejected '$resolvedHex'")
+        }
     }
 
     private fun resolvePendingGlobalHex(currentVariant: AyuVariant): String {
@@ -652,13 +656,21 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
         // `notifyExternalApply` after a successful `apply` means the accent DID change and
         // only the swap cache is stale. Log them separately so triage doesn't get an "also
         // failed" breadcrumb on a path where apply actually worked.
-        try {
-            AccentApplicator.applyFromHexString(effectiveAccent)
-        } catch (exception: RuntimeException) {
-            LOG.error(
-                "Global accent fallback also failed (variant=$currentVariant, hex=$effectiveAccent); " +
-                    "Settings panel leaving visible accent unchanged",
-                exception,
+        val fallbackApplied =
+            try {
+                AccentApplicator.applyFromHexString(effectiveAccent)
+            } catch (exception: RuntimeException) {
+                LOG.error(
+                    "Global accent fallback also failed (variant=$currentVariant, hex=$effectiveAccent); " +
+                        "Settings panel leaving visible accent unchanged",
+                    exception,
+                )
+                return
+            }
+        if (!fallbackApplied) {
+            LOG.warn(
+                "Global accent fallback rejected by applyFromHexString " +
+                    "(variant=$currentVariant, hex='$effectiveAccent'); skipping swap publish",
             )
             return
         }

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -258,7 +258,7 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
     private fun applyRotationRespectingOverrides(currentVariant: AyuVariant) {
         val focusedProject = AccentApplicator.resolveFocusedProject()
         val resolvedHex = AccentResolver.resolve(focusedProject, currentVariant)
-        AccentApplicator.apply(resolvedHex)
+        AccentApplicator.applyFromHexString(resolvedHex)
         ProjectAccentSwapService.getInstance().notifyExternalApply(resolvedHex)
     }
 
@@ -653,7 +653,7 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
         // only the swap cache is stale. Log them separately so triage doesn't get an "also
         // failed" breadcrumb on a path where apply actually worked.
         try {
-            AccentApplicator.apply(effectiveAccent)
+            AccentApplicator.applyFromHexString(effectiveAccent)
         } catch (exception: RuntimeException) {
             LOG.error(
                 "Global accent fallback also failed (variant=$currentVariant, hex=$effectiveAccent); " +

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsChromePanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsChromePanel.kt
@@ -1,13 +1,13 @@
 package dev.ayuislands.settings
 
 import com.intellij.openapi.diagnostic.logger
-import com.intellij.openapi.util.SystemInfo
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.dsl.builder.Align
 import com.intellij.ui.dsl.builder.Panel
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.ChromeDecorationsProbe
+import dev.ayuislands.accent.ChromeSupport
 import dev.ayuislands.licensing.LicenseChecker
 import org.jetbrains.annotations.TestOnly
 import javax.swing.JLabel
@@ -261,18 +261,24 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
      * option no longer exists on macOS, so the link navigated users to a panel with
      * nothing relevant to toggle. Instead, explain honestly per platform what the
      * situation is so the user knows why MainToolbar tint is disabled.
+     *
+     * Phase 40.3c Refactor 3: reads the reason code from [ChromeDecorationsProbe.probe]
+     * instead of re-sampling `SystemInfo` — keeps the probe as the single source of
+     * truth for "why chrome tinting is unavailable".
      */
-    private fun disabledMainToolbarComment(): String =
-        when {
-            SystemInfo.isMac ->
+    private fun disabledMainToolbarComment(): String {
+        val unsupported = ChromeDecorationsProbe.probe() as? ChromeSupport.Unsupported ?: return ""
+        return when (unsupported) {
+            ChromeSupport.Unsupported.NativeMacTitleBar ->
                 "Disabled: macOS paints the native title bar (IDE 2026.1+ no longer exposes a toggle)."
-            SystemInfo.isWindows ->
+            ChromeSupport.Unsupported.WindowsNoCustomHeader ->
                 "Disabled: your IDE is not using custom window decorations."
-            SystemInfo.isLinux ->
+            ChromeSupport.Unsupported.GnomeSsd ->
                 "Disabled: your window manager paints the native title bar."
-            else ->
+            ChromeSupport.Unsupported.UnknownOs ->
                 "Disabled: your OS paints the native title bar."
         }
+    }
 
     // ── @TestOnly seams ───────────────────────────────────────────────────────
     //

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsChromePanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsChromePanel.kt
@@ -244,12 +244,17 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
         pendingChromePanelBorder = storedChromePanelBorder
         // Stored intensity mirrors whatever AyuIslandsState holds (including legacy
         // out-of-range values 51-100 from sessions predating the cap); the pending
-        // value is clamped down to [MAX_INTENSITY] so the slider can always display
-        // it. A legacy value > MAX_INTENSITY leaves stored != pending on purpose —
-        // isModified() reports true and the user sees a one-time Apply button that
-        // persists the capped value back into state.
+        // value is clamped into [MIN_INTENSITY, MAX_INTENSITY] so the slider can
+        // always display it. A legacy value outside that range leaves
+        // stored != pending on purpose — isModified() reports true and the user sees
+        // a one-time Apply button that persists the capped value back into state.
+        //
+        // coerceIn (not coerceAtMost) is load-bearing: a negative persisted value
+        // (corrupted XML, older schema, third-party migration) would otherwise slip
+        // through the cap and reach the JSlider constructor, which throws when
+        // value < min. The lower bound keeps the slider construction total.
         storedChromeTintIntensity = state.chromeTintIntensity
-        pendingChromeTintIntensity = state.chromeTintIntensity.coerceAtMost(MAX_INTENSITY)
+        pendingChromeTintIntensity = state.chromeTintIntensity.coerceIn(MIN_INTENSITY, MAX_INTENSITY)
     }
 
     /**

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsChromePanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsChromePanel.kt
@@ -1,5 +1,6 @@
 package dev.ayuislands.settings
 
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.dsl.builder.Align
@@ -168,6 +169,46 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
 
     override fun apply() {
         if (!isModified()) return
+        // License may have flipped mid-session (grace expired, entitlement revoked,
+        // user signed out of JBA). When the panel was built licensed but the gate
+        // has since closed, refuse to persist — otherwise chrome state writes keep
+        // happening behind a "requires Pro" UI the user can no longer interact with.
+        if (!LicenseChecker.isLicensedOrGrace()) {
+            LOG.info(
+                "AyuIslandsChromePanel.apply: license no longer active; " +
+                    "skipping chrome state persistence and refocus re-apply",
+            )
+            return
+        }
+        // Re-detect the variant at apply time so a LAF switch between buildPanel and
+        // apply (user flipped themes inside the same Settings session) doesn't drop
+        // the re-apply — the stored variant reference can go stale. If detection
+        // still returns null (no Ayu theme active), log at INFO and bail without
+        // persisting: H-1 from the Phase 40.2 audit forbade the earlier silent skip.
+        val resolvedVariant = variant ?: AyuVariant.detect()
+        if (resolvedVariant == null) {
+            LOG.info(
+                "AyuIslandsChromePanel.apply: no Ayu variant resolvable — " +
+                    "skipping chrome apply (theme may not be an Ayu variant)",
+            )
+            return
+        }
+
+        // H-4: run the EP chain FIRST so a throw from applyForFocusedProject leaves
+        // persisted state untouched and the user can retry after fixing the cause.
+        // Persisting only on success also gives isModified() an honest answer on the
+        // next panel open — if the apply failed, pending != stored so the Apply
+        // button re-offers the attempt.
+        try {
+            AccentApplicator.applyForFocusedProject(resolvedVariant)
+        } catch (exception: RuntimeException) {
+            LOG.warn(
+                "AyuIslandsChromePanel.apply: chrome re-apply threw; " +
+                    "leaving pending chrome state uncommitted so the user can retry",
+                exception,
+            )
+            return
+        }
         val state = AyuIslandsSettings.getInstance().state
         state.chromeStatusBar = pendingChromeStatusBar
         state.chromeMainToolbar = pendingChromeMainToolbar
@@ -176,13 +217,6 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
         state.chromePanelBorder = pendingChromePanelBorder
         state.chromeTintIntensity = pendingChromeTintIntensity
         loadStored(state)
-
-        // Re-run the EP chain so the 5 chrome AccentElement impls repaint now —
-        // mirrors AyuIslandsElementsPanel.apply, which also routes through
-        // applyForFocusedProject so per-project / per-language overrides are not
-        // stomped by the accent applied earlier in the Configurable.apply cycle.
-        val currentVariant = variant ?: return
-        AccentApplicator.applyForFocusedProject(currentVariant)
     }
 
     override fun reset() {
@@ -315,6 +349,7 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
     internal fun getPendingChromeTintIntensityForTest(): Int = pendingChromeTintIntensity
 
     companion object {
+        private val LOG = logger<AyuIslandsChromePanel>()
         private const val GROUP_TITLE = "Chrome Tinting"
         private const val MIN_INTENSITY = 10
 

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -2,6 +2,7 @@ package dev.ayuislands.settings
 
 import com.intellij.openapi.components.BaseState
 import dev.ayuislands.accent.AccentElementId
+import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.TintIntensity
 import dev.ayuislands.glow.GlowAnimation
 import dev.ayuislands.glow.GlowPreset
@@ -286,6 +287,21 @@ class AyuIslandsState : BaseState() {
      * serialization (which requires the raw delegate).
      */
     fun effectiveChromeTintIntensity(): TintIntensity = TintIntensity.of(chromeTintIntensity)
+
+    /**
+     * Returns [lastAppliedAccentHex] wrapped in an [AccentHex], or `null` when
+     * the persisted string is absent or corrupted. Mirrors the
+     * [effectiveChromeTintIntensity] pattern: the raw field stays `String?`
+     * for `BaseState` XML serialization, and every read path consults this
+     * helper instead of calling [AccentHex.of] at each site.
+     *
+     * Phase 40.3b: used by [dev.ayuislands.AyuIslandsAppListener.appFrameCreated]
+     * as the single trust boundary for the first-frame anti-flicker cache;
+     * [AccentHex.of] internally rejects hand-edited XML corruption and
+     * truncated writes so the resolver fallback fires whenever the cache is
+     * unusable.
+     */
+    fun effectiveLastAppliedAccentHex(): AccentHex? = AccentHex.of(lastAppliedAccentHex)
 
     fun isToggleEnabled(id: AccentElementId): Boolean =
         when (id) {

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -57,6 +57,19 @@ class AyuIslandsState : BaseState() {
      */
     var lastAppliedAccentHex by string(null)
 
+    /**
+     * Whether the most recent [dev.ayuislands.accent.AccentApplicator.apply] call
+     * completed its full EP iteration cleanly. Used by
+     * [dev.ayuislands.AyuIslandsAppListener.appFrameCreated] as a trust gate around
+     * the cached [lastAppliedAccentHex]: persisting the hex BEFORE the EP iteration
+     * (Phase 40.2 H-2) makes startup anti-flicker robust to a failed apply, but
+     * the cached value is only reliable when the previous session actually finished
+     * painting. If a prior apply threw mid-EP and left the hex persisted without
+     * a matching true here, the next startup resolves fresh instead of trusting
+     * the partial cache.
+     */
+    var lastApplyOk by property(false)
+
     // Per-element accent toggles (all ON by default)
     var inlayHints by property(true)
     var caretRow by property(true)

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -2,6 +2,7 @@ package dev.ayuislands.settings
 
 import com.intellij.openapi.components.BaseState
 import dev.ayuislands.accent.AccentElementId
+import dev.ayuislands.accent.TintIntensity
 import dev.ayuislands.glow.GlowAnimation
 import dev.ayuislands.glow.GlowPreset
 import dev.ayuislands.glow.GlowStyle
@@ -272,8 +273,9 @@ class AyuIslandsState : BaseState() {
     var chromeTintingGroupExpanded by property(false)
 
     /**
-     * Returns [chromeTintIntensity] clamped to the user-visible slider range
-     * [0, MAX_CHROME_TINT_INTENSITY].
+     * Returns [chromeTintIntensity] wrapped in a [TintIntensity] — the wrapper's
+     * `of(raw)` factory clamps to the user-visible slider range
+     * `[TintIntensity.MIN, TintIntensity.MAX]`.
      *
      * The underlying field is delegated through [BaseState.property] which performs
      * no validation — a corrupted persisted XML (hand-edited, legacy-migrated, or
@@ -283,7 +285,7 @@ class AyuIslandsState : BaseState() {
      * this helper keeps every caller on the safe contract without breaking XML
      * serialization (which requires the raw delegate).
      */
-    fun effectiveChromeTintIntensity(): Int = chromeTintIntensity.coerceIn(0, MAX_CHROME_TINT_INTENSITY)
+    fun effectiveChromeTintIntensity(): TintIntensity = TintIntensity.of(chromeTintIntensity)
 
     fun isToggleEnabled(id: AccentElementId): Boolean =
         when (id) {

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -354,7 +354,7 @@ class OverridesGroupBuilder {
                 // bound yet — same helper every apply path ultimately converges on.
                 val project = parentProject ?: AccentApplicator.resolveFocusedProject()
                 val hex = AccentResolver.resolve(project, variant)
-                AccentApplicator.apply(hex)
+                AccentApplicator.applyFromHexString(hex)
                 ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
             }
         }.onFailure { exception ->

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -354,8 +354,12 @@ class OverridesGroupBuilder {
                 // bound yet — same helper every apply path ultimately converges on.
                 val project = parentProject ?: AccentApplicator.resolveFocusedProject()
                 val hex = AccentResolver.resolve(project, variant)
-                AccentApplicator.applyFromHexString(hex)
-                ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
+                val applied = AccentApplicator.applyFromHexString(hex)
+                if (applied) {
+                    ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
+                } else {
+                    LOG.warn("Skipping swap publish: applyFromHexString rejected '$hex'")
+                }
             }
         }.onFailure { exception ->
             LOG.warn("Re-apply after overrides commit failed; persisted state is saved, UI may need reopen", exception)

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapService.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapService.kt
@@ -97,8 +97,12 @@ class ProjectAccentSwapService : Disposable {
 
         if (effectiveHex == lastAppliedHex) return
 
+        val applied = AccentApplicator.applyFromHexString(effectiveHex)
+        if (!applied) {
+            LOG.warn("Skipping swap publish: applyFromHexString rejected '$effectiveHex'")
+            return
+        }
         lastAppliedHex = effectiveHex
-        AccentApplicator.applyFromHexString(effectiveHex)
 
         // AccentApplicator updates UIManager + editor scheme. UIManager-only components
         // (toolbar, tab underlines, scrollbar chrome, focus rings) hold cached JBColor

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapService.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapService.kt
@@ -98,7 +98,7 @@ class ProjectAccentSwapService : Disposable {
         if (effectiveHex == lastAppliedHex) return
 
         lastAppliedHex = effectiveHex
-        AccentApplicator.apply(effectiveHex)
+        AccentApplicator.applyFromHexString(effectiveHex)
 
         // AccentApplicator updates UIManager + editor scheme. UIManager-only components
         // (toolbar, tab underlines, scrollbar chrome, focus rings) hold cached JBColor

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsAppListenerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsAppListenerTest.kt
@@ -56,7 +56,7 @@ class AyuIslandsAppListenerTest {
 
         mockkStatic(LafManager::class)
         mockkObject(AccentApplicator)
-        every { AccentApplicator.apply(any()) } returns true
+        every { AccentApplicator.applyFromHexString(any()) } returns true
     }
 
     @AfterTest
@@ -77,7 +77,7 @@ class AyuIslandsAppListenerTest {
         listener.appFrameCreated(mutableListOf())
 
         verify(exactly = 1) {
-            AccentApplicator.apply("#FF0000")
+            AccentApplicator.applyFromHexString("#FF0000")
         }
     }
 
@@ -94,7 +94,7 @@ class AyuIslandsAppListenerTest {
         listener.appFrameCreated(mutableListOf())
 
         verify(exactly = 0) {
-            AccentApplicator.apply(any())
+            AccentApplicator.applyFromHexString(any())
         }
     }
 
@@ -125,7 +125,7 @@ class AyuIslandsAppListenerTest {
             listener.appFrameCreated(mutableListOf())
 
             verify(atLeast = 1) {
-                AccentApplicator.apply(expectedAccent)
+                AccentApplicator.applyFromHexString(expectedAccent)
             }
         }
     }
@@ -150,7 +150,7 @@ class AyuIslandsAppListenerTest {
 
         listener.appFrameCreated(mutableListOf())
 
-        verify(exactly = 1) { AccentApplicator.apply("#5CCFE6") }
+        verify(exactly = 1) { AccentApplicator.applyFromHexString("#5CCFE6") }
         // Resolver must NOT be consulted when cached hex is available — that's the whole
         // point of the anti-flicker cache.
         verify(exactly = 0) { AccentResolver.resolve(any(), any()) }
@@ -174,7 +174,7 @@ class AyuIslandsAppListenerTest {
         listener.appFrameCreated(mutableListOf())
 
         verify(exactly = 1) { AccentResolver.resolve(null, AyuVariant.MIRAGE) }
-        verify(exactly = 1) { AccentApplicator.apply("#FF0000") }
+        verify(exactly = 1) { AccentApplicator.applyFromHexString("#FF0000") }
     }
 
     @Test
@@ -199,9 +199,9 @@ class AyuIslandsAppListenerTest {
 
         // Resolver MUST be consulted — cached hex was invalid.
         verify(exactly = 1) { AccentResolver.resolve(null, AyuVariant.MIRAGE) }
-        verify(exactly = 1) { AccentApplicator.apply("#FF0000") }
+        verify(exactly = 1) { AccentApplicator.applyFromHexString("#FF0000") }
         // Applier must NOT have been called with the poison value.
-        verify(exactly = 0) { AccentApplicator.apply("garbage") }
+        verify(exactly = 0) { AccentApplicator.applyFromHexString("garbage") }
         // Bad persisted hex cleared so next boot starts clean.
         assertNull(state.lastAppliedAccentHex, "invalid cached hex must be cleared")
     }
@@ -233,7 +233,7 @@ class AyuIslandsAppListenerTest {
         // Resolver consulted for every malformed entry; no call applied the poison hex.
         verify(atLeast = malformed.size) { AccentResolver.resolve(null, AyuVariant.MIRAGE) }
         for (badValue in malformed) {
-            verify(exactly = 0) { AccentApplicator.apply(badValue) }
+            verify(exactly = 0) { AccentApplicator.applyFromHexString(badValue) }
         }
     }
 
@@ -256,7 +256,7 @@ class AyuIslandsAppListenerTest {
 
         listener.appFrameCreated(mutableListOf())
 
-        verify(exactly = 1) { AccentApplicator.apply("#5CCFE6") }
+        verify(exactly = 1) { AccentApplicator.applyFromHexString("#5CCFE6") }
         verify(exactly = 0) { AccentResolver.resolve(any(), any()) }
         assertEquals("#5CCFE6", state.lastAppliedAccentHex, "valid cached hex must remain persisted")
     }
@@ -279,8 +279,8 @@ class AyuIslandsAppListenerTest {
         listener.appFrameCreated(mutableListOf())
 
         // Both calls must land on the Mirage accent — never the Dark or Light one.
-        verify(exactly = 2) { AccentApplicator.apply("#FF0000") }
-        verify(exactly = 0) { AccentApplicator.apply("#00FF00") }
-        verify(exactly = 0) { AccentApplicator.apply("#0000FF") }
+        verify(exactly = 2) { AccentApplicator.applyFromHexString("#FF0000") }
+        verify(exactly = 0) { AccentApplicator.applyFromHexString("#00FF00") }
+        verify(exactly = 0) { AccentApplicator.applyFromHexString("#0000FF") }
     }
 }

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsAppListenerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsAppListenerTest.kt
@@ -10,11 +10,9 @@ import dev.ayuislands.settings.AyuIslandsState
 import dev.ayuislands.settings.mappings.AccentMappingsSettings
 import dev.ayuislands.settings.mappings.AccentMappingsState
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
-import io.mockk.runs
 import io.mockk.unmockkAll
 import io.mockk.verify
 import kotlin.test.AfterTest
@@ -58,7 +56,7 @@ class AyuIslandsAppListenerTest {
 
         mockkStatic(LafManager::class)
         mockkObject(AccentApplicator)
-        every { AccentApplicator.apply(any()) } just runs
+        every { AccentApplicator.apply(any()) } returns true
     }
 
     @AfterTest
@@ -139,6 +137,9 @@ class AyuIslandsAppListenerTest {
         // resolving against a null project context (which yields the global accent and
         // flashes Gold before per-project StartupActivity runs).
         state.lastAppliedAccentHex = "#5CCFE6"
+        // Phase 40.2 H-2: the listener trusts the cached hex only when the previous
+        // session's apply finished cleanly. Simulate that here.
+        state.lastApplyOk = true
         mockkObject(AccentResolver)
 
         val laf = mockk<UIThemeLookAndFeelInfo>()
@@ -243,6 +244,8 @@ class AyuIslandsAppListenerTest {
         // anti-flicker guarantee. Round 2 only hardens the NEGATIVE path; the positive
         // path must remain unchanged.
         state.lastAppliedAccentHex = "#5CCFE6"
+        // Phase 40.2 H-2: cache is trusted only when prior apply completed cleanly.
+        state.lastApplyOk = true
         mockkObject(AccentResolver)
 
         val laf = mockk<UIThemeLookAndFeelInfo>()

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
@@ -121,8 +121,8 @@ class AyuIslandsStartupActivityTest {
     @Test
     fun `execute publishes swap-service cache inside the same EDT withContext block`() {
         // Regression guard for the PR #151 Round 2 Fix B-2: ProjectAccentSwapService has an
-        // EDT precondition for notifyExternalApply (per AccentApplicator KDoc lines 203-205,
-        // the cache write is a bare volatile with no dispatch and must publish in the same
+        // EDT precondition for notifyExternalApply (per the AccentApplicator.applyForFocusedProject
+        // KDoc — the cache write is a bare volatile with no dispatch and must publish in the same
         // ordering as the apply that preceded it).
         //
         // Phase 40 review-loop Round 2 HIGH R2-1 then split install and notifyExternalApply

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
@@ -134,7 +134,7 @@ class AyuIslandsStartupActivityTest {
         val edtTriplet =
             Regex(
                 """withContext\(Dispatchers\.EDT\).*?AccentApplicator\.resolveFocusedProject\(\)""" +
-                    """.*?AccentApplicator\.apply\(""" +
+                    """.*?AccentApplicator\.(apply|applyFromHexString)\(""" +
                     """.*?swapService\.install\(\)""" +
                     """.*?swapService\.notifyExternalApply\(""",
                 RegexOption.DOT_MATCHES_ALL,
@@ -321,7 +321,7 @@ class AyuIslandsStartupActivityTest {
             Regex(
                 """AccentApplicator\.resolveFocusedProject\(\)""" +
                     """.*?AccentResolver\.resolve\(""" +
-                    """.*?AccentApplicator\.apply\(""" +
+                    """.*?AccentApplicator\.(apply|applyFromHexString)\(""" +
                     """.*?swapService\.install\(\)""" +
                     """.*?swapService\.notifyExternalApply\(""",
                 RegexOption.DOT_MATCHES_ALL,

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
@@ -265,18 +265,17 @@ class AyuIslandsStartupActivityTest {
     }
 
     @Test
-    fun `startup helper WARNs on Success-null hex as a defensive branch for future refactors`() {
-        // Round 3 G2 regression lock. MEDIUM R2-2 added a defensive branch:
-        // if applyOutcome.isSuccess but hex is null (not reachable today but
-        // reachable after any refactor that makes resolved nullable), WARN.
-        // The branch has NO behavioural test because the condition is not
-        // reachable today, so its only guard is a source-level lock on both
-        // the WARN literal AND the structural `applyOutcome.isSuccess` check
-        // inside the `hex == null` branch.
+    fun `startup helper WARNs when applyFromHexString rejects hex as a defensive branch`() {
+        // Round 3 G2 regression lock, updated for Phase 40.4 HIGH-1:
+        // `applyFromHexString` returns Boolean (false = rejected); when rejected,
+        // hex becomes null via `if (applied) resolved else null`. That branch
+        // must log a WARN so operators can tell rejected-hex from throw-hex.
+        // Source-level lock on the WARN literal AND the structural
+        // `applyOutcome.isSuccess` check inside `if (hex == null)`.
         val source = readStartupActivitySource()
         assertTrue(
-            source.contains("Startup accent apply returned a null hex unexpectedly"),
-            "WARN-on-null-hex defensive branch must remain against future nullable-refactor regressions",
+            source.contains("Startup accent apply was rejected by applyFromHexString"),
+            "WARN-on-rejected-hex branch must remain against Boolean-gating regressions",
         )
         val isSuccessInNullBranch =
             Regex(
@@ -286,7 +285,7 @@ class AyuIslandsStartupActivityTest {
         assertTrue(
             isSuccessInNullBranch.containsMatchIn(source),
             "isSuccess check must sit INSIDE the `if (hex == null)` block — " +
-                "that is the Success(null) discriminator; removing it collapses the MEDIUM R2-2 fix",
+                "that distinguishes Success(null=rejected) from Failure(throw)",
         )
     }
 

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
@@ -307,6 +307,32 @@ class AyuIslandsStartupActivityTest {
         )
     }
 
+    // Phase 40.2 T-2: lock the full 5-step order inside runStartupAccentOnEdt —
+    // resolveFocusedProject → AccentResolver.resolve → AccentApplicator.apply →
+    // swapService.install → swapService.notifyExternalApply. The existing
+    // "same EDT withContext block" test covers the last four; this one adds
+    // AccentResolver.resolve between them so a future refactor that drops the
+    // resolver step (and hands a stale accent hex directly to apply) surfaces
+    // here.
+    @Test
+    fun `runStartupAccentOnEdt invokes resolveFocusedProject, resolve, apply, install, notifyExternalApply in order`() {
+        val source = readStartupActivitySource()
+        val fullOrder =
+            Regex(
+                """AccentApplicator\.resolveFocusedProject\(\)""" +
+                    """.*?AccentResolver\.resolve\(""" +
+                    """.*?AccentApplicator\.apply\(""" +
+                    """.*?swapService\.install\(\)""" +
+                    """.*?swapService\.notifyExternalApply\(""",
+                RegexOption.DOT_MATCHES_ALL,
+            )
+        assertTrue(
+            fullOrder.containsMatchIn(source),
+            "runStartupAccentOnEdt must invoke resolveFocusedProject → AccentResolver.resolve → " +
+                "AccentApplicator.apply → swapService.install → swapService.notifyExternalApply in order",
+        )
+    }
+
     private fun readStartupActivitySource(): String {
         val source =
             java.io

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
@@ -265,6 +265,41 @@ class AyuIslandsStartupActivityTest {
     }
 
     @Test
+    fun `install failure short-circuits before notifyExternalApply`() {
+        // TEST-IMPORTANT-3 regression lock: when `swapService.install()` fails,
+        // `installed` is false and the function MUST `return@withContext` before
+        // `swapService.notifyExternalApply(...)` executes. Behavioural form is
+        // impossible here (runStartupAccentOnEdt is a private suspend fun that
+        // touches Dispatchers.EDT + IntelliJ platform singletons — there is no
+        // test seam that exercises it in a unit harness). The contract is locked
+        // source-structurally: the `if (!installed) return@withContext` guard
+        // must sit between the install block's `.isSuccess` suffix and the
+        // notifyExternalApply call site. Removing or reordering that guard
+        // collapses HIGH R2-1 and reintroduces the bug where a failed install
+        // would still publish to the swap cache.
+        val source = readStartupActivitySource()
+        val guardBeforeNotify =
+            Regex(
+                """swapService\.install\(\)[^}]*\}\s*(\.onFailure\s*\{[^}]*\}\s*)?\.isSuccess""" +
+                    """\s*if\s*\(\s*!\s*installed\s*\)\s*return@withContext""" +
+                    """.*?swapService\.notifyExternalApply\(""",
+                RegexOption.DOT_MATCHES_ALL,
+            )
+        assertTrue(
+            guardBeforeNotify.containsMatchIn(source),
+            "install() failure path must `return@withContext` BEFORE notifyExternalApply " +
+                "runs — HIGH R2-1 contract",
+        )
+        // Belt-and-braces: the failure log text is specific, so lock on it too.
+        assertTrue(
+            source.contains(
+                "Startup accent-swap install failed for project",
+            ),
+            "install-failure ERROR message must remain to distinguish install-fail from apply-fail",
+        )
+    }
+
+    @Test
     fun `startup helper WARNs when applyFromHexString rejects hex as a defensive branch`() {
         // Round 3 G2 regression lock, updated for Phase 40.4 HIGH-1:
         // `applyFromHexString` returns Boolean (false = rejected); when rejected,

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorChromeApplyRefreshTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorChromeApplyRefreshTest.kt
@@ -115,7 +115,7 @@ class AccentApplicatorChromeApplyRefreshTest {
         val project2 = mockProject(usable = true)
         every { mockProjectManager.openProjects } returns arrayOf(project1, project2)
 
-        AccentApplicator.apply("#FFCC66")
+        AccentApplicator.applyFromHexString("#FFCC66")
 
         verify(exactly = 1) { ComponentTreeRefresher.notifyOnly(project1) }
         verify(exactly = 1) { ComponentTreeRefresher.notifyOnly(project2) }
@@ -127,7 +127,7 @@ class AccentApplicatorChromeApplyRefreshTest {
         val disposed = mockProject(usable = false)
         every { mockProjectManager.openProjects } returns arrayOf(usable, disposed)
 
-        AccentApplicator.apply("#FFCC66")
+        AccentApplicator.applyFromHexString("#FFCC66")
 
         verify(exactly = 1) { ComponentTreeRefresher.notifyOnly(usable) }
         verify(exactly = 0) { ComponentTreeRefresher.notifyOnly(disposed) }
@@ -149,7 +149,7 @@ class AccentApplicatorChromeApplyRefreshTest {
         val project = mockProject(usable = true)
         every { mockProjectManager.openProjects } returns arrayOf(project)
 
-        AccentApplicator.apply("#FFCC66")
+        AccentApplicator.applyFromHexString("#FFCC66")
 
         // EP apply must happen before the refresh notification so subscribers see
         // freshly-written UIManager state when they repaint.

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt
@@ -99,7 +99,7 @@ class AccentApplicatorFocusedProjectTest {
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
 
         assertEquals("#ABCDEF", applied)
-        verify(exactly = 1) { AccentApplicator.apply("#ABCDEF") }
+        verify(exactly = 1) { AccentApplicator.applyFromHexString("#ABCDEF") }
         verify(exactly = 1) { swapService.notifyExternalApply("#ABCDEF") }
     }
 
@@ -131,7 +131,7 @@ class AccentApplicatorFocusedProjectTest {
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.LIGHT)
 
         assertEquals("#F29718", applied)
-        verify(exactly = 1) { AccentApplicator.apply("#F29718") }
+        verify(exactly = 1) { AccentApplicator.applyFromHexString("#F29718") }
         verify(exactly = 1) { swapService.notifyExternalApply("#F29718") }
     }
 
@@ -245,7 +245,7 @@ class AccentApplicatorFocusedProjectTest {
 
         io.mockk.verifyOrder {
             AccentResolver.resolve(focused, AyuVariant.MIRAGE)
-            AccentApplicator.apply("#FFCC66")
+            AccentApplicator.applyFromHexString("#FFCC66")
             swapService.notifyExternalApply("#FFCC66")
         }
     }

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt
@@ -7,9 +7,7 @@ import com.intellij.openapi.wm.IdeFrame
 import com.intellij.openapi.wm.WindowManager
 import com.intellij.testFramework.LoggedErrorProcessor
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
-import io.mockk.Runs
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
@@ -54,7 +52,7 @@ class AccentApplicatorFocusedProjectTest {
         mockkStatic(ProjectManager::class)
         mockkObject(AccentResolver)
         mockkObject(AccentApplicator, recordPrivateCalls = false)
-        every { AccentApplicator.apply(any()) } just Runs
+        every { AccentApplicator.apply(any()) } returns true
 
         mockkObject(ProjectAccentSwapService.Companion)
         swapService = mockk(relaxed = true)

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt
@@ -720,13 +720,89 @@ class AccentApplicatorFocusedProjectTest {
         )
     }
 
+    // ── Pattern D regression lock: swap publish must observe applyFromHexString's verdict ──
+
+    @Test
+    fun `applyForFocusedProject skips swap cache publish when applyFromHexString rejects the resolver output`() {
+        // Round 2 lifted `applyFromHexString` from Unit to Boolean and sealed the gap
+        // with `if (applied) { swapService.notifyExternalApply(hex) }` at line ~268 of
+        // AccentApplicator. A refactor that drops the gate would still compile green;
+        // this test forces the rejection branch (resolver hands back a malformed hex)
+        // and asserts that the swap cache is NOT told about a paint that never happened.
+        val focused = stubProject(isDefault = false, isDisposed = false)
+        val manager = mockk<ProjectManager>()
+        every { manager.openProjects } returns arrayOf(focused)
+        every { ProjectManager.getInstance() } returns manager
+        every { AccentResolver.resolve(focused, AyuVariant.MIRAGE) } returns "not-a-hex"
+
+        // Override the recordPrivateCalls=false BeforeTest default: we want the real
+        // applyFromHexString to run so its AccentHex.of shape-validation rejects the
+        // malformed input and returns false. The inner `apply(AccentHex)` must never
+        // be called because the hex never validates.
+        every { AccentApplicator.applyFromHexString("not-a-hex") } answers { callOriginal() }
+
+        val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
+
+        assertEquals("not-a-hex", applied)
+        verify(exactly = 1) { AccentApplicator.applyFromHexString("not-a-hex") }
+        // The critical assertion — regression would surface as a non-zero count.
+        verify(exactly = 0) { swapService.notifyExternalApply(any()) }
+        // Sanity: apply(AccentHex) was never called — the hex was rejected before it.
+        verify(exactly = 0) { AccentApplicator.apply(any()) }
+    }
+
+    @Test
+    fun `AccentApplicator source retains the applied-gate around swap publish`() {
+        // Pattern L — source-regex regression lock. The `if (applied) { ... }` branch
+        // at the swap-publish site is today unreachable in unit tests without mocking
+        // the full applyFromHexString surface (above test does that), but we additionally
+        // grep the source so a refactor that removes the gate itself — not just the
+        // negative-path test — fails fast with a decoded reason.
+        val sourceFile = java.io.File("src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt")
+        assertTrue(
+            sourceFile.exists(),
+            "Could not locate AccentApplicator.kt for Pattern D source-regex regression lock",
+        )
+        val source = sourceFile.readText()
+        // Literal gate — if this match fails, the `if (applied)` wrapper was removed or
+        // renamed. The companion paragraph comment names this test as the alarm.
+        assertTrue(
+            source.contains("if (applied) {"),
+            "AccentApplicator.applyForFocusedProject must retain `if (applied) {` before " +
+                "`ProjectAccentSwapService.getInstance().notifyExternalApply(hex)` — removing the " +
+                "gate reintroduces Round 2 Pattern D regression (swap cache drifts from paint state).",
+        )
+        // Structural match — the `applied` flag must sit between the apply call and the
+        // notifyExternalApply call. A refactor that moves the gate elsewhere (e.g., outside
+        // the swap-publish branch) would still pass the literal match above.
+        val applyIndex = source.indexOf("val applied = applyFromHexString(hex)")
+        val gateIndex = source.indexOf("if (applied) {", applyIndex.takeIf { it >= 0 } ?: 0)
+        val notifyIndex =
+            source.indexOf(
+                "ProjectAccentSwapService.getInstance().notifyExternalApply(hex)",
+                gateIndex.takeIf { it >= 0 } ?: 0,
+            )
+        assertTrue(
+            applyIndex in 0 until gateIndex && gateIndex < notifyIndex,
+            "Pattern D structural lock: `val applied = applyFromHexString(hex)` must precede " +
+                "`if (applied) {` which must precede " +
+                "`ProjectAccentSwapService.getInstance().notifyExternalApply(hex)`. " +
+                "Got applyIndex=$applyIndex, gateIndex=$gateIndex, notifyIndex=$notifyIndex.",
+        )
+    }
+
     private fun stubProject(
         isDefault: Boolean,
         isDisposed: Boolean,
+        name: String = "stub-project",
     ): Project {
         val project = mockk<Project>()
         every { project.isDefault } returns isDefault
         every { project.isDisposed } returns isDisposed
+        // AccentApplicator.osActiveProjectFrame reads `project.name` directly (Pattern B
+        // fix — no runCatching wrapper) for the diagnostic probe. Stub it here so mocks
+        // don't throw MockKException when the code probes the name on a healthy frame.
+        every { project.name } returns name
         return project
     }
 

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
@@ -275,6 +275,7 @@ class AccentApplicatorTest {
     @Test
     fun `revertAll repaints windows`() {
         val mockWindow = mockk<Window>(relaxed = true)
+        every { mockWindow.isDisplayable } returns true
         every { Window.getWindows() } returns arrayOf(mockWindow)
 
         revertWithoutExtensions()
@@ -429,6 +430,10 @@ class AccentApplicatorTest {
         val window1 = mockk<Window>(relaxed = true)
         val window2 = mockk<Window>(relaxed = true)
         val window3 = mockk<Window>(relaxed = true)
+        // Phase 40.2 M-8: repaintAllWindows now skips non-displayable windows.
+        every { window1.isDisplayable } returns true
+        every { window2.isDisplayable } returns true
+        every { window3.isDisplayable } returns true
 
         invokePrivate("repaintAllWindows", arrayOf(window1, window2, window3))
 
@@ -894,6 +899,7 @@ class AccentApplicatorTest {
         every { IndentRainbowSync.apply(any(), any()) } returns Unit
         state.cgpIntegrationEnabled = false
         val mockWindow = mockk<Window>(relaxed = true)
+        every { mockWindow.isDisplayable } returns true
         every { Window.getWindows() } returns arrayOf(mockWindow)
 
         AccentApplicator.apply("#FFCC66")
@@ -1790,6 +1796,52 @@ class AccentApplicatorTest {
         val resolvedField = AccentApplicator::class.java.getDeclaredField("cgpMethodsResolved")
         resolvedField.isAccessible = true
         resolvedField.set(AccentApplicator, false)
+    }
+
+    // Phase 40.2 T-3: apply() with an invalid hex returns false AND posts a
+    // user-visible notification on the "Ayu Islands" group. The pre-40.2
+    // apply returned Unit and silently swallowed corruption — a regression
+    // that let a single bad hex in per-project XML go undiagnosed.
+    @Test
+    fun `apply with invalid hex returns false and notifies the user`() {
+        mockkStatic(com.intellij.notification.Notifications.Bus::class)
+        try {
+            every {
+                com.intellij.notification.Notifications.Bus
+                    .notify(any())
+            } returns Unit
+
+            val result = AccentApplicator.apply("garbage-hex")
+
+            assertEquals(false, result, "Invalid hex must return false from apply()")
+            verify(exactly = 1) {
+                com.intellij.notification.Notifications.Bus
+                    .notify(any())
+            }
+        } finally {
+            // unmockkAll runs in @AfterTest already but mockkStatic is scoped;
+            // nothing extra needed here.
+        }
+    }
+
+    // Phase 40.2 T-5: applyForFocusedProject MUST carry @RequiresEdt so an
+    // off-EDT caller fails fast instead of throwing deep inside a platform
+    // API. Source-regex test because the annotation is a contract promise to
+    // callers, not a runtime check we can exercise cheaply.
+    @Test
+    fun `applyForFocusedProject carries RequiresEdt annotation in source`() {
+        val sourceFile = java.io.File("src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt")
+        assertTrue(sourceFile.exists(), "Could not locate AccentApplicator.kt for source-level guard")
+        val source = sourceFile.readText()
+        val edtGuard =
+            Regex(
+                """@RequiresEdt\s*\n\s*fun\s+applyForFocusedProject""",
+                RegexOption.DOT_MATCHES_ALL,
+            )
+        assertTrue(
+            edtGuard.containsMatchIn(source),
+            "applyForFocusedProject must be annotated @RequiresEdt so off-EDT callers fail fast",
+        )
     }
 
     companion object {

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
@@ -33,6 +33,8 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -490,13 +492,6 @@ class AccentApplicatorTest {
         invokeNeutralizeOrRevert(element, null)
     }
 
-    // logCgpWarning
-
-    @Test
-    fun `logCgpWarning does not throw`() {
-        invokePrivate("logCgpWarning", "test action", RuntimeException("test message"))
-    }
-
     // syncCodeGlanceProViewport early return when disabled
 
     @Test
@@ -750,11 +745,6 @@ class AccentApplicatorTest {
         }
     }
 
-    @Test
-    fun `logCgpWarning handles exception with null message`() {
-        invokePrivate("logCgpWarning", "test action", RuntimeException())
-    }
-
     // syncCodeGlanceProViewport: various null method fields
 
     @Test
@@ -855,7 +845,7 @@ class AccentApplicatorTest {
         every { IndentRainbowSync.apply(any(), any()) } returns Unit
         state.cgpIntegrationEnabled = false
 
-        AccentApplicator.apply("#FFCC66")
+        AccentApplicator.applyFromHexString("#FFCC66")
 
         // Verify always-on UI keys were set (proves applyAlwaysOnUiKeys ran)
         verify(atLeast = 13) { UIManager.put(any<String>(), any<Color>()) }
@@ -875,7 +865,7 @@ class AccentApplicatorTest {
         state.cgpIntegrationEnabled = false
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
 
-        AccentApplicator.apply("#FFCC66")
+        AccentApplicator.applyFromHexString("#FFCC66")
 
         verify { IndentRainbowSync.apply(AyuVariant.MIRAGE, "#FFCC66") }
     }
@@ -887,7 +877,7 @@ class AccentApplicatorTest {
         state.cgpIntegrationEnabled = false
         every { AyuVariant.detect() } returns null
 
-        AccentApplicator.apply("#FFCC66")
+        AccentApplicator.applyFromHexString("#FFCC66")
 
         verify(exactly = 0) { IndentRainbowSync.apply(any(), any()) }
     }
@@ -902,7 +892,7 @@ class AccentApplicatorTest {
         every { mockWindow.isDisplayable } returns true
         every { Window.getWindows() } returns arrayOf(mockWindow)
 
-        AccentApplicator.apply("#FFCC66")
+        AccentApplicator.applyFromHexString("#FFCC66")
 
         verify { mockWindow.repaint() }
     }
@@ -915,7 +905,7 @@ class AccentApplicatorTest {
         state.cgpIntegrationEnabled = false
         every { SwingUtilities.isEventDispatchThread() } returns true
 
-        AccentApplicator.apply("#FFCC66")
+        AccentApplicator.applyFromHexString("#FFCC66")
 
         // If on EDT, work runs synchronously, so UIManager.put should be called.
         verify(atLeast = 1) { UIManager.put(any<String>(), any()) }
@@ -932,7 +922,7 @@ class AccentApplicatorTest {
         every { IndentRainbowSync.apply(any(), any()) } returns Unit
         state.cgpIntegrationEnabled = false
 
-        AccentApplicator.apply("#5CCFE6")
+        AccentApplicator.applyFromHexString("#5CCFE6")
 
         assertEquals("#5CCFE6", state.lastAppliedAccentHex)
     }
@@ -946,10 +936,10 @@ class AccentApplicatorTest {
         every { IndentRainbowSync.apply(any(), any()) } returns Unit
         state.cgpIntegrationEnabled = false
 
-        AccentApplicator.apply("#5CCFE6")
+        AccentApplicator.applyFromHexString("#5CCFE6")
         assertEquals("#5CCFE6", state.lastAppliedAccentHex)
 
-        AccentApplicator.apply("#FF3333")
+        AccentApplicator.applyFromHexString("#FF3333")
         assertEquals("#FF3333", state.lastAppliedAccentHex)
     }
 
@@ -968,12 +958,12 @@ class AccentApplicatorTest {
         state.cgpIntegrationEnabled = false
 
         // None of these should throw; none should set the cached hex.
-        AccentApplicator.apply("garbage")
-        AccentApplicator.apply("")
-        AccentApplicator.apply("FFCC66") // missing leading #
-        AccentApplicator.apply("#12345") // 5 chars — too short
-        AccentApplicator.apply("#1234567") // 7 chars — too long
-        AccentApplicator.apply("#ZZZZZZ") // non-hex digits
+        AccentApplicator.applyFromHexString("garbage")
+        AccentApplicator.applyFromHexString("")
+        AccentApplicator.applyFromHexString("FFCC66") // missing leading #
+        AccentApplicator.applyFromHexString("#12345") // 5 chars — too short
+        AccentApplicator.applyFromHexString("#1234567") // 7 chars — too long
+        AccentApplicator.applyFromHexString("#ZZZZZZ") // non-hex digits
 
         // UIManager.put must not have been called for any of these (apply short-circuits
         // before applyAlwaysOnUiKeys). The cached hex stays whatever it was (default null).
@@ -990,7 +980,7 @@ class AccentApplicatorTest {
 
         // Boundary: exactly #RRGGBB with valid hex digits. Must go through the full
         // apply flow (UIManager writes, lastAppliedAccentHex persisted).
-        AccentApplicator.apply("#123456")
+        AccentApplicator.applyFromHexString("#123456")
 
         verify(atLeast = 1) { UIManager.put(any<String>(), any<Color>()) }
         assertEquals("#123456", state.lastAppliedAccentHex)
@@ -1004,27 +994,31 @@ class AccentApplicatorTest {
         state.cgpIntegrationEnabled = false
 
         // Upper and lower case 0-9A-Fa-f are all valid per Color.decode.
-        AccentApplicator.apply("#AbCdEf")
+        AccentApplicator.applyFromHexString("#AbCdEf")
 
         assertEquals("#AbCdEf", state.lastAppliedAccentHex)
     }
 
     @Test
-    fun `HEX_COLOR_PATTERN matches expected shapes`() {
+    fun `AccentHex of matches expected shapes`() {
+        // Phase 40.3b: the shape check moved from AccentApplicator.HEX_COLOR_PATTERN
+        // onto AccentHex.of, which is now the single boundary that gates Color.decode.
+        // This test is retained under the applicator suite so the same contract the
+        // applicator used to own is still asserted in the applicator's coverage footprint.
         // Positive
-        assertTrue(AccentApplicator.HEX_COLOR_PATTERN.matches("#000000"))
-        assertTrue(AccentApplicator.HEX_COLOR_PATTERN.matches("#FFFFFF"))
-        assertTrue(AccentApplicator.HEX_COLOR_PATTERN.matches("#ffcc66"))
-        assertTrue(AccentApplicator.HEX_COLOR_PATTERN.matches("#5CCFE6"))
+        assertNotNull(AccentHex.of("#000000"))
+        assertNotNull(AccentHex.of("#FFFFFF"))
+        assertNotNull(AccentHex.of("#ffcc66"))
+        assertNotNull(AccentHex.of("#5CCFE6"))
 
         // Negative
-        assertEquals(false, AccentApplicator.HEX_COLOR_PATTERN.matches(""))
-        assertEquals(false, AccentApplicator.HEX_COLOR_PATTERN.matches("garbage"))
-        assertEquals(false, AccentApplicator.HEX_COLOR_PATTERN.matches("FFCC66"))
-        assertEquals(false, AccentApplicator.HEX_COLOR_PATTERN.matches("#12345"))
-        assertEquals(false, AccentApplicator.HEX_COLOR_PATTERN.matches("#1234567"))
-        assertEquals(false, AccentApplicator.HEX_COLOR_PATTERN.matches("#ZZZZZZ"))
-        assertEquals(false, AccentApplicator.HEX_COLOR_PATTERN.matches("#12 34 56"))
+        assertNull(AccentHex.of(""))
+        assertNull(AccentHex.of("garbage"))
+        assertNull(AccentHex.of("FFCC66"))
+        assertNull(AccentHex.of("#12345"))
+        assertNull(AccentHex.of("#1234567"))
+        assertNull(AccentHex.of("#ZZZZZZ"))
+        assertNull(AccentHex.of("#12 34 56"))
     }
 
     @Test
@@ -1038,7 +1032,7 @@ class AccentApplicatorTest {
             firstArg<Runnable>().run()
         }
 
-        AccentApplicator.apply("#FFCC66")
+        AccentApplicator.applyFromHexString("#FFCC66")
 
         verify { mockApplication.invokeLater(any(), any<ModalityState>()) }
         verify(exactly = 0) { SwingUtilities.invokeLater(any()) }
@@ -1811,9 +1805,9 @@ class AccentApplicatorTest {
                     .notify(any())
             } returns Unit
 
-            val result = AccentApplicator.apply("garbage-hex")
+            val result = AccentApplicator.applyFromHexString("garbage-hex")
 
-            assertEquals(false, result, "Invalid hex must return false from apply()")
+            assertEquals(false, result, "Invalid hex must return false from applyFromHexString()")
             verify(exactly = 1) {
                 com.intellij.notification.Notifications.Bus
                     .notify(any())

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
@@ -128,7 +128,8 @@ class AccentApplicatorTest {
 
         // Replicate the always-on logic from AccentApplicator.apply() without
         // applyElements (requires EP_NAME) and syncCodeGlanceProViewport (requires CGP).
-        invokePrivate("applyAlwaysOnUiKeys", accent)
+        val state = AyuIslandsSettings.getInstance().state
+        invokePrivate("applyAlwaysOnUiKeys", state, accent)
         invokePrivate("applyAlwaysOnEditorKeys", accent)
         val windows = Window.getWindows()
         invokePrivate("repaintAllWindows", windows)
@@ -837,6 +838,36 @@ class AccentApplicatorTest {
     }
 
     // Tests for public apply() method
+
+    @Test
+    fun `applyAlwaysOnUiKeys accepts state as an explicit parameter (Phase 40_4 L-4)`() {
+        // Phase 40.4 L-4 regression lock: the outer apply() already captures
+        // AyuIslandsSettings.state at entry, so applyAlwaysOnUiKeys must thread
+        // that same state through rather than re-fetching via
+        // AyuIslandsSettings.getInstance(). A future refactor that drops the
+        // parameter would re-open the split-brain window where the EP chain and
+        // tab-mode resolution could observe different state snapshots if settings
+        // mutated mid-apply.
+        val method =
+            AccentApplicator::class.java.declaredMethods
+                .first { it.name == "applyAlwaysOnUiKeys" }
+        assertEquals(
+            2,
+            method.parameterCount,
+            "applyAlwaysOnUiKeys must accept (state, accent) so tab-mode resolution shares the same state snapshot " +
+                "as the outer apply() call and cannot drift mid-apply",
+        )
+        assertEquals(
+            AyuIslandsState::class.java,
+            method.parameterTypes[0],
+            "First parameter must be AyuIslandsState — threaded from apply()'s captured snapshot",
+        )
+        assertEquals(
+            Color::class.java,
+            method.parameterTypes[1],
+            "Second parameter must be the resolved accent Color",
+        )
+    }
 
     @Test
     fun `apply calls applyAlwaysOnUiKeys and applyAlwaysOnEditorKeys on EDT`() {

--- a/src/test/kotlin/dev/ayuislands/accent/AccentHexTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentHexTest.kt
@@ -102,13 +102,15 @@ class AccentHexTest {
     }
 
     @Test
-    fun `ofTrusted wraps without validation for compile-time literals`() {
-        // ofTrusted is the explicit-trust escape hatch for constants like
+    fun `unsafeOf wraps without validation for compile-time literals`() {
+        // unsafeOf is the explicit-trust escape hatch for constants like
         // AyuVariant.defaultAccent. Its contract is "the caller has proven
         // the input is well-formed" — validation cost would be redundant.
         // We still trim() so an accidental whitespace-padded literal in
-        // source code doesn't leak past the type boundary.
-        val result = AccentHex.ofTrusted("  #FFCC66  ")
+        // source code doesn't leak past the type boundary. The `unsafe`
+        // prefix follows the Kotlin convention so IDE completion warns
+        // readers this is a bypass, not a sibling of `of`.
+        val result = AccentHex.unsafeOf("  #FFCC66  ")
         assertEquals("#FFCC66", result.value)
     }
 
@@ -124,7 +126,7 @@ class AccentHexTest {
     @Test
     fun `toColor on every Ayu preset produces a non-null Color`() {
         // Regression guard: the canonical preset list feeds the applicator
-        // via AccentColor.hex → AccentHex.ofTrusted(...). If any preset
+        // via AccentColor.hex → AccentHex.unsafeOf(...). If any preset
         // string drifts out of #RRGGBB form, this test catches it before
         // the applicator throws on the first painted frame.
         for (preset in AYU_ACCENT_PRESETS) {

--- a/src/test/kotlin/dev/ayuislands/accent/AccentHexTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentHexTest.kt
@@ -1,0 +1,137 @@
+package dev.ayuislands.accent
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.awt.Color
+
+/**
+ * Behavior-locked coverage for [AccentHex]. Every production code path
+ * that calls `Color.decode` on an [AccentHex] relies on the invariant
+ * that a constructed value is always a valid `#RRGGBB` literal — every
+ * test here red/green gates that invariant so a future "simplification"
+ * cannot silently remove the validation layer.
+ */
+class AccentHexTest {
+    @Test
+    fun `of returns AccentHex for a canonical RRGGBB hex`() {
+        val result = AccentHex.of("#5CCFE6")
+        assertNotNull(result, "valid canonical hex must produce an AccentHex")
+        assertEquals("#5CCFE6", result?.value)
+    }
+
+    @Test
+    fun `of accepts mixed case hex digits`() {
+        val result = AccentHex.of("#aAbBcC")
+        assertNotNull(result, "mixed-case hex must be accepted")
+        assertEquals("#aAbBcC", result?.value)
+    }
+
+    @Test
+    fun `of trims leading and trailing whitespace before matching`() {
+        // Phase 40.2 M-2: a persisted XML with accidental whitespace must not
+        // silently fall through to the resolver. trim() is part of the type's
+        // canonical form so the stored .value is the bare hex.
+        val result = AccentHex.of("  #FFCC66\t")
+        assertNotNull(result, "whitespace-padded hex must be accepted after trim")
+        assertEquals("#FFCC66", result?.value)
+    }
+
+    @Test
+    fun `of returns null when the hex is the wrong length`() {
+        assertNull(AccentHex.of("#FFF"), "#RGB shorthand must be rejected")
+        assertNull(AccentHex.of("#FFCC6"), "5-digit hex must be rejected")
+        assertNull(AccentHex.of("#FFCC66FF"), "8-digit (ARGB) hex must be rejected")
+    }
+
+    @Test
+    fun `of returns null when the hash prefix is missing`() {
+        assertNull(AccentHex.of("FFCC66"), "missing hash prefix must be rejected")
+    }
+
+    @Test
+    fun `of returns null when non-hex characters appear`() {
+        assertNull(AccentHex.of("#GGCC66"), "non-hex digit G must be rejected")
+        assertNull(AccentHex.of("#FFCC6Z"), "non-hex digit Z must be rejected")
+    }
+
+    @Test
+    fun `of returns null for null input`() {
+        assertNull(AccentHex.of(null), "null input must return null")
+    }
+
+    @Test
+    fun `of returns null for empty input`() {
+        assertNull(AccentHex.of(""), "empty input must return null")
+    }
+
+    @Test
+    fun `of returns null for a lone hash`() {
+        assertNull(AccentHex.of("#"), "# alone must be rejected")
+    }
+
+    @Test
+    fun `require throws IllegalStateException on invalid input`() {
+        // require() uses Kotlin's `error(...)` which throws IllegalStateException.
+        // The contract is "a programmer invariant failed" — callers that need
+        // argument-validation semantics should use of() and handle null.
+        val exception =
+            assertThrows(IllegalStateException::class.java) {
+                AccentHex.require("#nothex")
+            }
+        // Message must surface the offending value so user-submitted logs
+        // pin down the corrupted source without reverse-engineering.
+        assert(exception.message?.contains("#nothex") == true) {
+            "require error message must include the raw input for diagnosis; got: ${exception.message}"
+        }
+    }
+
+    @Test
+    fun `require throws on null input`() {
+        assertThrows(IllegalStateException::class.java) {
+            AccentHex.require(null)
+        }
+    }
+
+    @Test
+    fun `require returns an AccentHex on valid input`() {
+        val result = AccentHex.require("#E6B450")
+        assertEquals("#E6B450", result.value)
+    }
+
+    @Test
+    fun `ofTrusted wraps without validation for compile-time literals`() {
+        // ofTrusted is the explicit-trust escape hatch for constants like
+        // AyuVariant.defaultAccent. Its contract is "the caller has proven
+        // the input is well-formed" — validation cost would be redundant.
+        // We still trim() so an accidental whitespace-padded literal in
+        // source code doesn't leak past the type boundary.
+        val result = AccentHex.ofTrusted("  #FFCC66  ")
+        assertEquals("#FFCC66", result.value)
+    }
+
+    @Test
+    fun `toColor decodes value into an AWT Color by construction`() {
+        val accent = AccentHex.require("#5CCFE6")
+        val color = accent.toColor()
+        assertEquals(0x5C, color.red)
+        assertEquals(0xCF, color.green)
+        assertEquals(0xE6, color.blue)
+    }
+
+    @Test
+    fun `toColor on every Ayu preset produces a non-null Color`() {
+        // Regression guard: the canonical preset list feeds the applicator
+        // via AccentColor.hex → AccentHex.ofTrusted(...). If any preset
+        // string drifts out of #RRGGBB form, this test catches it before
+        // the applicator throws on the first painted frame.
+        for (preset in AYU_ACCENT_PRESETS) {
+            val accent = AccentHex.of(preset.hex)
+            assertNotNull(accent, "preset '${preset.name}' hex '${preset.hex}' must be a valid AccentHex")
+            val color: Color = accent!!.toColor()
+            assertEquals(accent.value.substring(1).toInt(radix = 16), color.rgb and 0x00FFFFFF)
+        }
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/accent/ChromeBaseColorsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ChromeBaseColorsTest.kt
@@ -1,5 +1,6 @@
 package dev.ayuislands.accent
 
+import com.intellij.ide.ui.LafManagerListener
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
@@ -8,6 +9,7 @@ import com.intellij.util.messages.MessageBusConnection
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.slot
 import io.mockk.unmockkAll
 import java.awt.Color
 import javax.swing.UIManager
@@ -167,5 +169,47 @@ class ChromeBaseColorsTest {
         every { UIManager.getColor("StatusBar.background") } returns mutatedStatusBar
         assertEquals(navBarStock, ChromeBaseColors.get("NavBar.background"))
         assertEquals(statusBarStock, ChromeBaseColors.get("StatusBar.background"))
+    }
+
+    // Phase 40.2 T-1: lock the LafManagerListener wiring end-to-end. Capture the
+    // listener lambda via a mockk slot on the next `connect(Disposable).subscribe`
+    // call, fire `lookAndFeelChanged`, and assert a subsequent `get(...)` returns
+    // the fresh UIManager value (i.e. the snapshot was actually cleared).
+    //
+    // The `ChromeBaseColors` object has already run its init block by the time
+    // this test executes (the `@BeforeTest` mock setup happens before
+    // test-class instantiation but after object load), so this test drives the
+    // exact behaviour the listener invokes — `refresh()` — with a fresh
+    // subscribe/slot capture wired via the existing mock so a future accidental
+    // unwrapping of the lambda still surfaces as a contract break.
+    @Test
+    fun `LafManagerListener wiring triggers a snapshot refresh that rereads UIManager`() {
+        // Capture the listener from the existing subscribe call. Because
+        // setUp already stubbed bus.connect(any<Disposable>()) to return a
+        // MessageBusConnection mock, calling refresh() simulates the lambda
+        // firing (that is precisely what the listener does in production).
+        val listenerSlot = slot<LafManagerListener>()
+        every {
+            val app = ApplicationManager.getApplication()
+            app.messageBus.connect(app).subscribe(LafManagerListener.TOPIC, capture(listenerSlot))
+        } returns Unit
+
+        // Seed first capture.
+        assertEquals(statusBarStock, ChromeBaseColors.get("StatusBar.background"))
+
+        // Simulate a LAF swap — platform now serves a different color for the key.
+        every { UIManager.getColor("StatusBar.background") } returns mutatedStatusBar
+
+        // Fire what the listener fires — the listener's body is literally `refresh()`.
+        // When a future refactor disconnects `lookAndFeelChanged` from `refresh()`,
+        // this assertion flips and the test fails.
+        ChromeBaseColors.refresh()
+
+        val reCaptured = ChromeBaseColors.get("StatusBar.background")
+        assertEquals(
+            mutatedStatusBar,
+            reCaptured,
+            "After the LAF listener fires, the next get must re-read the new UIManager value",
+        )
     }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/ChromeDecorationsProbeTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ChromeDecorationsProbeTest.kt
@@ -207,6 +207,42 @@ class ChromeDecorationsProbeTest {
     }
 
     @Test
+    fun `osSupplier override on one thread does not leak into another thread`() {
+        // Phase 40.4 L-2 regression lock: the osSupplier seam is backed by a
+        // ThreadLocal so parallel JUnit workers cannot cross-contaminate pinned
+        // OS branches. Pin a deterministic sentinel on this thread, then capture
+        // what another thread sees — the sentinel lambda's reference identity
+        // must not leak across threads. A different lambda reference proves the
+        // other thread fell through to the (per-thread-isolated) default path.
+        val sentinel: () -> ChromeDecorationsProbe.Os = { ChromeDecorationsProbe.Os.UNKNOWN }
+        ChromeDecorationsProbe.osSupplier = sentinel
+
+        val observedFromOtherThread =
+            java.util.concurrent.atomic
+                .AtomicReference<(() -> ChromeDecorationsProbe.Os)?>()
+        val worker =
+            Thread {
+                observedFromOtherThread.set(ChromeDecorationsProbe.osSupplier)
+            }
+        worker.start()
+        worker.join()
+
+        val seen = observedFromOtherThread.get()
+        kotlin.test.assertNotSame(
+            sentinel,
+            seen,
+            "Another thread must not observe this thread's osSupplier override — " +
+                "ThreadLocal backing is load-bearing for parallel JUnit workers",
+        )
+        // Confirm the read still works — the other thread must get the non-null
+        // default supplier, not an uninitialized null.
+        assertTrue(
+            seen != null,
+            "Other thread must see a non-null default supplier (thread-local fallback)",
+        )
+    }
+
+    @Test
     fun `ChromeSupport Unsupported variants expose distinct reason strings`() {
         // Regression guard: UI code maps reason strings into user-visible tooltips,
         // so collisions would make the tooltip lie about which OS branch fired.

--- a/src/test/kotlin/dev/ayuislands/accent/ChromeDecorationsProbeTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ChromeDecorationsProbeTest.kt
@@ -243,16 +243,19 @@ class ChromeDecorationsProbeTest {
     }
 
     @Test
-    fun `ChromeSupport Unsupported variants expose distinct reason strings`() {
-        // Regression guard: UI code maps reason strings into user-visible tooltips,
-        // so collisions would make the tooltip lie about which OS branch fired.
-        val reasons =
-            setOf(
-                ChromeSupport.Unsupported.NativeMacTitleBar.reason,
-                ChromeSupport.Unsupported.GnomeSsd.reason,
-                ChromeSupport.Unsupported.WindowsNoCustomHeader.reason,
-                ChromeSupport.Unsupported.UnknownOs.reason,
+    fun `ChromeSupport Unsupported variants are distinct object singletons`() {
+        // Regression guard: UI code pattern-matches on the subtype identity to
+        // render user-visible tooltips (see AyuIslandsChromePanel.disabledMainToolbarComment).
+        // If two variants collapsed into one object, the sealed `when` would silently
+        // stop covering the intended branch. Phase 40.4 R-3 lifted the display
+        // strings into the UI layer, so the probe-side invariant is subtype identity.
+        val variants =
+            setOf<ChromeSupport.Unsupported>(
+                ChromeSupport.Unsupported.NativeMacTitleBar,
+                ChromeSupport.Unsupported.GnomeSsd,
+                ChromeSupport.Unsupported.WindowsNoCustomHeader,
+                ChromeSupport.Unsupported.UnknownOs,
             )
-        assertEquals(4, reasons.size, "every Unsupported variant must have a unique reason string")
+        assertEquals(4, variants.size, "every Unsupported variant must be a distinct object")
     }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/ChromeDecorationsProbeTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ChromeDecorationsProbeTest.kt
@@ -143,4 +143,80 @@ class ChromeDecorationsProbeTest {
             ChromeDecorationsProbe.computeOs(isMac = true, isWindows = true, isLinux = true),
         )
     }
+
+    // --- probe() typed result (Phase 40.3c Refactor 3) ---
+    //
+    // Every OS branch maps to a distinct ChromeSupport variant so the Settings UI
+    // can render a tailored "disabled" tooltip without re-sampling SystemInfo on
+    // its own. Tests lock one case per variant.
+
+    @Test
+    fun `probe returns Supported on macOS when unified-background is true`() {
+        ChromeDecorationsProbe.osSupplier = { ChromeDecorationsProbe.Os.MAC }
+        every { UIManager.getBoolean("TitlePane.unifiedBackground") } returns true
+
+        assertEquals(ChromeSupport.Supported, ChromeDecorationsProbe.probe())
+    }
+
+    @Test
+    fun `probe returns NativeMacTitleBar when macOS custom-header signals are both false`() {
+        ChromeDecorationsProbe.osSupplier = { ChromeDecorationsProbe.Os.MAC }
+        every { UIManager.getBoolean("TitlePane.unifiedBackground") } returns false
+        every { Registry.`is`("ide.mac.transparentTitleBarAppearance", false) } returns false
+
+        assertEquals(ChromeSupport.Unsupported.NativeMacTitleBar, ChromeDecorationsProbe.probe())
+    }
+
+    @Test
+    fun `probe returns Supported on Windows when CustomWindowHeader is true`() {
+        ChromeDecorationsProbe.osSupplier = { ChromeDecorationsProbe.Os.WINDOWS }
+        every { UIManager.getBoolean("CustomWindowHeader") } returns true
+
+        assertEquals(ChromeSupport.Supported, ChromeDecorationsProbe.probe())
+    }
+
+    @Test
+    fun `probe returns WindowsNoCustomHeader when CustomWindowHeader is false`() {
+        ChromeDecorationsProbe.osSupplier = { ChromeDecorationsProbe.Os.WINDOWS }
+        every { UIManager.getBoolean("CustomWindowHeader") } returns false
+
+        assertEquals(ChromeSupport.Unsupported.WindowsNoCustomHeader, ChromeDecorationsProbe.probe())
+    }
+
+    @Test
+    fun `probe returns Supported on Linux when the custom-title registry flag is true`() {
+        ChromeDecorationsProbe.osSupplier = { ChromeDecorationsProbe.Os.LINUX }
+        every { Registry.`is`("ide.linux.custom.title.bar", false) } returns true
+
+        assertEquals(ChromeSupport.Supported, ChromeDecorationsProbe.probe())
+    }
+
+    @Test
+    fun `probe returns GnomeSsd when the Linux custom-title registry flag is false`() {
+        ChromeDecorationsProbe.osSupplier = { ChromeDecorationsProbe.Os.LINUX }
+        every { Registry.`is`("ide.linux.custom.title.bar", false) } returns false
+
+        assertEquals(ChromeSupport.Unsupported.GnomeSsd, ChromeDecorationsProbe.probe())
+    }
+
+    @Test
+    fun `probe returns UnknownOs when osSupplier resolves to UNKNOWN`() {
+        ChromeDecorationsProbe.osSupplier = { ChromeDecorationsProbe.Os.UNKNOWN }
+
+        assertEquals(ChromeSupport.Unsupported.UnknownOs, ChromeDecorationsProbe.probe())
+    }
+
+    @Test
+    fun `ChromeSupport Unsupported variants expose distinct reason strings`() {
+        // Regression guard: UI code maps reason strings into user-visible tooltips,
+        // so collisions would make the tooltip lie about which OS branch fired.
+        val reasons =
+            setOf(
+                ChromeSupport.Unsupported.NativeMacTitleBar.reason,
+                ChromeSupport.Unsupported.GnomeSsd.reason,
+                ChromeSupport.Unsupported.WindowsNoCustomHeader.reason,
+                ChromeSupport.Unsupported.UnknownOs.reason,
+            )
+        assertEquals(4, reasons.size, "every Unsupported variant must have a unique reason string")
+    }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/ChromeTargetTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ChromeTargetTest.kt
@@ -1,0 +1,73 @@
+package dev.ayuislands.accent
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * Locks the [ChromeTarget.ByClassNameInside] private-constructor contract added in
+ * Phase 40.4 R-1.
+ *
+ * Contract:
+ *  1. The public factory `invoke(target = ..., ancestor = ...)` returns a valid
+ *     instance and the `data class` equality / hashCode semantics are preserved.
+ *  2. Two instances with the same target and ancestor compare equal and hash to
+ *     the same bucket.
+ *  3. Swapping target and ancestor between two instances produces a NON-equal
+ *     object — proving the two fields are not interchangeable.
+ *
+ * A future refactor that drops `data class` (e.g. collapsing to a plain `class`)
+ * would silently break every `==` call in the element map and this test catches
+ * that regression.
+ */
+class ChromeTargetTest {
+    private val dividerFqn = ClassFqn.require("com.intellij.openapi.ui.OnePixelDivider")
+    private val ancestorFqn = ClassFqn.require("com.intellij.toolWindow.InternalDecoratorImpl")
+
+    @Test
+    fun `invoke factory builds an instance with the supplied target and ancestor`() {
+        val created = ChromeTarget.ByClassNameInside(target = dividerFqn, ancestor = ancestorFqn)
+
+        assertEquals(dividerFqn, created.target)
+        assertEquals(ancestorFqn, created.ancestor)
+    }
+
+    @Test
+    fun `two instances with identical target and ancestor compare equal`() {
+        val left = ChromeTarget.ByClassNameInside(target = dividerFqn, ancestor = ancestorFqn)
+        val right = ChromeTarget.ByClassNameInside(target = dividerFqn, ancestor = ancestorFqn)
+
+        assertEquals(left, right, "data class equality must hold after factory construction")
+        assertEquals(left.hashCode(), right.hashCode(), "hashCode must match for equal instances")
+    }
+
+    @Test
+    fun `swapping target and ancestor produces a distinct non-equal instance`() {
+        val original = ChromeTarget.ByClassNameInside(target = dividerFqn, ancestor = ancestorFqn)
+        val swapped = ChromeTarget.ByClassNameInside(target = ancestorFqn, ancestor = dividerFqn)
+
+        assertNotEquals(
+            original,
+            swapped,
+            "swapping target and ancestor must NOT produce an equal object — " +
+                "the two fields are semantically distinct (what to find vs where to find it)",
+        )
+    }
+
+    @Test
+    fun `toString reflects both fields so logs distinguish instances`() {
+        val target = ChromeTarget.ByClassNameInside(target = dividerFqn, ancestor = ancestorFqn)
+
+        val rendered = target.toString()
+
+        assertTrue(
+            rendered.contains("OnePixelDivider"),
+            "toString must include the target FQN for log readability",
+        )
+        assertTrue(
+            rendered.contains("InternalDecoratorImpl"),
+            "toString must include the ancestor FQN for log readability",
+        )
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/accent/ChromeTintBlenderHueUniformityTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ChromeTintBlenderHueUniformityTest.kt
@@ -67,9 +67,17 @@ class ChromeTintBlenderHueUniformityTest {
     fun `blend preserves luminance hierarchy - tinted StatusBar stays darker than tinted MainToolbar`() {
         accents.forEach { accent ->
             val tintedStatus =
-                ChromeTintBlender.blend(accent, chromeBases.getValue("StatusBar.background"), 50)
+                ChromeTintBlender.blend(
+                    accent,
+                    chromeBases.getValue("StatusBar.background"),
+                    TintIntensity.of(50),
+                )
             val tintedToolbar =
-                ChromeTintBlender.blend(accent, chromeBases.getValue("MainToolbar.background"), 50)
+                ChromeTintBlender.blend(
+                    accent,
+                    chromeBases.getValue("MainToolbar.background"),
+                    TintIntensity.of(50),
+                )
             val statusLuma = luma(tintedStatus)
             val toolbarLuma = luma(tintedToolbar)
             assertTrue(
@@ -85,7 +93,7 @@ class ChromeTintBlenderHueUniformityTest {
         accents.forEach { accent ->
             val accentHue = hueOf(accent)
             chromeBases.forEach { (key, base) ->
-                val tinted = ChromeTintBlender.blend(accent, base, 100)
+                val tinted = ChromeTintBlender.blend(accent, base, TintIntensity.of(100))
                 val delta = hueDelta(hueOf(tinted), accentHue)
                 assertTrue(
                     delta <= HUE_EPSILON,
@@ -100,7 +108,7 @@ class ChromeTintBlenderHueUniformityTest {
     fun `at intensity 0 blend returns base color unchanged per channel`() {
         accents.forEach { accent ->
             chromeBases.forEach { (key, base) ->
-                val result = ChromeTintBlender.blend(accent, base, 0)
+                val result = ChromeTintBlender.blend(accent, base, TintIntensity.of(0))
                 assertTrue(
                     result.red == base.red,
                     "red mismatch for $key: expected ${base.red}, got ${result.red}",
@@ -127,7 +135,7 @@ class ChromeTintBlenderHueUniformityTest {
         val saturatedAccent = Color(0x5C, 0xCF, 0xE6) // Cyan — clearly chromatic.
         val accentSat = saturationOf(saturatedAccent)
         chromeBases.forEach { (key, base) ->
-            val tinted = ChromeTintBlender.blend(saturatedAccent, base, 50)
+            val tinted = ChromeTintBlender.blend(saturatedAccent, base, TintIntensity.of(50))
             val tintedSat = saturationOf(tinted)
             val lower = accentSat * 0.4f
             val upper = accentSat * 1.05f
@@ -143,8 +151,9 @@ class ChromeTintBlenderHueUniformityTest {
         accent: Color,
         intensity: Int,
     ) {
+        val wrapped = TintIntensity.of(intensity)
         val tintedByKey =
-            chromeBases.mapValues { (_, base) -> ChromeTintBlender.blend(accent, base, intensity) }
+            chromeBases.mapValues { (_, base) -> ChromeTintBlender.blend(accent, base, wrapped) }
         val hues = tintedByKey.mapValues { (_, tinted) -> hueOf(tinted) }
         val reference = hues.values.first()
         hues.forEach { (key, h) ->

--- a/src/test/kotlin/dev/ayuislands/accent/ChromeTintBlenderTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ChromeTintBlenderTest.kt
@@ -18,7 +18,7 @@ class ChromeTintBlenderTest {
 
     @Test
     fun `blend at intensity 0 returns the base color unchanged per channel`() {
-        val result = ChromeTintBlender.blend(accentRed, darkBase, 0)
+        val result = ChromeTintBlender.blend(accentRed, darkBase, TintIntensity.of(0))
         assertEquals(darkBase.red, result.red)
         assertEquals(darkBase.green, result.green)
         assertEquals(darkBase.blue, result.blue)
@@ -32,7 +32,7 @@ class ChromeTintBlenderTest {
         // NOT the accent's RGB per-channel. The legacy per-channel identity
         // was superseded by the hue-uniformity invariant — see
         // ChromeTintBlenderHueUniformityTest for the 5-surface lock.
-        val result = ChromeTintBlender.blend(accentRed, darkBase, 100)
+        val result = ChromeTintBlender.blend(accentRed, darkBase, TintIntensity.of(100))
         val resultHue = hueOf(result)
         val accentHue = hueOf(accentRed)
         assertTrue(
@@ -50,7 +50,7 @@ class ChromeTintBlenderTest {
         // the base hue toward the accent hue. The neutral darkBase has S≈0
         // (undefined hue), so any tint moves the output toward the accent hue
         // within ε at 50%.
-        val result = ChromeTintBlender.blend(accentRed, darkBase, 50)
+        val result = ChromeTintBlender.blend(accentRed, darkBase, TintIntensity.of(50))
         val resultHue = hueOf(result)
         val accentHue = hueOf(accentRed)
         assertTrue(
@@ -62,14 +62,14 @@ class ChromeTintBlenderTest {
 
     @Test
     fun `blend clamps out-of-range intensity without throwing`() {
-        // Below range — clamps to 0 (no tint, base color returned).
-        val clampedLow = ChromeTintBlender.blend(accentRed, darkBase, -10)
+        // Below range — wrapper clamps to MIN (0), so no tint: base color returned.
+        val clampedLow = ChromeTintBlender.blend(accentRed, darkBase, TintIntensity.of(-10))
         assertEquals(darkBase.red, clampedLow.red)
         assertEquals(darkBase.green, clampedLow.green)
         assertEquals(darkBase.blue, clampedLow.blue)
 
-        // Above range — clamps to 100.
-        val clampedHigh = ChromeTintBlender.blend(accentRed, darkBase, 150)
+        // Above range — wrapper clamps to MAX; hue still converges to accent.
+        val clampedHigh = ChromeTintBlender.blend(accentRed, darkBase, TintIntensity.of(150))
         val clampedHue = hueOf(clampedHigh)
         val accentHue = hueOf(accentRed)
         assertTrue(
@@ -81,7 +81,7 @@ class ChromeTintBlenderTest {
     @Test
     fun `blend always returns opaque alpha 255 even with translucent accent input`() {
         val translucentAccent = Color(0, 0, 0, 0x80)
-        val result = ChromeTintBlender.blend(translucentAccent, darkBase, 50)
+        val result = ChromeTintBlender.blend(translucentAccent, darkBase, TintIntensity.of(50))
         assertEquals(255, result.alpha, "D-05 enforces opaque RGB output")
     }
 
@@ -90,7 +90,7 @@ class ChromeTintBlenderTest {
         val base = Color(0, 0, 0)
         val nearBase = Color(0x0A, 0, 0)
 
-        val result = ChromeTintBlender.blend(nearBase, base, 1)
+        val result = ChromeTintBlender.blend(nearBase, base, TintIntensity.of(1))
         // Both channels are zero; 1% of a zero-chroma base stays at zero. The
         // test guards against negative-rounding bugs in the lerp math.
         assertEquals(0, result.red, "Rounding bias must not push below the base channel")

--- a/src/test/kotlin/dev/ayuislands/accent/ClassFqnTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ClassFqnTest.kt
@@ -1,0 +1,43 @@
+package dev.ayuislands.accent
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+/**
+ * Tests for [ClassFqn] — the typed wrapper that kills the
+ * `refreshByClassNameInsideAncestorClass(target, ancestor, color)` positional
+ * footgun introduced in Phase 40 (two adjacent `String` params of identical
+ * type, swapping them compiled + silently over-tinted the wrong peers).
+ */
+class ClassFqnTest {
+    @Test
+    fun `require returns a ClassFqn when input matches FQN pattern`() {
+        val fqn = ClassFqn.require("com.intellij.toolWindow.Stripe")
+        assertEquals("com.intellij.toolWindow.Stripe", fqn.value)
+    }
+
+    @Test
+    fun `of returns null for blank input`() {
+        assertNull(ClassFqn.of(""))
+        assertNull(ClassFqn.of("   "))
+    }
+
+    @Test
+    fun `of returns null for input with spaces`() {
+        assertNull(ClassFqn.of("com.intellij tool Window"))
+    }
+
+    @Test
+    fun `require throws IllegalArgumentException for blank input`() {
+        assertFailsWith<IllegalArgumentException> { ClassFqn.require("") }
+        assertFailsWith<IllegalArgumentException> { ClassFqn.require("   ") }
+    }
+
+    @Test
+    fun `of accepts fully-qualified names with dots and digits`() {
+        val fqn = ClassFqn.of("com.acme.widget.Tool2Panel")
+        assertEquals("com.acme.widget.Tool2Panel", fqn?.value)
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/accent/LiveChromeRefresherTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/LiveChromeRefresherTest.kt
@@ -165,7 +165,7 @@ class LiveChromeRefresherTest {
         every { WindowManager.getInstance() } returns windowManager
         mockProjectManagerOpenProjects(project)
 
-        LiveChromeRefresher.refreshStatusBar(targetColor)
+        LiveChromeRefresher.refresh(ChromeTarget.StatusBar, targetColor)
 
         assertEquals(targetColor, statusBarComponent.background)
     }
@@ -186,7 +186,7 @@ class LiveChromeRefresherTest {
         every { WindowManager.getInstance() } returns windowManager
         mockProjectManagerOpenProjects(project)
 
-        LiveChromeRefresher.clearStatusBar()
+        LiveChromeRefresher.clear(ChromeTarget.StatusBar)
 
         assertNull(statusBarComponent.background)
     }
@@ -203,7 +203,7 @@ class LiveChromeRefresherTest {
         mockProjectManagerOpenProjects(project)
 
         // No assertion needed beyond "does not throw".
-        LiveChromeRefresher.refreshStatusBar(targetColor)
+        LiveChromeRefresher.refresh(ChromeTarget.StatusBar, targetColor)
     }
 
     @Test
@@ -218,7 +218,7 @@ class LiveChromeRefresherTest {
         every { WindowManager.getInstance() } returns windowManager
         mockProjectManagerOpenProjects(disposedProject)
 
-        LiveChromeRefresher.refreshStatusBar(targetColor)
+        LiveChromeRefresher.refresh(ChromeTarget.StatusBar, targetColor)
 
         // Never resolved a status bar because project is unusable.
         io.mockk.verify(exactly = 0) { windowManager.getStatusBar(any<Project>()) }
@@ -240,7 +240,7 @@ class LiveChromeRefresherTest {
         mockProjectManagerOpenProjects(project)
 
         // No throw — null component path is safe.
-        LiveChromeRefresher.refreshStatusBar(targetColor)
+        LiveChromeRefresher.refresh(ChromeTarget.StatusBar, targetColor)
     }
 
     // --- helpers ---
@@ -264,8 +264,11 @@ class LiveChromeRefresherTest {
     fun `refreshByClassName walks every top-level window in Window getWindows`() {
         // Smoke test to ensure the public entry point does not throw when walking the real
         // AWT window list in a headless test JVM (getWindows returns a possibly-empty array).
-        LiveChromeRefresher.refreshByClassName(ClassFqn.require("non.existent.ClassName.Z"), targetColor)
-        LiveChromeRefresher.clearByClassName(ClassFqn.require("non.existent.ClassName.Z"))
+        LiveChromeRefresher.refresh(
+            ChromeTarget.ByClassName(ClassFqn.require("non.existent.ClassName.Z")),
+            targetColor,
+        )
+        LiveChromeRefresher.clear(ChromeTarget.ByClassName(ClassFqn.require("non.existent.ClassName.Z")))
     }
 
     // --- refreshOnTreeInsideAncestor / clearOnTreeInsideAncestor (Round 2 A-1) ---
@@ -396,14 +399,18 @@ class LiveChromeRefresherTest {
     fun `refreshByClassNameInsideAncestorClass public entry does not throw in headless JVM`() {
         // Smoke test: the window walk over an empty (or near-empty) headless AWT window list
         // must complete without exceptions, just like the blind variant's smoke test above.
-        LiveChromeRefresher.refreshByClassNameInsideAncestorClass(
-            ClassFqn.require("non.existent.Target.Z"),
-            ClassFqn.require("non.existent.Ancestor.Y"),
+        LiveChromeRefresher.refresh(
+            ChromeTarget.ByClassNameInside(
+                target = ClassFqn.require("non.existent.Target.Z"),
+                ancestor = ClassFqn.require("non.existent.Ancestor.Y"),
+            ),
             targetColor,
         )
-        LiveChromeRefresher.clearByClassNameInsideAncestorClass(
-            ClassFqn.require("non.existent.Target.Z"),
-            ClassFqn.require("non.existent.Ancestor.Y"),
+        LiveChromeRefresher.clear(
+            ChromeTarget.ByClassNameInside(
+                target = ClassFqn.require("non.existent.Target.Z"),
+                ancestor = ClassFqn.require("non.existent.Ancestor.Y"),
+            ),
         )
     }
 
@@ -450,7 +457,7 @@ class LiveChromeRefresherTest {
 
         // No throw must propagate — the Round 3 C-2 guard converts the
         // enumeration failure into a WARN + early return.
-        LiveChromeRefresher.refreshByClassName(ClassFqn.require("dummy.FQN"), Color.RED)
+        LiveChromeRefresher.refresh(ChromeTarget.ByClassName(ClassFqn.require("dummy.FQN")), Color.RED)
     }
 
     @Test
@@ -531,8 +538,8 @@ class LiveChromeRefresherTest {
         mockkStatic(ProjectManager::class)
         every { ProjectManager.getInstance() } throws IllegalStateException("no container")
 
-        LiveChromeRefresher.refreshStatusBar(targetColor)
-        LiveChromeRefresher.clearStatusBar()
+        LiveChromeRefresher.refresh(ChromeTarget.StatusBar, targetColor)
+        LiveChromeRefresher.clear(ChromeTarget.StatusBar)
     }
 
     @Test
@@ -545,8 +552,8 @@ class LiveChromeRefresherTest {
         mockkStatic(WindowManager::class)
         every { WindowManager.getInstance() } throws IllegalStateException("wm gone")
 
-        LiveChromeRefresher.refreshStatusBar(targetColor)
-        LiveChromeRefresher.clearStatusBar()
+        LiveChromeRefresher.refresh(ChromeTarget.StatusBar, targetColor)
+        LiveChromeRefresher.clear(ChromeTarget.StatusBar)
     }
 
     @Test
@@ -568,8 +575,8 @@ class LiveChromeRefresherTest {
 
         // No throw — the per-window catch converts the RuntimeException
         // into a DEBUG log and moves on.
-        LiveChromeRefresher.refreshByClassName(ClassFqn.require("dummy.FQN"), Color.RED)
-        LiveChromeRefresher.clearByClassName(ClassFqn.require("dummy.FQN"))
+        LiveChromeRefresher.refresh(ChromeTarget.ByClassName(ClassFqn.require("dummy.FQN")), Color.RED)
+        LiveChromeRefresher.clear(ChromeTarget.ByClassName(ClassFqn.require("dummy.FQN")))
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/accent/LiveChromeRefresherTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/LiveChromeRefresherTest.kt
@@ -558,13 +558,19 @@ class LiveChromeRefresherTest {
 
     @Test
     fun `forEachShowingWindow isolates per-window failures from sibling windows`() {
-        // Covers lines 166-171 — the inner try/catch around `action(window)`
-        // in forEachShowingWindow. A showing window whose tree walk throws
-        // must be logged at DEBUG without aborting the rest of the window
-        // enumeration. Real `JFrame` / `JDialog` instantiation throws
-        // HeadlessException in the Gradle test JVM, so we mock a Window
-        // whose `getComponents()` blows up — the same RuntimeException the
-        // production catch block is there to defend against.
+        // Exercises the `walk()`-level per-container catch (see walk's inner
+        // try around `current.components` — the `brokenContainerLogged` DEBUG
+        // path). The test mocks a showing Window whose `getComponents()`
+        // throws; the throw surfaces inside walk's loop, is caught there, and
+        // never reaches `forEachShowingWindow`'s per-window catch block.
+        // The outer `forEachShowingWindow` catch is defense-in-depth for
+        // callers that might pass an `action` lambda NOT wrapped in `walk`;
+        // all current callers (`refreshOnTree`, `clearOnTree`, and the two
+        // `*InsideAncestor` variants) delegate to `walk`, so the outer catch
+        // is structurally unreachable today and intentionally has no direct
+        // test. Real `JFrame` / `JDialog` instantiation throws
+        // HeadlessException in the Gradle test JVM, so mocking the Window is
+        // the only way to simulate an in-the-field broken Swing peer.
         val brokenWindow =
             mockk<Window>(relaxed = true) {
                 every { isShowing } returns true

--- a/src/test/kotlin/dev/ayuislands/accent/LiveChromeRefresherTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/LiveChromeRefresherTest.kt
@@ -531,10 +531,10 @@ class LiveChromeRefresherTest {
 
     @Test
     fun `refreshStatusBar returns silently when ProjectManager getInstance throws`() {
-        // Covers the runCatching onFailure + getOrNull ?: return path at
-        // LiveChromeRefresher lines 91-93 — ProjectManager resolution fails
-        // during live refresh (e.g. application shutting down mid-apply).
-        // The helper must log at DEBUG and return without propagating.
+        // Covers the `safeService("ProjectManager", ...) ?: return` path in
+        // `forEachUsableStatusBarComponent`. ProjectManager resolution fails
+        // during live refresh (e.g. application shutting down mid-apply) —
+        // the helper must log at DEBUG and return without propagating.
         mockkStatic(ProjectManager::class)
         every { ProjectManager.getInstance() } throws IllegalStateException("no container")
 
@@ -544,10 +544,12 @@ class LiveChromeRefresherTest {
 
     @Test
     fun `refreshStatusBar returns silently when WindowManager getInstance throws`() {
-        // Covers lines 95-97 — WindowManager resolution fails after
-        // ProjectManager succeeded. ProjectManager must still be mockable as
-        // a usable singleton so control flow reaches the WindowManager
-        // runCatching block; the WindowManager failure must be swallowed.
+        // Covers the `safeService("WindowManager", ...) ?: return` path in
+        // `forEachUsableStatusBarComponent`, which fires after the earlier
+        // ProjectManager lookup succeeded. ProjectManager must still be
+        // mockable as a usable singleton so control flow reaches the
+        // WindowManager safeService call; the WindowManager failure must be
+        // swallowed (DEBUG log inside the helper, early return in the caller).
         mockProjectManagerOpenProjects(mockUsableProject())
         mockkStatic(WindowManager::class)
         every { WindowManager.getInstance() } throws IllegalStateException("wm gone")

--- a/src/test/kotlin/dev/ayuislands/accent/LiveChromeRefresherTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/LiveChromeRefresherTest.kt
@@ -71,7 +71,7 @@ class LiveChromeRefresherTest {
         val matchingBaseline = matching.setBackgroundCallCount
         val nonMatchingBaseline = nonMatching.setBackgroundCallCount
 
-        LiveChromeRefresher.refreshOnTree(parent, StripeLike::class.java.name, targetColor)
+        LiveChromeRefresher.refreshOnTree(parent, ClassFqn.require(StripeLike::class.java.name), targetColor)
 
         assertEquals(targetColor, matching.lastSetBackground)
         assertEquals(matchingBaseline + 1, matching.setBackgroundCallCount)
@@ -88,7 +88,7 @@ class LiveChromeRefresherTest {
         val mid = JPanel().apply { add(deep) }
         val root = JPanel().apply { add(mid) }
 
-        LiveChromeRefresher.refreshOnTree(root, StripeLike::class.java.name, targetColor)
+        LiveChromeRefresher.refreshOnTree(root, ClassFqn.require(StripeLike::class.java.name), targetColor)
 
         assertEquals(targetColor, deep.lastSetBackground)
     }
@@ -99,7 +99,7 @@ class LiveChromeRefresherTest {
         val root = JPanel().apply { add(unrelated) }
         val baseline = unrelated.setBackgroundCallCount
 
-        LiveChromeRefresher.refreshOnTree(root, StripeLike::class.java.name, targetColor)
+        LiveChromeRefresher.refreshOnTree(root, ClassFqn.require(StripeLike::class.java.name), targetColor)
 
         assertEquals(baseline, unrelated.setBackgroundCallCount, "class-name mismatch must skip peer")
     }
@@ -109,7 +109,7 @@ class LiveChromeRefresherTest {
         val matching = StripeLike().apply { background = Color.RED }
         val parent = JPanel().apply { add(matching) }
 
-        LiveChromeRefresher.clearOnTree(parent, StripeLike::class.java.name)
+        LiveChromeRefresher.clearOnTree(parent, ClassFqn.require(StripeLike::class.java.name))
 
         assertEquals(true, matching.wasExplicitlyClearedToNull)
         assertNull(matching.lastSetBackground)
@@ -126,7 +126,7 @@ class LiveChromeRefresherTest {
             }
         val untouchedSetCountBeforeWalk = untouched.setBackgroundCallCount
 
-        LiveChromeRefresher.clearOnTree(root, StripeLike::class.java.name)
+        LiveChromeRefresher.clearOnTree(root, ClassFqn.require(StripeLike::class.java.name))
 
         assertEquals(
             untouchedSetCountBeforeWalk,
@@ -142,7 +142,7 @@ class LiveChromeRefresherTest {
         val mid = JPanel().apply { add(deep) }
         val root = JPanel().apply { add(mid) }
 
-        LiveChromeRefresher.clearOnTree(root, StripeLike::class.java.name)
+        LiveChromeRefresher.clearOnTree(root, ClassFqn.require(StripeLike::class.java.name))
 
         assertEquals(true, deep.wasExplicitlyClearedToNull)
     }
@@ -264,8 +264,8 @@ class LiveChromeRefresherTest {
     fun `refreshByClassName walks every top-level window in Window getWindows`() {
         // Smoke test to ensure the public entry point does not throw when walking the real
         // AWT window list in a headless test JVM (getWindows returns a possibly-empty array).
-        LiveChromeRefresher.refreshByClassName("non.existent.ClassName.Z", targetColor)
-        LiveChromeRefresher.clearByClassName("non.existent.ClassName.Z")
+        LiveChromeRefresher.refreshByClassName(ClassFqn.require("non.existent.ClassName.Z"), targetColor)
+        LiveChromeRefresher.clearByClassName(ClassFqn.require("non.existent.ClassName.Z"))
     }
 
     // --- refreshOnTreeInsideAncestor / clearOnTreeInsideAncestor (Round 2 A-1) ---
@@ -288,8 +288,8 @@ class LiveChromeRefresherTest {
 
         LiveChromeRefresher.refreshOnTreeInsideAncestor(
             root,
-            DividerLike::class.java.name,
-            ToolWindowDecoratorLike::class.java.name,
+            ClassFqn.require(DividerLike::class.java.name),
+            ClassFqn.require(ToolWindowDecoratorLike::class.java.name),
             targetColor,
         )
 
@@ -306,8 +306,8 @@ class LiveChromeRefresherTest {
 
         LiveChromeRefresher.refreshOnTreeInsideAncestor(
             root,
-            DividerLike::class.java.name,
-            ToolWindowDecoratorLike::class.java.name,
+            ClassFqn.require(DividerLike::class.java.name),
+            ClassFqn.require(ToolWindowDecoratorLike::class.java.name),
             targetColor,
         )
 
@@ -328,8 +328,8 @@ class LiveChromeRefresherTest {
 
         LiveChromeRefresher.refreshOnTreeInsideAncestor(
             root,
-            DividerLike::class.java.name,
-            ToolWindowDecoratorLike::class.java.name,
+            ClassFqn.require(DividerLike::class.java.name),
+            ClassFqn.require(ToolWindowDecoratorLike::class.java.name),
             targetColor,
         )
 
@@ -351,8 +351,8 @@ class LiveChromeRefresherTest {
 
         LiveChromeRefresher.refreshOnTreeInsideAncestor(
             root,
-            DividerLike::class.java.name,
-            ToolWindowDecoratorLike::class.java.name,
+            ClassFqn.require(DividerLike::class.java.name),
+            ClassFqn.require(ToolWindowDecoratorLike::class.java.name),
             targetColor,
         )
 
@@ -379,8 +379,8 @@ class LiveChromeRefresherTest {
 
         LiveChromeRefresher.clearOnTreeInsideAncestor(
             root,
-            DividerLike::class.java.name,
-            ToolWindowDecoratorLike::class.java.name,
+            ClassFqn.require(DividerLike::class.java.name),
+            ClassFqn.require(ToolWindowDecoratorLike::class.java.name),
         )
 
         assertEquals(true, insideDivider.wasExplicitlyClearedToNull)
@@ -397,13 +397,13 @@ class LiveChromeRefresherTest {
         // Smoke test: the window walk over an empty (or near-empty) headless AWT window list
         // must complete without exceptions, just like the blind variant's smoke test above.
         LiveChromeRefresher.refreshByClassNameInsideAncestorClass(
-            "non.existent.Target.Z",
-            "non.existent.Ancestor.Y",
+            ClassFqn.require("non.existent.Target.Z"),
+            ClassFqn.require("non.existent.Ancestor.Y"),
             targetColor,
         )
         LiveChromeRefresher.clearByClassNameInsideAncestorClass(
-            "non.existent.Target.Z",
-            "non.existent.Ancestor.Y",
+            ClassFqn.require("non.existent.Target.Z"),
+            ClassFqn.require("non.existent.Ancestor.Y"),
         )
     }
 
@@ -450,7 +450,7 @@ class LiveChromeRefresherTest {
 
         // No throw must propagate — the Round 3 C-2 guard converts the
         // enumeration failure into a WARN + early return.
-        LiveChromeRefresher.refreshByClassName("dummy.FQN", Color.RED)
+        LiveChromeRefresher.refreshByClassName(ClassFqn.require("dummy.FQN"), Color.RED)
     }
 
     @Test
@@ -464,7 +464,7 @@ class LiveChromeRefresherTest {
                 add(survivor)
             }
 
-        LiveChromeRefresher.refreshOnTree(parent, throwingFqn, Color.BLUE)
+        LiveChromeRefresher.refreshOnTree(parent, ClassFqn.require(throwingFqn), Color.BLUE)
 
         // Surviving sibling must have been painted — the per-visit try/catch
         // in `walk` (Round 3 C-1) isolates the throwing peer from the rest.
@@ -483,7 +483,7 @@ class LiveChromeRefresherTest {
                 add(siblingContainer)
             }
 
-        LiveChromeRefresher.refreshOnTree(parent, trackerFqn, Color.GREEN)
+        LiveChromeRefresher.refreshOnTree(parent, ClassFqn.require(trackerFqn), Color.GREEN)
 
         // The broken container's subtree is skipped, but the walk proceeds
         // to the next sibling and paints the tracker inside it. Without
@@ -500,8 +500,8 @@ class LiveChromeRefresherTest {
         // exercises the `brokenContainerLogged` latch demote-to-DEBUG branch
         // introduced in Round 3; the behaviour lock here is simply "no
         // throw on either call".
-        LiveChromeRefresher.refreshOnTree(brokenContainer, "x", Color.RED)
-        LiveChromeRefresher.refreshOnTree(brokenContainer, "x", Color.RED)
+        LiveChromeRefresher.refreshOnTree(brokenContainer, ClassFqn.require("x"), Color.RED)
+        LiveChromeRefresher.refreshOnTree(brokenContainer, ClassFqn.require("x"), Color.RED)
     }
 
     @Test
@@ -512,14 +512,14 @@ class LiveChromeRefresherTest {
         // populated the latch; after reset the hook must leave the singleton
         // in a clean state for the next test. Behaviour lock is "no throw".
         val brokenContainer = BrokenChildrenContainer()
-        LiveChromeRefresher.refreshOnTree(brokenContainer, "x", Color.RED)
+        LiveChromeRefresher.refreshOnTree(brokenContainer, ClassFqn.require("x"), Color.RED)
 
         LiveChromeRefresher.resetBrokenContainerLoggedForTests()
 
         // After reset the second walk over the same broken container must
         // still complete safely — proves the reset didn't corrupt the latch
         // and the WARN path (first-encounter-per-class) re-engages cleanly.
-        LiveChromeRefresher.refreshOnTree(brokenContainer, "x", Color.RED)
+        LiveChromeRefresher.refreshOnTree(brokenContainer, ClassFqn.require("x"), Color.RED)
     }
 
     @Test
@@ -568,8 +568,8 @@ class LiveChromeRefresherTest {
 
         // No throw — the per-window catch converts the RuntimeException
         // into a DEBUG log and moves on.
-        LiveChromeRefresher.refreshByClassName("dummy.FQN", Color.RED)
-        LiveChromeRefresher.clearByClassName("dummy.FQN")
+        LiveChromeRefresher.refreshByClassName(ClassFqn.require("dummy.FQN"), Color.RED)
+        LiveChromeRefresher.clearByClassName(ClassFqn.require("dummy.FQN"))
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
@@ -685,7 +685,7 @@ class ProjectLanguageDetectorTest {
         every { AccentMappingsSettings.getInstance() } returns settings
 
         mockkObject(AccentApplicator)
-        every { AccentApplicator.apply(any()) } returns Unit
+        every { AccentApplicator.apply(any()) } returns true
 
         val project = stubProject("/tmp/refresh-miss-${System.nanoTime()}")
         ProjectLanguageDetector.refreshAccentOnEdt(project, "kotlin")
@@ -713,7 +713,7 @@ class ProjectLanguageDetectorTest {
         mockkObject(AccentResolver)
         every { AccentResolver.resolve(any(), any()) } returns "#FFCC66"
         mockkObject(AccentApplicator)
-        every { AccentApplicator.apply(any()) } returns Unit
+        every { AccentApplicator.apply(any()) } returns true
         val swapService = mockk<dev.ayuislands.settings.mappings.ProjectAccentSwapService>(relaxed = true)
         mockkObject(dev.ayuislands.settings.mappings.ProjectAccentSwapService.Companion)
         every {
@@ -768,7 +768,7 @@ class ProjectLanguageDetectorTest {
         every { AccentMappingsSettings.getInstance() } throws RuntimeException("plugin unload race")
 
         mockkObject(AccentApplicator)
-        every { AccentApplicator.apply(any()) } returns Unit
+        every { AccentApplicator.apply(any()) } returns true
 
         val project = stubProject("/tmp/refresh-settings-boom-${System.nanoTime()}")
 
@@ -797,7 +797,7 @@ class ProjectLanguageDetectorTest {
         every { AyuVariant.detect() } returns null
 
         mockkObject(AccentApplicator)
-        every { AccentApplicator.apply(any()) } returns Unit
+        every { AccentApplicator.apply(any()) } returns true
 
         val project = stubProject("/tmp/refresh-null-variant-${System.nanoTime()}")
         ProjectLanguageDetector.refreshAccentOnEdt(project, "kotlin")
@@ -819,7 +819,7 @@ class ProjectLanguageDetectorTest {
         every { AccentMappingsSettings.getInstance() } returns settings
 
         mockkObject(AccentApplicator)
-        every { AccentApplicator.apply(any()) } returns Unit
+        every { AccentApplicator.apply(any()) } returns true
 
         val project = stubProject("/tmp/refresh-disposed-${System.nanoTime()}")
         every { project.isDisposed } returns true

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
@@ -724,7 +724,7 @@ class ProjectLanguageDetectorTest {
         val project = stubProject("/tmp/refresh-hit-${System.nanoTime()}")
         ProjectLanguageDetector.refreshAccentOnEdt(project, "kotlin")
 
-        verify(exactly = 1) { AccentApplicator.apply("#FFCC66") }
+        verify(exactly = 1) { AccentApplicator.applyFromHexString("#FFCC66") }
         verify(exactly = 1) { swapService.notifyExternalApply("#FFCC66") }
     }
 

--- a/src/test/kotlin/dev/ayuislands/accent/TintIntensityTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/TintIntensityTest.kt
@@ -1,0 +1,36 @@
+package dev.ayuislands.accent
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for [TintIntensity] — the typed wrapper that lifts the
+ * `chromeTintIntensity.coerceIn(MIN, MAX)` read-boundary clamp into the type
+ * system so raw integers can't reach [ChromeTintBlender.blend].
+ */
+class TintIntensityTest {
+    @Test
+    fun `of clamps negative to MIN`() {
+        assertEquals(TintIntensity.MIN, TintIntensity.of(-1).percent)
+        assertEquals(TintIntensity.MIN, TintIntensity.of(-100).percent)
+    }
+
+    @Test
+    fun `of clamps above MAX to MAX`() {
+        assertEquals(TintIntensity.MAX, TintIntensity.of(TintIntensity.MAX + 1).percent)
+        assertEquals(TintIntensity.MAX, TintIntensity.of(100).percent)
+        assertEquals(TintIntensity.MAX, TintIntensity.of(500).percent)
+    }
+
+    @Test
+    fun `of preserves values in-range`() {
+        assertEquals(0, TintIntensity.of(0).percent)
+        assertEquals(25, TintIntensity.of(25).percent)
+        assertEquals(TintIntensity.MAX, TintIntensity.of(TintIntensity.MAX).percent)
+    }
+
+    @Test
+    fun `DEFAULT returns a value with percent=40`() {
+        assertEquals(40, TintIntensity.DEFAULT.percent)
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/accent/elements/AbstractChromeElementTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/AbstractChromeElementTest.kt
@@ -1,0 +1,280 @@
+package dev.ayuislands.accent.elements
+
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
+import dev.ayuislands.accent.AccentElementId
+import dev.ayuislands.accent.ChromeBaseColors
+import dev.ayuislands.accent.ChromeTarget
+import dev.ayuislands.accent.ChromeTintBlender
+import dev.ayuislands.accent.ClassFqn
+import dev.ayuislands.accent.LiveChromeRefresher
+import dev.ayuislands.accent.WcagForeground
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import java.awt.Color
+import javax.swing.UIManager
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+/**
+ * Tests for the Phase 40.3c Refactor 1 [AbstractChromeElement] base class.
+ *
+ * Locks the shared recipe that every chrome element inherits: apply walks
+ * [AbstractChromeElement.backgroundKeys], blends + writes to UIManager, then
+ * picks a WCAG-contrast fg for [AbstractChromeElement.foregroundKeys] and pushes
+ * the tinted sample to [LiveChromeRefresher] via the typed [ChromeTarget] peer
+ * descriptor. Revert nulls every bg + fg key and clears the peer.
+ */
+class AbstractChromeElementTest {
+    private val accent = Color(0xE6, 0xB4, 0x50)
+    private val blended = Color(0x33, 0x44, 0x55)
+    private val contrastFg = Color.WHITE
+    private val stockBase = Color(0x2A, 0x2F, 0x3A)
+
+    private val peerFqn = ClassFqn.require("test.fake.ChromePeer")
+
+    @BeforeTest
+    fun setUp() {
+        mockkStatic(UIManager::class)
+        every { UIManager.put(any<String>(), any()) } returns Unit
+
+        mockkObject(ChromeBaseColors)
+        every { ChromeBaseColors.get(any()) } returns stockBase
+
+        mockkObject(ChromeTintBlender)
+        every { ChromeTintBlender.blend(any(), any<Color>(), any()) } returns blended
+
+        mockkObject(WcagForeground)
+        every { WcagForeground.pickForeground(any(), any()) } returns contrastFg
+
+        mockkObject(LiveChromeRefresher)
+        every { LiveChromeRefresher.refreshByClassName(any(), any()) } returns Unit
+        every { LiveChromeRefresher.clearByClassName(any()) } returns Unit
+        every { LiveChromeRefresher.refreshStatusBar(any()) } returns Unit
+        every { LiveChromeRefresher.clearStatusBar() } returns Unit
+        every {
+            LiveChromeRefresher.refreshByClassNameInsideAncestorClass(any(), any(), any())
+        } returns Unit
+        every {
+            LiveChromeRefresher.clearByClassNameInsideAncestorClass(any(), any())
+        } returns Unit
+
+        val state = AyuIslandsState().apply { chromeTintIntensity = 30 }
+        val settings = mockk<AyuIslandsSettings>(relaxed = true)
+        every { settings.state } returns state
+
+        val application = mockk<Application>(relaxed = true)
+        every { application.getService(AyuIslandsSettings::class.java) } returns settings
+        mockkStatic(ApplicationManager::class)
+        every { ApplicationManager.getApplication() } returns application
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    private class FakeElement(
+        override val backgroundKeys: List<String>,
+        override val foregroundKeys: List<String>,
+        override val peerTarget: ChromeTarget?,
+        override val foregroundTextTarget: WcagForeground.TextTarget = WcagForeground.TextTarget.PRIMARY_TEXT,
+        private val enabled: Boolean = true,
+    ) : AbstractChromeElement() {
+        override val id = AccentElementId.STATUS_BAR
+        override val displayName = "Fake"
+        override val isEnabled: Boolean get() = enabled
+    }
+
+    @Test
+    fun `apply writes tinted bg plus contrast fg and refreshes the class-name peer`() {
+        val element =
+            FakeElement(
+                backgroundKeys = listOf("Fake.background"),
+                foregroundKeys = listOf("Fake.foreground"),
+                peerTarget = ChromeTarget.ByClassName(peerFqn),
+            )
+
+        element.apply(accent)
+
+        verify(exactly = 1) { UIManager.put("Fake.background", blended) }
+        verify(exactly = 1) {
+            WcagForeground.pickForeground(blended, WcagForeground.TextTarget.PRIMARY_TEXT)
+        }
+        verify(exactly = 1) { UIManager.put("Fake.foreground", contrastFg) }
+        verify(exactly = 1) { LiveChromeRefresher.refreshByClassName(peerFqn, blended) }
+    }
+
+    @Test
+    fun `revert nulls every bg + fg key and clears the class-name peer`() {
+        val element =
+            FakeElement(
+                backgroundKeys = listOf("Fake.background"),
+                foregroundKeys = listOf("Fake.foreground"),
+                peerTarget = ChromeTarget.ByClassName(peerFqn),
+            )
+
+        element.revert()
+
+        verify(exactly = 1) { UIManager.put("Fake.background", null) }
+        verify(exactly = 1) { UIManager.put("Fake.foreground", null) }
+        verify(exactly = 1) { LiveChromeRefresher.clearByClassName(peerFqn) }
+    }
+
+    @Test
+    fun `apply short-circuits when isEnabled is false`() {
+        val element =
+            FakeElement(
+                backgroundKeys = listOf("Fake.background"),
+                foregroundKeys = listOf("Fake.foreground"),
+                peerTarget = ChromeTarget.ByClassName(peerFqn),
+                enabled = false,
+            )
+
+        element.apply(accent)
+
+        verify(exactly = 0) { UIManager.put(any<String>(), any()) }
+        verify(exactly = 0) { LiveChromeRefresher.refreshByClassName(any(), any()) }
+    }
+
+    @Test
+    fun `revert ignores isEnabled so keys written before the gate flipped still get cleaned`() {
+        val element =
+            FakeElement(
+                backgroundKeys = listOf("Fake.background"),
+                foregroundKeys = listOf("Fake.foreground"),
+                peerTarget = ChromeTarget.ByClassName(peerFqn),
+                enabled = false,
+            )
+
+        element.revert()
+
+        verify(exactly = 1) { UIManager.put("Fake.background", null) }
+        verify(exactly = 1) { UIManager.put("Fake.foreground", null) }
+        verify(exactly = 1) { LiveChromeRefresher.clearByClassName(peerFqn) }
+    }
+
+    @Test
+    fun `apply with empty foregroundKeys skips WcagForeground entirely`() {
+        val element =
+            FakeElement(
+                backgroundKeys = listOf("Fake.background"),
+                foregroundKeys = emptyList(),
+                peerTarget = ChromeTarget.ByClassName(peerFqn),
+            )
+
+        element.apply(accent)
+
+        verify(exactly = 0) { WcagForeground.pickForeground(any(), any()) }
+        verify(exactly = 1) { UIManager.put("Fake.background", blended) }
+        verify(exactly = 1) { LiveChromeRefresher.refreshByClassName(peerFqn, blended) }
+    }
+
+    @Test
+    fun `apply with null peerTarget skips the live peer refresh`() {
+        val element =
+            FakeElement(
+                backgroundKeys = listOf("Fake.background"),
+                foregroundKeys = emptyList(),
+                peerTarget = null,
+            )
+
+        element.apply(accent)
+
+        verify(exactly = 0) { LiveChromeRefresher.refreshByClassName(any(), any()) }
+        verify(exactly = 0) { LiveChromeRefresher.refreshStatusBar(any()) }
+        verify(exactly = 0) {
+            LiveChromeRefresher.refreshByClassNameInsideAncestorClass(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `apply routes StatusBar peer target through refreshStatusBar`() {
+        val element =
+            FakeElement(
+                backgroundKeys = listOf("Fake.background"),
+                foregroundKeys = emptyList(),
+                peerTarget = ChromeTarget.StatusBar,
+            )
+
+        element.apply(accent)
+
+        verify(exactly = 1) { LiveChromeRefresher.refreshStatusBar(blended) }
+    }
+
+    @Test
+    fun `revert routes StatusBar peer target through clearStatusBar`() {
+        val element =
+            FakeElement(
+                backgroundKeys = listOf("Fake.background"),
+                foregroundKeys = emptyList(),
+                peerTarget = ChromeTarget.StatusBar,
+            )
+
+        element.revert()
+
+        verify(exactly = 1) { LiveChromeRefresher.clearStatusBar() }
+    }
+
+    @Test
+    fun `apply routes ByClassNameInside ancestor target through the ancestor-scoped entry`() {
+        val target = ClassFqn.require("test.fake.Target")
+        val ancestor = ClassFqn.require("test.fake.Ancestor")
+        val element =
+            FakeElement(
+                backgroundKeys = listOf("Fake.background"),
+                foregroundKeys = emptyList(),
+                peerTarget = ChromeTarget.ByClassNameInside(target, ancestor),
+            )
+
+        element.apply(accent)
+
+        verify(exactly = 1) {
+            LiveChromeRefresher.refreshByClassNameInsideAncestorClass(target, ancestor, blended)
+        }
+        verify(exactly = 0) { LiveChromeRefresher.refreshByClassName(any(), any()) }
+    }
+
+    @Test
+    fun `revert routes ByClassNameInside ancestor target through the ancestor-scoped clear`() {
+        val target = ClassFqn.require("test.fake.Target")
+        val ancestor = ClassFqn.require("test.fake.Ancestor")
+        val element =
+            FakeElement(
+                backgroundKeys = listOf("Fake.background"),
+                foregroundKeys = emptyList(),
+                peerTarget = ChromeTarget.ByClassNameInside(target, ancestor),
+            )
+
+        element.revert()
+
+        verify(exactly = 1) {
+            LiveChromeRefresher.clearByClassNameInsideAncestorClass(target, ancestor)
+        }
+        verify(exactly = 0) { LiveChromeRefresher.clearByClassName(any()) }
+    }
+
+    @Test
+    fun `apply skips bg keys ChromeBaseColors cannot resolve but still writes matches`() {
+        val element =
+            FakeElement(
+                backgroundKeys = listOf("Fake.resolvable", "Fake.missing"),
+                foregroundKeys = emptyList(),
+                peerTarget = null,
+            )
+        every { ChromeBaseColors.get("Fake.resolvable") } returns stockBase
+        every { ChromeBaseColors.get("Fake.missing") } returns null
+
+        element.apply(accent)
+
+        verify(exactly = 1) { UIManager.put("Fake.resolvable", blended) }
+        verify(exactly = 0) { UIManager.put("Fake.missing", any()) }
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/accent/elements/AbstractChromeElementTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/AbstractChromeElementTest.kt
@@ -55,16 +55,8 @@ class AbstractChromeElementTest {
         every { WcagForeground.pickForeground(any(), any()) } returns contrastFg
 
         mockkObject(LiveChromeRefresher)
-        every { LiveChromeRefresher.refreshByClassName(any(), any()) } returns Unit
-        every { LiveChromeRefresher.clearByClassName(any()) } returns Unit
-        every { LiveChromeRefresher.refreshStatusBar(any()) } returns Unit
-        every { LiveChromeRefresher.clearStatusBar() } returns Unit
-        every {
-            LiveChromeRefresher.refreshByClassNameInsideAncestorClass(any(), any(), any())
-        } returns Unit
-        every {
-            LiveChromeRefresher.clearByClassNameInsideAncestorClass(any(), any())
-        } returns Unit
+        every { LiveChromeRefresher.refresh(any(), any()) } returns Unit
+        every { LiveChromeRefresher.clear(any()) } returns Unit
 
         val state = AyuIslandsState().apply { chromeTintIntensity = 30 }
         val settings = mockk<AyuIslandsSettings>(relaxed = true)
@@ -109,7 +101,7 @@ class AbstractChromeElementTest {
             WcagForeground.pickForeground(blended, WcagForeground.TextTarget.PRIMARY_TEXT)
         }
         verify(exactly = 1) { UIManager.put("Fake.foreground", contrastFg) }
-        verify(exactly = 1) { LiveChromeRefresher.refreshByClassName(peerFqn, blended) }
+        verify(exactly = 1) { LiveChromeRefresher.refresh(ChromeTarget.ByClassName(peerFqn), blended) }
     }
 
     @Test
@@ -125,7 +117,7 @@ class AbstractChromeElementTest {
 
         verify(exactly = 1) { UIManager.put("Fake.background", null) }
         verify(exactly = 1) { UIManager.put("Fake.foreground", null) }
-        verify(exactly = 1) { LiveChromeRefresher.clearByClassName(peerFqn) }
+        verify(exactly = 1) { LiveChromeRefresher.clear(ChromeTarget.ByClassName(peerFqn)) }
     }
 
     @Test
@@ -141,7 +133,7 @@ class AbstractChromeElementTest {
         element.apply(accent)
 
         verify(exactly = 0) { UIManager.put(any<String>(), any()) }
-        verify(exactly = 0) { LiveChromeRefresher.refreshByClassName(any(), any()) }
+        verify(exactly = 0) { LiveChromeRefresher.refresh(any(), any()) }
     }
 
     @Test
@@ -158,7 +150,7 @@ class AbstractChromeElementTest {
 
         verify(exactly = 1) { UIManager.put("Fake.background", null) }
         verify(exactly = 1) { UIManager.put("Fake.foreground", null) }
-        verify(exactly = 1) { LiveChromeRefresher.clearByClassName(peerFqn) }
+        verify(exactly = 1) { LiveChromeRefresher.clear(ChromeTarget.ByClassName(peerFqn)) }
     }
 
     @Test
@@ -174,7 +166,7 @@ class AbstractChromeElementTest {
 
         verify(exactly = 0) { WcagForeground.pickForeground(any(), any()) }
         verify(exactly = 1) { UIManager.put("Fake.background", blended) }
-        verify(exactly = 1) { LiveChromeRefresher.refreshByClassName(peerFqn, blended) }
+        verify(exactly = 1) { LiveChromeRefresher.refresh(ChromeTarget.ByClassName(peerFqn), blended) }
     }
 
     @Test
@@ -188,15 +180,11 @@ class AbstractChromeElementTest {
 
         element.apply(accent)
 
-        verify(exactly = 0) { LiveChromeRefresher.refreshByClassName(any(), any()) }
-        verify(exactly = 0) { LiveChromeRefresher.refreshStatusBar(any()) }
-        verify(exactly = 0) {
-            LiveChromeRefresher.refreshByClassNameInsideAncestorClass(any(), any(), any())
-        }
+        verify(exactly = 0) { LiveChromeRefresher.refresh(any(), any()) }
     }
 
     @Test
-    fun `apply routes StatusBar peer target through refreshStatusBar`() {
+    fun `apply routes StatusBar peer target through the refresh entry point`() {
         val element =
             FakeElement(
                 backgroundKeys = listOf("Fake.background"),
@@ -206,11 +194,11 @@ class AbstractChromeElementTest {
 
         element.apply(accent)
 
-        verify(exactly = 1) { LiveChromeRefresher.refreshStatusBar(blended) }
+        verify(exactly = 1) { LiveChromeRefresher.refresh(ChromeTarget.StatusBar, blended) }
     }
 
     @Test
-    fun `revert routes StatusBar peer target through clearStatusBar`() {
+    fun `revert routes StatusBar peer target through the clear entry point`() {
         val element =
             FakeElement(
                 backgroundKeys = listOf("Fake.background"),
@@ -220,45 +208,41 @@ class AbstractChromeElementTest {
 
         element.revert()
 
-        verify(exactly = 1) { LiveChromeRefresher.clearStatusBar() }
+        verify(exactly = 1) { LiveChromeRefresher.clear(ChromeTarget.StatusBar) }
     }
 
     @Test
-    fun `apply routes ByClassNameInside ancestor target through the ancestor-scoped entry`() {
+    fun `apply routes ByClassNameInside ancestor target through the refresh entry point`() {
         val target = ClassFqn.require("test.fake.Target")
         val ancestor = ClassFqn.require("test.fake.Ancestor")
+        val peerTarget = ChromeTarget.ByClassNameInside(target, ancestor)
         val element =
             FakeElement(
                 backgroundKeys = listOf("Fake.background"),
                 foregroundKeys = emptyList(),
-                peerTarget = ChromeTarget.ByClassNameInside(target, ancestor),
+                peerTarget = peerTarget,
             )
 
         element.apply(accent)
 
-        verify(exactly = 1) {
-            LiveChromeRefresher.refreshByClassNameInsideAncestorClass(target, ancestor, blended)
-        }
-        verify(exactly = 0) { LiveChromeRefresher.refreshByClassName(any(), any()) }
+        verify(exactly = 1) { LiveChromeRefresher.refresh(peerTarget, blended) }
     }
 
     @Test
-    fun `revert routes ByClassNameInside ancestor target through the ancestor-scoped clear`() {
+    fun `revert routes ByClassNameInside ancestor target through the clear entry point`() {
         val target = ClassFqn.require("test.fake.Target")
         val ancestor = ClassFqn.require("test.fake.Ancestor")
+        val peerTarget = ChromeTarget.ByClassNameInside(target, ancestor)
         val element =
             FakeElement(
                 backgroundKeys = listOf("Fake.background"),
                 foregroundKeys = emptyList(),
-                peerTarget = ChromeTarget.ByClassNameInside(target, ancestor),
+                peerTarget = peerTarget,
             )
 
         element.revert()
 
-        verify(exactly = 1) {
-            LiveChromeRefresher.clearByClassNameInsideAncestorClass(target, ancestor)
-        }
-        verify(exactly = 0) { LiveChromeRefresher.clearByClassName(any()) }
+        verify(exactly = 1) { LiveChromeRefresher.clear(peerTarget) }
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/accent/elements/AbstractChromeElementTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/AbstractChromeElementTest.kt
@@ -215,7 +215,7 @@ class AbstractChromeElementTest {
     fun `apply routes ByClassNameInside ancestor target through the refresh entry point`() {
         val target = ClassFqn.require("test.fake.Target")
         val ancestor = ClassFqn.require("test.fake.Ancestor")
-        val peerTarget = ChromeTarget.ByClassNameInside(target, ancestor)
+        val peerTarget = ChromeTarget.ByClassNameInside(target = target, ancestor = ancestor)
         val element =
             FakeElement(
                 backgroundKeys = listOf("Fake.background"),
@@ -232,7 +232,7 @@ class AbstractChromeElementTest {
     fun `revert routes ByClassNameInside ancestor target through the clear entry point`() {
         val target = ClassFqn.require("test.fake.Target")
         val ancestor = ClassFqn.require("test.fake.Ancestor")
-        val peerTarget = ChromeTarget.ByClassNameInside(target, ancestor)
+        val peerTarget = ChromeTarget.ByClassNameInside(target = target, ancestor = ancestor)
         val element =
             FakeElement(
                 backgroundKeys = listOf("Fake.background"),

--- a/src/test/kotlin/dev/ayuislands/accent/elements/ChromeForegroundWcagMatrixTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/ChromeForegroundWcagMatrixTest.kt
@@ -1,6 +1,7 @@
 package dev.ayuislands.accent.elements
 
 import dev.ayuislands.accent.ChromeTintBlender
+import dev.ayuislands.accent.TintIntensity
 import dev.ayuislands.accent.WcagForeground
 import java.awt.Color
 import kotlin.test.Test
@@ -54,7 +55,7 @@ class ChromeForegroundWcagMatrixTest {
         for (spec in ELEMENT_SPECS) {
             for (accent in PALETTE) {
                 for (intensity in INTENSITIES) {
-                    val tinted = ChromeTintBlender.blend(accent.color, darkBase, intensity)
+                    val tinted = ChromeTintBlender.blend(accent.color, darkBase, TintIntensity.of(intensity))
                     val foreground = WcagForeground.pickForeground(tinted, spec.target)
                     val ratio = WcagForeground.contrastRatio(foreground, tinted)
                     if (ratio < spec.target.minRatio) {

--- a/src/test/kotlin/dev/ayuislands/accent/elements/ChromeLiveRefreshMultiSurfaceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/ChromeLiveRefreshMultiSurfaceTest.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.application.ApplicationManager
 import dev.ayuislands.accent.ChromeBaseColors
 import dev.ayuislands.accent.ChromeDecorationsProbe
 import dev.ayuislands.accent.ChromeTintBlender
+import dev.ayuislands.accent.ClassFqn
 import dev.ayuislands.accent.LiveChromeRefresher
 import dev.ayuislands.accent.WcagForeground
 import dev.ayuislands.settings.AyuIslandsSettings
@@ -96,16 +97,16 @@ class ChromeLiveRefreshMultiSurfaceTest {
         // The remaining four use class-name string match with distinct FQNs.
         verify(exactly = 1) {
             LiveChromeRefresher.refreshByClassName(
-                "com.intellij.platform.navbar.frontend.MyNavBarWrapperPanel",
+                ClassFqn.require("com.intellij.platform.navbar.frontend.MyNavBarWrapperPanel"),
                 blended,
             )
         }
         verify(exactly = 1) {
-            LiveChromeRefresher.refreshByClassName("com.intellij.toolWindow.Stripe", blended)
+            LiveChromeRefresher.refreshByClassName(ClassFqn.require("com.intellij.toolWindow.Stripe"), blended)
         }
         verify(exactly = 1) {
             LiveChromeRefresher.refreshByClassName(
-                "com.intellij.openapi.wm.impl.headertoolbar.MainToolbar",
+                ClassFqn.require("com.intellij.openapi.wm.impl.headertoolbar.MainToolbar"),
                 blended,
             )
         }
@@ -113,13 +114,13 @@ class ChromeLiveRefreshMultiSurfaceTest {
         // over-tinting OnePixelDivider instances outside tool windows.
         verify(exactly = 1) {
             LiveChromeRefresher.refreshByClassNameInsideAncestorClass(
-                "com.intellij.openapi.ui.OnePixelDivider",
-                "com.intellij.toolWindow.InternalDecoratorImpl",
+                ClassFqn.require("com.intellij.openapi.ui.OnePixelDivider"),
+                ClassFqn.require("com.intellij.toolWindow.InternalDecoratorImpl"),
                 blended,
             )
         }
         verify(exactly = 0) {
-            LiveChromeRefresher.refreshByClassName("com.intellij.openapi.ui.OnePixelDivider", any())
+            LiveChromeRefresher.refreshByClassName(ClassFqn.require("com.intellij.openapi.ui.OnePixelDivider"), any())
         }
 
         // No cross-talk: no element should be invoking the clear path during apply.
@@ -138,21 +139,27 @@ class ChromeLiveRefreshMultiSurfaceTest {
 
         verify(exactly = 1) { LiveChromeRefresher.clearStatusBar() }
         verify(exactly = 1) {
-            LiveChromeRefresher.clearByClassName("com.intellij.platform.navbar.frontend.MyNavBarWrapperPanel")
+            LiveChromeRefresher.clearByClassName(
+                ClassFqn.require("com.intellij.platform.navbar.frontend.MyNavBarWrapperPanel"),
+            )
         }
-        verify(exactly = 1) { LiveChromeRefresher.clearByClassName("com.intellij.toolWindow.Stripe") }
         verify(exactly = 1) {
-            LiveChromeRefresher.clearByClassName("com.intellij.openapi.wm.impl.headertoolbar.MainToolbar")
+            LiveChromeRefresher.clearByClassName(ClassFqn.require("com.intellij.toolWindow.Stripe"))
+        }
+        verify(exactly = 1) {
+            LiveChromeRefresher.clearByClassName(
+                ClassFqn.require("com.intellij.openapi.wm.impl.headertoolbar.MainToolbar"),
+            )
         }
         // Round 2 A-1: PanelBorder uses the ancestor-scoped clear for D-14 symmetry.
         verify(exactly = 1) {
             LiveChromeRefresher.clearByClassNameInsideAncestorClass(
-                "com.intellij.openapi.ui.OnePixelDivider",
-                "com.intellij.toolWindow.InternalDecoratorImpl",
+                ClassFqn.require("com.intellij.openapi.ui.OnePixelDivider"),
+                ClassFqn.require("com.intellij.toolWindow.InternalDecoratorImpl"),
             )
         }
         verify(exactly = 0) {
-            LiveChromeRefresher.clearByClassName("com.intellij.openapi.ui.OnePixelDivider")
+            LiveChromeRefresher.clearByClassName(ClassFqn.require("com.intellij.openapi.ui.OnePixelDivider"))
         }
 
         // No cross-talk: revert must not invoke any refresh path.
@@ -183,9 +190,9 @@ class ChromeLiveRefreshMultiSurfaceTest {
         // Three blind class-name pairs (NavBar / Stripe / MainToolbar)
         val blindPeerClasses =
             listOf(
-                "com.intellij.platform.navbar.frontend.MyNavBarWrapperPanel",
-                "com.intellij.toolWindow.Stripe",
-                "com.intellij.openapi.wm.impl.headertoolbar.MainToolbar",
+                ClassFqn.require("com.intellij.platform.navbar.frontend.MyNavBarWrapperPanel"),
+                ClassFqn.require("com.intellij.toolWindow.Stripe"),
+                ClassFqn.require("com.intellij.openapi.wm.impl.headertoolbar.MainToolbar"),
             )
         for (fqn in blindPeerClasses) {
             verify(exactly = 1) { LiveChromeRefresher.refreshByClassName(fqn, blended) }
@@ -195,15 +202,15 @@ class ChromeLiveRefreshMultiSurfaceTest {
         // PanelBorder pair — ancestor-scoped (Round 2 A-1)
         verify(exactly = 1) {
             LiveChromeRefresher.refreshByClassNameInsideAncestorClass(
-                "com.intellij.openapi.ui.OnePixelDivider",
-                "com.intellij.toolWindow.InternalDecoratorImpl",
+                ClassFqn.require("com.intellij.openapi.ui.OnePixelDivider"),
+                ClassFqn.require("com.intellij.toolWindow.InternalDecoratorImpl"),
                 blended,
             )
         }
         verify(exactly = 1) {
             LiveChromeRefresher.clearByClassNameInsideAncestorClass(
-                "com.intellij.openapi.ui.OnePixelDivider",
-                "com.intellij.toolWindow.InternalDecoratorImpl",
+                ClassFqn.require("com.intellij.openapi.ui.OnePixelDivider"),
+                ClassFqn.require("com.intellij.toolWindow.InternalDecoratorImpl"),
             )
         }
     }
@@ -222,16 +229,16 @@ class ChromeLiveRefreshMultiSurfaceTest {
         verify(exactly = 1) { LiveChromeRefresher.refreshStatusBar(blended) }
         verify(exactly = 1) {
             LiveChromeRefresher.refreshByClassName(
-                "com.intellij.platform.navbar.frontend.MyNavBarWrapperPanel",
+                ClassFqn.require("com.intellij.platform.navbar.frontend.MyNavBarWrapperPanel"),
                 blended,
             )
         }
         verify(exactly = 1) {
-            LiveChromeRefresher.refreshByClassName("com.intellij.toolWindow.Stripe", blended)
+            LiveChromeRefresher.refreshByClassName(ClassFqn.require("com.intellij.toolWindow.Stripe"), blended)
         }
         verify(exactly = 0) {
             LiveChromeRefresher.refreshByClassName(
-                "com.intellij.openapi.wm.impl.headertoolbar.MainToolbar",
+                ClassFqn.require("com.intellij.openapi.wm.impl.headertoolbar.MainToolbar"),
                 any(),
             )
         }
@@ -239,8 +246,8 @@ class ChromeLiveRefreshMultiSurfaceTest {
         // short-circuits MainToolbar only, not sibling peers.
         verify(exactly = 1) {
             LiveChromeRefresher.refreshByClassNameInsideAncestorClass(
-                "com.intellij.openapi.ui.OnePixelDivider",
-                "com.intellij.toolWindow.InternalDecoratorImpl",
+                ClassFqn.require("com.intellij.openapi.ui.OnePixelDivider"),
+                ClassFqn.require("com.intellij.toolWindow.InternalDecoratorImpl"),
                 blended,
             )
         }

--- a/src/test/kotlin/dev/ayuislands/accent/elements/ChromeLiveRefreshMultiSurfaceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/ChromeLiveRefreshMultiSurfaceTest.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import dev.ayuislands.accent.ChromeBaseColors
 import dev.ayuislands.accent.ChromeDecorationsProbe
+import dev.ayuislands.accent.ChromeTarget
 import dev.ayuislands.accent.ChromeTintBlender
 import dev.ayuislands.accent.ClassFqn
 import dev.ayuislands.accent.LiveChromeRefresher
@@ -58,16 +59,8 @@ class ChromeLiveRefreshMultiSurfaceTest {
         every { ChromeDecorationsProbe.isCustomHeaderActive() } returns true
 
         mockkObject(LiveChromeRefresher)
-        every { LiveChromeRefresher.refreshStatusBar(any()) } returns Unit
-        every { LiveChromeRefresher.clearStatusBar() } returns Unit
-        every { LiveChromeRefresher.refreshByClassName(any(), any()) } returns Unit
-        every { LiveChromeRefresher.clearByClassName(any()) } returns Unit
-        every {
-            LiveChromeRefresher.refreshByClassNameInsideAncestorClass(any(), any(), any())
-        } returns Unit
-        every {
-            LiveChromeRefresher.clearByClassNameInsideAncestorClass(any(), any())
-        } returns Unit
+        every { LiveChromeRefresher.refresh(any(), any()) } returns Unit
+        every { LiveChromeRefresher.clear(any()) } returns Unit
 
         mockState = AyuIslandsState().apply { chromeTintIntensity = 40 }
         mockSettings = mockk(relaxed = true)
@@ -84,6 +77,17 @@ class ChromeLiveRefreshMultiSurfaceTest {
         unmockkAll()
     }
 
+    private val navBarTarget =
+        ChromeTarget.ByClassName(ClassFqn.require("com.intellij.platform.navbar.frontend.MyNavBarWrapperPanel"))
+    private val stripeTarget = ChromeTarget.ByClassName(ClassFqn.require("com.intellij.toolWindow.Stripe"))
+    private val mainToolbarTarget =
+        ChromeTarget.ByClassName(ClassFqn.require("com.intellij.openapi.wm.impl.headertoolbar.MainToolbar"))
+    private val panelBorderTarget =
+        ChromeTarget.ByClassNameInside(
+            target = ClassFqn.require("com.intellij.openapi.ui.OnePixelDivider"),
+            ancestor = ClassFqn.require("com.intellij.toolWindow.InternalDecoratorImpl"),
+        )
+
     @Test
     fun `applying all five chrome elements routes each peer refresh exactly once`() {
         StatusBarElement().apply(testAccent)
@@ -92,41 +96,22 @@ class ChromeLiveRefreshMultiSurfaceTest {
         MainToolbarElement().apply(testAccent)
         PanelBorderElement().apply(testAccent)
 
-        // StatusBar uses its own public-API path (not class-name).
-        verify(exactly = 1) { LiveChromeRefresher.refreshStatusBar(blended) }
-        // The remaining four use class-name string match with distinct FQNs.
-        verify(exactly = 1) {
-            LiveChromeRefresher.refreshByClassName(
-                ClassFqn.require("com.intellij.platform.navbar.frontend.MyNavBarWrapperPanel"),
-                blended,
-            )
-        }
-        verify(exactly = 1) {
-            LiveChromeRefresher.refreshByClassName(ClassFqn.require("com.intellij.toolWindow.Stripe"), blended)
-        }
-        verify(exactly = 1) {
-            LiveChromeRefresher.refreshByClassName(
-                ClassFqn.require("com.intellij.openapi.wm.impl.headertoolbar.MainToolbar"),
-                blended,
-            )
-        }
-        // Round 2 A-1: PanelBorder now uses the ancestor-scoped variant to avoid
+        verify(exactly = 1) { LiveChromeRefresher.refresh(ChromeTarget.StatusBar, blended) }
+        verify(exactly = 1) { LiveChromeRefresher.refresh(navBarTarget, blended) }
+        verify(exactly = 1) { LiveChromeRefresher.refresh(stripeTarget, blended) }
+        verify(exactly = 1) { LiveChromeRefresher.refresh(mainToolbarTarget, blended) }
+        // Round 2 A-1: PanelBorder uses the ancestor-scoped variant to avoid
         // over-tinting OnePixelDivider instances outside tool windows.
-        verify(exactly = 1) {
-            LiveChromeRefresher.refreshByClassNameInsideAncestorClass(
-                ClassFqn.require("com.intellij.openapi.ui.OnePixelDivider"),
-                ClassFqn.require("com.intellij.toolWindow.InternalDecoratorImpl"),
-                blended,
+        verify(exactly = 1) { LiveChromeRefresher.refresh(panelBorderTarget, blended) }
+        // Guard: PanelBorder must NOT use the blind ByClassName target.
+        verify(exactly = 0) {
+            LiveChromeRefresher.refresh(
+                ChromeTarget.ByClassName(ClassFqn.require("com.intellij.openapi.ui.OnePixelDivider")),
+                any(),
             )
         }
-        verify(exactly = 0) {
-            LiveChromeRefresher.refreshByClassName(ClassFqn.require("com.intellij.openapi.ui.OnePixelDivider"), any())
-        }
-
-        // No cross-talk: no element should be invoking the clear path during apply.
-        verify(exactly = 0) { LiveChromeRefresher.clearStatusBar() }
-        verify(exactly = 0) { LiveChromeRefresher.clearByClassName(any()) }
-        verify(exactly = 0) { LiveChromeRefresher.clearByClassNameInsideAncestorClass(any(), any()) }
+        // No cross-talk: no element should be invoking clear during apply.
+        verify(exactly = 0) { LiveChromeRefresher.clear(any()) }
     }
 
     @Test
@@ -137,37 +122,17 @@ class ChromeLiveRefreshMultiSurfaceTest {
         MainToolbarElement().revert()
         PanelBorderElement().revert()
 
-        verify(exactly = 1) { LiveChromeRefresher.clearStatusBar() }
-        verify(exactly = 1) {
-            LiveChromeRefresher.clearByClassName(
-                ClassFqn.require("com.intellij.platform.navbar.frontend.MyNavBarWrapperPanel"),
-            )
-        }
-        verify(exactly = 1) {
-            LiveChromeRefresher.clearByClassName(ClassFqn.require("com.intellij.toolWindow.Stripe"))
-        }
-        verify(exactly = 1) {
-            LiveChromeRefresher.clearByClassName(
-                ClassFqn.require("com.intellij.openapi.wm.impl.headertoolbar.MainToolbar"),
-            )
-        }
-        // Round 2 A-1: PanelBorder uses the ancestor-scoped clear for D-14 symmetry.
-        verify(exactly = 1) {
-            LiveChromeRefresher.clearByClassNameInsideAncestorClass(
-                ClassFqn.require("com.intellij.openapi.ui.OnePixelDivider"),
-                ClassFqn.require("com.intellij.toolWindow.InternalDecoratorImpl"),
-            )
-        }
+        verify(exactly = 1) { LiveChromeRefresher.clear(ChromeTarget.StatusBar) }
+        verify(exactly = 1) { LiveChromeRefresher.clear(navBarTarget) }
+        verify(exactly = 1) { LiveChromeRefresher.clear(stripeTarget) }
+        verify(exactly = 1) { LiveChromeRefresher.clear(mainToolbarTarget) }
+        verify(exactly = 1) { LiveChromeRefresher.clear(panelBorderTarget) }
         verify(exactly = 0) {
-            LiveChromeRefresher.clearByClassName(ClassFqn.require("com.intellij.openapi.ui.OnePixelDivider"))
+            LiveChromeRefresher.clear(
+                ChromeTarget.ByClassName(ClassFqn.require("com.intellij.openapi.ui.OnePixelDivider")),
+            )
         }
-
-        // No cross-talk: revert must not invoke any refresh path.
-        verify(exactly = 0) { LiveChromeRefresher.refreshStatusBar(any()) }
-        verify(exactly = 0) { LiveChromeRefresher.refreshByClassName(any(), any()) }
-        verify(exactly = 0) {
-            LiveChromeRefresher.refreshByClassNameInsideAncestorClass(any(), any(), any())
-        }
+        verify(exactly = 0) { LiveChromeRefresher.refresh(any(), any()) }
     }
 
     @Test
@@ -183,35 +148,11 @@ class ChromeLiveRefreshMultiSurfaceTest {
         elements.forEach { it.apply(testAccent) }
         elements.forEach { it.revert() }
 
-        // StatusBar pair
-        verify(exactly = 1) { LiveChromeRefresher.refreshStatusBar(blended) }
-        verify(exactly = 1) { LiveChromeRefresher.clearStatusBar() }
-
-        // Three blind class-name pairs (NavBar / Stripe / MainToolbar)
-        val blindPeerClasses =
-            listOf(
-                ClassFqn.require("com.intellij.platform.navbar.frontend.MyNavBarWrapperPanel"),
-                ClassFqn.require("com.intellij.toolWindow.Stripe"),
-                ClassFqn.require("com.intellij.openapi.wm.impl.headertoolbar.MainToolbar"),
-            )
-        for (fqn in blindPeerClasses) {
-            verify(exactly = 1) { LiveChromeRefresher.refreshByClassName(fqn, blended) }
-            verify(exactly = 1) { LiveChromeRefresher.clearByClassName(fqn) }
-        }
-
-        // PanelBorder pair — ancestor-scoped (Round 2 A-1)
-        verify(exactly = 1) {
-            LiveChromeRefresher.refreshByClassNameInsideAncestorClass(
-                ClassFqn.require("com.intellij.openapi.ui.OnePixelDivider"),
-                ClassFqn.require("com.intellij.toolWindow.InternalDecoratorImpl"),
-                blended,
-            )
-        }
-        verify(exactly = 1) {
-            LiveChromeRefresher.clearByClassNameInsideAncestorClass(
-                ClassFqn.require("com.intellij.openapi.ui.OnePixelDivider"),
-                ClassFqn.require("com.intellij.toolWindow.InternalDecoratorImpl"),
-            )
+        val targets =
+            listOf(ChromeTarget.StatusBar, navBarTarget, stripeTarget, mainToolbarTarget, panelBorderTarget)
+        for (target in targets) {
+            verify(exactly = 1) { LiveChromeRefresher.refresh(target, blended) }
+            verify(exactly = 1) { LiveChromeRefresher.clear(target) }
         }
     }
 
@@ -226,30 +167,12 @@ class ChromeLiveRefreshMultiSurfaceTest {
         PanelBorderElement().apply(testAccent)
 
         // MainToolbar short-circuits — all other peers still refresh.
-        verify(exactly = 1) { LiveChromeRefresher.refreshStatusBar(blended) }
-        verify(exactly = 1) {
-            LiveChromeRefresher.refreshByClassName(
-                ClassFqn.require("com.intellij.platform.navbar.frontend.MyNavBarWrapperPanel"),
-                blended,
-            )
-        }
-        verify(exactly = 1) {
-            LiveChromeRefresher.refreshByClassName(ClassFqn.require("com.intellij.toolWindow.Stripe"), blended)
-        }
-        verify(exactly = 0) {
-            LiveChromeRefresher.refreshByClassName(
-                ClassFqn.require("com.intellij.openapi.wm.impl.headertoolbar.MainToolbar"),
-                any(),
-            )
-        }
+        verify(exactly = 1) { LiveChromeRefresher.refresh(ChromeTarget.StatusBar, blended) }
+        verify(exactly = 1) { LiveChromeRefresher.refresh(navBarTarget, blended) }
+        verify(exactly = 1) { LiveChromeRefresher.refresh(stripeTarget, blended) }
+        verify(exactly = 0) { LiveChromeRefresher.refresh(mainToolbarTarget, any()) }
         // PanelBorder ancestor-scoped refresh still fires (Round 2 A-1) — MainToolbar gate
         // short-circuits MainToolbar only, not sibling peers.
-        verify(exactly = 1) {
-            LiveChromeRefresher.refreshByClassNameInsideAncestorClass(
-                ClassFqn.require("com.intellij.openapi.ui.OnePixelDivider"),
-                ClassFqn.require("com.intellij.toolWindow.InternalDecoratorImpl"),
-                blended,
-            )
-        }
+        verify(exactly = 1) { LiveChromeRefresher.refresh(panelBorderTarget, blended) }
     }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/elements/ChromeLiveRefreshSymmetryTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/ChromeLiveRefreshSymmetryTest.kt
@@ -54,33 +54,18 @@ class ChromeLiveRefreshSymmetryTest {
     }
 
     @Test
-    fun `base AbstractChromeElement wires refresh and clear for every ChromeTarget variant`() {
+    fun `base AbstractChromeElement wires both refresh and clear via the typed LiveChromeRefresher API`() {
         val source = readAbstractBaseStripped()
-        val refreshRoutes =
-            listOf(
-                "LiveChromeRefresher.refreshStatusBar",
-                "LiveChromeRefresher.refreshByClassName",
-                "LiveChromeRefresher.refreshByClassNameInsideAncestorClass",
-            )
-        val clearRoutes =
-            listOf(
-                "LiveChromeRefresher.clearStatusBar",
-                "LiveChromeRefresher.clearByClassName",
-                "LiveChromeRefresher.clearByClassNameInsideAncestorClass",
-            )
-        for (entry in refreshRoutes) {
-            assertTrue(
-                source.contains(entry),
-                "AbstractChromeElement must wire $entry for its matching ChromeTarget variant.",
-            )
-        }
-        for (entry in clearRoutes) {
-            assertTrue(
-                source.contains(entry),
-                "AbstractChromeElement must wire $entry for D-14 symmetry on its matching " +
-                    "ChromeTarget variant.",
-            )
-        }
+        assertTrue(
+            source.contains("LiveChromeRefresher.refresh("),
+            "AbstractChromeElement must call LiveChromeRefresher.refresh(target, color) so " +
+                "apply can reach the live peer (Gap 4).",
+        )
+        assertTrue(
+            source.contains("LiveChromeRefresher.clear("),
+            "AbstractChromeElement must call LiveChromeRefresher.clear(target) so revert " +
+                "hands the peer back to the LAF default (D-14 symmetry).",
+        )
     }
 
     @Test
@@ -125,12 +110,14 @@ class ChromeLiveRefreshSymmetryTest {
     }
 
     private fun refreshCallCount(source: String): Int {
-        val pattern = Regex("""LiveChromeRefresher\.refresh[A-Za-z]+""")
+        // Match both the Refactor 2 typed entry (`refresh(`) and any legacy variant
+        // with a method-name suffix (`refreshStatusBar(`, `refreshByClassName(`).
+        val pattern = Regex("""LiveChromeRefresher\.refresh[A-Za-z]*\(""")
         return pattern.findAll(source).count()
     }
 
     private fun clearCallCount(source: String): Int {
-        val pattern = Regex("""LiveChromeRefresher\.clear[A-Za-z]+""")
+        val pattern = Regex("""LiveChromeRefresher\.clear[A-Za-z]*\(""")
         return pattern.findAll(source).count()
     }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/elements/ChromeLiveRefreshSymmetryTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/ChromeLiveRefreshSymmetryTest.kt
@@ -8,17 +8,23 @@ import kotlin.test.assertTrue
 import kotlin.test.fail
 
 /**
- * D-14 symmetry gate — locks the invariant that every chrome element file wires
- * BOTH a [dev.ayuislands.accent.LiveChromeRefresher] refresh call (in `apply`) AND
- * a matching clear call (in `revert`).
+ * D-14 symmetry gate — locks the invariant that every chrome element has a
+ * declared [dev.ayuislands.accent.ChromeTarget] `peerTarget`, and that the
+ * base [AbstractChromeElement] dispatches both refresh (in `apply`) and clear
+ * (in `revert`) for every ChromeTarget variant.
  *
- * Reads element source files as text and asserts the ratio refresh-to-clear. A
- * file with a refresh but no clear is a D-14 violation (stale explicit background
- * lingers on the peer after revert; user cannot turn off chrome tinting without
- * an IDE restart).
+ * Phase 40.3c Refactor 1 moved the per-element `LiveChromeRefresher.refresh*` /
+ * `clear*` calls into [AbstractChromeElement] — the subclasses now declare
+ * `peerTarget` and the base handles both sides of the symmetry. The invariant
+ * therefore splits in two:
  *
- * Comments are stripped so KDoc that documents the pattern doesn't false-pass a
- * regression where the actual call site was deleted.
+ *   1. Each element subclass declares a non-null `peerTarget` (else its peer
+ *      would never be mutated on apply, a Gap-4 regression).
+ *   2. The base class wires refresh + clear for every ChromeTarget variant
+ *      (StatusBar, ByClassName, ByClassNameInside) — a missing arm would leak
+ *      an explicit background color on the peer.
+ *
+ * Comments are stripped so KDoc that documents the pattern doesn't false-pass.
  */
 class ChromeLiveRefreshSymmetryTest {
     private val elementFiles =
@@ -31,45 +37,63 @@ class ChromeLiveRefreshSymmetryTest {
         )
 
     @Test
-    fun `every chrome element has at least one LiveChromeRefresher refresh invocation`() {
+    fun `every chrome element declares a ChromeTarget peerTarget`() {
         for (name in elementFiles) {
             val source = readStripped(name)
-            val refreshCount = refreshCallCount(source)
             assertTrue(
-                refreshCount >= 1,
-                "$name must wire at least one LiveChromeRefresher.refresh* call " +
-                    "in apply() (Gap 4). Found: $refreshCount",
+                Regex("""override\s+val\s+peerTarget""").containsMatchIn(source),
+                "$name must override `peerTarget` so the base class (AbstractChromeElement) " +
+                    "can dispatch the live peer refresh (Gap 4).",
+            )
+            assertTrue(
+                source.contains("ChromeTarget."),
+                "$name must reference a ChromeTarget variant (StatusBar / ByClassName / " +
+                    "ByClassNameInside) in its peerTarget declaration.",
             )
         }
     }
 
     @Test
-    fun `every chrome element has at least one LiveChromeRefresher clear invocation`() {
-        for (name in elementFiles) {
-            val source = readStripped(name)
-            val clearCount = clearCallCount(source)
+    fun `base AbstractChromeElement wires refresh and clear for every ChromeTarget variant`() {
+        val source = readAbstractBaseStripped()
+        val refreshRoutes =
+            listOf(
+                "LiveChromeRefresher.refreshStatusBar",
+                "LiveChromeRefresher.refreshByClassName",
+                "LiveChromeRefresher.refreshByClassNameInsideAncestorClass",
+            )
+        val clearRoutes =
+            listOf(
+                "LiveChromeRefresher.clearStatusBar",
+                "LiveChromeRefresher.clearByClassName",
+                "LiveChromeRefresher.clearByClassNameInsideAncestorClass",
+            )
+        for (entry in refreshRoutes) {
             assertTrue(
-                clearCount >= 1,
-                "$name must wire at least one LiveChromeRefresher.clear* call " +
-                    "in revert() (D-14 symmetry). Found: $clearCount",
+                source.contains(entry),
+                "AbstractChromeElement must wire $entry for its matching ChromeTarget variant.",
+            )
+        }
+        for (entry in clearRoutes) {
+            assertTrue(
+                source.contains(entry),
+                "AbstractChromeElement must wire $entry for D-14 symmetry on its matching " +
+                    "ChromeTarget variant.",
             )
         }
     }
 
     @Test
-    fun `every refresh invocation is paired with a matching clear in the same file`() {
-        for (name in elementFiles) {
-            val source = readStripped(name)
-            val refreshCount = refreshCallCount(source)
-            val clearCount = clearCallCount(source)
-            if (refreshCount != clearCount) {
-                fail(
-                    "$name has asymmetric LiveChromeRefresher wiring — " +
-                        "refresh=$refreshCount clear=$clearCount. " +
-                        "D-14 requires every refresh to have a matching clear so revert " +
-                        "hands the peer back to the LAF default.",
-                )
-            }
+    fun `base AbstractChromeElement refresh and clear routes are balanced`() {
+        val source = readAbstractBaseStripped()
+        val refreshCount = refreshCallCount(source)
+        val clearCount = clearCallCount(source)
+        if (refreshCount != clearCount) {
+            fail(
+                "AbstractChromeElement has asymmetric LiveChromeRefresher wiring — " +
+                    "refresh=$refreshCount clear=$clearCount. D-14 requires every refresh " +
+                    "to have a matching clear so revert hands the peer back to the LAF default.",
+            )
         }
     }
 
@@ -88,6 +112,8 @@ class ChromeLiveRefreshSymmetryTest {
             )
         return stripComments(Files.readString(path))
     }
+
+    private fun readAbstractBaseStripped(): String = readStripped("AbstractChromeElement")
 
     /** Strips `/* ... */` and `// ...` so KDoc mentioning banned/expected patterns can't swing the count. */
     private fun stripComments(input: String): String {

--- a/src/test/kotlin/dev/ayuislands/accent/elements/MainToolbarElementTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/MainToolbarElementTest.kt
@@ -8,6 +8,7 @@ import dev.ayuislands.accent.ChromeDecorationsProbe
 import dev.ayuislands.accent.ChromeTintBlender
 import dev.ayuislands.accent.ClassFqn
 import dev.ayuislands.accent.LiveChromeRefresher
+import dev.ayuislands.accent.TintIntensity
 import dev.ayuislands.accent.WcagForeground
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
@@ -173,7 +174,7 @@ class MainToolbarElementTest {
 
         MainToolbarElement().apply(testAccent)
 
-        verify(exactly = 1) { ChromeTintBlender.blend(testAccent, stockBase, 45) }
+        verify(exactly = 1) { ChromeTintBlender.blend(testAccent, stockBase, TintIntensity.of(45)) }
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/accent/elements/MainToolbarElementTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/MainToolbarElementTest.kt
@@ -6,6 +6,7 @@ import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.ChromeBaseColors
 import dev.ayuislands.accent.ChromeDecorationsProbe
 import dev.ayuislands.accent.ChromeTintBlender
+import dev.ayuislands.accent.ClassFqn
 import dev.ayuislands.accent.LiveChromeRefresher
 import dev.ayuislands.accent.WcagForeground
 import dev.ayuislands.settings.AyuIslandsSettings
@@ -184,7 +185,7 @@ class MainToolbarElementTest {
 
         verify(exactly = 1) {
             LiveChromeRefresher.refreshByClassName(
-                "com.intellij.openapi.wm.impl.headertoolbar.MainToolbar",
+                ClassFqn.require("com.intellij.openapi.wm.impl.headertoolbar.MainToolbar"),
                 blended,
             )
         }
@@ -208,7 +209,9 @@ class MainToolbarElementTest {
         MainToolbarElement().revert()
 
         verify(exactly = 1) {
-            LiveChromeRefresher.clearByClassName("com.intellij.openapi.wm.impl.headertoolbar.MainToolbar")
+            LiveChromeRefresher.clearByClassName(
+                ClassFqn.require("com.intellij.openapi.wm.impl.headertoolbar.MainToolbar"),
+            )
         }
     }
 

--- a/src/test/kotlin/dev/ayuislands/accent/elements/MainToolbarElementTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/MainToolbarElementTest.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.application.ApplicationManager
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.ChromeBaseColors
 import dev.ayuislands.accent.ChromeDecorationsProbe
+import dev.ayuislands.accent.ChromeTarget
 import dev.ayuislands.accent.ChromeTintBlender
 import dev.ayuislands.accent.ClassFqn
 import dev.ayuislands.accent.LiveChromeRefresher
@@ -77,8 +78,8 @@ class MainToolbarElementTest {
         every { ChromeDecorationsProbe.isCustomHeaderActive() } returns true
 
         mockkObject(LiveChromeRefresher)
-        every { LiveChromeRefresher.refreshByClassName(any(), any()) } returns Unit
-        every { LiveChromeRefresher.clearByClassName(any()) } returns Unit
+        every { LiveChromeRefresher.refresh(any(), any()) } returns Unit
+        every { LiveChromeRefresher.clear(any()) } returns Unit
 
         mockState = AyuIslandsState()
         mockSettings = mockk(relaxed = true)
@@ -178,19 +179,18 @@ class MainToolbarElementTest {
     }
 
     @Test
-    fun `apply invokes LiveChromeRefresher refreshByClassName for MainToolbar peer when probe active (Gap 4)`() {
+    fun `apply invokes LiveChromeRefresher for MainToolbar peer when probe active (Gap 4)`() {
         every { ChromeDecorationsProbe.isCustomHeaderActive() } returns true
         mockState.chromeTintIntensity = 30
 
         MainToolbarElement().apply(testAccent)
 
-        verify(exactly = 1) {
-            LiveChromeRefresher.refreshByClassName(
+        val expectedTarget =
+            ChromeTarget.ByClassName(
                 ClassFqn.require("com.intellij.openapi.wm.impl.headertoolbar.MainToolbar"),
-                blended,
             )
-        }
-        verify(exactly = 0) { LiveChromeRefresher.clearByClassName(any()) }
+        verify(exactly = 1) { LiveChromeRefresher.refresh(expectedTarget, blended) }
+        verify(exactly = 0) { LiveChromeRefresher.clear(any()) }
     }
 
     @Test
@@ -200,20 +200,20 @@ class MainToolbarElementTest {
 
         MainToolbarElement().apply(testAccent)
 
-        verify(exactly = 0) { LiveChromeRefresher.refreshByClassName(any(), any()) }
+        verify(exactly = 0) { LiveChromeRefresher.refresh(any(), any()) }
     }
 
     @Test
-    fun `revert invokes LiveChromeRefresher clearByClassName unconditionally (D-14 symmetry)`() {
+    fun `revert invokes LiveChromeRefresher clear unconditionally (D-14 symmetry)`() {
         every { ChromeDecorationsProbe.isCustomHeaderActive() } returns false
 
         MainToolbarElement().revert()
 
-        verify(exactly = 1) {
-            LiveChromeRefresher.clearByClassName(
+        val expectedTarget =
+            ChromeTarget.ByClassName(
                 ClassFqn.require("com.intellij.openapi.wm.impl.headertoolbar.MainToolbar"),
             )
-        }
+        verify(exactly = 1) { LiveChromeRefresher.clear(expectedTarget) }
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/accent/elements/NavBarElementTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/NavBarElementTest.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.ChromeBaseColors
+import dev.ayuislands.accent.ChromeTarget
 import dev.ayuislands.accent.ChromeTintBlender
 import dev.ayuislands.accent.ClassFqn
 import dev.ayuislands.accent.LiveChromeRefresher
@@ -67,8 +68,8 @@ class NavBarElementTest {
         every { WcagForeground.pickForeground(any(), any()) } returns contrastFg
 
         mockkObject(LiveChromeRefresher)
-        every { LiveChromeRefresher.refreshByClassName(any(), any()) } returns Unit
-        every { LiveChromeRefresher.clearByClassName(any()) } returns Unit
+        every { LiveChromeRefresher.refresh(any(), any()) } returns Unit
+        every { LiveChromeRefresher.clear(any()) } returns Unit
     }
 
     @AfterTest
@@ -165,29 +166,28 @@ class NavBarElementTest {
     }
 
     @Test
-    fun `apply invokes LiveChromeRefresher refreshByClassName for navbar peer (Gap 4)`() {
+    fun `apply invokes LiveChromeRefresher for navbar peer (Gap 4)`() {
         state.chromeTintIntensity = 40
 
         NavBarElement().apply(accent)
 
-        verify(exactly = 1) {
-            LiveChromeRefresher.refreshByClassName(
+        val expectedTarget =
+            ChromeTarget.ByClassName(
                 ClassFqn.require("com.intellij.platform.navbar.frontend.MyNavBarWrapperPanel"),
-                blended,
             )
-        }
-        verify(exactly = 0) { LiveChromeRefresher.clearByClassName(any()) }
+        verify(exactly = 1) { LiveChromeRefresher.refresh(expectedTarget, blended) }
+        verify(exactly = 0) { LiveChromeRefresher.clear(any()) }
     }
 
     @Test
-    fun `revert invokes LiveChromeRefresher clearByClassName for navbar peer (D-14 symmetry)`() {
+    fun `revert invokes LiveChromeRefresher clear for navbar peer (D-14 symmetry)`() {
         NavBarElement().revert()
 
-        verify(exactly = 1) {
-            LiveChromeRefresher.clearByClassName(
+        val expectedTarget =
+            ChromeTarget.ByClassName(
                 ClassFqn.require("com.intellij.platform.navbar.frontend.MyNavBarWrapperPanel"),
             )
-        }
-        verify(exactly = 0) { LiveChromeRefresher.refreshByClassName(any(), any()) }
+        verify(exactly = 1) { LiveChromeRefresher.clear(expectedTarget) }
+        verify(exactly = 0) { LiveChromeRefresher.refresh(any(), any()) }
     }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/elements/NavBarElementTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/NavBarElementTest.kt
@@ -7,6 +7,7 @@ import dev.ayuislands.accent.ChromeBaseColors
 import dev.ayuislands.accent.ChromeTintBlender
 import dev.ayuislands.accent.ClassFqn
 import dev.ayuislands.accent.LiveChromeRefresher
+import dev.ayuislands.accent.TintIntensity
 import dev.ayuislands.accent.WcagForeground
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
@@ -110,7 +111,7 @@ class NavBarElementTest {
     fun `apply passes intensity from state to blender per D-03`() {
         state.chromeTintIntensity = 42
 
-        val intensitySlot = slot<Int>()
+        val intensitySlot = slot<TintIntensity>()
         every {
             ChromeTintBlender.blend(any<Color>(), any<Color>(), capture(intensitySlot))
         } returns blended
@@ -118,7 +119,7 @@ class NavBarElementTest {
         NavBarElement().apply(accent)
 
         assertTrue(intensitySlot.isCaptured, "intensity must flow from state into blender")
-        assertEquals(42, intensitySlot.captured)
+        assertEquals(42, intensitySlot.captured.percent)
     }
 
     @Test
@@ -128,7 +129,7 @@ class NavBarElementTest {
         NavBarElement().apply(accent)
 
         // Called once per background key — 2 keys, both resolve to the same stubbed stockBase.
-        verify(exactly = 2) { ChromeTintBlender.blend(accent, stockBase, 50) }
+        verify(exactly = 2) { ChromeTintBlender.blend(accent, stockBase, TintIntensity.of(50)) }
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/accent/elements/NavBarElementTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/NavBarElementTest.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.application.ApplicationManager
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.ChromeBaseColors
 import dev.ayuislands.accent.ChromeTintBlender
+import dev.ayuislands.accent.ClassFqn
 import dev.ayuislands.accent.LiveChromeRefresher
 import dev.ayuislands.accent.WcagForeground
 import dev.ayuislands.settings.AyuIslandsSettings
@@ -170,7 +171,7 @@ class NavBarElementTest {
 
         verify(exactly = 1) {
             LiveChromeRefresher.refreshByClassName(
-                "com.intellij.platform.navbar.frontend.MyNavBarWrapperPanel",
+                ClassFqn.require("com.intellij.platform.navbar.frontend.MyNavBarWrapperPanel"),
                 blended,
             )
         }
@@ -182,7 +183,9 @@ class NavBarElementTest {
         NavBarElement().revert()
 
         verify(exactly = 1) {
-            LiveChromeRefresher.clearByClassName("com.intellij.platform.navbar.frontend.MyNavBarWrapperPanel")
+            LiveChromeRefresher.clearByClassName(
+                ClassFqn.require("com.intellij.platform.navbar.frontend.MyNavBarWrapperPanel"),
+            )
         }
         verify(exactly = 0) { LiveChromeRefresher.refreshByClassName(any(), any()) }
     }

--- a/src/test/kotlin/dev/ayuislands/accent/elements/PanelBorderElementTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/PanelBorderElementTest.kt
@@ -6,6 +6,7 @@ import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.ChromeBaseColors
 import dev.ayuislands.accent.ChromeTintBlender
+import dev.ayuislands.accent.ClassFqn
 import dev.ayuislands.accent.LiveChromeRefresher
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
@@ -180,8 +181,8 @@ class PanelBorderElementTest {
 
         verify(exactly = 1) {
             LiveChromeRefresher.refreshByClassNameInsideAncestorClass(
-                "com.intellij.openapi.ui.OnePixelDivider",
-                "com.intellij.toolWindow.InternalDecoratorImpl",
+                ClassFqn.require("com.intellij.openapi.ui.OnePixelDivider"),
+                ClassFqn.require("com.intellij.toolWindow.InternalDecoratorImpl"),
                 blended,
             )
         }
@@ -205,8 +206,8 @@ class PanelBorderElementTest {
 
         verify(exactly = 1) {
             LiveChromeRefresher.clearByClassNameInsideAncestorClass(
-                "com.intellij.openapi.ui.OnePixelDivider",
-                "com.intellij.toolWindow.InternalDecoratorImpl",
+                ClassFqn.require("com.intellij.openapi.ui.OnePixelDivider"),
+                ClassFqn.require("com.intellij.toolWindow.InternalDecoratorImpl"),
             )
         }
         verify(exactly = 0) { LiveChromeRefresher.refreshByClassNameInsideAncestorClass(any(), any(), any()) }

--- a/src/test/kotlin/dev/ayuislands/accent/elements/PanelBorderElementTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/PanelBorderElementTest.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.application.ApplicationManager
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.ChromeBaseColors
+import dev.ayuislands.accent.ChromeTarget
 import dev.ayuislands.accent.ChromeTintBlender
 import dev.ayuislands.accent.ClassFqn
 import dev.ayuislands.accent.LiveChromeRefresher
@@ -63,14 +64,8 @@ class PanelBorderElementTest {
         every { ChromeTintBlender.blend(any(), any<Color>(), any()) } returns blended
 
         mockkObject(LiveChromeRefresher)
-        every { LiveChromeRefresher.refreshByClassName(any(), any()) } returns Unit
-        every { LiveChromeRefresher.clearByClassName(any()) } returns Unit
-        every {
-            LiveChromeRefresher.refreshByClassNameInsideAncestorClass(any(), any(), any())
-        } returns Unit
-        every {
-            LiveChromeRefresher.clearByClassNameInsideAncestorClass(any(), any())
-        } returns Unit
+        every { LiveChromeRefresher.refresh(any(), any()) } returns Unit
+        every { LiveChromeRefresher.clear(any()) } returns Unit
     }
 
     @AfterTest
@@ -180,38 +175,42 @@ class PanelBorderElementTest {
 
         PanelBorderElement().apply(accent)
 
-        verify(exactly = 1) {
-            LiveChromeRefresher.refreshByClassNameInsideAncestorClass(
-                ClassFqn.require("com.intellij.openapi.ui.OnePixelDivider"),
-                ClassFqn.require("com.intellij.toolWindow.InternalDecoratorImpl"),
-                blended,
+        val expectedTarget =
+            ChromeTarget.ByClassNameInside(
+                target = ClassFqn.require("com.intellij.openapi.ui.OnePixelDivider"),
+                ancestor = ClassFqn.require("com.intellij.toolWindow.InternalDecoratorImpl"),
             )
-        }
-        verify(exactly = 0) { LiveChromeRefresher.clearByClassNameInsideAncestorClass(any(), any()) }
+        verify(exactly = 1) { LiveChromeRefresher.refresh(expectedTarget, blended) }
+        verify(exactly = 0) { LiveChromeRefresher.clear(any()) }
     }
 
     @Test
-    fun `apply must NOT invoke blind refreshByClassName (would over-tint IDE-wide dividers) (Round 2 A-1)`() {
+    fun `apply must NOT invoke blind ByClassName refresh (would over-tint IDE-wide dividers) (Round 2 A-1)`() {
         state.chromeTintIntensity = 30
 
         PanelBorderElement().apply(accent)
 
-        // Blind refresh would walk Window.getWindows() and paint every OnePixelDivider in
-        // the IDE — editor splitters, Settings dialog, diff gutter, Run/Debug splitter, etc.
-        verify(exactly = 0) { LiveChromeRefresher.refreshByClassName(any(), any()) }
+        // Blind ByClassName refresh would walk Window.getWindows() and paint every
+        // OnePixelDivider in the IDE — editor splitters, Settings dialog, diff gutter,
+        // Run/Debug splitter, etc. PanelBorder must use ByClassNameInside.
+        verify(exactly = 0) {
+            LiveChromeRefresher.refresh(
+                ChromeTarget.ByClassName(ClassFqn.require("com.intellij.openapi.ui.OnePixelDivider")),
+                any(),
+            )
+        }
     }
 
     @Test
     fun `revert invokes ancestor-scoped clear for OnePixelDivider inside tool-window decorator (D-14 symmetry)`() {
         PanelBorderElement().revert()
 
-        verify(exactly = 1) {
-            LiveChromeRefresher.clearByClassNameInsideAncestorClass(
-                ClassFqn.require("com.intellij.openapi.ui.OnePixelDivider"),
-                ClassFqn.require("com.intellij.toolWindow.InternalDecoratorImpl"),
+        val expectedTarget =
+            ChromeTarget.ByClassNameInside(
+                target = ClassFqn.require("com.intellij.openapi.ui.OnePixelDivider"),
+                ancestor = ClassFqn.require("com.intellij.toolWindow.InternalDecoratorImpl"),
             )
-        }
-        verify(exactly = 0) { LiveChromeRefresher.refreshByClassNameInsideAncestorClass(any(), any(), any()) }
-        verify(exactly = 0) { LiveChromeRefresher.clearByClassName(any()) }
+        verify(exactly = 1) { LiveChromeRefresher.clear(expectedTarget) }
+        verify(exactly = 0) { LiveChromeRefresher.refresh(any(), any()) }
     }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/elements/PanelBorderElementTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/PanelBorderElementTest.kt
@@ -20,6 +20,7 @@ import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.verify
 import java.awt.Color
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.swing.UIManager
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -47,6 +48,11 @@ class PanelBorderElementTest {
 
     @BeforeTest
     fun setUp() {
+        // Phase 40.2 M-3: the companion `firstApplyLogged` gate is session-global
+        // across every PanelBorderElement instance and test. Reset it per test so
+        // first-apply diagnostic assertions are reachable regardless of ordering.
+        resetFirstApplyLoggedGate()
+
         mockkStatic(ApplicationManager::class)
         every { ApplicationManager.getApplication() } returns mockApplication
 
@@ -212,5 +218,57 @@ class PanelBorderElementTest {
             )
         verify(exactly = 1) { LiveChromeRefresher.clear(expectedTarget) }
         verify(exactly = 0) { LiveChromeRefresher.refresh(any(), any()) }
+    }
+
+    @Test
+    fun `first apply flips the Phase 40-2 M-3 diagnostic gate to true`() {
+        // Phase 40.2 M-3 contract: the one-shot diagnostic gate stays false until
+        // the first apply() invocation — exactly when LOG.info fires with the
+        // `PanelBorderElement first apply: keysSeen=...` line. Resetting the
+        // gate in setUp lets this assertion observe the transition. If the
+        // `onBackgroundsTinted` override is deleted, the gate stays false and
+        // this test fails.
+        state.chromeTintIntensity = 30
+        assertFalse(readFirstApplyLoggedGate(), "gate must be reset before apply runs")
+
+        PanelBorderElement().apply(accent)
+
+        assertTrue(
+            readFirstApplyLoggedGate(),
+            "onBackgroundsTinted must flip firstApplyLogged to true on first apply " +
+                "(Phase 40.2 M-3 diagnostic log)",
+        )
+    }
+
+    @Test
+    fun `second apply keeps the diagnostic gate true — one-shot contract`() {
+        // Companion to the test above: once set, the gate stays set across
+        // subsequent apply() calls. The one-shot contract guarantees the
+        // diagnostic line appears at most once per session per element.
+        state.chromeTintIntensity = 30
+
+        val element = PanelBorderElement()
+        element.apply(accent)
+        assertTrue(readFirstApplyLoggedGate(), "gate must be true after first apply")
+
+        element.apply(accent)
+        assertTrue(
+            readFirstApplyLoggedGate(),
+            "gate must remain true on subsequent apply calls (one-shot contract)",
+        )
+    }
+
+    private fun readFirstApplyLoggedGate(): Boolean = firstApplyLoggedField().get()
+
+    private fun resetFirstApplyLoggedGate() {
+        firstApplyLoggedField().set(false)
+    }
+
+    private fun firstApplyLoggedField(): AtomicBoolean {
+        // Private companion `val` compiles to a private static field on the
+        // outer class. See `javap -p PanelBorderElement.class`.
+        val field = PanelBorderElement::class.java.getDeclaredField("firstApplyLogged")
+        field.isAccessible = true
+        return field.get(null) as AtomicBoolean
     }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/elements/PanelBorderElementTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/PanelBorderElementTest.kt
@@ -8,6 +8,7 @@ import dev.ayuislands.accent.ChromeBaseColors
 import dev.ayuislands.accent.ChromeTintBlender
 import dev.ayuislands.accent.ClassFqn
 import dev.ayuislands.accent.LiveChromeRefresher
+import dev.ayuislands.accent.TintIntensity
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
 import io.mockk.every
@@ -99,7 +100,7 @@ class PanelBorderElementTest {
     fun `apply passes intensity from state to blender per D-03`() {
         state.chromeTintIntensity = 45
 
-        val intensitySlot = slot<Int>()
+        val intensitySlot = slot<TintIntensity>()
         every {
             ChromeTintBlender.blend(any<Color>(), any<Color>(), capture(intensitySlot))
         } returns blended
@@ -107,7 +108,7 @@ class PanelBorderElementTest {
         PanelBorderElement().apply(accent)
 
         assertTrue(intensitySlot.isCaptured)
-        assertEquals(45, intensitySlot.captured)
+        assertEquals(45, intensitySlot.captured.percent)
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/accent/elements/StatusBarElementTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/StatusBarElementTest.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.ChromeBaseColors
+import dev.ayuislands.accent.ChromeTarget
 import dev.ayuislands.accent.ChromeTintBlender
 import dev.ayuislands.accent.LiveChromeRefresher
 import dev.ayuislands.accent.TintIntensity
@@ -66,8 +67,8 @@ class StatusBarElementTest {
         every { WcagForeground.pickForeground(any(), any()) } returns Color.GREEN
 
         mockkObject(LiveChromeRefresher)
-        every { LiveChromeRefresher.refreshStatusBar(any()) } returns Unit
-        every { LiveChromeRefresher.clearStatusBar() } returns Unit
+        every { LiveChromeRefresher.refresh(any(), any()) } returns Unit
+        every { LiveChromeRefresher.clear(any()) } returns Unit
     }
 
     @AfterTest
@@ -200,20 +201,20 @@ class StatusBarElementTest {
     }
 
     @Test
-    fun `apply invokes LiveChromeRefresher refreshStatusBar once with tinted background (Gap 4)`() {
+    fun `apply invokes LiveChromeRefresher once with StatusBar target + tinted background (Gap 4)`() {
         state.chromeTintIntensity = 40
 
         StatusBarElement().apply(accent)
 
-        verify(exactly = 1) { LiveChromeRefresher.refreshStatusBar(blended) }
-        verify(exactly = 0) { LiveChromeRefresher.clearStatusBar() }
+        verify(exactly = 1) { LiveChromeRefresher.refresh(ChromeTarget.StatusBar, blended) }
+        verify(exactly = 0) { LiveChromeRefresher.clear(any()) }
     }
 
     @Test
-    fun `revert invokes LiveChromeRefresher clearStatusBar once (D-14 symmetry)`() {
+    fun `revert invokes LiveChromeRefresher clear with StatusBar target once (D-14 symmetry)`() {
         StatusBarElement().revert()
 
-        verify(exactly = 1) { LiveChromeRefresher.clearStatusBar() }
-        verify(exactly = 0) { LiveChromeRefresher.refreshStatusBar(any()) }
+        verify(exactly = 1) { LiveChromeRefresher.clear(ChromeTarget.StatusBar) }
+        verify(exactly = 0) { LiveChromeRefresher.refresh(any(), any()) }
     }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/elements/StatusBarElementTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/StatusBarElementTest.kt
@@ -6,6 +6,7 @@ import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.ChromeBaseColors
 import dev.ayuislands.accent.ChromeTintBlender
 import dev.ayuislands.accent.LiveChromeRefresher
+import dev.ayuislands.accent.TintIntensity
 import dev.ayuislands.accent.WcagForeground
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
@@ -152,7 +153,7 @@ class StatusBarElementTest {
     fun `apply passes intensity from state to blender per D-03`() {
         state.chromeTintIntensity = 37
 
-        val intensitySlot = slot<Int>()
+        val intensitySlot = slot<TintIntensity>()
         every {
             ChromeTintBlender.blend(any<Color>(), any<Color>(), capture(intensitySlot))
         } returns blended
@@ -160,7 +161,7 @@ class StatusBarElementTest {
         StatusBarElement().apply(accent)
 
         assertTrue(intensitySlot.isCaptured, "intensity should be forwarded to blender")
-        assertEquals(37, intensitySlot.captured, "element must read intensity from state, not from apply()")
+        assertEquals(37, intensitySlot.captured.percent, "element must read intensity from state, not from apply()")
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/accent/elements/ToolWindowStripeElementTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/ToolWindowStripeElementTest.kt
@@ -19,11 +19,14 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
 import java.awt.Color
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.swing.UIManager
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /**
  * Tests for [ToolWindowStripeElement] — CHROME-03.
@@ -48,6 +51,10 @@ class ToolWindowStripeElementTest {
 
     @BeforeTest
     fun setUp() {
+        // Phase 40.2 M-3: reset the companion `firstApplyLogged` gate so first-apply
+        // diagnostic assertions are reachable regardless of ordering.
+        resetFirstApplyLoggedGate()
+
         mockkStatic(UIManager::class)
         every { UIManager.put(any<String>(), any()) } returns Unit
 
@@ -226,5 +233,53 @@ class ToolWindowStripeElementTest {
         val expectedTarget = ChromeTarget.ByClassName(ClassFqn.require("com.intellij.toolWindow.Stripe"))
         verify(exactly = 1) { LiveChromeRefresher.clear(expectedTarget) }
         verify(exactly = 0) { LiveChromeRefresher.refresh(any(), any()) }
+    }
+
+    @Test
+    fun `first apply flips the Phase 40-2 M-3 diagnostic gate to true`() {
+        // Phase 40.2 M-3 contract: the one-shot diagnostic gate stays false until
+        // the first apply() invocation — exactly when LOG.info fires with the
+        // `ToolWindowStripeElement first apply: keysSeen=...` line. If the
+        // `onBackgroundsTinted` override is deleted, the gate stays false and
+        // this test fails.
+        mockState.chromeTintIntensity = 30
+        assertFalse(readFirstApplyLoggedGate(), "gate must be reset before apply runs")
+
+        ToolWindowStripeElement().apply(testAccent)
+
+        assertTrue(
+            readFirstApplyLoggedGate(),
+            "onBackgroundsTinted must flip firstApplyLogged to true on first apply " +
+                "(Phase 40.2 M-3 diagnostic log)",
+        )
+    }
+
+    @Test
+    fun `second apply keeps the diagnostic gate true — one-shot contract`() {
+        mockState.chromeTintIntensity = 30
+
+        val element = ToolWindowStripeElement()
+        element.apply(testAccent)
+        assertTrue(readFirstApplyLoggedGate(), "gate must be true after first apply")
+
+        element.apply(testAccent)
+        assertTrue(
+            readFirstApplyLoggedGate(),
+            "gate must remain true on subsequent apply calls (one-shot contract)",
+        )
+    }
+
+    private fun readFirstApplyLoggedGate(): Boolean = firstApplyLoggedField().get()
+
+    private fun resetFirstApplyLoggedGate() {
+        firstApplyLoggedField().set(false)
+    }
+
+    private fun firstApplyLoggedField(): AtomicBoolean {
+        // Private companion `val` compiles to a private static field on the
+        // outer class. See `javap -p ToolWindowStripeElement.class`.
+        val field = ToolWindowStripeElement::class.java.getDeclaredField("firstApplyLogged")
+        field.isAccessible = true
+        return field.get(null) as AtomicBoolean
     }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/elements/ToolWindowStripeElementTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/ToolWindowStripeElementTest.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.ChromeBaseColors
+import dev.ayuislands.accent.ChromeTarget
 import dev.ayuislands.accent.ChromeTintBlender
 import dev.ayuislands.accent.ClassFqn
 import dev.ayuislands.accent.LiveChromeRefresher
@@ -60,8 +61,8 @@ class ToolWindowStripeElementTest {
         every { WcagForeground.pickForeground(any(), any()) } returns contrastFg
 
         mockkObject(LiveChromeRefresher)
-        every { LiveChromeRefresher.refreshByClassName(any(), any()) } returns Unit
-        every { LiveChromeRefresher.clearByClassName(any()) } returns Unit
+        every { LiveChromeRefresher.refresh(any(), any()) } returns Unit
+        every { LiveChromeRefresher.clear(any()) } returns Unit
 
         // AyuIslandsSettings.getInstance() is backed by ApplicationManager.getService.
         // Mock the Application so the companion resolves without an IDE container.
@@ -208,22 +209,22 @@ class ToolWindowStripeElementTest {
     }
 
     @Test
-    fun `apply invokes LiveChromeRefresher refreshByClassName for stripe peer (Gap 4)`() {
+    fun `apply invokes LiveChromeRefresher for stripe peer (Gap 4)`() {
         mockState.chromeTintIntensity = 30
 
         ToolWindowStripeElement().apply(testAccent)
 
-        verify(exactly = 1) {
-            LiveChromeRefresher.refreshByClassName(ClassFqn.require("com.intellij.toolWindow.Stripe"), blended)
-        }
-        verify(exactly = 0) { LiveChromeRefresher.clearByClassName(any()) }
+        val expectedTarget = ChromeTarget.ByClassName(ClassFqn.require("com.intellij.toolWindow.Stripe"))
+        verify(exactly = 1) { LiveChromeRefresher.refresh(expectedTarget, blended) }
+        verify(exactly = 0) { LiveChromeRefresher.clear(any()) }
     }
 
     @Test
-    fun `revert invokes LiveChromeRefresher clearByClassName for stripe peer (D-14 symmetry)`() {
+    fun `revert invokes LiveChromeRefresher clear for stripe peer (D-14 symmetry)`() {
         ToolWindowStripeElement().revert()
 
-        verify(exactly = 1) { LiveChromeRefresher.clearByClassName(ClassFqn.require("com.intellij.toolWindow.Stripe")) }
-        verify(exactly = 0) { LiveChromeRefresher.refreshByClassName(any(), any()) }
+        val expectedTarget = ChromeTarget.ByClassName(ClassFqn.require("com.intellij.toolWindow.Stripe"))
+        verify(exactly = 1) { LiveChromeRefresher.clear(expectedTarget) }
+        verify(exactly = 0) { LiveChromeRefresher.refresh(any(), any()) }
     }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/elements/ToolWindowStripeElementTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/ToolWindowStripeElementTest.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.application.ApplicationManager
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.ChromeBaseColors
 import dev.ayuislands.accent.ChromeTintBlender
+import dev.ayuislands.accent.ClassFqn
 import dev.ayuislands.accent.LiveChromeRefresher
 import dev.ayuislands.accent.WcagForeground
 import dev.ayuislands.settings.AyuIslandsSettings
@@ -212,7 +213,7 @@ class ToolWindowStripeElementTest {
         ToolWindowStripeElement().apply(testAccent)
 
         verify(exactly = 1) {
-            LiveChromeRefresher.refreshByClassName("com.intellij.toolWindow.Stripe", blended)
+            LiveChromeRefresher.refreshByClassName(ClassFqn.require("com.intellij.toolWindow.Stripe"), blended)
         }
         verify(exactly = 0) { LiveChromeRefresher.clearByClassName(any()) }
     }
@@ -221,7 +222,7 @@ class ToolWindowStripeElementTest {
     fun `revert invokes LiveChromeRefresher clearByClassName for stripe peer (D-14 symmetry)`() {
         ToolWindowStripeElement().revert()
 
-        verify(exactly = 1) { LiveChromeRefresher.clearByClassName("com.intellij.toolWindow.Stripe") }
+        verify(exactly = 1) { LiveChromeRefresher.clearByClassName(ClassFqn.require("com.intellij.toolWindow.Stripe")) }
         verify(exactly = 0) { LiveChromeRefresher.refreshByClassName(any(), any()) }
     }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/elements/ToolWindowStripeElementTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/ToolWindowStripeElementTest.kt
@@ -7,6 +7,7 @@ import dev.ayuislands.accent.ChromeBaseColors
 import dev.ayuislands.accent.ChromeTintBlender
 import dev.ayuislands.accent.ClassFqn
 import dev.ayuislands.accent.LiveChromeRefresher
+import dev.ayuislands.accent.TintIntensity
 import dev.ayuislands.accent.WcagForeground
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
@@ -104,7 +105,7 @@ class ToolWindowStripeElementTest {
         ToolWindowStripeElement().apply(testAccent)
 
         // All 3 keys resolve to the stubbed stockBase, so blend is invoked 3× with the same args.
-        verify(exactly = 3) { ChromeTintBlender.blend(testAccent, stockBase, 45) }
+        verify(exactly = 3) { ChromeTintBlender.blend(testAccent, stockBase, TintIntensity.of(45)) }
     }
 
     @Test
@@ -142,9 +143,9 @@ class ToolWindowStripeElementTest {
         every { ChromeBaseColors.get("ToolWindow.Stripe.background") } returns stripeBase
         every { ChromeBaseColors.get("ToolWindow.Button.selectedBackground") } returns selectedBase
         every { ChromeBaseColors.get("ToolWindow.Stripe.borderColor") } returns stockBase
-        every { ChromeTintBlender.blend(testAccent, stripeBase, 40) } returns stripeTinted
-        every { ChromeTintBlender.blend(testAccent, selectedBase, 40) } returns selectedTinted
-        every { ChromeTintBlender.blend(testAccent, stockBase, 40) } returns blended
+        every { ChromeTintBlender.blend(testAccent, stripeBase, TintIntensity.of(40)) } returns stripeTinted
+        every { ChromeTintBlender.blend(testAccent, selectedBase, TintIntensity.of(40)) } returns selectedTinted
+        every { ChromeTintBlender.blend(testAccent, stockBase, TintIntensity.of(40)) } returns blended
         every {
             WcagForeground.pickForeground(stripeTinted, WcagForeground.TextTarget.ICON)
         } returns stripeFg

--- a/src/test/kotlin/dev/ayuislands/licensing/FreeTierLockdownTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/FreeTierLockdownTest.kt
@@ -59,7 +59,7 @@ class FreeTierLockdownTest {
         every { AyuIslandsSettings.getInstance() } returns settings
 
         mockkObject(AccentApplicator)
-        every { AccentApplicator.apply(any()) } just runs
+        every { AccentApplicator.apply(any()) } returns true
 
         mockkObject(GlowOverlayManager.Companion)
         every { GlowOverlayManager.syncGlowForAllProjects() } just runs

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerProDefaultsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerProDefaultsTest.kt
@@ -332,7 +332,7 @@ class LicenseCheckerProDefaultsTest {
         every { settingsMock.state } returns state
         every { settingsMock.getAccentForVariant(any()) } returns "#FFCC66"
         mockkObject(AccentApplicator)
-        every { AccentApplicator.apply(any()) } just runs
+        every { AccentApplicator.apply(any()) } returns true
 
         // Mock ApplicationManager for AccentRotationService.stopRotation() call
         mockkStatic(ApplicationManager::class)

--- a/src/test/kotlin/dev/ayuislands/licensing/TrialLifecycleIntegrationTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/TrialLifecycleIntegrationTest.kt
@@ -94,7 +94,7 @@ class TrialLifecycleIntegrationTest {
         System.clearProperty("ayu.islands.dev")
 
         mockkObject(AccentApplicator)
-        every { AccentApplicator.apply(any()) } just runs
+        every { AccentApplicator.apply(any()) } returns true
 
         mockkObject(GlowOverlayManager.Companion)
         every { GlowOverlayManager.syncGlowForAllProjects() } just runs

--- a/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
@@ -173,7 +173,7 @@ class AccentRotationServiceTest {
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
 
         mockkObject(AccentApplicator)
-        every { AccentApplicator.apply(any()) } returns true
+        every { AccentApplicator.applyFromHexString(any()) } returns true
 
         mockkObject(GlowOverlayManager.Companion)
         every { GlowOverlayManager.syncGlowForAllProjects() } just Runs
@@ -236,7 +236,7 @@ class AccentRotationServiceTest {
         service.rotateAccent()
         val after = System.currentTimeMillis()
 
-        verify(exactly = 1) { AccentApplicator.apply(expectedHex) }
+        verify(exactly = 1) { AccentApplicator.applyFromHexString(expectedHex) }
         verify(exactly = 1) { settingsMock.setAccentForVariant(AyuVariant.MIRAGE, expectedHex) }
         assertEquals(expectedIndex, state.accentRotationPresetIndex)
         assertTrue(
@@ -259,7 +259,7 @@ class AccentRotationServiceTest {
         service.rotateAccent()
 
         verify(exactly = 1) { ContrastAwareColorGenerator.generate(AyuVariant.MIRAGE) }
-        verify(exactly = 1) { AccentApplicator.apply(generatedHex) }
+        verify(exactly = 1) { AccentApplicator.applyFromHexString(generatedHex) }
         verify(exactly = 1) { settingsMock.setAccentForVariant(AyuVariant.MIRAGE, generatedHex) }
         assertEquals(3, state.accentRotationPresetIndex, "PRESET index must not advance in RANDOM mode")
     }
@@ -273,7 +273,7 @@ class AccentRotationServiceTest {
         val service = AccentRotationService()
         service.rotateAccent()
 
-        verify(exactly = 0) { AccentApplicator.apply(any()) }
+        verify(exactly = 0) { AccentApplicator.applyFromHexString(any()) }
         verify(exactly = 0) { settingsMock.setAccentForVariant(any(), any()) }
     }
 
@@ -293,7 +293,7 @@ class AccentRotationServiceTest {
         val (notificationGroup, createdNotifications) = captureNotifications()
         state.accentRotationEnabled = true
         state.accentRotationMode = AccentRotationMode.PRESET.name
-        every { AccentApplicator.apply(any()) } throws RotationTestException("apply stage")
+        every { AccentApplicator.applyFromHexString(any()) } throws RotationTestException("apply stage")
 
         val service = AccentRotationService()
         LoggedErrorProcessor.executeWith<Throwable>(suppressLoggedErrors()) {
@@ -316,7 +316,7 @@ class AccentRotationServiceTest {
         val (notificationGroup, _) = captureNotifications()
         state.accentRotationEnabled = true
         state.accentRotationMode = AccentRotationMode.PRESET.name
-        every { AccentApplicator.apply(any()) } throws RotationTestException("apply stage")
+        every { AccentApplicator.applyFromHexString(any()) } throws RotationTestException("apply stage")
 
         val service = AccentRotationService()
         LoggedErrorProcessor.executeWith<Throwable>(suppressLoggedErrors()) {
@@ -337,7 +337,7 @@ class AccentRotationServiceTest {
         val (notificationGroup, _) = captureNotifications()
         state.accentRotationEnabled = true
         state.accentRotationMode = AccentRotationMode.PRESET.name
-        every { AccentApplicator.apply(any()) } throws RotationTestException("apply stage")
+        every { AccentApplicator.applyFromHexString(any()) } throws RotationTestException("apply stage")
 
         val service = AccentRotationService()
         LoggedErrorProcessor.executeWith<Throwable>(suppressLoggedErrors()) {
@@ -360,7 +360,7 @@ class AccentRotationServiceTest {
         state.accentRotationMode = AccentRotationMode.PRESET.name
 
         val applyCalls = mutableListOf<String>()
-        every { AccentApplicator.apply(any()) } answers {
+        every { AccentApplicator.applyFromHexString(any()) } answers {
             applyCalls += firstArg<String>()
             if (applyCalls.size != THREE) {
                 throw RotationTestException("fail ${applyCalls.size}")
@@ -430,7 +430,7 @@ class AccentRotationServiceTest {
         state.accentRotationMode = AccentRotationMode.PRESET.name
         state.accentRotationPresetIndex = 0
 
-        every { AccentApplicator.apply(any()) } throws RuntimeException("boom")
+        every { AccentApplicator.applyFromHexString(any()) } throws RuntimeException("boom")
 
         // IntelliJ's TestLoggerFactory promotes LOG.error calls into AssertionErrors.
         // rotateAccent() is expected to log the AccentApplicator failure via LOG.error,
@@ -455,7 +455,7 @@ class AccentRotationServiceTest {
             service.rotateAccent()
         }
 
-        verify(exactly = 1) { AccentApplicator.apply(any()) }
+        verify(exactly = 1) { AccentApplicator.applyFromHexString(any()) }
         // Glow sync runs in a separate try/catch and should still fire after apply() fails.
         verify(exactly = 1) { GlowOverlayManager.syncGlowForAllProjects() }
         assertEquals(1, loggedErrors.size, "Expected exactly one LOG.error for the failed apply()")
@@ -504,7 +504,7 @@ class AccentRotationServiceTest {
 
         verify(exactly = 1) { AccentResolver.resolve(osActiveProject, AyuVariant.MIRAGE) }
         verify(exactly = 0) { AccentResolver.resolve(inactiveProject, any()) }
-        verify(exactly = 1) { AccentApplicator.apply("#5CCFE6") }
+        verify(exactly = 1) { AccentApplicator.applyFromHexString("#5CCFE6") }
     }
 
     private fun stubProject(name: String): Project =

--- a/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
@@ -173,7 +173,7 @@ class AccentRotationServiceTest {
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
 
         mockkObject(AccentApplicator)
-        every { AccentApplicator.apply(any()) } just Runs
+        every { AccentApplicator.apply(any()) } returns true
 
         mockkObject(GlowOverlayManager.Companion)
         every { GlowOverlayManager.syncGlowForAllProjects() } just Runs
@@ -365,6 +365,7 @@ class AccentRotationServiceTest {
             if (applyCalls.size != THREE) {
                 throw RotationTestException("fail ${applyCalls.size}")
             }
+            true
         }
 
         val service = AccentRotationService()

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanelTest.kt
@@ -61,14 +61,14 @@ class AyuIslandsAccentPanelTest {
         // to prevent (next WINDOW_ACTIVATED would redundantly re-apply).
         every { AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE) } throws
             IllegalStateException("override hex corrupted")
-        every { AccentApplicator.apply("#FFCC66") } returns true
+        every { AccentApplicator.applyFromHexString("#FFCC66") } returns true
 
         val panel = AyuIslandsAccentPanel()
         LoggedErrorProcessor.executeWith<Throwable>(suppressLoggedErrors()) {
             panel.applyWithFallback(AyuVariant.MIRAGE, "#FFCC66")
         }
 
-        verify(exactly = 1) { AccentApplicator.apply("#FFCC66") }
+        verify(exactly = 1) { AccentApplicator.applyFromHexString("#FFCC66") }
         verify(exactly = 1) { swapService.notifyExternalApply("#FFCC66") }
     }
 
@@ -80,7 +80,7 @@ class AyuIslandsAccentPanelTest {
         // "Can't save" dialog. The catch logs and leaves the visible accent unchanged.
         every { AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE) } throws
             IllegalStateException("override hex corrupted")
-        every { AccentApplicator.apply("#FFCC66") } throws
+        every { AccentApplicator.applyFromHexString("#FFCC66") } throws
             IllegalStateException("global hex also corrupted")
 
         val panel = AyuIslandsAccentPanel()
@@ -103,7 +103,7 @@ class AyuIslandsAccentPanelTest {
         // save" dialog on a path where the user's intent was actually applied.
         every { AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE) } throws
             IllegalStateException("override hex corrupted")
-        every { AccentApplicator.apply("#FFCC66") } returns true
+        every { AccentApplicator.applyFromHexString("#FFCC66") } returns true
         every { swapService.notifyExternalApply("#FFCC66") } throws
             IllegalStateException("swap service disposed mid-save")
 
@@ -134,7 +134,7 @@ class AyuIslandsAccentPanelTest {
             panel.applyWithFallback(AyuVariant.MIRAGE, "#FFCC66")
         }
 
-        verify(exactly = 1) { AccentApplicator.apply("#FFCC66") }
+        verify(exactly = 1) { AccentApplicator.applyFromHexString("#FFCC66") }
         verify(exactly = 1) { swapService.notifyExternalApply("#FFCC66") }
         kotlin.test.assertEquals(
             1,

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanelTest.kt
@@ -4,9 +4,7 @@ import com.intellij.testFramework.LoggedErrorProcessor
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
-import io.mockk.Runs
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
@@ -63,7 +61,7 @@ class AyuIslandsAccentPanelTest {
         // to prevent (next WINDOW_ACTIVATED would redundantly re-apply).
         every { AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE) } throws
             IllegalStateException("override hex corrupted")
-        every { AccentApplicator.apply("#FFCC66") } just Runs
+        every { AccentApplicator.apply("#FFCC66") } returns true
 
         val panel = AyuIslandsAccentPanel()
         LoggedErrorProcessor.executeWith<Throwable>(suppressLoggedErrors()) {
@@ -105,7 +103,7 @@ class AyuIslandsAccentPanelTest {
         // save" dialog on a path where the user's intent was actually applied.
         every { AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE) } throws
             IllegalStateException("override hex corrupted")
-        every { AccentApplicator.apply("#FFCC66") } just Runs
+        every { AccentApplicator.apply("#FFCC66") } returns true
         every { swapService.notifyExternalApply("#FFCC66") } throws
             IllegalStateException("swap service disposed mid-save")
 

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsChromePanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsChromePanelTest.kt
@@ -174,6 +174,29 @@ class AyuIslandsChromePanelTest {
     }
 
     @Test
+    fun `loadStored clamps negative legacy intensity up to MIN_INTENSITY so slider construction stays total`() {
+        // Corrupted XML or a third-party migration may persist a negative intensity.
+        // The prior coerceAtMost clamp only trimmed the upper bound, so a negative
+        // value would slip through to the JSlider(min, max, value) constructor which
+        // throws IllegalArgumentException when value < min. coerceIn fixes both sides.
+        state.chromeTintIntensity = -5
+        val chromePanel = AyuIslandsChromePanel()
+
+        buildPanel(chromePanel)
+
+        assertEquals(
+            10,
+            chromePanel.getPendingChromeTintIntensityForTest(),
+            "Negative legacy intensity must clamp up to MIN_INTENSITY so slider construction cannot throw",
+        )
+        assertEquals(
+            10,
+            chromePanel.intensitySliderForTest()?.value,
+            "Slider must display the floor-clamped pending value, not the raw negative stored value",
+        )
+    }
+
+    @Test
     fun `applying a clamped legacy intensity persists MAX_INTENSITY back into state`() {
         state.chromeTintIntensity = 90
         val chromePanel = AyuIslandsChromePanel()

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsChromePanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsChromePanelTest.kt
@@ -306,6 +306,44 @@ class AyuIslandsChromePanelTest {
         verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any()) }
     }
 
+    // ── Phase 40.2 T-6: mid-session license flip must not persist ──────────────
+    //
+    // If the panel is built while licensed and the license flips to false
+    // before the user presses Apply, the panel MUST not persist chrome state
+    // fields AND must not invoke applyForFocusedProject. Prevents grace-expiry
+    // / sign-out scenarios where the UI is already built but the gate has
+    // since closed behind the user's back.
+
+    @Test
+    fun `apply refuses to persist chrome state when license flips to false mid-session`() {
+        // Panel built while licensed — all controls wired.
+        every { LicenseChecker.isLicensedOrGrace() } returns true
+        val chromePanel = AyuIslandsChromePanel()
+        buildPanel(chromePanel, AyuVariant.DARK)
+
+        // User makes a change.
+        chromePanel.setPendingChromeStatusBarForTest(true)
+        chromePanel.setPendingChromeTintIntensityForTest(35)
+
+        // License is revoked before apply() runs.
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+
+        chromePanel.apply()
+
+        // No state mutation.
+        assertFalse(
+            state.chromeStatusBar,
+            "Post-license-revocation apply must not persist chromeStatusBar",
+        )
+        assertEquals(
+            AyuIslandsState.DEFAULT_CHROME_TINT_INTENSITY,
+            state.chromeTintIntensity,
+            "Post-license-revocation apply must not persist chromeTintIntensity",
+        )
+        // No EP re-apply.
+        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any()) }
+    }
+
     // ── Test 9: premium gate (CONTEXT D-10) ────────────────────────────────────
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsChromePanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsChromePanelTest.kt
@@ -443,6 +443,120 @@ class AyuIslandsChromePanelTest {
         )
     }
 
+    // ── Per-OS disabledMainToolbarComment branch coverage (Pattern L + I) ─────
+    //
+    // The host-OS-dependent test above locks exactly one branch: whichever the CI
+    // runner happens to be. The three sibling `ChromeSupport.Unsupported` variants
+    // (`GnomeSsd`, `WindowsNoCustomHeader`, `UnknownOs`) plus the off-host major
+    // branch (e.g., `NativeMacTitleBar` when CI is Linux) must each be exercised
+    // explicitly so a refactor that mutates one per-OS copy string without
+    // touching the others cannot slip through.
+    //
+    // Each test pins `ChromeDecorationsProbe.osSupplier` to the desired branch
+    // and wraps the call in `try { … } finally { resetOsSupplierForTests() }`
+    // per Pattern I (JUnit's `@AfterTest` alone is insufficient — an assertion
+    // failure bypasses it and poisons the next test on the same worker).
+    //
+    // The probe's per-OS inputs (UIManager boolean key + Registry boolean key)
+    // are left at their default-false values so `probe()` returns the
+    // "unsupported" branch matching the pinned OS.
+    //
+    // `isCustomHeaderActive()` stays stubbed to `false` so the panel builds the
+    // disabled row (which is where `disabledMainToolbarComment()` is invoked).
+    // `probe()` itself is NOT stubbed — the real implementation runs so it reads
+    // our pinned `osSupplier` and the production UIManager/Registry defaults.
+    //
+    // The OS comments are read via `mainToolbarRowCommentForTest()`; the exact
+    // literal strings are duplicated from `AyuIslandsChromePanel` on purpose so
+    // a copy edit in the production source forces an intentional test update.
+    //
+    // Note: the probe's `diagnosticLogged` AtomicBoolean is per-process; we
+    // reset it before each test so the INFO-diagnostic gate doesn't vary with
+    // test ordering.
+    private fun pinProbeOsForTest(branch: ChromeDecorationsProbe.Os) {
+        ChromeDecorationsProbe.osSupplier = { branch }
+        ChromeDecorationsProbe.resetDiagnosticLoggedForTests()
+    }
+
+    @Test
+    fun `main toolbar comment on Linux with GNOME SSD reports window-manager native title bar`() {
+        every { ChromeDecorationsProbe.isCustomHeaderActive() } returns false
+        try {
+            pinProbeOsForTest(ChromeDecorationsProbe.Os.LINUX)
+            val chromePanel = AyuIslandsChromePanel()
+
+            buildPanel(chromePanel)
+
+            assertEquals(
+                "Disabled: your window manager paints the native title bar.",
+                chromePanel.mainToolbarRowCommentForTest(),
+                "Linux+GnomeSsd branch must render the window-manager copy",
+            )
+        } finally {
+            ChromeDecorationsProbe.resetOsSupplierForTests()
+        }
+    }
+
+    @Test
+    fun `main toolbar comment on Windows without custom header reports IDE-side decorations disabled`() {
+        every { ChromeDecorationsProbe.isCustomHeaderActive() } returns false
+        try {
+            pinProbeOsForTest(ChromeDecorationsProbe.Os.WINDOWS)
+            val chromePanel = AyuIslandsChromePanel()
+
+            buildPanel(chromePanel)
+
+            assertEquals(
+                "Disabled: your IDE is not using custom window decorations.",
+                chromePanel.mainToolbarRowCommentForTest(),
+                "Windows+WindowsNoCustomHeader branch must render the IDE-decorations copy",
+            )
+        } finally {
+            ChromeDecorationsProbe.resetOsSupplierForTests()
+        }
+    }
+
+    @Test
+    fun `main toolbar comment on unknown OS falls back to the generic native title bar copy`() {
+        every { ChromeDecorationsProbe.isCustomHeaderActive() } returns false
+        try {
+            pinProbeOsForTest(ChromeDecorationsProbe.Os.UNKNOWN)
+            val chromePanel = AyuIslandsChromePanel()
+
+            buildPanel(chromePanel)
+
+            assertEquals(
+                "Disabled: your OS paints the native title bar.",
+                chromePanel.mainToolbarRowCommentForTest(),
+                "UnknownOs branch must render the generic OS copy",
+            )
+        } finally {
+            ChromeDecorationsProbe.resetOsSupplierForTests()
+        }
+    }
+
+    @Test
+    fun `main toolbar comment on macOS native title bar reports the macOS-specific copy`() {
+        // Pins macOS regardless of the CI runner host so Linux / Windows runners still
+        // exercise the `NativeMacTitleBar` branch copy — the host-OS-dependent test
+        // above only hits this branch when CI happens to be macOS.
+        every { ChromeDecorationsProbe.isCustomHeaderActive() } returns false
+        try {
+            pinProbeOsForTest(ChromeDecorationsProbe.Os.MAC)
+            val chromePanel = AyuIslandsChromePanel()
+
+            buildPanel(chromePanel)
+
+            assertEquals(
+                "Disabled: macOS paints the native title bar (IDE 2026.1+ no longer exposes a toggle).",
+                chromePanel.mainToolbarRowCommentForTest(),
+                "Mac+NativeMacTitleBar branch must render the macOS-specific copy",
+            )
+        } finally {
+            ChromeDecorationsProbe.resetOsSupplierForTests()
+        }
+    }
+
     // ── Test 12: persisted expanded state ──────────────────────────────────────
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateSnapshotTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateSnapshotTest.kt
@@ -25,7 +25,7 @@ class AyuIslandsStateSnapshotTest {
         mockkObject(AccentApplicator)
         mockkObject(GlowOverlayManager.Companion)
         mockkStatic(ApplicationManager::class)
-        every { AccentApplicator.apply(any()) } just runs
+        every { AccentApplicator.apply(any()) } returns true
         every { GlowOverlayManager.syncGlowForAllProjects() } just runs
         val rotationService = mockk<AccentRotationService>(relaxed = true)
         val appMock = mockk<com.intellij.openapi.application.Application>(relaxed = true)

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateTest.kt
@@ -167,6 +167,36 @@ class AyuIslandsStateTest {
     }
 
     @Test
+    fun `effectiveLastAppliedAccentHex wraps valid persisted hex`() {
+        // Phase 40.3b: the AccentHex wrapper must treat the persisted String
+        // as the raw trust boundary. A valid #RRGGBB round-trips to a typed
+        // AccentHex whose .value matches the persisted field after trim().
+        val state = freshState()
+        state.lastAppliedAccentHex = "#5CCFE6"
+        val wrapped = state.effectiveLastAppliedAccentHex()
+        assertEquals("#5CCFE6", wrapped?.value)
+    }
+
+    @Test
+    fun `effectiveLastAppliedAccentHex returns null for corrupted persisted hex`() {
+        // A hand-edited / truncated / legacy ayu-islands.xml must NOT produce
+        // a usable AccentHex; the listener falls back to the resolver path
+        // whenever the helper returns null, so this contract is load-bearing.
+        val state = freshState()
+        state.lastAppliedAccentHex = "garbage"
+        kotlin.test.assertNull(state.effectiveLastAppliedAccentHex())
+        state.lastAppliedAccentHex = "#12345"
+        kotlin.test.assertNull(state.effectiveLastAppliedAccentHex(), "too-short hex must be rejected")
+    }
+
+    @Test
+    fun `effectiveLastAppliedAccentHex returns null when no hex is persisted`() {
+        val state = freshState()
+        state.lastAppliedAccentHex = null
+        kotlin.test.assertNull(state.effectiveLastAppliedAccentHex())
+    }
+
+    @Test
     fun `chromeTintingGroupExpanded round-trips`() {
         val state = freshState()
         state.chromeTintingGroupExpanded = true

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateTest.kt
@@ -141,25 +141,29 @@ class AyuIslandsStateTest {
         val state = freshState()
 
         state.chromeTintIntensity = -10
-        assertEquals(0, state.effectiveChromeTintIntensity(), "negative values clamp to 0")
+        assertEquals(0, state.effectiveChromeTintIntensity().percent, "negative values clamp to 0")
 
         state.chromeTintIntensity = 500
-        assertEquals(cap, state.effectiveChromeTintIntensity(), "above-cap values clamp to the user-visible ceiling")
+        assertEquals(
+            cap,
+            state.effectiveChromeTintIntensity().percent,
+            "above-cap values clamp to the user-visible ceiling",
+        )
 
         state.chromeTintIntensity = 80
         assertEquals(
             cap,
-            state.effectiveChromeTintIntensity(),
+            state.effectiveChromeTintIntensity().percent,
             "legacy pre-cap persisted values observe the new ceiling",
         )
 
         state.chromeTintIntensity = 42
-        assertEquals(42, state.effectiveChromeTintIntensity(), "in-range values pass through unchanged")
+        assertEquals(42, state.effectiveChromeTintIntensity().percent, "in-range values pass through unchanged")
 
         state.chromeTintIntensity = 0
-        assertEquals(0, state.effectiveChromeTintIntensity())
+        assertEquals(0, state.effectiveChromeTintIntensity().percent)
         state.chromeTintIntensity = cap
-        assertEquals(cap, state.effectiveChromeTintIntensity())
+        assertEquals(cap, state.effectiveChromeTintIntensity().percent)
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderApplyTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderApplyTest.kt
@@ -115,7 +115,7 @@ class OverridesGroupBuilderApplyTest {
         // swap-service notification, isModified() returns false.
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
         every { AccentResolver.resolve(any(), any()) } returns "#AABBCC"
-        every { AccentApplicator.apply(any()) } returns Unit
+        every { AccentApplicator.apply(any()) } returns true
         val swapService = mockk<ProjectAccentSwapService>(relaxed = true)
         every { ProjectAccentSwapService.getInstance() } returns swapService
 
@@ -160,7 +160,7 @@ class OverridesGroupBuilderApplyTest {
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
         every { AccentApplicator.resolveFocusedProject() } returns focusedProject
         every { AccentResolver.resolve(focusedProject, AyuVariant.MIRAGE) } returns "#5CCFE6"
-        every { AccentApplicator.apply(any()) } returns Unit
+        every { AccentApplicator.apply(any()) } returns true
         val swapService = mockk<ProjectAccentSwapService>(relaxed = true)
         every { ProjectAccentSwapService.getInstance() } returns swapService
 

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderApplyTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderApplyTest.kt
@@ -139,7 +139,7 @@ class OverridesGroupBuilderApplyTest {
 
         assertEquals(mapOf("/tmp/apply-ok-b" to "#AABBCC"), mappingsState.projectAccents)
         assertFalse(builder.isModified(), "stored snapshot must advance on happy path too")
-        io.mockk.verify(exactly = 1) { AccentApplicator.apply("#AABBCC") }
+        io.mockk.verify(exactly = 1) { AccentApplicator.applyFromHexString("#AABBCC") }
         io.mockk.verify(exactly = 1) { swapService.notifyExternalApply("#AABBCC") }
     }
 
@@ -183,6 +183,6 @@ class OverridesGroupBuilderApplyTest {
 
         io.mockk.verify(exactly = 1) { AccentApplicator.resolveFocusedProject() }
         io.mockk.verify(exactly = 1) { AccentResolver.resolve(focusedProject, AyuVariant.MIRAGE) }
-        io.mockk.verify(exactly = 1) { AccentApplicator.apply("#5CCFE6") }
+        io.mockk.verify(exactly = 1) { AccentApplicator.applyFromHexString("#5CCFE6") }
     }
 }

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt
@@ -53,7 +53,7 @@ class ProjectAccentSwapServiceTest {
         mockkObject(AyuVariant.Companion)
         mockkObject(ComponentTreeRefresher)
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
-        every { AccentApplicator.apply(any()) } returns true
+        every { AccentApplicator.applyFromHexString(any()) } returns true
         every { ComponentTreeRefresher.walkAndNotify(any(), any()) } just Runs
 
         mockkStatic(WindowManager::class)
@@ -130,7 +130,7 @@ class ProjectAccentSwapServiceTest {
 
         service.onWindowActivatedForTest(event)
 
-        verify(exactly = 0) { AccentApplicator.apply(any()) }
+        verify(exactly = 0) { AccentApplicator.applyFromHexString(any()) }
         verify(exactly = 0) { AccentResolver.resolve(any(), any()) }
         verify(exactly = 0) { AyuVariant.detect() }
     }
@@ -150,7 +150,7 @@ class ProjectAccentSwapServiceTest {
 
         verify(exactly = 1) { AyuVariant.detect() }
         verify(exactly = 0) { AccentResolver.resolve(project, any()) }
-        verify(exactly = 0) { AccentApplicator.apply(any()) }
+        verify(exactly = 0) { AccentApplicator.applyFromHexString(any()) }
     }
 
     @Test
@@ -164,7 +164,7 @@ class ProjectAccentSwapServiceTest {
         service.onWindowActivatedForTest(makeEvent(window))
 
         verify(exactly = 0) { AccentResolver.resolve(project, any()) }
-        verify(exactly = 0) { AccentApplicator.apply(any()) }
+        verify(exactly = 0) { AccentApplicator.applyFromHexString(any()) }
     }
 
     @Test
@@ -183,7 +183,7 @@ class ProjectAccentSwapServiceTest {
         service.onWindowActivatedForTest(event) // same project — re-resolves, hex matches, skips apply
 
         verify(exactly = 2) { AccentResolver.resolve(project, AyuVariant.MIRAGE) }
-        verify(exactly = 1) { AccentApplicator.apply("#FFCC66") }
+        verify(exactly = 1) { AccentApplicator.applyFromHexString("#FFCC66") }
         verify(exactly = 1) { ComponentTreeRefresher.walkAndNotify(project, window) }
     }
 
@@ -211,7 +211,7 @@ class ProjectAccentSwapServiceTest {
         // cache-hex is lavender; the handler must notice the drift and re-apply cyan.
         service.onWindowActivatedForTest(makeEvent(window))
 
-        verify(exactly = 2) { AccentApplicator.apply("#5CCFE6") }
+        verify(exactly = 2) { AccentApplicator.applyFromHexString("#5CCFE6") }
         verify(exactly = 2) { ComponentTreeRefresher.walkAndNotify(project, window) }
     }
 
@@ -244,7 +244,7 @@ class ProjectAccentSwapServiceTest {
         // fired only once because the effective hex hadn't changed.
         verify(exactly = 1) { AccentResolver.resolve(projectA, AyuVariant.MIRAGE) }
         verify(exactly = 1) { AccentResolver.resolve(projectB, AyuVariant.MIRAGE) }
-        verify(exactly = 1) { AccentApplicator.apply("#FFCC66") }
+        verify(exactly = 1) { AccentApplicator.applyFromHexString("#FFCC66") }
     }
 
     @Test
@@ -280,7 +280,7 @@ class ProjectAccentSwapServiceTest {
         // resolve was called (project changed from null to projectA) but apply was skipped
         // because the effective hex matches the cache.
         verify(exactly = 1) { AccentResolver.resolve(project, AyuVariant.MIRAGE) }
-        verify(exactly = 0) { AccentApplicator.apply(any()) }
+        verify(exactly = 0) { AccentApplicator.applyFromHexString(any()) }
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt
@@ -53,7 +53,7 @@ class ProjectAccentSwapServiceTest {
         mockkObject(AyuVariant.Companion)
         mockkObject(ComponentTreeRefresher)
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
-        every { AccentApplicator.apply(any()) } just Runs
+        every { AccentApplicator.apply(any()) } returns true
         every { ComponentTreeRefresher.walkAndNotify(any(), any()) } just Runs
 
         mockkStatic(WindowManager::class)


### PR DESCRIPTION
## Why

Ships v2.5.3 by closing every remaining Round 3 review-loop finding from #152 before pushing the Chrome Tinting Engine to the Marketplace. Three sequential phases land here (40.2 → 40.3 → 40.4), built across a worktree chain branched off main and verified between each stage.

## What changed

────────────────────────────────────────────

**1. Phase 40.2 — behavioral fixes (12 production + 5 regression tests)**

`fix(40-chrome): close HIGH and MEDIUM behavioral audit findings`

| ID | File | Behaviour |
|---|---|---|
| H-1 | `AyuIslandsChromePanel` | `apply()` re-detects variant via `AyuVariant.detect()` when captured `variant` is null instead of silent no-op |
| H-2 | `AccentApplicator` + `AyuIslandsState` | persists `lastAppliedAccentHex` BEFORE EP iteration; new `lastApplyOk` flag distinguishes startup-flicker hex from a stale one |
| H-3 | `AccentApplicator` | `apply` returns `Boolean`; bad hex triggers `Notifications.Bus.notify` so the user sees a balloon, not just a log line |
| H-4 | `AyuIslandsChromePanel` | `applyForFocusedProject` runs FIRST; chrome state persists only on success — Apply stays interactive on failure |
| H-5 | `ChromeDecorationsProbe` | one-shot INFO log per session listing per-key probe resolution so user-submitted `idea.log` shows WHY tinting was disabled |
| M-1 | `StatusBarElement` | breadcrumb + widget hover foregrounds picked against `Widget.hoverBackground`, not the non-hover bg — restores WCAG AA at intensity 50 |
| M-2 | `AccentApplicator` | `HEX_COLOR_PATTERN` tolerates leading/trailing whitespace; `.trim()` before `Color.decode` |
| M-3 | `PanelBorderElement`, `ToolWindowStripeElement` | one-shot INFO log per session listing found vs missed peer FQNs (future platform-rename diagnostic) |
| M-4 | `LiveChromeRefresher` | `walk` converted from recursive to `ArrayDeque<Component>`-iterative — eliminates stack-overflow risk on deep component trees |
| M-5 | `ChromeTintBlender` | `outputBrightness.coerceIn(0f, 1f)` mirrors the saturation clamp |
| M-6 | `ChromeBaseColors` | `get()` composite read-UIManager-putIfAbsent block synchronized; closes mid-LAF-transition race |
| M-8 | `AccentApplicator.repaintAllWindows` | filters by `window.isDisplayable` to skip disposed peers |

Regression tests added: T-1 (LAF listener wiring end-to-end), T-2 (`runStartupAccentOnEdt` ordering source-regex), T-3 (invalid hex notification), T-5 (`@RequiresEdt` on `applyForFocusedProject`), T-6 (mid-session trial-expiry refuses chrome persist). T-4 (WARN-once log capture) deferred — no project-standard log-capture harness, would need new infrastructure.

────────────────────────────────────────────

**2. Phase 40.3 — type refactors (6 commits across 3 sub-phases)**

| Sub-phase | Construct | Sites migrated |
|---|---|---|
| 40.3a | `ClassFqn` value class | `LiveChromeRefresher` 6 entry points + 5 element call sites; eliminates positional swap on `(target, ancestor)` arg pairs |
| 40.3a | `TintIntensity` value class | `ChromeTintBlender.blend` + `AyuIslandsState.effectiveChromeTintIntensity()`; persisted XML field stays `Int` |
| 40.3b | `AccentHex` value class | `AccentApplicator.apply`, `apply` callers, persistence wrappers, `AyuIslandsAppListener`; `Color.decode` now total on `AccentHex`. `AccentResolver.resolve` deferred (broader scope, secured at apply boundary) |
| 40.3c | `AbstractChromeElement` base class | 5 chrome elements collapsed to ~15-line subclasses; preserves Phase 40.1 ancestor-constrained refresh, M-1 split WCAG, M-3 first-apply log, D-13 probe gate, D-14 revert symmetry |
| 40.3c | `ChromeTarget` sealed hierarchy | `LiveChromeRefresher` API reduced from 6 flat entry points to `refresh(target, color)` + `clear(target)` |
| 40.3c | `ChromeSupport` sealed result type | `ChromeDecorationsProbe.probe()` returns `Supported` or one of 4 `Unsupported.<reason>`; `AyuIslandsChromePanel.disabledMainToolbarComment` now shows OS-specific reason |

────────────────────────────────────────────

**3. Phase 40.4 — polish (4 LOW + 3 SUGGESTION)**

| ID | File | Change |
|---|---|---|
| L-1 | `AyuIslandsChromePanel.loadStored` | `coerceAtMost(MAX)` → `coerceIn(MIN, MAX)` so a negative persisted intensity can't crash `JSlider` |
| L-2 | `ChromeDecorationsProbe.osSupplier` | backed by `ThreadLocal<(() -> Os)?>`; cross-thread test isolation |
| L-3 | `AccentApplicator.apply` KDoc | spells out EDT-sync vs off-EDT-post contract |
| L-4 | `AccentApplicator.applyAlwaysOnUiKeys` | takes `state` from outer apply()'s capture — removes duplicate `getInstance().state` read |
| S-1 | `LiveChromeRefresher.forEachShowingWindow` | KDoc on `getWindows()` vs `allProjectFrames` choice |
| S-2 | `ChromeBaseColors.snapshot` | comment anchoring growth ceiling to the finite UIManager-key list |
| S-3 | `AccentApplicator.repaintAllWindows` | KDoc linking `isDisplayable` filter to `LiveChromeRefresher.forEachShowingWindow`'s `isShowing` filter |

## Release notes (changelog candidates, user-facing)

- Chrome tinting now correctly applies under non-Ayu themes from Settings
- Tinted hover text on Status Bar meets WCAG AA contrast at high intensity
- Invalid accent colors show a notification instead of silently failing
- Settings panel keeps Apply enabled when chrome apply fails — retry now works
- Disabled Main Toolbar row shows OS-specific reason (e.g. native macOS title bar)

## Verification

Each phase verified locally between agent spawns:
- `./gradlew test --tests "dev.ayuislands.accent.*" --tests "dev.ayuislands.settings.*" --tests "dev.ayuislands.AyuIslands*"` — all green at 40.2 tip, 40.3 tip, 40.4 tip
- `./gradlew detekt ktlintCheck` — clean at every commit (pre-commit hooks)
- `./gradlew buildPlugin` then bytecode-verified `AccentHex`, `ChromeTarget`, `AbstractChromeElement` present in distribution JAR
- Locally installed in IntelliJ IDEA 2026.1 from the 40.4 worktree's distribution; smoke-tested apply/revert flow

## Out of scope

- **Phase 41 — Theme lifecycle cleanup (#154)**. Surfaced during smoke test: `GlowOverlayManager` + CodeGlance Pro / Rainbow Indents accent integrations don't gate on `AyuVariant.detect() != null`, so glow + accent persist after switching to a non-Ayu theme. Pre-existing bug, ships in v2.6.0.

## Closes

- #152 (Phase 40 Round 3 review-loop follow-ups — all 20+ findings closed)