### PR TITLE
fix(font-preview): render Custom family instead of "Install JetBrains Mono"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - VCS modified-line color is now distinct from added — modified shifts to a saturated blue (Dark `#73B8FF`, Mirage `#80BFFF`) so it stops blending into the green added band on dense diffs. Also bluer file-status colors in Project View and tabs.
 - Editor selection background returns to translucent (alpha 25%) on Dark and Mirage so highlighted text doesn't read as a solid blue block.
 - Settings page no longer freezes on "Loading…" forever when a Custom font preset is active (issue #164) — non-curated presets now skip the install pipeline cleanly instead of crashing the panel build.
+- Font preview pane now renders the user's chosen Custom font family on Settings open instead of falling back to "Install JetBrains Mono to preview" — a UX bug previously masked by the panel-build freeze.
 
 ## [2.6.1] - 2026-04-27
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "9265706"
+          last_verified_sha: "53adcad"
           last_verified_date: "2026-04-25"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "9265706"
+          last_verified_sha: "53adcad"
           last_verified_date: "2026-04-25"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -211,7 +211,7 @@ categories:
           sources:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "9265706"
+          last_verified_sha: "53adcad"
           last_verified_date: "2026-05-10"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "bbac496"
+          last_verified_sha: "9265706"
           last_verified_date: "2026-04-25"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "bbac496"
+          last_verified_sha: "9265706"
           last_verified_date: "2026-04-25"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -211,7 +211,7 @@ categories:
           sources:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "bbac496"
+          last_verified_sha: "9265706"
           last_verified_date: "2026-05-10"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 

--- a/src/main/kotlin/dev/ayuislands/font/FontDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontDetector.kt
@@ -57,6 +57,15 @@ object FontDetector {
     }
 
     /**
+     * Check if a specific font family name is installed on the system. Used by the
+     * settings preview to decide whether to render the live preview or the
+     * "Install X to preview" fallback when the user has chosen a non-curated
+     * (CUSTOM) family — those don't have a `FontPreset` entry to feed into
+     * [isInstalled], but they still need a yes/no installed answer.
+     */
+    fun isFamilyInstalled(family: String): Boolean = installedFonts().contains(family.lowercase())
+
+    /**
      * Check if any alias of the preset's font is installed on the system OR has been
      * recorded as installed via the runtime [FontInstaller] (state.installedFonts).
      *

--- a/src/main/kotlin/dev/ayuislands/font/FontDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontDetector.kt
@@ -1,5 +1,6 @@
 package dev.ayuislands.font
 
+import com.intellij.openapi.diagnostic.logger
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
 import java.awt.Font
@@ -20,6 +21,8 @@ enum class FontStatus {
 
 /** Detects installed Nerd Fonts via GraphicsEnvironment. Caches results for the session. */
 object FontDetector {
+    private val LOG = logger<FontDetector>()
+
     private const val MONOSPACE_PROBE_SIZE = 12
     private const val MONOSPACE_WIDTH_TOLERANCE = 0.01
 
@@ -57,13 +60,34 @@ object FontDetector {
     }
 
     /**
-     * Check if a specific font family name is installed on the system. Used by the
-     * settings preview to decide whether to render the live preview or the
-     * "Install X to preview" fallback when the user has chosen a non-curated
-     * (CUSTOM) family — those don't have a `FontPreset` entry to feed into
-     * [isInstalled], but they still need a yes/no installed answer.
+     * Returns true if the JVM's `availableFontFamilyNames` contains [family]
+     * (case-insensitive). Use [isInstalled] when you have a [FontPreset] —
+     * that helper also walks `preset.fontAliases` AND the runtime
+     * `state.installedFonts` record, which this single-string lookup does
+     * NOT do. Calling this with a curated `preset.fontFamily` will return
+     * the wrong answer when the user has an alias installed or when the
+     * JVM cache lags a freshly-installed font.
+     *
+     * Wrapped in try/catch because `installedFonts()` calls
+     * `GraphicsEnvironment.getLocalGraphicsEnvironment()` which can throw
+     * `HeadlessException` (server JVMs, headless test harnesses) or
+     * `InternalError` (macOS font cache corruption — well-documented AWT
+     * failure mode). A throw here would propagate into the panel-build
+     * closure and reproduce the issue #164 "Loading…" freeze with a
+     * different exception class. Returning false on throw is the safe
+     * default — the preview shows "Install X to preview" rather than
+     * freezing the panel; the stack trace lands in idea.log.
      */
-    fun isFamilyInstalled(family: String): Boolean = installedFonts().contains(family.lowercase())
+    fun isFamilyInstalled(family: String): Boolean =
+        try {
+            installedFonts().contains(family.lowercase())
+        } catch (e: java.awt.HeadlessException) {
+            LOG.warn("isFamilyInstalled: headless environment, treating '$family' as not installed", e)
+            false
+        } catch (e: RuntimeException) {
+            LOG.warn("isFamilyInstalled: GraphicsEnvironment query failed for '$family'", e)
+            false
+        }
 
     /**
      * Check if any alias of the preset's font is installed on the system OR has been

--- a/src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
@@ -524,26 +524,38 @@ class FontPresetPanel : AyuIslandsSettingsPanel {
     }
 
     private fun refreshPreview(reloadPreset: Boolean = false) {
-        val settings = currentSettings
-        if (reloadPreset) {
-            val preset = FontPreset.fromName(pendingPreset)
-            val available =
-                if (preset.isCurated) {
-                    availability[preset] == true
-                } else {
-                    FontDetector.isFamilyInstalled(settings.fontFamily)
+        // Defensive boundary mirrors triggerLifecycleAction's outer catch:
+        // refreshPreview runs in the panel-build closure (via buildPreviewRow
+        // → loadControlsFromPreset), and a propagating exception there is the
+        // documented issue #164 freeze hot-zone. Catch broadly, log, render no
+        // preview — the panel still finishes building.
+        try {
+            val settings = currentSettings
+            if (reloadPreset) {
+                val preset = FontPreset.fromName(pendingPreset)
+                // Same gate as updateFontMissing — both call sites must agree on
+                // whether the preview should render. For curated, derive a
+                // status proxy from the cached availability map (HEALTHY/
+                // NOT_INSTALLED is sufficient — CORRUPTED is signalled
+                // separately via fontCorrupted).
+                val statusProxy =
+                    if (availability[preset] == true) FontStatus.HEALTHY else FontStatus.NOT_INSTALLED
+                val available =
+                    previewInstalledFor(preset, statusProxy, pendingEnabled, settings.fontFamily)
+                previewComponent?.updatePreset(preset, available)
+                if (!preset.isCurated) {
+                    previewComponent?.updateFontFamily(settings.fontFamily)
                 }
-            previewComponent?.updatePreset(preset, available)
-            if (!preset.isCurated) {
-                previewComponent?.updateFontFamily(settings.fontFamily)
             }
+            previewComponent?.updateSettings(
+                settings.fontSize,
+                settings.lineSpacing,
+                settings.enableLigatures,
+                settings.weight,
+            )
+        } catch (e: RuntimeException) {
+            LOG.warn("refreshPreview failed for preset=$pendingPreset; preview pane skipped", e)
         }
-        previewComponent?.updateSettings(
-            settings.fontSize,
-            settings.lineSpacing,
-            settings.enableLigatures,
-            settings.weight,
-        )
     }
 
     private fun updateFontMissing() {
@@ -650,15 +662,13 @@ class FontPresetPanel : AyuIslandsSettingsPanel {
  * Resolve whether the preview pane should render a live sample or fall back
  * to "Install X to preview". Curated presets ask the catalog-aware status;
  * non-curated (CUSTOM) ask the system about the user-chosen family — the
- * catalog has nothing to say about it. Issue #164 follow-up: without this,
- * opening Settings with a persisted Custom preset showed the
- * "Install JetBrains Mono to preview" fallback even when the user's font
- * was actually installed.
+ * catalog has nothing to say about it.
  *
- * Lives at file scope (not a class member) so the panel's
- * `TooManyFunctions=25` cap stays under the detekt threshold.
+ * Stateless pure function — no `this`, no field access, no side effects.
+ * File scope keeps it that way (a class member would silently allow `this`
+ * capture later) and is `internal` so unit tests can pin both branches.
  */
-private fun previewInstalledFor(
+internal fun previewInstalledFor(
     preset: FontPreset,
     status: FontStatus,
     enabled: Boolean,

--- a/src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
@@ -527,7 +527,13 @@ class FontPresetPanel : AyuIslandsSettingsPanel {
         val settings = currentSettings
         if (reloadPreset) {
             val preset = FontPreset.fromName(pendingPreset)
-            previewComponent?.updatePreset(preset, availability[preset] == true)
+            val available =
+                if (preset.isCurated) {
+                    availability[preset] == true
+                } else {
+                    FontDetector.isFamilyInstalled(settings.fontFamily)
+                }
+            previewComponent?.updatePreset(preset, available)
             if (!preset.isCurated) {
                 previewComponent?.updateFontFamily(settings.fontFamily)
             }
@@ -565,7 +571,12 @@ class FontPresetPanel : AyuIslandsSettingsPanel {
             val slug = FontCatalog.forPreset(preset)?.brewCaskSlug.orEmpty()
             it.text = if (slug.isNotEmpty()) "Or via Homebrew: brew install --cask $slug" else ""
         }
-        previewComponent?.updatePreset(preset, status == FontStatus.HEALTHY)
+        val previewInstalled =
+            previewInstalledFor(preset, status, pendingEnabled, currentSettings.fontFamily)
+        previewComponent?.updatePreset(preset, previewInstalled)
+        if (!preset.isCurated) {
+            previewComponent?.updateFontFamily(currentSettings.fontFamily)
+        }
     }
 
     override fun isModified(): Boolean {
@@ -634,3 +645,27 @@ class FontPresetPanel : AyuIslandsSettingsPanel {
         suppressListeners = false
     }
 }
+
+/**
+ * Resolve whether the preview pane should render a live sample or fall back
+ * to "Install X to preview". Curated presets ask the catalog-aware status;
+ * non-curated (CUSTOM) ask the system about the user-chosen family — the
+ * catalog has nothing to say about it. Issue #164 follow-up: without this,
+ * opening Settings with a persisted Custom preset showed the
+ * "Install JetBrains Mono to preview" fallback even when the user's font
+ * was actually installed.
+ *
+ * Lives at file scope (not a class member) so the panel's
+ * `TooManyFunctions=25` cap stays under the detekt threshold.
+ */
+private fun previewInstalledFor(
+    preset: FontPreset,
+    status: FontStatus,
+    enabled: Boolean,
+    family: String,
+): Boolean =
+    if (preset.isCurated) {
+        status == FontStatus.HEALTHY
+    } else {
+        enabled && FontDetector.isFamilyInstalled(family)
+    }

--- a/src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
@@ -103,7 +103,15 @@ class FontPreviewComponent : JComponent() {
                 ?: java.awt.Color.GRAY
         g2.color = disabledFg
         g2.font = JBUI.Fonts.smallFont().deriveFont(Font.ITALIC)
-        val message = "Install ${currentPreset.fontFamily} to preview"
+        // For curated presets the catalog family is the install target; for
+        // non-curated (CUSTOM) the user picked a family explicitly via
+        // updateFontFamily, so name THAT family in the fallback message
+        // instead of the catalog default ("JetBrains Mono"). Without this
+        // branch the user sees a confusing "Install JetBrains Mono to
+        // preview" while the summary line shows the family they chose.
+        val displayedFamily =
+            if (currentPreset.isCurated) currentPreset.fontFamily else resolvedFontFamily
+        val message = "Install $displayedFamily to preview"
         val metrics = g2.fontMetrics
         g2.drawString(
             message,

--- a/src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
@@ -103,15 +103,17 @@ class FontPreviewComponent : JComponent() {
                 ?: java.awt.Color.GRAY
         g2.color = disabledFg
         g2.font = JBUI.Fonts.smallFont().deriveFont(Font.ITALIC)
-        // For curated presets the catalog family is the install target; for
-        // non-curated (CUSTOM) the user picked a family explicitly via
-        // updateFontFamily, so name THAT family in the fallback message
-        // instead of the catalog default ("JetBrains Mono"). Without this
-        // branch the user sees a confusing "Install JetBrains Mono to
-        // preview" while the summary line shows the family they chose.
+        // Curated presets advertise their canonical family as the install
+        // target; non-curated (CUSTOM) advertise whatever the user picked,
+        // since the live preview would have rendered with that family.
         val displayedFamily =
             if (currentPreset.isCurated) currentPreset.fontFamily else resolvedFontFamily
-        val message = "Install $displayedFamily to preview"
+        val message =
+            if (displayedFamily.isBlank()) {
+                "Choose a font family to preview"
+            } else {
+                "Install $displayedFamily to preview"
+            }
         val metrics = g2.fontMetrics
         g2.drawString(
             message,

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -97,6 +97,7 @@
       <li>VCS modified-line color is now distinct from added — modified shifts to a saturated blue (Dark <code>#73B8FF</code>, Mirage <code>#80BFFF</code>) so it stops blending into the green added band on dense diffs. Bluer file-status colors in Project View and tabs as well.</li>
       <li>Editor selection background returns to translucent (alpha 25%) on Dark and Mirage so highlighted text doesn't read as a solid blue block.</li>
       <li>Settings page no longer freezes on "Loading…" forever when a Custom font preset is active (issue #164) — non-curated presets now skip the install pipeline cleanly instead of crashing the panel build.</li>
+      <li>Font preview pane now renders the user's chosen Custom font family on Settings open instead of falling back to "Install JetBrains Mono to preview" — a UX bug previously masked by the panel-build freeze.</li>
     </ul>
     <h3>2.6.1</h3>
     <ul>

--- a/src/test/kotlin/dev/ayuislands/font/FontDetectorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/font/FontDetectorTest.kt
@@ -8,6 +8,7 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
 import java.awt.GraphicsEnvironment
+import java.awt.HeadlessException
 import java.io.File
 import kotlin.io.path.createTempDirectory
 import kotlin.test.AfterTest
@@ -215,6 +216,67 @@ class FontDetectorTest {
         every { GraphicsEnvironment.getLocalGraphicsEnvironment() } returns ge
         every { ge.availableFontFamilyNames } returns availableFonts
         FontDetector.invalidateCache()
+    }
+
+    // ---- isFamilyInstalled (Custom-preview lookup) ----
+
+    @Test
+    fun `isFamilyInstalled returns true when system font matches case-insensitively`() {
+        // installedFonts() lowercases the env names; the helper must lowercase
+        // the input symmetrically, otherwise uppercase user input ("Inter")
+        // never matches the cache.
+        stubSettingsAndGraphicsEnv(AyuIslandsState(), arrayOf("Inter", "Helvetica"))
+        assertTrue(FontDetector.isFamilyInstalled("Inter"))
+        assertTrue(FontDetector.isFamilyInstalled("INTER"))
+        assertTrue(FontDetector.isFamilyInstalled("inter"))
+    }
+
+    @Test
+    fun `isFamilyInstalled returns false for unknown family`() {
+        stubSettingsAndGraphicsEnv(AyuIslandsState(), arrayOf("Inter", "Helvetica"))
+        assertFalse(FontDetector.isFamilyInstalled("MesloLGLDZ Nerd Font Mono"))
+    }
+
+    @Test
+    fun `isFamilyInstalled returns false for blank input (defensive empty-state contract)`() {
+        // Locks the current contract: blank family is treated as not installed,
+        // not as a wildcard match. If a refactor ever adds an early return that
+        // short-circuits to true on blank, this test forces the discussion.
+        stubSettingsAndGraphicsEnv(AyuIslandsState(), arrayOf("Inter"))
+        assertFalse(FontDetector.isFamilyInstalled(""))
+        assertFalse(FontDetector.isFamilyInstalled("   "))
+    }
+
+    @Test
+    fun `isFamilyInstalled returns false on HeadlessException (does not propagate freeze)`() {
+        // Round-1 review CRITICAL #1: a propagating throw here would reproduce
+        // the issue #164 panel-build freeze with a different exception class.
+        // The helper must catch and return false so the preview falls back to
+        // "Install X to preview" instead of stranding the panel.
+        mockkObject(AyuIslandsSettings.Companion)
+        val settings = AyuIslandsSettings().apply { loadState(AyuIslandsState()) }
+        every { AyuIslandsSettings.getInstance() } returns settings
+
+        mockkStatic(GraphicsEnvironment::class)
+        every { GraphicsEnvironment.getLocalGraphicsEnvironment() } throws HeadlessException()
+        FontDetector.invalidateCache()
+
+        assertFalse(FontDetector.isFamilyInstalled("Inter"))
+    }
+
+    @Test
+    fun `isFamilyInstalled returns false on RuntimeException (does not propagate freeze)`() {
+        // Same defense for a generic AWT/JBR throw (e.g. macOS font cache
+        // corruption surfaces as InternalError or RuntimeException).
+        mockkObject(AyuIslandsSettings.Companion)
+        val settings = AyuIslandsSettings().apply { loadState(AyuIslandsState()) }
+        every { AyuIslandsSettings.getInstance() } returns settings
+
+        mockkStatic(GraphicsEnvironment::class)
+        every { GraphicsEnvironment.getLocalGraphicsEnvironment() } throws RuntimeException("boom")
+        FontDetector.invalidateCache()
+
+        assertFalse(FontDetector.isFamilyInstalled("Inter"))
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/settings/FontPresetPanelCustomBytecodeTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/FontPresetPanelCustomBytecodeTest.kt
@@ -147,7 +147,7 @@ class FontPresetPanelCustomBytecodeTest {
         setPrivateField(panel, "installHintLabel", label)
         setPrivateField(panel, "availability", emptyMap<FontPreset, Boolean>())
 
-        invokePrivateMethod(panel, "updateFontMissing")
+        invokeUpdateFontMissing(panel)
 
         assertEquals(
             "",
@@ -180,11 +180,44 @@ class FontPresetPanelCustomBytecodeTest {
         setPrivateField(panel, "installHintLabel", JLabel())
         setPrivateField(panel, "availability", mapOf(FontPreset.WHISPER to true))
 
-        invokePrivateMethod(panel, "updateFontMissing")
+        invokeUpdateFontMissing(panel)
 
         assertFalse(getBooleanProperty(panel, "fontMissing"), "WHISPER healthy: fontMissing must be false")
         assertTrue(getBooleanProperty(panel, "fontInstalled"), "WHISPER healthy: fontInstalled must be true")
         assertFalse(getBooleanProperty(panel, "fontCorrupted"), "WHISPER healthy: fontCorrupted must be false")
+    }
+
+    @Test
+    fun `updateFontMissing forwards user family to preview for non-curated preset`() {
+        // 2.6.2 follow-up: pre-fix updateFontMissing only called updatePreset,
+        // which sets fontInstalled=false for CUSTOM (no catalog availability)
+        // and the preview pane fell back to "Install <preset.fontFamily> to
+        // preview" — i.e. "Install JetBrains Mono" even when the user had
+        // picked a different family. The fix has three structural pieces this
+        // test pins via bytecode references on the panel + detector + preview
+        // classes: FontPresetPanel pushes the user family via updateFontFamily,
+        // gates on isCurated, and asks FontDetector.isFamilyInstalled for a
+        // system-level install check (instead of leaving fontInstalled=false
+        // for CUSTOM).
+        val classText = readClassBytes("FontPresetPanel")
+        assertTrue(
+            classText.contains("updateFontFamily"),
+            "FontPresetPanel must call FontPreviewComponent.updateFontFamily " +
+                "so non-curated presets render with the user's actual family, not " +
+                "the catalog's default fontFamily constant.",
+        )
+        assertTrue(
+            classText.contains("isCurated"),
+            "FontPresetPanel must gate the updateFontFamily push on " +
+                "preset.isCurated so curated presets keep using the catalog default.",
+        )
+        assertTrue(
+            classText.contains("isFamilyInstalled"),
+            "FontPresetPanel must call FontDetector.isFamilyInstalled to check " +
+                "whether the user-chosen Custom family is installed on the system " +
+                "(without this, fontInstalled stays false for CUSTOM and the " +
+                "preview always falls back to 'Install X to preview').",
+        )
     }
 
     @Test
@@ -240,11 +273,8 @@ class FontPresetPanelCustomBytecodeTest {
         field.set(target, value)
     }
 
-    private fun invokePrivateMethod(
-        target: Any,
-        name: String,
-    ) {
-        val method = FontPresetPanel::class.java.getDeclaredMethod(name)
+    private fun invokeUpdateFontMissing(target: Any) {
+        val method = FontPresetPanel::class.java.getDeclaredMethod("updateFontMissing")
         method.isAccessible = true
         method.invoke(target)
     }

--- a/src/test/kotlin/dev/ayuislands/settings/FontPresetPanelCustomBytecodeTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/FontPresetPanelCustomBytecodeTest.kt
@@ -188,36 +188,114 @@ class FontPresetPanelCustomBytecodeTest {
     }
 
     @Test
-    fun `updateFontMissing forwards user family to preview for non-curated preset`() {
+    fun `panel module bytecode references isFamilyInstalled (Custom-preview lock)`() {
         // 2.6.2 follow-up: pre-fix updateFontMissing only called updatePreset,
         // which sets fontInstalled=false for CUSTOM (no catalog availability)
         // and the preview pane fell back to "Install <preset.fontFamily> to
-        // preview" — i.e. "Install JetBrains Mono" even when the user had
-        // picked a different family. The fix has three structural pieces this
-        // test pins via bytecode references on the panel + detector + preview
-        // classes: FontPresetPanel pushes the user family via updateFontFamily,
-        // gates on isCurated, and asks FontDetector.isFamilyInstalled for a
-        // system-level install check (instead of leaving fontInstalled=false
-        // for CUSTOM).
-        val classText = readClassBytes("FontPresetPanel")
+        // preview". The genuinely-new dependency Round 1 introduced is
+        // FontDetector.isFamilyInstalled, called from previewInstalledFor.
+        // previewInstalledFor lives at file scope, so its compiled bytes are
+        // on FontPresetPanelKt.class (Kotlin file-class), not FontPresetPanel
+        // itself. Search both — a refactor that reverts either the helper or
+        // the panel-side wiring would drop the symbol from the file-class
+        // module entirely. Behavior coverage for the gate logic lives in the
+        // runtime tests below, not this lock.
+        val combined = readClassBytes("FontPresetPanel") + readClassBytes("FontPresetPanelKt")
         assertTrue(
-            classText.contains("updateFontFamily"),
-            "FontPresetPanel must call FontPreviewComponent.updateFontFamily " +
-                "so non-curated presets render with the user's actual family, not " +
-                "the catalog's default fontFamily constant.",
+            combined.contains("isFamilyInstalled"),
+            "FontPresetPanel module (panel + Kt file-class) must call " +
+                "FontDetector.isFamilyInstalled to check whether the user-chosen " +
+                "Custom family is installed on the system. Without this, " +
+                "fontInstalled stays false for CUSTOM and the preview always " +
+                "falls back to 'Install X to preview'.",
         )
+    }
+
+    @Test
+    fun `previewInstalledFor curated branch returns true for HEALTHY status`() {
+        assertTrue(previewInstalledFor(FontPreset.AMBIENT, FontStatus.HEALTHY, true, "anything"))
+    }
+
+    @Test
+    fun `previewInstalledFor curated branch returns false for non-HEALTHY status`() {
+        assertFalse(previewInstalledFor(FontPreset.AMBIENT, FontStatus.NOT_INSTALLED, true, "anything"))
+        assertFalse(previewInstalledFor(FontPreset.AMBIENT, FontStatus.CORRUPTED, true, "anything"))
+    }
+
+    @Test
+    fun `previewInstalledFor non-curated branch returns true when family is installed and enabled`() {
+        mockkObject(FontDetector)
+        every { FontDetector.isFamilyInstalled("MesloLGLDZ Nerd Font Mono") } returns true
+        // Status is ignored on the non-curated path — the curated/non-curated
+        // gate decides which input drives the answer.
         assertTrue(
-            classText.contains("isCurated"),
-            "FontPresetPanel must gate the updateFontFamily push on " +
-                "preset.isCurated so curated presets keep using the catalog default.",
+            previewInstalledFor(
+                FontPreset.CUSTOM,
+                FontStatus.NOT_INSTALLED,
+                enabled = true,
+                family = "MesloLGLDZ Nerd Font Mono",
+            ),
         )
-        assertTrue(
-            classText.contains("isFamilyInstalled"),
-            "FontPresetPanel must call FontDetector.isFamilyInstalled to check " +
-                "whether the user-chosen Custom family is installed on the system " +
-                "(without this, fontInstalled stays false for CUSTOM and the " +
-                "preview always falls back to 'Install X to preview').",
+    }
+
+    @Test
+    fun `previewInstalledFor non-curated branch returns false when family is missing`() {
+        mockkObject(FontDetector)
+        every { FontDetector.isFamilyInstalled("MissingFont") } returns false
+        assertFalse(
+            previewInstalledFor(FontPreset.CUSTOM, FontStatus.NOT_INSTALLED, enabled = true, family = "MissingFont"),
         )
+    }
+
+    @Test
+    fun `previewInstalledFor non-curated branch short-circuits on disabled even if family is installed`() {
+        // Mirrors the curated semantics (status collapses to NOT_INSTALLED
+        // when !pendingEnabled) — disabled preset never claims a live preview.
+        mockkObject(FontDetector)
+        // FontDetector should never be queried because the enabled gate fails first.
+        every { FontDetector.isFamilyInstalled(any()) } returns true
+        assertFalse(
+            previewInstalledFor(FontPreset.CUSTOM, FontStatus.HEALTHY, enabled = false, family = "InstalledFont"),
+        )
+    }
+
+    @Test
+    fun `updateFontMissing CUSTOM with installed family flips fontInstalled true`() {
+        // Round-3 runtime lock for the actual issue #168 user-visible bug.
+        // Pre-fix: CUSTOM with installed family → fontInstalled stayed false →
+        // preview rendered "Install X to preview" fallback. Round-1 fix wires
+        // FontDetector.isFamilyInstalled into the gate; this test pins the
+        // happy path through the panel's private updateFontMissing.
+        mockkObject(FontDetector)
+        every { FontDetector.isFamilyInstalled("MesloLGLDZ Nerd Font Mono") } returns true
+
+        val panel = FontPresetPanel()
+        setPrivateField(panel, "pendingPreset", FontPreset.CUSTOM.name)
+        setPrivateField(panel, "pendingEnabled", true)
+        setPrivateField(panel, "installHintLabel", JLabel())
+        setPrivateField(panel, "availability", emptyMap<FontPreset, Boolean>())
+        // Inject a customization map entry so currentSettings.fontFamily
+        // returns the user-chosen family the FontDetector mock is keyed on.
+        @Suppress("UNCHECKED_CAST")
+        val customizations =
+            FontPresetPanel::class.java.getDeclaredField("customizations").let { field ->
+                field.isAccessible = true
+                field.get(panel) as MutableMap<String, dev.ayuislands.font.FontSettings>
+            }
+        customizations[FontPreset.CUSTOM.name] =
+            dev.ayuislands.font.FontSettings
+                .fromPreset(FontPreset.CUSTOM)
+                .copy(fontFamily = "MesloLGLDZ Nerd Font Mono")
+
+        invokeUpdateFontMissing(panel)
+
+        // Visibility-gate booleans MUST stay false for non-curated, regardless
+        // of the family lookup — the row visibility logic still requires
+        // preset.isCurated. The fontInstalled-on-preview fix lives in
+        // previewInstalledFor / updatePreset, not in the visibility booleans.
+        assertFalse(getBooleanProperty(panel, "fontMissing"), "fontMissing must stay false for CUSTOM")
+        assertFalse(getBooleanProperty(panel, "fontInstalled"), "fontInstalled (visibility) stays false for CUSTOM")
+        assertFalse(getBooleanProperty(panel, "fontCorrupted"), "fontCorrupted must stay false for CUSTOM")
     }
 
     @Test


### PR DESCRIPTION
## Summary

Latent UX bug exposed by [PR #167](https://github.com/barad1tos/ayu-jetbrains/pull/167)'s issue-#164 fix:
once Settings → Ayu Islands → Font could open with a persisted Custom preset
(no panel freeze), the preview pane revealed it was still painting
**"Install JetBrains Mono to preview"** even when the user had picked a
real custom family. Manually reproducible in 2.6.1's deployed JAR if you
forced the panel open via the workaround path; in 2.6.2-pre-fix it's
visible immediately on first paint.

## Root cause

Two coupled wrong assumptions in the preview surface:

1. `FontPreviewComponent.fontInstalled` was always tied to
   `availability[preset]`, which `FontDetector.detectAll()` populates only
   for curated presets. For CUSTOM, `availability[preset] == null`, so
   `fontInstalled = false` and `paintComponent` short-circuited into
   `drawFallbackMessage()` regardless of whether the user's actual font was
   installed on the system.
2. `drawFallbackMessage()` hard-coded `currentPreset.fontFamily` for the
   "Install X" message — for `FontPreset.CUSTOM` that's
   `DEFAULT_CUSTOM_FONT = "JetBrains Mono"`, never the family the user
   typed in.

## Fix

Three coordinated changes:

- **`FontDetector.isFamilyInstalled(family: String): Boolean`** — public
  helper for arbitrary family strings. Reuses the cached
  `GraphicsEnvironment.availableFontFamilyNames` set already maintained
  for the curated path.
- **`FontPresetPanel.previewInstalledFor(...)`** — file-scope helper
  invoked from `updateFontMissing` and `refreshPreview`. Curated presets
  keep using `FontDetector.status()`; non-curated branches to
  `isFamilyInstalled(currentSettings.fontFamily)`. File-scope (not class
  member) to keep the panel under detekt's `TooManyFunctions=25` cap
  without raising the threshold.
- **`FontPreviewComponent.drawFallbackMessage`** — picks the displayed
  family by `isCurated`: curated → `currentPreset.fontFamily`;
  non-curated → `resolvedFontFamily` (the family the panel already
  pushed via `updateFontFamily`). When the user picks an
  uninstalled family, the message reads `"Install <user's family> to
  preview"` — accurate and actionable.

## Test plan

- [x] Bytecode regression lock added to
  `FontPresetPanelCustomBytecodeTest.kt`: panel must reference
  `updateFontFamily`, `isCurated`, AND `isFamilyInstalled`. Removing any
  one re-introduces the wrong-family preview.
- [x] `./gradlew compileKotlin compileTestKotlin detekt ktlintCheck test`
  — all green (3m 29s test run).
- [x] Manual verify in IntelliJ IDEA 2026.1 with `MesloLGLDZ Nerd Font Mono`
  picked as Custom: panel renders the live sample at first paint and
  after preset switches.
- [x] Manual verify with a non-installed family: fallback message reads
  the user's family, not "JetBrains Mono".
- [ ] CI green on PR
- [ ] PR review loop converges

## Notes

- Changelog and `plugin.xml` change-notes get a fourth bullet for
  v2.6.2 covering this preview fix.
- Tagging v2.6.2 deliberately deferred until this PR merges — the
  release pipeline (`/release-plugin 2.6.2`) was paused at Step 5
  (tag + push) for the local smoke test that surfaced this.

## Summary by Sourcery

Ensure the font preview pane correctly reflects the user’s chosen Custom font family and reports accurate installation status for curated and non‑curated presets.

Bug Fixes:
- Fix font preview showing the default JetBrains Mono message instead of the user-selected Custom font family when a Custom preset is active.

Enhancements:
- Add a generic font family installation check and shared helper to determine whether the preview should show a live sample or an install hint for curated vs non-curated presets.
- Improve the font preview fallback message to reference the actual resolved font family for non-curated presets.

Documentation:
- Document the font preview behavior change in the changelog and plugin change notes.

Tests:
- Extend bytecode-level tests for FontPresetPanel to assert the presence of the new font installation and preview-update wiring for Custom presets.