### PR TITLE
fix(v2.6.2): VCS modified-blue, selection translucency, CUSTOM freeze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [2.6.2] - 2026-05-10
+
+### Fixed
+- VCS modified-line color is now distinct from added — modified shifts to a saturated blue (Dark `#73B8FF`, Mirage `#80BFFF`) so it stops blending into the green added band on dense diffs. Also bluer file-status colors in Project View and tabs.
+- Editor selection background returns to translucent (alpha 25%) on Dark and Mirage so highlighted text doesn't read as a solid blue block.
+- Settings page no longer freezes on "Loading…" forever when a Custom font preset is active (issue #164) — non-curated presets now skip the install pipeline cleanly instead of crashing the panel build.
+
+## [2.6.1] - 2026-04-27
+
+### Fixed
+- Calmer DIFF_MODIFIED / INSERTED / DELETED backgrounds across all three variants — diff viewer no longer washes the whole gutter when reviewing large patches.
+
 ## [2.6.0] - 2026-04-26
 
 ### Added

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "e3d148d"
+          last_verified_sha: "025a41e"
           last_verified_date: "2026-04-25"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "e3d148d"
+          last_verified_sha: "025a41e"
           last_verified_date: "2026-04-25"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -211,7 +211,7 @@ categories:
           sources:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "e3d148d"
+          last_verified_sha: "025a41e"
           last_verified_date: "2026-05-10"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "025a41e"
+          last_verified_sha: "a9e6a4f"
           last_verified_date: "2026-04-25"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "025a41e"
+          last_verified_sha: "a9e6a4f"
           last_verified_date: "2026-04-25"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -211,7 +211,7 @@ categories:
           sources:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "025a41e"
+          last_verified_sha: "a9e6a4f"
           last_verified_date: "2026-05-10"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "a9e6a4f"
+          last_verified_sha: "bbac496"
           last_verified_date: "2026-04-25"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "a9e6a4f"
+          last_verified_sha: "bbac496"
           last_verified_date: "2026-04-25"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -211,7 +211,7 @@ categories:
           sources:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "a9e6a4f"
+          last_verified_sha: "bbac496"
           last_verified_date: "2026-05-10"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "202051b"
+          last_verified_sha: "e3d148d"
           last_verified_date: "2026-04-25"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "202051b"
+          last_verified_sha: "e3d148d"
           last_verified_date: "2026-04-25"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -211,8 +211,8 @@ categories:
           sources:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "232e835"
-          last_verified_date: "2026-04-16"
+          last_verified_sha: "e3d148d"
+          last_verified_date: "2026-05-10"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
   workspace:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.6.1
+pluginVersion=2.6.2
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/src/main/kotlin/dev/ayuislands/font/FontCatalog.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontCatalog.kt
@@ -98,7 +98,33 @@ object FontCatalog {
             ),
         )
 
-    fun forPreset(preset: FontPreset): Entry =
-        entries.firstOrNull { it.preset == preset }
-            ?: error("No FontCatalog entry for preset $preset")
+    /**
+     * Returns the install metadata for [preset], or `null` for non-curated presets
+     * (currently only [FontPreset.CUSTOM]).
+     *
+     * Use this from user-facing code paths where `CUSTOM` is reachable — Settings
+     * panel rows, Install/Reinstall/Delete buttons, Brew-cask hints. Issue #164:
+     * pre-2.6.2 versions threw `IllegalStateException` from a non-null variant of
+     * this method, which froze the Settings page on "Loading…" forever once the
+     * user persisted `fontPresetName = "CUSTOM"` and reopened settings.
+     *
+     * If you can statically guarantee a curated preset (e.g. iterating a hardcoded
+     * `WHISPER, AMBIENT, NEON, CYBERPUNK` list), prefer [requirePreset] — it
+     * encodes that invariant in the type and fails fast on regression.
+     */
+    fun forPreset(preset: FontPreset): Entry? = entries.firstOrNull { it.preset == preset }
+
+    /**
+     * Non-null variant for call sites that statically operate on curated presets
+     * only — onboarding cards (which iterate a hardcoded `FONT_PRESETS` list) and
+     * tests (which pin known curated presets). Throws if [preset] resolves to no
+     * entry, which is a programmer error in these contexts (e.g. someone added
+     * `CUSTOM` to the curated list).
+     *
+     * Do NOT use from defensive paths where the user can drive [preset] toward
+     * `CUSTOM` — use [forPreset] there and null-check.
+     */
+    fun requirePreset(preset: FontPreset): Entry =
+        forPreset(preset)
+            ?: error("FontCatalog has no entry for preset $preset (curated-only API called with non-curated value)")
 }

--- a/src/main/kotlin/dev/ayuislands/font/FontCatalog.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontCatalog.kt
@@ -45,7 +45,8 @@ object FontCatalog {
     private const val APPROX_MAPLE_MB = 2
     private const val APPROX_MONASPACE_MB = 4
 
-    val entries: List<Entry> =
+    @org.jetbrains.annotations.VisibleForTesting
+    internal val entries: List<Entry> =
         listOf(
             Entry(
                 preset = FontPreset.WHISPER,

--- a/src/main/kotlin/dev/ayuislands/font/FontCatalog.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontCatalog.kt
@@ -1,5 +1,7 @@
 package dev.ayuislands.font
 
+import org.jetbrains.annotations.VisibleForTesting
+
 /**
  * Static catalog of fonts that the plugin can auto-install at runtime.
  *
@@ -45,7 +47,7 @@ object FontCatalog {
     private const val APPROX_MAPLE_MB = 2
     private const val APPROX_MONASPACE_MB = 4
 
-    @org.jetbrains.annotations.VisibleForTesting
+    @VisibleForTesting
     internal val entries: List<Entry> =
         listOf(
             Entry(

--- a/src/main/kotlin/dev/ayuislands/font/FontInstaller.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontInstaller.kt
@@ -80,14 +80,21 @@ object FontInstaller {
         project: Project?,
         onComplete: (InstallResult) -> Unit,
     ) {
-        // Non-curated presets (currently only CUSTOM) have no install pipeline —
-        // user already chose their own font. Reaching this from UI requires a
-        // visibility-gate bypass; log + drop the call rather than throw to keep
-        // hot paths defensive against future caller changes (issue #164).
+        // Non-curated presets (CUSTOM) have no install pipeline — the user
+        // already chose their own font. Reaching this from UI requires a
+        // visibility-gate bypass; log + fire onComplete with a Failure so
+        // callers that track progress (e.g. an onboarding spinner backed by
+        // installingFonts) don't hang waiting for a callback that never came.
         val entry =
             FontCatalog.forPreset(preset)
                 ?: run {
                     LOG.warn("FontInstaller.install called for non-curated preset $preset; ignoring")
+                    onComplete(
+                        InstallResult.Failure(
+                            kind = FailureKind.UNKNOWN,
+                            message = "No catalog entry for preset $preset (non-curated)",
+                        ),
+                    )
                     return
                 }
         val task =
@@ -104,16 +111,18 @@ object FontInstaller {
         preset: FontPreset,
         project: Project?,
     ) {
-        // Same null-safe stance as install() — CUSTOM has no catalog entry, but
-        // applyOnly's branch CAN still call FontPresetApplicator (font preference
-        // is set via FontSettings.decode without needing install metadata). Skip
-        // only the failure-notification path that needs the entry's displayName.
+        // applyOnly does not need install metadata: FontSettings.decode + the
+        // applicator can run for any preset (the font family for CUSTOM lives
+        // in user settings, not the catalog). The catalog lookup is only used
+        // to surface a failure-notification with a real displayName when the
+        // applicator throws. For CUSTOM we still log the throw so a future
+        // regression surfaces in idea.log even without a notification.
         val entry = FontCatalog.forPreset(preset)
         ApplicationManager.getApplication().invokeLater {
             try {
                 FontPresetApplicator.apply(FontSettings.decode(null, preset))
             } catch (exception: RuntimeException) {
-                LOG.warn("FontPresetApplicator.apply failed (applyOnly)", exception)
+                LOG.warn("FontPresetApplicator.apply failed (applyOnly, preset=$preset)", exception)
                 if (entry != null) {
                     notify(entry, project, FailureKind.APPLY_FAILED, NotificationType.WARNING)
                 }

--- a/src/main/kotlin/dev/ayuislands/font/FontInstaller.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontInstaller.kt
@@ -80,7 +80,16 @@ object FontInstaller {
         project: Project?,
         onComplete: (InstallResult) -> Unit,
     ) {
-        val entry = FontCatalog.forPreset(preset)
+        // Non-curated presets (currently only CUSTOM) have no install pipeline —
+        // user already chose their own font. Reaching this from UI requires a
+        // visibility-gate bypass; log + drop the call rather than throw to keep
+        // hot paths defensive against future caller changes (issue #164).
+        val entry =
+            FontCatalog.forPreset(preset)
+                ?: run {
+                    LOG.warn("FontInstaller.install called for non-curated preset $preset; ignoring")
+                    return
+                }
         val task =
             object : Task.Backgroundable(project, "Installing ${entry.displayName}…", true) {
                 override fun run(indicator: ProgressIndicator) {
@@ -95,13 +104,19 @@ object FontInstaller {
         preset: FontPreset,
         project: Project?,
     ) {
+        // Same null-safe stance as install() — CUSTOM has no catalog entry, but
+        // applyOnly's branch CAN still call FontPresetApplicator (font preference
+        // is set via FontSettings.decode without needing install metadata). Skip
+        // only the failure-notification path that needs the entry's displayName.
         val entry = FontCatalog.forPreset(preset)
         ApplicationManager.getApplication().invokeLater {
             try {
                 FontPresetApplicator.apply(FontSettings.decode(null, preset))
             } catch (exception: RuntimeException) {
                 LOG.warn("FontPresetApplicator.apply failed (applyOnly)", exception)
-                notify(entry, project, FailureKind.APPLY_FAILED, NotificationType.WARNING)
+                if (entry != null) {
+                    notify(entry, project, FailureKind.APPLY_FAILED, NotificationType.WARNING)
+                }
             }
         }
     }

--- a/src/main/kotlin/dev/ayuislands/font/FontInstaller.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontInstaller.kt
@@ -56,6 +56,15 @@ object FontInstaller {
         PERMISSION_DENIED,
         DROPDOWN_STALE,
         APPLY_FAILED,
+
+        /**
+         * Caller invoked install/uninstall with a non-curated preset (CUSTOM)
+         * that has no install pipeline. Distinguishes "we deliberately skipped
+         * this" from `UNKNOWN` ("we have no idea what went wrong"). Notification
+         * code paths that route on `UNKNOWN` to "please file a bug" must not
+         * route on `NON_CURATED` — this is intentional plugin behaviour.
+         */
+        NON_CURATED,
         UNKNOWN,
     }
 
@@ -91,8 +100,8 @@ object FontInstaller {
                     LOG.warn("FontInstaller.install called for non-curated preset $preset; ignoring")
                     onComplete(
                         InstallResult.Failure(
-                            kind = FailureKind.UNKNOWN,
-                            message = "No catalog entry for preset $preset (non-curated)",
+                            kind = FailureKind.NON_CURATED,
+                            message = "No catalog entry for preset ${preset.name} (non-curated)",
                         ),
                     )
                     return
@@ -111,20 +120,34 @@ object FontInstaller {
         preset: FontPreset,
         project: Project?,
     ) {
-        // applyOnly does not need install metadata: FontSettings.decode + the
-        // applicator can run for any preset (the font family for CUSTOM lives
-        // in user settings, not the catalog). The catalog lookup is only used
-        // to surface a failure-notification with a real displayName when the
-        // applicator throws. For CUSTOM we still log the throw so a future
-        // regression surfaces in idea.log even without a notification.
+        // applyOnly does not need install metadata: FontSettings.decode +
+        // FontPresetApplicator can run for any preset — for CUSTOM the family
+        // is read from `preset.fontFamily` (default) or the encoded settings
+        // string when one is supplied. The catalog lookup only supplies the
+        // displayName for the rich failure notification. When the lookup is
+        // null and the applicator throws, we emit a generic notification so
+        // the user gets feedback instead of a silent log line.
         val entry = FontCatalog.forPreset(preset)
         ApplicationManager.getApplication().invokeLater {
             try {
                 FontPresetApplicator.apply(FontSettings.decode(null, preset))
             } catch (exception: RuntimeException) {
-                LOG.warn("FontPresetApplicator.apply failed (applyOnly, preset=$preset)", exception)
+                LOG.warn("FontPresetApplicator.apply failed (applyOnly, preset=${preset.name})", exception)
                 if (entry != null) {
                     notify(entry, project, FailureKind.APPLY_FAILED, NotificationType.WARNING)
+                } else {
+                    // No catalog entry — give the user a generic notification
+                    // pointing at Settings → Editor → Font, the manual recovery path.
+                    Notifications.Bus.notify(
+                        Notification(
+                            NOTIFICATION_GROUP,
+                            NOTIFICATION_TITLE,
+                            "Couldn't apply ${preset.fontFamily}. " +
+                                "Open Settings → Editor → Font to set it manually.",
+                            NotificationType.WARNING,
+                        ),
+                        project,
+                    )
                 }
             }
         }
@@ -421,6 +444,9 @@ object FontInstaller {
             FailureKind.APPLY_FAILED ->
                 "Installed, but couldn't apply automatically. " +
                     "Open Settings → Editor → Font to pick ${entry.familyName}."
+            FailureKind.NON_CURATED ->
+                "This preset has no install pipeline — set the editor font manually " +
+                    "in Settings → Editor → Font."
             FailureKind.UNKNOWN ->
                 "Unexpected error. Please report at $GH_ISSUES_URL."
         }

--- a/src/main/kotlin/dev/ayuislands/font/FontUninstaller.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontUninstaller.kt
@@ -97,7 +97,16 @@ object FontUninstaller {
         project: Project?,
         onComplete: (UninstallResult) -> Unit,
     ) {
-        val entry = FontCatalog.forPreset(preset)
+        // Issue #164: non-curated presets (CUSTOM) have no install metadata to
+        // uninstall against. UI rows that route here are gated by fontInstalled,
+        // which is force-false for non-curated, so this branch should be unreachable
+        // under normal flow. Defensive log + drop the call rather than throw.
+        val entry =
+            FontCatalog.forPreset(preset)
+                ?: run {
+                    LOG.warn("FontUninstaller.uninstall called for non-curated preset $preset; ignoring")
+                    return
+                }
         val task =
             object : Task.Backgroundable(project, "Removing ${entry.displayName}…", true) {
                 override fun run(indicator: ProgressIndicator) {

--- a/src/main/kotlin/dev/ayuislands/font/FontUninstaller.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontUninstaller.kt
@@ -106,10 +106,14 @@ object FontUninstaller {
             FontCatalog.forPreset(preset)
                 ?: run {
                     LOG.warn("FontUninstaller.uninstall called for non-curated preset $preset; ignoring")
+                    // familyName uses preset.name (sentinel "CUSTOM") rather than
+                    // preset.fontFamily — the latter is `DEFAULT_CUSTOM_FONT` for
+                    // CUSTOM unless overridden, which would lie to telemetry/logs
+                    // about "we removed JetBrains Mono" when nothing was removed.
                     onComplete(
                         UninstallResult.Failure(
-                            familyName = preset.fontFamily,
-                            message = "No catalog entry for preset $preset (non-curated)",
+                            familyName = preset.name,
+                            message = "No catalog entry for preset ${preset.name} (non-curated)",
                         ),
                     )
                     return

--- a/src/main/kotlin/dev/ayuislands/font/FontUninstaller.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontUninstaller.kt
@@ -97,14 +97,21 @@ object FontUninstaller {
         project: Project?,
         onComplete: (UninstallResult) -> Unit,
     ) {
-        // Issue #164: non-curated presets (CUSTOM) have no install metadata to
-        // uninstall against. UI rows that route here are gated by fontInstalled,
-        // which is force-false for non-curated, so this branch should be unreachable
-        // under normal flow. Defensive log + drop the call rather than throw.
+        // Non-curated presets (CUSTOM) have no install metadata to uninstall.
+        // UI rows that route here are gated by fontInstalled, which is
+        // force-false for non-curated; this is unreachable under normal flow.
+        // Defensive log + fire onComplete with a Failure so callers tracking
+        // progress don't hang waiting for a callback that never fires.
         val entry =
             FontCatalog.forPreset(preset)
                 ?: run {
                     LOG.warn("FontUninstaller.uninstall called for non-curated preset $preset; ignoring")
+                    onComplete(
+                        UninstallResult.Failure(
+                            familyName = preset.fontFamily,
+                            message = "No catalog entry for preset $preset (non-curated)",
+                        ),
+                    )
                     return
                 }
         val task =

--- a/src/main/kotlin/dev/ayuislands/onboarding/PremiumOnboardingPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/onboarding/PremiumOnboardingPanel.kt
@@ -469,7 +469,10 @@ internal class PremiumOnboardingPanel(
 
     @Suppress("LongMethod")
     private fun createFontCard(preset: FontPreset): JPanel {
-        val entry = FontCatalog.forPreset(preset)
+        // FONT_PRESETS hard-codes the four curated installable presets — CUSTOM
+        // is never passed in here. requirePreset encodes that invariant in the
+        // type and fails fast if someone ever adds CUSTOM to the curated list.
+        val entry = FontCatalog.requirePreset(preset)
         val state = AyuIslandsSettings.getInstance().state
         val installed = state.installedFonts.contains(entry.familyName)
         val installing = installingFonts.contains(preset)
@@ -565,7 +568,7 @@ internal class PremiumOnboardingPanel(
 
     private fun handleFontCardClick(preset: FontPreset) {
         if (preset in installingFonts) return
-        val entry = FontCatalog.forPreset(preset)
+        val entry = FontCatalog.requirePreset(preset)
         val state = AyuIslandsSettings.getInstance().state
         if (state.installedFonts.contains(entry.familyName)) {
             FontInstaller.applyOnly(preset, project)

--- a/src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
@@ -377,12 +377,21 @@ class FontPresetPanel : AyuIslandsSettingsPanel {
                         AccentApplicator.resolveFocusedProject()
                             ?: run {
                                 LOG.warn(
-                                    "Run-in-Terminal could not resolve focused project; " +
-                                        "clipboard set, terminal not opened",
+                                    "Run-in-Terminal: visibility gate bypassed — focused project " +
+                                        "could not be resolved; clipboard set, terminal not opened",
                                 )
                                 return@link
                             }
-                    ToolWindowManager.getInstance(project).getToolWindow("Terminal")?.activate(null)
+                    val toolWindow =
+                        ToolWindowManager.getInstance(project).getToolWindow("Terminal")
+                            ?: run {
+                                LOG.warn(
+                                    "Run-in-Terminal: visibility gate bypassed — Terminal tool " +
+                                        "window unavailable; clipboard set, terminal not opened",
+                                )
+                                return@link
+                            }
+                    toolWindow.activate(null)
                 }
             }
             val combo = ComboBox(arrayOf("Built-in Terminal", "System Terminal"))

--- a/src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
@@ -261,7 +261,12 @@ class FontPresetPanel : AyuIslandsSettingsPanel {
         try {
             val preset = FontPreset.fromName(pendingPreset)
             val project = AccentApplicator.resolveFocusedProject()
-            val entry = FontCatalog.forPreset(preset)
+            // CUSTOM has no install pipeline (issue #164). The Install / Reinstall / Delete
+            // rows that route here are already gated by fontMissing/fontInstalled/fontCorrupted
+            // — none of which can be true for a non-curated preset (see updateFontMissing
+            // L491-494). Defensive null-check for completeness in case a future caller
+            // bypasses the visibility gate.
+            val entry = FontCatalog.forPreset(preset) ?: return
             val refresh = {
                 ApplicationManager.getApplication().invokeLater {
                     FontDetector.invalidateCache()
@@ -311,9 +316,16 @@ class FontPresetPanel : AyuIslandsSettingsPanel {
         if (!IS_MAC) return
 
         row {
+            // Build the label eagerly so [installHintLabel] is captured for later
+            // updates from updateFontMissing (it lazily refreshes label.text whenever
+            // the active preset or install status changes). For CUSTOM the catalog
+            // entry is null (issue #164) — the row is also gated by fontMissing
+            // which is force-false for non-curated presets, so the empty text is
+            // never visible to the user. Eagerly evaluating brewCaskSlug here would
+            // otherwise NPE during panel build and freeze Settings on Loading.
             val label = JLabel()
-            val slug = FontCatalog.forPreset(FontPreset.fromName(pendingPreset)).brewCaskSlug
-            label.text = "Or via Homebrew: brew install --cask $slug"
+            val slug = FontCatalog.forPreset(FontPreset.fromName(pendingPreset))?.brewCaskSlug.orEmpty()
+            label.text = if (slug.isNotEmpty()) "Or via Homebrew: brew install --cask $slug" else ""
             installHintLabel = label
             cell(label)
         }.visibleIf(fontMissing)
@@ -321,12 +333,14 @@ class FontPresetPanel : AyuIslandsSettingsPanel {
         row {
             link("Copy") {
                 val preset = FontPreset.fromName(pendingPreset)
-                val command = "brew install --cask ${FontCatalog.forPreset(preset).brewCaskSlug}"
+                val slug = FontCatalog.forPreset(preset)?.brewCaskSlug ?: return@link
+                val command = "brew install --cask $slug"
                 CopyPasteManager.getInstance().setContents(StringSelection(command))
             }
             link("Run in Terminal") {
                 val preset = FontPreset.fromName(pendingPreset)
-                val command = "brew install --cask ${FontCatalog.forPreset(preset).brewCaskSlug}"
+                val slug = FontCatalog.forPreset(preset)?.brewCaskSlug ?: return@link
+                val command = "brew install --cask $slug"
                 CopyPasteManager.getInstance().setContents(StringSelection(command))
                 val state = AyuIslandsSettings.getInstance().state
                 if (state.fontInstallTerminal == "SYSTEM") {
@@ -499,8 +513,12 @@ class FontPresetPanel : AyuIslandsSettingsPanel {
 
         warningLabel?.let { it.text = "\u26A0 Requires ${preset.fontFamily}" }
         installHintLabel?.let {
-            val slug = FontCatalog.forPreset(preset).brewCaskSlug
-            it.text = "Or via Homebrew: brew install --cask $slug"
+            // Issue #164: CUSTOM has no catalog entry; null-coalesce to empty so the
+            // label refresh during preset changes can't crash. The owning row is
+            // visibleIf(fontMissing) which is force-false for non-curated presets,
+            // so an empty text is never on screen \u2014 but the lambda still runs.
+            val slug = FontCatalog.forPreset(preset)?.brewCaskSlug.orEmpty()
+            it.text = if (slug.isNotEmpty()) "Or via Homebrew: brew install --cask $slug" else ""
         }
         previewComponent?.updatePreset(preset, status == FontStatus.HEALTHY)
     }

--- a/src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
@@ -261,12 +261,22 @@ class FontPresetPanel : AyuIslandsSettingsPanel {
         try {
             val preset = FontPreset.fromName(pendingPreset)
             val project = AccentApplicator.resolveFocusedProject()
-            // CUSTOM has no install pipeline (issue #164). The Install / Reinstall / Delete
-            // rows that route here are already gated by fontMissing/fontInstalled/fontCorrupted
-            // — none of which can be true for a non-curated preset (see updateFontMissing
-            // L491-494). Defensive null-check for completeness in case a future caller
-            // bypasses the visibility gate.
-            val entry = FontCatalog.forPreset(preset) ?: return
+            // CUSTOM has no install pipeline. The Install / Reinstall / Delete
+            // rows that route here are gated by fontMissing/fontInstalled/
+            // fontCorrupted — none of which can be true for a non-curated
+            // preset (updateFontMissing forces all three to false when
+            // !preset.isCurated). Log + drop here if a future caller ever
+            // bypasses the visibility gate, so the bypass surfaces in idea.log
+            // instead of silently no-op'ing the user's click.
+            val entry =
+                FontCatalog.forPreset(preset)
+                    ?: run {
+                        LOG.warn(
+                            "triggerLifecycleAction reached non-curated preset $preset " +
+                                "(uninstall=$uninstall) — visibility gate bypassed; dropping click",
+                        )
+                        return
+                    }
             val refresh = {
                 ApplicationManager.getApplication().invokeLater {
                     FontDetector.invalidateCache()
@@ -317,12 +327,13 @@ class FontPresetPanel : AyuIslandsSettingsPanel {
 
         row {
             // Build the label eagerly so [installHintLabel] is captured for later
-            // updates from updateFontMissing (it lazily refreshes label.text whenever
-            // the active preset or install status changes). For CUSTOM the catalog
-            // entry is null (issue #164) — the row is also gated by fontMissing
-            // which is force-false for non-curated presets, so the empty text is
-            // never visible to the user. Eagerly evaluating brewCaskSlug here would
-            // otherwise NPE during panel build and freeze Settings on Loading.
+            // updates from updateFontMissing (it lazily refreshes label.text
+            // whenever the active preset or install status changes). For CUSTOM
+            // the catalog entry is null — the row is also gated by fontMissing
+            // which is force-false for non-curated presets, so the empty text
+            // is never on screen. The null-coalesce on the lookup is what stops
+            // panel build from throwing IllegalStateException when CUSTOM is
+            // the persisted preset on first paint.
             val label = JLabel()
             val slug = FontCatalog.forPreset(FontPreset.fromName(pendingPreset))?.brewCaskSlug.orEmpty()
             label.text = if (slug.isNotEmpty()) "Or via Homebrew: brew install --cask $slug" else ""
@@ -513,10 +524,11 @@ class FontPresetPanel : AyuIslandsSettingsPanel {
 
         warningLabel?.let { it.text = "\u26A0 Requires ${preset.fontFamily}" }
         installHintLabel?.let {
-            // Issue #164: CUSTOM has no catalog entry; null-coalesce to empty so the
-            // label refresh during preset changes can't crash. The owning row is
-            // visibleIf(fontMissing) which is force-false for non-curated presets,
-            // so an empty text is never on screen \u2014 but the lambda still runs.
+            // CUSTOM has no catalog entry; null-coalesce to empty so the label
+            // refresh during preset changes can't crash. The owning row is
+            // visibleIf(fontMissing) which is force-false for non-curated
+            // presets, so empty text is never on screen — but the lambda still
+            // runs on every preset switch, hence the defensive lookup.
             val slug = FontCatalog.forPreset(preset)?.brewCaskSlug.orEmpty()
             it.text = if (slug.isNotEmpty()) "Or via Homebrew: brew install --cask $slug" else ""
         }

--- a/src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
@@ -344,20 +344,44 @@ class FontPresetPanel : AyuIslandsSettingsPanel {
         row {
             link("Copy") {
                 val preset = FontPreset.fromName(pendingPreset)
-                val slug = FontCatalog.forPreset(preset)?.brewCaskSlug ?: return@link
+                val slug =
+                    FontCatalog.forPreset(preset)?.brewCaskSlug
+                        ?: run {
+                            LOG.warn(
+                                "Brew Copy reached non-curated preset $preset — " +
+                                    "visibility gate bypassed; dropping click",
+                            )
+                            return@link
+                        }
                 val command = "brew install --cask $slug"
                 CopyPasteManager.getInstance().setContents(StringSelection(command))
             }
             link("Run in Terminal") {
                 val preset = FontPreset.fromName(pendingPreset)
-                val slug = FontCatalog.forPreset(preset)?.brewCaskSlug ?: return@link
+                val slug =
+                    FontCatalog.forPreset(preset)?.brewCaskSlug
+                        ?: run {
+                            LOG.warn(
+                                "Brew Run-in-Terminal reached non-curated preset $preset — " +
+                                    "visibility gate bypassed; dropping click",
+                            )
+                            return@link
+                        }
                 val command = "brew install --cask $slug"
                 CopyPasteManager.getInstance().setContents(StringSelection(command))
                 val state = AyuIslandsSettings.getInstance().state
                 if (state.fontInstallTerminal == "SYSTEM") {
                     ProcessBuilder("open", "-a", "Terminal").start()
                 } else {
-                    val project = AccentApplicator.resolveFocusedProject() ?: return@link
+                    val project =
+                        AccentApplicator.resolveFocusedProject()
+                            ?: run {
+                                LOG.warn(
+                                    "Run-in-Terminal could not resolve focused project; " +
+                                        "clipboard set, terminal not opened",
+                                )
+                                return@link
+                            }
                     ToolWindowManager.getInstance(project).getToolWindow("Terminal")?.activate(null)
                 }
             }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -92,6 +92,12 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>2.6.2</h3>
+    <ul>
+      <li>VCS modified-line color is now distinct from added — modified shifts to a saturated blue (Dark <code>#73B8FF</code>, Mirage <code>#80BFFF</code>) so it stops blending into the green added band on dense diffs. Bluer file-status colors in Project View and tabs as well.</li>
+      <li>Editor selection background returns to translucent (alpha 25%) on Dark and Mirage so highlighted text doesn't read as a solid blue block.</li>
+      <li>Settings page no longer freezes on "Loading…" forever when a Custom font preset is active (issue #164) — non-curated presets now skip the install pipeline cleanly instead of crashing the panel build.</li>
+    </ul>
     <h3>2.6.1</h3>
     <ul>
       <li>Calmed diff backgrounds across Dark, Light, and Mirage variants — modified diff no longer blends with text selection</li>

--- a/src/main/resources/themes/AyuIslandsDark.xml
+++ b/src/main/resources/themes/AyuIslandsDark.xml
@@ -27,8 +27,8 @@
         <option name="TEARLINE_COLOR" value="181C24" />
 
         <!-- Selection & hover -->
-        <option name="SELECTION_BACKGROUND" value="3388FF" />
-        <option name="INACTIVE_SELECTION_BACKGROUND" value="3388FF" />
+        <option name="SELECTION_BACKGROUND" value="3388FF40" />
+        <option name="INACTIVE_SELECTION_BACKGROUND" value="80B5FF26" />
         <option name="SELECTED_BACKGROUND" value="475266" />
         <option name="SELECTED_FOREGROUND" value="BFBDB6" />
         <option name="HOVER_BACKGROUND" value="475266" />
@@ -85,10 +85,10 @@
 
         <!-- VCS lines -->
         <option name="ADDED_LINES_COLOR" value="70BF56" />
-        <option name="MODIFIED_LINES_COLOR" value="59C2FF" />
+        <option name="MODIFIED_LINES_COLOR" value="73B8FF" />
         <option name="DELETED_LINES_COLOR" value="F26D78" />
         <option name="IGNORED_ADDED_LINES_BORDER_COLOR" value="70BF56" />
-        <option name="IGNORED_MODIFIED_LINES_BORDER_COLOR" value="59C2FF" />
+        <option name="IGNORED_MODIFIED_LINES_BORDER_COLOR" value="73B8FF" />
         <option name="IGNORED_DELETED_LINES_BORDER_COLOR" value="F26D78" />
 
         <!-- File status -->
@@ -102,24 +102,24 @@
         <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="F26D78" />
         <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="F26D78" />
         <option name="FILESTATUS_MERGED" value="5C61B4" />
-        <option name="FILESTATUS_MODIFIED" value="6BBCB4" />
+        <option name="FILESTATUS_MODIFIED" value="73B8FF" />
         <option name="FILESTATUS_NOT_CHANGED" value="9CA6B3" />
-        <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="6BBCB4" />
-        <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="6BBCB4" />
+        <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="73B8FF" />
+        <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="73B8FF" />
         <option name="FILESTATUS_OBSOLETE" value="FFB454" />
-        <option name="FILESTATUS_RENAMED" value="6BBCB4" />
+        <option name="FILESTATUS_RENAMED" value="73B8FF" />
         <option name="FILESTATUS_SUPPRESSED" value="44606A" />
         <option name="FILESTATUS_SWITCHED" value="F07178" />
         <option name="FILESTATUS_UNKNOWN" value="F07178" />
         <option name="FILESTATUS_addedOutside" value="AAD94C" />
         <option name="FILESTATUS_changelistConflict" value="F26D78" />
-        <option name="FILESTATUS_modifiedOutside" value="6BBCB4" />
+        <option name="FILESTATUS_modifiedOutside" value="73B8FF" />
 
         <!-- Diff -->
         <option name="DIFF_CONFLICT" value="D95757" />
         <option name="DIFF_DELETED" value="F26D78" />
         <option name="DIFF_INSERTED" value="70BF56" />
-        <option name="DIFF_MODIFIED" value="59C2FF" />
+        <option name="DIFF_MODIFIED" value="73B8FF" />
         <option name="DIFF_SEPARATORS_BACKGROUND" value="141821" />
 
         <!-- Borders & misc -->
@@ -890,8 +890,8 @@
         </option>
         <option name="DIFF_MODIFIED">
             <value>
-                <option name="BACKGROUND" value="25493D" />
-                <option name="ERROR_STRIPE_COLOR" value="59C2FF" />
+                <option name="BACKGROUND" value="2E4560" />
+                <option name="ERROR_STRIPE_COLOR" value="73B8FF" />
             </value>
         </option>
 

--- a/src/main/resources/themes/AyuIslandsMirage.xml
+++ b/src/main/resources/themes/AyuIslandsMirage.xml
@@ -27,8 +27,8 @@
         <option name="TEARLINE_COLOR" value="282C34" />
 
         <!-- Selection & hover -->
-        <option name="SELECTION_BACKGROUND" value="409FFF" />
-        <option name="INACTIVE_SELECTION_BACKGROUND" value="409FFF" />
+        <option name="SELECTION_BACKGROUND" value="409FFF40" />
+        <option name="INACTIVE_SELECTION_BACKGROUND" value="409FFF21" />
         <option name="SELECTED_BACKGROUND" value="637599" />
         <option name="SELECTED_FOREGROUND" value="CCCAC2" />
         <option name="HOVER_BACKGROUND" value="637599" />
@@ -85,10 +85,10 @@
 
         <!-- VCS lines -->
         <option name="ADDED_LINES_COLOR" value="87D96C" />
-        <option name="MODIFIED_LINES_COLOR" value="73D0FF" />
+        <option name="MODIFIED_LINES_COLOR" value="80BFFF" />
         <option name="DELETED_LINES_COLOR" value="F27983" />
         <option name="IGNORED_ADDED_LINES_BORDER_COLOR" value="87D96C" />
-        <option name="IGNORED_MODIFIED_LINES_BORDER_COLOR" value="73D0FF" />
+        <option name="IGNORED_MODIFIED_LINES_BORDER_COLOR" value="80BFFF" />
         <option name="IGNORED_DELETED_LINES_BORDER_COLOR" value="F27983" />
 
         <!-- File status (matches Ayu Mirage Complete) -->
@@ -102,24 +102,24 @@
         <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_CONFLICTS" value="F27983" />
         <option name="FILESTATUS_IDEA_FILESTATUS_MERGED_WITH_PROPERTY_CONFLICTS" value="F27983" />
         <option name="FILESTATUS_MERGED" value="6C71C4" />
-        <option name="FILESTATUS_MODIFIED" value="80CBC4" />
+        <option name="FILESTATUS_MODIFIED" value="80BFFF" />
         <option name="FILESTATUS_NOT_CHANGED" value="AFB9C3" />
-        <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="80CBC4" />
-        <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="80CBC4" />
+        <option name="FILESTATUS_NOT_CHANGED_IMMEDIATE" value="80BFFF" />
+        <option name="FILESTATUS_NOT_CHANGED_RECURSIVE" value="80BFFF" />
         <option name="FILESTATUS_OBSOLETE" value="FFCB6B" />
-        <option name="FILESTATUS_RENAMED" value="80CBC4" />
+        <option name="FILESTATUS_RENAMED" value="80BFFF" />
         <option name="FILESTATUS_SUPPRESSED" value="546E7A" />
         <option name="FILESTATUS_SWITCHED" value="F77669" />
         <option name="FILESTATUS_UNKNOWN" value="F77669" />
         <option name="FILESTATUS_addedOutside" value="C3E887" />
         <option name="FILESTATUS_changelistConflict" value="F27983" />
-        <option name="FILESTATUS_modifiedOutside" value="80CBC4" />
+        <option name="FILESTATUS_modifiedOutside" value="80BFFF" />
 
         <!-- Diff -->
         <option name="DIFF_CONFLICT" value="FF6666" />
         <option name="DIFF_DELETED" value="F27983" />
         <option name="DIFF_INSERTED" value="87D96C" />
-        <option name="DIFF_MODIFIED" value="73D0FF" />
+        <option name="DIFF_MODIFIED" value="80BFFF" />
         <option name="DIFF_SEPARATORS_BACKGROUND" value="282E3B" />
 
         <!-- Borders & misc -->
@@ -801,8 +801,8 @@
         </option>
         <option name="DIFF_MODIFIED">
             <value>
-                <option name="BACKGROUND" value="3A5B72" />
-                <option name="ERROR_STRIPE_COLOR" value="73D0FF" />
+                <option name="BACKGROUND" value="405672" />
+                <option name="ERROR_STRIPE_COLOR" value="80BFFF" />
             </value>
         </option>
 

--- a/src/test/kotlin/dev/ayuislands/font/FontAssetResolverTest.kt
+++ b/src/test/kotlin/dev/ayuislands/font/FontAssetResolverTest.kt
@@ -6,9 +6,9 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
 class FontAssetResolverTest {
-    private val mapleEntry = FontCatalog.forPreset(FontPreset.AMBIENT)
-    private val victorEntry = FontCatalog.forPreset(FontPreset.WHISPER)
-    private val neonEntry = FontCatalog.forPreset(FontPreset.NEON)
+    private val mapleEntry = FontCatalog.requirePreset(FontPreset.AMBIENT)
+    private val victorEntry = FontCatalog.requirePreset(FontPreset.WHISPER)
+    private val neonEntry = FontCatalog.requirePreset(FontPreset.NEON)
 
     @Test
     fun `direct-url entry bypasses http client`() {

--- a/src/test/kotlin/dev/ayuislands/font/FontCatalogTest.kt
+++ b/src/test/kotlin/dev/ayuislands/font/FontCatalogTest.kt
@@ -4,43 +4,66 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class FontCatalogTest {
-    // ---- forPreset lookups ----
+    // ---- forPreset / requirePreset lookups ----
 
     @Test
     fun `forPreset WHISPER returns Victor Mono`() {
-        val entry = FontCatalog.forPreset(FontPreset.WHISPER)
+        val entry = FontCatalog.requirePreset(FontPreset.WHISPER)
         assertEquals("Victor Mono", entry.familyName)
         assertEquals("Victor Mono", entry.displayName)
     }
 
     @Test
     fun `forPreset AMBIENT returns Maple Mono`() {
-        val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+        val entry = FontCatalog.requirePreset(FontPreset.AMBIENT)
         assertEquals("Maple Mono", entry.familyName)
         assertEquals("Maple Mono", entry.displayName)
     }
 
     @Test
     fun `forPreset NEON returns Monaspace Neon`() {
-        val entry = FontCatalog.forPreset(FontPreset.NEON)
+        val entry = FontCatalog.requirePreset(FontPreset.NEON)
         assertEquals("Monaspace Neon", entry.familyName)
         assertEquals("Monaspace Neon", entry.displayName)
     }
 
     @Test
     fun `forPreset CYBERPUNK returns Monaspace Xenon`() {
-        val entry = FontCatalog.forPreset(FontPreset.CYBERPUNK)
+        val entry = FontCatalog.requirePreset(FontPreset.CYBERPUNK)
         assertEquals("Monaspace Xenon", entry.familyName)
         assertEquals("Monaspace Xenon", entry.displayName)
     }
 
     @Test
-    fun `forPreset CUSTOM throws IllegalStateException`() {
+    fun `forPreset CUSTOM returns null (issue #164 — non-curated has no catalog entry)`() {
+        // RED-test for issue #164: pre-2.6.2 forPreset threw IllegalStateException here,
+        // freezing the Settings page on "Loading…" forever for users with persisted
+        // fontPresetName="CUSTOM". forPreset must return null so defensive callers can
+        // gracefully skip the install pipeline for non-curated presets.
+        assertNull(FontCatalog.forPreset(FontPreset.CUSTOM))
+    }
+
+    @Test
+    fun `requirePreset CUSTOM throws (curated-only API contract)`() {
+        // requirePreset is the non-null variant for call sites that statically
+        // operate on curated presets only (onboarding cards iterating FONT_PRESETS,
+        // tests pinning known presets). Passing CUSTOM is a programmer error and
+        // must fail fast.
         assertFailsWith<IllegalStateException> {
-            FontCatalog.forPreset(FontPreset.CUSTOM)
+            FontCatalog.requirePreset(FontPreset.CUSTOM)
+        }
+    }
+
+    @Test
+    fun `forPreset returns non-null entry for every curated preset`() {
+        val curatedPresets = FontPreset.entries.filter { it.isCurated }
+        for (preset in curatedPresets) {
+            assertNotNull(FontCatalog.forPreset(preset), "curated preset $preset must resolve to a catalog entry")
         }
     }
 
@@ -99,20 +122,20 @@ class FontCatalogTest {
 
     @Test
     fun `AMBIENT assetPattern matches expected zip filename`() {
-        val pattern = FontCatalog.forPreset(FontPreset.AMBIENT).assetPattern
+        val pattern = FontCatalog.requirePreset(FontPreset.AMBIENT).assetPattern
         assertTrue(pattern.matches("MapleMono-TTF.zip"))
         assertFalse(pattern.matches("MapleMono-OTF.zip"))
     }
 
     @Test
     fun `NEON assetPattern matches variable font zip`() {
-        val pattern = FontCatalog.forPreset(FontPreset.NEON).assetPattern
+        val pattern = FontCatalog.requirePreset(FontPreset.NEON).assetPattern
         assertTrue(pattern.containsMatchIn("monaspace-variable-v1.400.zip"))
     }
 
     @Test
     fun `CYBERPUNK assetPattern matches variable font zip`() {
-        val pattern = FontCatalog.forPreset(FontPreset.CYBERPUNK).assetPattern
+        val pattern = FontCatalog.requirePreset(FontPreset.CYBERPUNK).assetPattern
         assertTrue(pattern.containsMatchIn("monaspace-variable-v1.400.zip"))
     }
 
@@ -120,52 +143,52 @@ class FontCatalogTest {
 
     @Test
     fun `WHISPER filesToKeep matches VictorMono-Light ttf`() {
-        val regexes = FontCatalog.forPreset(FontPreset.WHISPER).filesToKeep
+        val regexes = FontCatalog.requirePreset(FontPreset.WHISPER).filesToKeep
         assertTrue(regexes.any { it.matches("fonts/VictorMono-Light.ttf") })
         assertTrue(regexes.any { it.matches("VictorMono-Light.otf") })
     }
 
     @Test
     fun `WHISPER filesToKeep rejects VictorMono-Bold`() {
-        val regexes = FontCatalog.forPreset(FontPreset.WHISPER).filesToKeep
+        val regexes = FontCatalog.requirePreset(FontPreset.WHISPER).filesToKeep
         assertFalse(regexes.any { it.matches("VictorMono-Bold.ttf") })
     }
 
     @Test
     fun `AMBIENT filesToKeep matches MapleMono-Regular ttf`() {
-        val regexes = FontCatalog.forPreset(FontPreset.AMBIENT).filesToKeep
+        val regexes = FontCatalog.requirePreset(FontPreset.AMBIENT).filesToKeep
         assertTrue(regexes.any { it.matches("MapleMono-Regular.ttf") })
     }
 
     @Test
     fun `AMBIENT filesToKeep rejects MapleMono-Bold`() {
-        val regexes = FontCatalog.forPreset(FontPreset.AMBIENT).filesToKeep
+        val regexes = FontCatalog.requirePreset(FontPreset.AMBIENT).filesToKeep
         assertFalse(regexes.any { it.matches("MapleMono-Bold.ttf") })
     }
 
     @Test
     fun `NEON filesToKeep matches MonaspaceNeonVarVF ttf`() {
-        val regexes = FontCatalog.forPreset(FontPreset.NEON).filesToKeep
+        val regexes = FontCatalog.requirePreset(FontPreset.NEON).filesToKeep
         assertTrue(regexes.any { it.matches("MonaspaceNeonVarVF.ttf") })
         assertTrue(regexes.any { it.matches("path/to/MonaspaceNeonVarVF.otf") })
     }
 
     @Test
     fun `NEON filesToKeep rejects MonaspaceXenonVarVF`() {
-        val regexes = FontCatalog.forPreset(FontPreset.NEON).filesToKeep
+        val regexes = FontCatalog.requirePreset(FontPreset.NEON).filesToKeep
         assertFalse(regexes.any { it.matches("MonaspaceXenonVarVF.ttf") })
     }
 
     @Test
     fun `CYBERPUNK filesToKeep matches MonaspaceXenonVarVF ttf`() {
-        val regexes = FontCatalog.forPreset(FontPreset.CYBERPUNK).filesToKeep
+        val regexes = FontCatalog.requirePreset(FontPreset.CYBERPUNK).filesToKeep
         assertTrue(regexes.any { it.matches("MonaspaceXenonVarVF.ttf") })
         assertTrue(regexes.any { it.matches("fonts/MonaspaceXenonVarVF.otf") })
     }
 
     @Test
     fun `CYBERPUNK filesToKeep rejects MonaspaceNeonVarVF`() {
-        val regexes = FontCatalog.forPreset(FontPreset.CYBERPUNK).filesToKeep
+        val regexes = FontCatalog.requirePreset(FontPreset.CYBERPUNK).filesToKeep
         assertFalse(regexes.any { it.matches("MonaspaceNeonVarVF.ttf") })
     }
 
@@ -173,7 +196,7 @@ class FontCatalogTest {
 
     @Test
     fun `WHISPER uses direct URL`() {
-        assertTrue(FontCatalog.forPreset(FontPreset.WHISPER).useDirectUrl)
+        assertTrue(FontCatalog.requirePreset(FontPreset.WHISPER).useDirectUrl)
     }
 
     @Test
@@ -189,16 +212,16 @@ class FontCatalogTest {
 
     @Test
     fun `NEON and CYBERPUNK share the same GitHub repo`() {
-        val neon = FontCatalog.forPreset(FontPreset.NEON)
-        val cyberpunk = FontCatalog.forPreset(FontPreset.CYBERPUNK)
+        val neon = FontCatalog.requirePreset(FontPreset.NEON)
+        val cyberpunk = FontCatalog.requirePreset(FontPreset.CYBERPUNK)
         assertEquals(neon.githubOwner, cyberpunk.githubOwner)
         assertEquals(neon.githubRepo, cyberpunk.githubRepo)
     }
 
     @Test
     fun `NEON and CYBERPUNK share the same fallbackUrl`() {
-        val neon = FontCatalog.forPreset(FontPreset.NEON)
-        val cyberpunk = FontCatalog.forPreset(FontPreset.CYBERPUNK)
+        val neon = FontCatalog.requirePreset(FontPreset.NEON)
+        val cyberpunk = FontCatalog.requirePreset(FontPreset.CYBERPUNK)
         assertEquals(neon.fallbackUrl, cyberpunk.fallbackUrl)
     }
 
@@ -217,7 +240,7 @@ class FontCatalogTest {
     fun `every curated FontPreset has a catalog entry`() {
         val curatedPresets = FontPreset.entries.filter { it.isCurated }
         for (preset in curatedPresets) {
-            val entry = FontCatalog.forPreset(preset)
+            val entry = FontCatalog.requirePreset(preset)
             assertEquals(preset, entry.preset)
         }
     }

--- a/src/test/kotlin/dev/ayuislands/font/FontCatalogTest.kt
+++ b/src/test/kotlin/dev/ayuislands/font/FontCatalogTest.kt
@@ -4,7 +4,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
-import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -12,35 +11,35 @@ class FontCatalogTest {
     // ---- forPreset / requirePreset lookups ----
 
     @Test
-    fun `forPreset WHISPER returns Victor Mono`() {
+    fun `requirePreset WHISPER returns Victor Mono`() {
         val entry = FontCatalog.requirePreset(FontPreset.WHISPER)
         assertEquals("Victor Mono", entry.familyName)
         assertEquals("Victor Mono", entry.displayName)
     }
 
     @Test
-    fun `forPreset AMBIENT returns Maple Mono`() {
+    fun `requirePreset AMBIENT returns Maple Mono`() {
         val entry = FontCatalog.requirePreset(FontPreset.AMBIENT)
         assertEquals("Maple Mono", entry.familyName)
         assertEquals("Maple Mono", entry.displayName)
     }
 
     @Test
-    fun `forPreset NEON returns Monaspace Neon`() {
+    fun `requirePreset NEON returns Monaspace Neon`() {
         val entry = FontCatalog.requirePreset(FontPreset.NEON)
         assertEquals("Monaspace Neon", entry.familyName)
         assertEquals("Monaspace Neon", entry.displayName)
     }
 
     @Test
-    fun `forPreset CYBERPUNK returns Monaspace Xenon`() {
+    fun `requirePreset CYBERPUNK returns Monaspace Xenon`() {
         val entry = FontCatalog.requirePreset(FontPreset.CYBERPUNK)
         assertEquals("Monaspace Xenon", entry.familyName)
         assertEquals("Monaspace Xenon", entry.displayName)
     }
 
     @Test
-    fun `forPreset CUSTOM returns null (issue #164 — non-curated has no catalog entry)`() {
+    fun `forPreset CUSTOM returns null (issue #164 - non-curated has no catalog entry)`() {
         // RED-test for issue #164: pre-2.6.2 forPreset threw IllegalStateException here,
         // freezing the Settings page on "Loading…" forever for users with persisted
         // fontPresetName="CUSTOM". forPreset must return null so defensive callers can
@@ -56,14 +55,6 @@ class FontCatalogTest {
         // must fail fast.
         assertFailsWith<IllegalStateException> {
             FontCatalog.requirePreset(FontPreset.CUSTOM)
-        }
-    }
-
-    @Test
-    fun `forPreset returns non-null entry for every curated preset`() {
-        val curatedPresets = FontPreset.entries.filter { it.isCurated }
-        for (preset in curatedPresets) {
-            assertNotNull(FontCatalog.forPreset(preset), "curated preset $preset must resolve to a catalog entry")
         }
     }
 

--- a/src/test/kotlin/dev/ayuislands/font/FontInstallConsentTest.kt
+++ b/src/test/kotlin/dev/ayuislands/font/FontInstallConsentTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class FontInstallConsentTest {
-    private val mapleEntry = FontCatalog.forPreset(FontPreset.AMBIENT)
+    private val mapleEntry = FontCatalog.requirePreset(FontPreset.AMBIENT)
 
     @BeforeTest
     fun setup() {

--- a/src/test/kotlin/dev/ayuislands/font/FontInstallerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/font/FontInstallerTest.kt
@@ -280,12 +280,11 @@ class FontInstallerTest {
     }
 
     @Test
-    fun `install fires Failure callback for non-curated preset and skips ProgressManager`() {
-        // Issue #164 follow-up — visibility-gate bypass with CUSTOM must NOT
-        // hang the caller waiting for a callback that never fires. The previous
-        // shape (LOG.warn + return) silently dropped onComplete, which would
-        // strand any progress-tracking caller (e.g. onboarding's installingFonts
-        // set + spinner). Lock the contract: callback fires, task is never queued.
+    fun `install fires NON_CURATED Failure callback and skips ProgressManager`() {
+        // Round-2 review: visibility-gate bypass with CUSTOM must NOT hang the
+        // caller waiting for a callback that never fires. Failure must use the
+        // typed NON_CURATED kind (not UNKNOWN — that copy reads "Please report",
+        // misleading users about an intentional skip). Task is never queued.
         mockkStatic(com.intellij.openapi.progress.ProgressManager::class)
         val progressMgr = mockk<com.intellij.openapi.progress.ProgressManager>(relaxed = true)
         every {
@@ -296,20 +295,18 @@ class FontInstallerTest {
         var captured: FontInstaller.InstallResult? = null
         FontInstaller.install(FontPreset.CUSTOM, project = null) { captured = it }
 
-        assertTrue(
-            captured is FontInstaller.InstallResult.Failure,
-            "non-curated install must fire Failure callback, got: $captured",
-        )
-        assertEquals(FontInstaller.FailureKind.UNKNOWN, (captured as FontInstaller.InstallResult.Failure).kind)
+        val failure = captured as? FontInstaller.InstallResult.Failure
+        assertTrue(failure != null, "non-curated install must fire Failure callback, got: $captured")
+        assertEquals(FontInstaller.FailureKind.NON_CURATED, failure.kind)
+        assertTrue(failure.message.contains("non-curated"), "message must signal non-curated origin")
         verify(exactly = 0) { progressMgr.run(any<com.intellij.openapi.progress.Task.Backgroundable>()) }
     }
 
     @Test
-    fun `applyOnly invokes applicator for non-curated preset without notification`() {
-        // Issue #164 follow-up — applyOnly is the asymmetric path: applicator
-        // still runs (the font family for CUSTOM lives in user settings, not
-        // the catalog), but the failure-notification needs entry.displayName
-        // and is skipped when entry is null. Lock both halves of that contract.
+    fun `applyOnly invokes applicator with CUSTOM-decoded settings for non-curated preset`() {
+        // Round-2 review: assert applicator runs with the RIGHT preset, not
+        // any preset. Previous test used `any()` and would pass on a future
+        // refactor that called apply with WHISPER instead of CUSTOM.
         mockkStatic(ApplicationManager::class)
         mockkStatic(Notifications.Bus::class)
         mockkObject(FontPresetApplicator)
@@ -321,16 +318,20 @@ class FontInstallerTest {
 
         FontInstaller.applyOnly(FontPreset.CUSTOM, project = null)
 
-        verify(exactly = 1) { FontPresetApplicator.apply(any()) }
+        verify(exactly = 1) {
+            FontPresetApplicator.apply(match { it.fontFamily == FontPreset.CUSTOM.fontFamily })
+        }
+        // Success path — no notification (the "couldn't apply" notification is
+        // for the catch branch, not the happy path).
         verify(exactly = 0) { Notifications.Bus.notify(any<Notification>(), null) }
     }
 
     @Test
-    fun `applyOnly skips notification when applicator throws and preset is non-curated`() {
-        // Same path, throwing case: applicator throws, entry is null, the
-        // catch block must log + skip notification (no displayName available).
-        // Verifies the silent-failure-hunter IMPORTANT-2 fix didn't introduce
-        // a notification-on-CUSTOM regression.
+    fun `applyOnly emits generic notification when applicator throws and preset is non-curated`() {
+        // Round-2 review: when entry is null AND apply throws, the user clicked
+        // something that visibly failed. Round 1 left this path silent (log
+        // only); Round 2 emits a generic notification pointing to manual
+        // recovery (Settings → Editor → Font). Lock the new contract.
         mockkStatic(ApplicationManager::class)
         mockkStatic(Notifications.Bus::class)
         mockkObject(FontPresetApplicator)
@@ -342,7 +343,14 @@ class FontInstallerTest {
 
         FontInstaller.applyOnly(FontPreset.CUSTOM, project = null)
 
-        verify(exactly = 0) { Notifications.Bus.notify(any<Notification>(), null) }
+        verify(exactly = 1) {
+            Notifications.Bus.notify(
+                match<Notification> {
+                    it.content.contains("Settings") && it.content.contains("Editor")
+                },
+                null,
+            )
+        }
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/font/FontInstallerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/font/FontInstallerTest.kt
@@ -280,6 +280,72 @@ class FontInstallerTest {
     }
 
     @Test
+    fun `install fires Failure callback for non-curated preset and skips ProgressManager`() {
+        // Issue #164 follow-up — visibility-gate bypass with CUSTOM must NOT
+        // hang the caller waiting for a callback that never fires. The previous
+        // shape (LOG.warn + return) silently dropped onComplete, which would
+        // strand any progress-tracking caller (e.g. onboarding's installingFonts
+        // set + spinner). Lock the contract: callback fires, task is never queued.
+        mockkStatic(com.intellij.openapi.progress.ProgressManager::class)
+        val progressMgr = mockk<com.intellij.openapi.progress.ProgressManager>(relaxed = true)
+        every {
+            com.intellij.openapi.progress.ProgressManager
+                .getInstance()
+        } returns progressMgr
+
+        var captured: FontInstaller.InstallResult? = null
+        FontInstaller.install(FontPreset.CUSTOM, project = null) { captured = it }
+
+        assertTrue(
+            captured is FontInstaller.InstallResult.Failure,
+            "non-curated install must fire Failure callback, got: $captured",
+        )
+        assertEquals(FontInstaller.FailureKind.UNKNOWN, (captured as FontInstaller.InstallResult.Failure).kind)
+        verify(exactly = 0) { progressMgr.run(any<com.intellij.openapi.progress.Task.Backgroundable>()) }
+    }
+
+    @Test
+    fun `applyOnly invokes applicator for non-curated preset without notification`() {
+        // Issue #164 follow-up — applyOnly is the asymmetric path: applicator
+        // still runs (the font family for CUSTOM lives in user settings, not
+        // the catalog), but the failure-notification needs entry.displayName
+        // and is skipped when entry is null. Lock both halves of that contract.
+        mockkStatic(ApplicationManager::class)
+        mockkStatic(Notifications.Bus::class)
+        mockkObject(FontPresetApplicator)
+        val appMock = mockk<Application>(relaxed = true)
+        every { ApplicationManager.getApplication() } returns appMock
+        every { appMock.invokeLater(any()) } answers { firstArg<Runnable>().run() }
+        every { FontPresetApplicator.apply(any()) } answers { /* no-op */ }
+        every { Notifications.Bus.notify(any<Notification>(), null) } answers { }
+
+        FontInstaller.applyOnly(FontPreset.CUSTOM, project = null)
+
+        verify(exactly = 1) { FontPresetApplicator.apply(any()) }
+        verify(exactly = 0) { Notifications.Bus.notify(any<Notification>(), null) }
+    }
+
+    @Test
+    fun `applyOnly skips notification when applicator throws and preset is non-curated`() {
+        // Same path, throwing case: applicator throws, entry is null, the
+        // catch block must log + skip notification (no displayName available).
+        // Verifies the silent-failure-hunter IMPORTANT-2 fix didn't introduce
+        // a notification-on-CUSTOM regression.
+        mockkStatic(ApplicationManager::class)
+        mockkStatic(Notifications.Bus::class)
+        mockkObject(FontPresetApplicator)
+        val appMock = mockk<Application>(relaxed = true)
+        every { ApplicationManager.getApplication() } returns appMock
+        every { appMock.invokeLater(any()) } answers { firstArg<Runnable>().run() }
+        every { FontPresetApplicator.apply(any()) } throws RuntimeException("boom")
+        every { Notifications.Bus.notify(any<Notification>(), null) } answers { }
+
+        FontInstaller.applyOnly(FontPreset.CUSTOM, project = null)
+
+        verify(exactly = 0) { Notifications.Bus.notify(any<Notification>(), null) }
+    }
+
+    @Test
     fun `applyOnly notifies user when apply fails (regression for silent warn)`() {
         mockkStatic(ApplicationManager::class)
         mockkStatic(Notifications.Bus::class)

--- a/src/test/kotlin/dev/ayuislands/font/FontInstallerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/font/FontInstallerTest.kt
@@ -180,7 +180,7 @@ class FontInstallerTest {
                 ),
             )
         val extractDir = File(tmpRoot, "extracted").apply { mkdirs() }
-        val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+        val entry = FontCatalog.requirePreset(FontPreset.AMBIENT)
 
         val extracted = FontInstaller.extractFonts(zip, extractDir, entry)
 
@@ -197,7 +197,7 @@ class FontInstallerTest {
                 mapOf("README.md" to "docs".toByteArray()),
             )
         val extractDir = File(tmpRoot, "extracted-empty").apply { mkdirs() }
-        val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+        val entry = FontCatalog.requirePreset(FontPreset.AMBIENT)
 
         val thrown =
             runCatching { FontInstaller.extractFonts(zip, extractDir, entry) }

--- a/src/test/kotlin/dev/ayuislands/font/FontInstallerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/font/FontInstallerTest.kt
@@ -318,8 +318,12 @@ class FontInstallerTest {
 
         FontInstaller.applyOnly(FontPreset.CUSTOM, project = null)
 
+        // Hard-coded "JetBrains Mono" rather than `FontPreset.CUSTOM.fontFamily`
+        // so the test fails loudly if either side (preset constant OR apply call)
+        // moves independently. Coupling to the same enum field both sides would
+        // weaken the lock to "they happen to agree right now".
         verify(exactly = 1) {
-            FontPresetApplicator.apply(match { it.fontFamily == FontPreset.CUSTOM.fontFamily })
+            FontPresetApplicator.apply(match { it.fontFamily == "JetBrains Mono" })
         }
         // Success path — no notification (the "couldn't apply" notification is
         // for the catch branch, not the happy path).

--- a/src/test/kotlin/dev/ayuislands/font/FontLifecycleIntegrationTest.kt
+++ b/src/test/kotlin/dev/ayuislands/font/FontLifecycleIntegrationTest.kt
@@ -96,7 +96,7 @@ class FontLifecycleIntegrationTest {
             assertEquals(fontFile.absolutePath, state.installedFontFiles["Maple Mono"], "File path must be tracked")
 
             // Step 2: Simulate delete via Settings panel.
-            val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+            val entry = FontCatalog.requirePreset(FontPreset.AMBIENT)
             val indicator = mockk<ProgressIndicator>(relaxed = true)
             var result: FontUninstaller.UninstallResult? = null
             FontUninstaller.runUninstallPipeline(entry, null, indicator) { result = it }
@@ -142,7 +142,7 @@ class FontLifecycleIntegrationTest {
             assertTrue(state.installedFonts.contains("Victor Mono"))
 
             // Delete Maple Mono only.
-            val entry = FontCatalog.forPreset(FontPreset.AMBIENT) // Maple Mono
+            val entry = FontCatalog.requirePreset(FontPreset.AMBIENT) // Maple Mono
             val indicator = mockk<ProgressIndicator>(relaxed = true)
             FontUninstaller.runUninstallPipeline(entry, null, indicator) { }
 
@@ -215,7 +215,7 @@ class FontLifecycleIntegrationTest {
             // Install + delete via plugin.
             val fontFile = File(platformDir, "MapleMono-Regular.ttf").apply { writeText("font") }
             FontInstaller.persistFontState("Maple Mono", listOf(fontFile))
-            val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+            val entry = FontCatalog.requirePreset(FontPreset.AMBIENT)
             val indicator = mockk<ProgressIndicator>(relaxed = true)
             FontUninstaller.runUninstallPipeline(entry, null, indicator) { }
 
@@ -250,7 +250,7 @@ class FontLifecycleIntegrationTest {
             val fontFile = File(platformDir, "MapleMono-Regular.ttf").apply { writeText("font") }
             FontInstaller.persistFontState("Maple Mono", listOf(fontFile))
 
-            val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+            val entry = FontCatalog.requirePreset(FontPreset.AMBIENT)
             val indicator = mockk<ProgressIndicator>(relaxed = true)
             FontUninstaller.runUninstallPipeline(entry, null, indicator) { }
 
@@ -274,7 +274,7 @@ class FontLifecycleIntegrationTest {
             val fontFile = File(platformDir, "MapleMono-Regular.ttf").apply { writeText("font") }
             FontInstaller.persistFontState("Maple Mono", listOf(fontFile))
 
-            val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+            val entry = FontCatalog.requirePreset(FontPreset.AMBIENT)
             val indicator = mockk<ProgressIndicator>(relaxed = true)
             FontUninstaller.runUninstallPipeline(entry, null, indicator) { }
 

--- a/src/test/kotlin/dev/ayuislands/font/FontUninstallerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/font/FontUninstallerTest.kt
@@ -293,6 +293,27 @@ class FontUninstallerTest {
         verify(exactly = 1) { progressMgr.run(any<Task.Backgroundable>()) }
     }
 
+    @Test
+    fun `uninstall fires Failure callback for non-curated preset and skips ProgressManager`() {
+        // Issue #164 follow-up — the non-curated defensive guard must invoke
+        // onComplete with a Failure rather than silently dropping the callback.
+        // Symmetric to FontInstaller.install(CUSTOM). Locks the contract at the
+        // public entry point so a future refactor can't strand a progress-
+        // tracking caller in a permanent in-flight state.
+        mockkStatic(ProgressManager::class)
+        val progressMgr = mockk<ProgressManager>(relaxed = true)
+        every { ProgressManager.getInstance() } returns progressMgr
+
+        var captured: FontUninstaller.UninstallResult? = null
+        FontUninstaller.uninstall(FontPreset.CUSTOM, null) { captured = it }
+
+        assertTrue(
+            captured is FontUninstaller.UninstallResult.Failure,
+            "non-curated uninstall must fire Failure callback, got: $captured",
+        )
+        verify(exactly = 0) { progressMgr.run(any<Task.Backgroundable>()) }
+    }
+
     // ---- user-related edge cases ----
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/font/FontUninstallerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/font/FontUninstallerTest.kt
@@ -93,7 +93,7 @@ class FontUninstallerTest {
                 }
             stubUninstallPipeline(state, platformDir, activeEditorFont = "JetBrains Mono")
 
-            val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+            val entry = FontCatalog.requirePreset(FontPreset.AMBIENT)
             val indicator = mockk<ProgressIndicator>(relaxed = true)
             var result: FontUninstaller.UninstallResult? = null
             FontUninstaller.runUninstallPipeline(entry, null, indicator) { result = it }
@@ -120,7 +120,7 @@ class FontUninstallerTest {
                 }
             stubUninstallPipeline(state, platformDir, activeEditorFont = "JetBrains Mono")
 
-            val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+            val entry = FontCatalog.requirePreset(FontPreset.AMBIENT)
             val indicator = mockk<ProgressIndicator>(relaxed = true)
             FontUninstaller.runUninstallPipeline(entry, null, indicator) { }
 
@@ -147,7 +147,7 @@ class FontUninstallerTest {
                 }
             stubUninstallPipeline(state, platformDir, activeEditorFont = "Maple Mono")
 
-            val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+            val entry = FontCatalog.requirePreset(FontPreset.AMBIENT)
             val indicator = mockk<ProgressIndicator>(relaxed = true)
             FontUninstaller.runUninstallPipeline(entry, null, indicator) { }
 
@@ -169,7 +169,7 @@ class FontUninstallerTest {
                 }
             stubUninstallPipeline(state, platformDir, activeEditorFont = "JetBrains Mono")
 
-            val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+            val entry = FontCatalog.requirePreset(FontPreset.AMBIENT)
             val indicator = mockk<ProgressIndicator>(relaxed = true)
             FontUninstaller.runUninstallPipeline(entry, null, indicator) { }
 
@@ -193,7 +193,7 @@ class FontUninstallerTest {
                 }
             stubUninstallPipeline(state, platformDir, activeEditorFont = "JetBrains Mono")
 
-            val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+            val entry = FontCatalog.requirePreset(FontPreset.AMBIENT)
             val indicator = mockk<ProgressIndicator>(relaxed = true)
             var result: FontUninstaller.UninstallResult? = null
             FontUninstaller.runUninstallPipeline(entry, null, indicator) { result = it }
@@ -232,7 +232,7 @@ class FontUninstallerTest {
                 }
             stubUninstallPipeline(state, platformDir, activeEditorFont = "JetBrains Mono")
 
-            val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+            val entry = FontCatalog.requirePreset(FontPreset.AMBIENT)
             val indicator = mockk<ProgressIndicator>(relaxed = true)
             var result: FontUninstaller.UninstallResult? = null
             try {
@@ -265,7 +265,7 @@ class FontUninstallerTest {
                 }
             stubUninstallPipeline(state, platformDir, activeEditorFont = "JetBrains Mono")
 
-            val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+            val entry = FontCatalog.requirePreset(FontPreset.AMBIENT)
             val indicator = mockk<ProgressIndicator>(relaxed = true)
             var result: FontUninstaller.UninstallResult? = null
             FontUninstaller.runUninstallPipeline(entry, null, indicator) { result = it }
@@ -308,7 +308,7 @@ class FontUninstallerTest {
             stubUninstallPipeline(state, platformDir, activeEditorFont = "Maple Mono")
             every { FontPresetApplicator.revert() } throws RuntimeException("EDT crash")
 
-            val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+            val entry = FontCatalog.requirePreset(FontPreset.AMBIENT)
             val indicator = mockk<ProgressIndicator>(relaxed = true)
             var result: FontUninstaller.UninstallResult? = null
             FontUninstaller.runUninstallPipeline(entry, null, indicator) { result = it }
@@ -334,7 +334,7 @@ class FontUninstallerTest {
                 }
             stubUninstallPipeline(state, platformDir, activeEditorFont = "JetBrains Mono")
 
-            val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+            val entry = FontCatalog.requirePreset(FontPreset.AMBIENT)
             val indicator = mockk<ProgressIndicator>(relaxed = true)
             var result: FontUninstaller.UninstallResult? = null
             FontUninstaller.runUninstallPipeline(entry, null, indicator) { result = it }
@@ -371,7 +371,7 @@ class FontUninstallerTest {
         mockkStatic(Notifications.Bus::class)
         every { Notifications.Bus.notify(any<Notification>(), null) } answers { }
 
-        val entry = FontCatalog.forPreset(FontPreset.AMBIENT)
+        val entry = FontCatalog.requirePreset(FontPreset.AMBIENT)
         val indicator = mockk<ProgressIndicator>(relaxed = true)
         var result: FontUninstaller.UninstallResult? = null
         FontUninstaller.runUninstallPipeline(entry, null, indicator) { result = it }

--- a/src/test/kotlin/dev/ayuislands/font/FontUninstallerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/font/FontUninstallerTest.kt
@@ -294,12 +294,12 @@ class FontUninstallerTest {
     }
 
     @Test
-    fun `uninstall fires Failure callback for non-curated preset and skips ProgressManager`() {
-        // Issue #164 follow-up — the non-curated defensive guard must invoke
-        // onComplete with a Failure rather than silently dropping the callback.
-        // Symmetric to FontInstaller.install(CUSTOM). Locks the contract at the
-        // public entry point so a future refactor can't strand a progress-
-        // tracking caller in a permanent in-flight state.
+    fun `uninstall fires Failure with CUSTOM sentinel familyName and skips ProgressManager`() {
+        // Round-2 review: familyName must use preset.name ("CUSTOM") sentinel,
+        // not preset.fontFamily — the latter is DEFAULT_CUSTOM_FONT
+        // ("JetBrains Mono") for CUSTOM, which lies to telemetry/logs about
+        // a removal that never happened. Symmetric to FontInstaller.install
+        // contract: callback fires, task is never queued.
         mockkStatic(ProgressManager::class)
         val progressMgr = mockk<ProgressManager>(relaxed = true)
         every { ProgressManager.getInstance() } returns progressMgr
@@ -307,9 +307,16 @@ class FontUninstallerTest {
         var captured: FontUninstaller.UninstallResult? = null
         FontUninstaller.uninstall(FontPreset.CUSTOM, null) { captured = it }
 
+        val failure = captured as? FontUninstaller.UninstallResult.Failure
+        assertTrue(failure != null, "non-curated uninstall must fire Failure callback, got: $captured")
+        assertEquals(
+            "CUSTOM",
+            failure.familyName,
+            "familyName must be the preset.name sentinel, not the default font family",
+        )
         assertTrue(
-            captured is FontUninstaller.UninstallResult.Failure,
-            "non-curated uninstall must fire Failure callback, got: $captured",
+            failure.message.contains("non-curated"),
+            "message must signal non-curated origin",
         )
         verify(exactly = 0) { progressMgr.run(any<Task.Backgroundable>()) }
     }

--- a/src/test/kotlin/dev/ayuislands/settings/FontPresetPanelCustomBytecodeTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/FontPresetPanelCustomBytecodeTest.kt
@@ -1,9 +1,20 @@
 package dev.ayuislands.settings
 
+import com.intellij.openapi.observable.properties.AtomicBooleanProperty
+import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.font.FontCatalog
+import dev.ayuislands.font.FontDetector
+import dev.ayuislands.font.FontInstaller
 import dev.ayuislands.font.FontPreset
+import dev.ayuislands.font.FontStatus
+import dev.ayuislands.font.FontUninstaller
 import dev.ayuislands.onboarding.PremiumOnboardingPanel
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.verify
 import javax.swing.JLabel
+import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -31,6 +42,11 @@ import kotlin.test.assertTrue
  * raw bytes. No Swing / DSL runtime is required.
  */
 class FontPresetPanelCustomBytecodeTest {
+    @AfterTest
+    fun cleanup() {
+        unmockkAll()
+    }
+
     @Test
     fun `FontPresetPanel bytecode references nullable forPreset (issue #164 defensive lock)`() {
         // Defensive call sites in triggerLifecycleAction, buildInstallHintRow,
@@ -115,24 +131,20 @@ class FontPresetPanelCustomBytecodeTest {
 
     @Test
     fun `updateFontMissing runs without throwing when pendingPreset is CUSTOM (issue #164 runtime lock)`() {
-        // Round-2 review C1: bytecode tests above prove the symbols are right,
-        // but they pass even if a future regression writes
-        // `forPreset(preset)!!.brewCaskSlug` (still references "forPreset"). The
-        // actual freeze in 2.6.1 happened at panel-build time when the
+        // Round-2 C1: bytecode tests prove the symbols are right but pass on a
+        // future `forPreset(preset)!!.brewCaskSlug` regression. The actual
+        // 2.6.1 freeze happened at panel-build time when the
         // installHintLabel?.let { FontCatalog.forPreset(...).brewCaskSlug }
-        // lambda evaluated for CUSTOM. Run that lambda directly: set
-        // pendingPreset="CUSTOM", attach a real JLabel to installHintLabel,
-        // invoke updateFontMissing() — must not throw, must leave label.text
-        // empty (no Brew cask slug for non-curated).
+        // lambda evaluated for CUSTOM. Run that lambda directly with
+        // pendingPreset="CUSTOM" and assert the visibility-gate booleans
+        // collapse to false (Round-3 strengthening — the original test only
+        // asserted label.text==""; that left the `preset.isCurated &&` guard
+        // on the boolean assignments untested).
         val panel = FontPresetPanel()
         setPrivateField(panel, "pendingPreset", FontPreset.CUSTOM.name)
-        setPrivateField(panel, "pendingEnabled", false) // collapses to NOT_INSTALLED, skips FontDetector
+        setPrivateField(panel, "pendingEnabled", true) // would force-enable for curated; CUSTOM still collapses
         val label = JLabel("placeholder")
         setPrivateField(panel, "installHintLabel", label)
-
-        // Initialize the lateinit `availability` field so the previewComponent
-        // line at the bottom of updateFontMissing doesn't NPE — empty map is
-        // fine since updatePreset takes a preset parameter we don't care about.
         setPrivateField(panel, "availability", emptyMap<FontPreset, Boolean>())
 
         invokePrivateMethod(panel, "updateFontMissing")
@@ -142,28 +154,80 @@ class FontPresetPanelCustomBytecodeTest {
             label.text,
             "installHintLabel.text must be empty for CUSTOM (no Brew cask slug for non-curated)",
         )
+        // Visibility-gate invariant: all three booleans must be false for
+        // non-curated presets regardless of pendingEnabled. A future regression
+        // that strips `preset.isCurated &&` from the boolean assignments would
+        // re-expose the install row for CUSTOM and reproduce issue #164.
+        assertFalse(getBooleanProperty(panel, "fontMissing"), "fontMissing must be false for CUSTOM")
+        assertFalse(getBooleanProperty(panel, "fontInstalled"), "fontInstalled must be false for CUSTOM")
+        assertFalse(getBooleanProperty(panel, "fontCorrupted"), "fontCorrupted must be false for CUSTOM")
     }
 
     @Test
-    fun `triggerLifecycleAction does not throw when pendingPreset is CUSTOM`() {
-        // Round-2 review C1: the install-row link callback routes through
-        // triggerLifecycleAction. With pendingPreset=CUSTOM, the new LOG.warn
-        // path must run cleanly: forPreset returns null, the warn fires, the
-        // method returns without queuing any install/uninstall task. The catch
-        // block surrounding the body would also swallow any unexpected throw,
-        // but the goal here is to assert the happy path of the defensive guard.
+    fun `updateFontMissing handles curated preset with pendingEnabled and stubbed FontDetector`() {
+        // Round-3 I2: original updateFontMissing test ran with
+        // pendingEnabled=false to dodge FontDetector.status(). That left the
+        // FontDetector branch uncovered — exactly the kind of "build-time
+        // evaluation crashes" path issue #164 was about. Cover it explicitly
+        // here with a curated preset and stubbed status, asserting the boolean
+        // assignments mirror the status snapshot.
+        mockkObject(FontDetector)
+        every { FontDetector.status(FontPreset.WHISPER) } returns FontStatus.HEALTHY
+
+        val panel = FontPresetPanel()
+        setPrivateField(panel, "pendingPreset", FontPreset.WHISPER.name)
+        setPrivateField(panel, "pendingEnabled", true)
+        setPrivateField(panel, "installHintLabel", JLabel())
+        setPrivateField(panel, "availability", mapOf(FontPreset.WHISPER to true))
+
+        invokePrivateMethod(panel, "updateFontMissing")
+
+        assertFalse(getBooleanProperty(panel, "fontMissing"), "WHISPER healthy: fontMissing must be false")
+        assertTrue(getBooleanProperty(panel, "fontInstalled"), "WHISPER healthy: fontInstalled must be true")
+        assertFalse(getBooleanProperty(panel, "fontCorrupted"), "WHISPER healthy: fontCorrupted must be false")
+    }
+
+    @Test
+    fun `triggerLifecycleAction with CUSTOM hits visibility-gate guard and never dispatches install or uninstall`() {
+        // Round-3 C1: the original "does not throw" test was masked by the
+        // outer try/catch — AccentApplicator.resolveFocusedProject() throws on
+        // a plain JVM (no platform Application bootstrapped) and the catch
+        // swallows the throw, so the test passed without ever reaching the
+        // forPreset null-guard. Stub the platform call AND the install /
+        // uninstall objects, then assert via verify(exactly = 0) that no
+        // install/uninstall was dispatched. That's the actual behavior we
+        // want to lock for the CUSTOM defensive path.
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.resolveFocusedProject() } returns null
+        mockkObject(FontInstaller)
+        mockkObject(FontUninstaller)
+
         val panel = FontPresetPanel()
         setPrivateField(panel, "pendingPreset", FontPreset.CUSTOM.name)
         setPrivateField(panel, "pendingEnabled", false)
         setPrivateField(panel, "availability", emptyMap<FontPreset, Boolean>())
 
         val method =
-            FontPresetPanel::class.java.getDeclaredMethod("triggerLifecycleAction", Boolean::class.javaPrimitiveType)
+            FontPresetPanel::class.java.getDeclaredMethod(
+                "triggerLifecycleAction",
+                Boolean::class.javaPrimitiveType,
+            )
         method.isAccessible = true
-        // Should return cleanly — visibility-gate-bypass guard fires LOG.warn
-        // and returns without dispatching to FontInstaller / FontUninstaller.
-        method.invoke(panel, false)
-        method.invoke(panel, true)
+        method.invoke(panel, false) // install attempt
+        method.invoke(panel, true) // uninstall attempt
+
+        verify(exactly = 0) { FontInstaller.install(any(), any(), any()) }
+        verify(exactly = 0) { FontUninstaller.uninstall(any(), any(), any()) }
+    }
+
+    private fun getBooleanProperty(
+        target: Any,
+        name: String,
+    ): Boolean {
+        val field = FontPresetPanel::class.java.getDeclaredField(name)
+        field.isAccessible = true
+        val property = field.get(target) as AtomicBooleanProperty
+        return property.get()
     }
 
     private fun setPrivateField(

--- a/src/test/kotlin/dev/ayuislands/settings/FontPresetPanelCustomBytecodeTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/FontPresetPanelCustomBytecodeTest.kt
@@ -1,0 +1,123 @@
+package dev.ayuislands.settings
+
+import dev.ayuislands.font.FontCatalog
+import dev.ayuislands.font.FontPreset
+import dev.ayuislands.onboarding.PremiumOnboardingPanel
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Bytecode-level regression locks for the issue #164 fix.
+ *
+ * Issue #164 froze the Settings page on "Loading…" forever for users with
+ * persisted `fontPresetName="CUSTOM"` because `FontCatalog.forPreset(CUSTOM)`
+ * threw `IllegalStateException` from the eager Brew-cask hint row body in
+ * [FontPresetPanel] at panel-build time. The structural fix splits the
+ * catalog API into [FontCatalog.forPreset] (nullable) and
+ * [FontCatalog.requirePreset] (non-null, throws). Defensive call sites in
+ * `FontPresetPanel` MUST use `forPreset`; curated-only call sites in
+ * [PremiumOnboardingPanel] MUST use `requirePreset`.
+ *
+ * These tests pin those choices at the bytecode level so a future refactor
+ * that reverts `FontPresetPanel` to `requirePreset` (e.g. a "simplification"
+ * that misses the CUSTOM persisted-state code path) fails fast at CI rather
+ * than reproducing the freeze for users.
+ *
+ * Pattern mirrors `AyuIslandsAccentPanelTest`'s bytecode-inspection tests:
+ * read the compiled `.class` resource, search for symbol references in the
+ * raw bytes. No Swing / DSL runtime is required.
+ */
+class FontPresetPanelCustomBytecodeTest {
+    @Test
+    fun `FontPresetPanel bytecode references nullable forPreset (issue #164 defensive lock)`() {
+        // The defensive call sites at L269 (triggerLifecycleAction), L327
+        // (buildInstallHintRow), L336 / L342 (Copy / Run-in-Terminal links),
+        // L520 (updateFontMissing) all consume `pendingPreset`, which the user
+        // can drive to CUSTOM through the segmented button. They MUST use
+        // `forPreset` (nullable). If the bytecode references `requirePreset`
+        // anywhere in this class, issue #164 has been reintroduced.
+        val classText = readClassBytes("FontPresetPanel")
+        assertTrue(
+            classText.contains("forPreset"),
+            "FontPresetPanel bytecode must reference FontCatalog.forPreset (nullable) — " +
+                "the defensive code path that prevents issue #164 freeze on CUSTOM presets",
+        )
+        assertFalse(
+            classText.contains("requirePreset"),
+            "FontPresetPanel bytecode MUST NOT reference FontCatalog.requirePreset — " +
+                "user-driven preset paths route through pendingPreset which can be CUSTOM, " +
+                "and requirePreset throws IllegalStateException for non-curated presets " +
+                "(this is the regression that froze Settings on \"Loading…\" in 2.6.1).",
+        )
+    }
+
+    @Test
+    fun `FontPresetPanel bytecode logs a warning before dropping non-curated lifecycle clicks`() {
+        // triggerLifecycleAction's `?: return` was originally silent — a future
+        // visibility-gate bypass would silently no-op the user's click with no
+        // diagnostic in idea.log. Round-1 review fix added a LOG.warn before
+        // the early return. Lock it: bytecode must reference both `LOG.warn`
+        // and the `forPreset` lookup that precedes it.
+        val classText = readClassBytes("FontPresetPanel")
+        assertTrue(
+            classText.contains("visibility gate bypassed"),
+            "triggerLifecycleAction must log a 'visibility gate bypassed' warning when " +
+                "forPreset returns null (so future regressions surface in idea.log)",
+        )
+    }
+
+    @Test
+    fun `PremiumOnboardingPanel bytecode references requirePreset for curated-only paths`() {
+        // FONT_PRESETS = [WHISPER, AMBIENT, NEON, CYBERPUNK] — CUSTOM is never
+        // passed to createFontCard / handleFontCardClick. requirePreset encodes
+        // that invariant: a future regression that adds CUSTOM to FONT_PRESETS
+        // throws IllegalStateException at first paint, fail-fast.
+        val classText = readClassBytes("../onboarding/PremiumOnboardingPanel")
+        assertTrue(
+            classText.contains("requirePreset"),
+            "PremiumOnboardingPanel must use FontCatalog.requirePreset for FONT_PRESETS " +
+                "iteration so a regression that admits CUSTOM fails fast",
+        )
+    }
+
+    @Test
+    fun `PremiumOnboardingPanel FONT_PRESETS list contains only curated presets`() {
+        // Reflective invariant on the private FONT_PRESETS field. The bytecode
+        // test above asserts `requirePreset` is the lookup; this asserts the
+        // upstream filter (the list itself) excludes CUSTOM. Both together
+        // make the curated-only contract robust against either side drifting.
+        // Kotlin private companion-object vals get compiled as private static
+        // fields on the enclosing class, not on $Companion. Reflect there.
+        val fontPresetsField =
+            PremiumOnboardingPanel::class.java.getDeclaredField("FONT_PRESETS")
+        fontPresetsField.isAccessible = true
+
+        @Suppress("UNCHECKED_CAST")
+        val presets = fontPresetsField.get(null) as List<FontPreset>
+
+        assertTrue(presets.isNotEmpty(), "FONT_PRESETS must not be empty")
+        assertTrue(
+            presets.all { it.isCurated },
+            "FONT_PRESETS must contain only curated presets, got: " +
+                presets.filter { !it.isCurated },
+        )
+        assertFalse(
+            presets.contains(FontPreset.CUSTOM),
+            "FONT_PRESETS must not include CUSTOM (would break PremiumOnboardingPanel's requirePreset contract)",
+        )
+    }
+
+    private fun readClassBytes(simpleName: String): String {
+        // Anchor on FontPresetPanel for FontPresetPanel; cross-package paths
+        // (e.g. ../onboarding/PremiumOnboardingPanel) still resolve via the
+        // class loader's path-relative .class lookup.
+        val resource = "$simpleName.class"
+        val stream =
+            FontPresetPanel::class.java.getResourceAsStream(resource)
+                ?: error("$simpleName.class must be loadable for bytecode inspection")
+        val bytes = stream.use { it.readAllBytes() }
+        assertTrue(bytes.isNotEmpty(), "$simpleName.class must not be empty")
+        return String(bytes, Charsets.ISO_8859_1)
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/settings/FontPresetPanelCustomBytecodeTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/FontPresetPanelCustomBytecodeTest.kt
@@ -3,7 +3,9 @@ package dev.ayuislands.settings
 import dev.ayuislands.font.FontCatalog
 import dev.ayuislands.font.FontPreset
 import dev.ayuislands.onboarding.PremiumOnboardingPanel
+import javax.swing.JLabel
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -31,12 +33,13 @@ import kotlin.test.assertTrue
 class FontPresetPanelCustomBytecodeTest {
     @Test
     fun `FontPresetPanel bytecode references nullable forPreset (issue #164 defensive lock)`() {
-        // The defensive call sites at L269 (triggerLifecycleAction), L327
-        // (buildInstallHintRow), L336 / L342 (Copy / Run-in-Terminal links),
-        // L520 (updateFontMissing) all consume `pendingPreset`, which the user
-        // can drive to CUSTOM through the segmented button. They MUST use
-        // `forPreset` (nullable). If the bytecode references `requirePreset`
-        // anywhere in this class, issue #164 has been reintroduced.
+        // Defensive call sites in triggerLifecycleAction, buildInstallHintRow,
+        // the Copy / Run-in-Terminal link callbacks, and updateFontMissing all
+        // consume `pendingPreset`, which the user can drive to CUSTOM through
+        // the segmented button. They MUST use `forPreset` (nullable). If the
+        // bytecode references `requirePreset` anywhere in this class, issue
+        // #164 has been reintroduced. (No line numbers here on purpose —
+        // they would rot on every unrelated edit; bytecode lookup is symbolic.)
         val classText = readClassBytes("FontPresetPanel")
         assertTrue(
             classText.contains("forPreset"),
@@ -55,15 +58,17 @@ class FontPresetPanelCustomBytecodeTest {
     @Test
     fun `FontPresetPanel bytecode logs a warning before dropping non-curated lifecycle clicks`() {
         // triggerLifecycleAction's `?: return` was originally silent — a future
-        // visibility-gate bypass would silently no-op the user's click with no
-        // diagnostic in idea.log. Round-1 review fix added a LOG.warn before
-        // the early return. Lock it: bytecode must reference both `LOG.warn`
-        // and the `forPreset` lookup that precedes it.
+        // visibility-gate bypass would no-op the user's click with no
+        // diagnostic in idea.log. Round-1 fix added a LOG.warn message
+        // containing "visibility gate bypassed". Lock the diagnostic: bytecode
+        // must contain that string-constant from the LOG.warn call site so a
+        // future "simplification" that drops the warn fails this test fast.
         val classText = readClassBytes("FontPresetPanel")
         assertTrue(
             classText.contains("visibility gate bypassed"),
-            "triggerLifecycleAction must log a 'visibility gate bypassed' warning when " +
-                "forPreset returns null (so future regressions surface in idea.log)",
+            "triggerLifecycleAction (and Copy / Run-in-Terminal links) must log a " +
+                "'visibility gate bypassed' warning when forPreset returns null, so " +
+                "future regressions surface in idea.log instead of dropping clicks silently",
         )
     }
 
@@ -106,6 +111,78 @@ class FontPresetPanelCustomBytecodeTest {
             presets.contains(FontPreset.CUSTOM),
             "FONT_PRESETS must not include CUSTOM (would break PremiumOnboardingPanel's requirePreset contract)",
         )
+    }
+
+    @Test
+    fun `updateFontMissing runs without throwing when pendingPreset is CUSTOM (issue #164 runtime lock)`() {
+        // Round-2 review C1: bytecode tests above prove the symbols are right,
+        // but they pass even if a future regression writes
+        // `forPreset(preset)!!.brewCaskSlug` (still references "forPreset"). The
+        // actual freeze in 2.6.1 happened at panel-build time when the
+        // installHintLabel?.let { FontCatalog.forPreset(...).brewCaskSlug }
+        // lambda evaluated for CUSTOM. Run that lambda directly: set
+        // pendingPreset="CUSTOM", attach a real JLabel to installHintLabel,
+        // invoke updateFontMissing() — must not throw, must leave label.text
+        // empty (no Brew cask slug for non-curated).
+        val panel = FontPresetPanel()
+        setPrivateField(panel, "pendingPreset", FontPreset.CUSTOM.name)
+        setPrivateField(panel, "pendingEnabled", false) // collapses to NOT_INSTALLED, skips FontDetector
+        val label = JLabel("placeholder")
+        setPrivateField(panel, "installHintLabel", label)
+
+        // Initialize the lateinit `availability` field so the previewComponent
+        // line at the bottom of updateFontMissing doesn't NPE — empty map is
+        // fine since updatePreset takes a preset parameter we don't care about.
+        setPrivateField(panel, "availability", emptyMap<FontPreset, Boolean>())
+
+        invokePrivateMethod(panel, "updateFontMissing")
+
+        assertEquals(
+            "",
+            label.text,
+            "installHintLabel.text must be empty for CUSTOM (no Brew cask slug for non-curated)",
+        )
+    }
+
+    @Test
+    fun `triggerLifecycleAction does not throw when pendingPreset is CUSTOM`() {
+        // Round-2 review C1: the install-row link callback routes through
+        // triggerLifecycleAction. With pendingPreset=CUSTOM, the new LOG.warn
+        // path must run cleanly: forPreset returns null, the warn fires, the
+        // method returns without queuing any install/uninstall task. The catch
+        // block surrounding the body would also swallow any unexpected throw,
+        // but the goal here is to assert the happy path of the defensive guard.
+        val panel = FontPresetPanel()
+        setPrivateField(panel, "pendingPreset", FontPreset.CUSTOM.name)
+        setPrivateField(panel, "pendingEnabled", false)
+        setPrivateField(panel, "availability", emptyMap<FontPreset, Boolean>())
+
+        val method =
+            FontPresetPanel::class.java.getDeclaredMethod("triggerLifecycleAction", Boolean::class.javaPrimitiveType)
+        method.isAccessible = true
+        // Should return cleanly — visibility-gate-bypass guard fires LOG.warn
+        // and returns without dispatching to FontInstaller / FontUninstaller.
+        method.invoke(panel, false)
+        method.invoke(panel, true)
+    }
+
+    private fun setPrivateField(
+        target: Any,
+        name: String,
+        value: Any?,
+    ) {
+        val field = FontPresetPanel::class.java.getDeclaredField(name)
+        field.isAccessible = true
+        field.set(target, value)
+    }
+
+    private fun invokePrivateMethod(
+        target: Any,
+        name: String,
+    ) {
+        val method = FontPresetPanel::class.java.getDeclaredMethod(name)
+        method.isAccessible = true
+        method.invoke(target)
     }
 
     private fun readClassBytes(simpleName: String): String {

--- a/src/test/kotlin/dev/ayuislands/theme/VcsDiffSchemeColorsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/theme/VcsDiffSchemeColorsTest.kt
@@ -1,0 +1,169 @@
+package dev.ayuislands.theme
+
+import kotlin.math.sqrt
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Regression lock for VCS/diff colors that are easy to judge only after
+ * opening a diff editor. Dark-family selections must stay translucent, and
+ * modified highlights must stay visibly blue instead of drifting toward the
+ * same green band used for added lines.
+ */
+class VcsDiffSchemeColorsTest {
+    @Test
+    fun `dark-family selections match upstream Ayu translucent selection colors`() {
+        assertColorOption("/themes/AyuIslandsDark.xml", "SELECTION_BACKGROUND", "3388FF40")
+        assertColorOption("/themes/AyuIslandsDark.xml", "INACTIVE_SELECTION_BACKGROUND", "80B5FF26")
+        assertColorOption("/themes/AyuIslandsMirage.xml", "SELECTION_BACKGROUND", "409FFF40")
+        assertColorOption("/themes/AyuIslandsMirage.xml", "INACTIVE_SELECTION_BACKGROUND", "409FFF21")
+    }
+
+    @Test
+    fun `dark-family modified VCS accents use the upstream Ayu blue ramp`() {
+        assertModifiedVcsRamp(
+            resource = "/themes/AyuIslandsDark.xml",
+            expectedBlue = "73B8FF",
+            expectedDiffBackground = "2E4560",
+        )
+        assertModifiedVcsRamp(
+            resource = "/themes/AyuIslandsMirage.xml",
+            expectedBlue = "80BFFF",
+            expectedDiffBackground = "405672",
+        )
+    }
+
+    @Test
+    fun `modified diff backgrounds are blue-led and separated from added backgrounds`() {
+        assertModifiedBackgroundContrast("/themes/AyuIslandsDark.xml")
+        assertModifiedBackgroundContrast("/themes/AyuIslandsMirage.xml")
+    }
+
+    private fun assertModifiedVcsRamp(
+        resource: String,
+        expectedBlue: String,
+        expectedDiffBackground: String,
+    ) {
+        val modifiedKeys =
+            listOf(
+                "MODIFIED_LINES_COLOR",
+                "IGNORED_MODIFIED_LINES_BORDER_COLOR",
+                "FILESTATUS_MODIFIED",
+                "FILESTATUS_NOT_CHANGED_IMMEDIATE",
+                "FILESTATUS_NOT_CHANGED_RECURSIVE",
+                "FILESTATUS_RENAMED",
+                "FILESTATUS_modifiedOutside",
+                "DIFF_MODIFIED",
+            )
+
+        for (key in modifiedKeys) {
+            assertColorOption(resource, key, expectedBlue)
+        }
+        assertDiffAttributeOption(resource, "DIFF_MODIFIED", "BACKGROUND", expectedDiffBackground)
+        assertDiffAttributeOption(resource, "DIFF_MODIFIED", "ERROR_STRIPE_COLOR", expectedBlue)
+    }
+
+    private fun assertModifiedBackgroundContrast(resource: String) {
+        val added = colorOption(resource, "DIFF_INSERTED")
+        val modified = diffAttributeOption(resource, "DIFF_MODIFIED", "BACKGROUND")
+
+        assertTrue(
+            modified.blue > modified.green && modified.blue > modified.red,
+            "$resource DIFF_MODIFIED background should be led by blue, got ${modified.hex}",
+        )
+        assertTrue(
+            colorDistance(added, modified) >= MIN_ADDED_MODIFIED_DISTANCE,
+            "$resource added (${added.hex}) and modified (${modified.hex}) diff backgrounds " +
+                "are too close; keep modified visibly blue.",
+        )
+    }
+
+    private fun assertColorOption(
+        resource: String,
+        key: String,
+        expected: String,
+    ) {
+        assertEquals(expected, colorOption(resource, key).hex, "$resource $key")
+    }
+
+    private fun assertDiffAttributeOption(
+        resource: String,
+        attribute: String,
+        option: String,
+        expected: String,
+    ) {
+        assertEquals(
+            expected,
+            diffAttributeOption(resource, attribute, option).hex,
+            "$resource $attribute $option",
+        )
+    }
+
+    private fun colorOption(
+        resource: String,
+        key: String,
+    ): HexColor {
+        val xml = readResource(resource)
+        val match = Regex("""<option\s+name="$key"\s+value="([0-9A-Fa-f]{6,8})"\s*/>""").find(xml)
+        assertNotNull(match, "$resource missing top-level color option $key")
+        return HexColor.from(match.groupValues[1])
+    }
+
+    private fun diffAttributeOption(
+        resource: String,
+        attribute: String,
+        option: String,
+    ): HexColor {
+        val xml = readResource(resource)
+        val patternSource =
+            """<option\s+name="$attribute">\s*<value>""" +
+                """.*?<option\s+name="$option"\s+value="([0-9A-Fa-f]{6,8})"\s*/>""" +
+                """.*?</value>\s*</option>"""
+        val pattern = Regex(patternSource, RegexOption.DOT_MATCHES_ALL)
+        val match = pattern.find(xml)
+        assertNotNull(match, "$resource missing $option in $attribute attribute")
+        return HexColor.from(match.groupValues[1])
+    }
+
+    private fun readResource(path: String): String {
+        val stream =
+            javaClass.getResourceAsStream(path)
+                ?: error("Scheme XML not found on classpath: $path")
+        return stream.bufferedReader().use { it.readText() }
+    }
+
+    private data class HexColor(
+        val hex: String,
+        val red: Int,
+        val green: Int,
+        val blue: Int,
+    ) {
+        companion object {
+            fun from(value: String): HexColor {
+                val normalized = value.uppercase()
+                return HexColor(
+                    hex = normalized,
+                    red = normalized.substring(0, 2).toInt(16),
+                    green = normalized.substring(2, 4).toInt(16),
+                    blue = normalized.substring(4, 6).toInt(16),
+                )
+            }
+        }
+    }
+
+    private companion object {
+        const val MIN_ADDED_MODIFIED_DISTANCE = 50.0
+
+        fun colorDistance(
+            first: HexColor,
+            second: HexColor,
+        ): Double {
+            val red = first.red - second.red
+            val green = first.green - second.green
+            val blue = first.blue - second.blue
+            return sqrt((red * red + green * green + blue * blue).toDouble())
+        }
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/theme/VcsDiffSchemeColorsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/theme/VcsDiffSchemeColorsTest.kt
@@ -1,5 +1,10 @@
 package dev.ayuislands.theme
 
+import org.w3c.dom.Element
+import javax.xml.XMLConstants
+import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.xpath.XPathConstants
+import javax.xml.xpath.XPathFactory
 import kotlin.math.sqrt
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -111,20 +116,44 @@ class VcsDiffSchemeColorsTest {
         return HexColor.from(match.groupValues[1])
     }
 
+    /**
+     * Reads a nested attribute option (`<option name="$attribute"><value>
+     * <option name="$option" value="..."/></value></option>`) via DOM + XPath
+     * so the test stops being brittle to whitespace, attribute ordering, or
+     * intermediate `<option>` siblings inside `<value>`. Secure-XML defaults
+     * mirror [FreeTierLockdownTest]: DTDs disallowed, external entities off,
+     * FEATURE_SECURE_PROCESSING on — even though the XML lives on our own
+     * classpath, hardening the parser is a free habit.
+     */
     private fun diffAttributeOption(
         resource: String,
         attribute: String,
         option: String,
     ): HexColor {
-        val xml = readResource(resource)
-        val patternSource =
-            """<option\s+name="$attribute">\s*<value>""" +
-                """.*?<option\s+name="$option"\s+value="([0-9A-Fa-f]{6,8})"\s*/>""" +
-                """.*?</value>\s*</option>"""
-        val pattern = Regex(patternSource, RegexOption.DOT_MATCHES_ALL)
-        val match = pattern.find(xml)
-        assertNotNull(match, "$resource missing $option in $attribute attribute")
-        return HexColor.from(match.groupValues[1])
+        val factory =
+            DocumentBuilderFactory.newInstance().apply {
+                isNamespaceAware = false
+                isValidating = false
+                setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true)
+                setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+                setFeature("http://xml.org/sax/features/external-general-entities", false)
+                setFeature("http://xml.org/sax/features/external-parameter-entities", false)
+            }
+        val document =
+            javaClass
+                .getResourceAsStream(resource)
+                ?.use { factory.newDocumentBuilder().parse(it) }
+                ?: error("Scheme XML not found on classpath: $resource")
+        val xpath = "//option[@name='$attribute']/value/option[@name='$option']"
+        val node =
+            XPathFactory
+                .newInstance()
+                .newXPath()
+                .evaluate(xpath, document, XPathConstants.NODE) as? Element
+        assertNotNull(node, "$resource missing $option in $attribute attribute")
+        val value = node.getAttribute("value")
+        assertTrue(value.isNotBlank(), "$resource $attribute/$option has blank value")
+        return HexColor.from(value)
     }
 
     private fun readResource(path: String): String {

--- a/src/test/kotlin/dev/ayuislands/theme/VcsDiffSchemeColorsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/theme/VcsDiffSchemeColorsTest.kt
@@ -66,13 +66,13 @@ class VcsDiffSchemeColorsTest {
         for (key in modifiedKeys) {
             assertColorOption(resource, key, expectedBlue)
         }
-        assertDiffAttributeOption(resource, "DIFF_MODIFIED", "BACKGROUND", expectedDiffBackground)
-        assertDiffAttributeOption(resource, "DIFF_MODIFIED", "ERROR_STRIPE_COLOR", expectedBlue)
+        assertDiffModifiedOption(resource, "BACKGROUND", expectedDiffBackground)
+        assertDiffModifiedOption(resource, "ERROR_STRIPE_COLOR", expectedBlue)
     }
 
     private fun assertModifiedBackgroundContrast(resource: String) {
         val added = colorOption(resource, "DIFF_INSERTED")
-        val modified = diffAttributeOption(resource, "DIFF_MODIFIED", "BACKGROUND")
+        val modified = diffModifiedOption(resource, "BACKGROUND")
 
         assertTrue(
             modified.blue > modified.green && modified.blue > modified.red,
@@ -93,16 +93,15 @@ class VcsDiffSchemeColorsTest {
         assertEquals(expected, colorOption(resource, key).hex, "$resource $key")
     }
 
-    private fun assertDiffAttributeOption(
+    private fun assertDiffModifiedOption(
         resource: String,
-        attribute: String,
         option: String,
         expected: String,
     ) {
         assertEquals(
             expected,
-            diffAttributeOption(resource, attribute, option).hex,
-            "$resource $attribute $option",
+            diffModifiedOption(resource, option).hex,
+            "$resource DIFF_MODIFIED $option",
         )
     }
 
@@ -117,17 +116,16 @@ class VcsDiffSchemeColorsTest {
     }
 
     /**
-     * Reads a nested attribute option (`<option name="$attribute"><value>
-     * <option name="$option" value="..."/></value></option>`) via DOM + XPath
-     * so the test stops being brittle to whitespace, attribute ordering, or
-     * intermediate `<option>` siblings inside `<value>`. Secure-XML defaults
-     * mirror [FreeTierLockdownTest]: DTDs disallowed, external entities off,
-     * FEATURE_SECURE_PROCESSING on — even though the XML lives on our own
-     * classpath, hardening the parser is a free habit.
+     * Reads a nested DIFF_MODIFIED attribute option (`<option name="DIFF_MODIFIED">
+     * <value><option name="$option" value="..."/></value></option>`) via DOM +
+     * XPath so the test stops being brittle to whitespace, attribute ordering,
+     * or intermediate `<option>` siblings inside `<value>`. Secure-XML defaults
+     * mirror the licensing free-tier lockdown reader: DTDs disallowed, external
+     * entities off, FEATURE_SECURE_PROCESSING on — the XML lives on our own
+     * classpath so the threat surface is zero, but the hardening is free.
      */
-    private fun diffAttributeOption(
+    private fun diffModifiedOption(
         resource: String,
-        attribute: String,
         option: String,
     ): HexColor {
         val factory =
@@ -144,15 +142,15 @@ class VcsDiffSchemeColorsTest {
                 .getResourceAsStream(resource)
                 ?.use { factory.newDocumentBuilder().parse(it) }
                 ?: error("Scheme XML not found on classpath: $resource")
-        val xpath = "//option[@name='$attribute']/value/option[@name='$option']"
+        val xpath = "//option[@name='DIFF_MODIFIED']/value/option[@name='$option']"
         val node =
             XPathFactory
                 .newInstance()
                 .newXPath()
                 .evaluate(xpath, document, XPathConstants.NODE) as? Element
-        assertNotNull(node, "$resource missing $option in $attribute attribute")
+        assertNotNull(node, "$resource missing $option in DIFF_MODIFIED attribute")
         val value = node.getAttribute("value")
-        assertTrue(value.isNotBlank(), "$resource $attribute/$option has blank value")
+        assertTrue(value.isNotBlank(), "$resource DIFF_MODIFIED/$option has blank value")
         return HexColor.from(value)
     }
 

--- a/src/test/kotlin/dev/ayuislands/theme/VcsDiffSchemeColorsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/theme/VcsDiffSchemeColorsTest.kt
@@ -22,13 +22,36 @@ import kotlin.test.assertTrue
  */
 class VcsDiffSchemeColorsTest {
     @Test
-    fun `selections stay translucent across all variants (alpha-led, not solid)`() {
+    fun `selection backgrounds match upstream Ayu translucent values`() {
         assertColorOption("/themes/AyuIslandsDark.xml", "SELECTION_BACKGROUND", "3388FF40")
         assertColorOption("/themes/AyuIslandsDark.xml", "INACTIVE_SELECTION_BACKGROUND", "80B5FF26")
         assertColorOption("/themes/AyuIslandsMirage.xml", "SELECTION_BACKGROUND", "409FFF40")
         assertColorOption("/themes/AyuIslandsMirage.xml", "INACTIVE_SELECTION_BACKGROUND", "409FFF21")
         assertColorOption("/themes/AyuIslandsLight.xml", "SELECTION_BACKGROUND", "035BD626")
         assertColorOption("/themes/AyuIslandsLight.xml", "INACTIVE_SELECTION_BACKGROUND", "035BD612")
+    }
+
+    @Test
+    fun `selection backgrounds carry alpha less than fully opaque on every variant`() {
+        // Round-2 review: previous "alpha-led, not solid" test name promised an
+        // invariant the assertEquals(hex) didn't enforce — solid alpha 0xFF
+        // would have passed. This test names the actual constraint: highlighted
+        // text must NEVER read as a solid blue block on any variant.
+        listOf(
+            "/themes/AyuIslandsDark.xml",
+            "/themes/AyuIslandsMirage.xml",
+            "/themes/AyuIslandsLight.xml",
+        ).forEach { resource ->
+            listOf("SELECTION_BACKGROUND", "INACTIVE_SELECTION_BACKGROUND").forEach { key ->
+                val hex = colorOption(resource, key).hex
+                assertEquals(8, hex.length, "$resource $key must include alpha channel (8-char hex)")
+                val alpha = hex.takeLast(2).toInt(16)
+                assertTrue(
+                    alpha < 0xFF,
+                    "$resource $key alpha must be < 0xFF (translucent), got 0x${hex.takeLast(2)}",
+                )
+            }
+        }
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/theme/VcsDiffSchemeColorsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/theme/VcsDiffSchemeColorsTest.kt
@@ -13,21 +13,26 @@ import kotlin.test.assertTrue
 
 /**
  * Regression lock for VCS/diff colors that are easy to judge only after
- * opening a diff editor. Dark-family selections must stay translucent, and
- * modified highlights must stay visibly blue instead of drifting toward the
- * same green band used for added lines.
+ * opening a diff editor. Dark, Mirage, and Light variants share the same
+ * key set; this test pins the upstream Ayu blue ramp on every variant so a
+ * future palette tweak can't silently regress one family while the other
+ * stays correct. Modified backgrounds also stay visibly distinct from added
+ * (green) backgrounds — a colour-distance assertion catches "they look too
+ * similar on dense diffs" before users do.
  */
 class VcsDiffSchemeColorsTest {
     @Test
-    fun `dark-family selections match upstream Ayu translucent selection colors`() {
+    fun `selections stay translucent across all variants (alpha-led, not solid)`() {
         assertColorOption("/themes/AyuIslandsDark.xml", "SELECTION_BACKGROUND", "3388FF40")
         assertColorOption("/themes/AyuIslandsDark.xml", "INACTIVE_SELECTION_BACKGROUND", "80B5FF26")
         assertColorOption("/themes/AyuIslandsMirage.xml", "SELECTION_BACKGROUND", "409FFF40")
         assertColorOption("/themes/AyuIslandsMirage.xml", "INACTIVE_SELECTION_BACKGROUND", "409FFF21")
+        assertColorOption("/themes/AyuIslandsLight.xml", "SELECTION_BACKGROUND", "035BD626")
+        assertColorOption("/themes/AyuIslandsLight.xml", "INACTIVE_SELECTION_BACKGROUND", "035BD612")
     }
 
     @Test
-    fun `dark-family modified VCS accents use the upstream Ayu blue ramp`() {
+    fun `modified VCS accents use the upstream Ayu blue ramp on every variant`() {
         assertModifiedVcsRamp(
             resource = "/themes/AyuIslandsDark.xml",
             expectedBlue = "73B8FF",
@@ -38,12 +43,18 @@ class VcsDiffSchemeColorsTest {
             expectedBlue = "80BFFF",
             expectedDiffBackground = "405672",
         )
+        assertModifiedVcsRamp(
+            resource = "/themes/AyuIslandsLight.xml",
+            expectedBlue = "478ACC",
+            expectedDiffBackground = "478ACC1F",
+        )
     }
 
     @Test
     fun `modified diff backgrounds are blue-led and separated from added backgrounds`() {
         assertModifiedBackgroundContrast("/themes/AyuIslandsDark.xml")
         assertModifiedBackgroundContrast("/themes/AyuIslandsMirage.xml")
+        assertModifiedBackgroundContrast("/themes/AyuIslandsLight.xml")
     }
 
     private fun assertModifiedVcsRamp(


### PR DESCRIPTION
## Summary

Three user-visible bugs land together as **v2.6.2**:

- **VCS modified-line color is too close to added on dark variants** — modified now shifts to a saturated blue (Dark `#73B8FF`, Mirage `#80BFFF`) so it stops blending into the green added band on dense diffs. File-status colors in Project View and tabs follow the same blue ramp.
- **Editor selection background reads as a solid blue block on Dark/Mirage** — back to translucent (alpha 25%) so highlighted text stays legible.
- **Settings page freezes on "Loading…" forever when font preset is Custom** ([#164](https://github.com/barad1tos/ayu-jetbrains/issues/164)) — `FontCatalog.forPreset(CUSTOM)` was throwing from an eager Brew-cask hint row, killing the panel build before the JBLoadingPanel could swap. Fixed at the root.

## Issue #164 — what was actually broken

`FontCatalog.forPreset` used to throw `IllegalStateException("No FontCatalog entry for preset CUSTOM")` because `CUSTOM` is a user-chosen non-curated font with no install pipeline. The eager body of the Brew-cask hint row in `FontPresetPanel` called `forPreset(...).brewCaskSlug` at panel build time — `.visibleIf(fontMissing)` gates the row's visibility but not the lambda execution. Once a user persisted `fontPresetName="CUSTOM"` and reopened Settings, the panel build threw and the loading spinner never resolved.

### Fix design

Split the API into two methods so the type system encodes intent:

- `forPreset(preset): Entry?` — defensive nullable variant for user-driven call sites where `CUSTOM` is reachable (Settings rows, Install/Reinstall/Delete buttons, Brew hints).
- `requirePreset(preset): Entry` — non-null variant for call sites that statically operate on curated presets (onboarding cards iterating a hardcoded `FONT_PRESETS` list, tests pinning known presets). Throws if a non-curated preset slips in, so a future regression fails fast.

All call sites migrated. Defensive null-safe early returns where `CUSTOM` reaches `FontInstaller` / `FontUninstaller`. Three new RED tests in `FontCatalogTest` lock the contract: `forPreset(CUSTOM) == null`, `requirePreset(CUSTOM)` throws, and every curated preset still resolves non-null.

### Files of note

- `FontCatalog.kt` — API split with KDoc explaining when to pick which.
- `FontPresetPanel.kt` — five defensive null-safe sites (the actual root-cause path).
- `FontInstaller.kt` / `FontUninstaller.kt` — null-safe with WARN log + early return.
- `PremiumOnboardingPanel.kt` — `requirePreset` (curated-only by construction).
- All affected test files — migrated to `requirePreset` where they were already pinning curated presets.

## Test plan

- [x] `./gradlew compileKotlin compileTestKotlin detekt ktlintCheck` — all green
- [x] `./gradlew test` — full suite green (3m 30s), including 3 new RED tests in `FontCatalogTest`
- [x] `./gradlew buildPlugin` — green
- [x] Visual smoke-tested the modified-blue gutter and translucent selection in `runIde` against this branch's earlier theme commits
- [x] `/deploy-to-ide` smoke test for issue #164: set Font preset to Custom in Settings → close → reopen Settings → panel renders without freeze, font row falls through to the Custom variant
- [x] CI green on PR

## Notes

- `release-version=26` and `release-date=20260426` unchanged — Marketplace locks `release-date` per `release-version` and 2.6.x patches share the v2.6.0 release date.
- Branch was rebased on `origin/main` to pick up #165 (gradle-wrapper 9.5.0) and #166 (kotlin 2.3.21) before push.

## Summary by Sourcery

Release version 2.6.2 with visual tuning of dark themes and hardened font preset handling to prevent settings freezes and ensure safe font install/uninstall flows.

Bug Fixes:
- Make VCS modified-line and diff-modified colors clearly distinct from added/inserted greens on Dark and Mirage themes, and align related file status colors with the blue ramp.
- Restore translucent editor selection backgrounds for Dark and Mirage themes so selections no longer appear as solid blue blocks.
- Prevent the Settings page from freezing when a Custom font preset is active by treating non-curated presets as having no install pipeline and handling them defensively across the settings panel and font installer/uninstaller.

Enhancements:
- Split FontCatalog into nullable forPreset and non-null requirePreset APIs to encode curated vs non-curated font preset usage and fail fast on programmer errors.

Build:
- Bump plugin version to 2.6.2 and document the changes in the changelog and plugin.xml notes.

Tests:
- Add regression tests for FontCatalog behavior around curated and Custom presets, including nullability and failure cases.
- Add VCS/diff scheme color regression tests to lock in translucent selections and blue-led modified diff backgrounds on dark-family themes.