### PR TITLE
fix(theme): calmer diff backgrounds for v2.6.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.6.0
+pluginVersion=2.6.1
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -92,6 +92,10 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>2.6.1</h3>
+    <ul>
+      <li>Calmed diff backgrounds across Dark, Light, and Mirage variants — modified diff no longer blends with text selection</li>
+    </ul>
     <h3>2.6.0</h3>
     <ul>
       <li>[Paid] <b>Peacock parity for JetBrains</b> — pin an accent to a project window or to a programming language and every chrome surface (status bar, nav bar, tool stripes, panel borders) tints with that accent automatically. WCAG-aware foreground keeps text readable at any saturation. Inspired by Peacock for VS Code (johnpapa.net) — built on JetBrains primitives, not ported.</li>

--- a/src/main/resources/themes/AyuIslandsDark.xml
+++ b/src/main/resources/themes/AyuIslandsDark.xml
@@ -878,19 +878,19 @@
         </option>
         <option name="DIFF_DELETED">
             <value>
-                <option name="BACKGROUND" value="76070E" />
+                <option name="BACKGROUND" value="562E36" />
                 <option name="ERROR_STRIPE_COLOR" value="F26D78" />
             </value>
         </option>
         <option name="DIFF_INSERTED">
             <value>
-                <option name="BACKGROUND" value="0F6201" />
+                <option name="BACKGROUND" value="2D482B" />
                 <option name="ERROR_STRIPE_COLOR" value="70BF56" />
             </value>
         </option>
         <option name="DIFF_MODIFIED">
             <value>
-                <option name="BACKGROUND" value="152A48" />
+                <option name="BACKGROUND" value="25493D" />
                 <option name="ERROR_STRIPE_COLOR" value="59C2FF" />
             </value>
         </option>

--- a/src/main/resources/themes/AyuIslandsLight.xml
+++ b/src/main/resources/themes/AyuIslandsLight.xml
@@ -855,7 +855,7 @@
         </option>
         <option name="DIFF_INSERTED">
             <value>
-                <option name="BACKGROUND" value="6CBF4314" />
+                <option name="BACKGROUND" value="6CBF4320" />
                 <option name="ERROR_STRIPE_COLOR" value="6CBF43" />
             </value>
         </option>

--- a/src/main/resources/themes/AyuIslandsLight.xml
+++ b/src/main/resources/themes/AyuIslandsLight.xml
@@ -849,19 +849,19 @@
         </option>
         <option name="DIFF_DELETED">
             <value>
-                <option name="BACKGROUND" value="FF738320" />
+                <option name="BACKGROUND" value="FF738314" />
                 <option name="ERROR_STRIPE_COLOR" value="FF7383" />
             </value>
         </option>
         <option name="DIFF_INSERTED">
             <value>
-                <option name="BACKGROUND" value="6CBF4320" />
+                <option name="BACKGROUND" value="6CBF4314" />
                 <option name="ERROR_STRIPE_COLOR" value="6CBF43" />
             </value>
         </option>
         <option name="DIFF_MODIFIED">
             <value>
-                <option name="BACKGROUND" value="478ACC30" />
+                <option name="BACKGROUND" value="478ACC1F" />
                 <option name="ERROR_STRIPE_COLOR" value="478ACC" />
             </value>
         </option>

--- a/src/main/resources/themes/AyuIslandsMirage.xml
+++ b/src/main/resources/themes/AyuIslandsMirage.xml
@@ -789,19 +789,19 @@
         </option>
         <option name="DIFF_DELETED">
             <value>
-                <option name="BACKGROUND" value="86171E" />
+                <option name="BACKGROUND" value="623F4B" />
                 <option name="ERROR_STRIPE_COLOR" value="F27983" />
             </value>
         </option>
         <option name="DIFF_INSERTED">
             <value>
-                <option name="BACKGROUND" value="1F7201" />
+                <option name="BACKGROUND" value="405E43" />
                 <option name="ERROR_STRIPE_COLOR" value="87D96C" />
             </value>
         </option>
         <option name="DIFF_MODIFIED">
             <value>
-                <option name="BACKGROUND" value="253D58" />
+                <option name="BACKGROUND" value="3A5B72" />
                 <option name="ERROR_STRIPE_COLOR" value="73D0FF" />
             </value>
         </option>


### PR DESCRIPTION
## Summary

Diff backgrounds (modified / inserted / deleted) felt too bright after v2.6.0 — modified blue was visually indistinguishable from selection blue, and reds and greens were aggressive enough that user feedback explicitly called them out ([Reddit thread](https://www.reddit.com/r/IntelliJIDEA/)). Dialed them back across Dark, Light, and Mirage. `DIFF_CONFLICT` stays bright on purpose — conflict markers should still grab attention.

## What changed

- Softer `DIFF_MODIFIED` / `DIFF_INSERTED` / `DIFF_DELETED` backgrounds across the 3 colors XML files
- `DIFF_CONFLICT` and all `ERROR_STRIPE_COLOR` values untouched
- Version 2.6.0 → 2.6.1 (`release-version` stays at 26, `release-date` locked per marketplace rule)
- User-facing changelog entry

## Tested

Locally in IDE sandbox (`runIde`) for all 3 base variants — modified / inserted / deleted read calmly, text selection over a modified line no longer blends in, and conflict highlights still dominate in the 3-way merge view. `./gradlew detekt ktlintCheck buildPlugin verifyPlugin` all green.

## Summary by Sourcery

Soften diff background colors and document the change in a patch release.

Bug Fixes:
- Reduce visual intensity of diff backgrounds for modified, inserted, and deleted lines across all theme variants to improve readability and distinguishability from text selection.

Build:
- Bump plugin version from 2.6.0 to 2.6.1.

Documentation:
- Add changelog entry describing calmer diff backgrounds in version 2.6.1.