### PR TITLE
ci: raise test job timeout to 15m for gradle cache save

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,7 +175,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     needs: build
-    timeout-minutes: 10
+    timeout-minutes: 15
     environment: ci
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary

CI's `test` job has been getting cancelled at the 10-minute timeout for a while now — about half of recent merges to main hit it (runs #156, #157, #160, and #162 / our v2.6.1 merge today). The tests themselves pass; what's pushing past the limit is the post-action gradle cache save that runs after the test step finishes.

Typical timing in the cancelled run:

```
Test job started        12:22:45
Coverage uploaded ✓     12:32:25  (~9m 40s — tests done)
gradle cache save        ↓
canceled at 10:00 mark  12:32:45
```

Result: Test ends as `cancelled`, downstream jobs (Verify matrix, Gate) skip, and Gate ends as `failure` even though tests passed.

Bumping `timeout-minutes` from 10 to 15 gives the post-action cleanup enough headroom. Tests themselves don't change.

## Tested

Single-line workflow change. Will only show its effect on the next merge to main.

## Summary by Sourcery

CI:
- Extend the GitHub Actions Test job timeout from 10 to 15 minutes to accommodate Gradle cache save time.