### PR TITLE
feat(vcs): VCS color customization (v2.6.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.6.3] - 2026-05-12
+
+### Added
+- [Paid] **New VCS tab** in Settings (between Glow and Workspace) — tune VCS color intensity across five surfaces: diff viewer, Project View file status, editor gutter, conflict markers, and Git blame annotations. Four named profiles — Whisper, Ambient, Neon, Cyberpunk — plus a Custom mode with per-surface sliders. Master toggle stays off by default, so 2.6.2 colors are byte-identical until you opt in.
+
+### Roadmap
+Next patch wires the same intensity profile into the branch indicator, branches popup, and commit log highlights — they live on a different UI surface that needs its own platform research.
+
 ## [2.6.2] - 2026-05-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Ayu Islands synchronizes palette, font, glow, and accent color into a cohesive l
 
 **Tab styling** — Islands UI offers underline, full accent bar, or none; Classic UI has underline thickness from hairline to bold.
 
+**VCS color customization** — *Settings → Ayu Islands → VCS* tunes intensity across five surfaces (diff viewer, Project View file status, editor gutter, conflict markers, Git blame annotations). Each section carries its own profile — **Whisper**, **Ambient**, **Neon**, **Cyberpunk**, or **Custom** with per-surface sliders. Master toggle off by default; 2.6.2 colors stay byte-identical until you opt in.
+
 **Onboarding wizard** — a full-tab welcome opens on first install with preset cards, theme variant picker, and accent swatches. After upgrades, a **release showcase** tab opens automatically with captioned screenshots of the marquee features; reopen anytime via *Tools → Ayu Islands → Show What's New*.
 
 ## Free — a complete theme, not a teaser

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -151,6 +151,21 @@ categories:
           Theme Synchronization. Inspired by Peacock for VS Code,
           built on JetBrains platform primitives.
 
+      - id: vcs-color-customization
+        title: "VCS color customization"
+        keyword: "VCS color customization"
+        introduced: "2.6.3"
+        tier: paid
+        description: >
+          Tune VCS color intensity across five surfaces — diff viewer,
+          Project View file status, editor gutter, conflict markers, and
+          Git blame annotations. Each section carries its own profile:
+          Whisper (calmer), Ambient (2.6.2 defaults), Neon (brighter,
+          pre-2.6.2 punch), Cyberpunk (peak), or Custom with per-surface
+          sliders. Configured from Settings → Ayu Islands → VCS. Master
+          toggle off by default — 2.6.2 colors stay byte-identical until
+          users opt in.
+
   glow:
     title: "Glow effects"
     features:

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "53adcad"
+          last_verified_sha: "8386cd4"
           last_verified_date: "2026-04-25"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "53adcad"
+          last_verified_sha: "8386cd4"
           last_verified_date: "2026-04-25"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -226,7 +226,7 @@ categories:
           sources:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "53adcad"
+          last_verified_sha: "8386cd4"
           last_verified_date: "2026-05-10"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.6.2
+pluginVersion=2.6.3
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/proguard-rules.pro
+++ b/proguard-rules.pro
@@ -47,6 +47,8 @@
 -keep enum dev.ayuislands.glow.GlowPreset { *; }
 -keep enum dev.ayuislands.font.FontWeight { *; }
 -keep enum dev.ayuislands.font.FontPreset { *; }
+-keep enum dev.ayuislands.vcs.VcsColorPreset { *; }
+-keep enum dev.ayuislands.vcs.VcsColorCategory { *; }
 
 # plugin.xml: projectService (Project View tweaks)
 -keep class dev.ayuislands.projectview.ProjectViewScrollbarManager { *; }

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -205,7 +205,7 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
             )
         }
 
-        applyPersistedVcsColors(settings)
+        runStep("apply-persisted-vcs-colors") { applyPersistedVcsColors(settings) }
     }
 
     /**

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -25,6 +25,7 @@ import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.mappings.AccentMappingsSettings
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 import dev.ayuislands.ui.ComponentTreeRefresher
+import dev.ayuislands.vcs.VcsColorApplier
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import javax.swing.SwingUtilities
@@ -202,6 +203,26 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
                 { GlowOverlayManager.getInstance(project).initialize() },
                 project.disposed,
             )
+        }
+
+        applyPersistedVcsColors(settings)
+    }
+
+    /**
+     * Re-apply persisted VCS color customization (Phase 40.2). Extracted from
+     * [execute] so the cyclomatic complexity stays under detekt's threshold —
+     * mirrors [runStartupAccentOnEdt]'s extraction rationale.
+     *
+     * Two gates here:
+     *  1. Master toggle — when off, [com.intellij.openapi.editor.colors.EditorColorsScheme]
+     *     has no plugin-owned VCS color writes to restore, so we skip the apply entirely.
+     *  2. License — a Pro user whose license expired between sessions sees their
+     *     VCS tinting revert to stock on the first post-expiry startup. Without
+     *     this gate we'd silently keep painting premium colors after a downgrade.
+     */
+    private fun applyPersistedVcsColors(settings: AyuIslandsSettings) {
+        if (settings.state.vcsColorEnabled && LicenseChecker.isLicensedOrGrace()) {
+            VcsColorApplier.applyAll()
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -386,8 +386,11 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
      * Invokes [block] with fine-grained error handling so each startup step gets its own
      * log line, and the JVM's error-escalation path stays intact for genuinely fatal errors.
      *
-     * All production call sites run inside `SwingUtilities.invokeLater { ... }` (see
-     * [checkLicenseState]), so the surrounding Runnable is dispatched by `IdeEventQueue`:
+     * Most production call sites (the license-handling block in [checkLicenseState]
+     * and friends) run inside `SwingUtilities.invokeLater { ... }`, so the surrounding
+     * Runnable is dispatched by `IdeEventQueue`. The `apply-persisted-vcs-colors` step
+     * runs from the coroutine body of [execute] instead — RuntimeException semantics
+     * are identical regardless of thread context:
      *
      *  - [RuntimeException] — logged, swallowed; the next step runs.
      *  - [VirtualMachineError] (OutOfMemoryError, StackOverflowError, InternalError,

--- a/src/main/kotlin/dev/ayuislands/accent/ChromeTintSnapshot.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ChromeTintSnapshot.kt
@@ -1,6 +1,7 @@
 package dev.ayuislands.accent
 
 import dev.ayuislands.settings.AyuIslandsState
+import dev.ayuislands.util.withScopedValue
 
 /**
  * Immutable chrome settings captured from the Settings panel's pending values.
@@ -46,18 +47,5 @@ internal object ChromeTintContext {
     fun <T> withSnapshot(
         snapshot: ChromeTintSnapshot?,
         block: () -> T,
-    ): T {
-        if (snapshot == null) return block()
-        val previous = current.get()
-        current.set(snapshot)
-        return try {
-            block()
-        } finally {
-            if (previous == null) {
-                current.remove()
-            } else {
-                current.set(previous)
-            }
-        }
-    }
+    ): T = current.withScopedValue(snapshot, block)
 }

--- a/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
@@ -278,13 +278,17 @@ object LicenseChecker {
 
             // Reset VCS color customization (Phase 40.2) — premium feature. The
             // master toggle goes off so the EditorColorsScheme falls back to stock
-            // XML on the next applier pass; preset returns to AMBIENT and the three
-            // Wave 2 sliders return to the no-op AMBIENT_SLIDER position.
+            // XML on the next applier pass; every per-section preset returns to
+            // AMBIENT and every per-category slider returns to AMBIENT_SLIDER.
             state.vcsColorEnabled = false
-            state.vcsColorPreset = VcsColorPreset.AMBIENT.name
+            state.vcsDiffPreset = VcsColorPreset.AMBIENT.name
+            state.vcsMergePreset = VcsColorPreset.AMBIENT.name
+            state.vcsBlamePreset = VcsColorPreset.AMBIENT.name
             state.vcsDiffIntensity = VcsColorPreset.AMBIENT_SLIDER
             state.vcsProjectViewIntensity = VcsColorPreset.AMBIENT_SLIDER
             state.vcsGutterIntensity = VcsColorPreset.AMBIENT_SLIDER
+            state.vcsConflictMarkerIntensity = VcsColorPreset.AMBIENT_SLIDER
+            state.vcsBlameIntensity = VcsColorPreset.AMBIENT_SLIDER
 
             // Reset workspace settings to free defaults
             state.projectPanelWidthMode = PanelWidthMode.DEFAULT.name

--- a/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
@@ -30,6 +30,8 @@ import dev.ayuislands.rotation.AccentRotationService
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
 import dev.ayuislands.settings.PanelWidthMode
+import dev.ayuislands.vcs.VcsColorApplier
+import dev.ayuislands.vcs.VcsColorPreset
 import org.jetbrains.annotations.VisibleForTesting
 import java.time.LocalDate
 import java.time.ZoneId
@@ -274,6 +276,16 @@ object LicenseChecker {
             state.chromeTintIntensity = AyuIslandsState.DEFAULT_CHROME_TINT_INTENSITY
             state.chromeTintingGroupExpanded = false
 
+            // Reset VCS color customization (Phase 40.2) — premium feature. The
+            // master toggle goes off so the EditorColorsScheme falls back to stock
+            // XML on the next applier pass; preset returns to AMBIENT and the three
+            // Wave 2 sliders return to the no-op AMBIENT_SLIDER position.
+            state.vcsColorEnabled = false
+            state.vcsColorPreset = VcsColorPreset.AMBIENT.name
+            state.vcsDiffIntensity = VcsColorPreset.AMBIENT_SLIDER
+            state.vcsProjectViewIntensity = VcsColorPreset.AMBIENT_SLIDER
+            state.vcsGutterIntensity = VcsColorPreset.AMBIENT_SLIDER
+
             // Reset workspace settings to free defaults
             state.projectPanelWidthMode = PanelWidthMode.DEFAULT.name
             state.commitPanelWidthMode = PanelWidthMode.DEFAULT.name
@@ -327,6 +339,15 @@ object LicenseChecker {
                         "Restart your IDE to complete the reset.",
                     NotificationType.WARNING,
                 ).notify(null)
+        }
+
+        // Phase 40.2: write nulls into the editor scheme for every VCS color key
+        // the plugin owns so the user sees stock 2.6.2 colors restore immediately,
+        // without waiting for a theme switch or restart.
+        try {
+            VcsColorApplier.revertAll()
+        } catch (exception: RuntimeException) {
+            LOG.warn("VCS color revert after license revert failed", exception)
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
@@ -279,7 +279,16 @@ object LicenseChecker {
             // Reset VCS color customization (Phase 40.2) — premium feature. The
             // master toggle goes off so the EditorColorsScheme falls back to stock
             // XML on the next applier pass; every per-section preset returns to
-            // AMBIENT and every per-category slider returns to AMBIENT_SLIDER.
+            // AMBIENT, every per-category slider returns to AMBIENT_SLIDER, and
+            // every section-expanded flag returns to its default-constructor value.
+            //
+            // Reset covers all 11 categories — including the Wave 5+ placeholder
+            // intensities (merge 3-way, inline diff, local history, branch
+            // indicator, branches popup, commit highlights) — so when those
+            // categories ship in v2.6.4+, a user who downgraded mid-cycle starts
+            // from the same baseline as a fresh install. Without that, the
+            // re-purchase experience would surface non-default sliders from a
+            // stale premium session.
             state.vcsColorEnabled = false
             state.vcsDiffPreset = VcsColorPreset.AMBIENT.name
             state.vcsMergePreset = VcsColorPreset.AMBIENT.name
@@ -289,6 +298,17 @@ object LicenseChecker {
             state.vcsGutterIntensity = VcsColorPreset.AMBIENT_SLIDER
             state.vcsConflictMarkerIntensity = VcsColorPreset.AMBIENT_SLIDER
             state.vcsBlameIntensity = VcsColorPreset.AMBIENT_SLIDER
+            state.vcsMerge3WayIntensity = VcsColorPreset.AMBIENT_SLIDER
+            state.vcsInlineDiffIntensity = VcsColorPreset.AMBIENT_SLIDER
+            state.vcsLocalHistoryIntensity = VcsColorPreset.AMBIENT_SLIDER
+            state.vcsBranchIndicatorIntensity = VcsColorPreset.AMBIENT_SLIDER
+            state.vcsBranchesPopupIntensity = VcsColorPreset.AMBIENT_SLIDER
+            state.vcsCommitHighlightIntensity = VcsColorPreset.AMBIENT_SLIDER
+            // Diff section opens expanded by default per Phase 40.2 spec; the
+            // other two collapse on downgrade to match a fresh-install layout.
+            state.vcsDiffSectionExpanded = true
+            state.vcsMergeSectionExpanded = false
+            state.vcsBlameSectionExpanded = false
 
             // Reset workspace settings to free defaults
             state.projectPanelWidthMode = PanelWidthMode.DEFAULT.name

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt
@@ -49,6 +49,7 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
     private val pluginsPanel = PluginsPanel()
     private val fontPresetPanel = FontPresetPanel()
     private val effectsPanel = AyuIslandsEffectsPanel()
+    private val vcsColorPanel = VcsColorPanel()
 
     private val panels: List<AyuIslandsSettingsPanel> =
         listOf(
@@ -58,6 +59,7 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
             elementsPanel,
             fontPresetPanel,
             effectsPanel,
+            vcsColorPanel,
             workspacePanel,
             pluginsPanel,
         )
@@ -141,6 +143,11 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
                 effectsPanel.buildGlowPanel(this@panel)
             }
 
+        val vcsTab =
+            panel {
+                vcsColorPanel.buildPanel(this@panel, variant)
+            }
+
         val workspaceTab =
             panel {
                 workspacePanel.buildPanel(this@panel, variant)
@@ -167,6 +174,7 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
         tabs.addTab("Accent", accentTab)
         tabs.addTab("Font", fontTab)
         tabs.addTab("Glow", glowTab)
+        tabs.addTab("VCS", vcsTab)
         tabs.addTab("Workspace", workspaceTab)
         tabs.addTab("Plugins", pluginsTab)
 
@@ -303,6 +311,7 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
         elementsPanel.reset()
         fontPresetPanel.reset()
         effectsPanel.reset()
+        vcsColorPanel.reset()
         workspacePanel.reset()
         pluginsPanel.reset()
     }

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -327,6 +327,11 @@ class AyuIslandsState : BaseState() {
     // additional section-expanded flags land alongside their panels in waves 3-5.
     var vcsDiffSectionExpanded by property(true)
 
+    // VCS panel's "Merge & Conflict" collapsible group expanded state. Defaults
+    // to false — the section opens collapsed so the panel reads as "primary
+    // Diff & File Status controls visible, secondary surfaces tucked away".
+    var vcsMergeSectionExpanded by property(false)
+
     // Per-category intensities in `[0, 100]`. Defaults to AMBIENT_SLIDER (33)
     // across the board so a Pro user enabling the master toggle observes no
     // visible change until they cycle a preset or move a slider. Reads go

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -9,6 +9,9 @@ import dev.ayuislands.glow.GlowPreset
 import dev.ayuislands.glow.GlowStyle
 import dev.ayuislands.indent.IndentPreset
 import dev.ayuislands.rotation.AccentRotationMode
+import dev.ayuislands.vcs.VcsColorCategory
+import dev.ayuislands.vcs.VcsColorPreset
+import dev.ayuislands.vcs.VcsIntensity
 import java.io.File
 
 enum class PanelWidthMode {
@@ -308,6 +311,87 @@ class AyuIslandsState : BaseState() {
      * unusable.
      */
     fun effectiveLastAppliedAccentHex(): AccentHex? = AccentHex.of(lastAppliedAccentHex)
+
+    // --- VCS color customization (Phase 40.2, premium) ---
+    // Master kill-switch. Default OFF so 2.6.2 upgraders observe byte-identical
+    // diff/file-status/gutter colors until they opt in via the VCS settings tab.
+    var vcsColorEnabled by property(false)
+
+    // Active preset choice. String-backed for BaseState XML serialization;
+    // resolved through [effectiveVcsColorPreset] which falls back to MUTED on
+    // corrupted or unknown values (legacy XML, hand-edited config).
+    var vcsColorPreset by string(VcsColorPreset.MUTED.name)
+
+    // VCS tab expanded state for the four collapsible sections. First section
+    // (Diff & File Status) starts expanded by design; others collapsed.
+    var vcsColorDiffSectionExpanded by property(true)
+    var vcsColorMergeSectionExpanded by property(false)
+    var vcsColorBlameSectionExpanded by property(false)
+    var vcsColorBranchSectionExpanded by property(false)
+
+    // Per-category intensities in `[0, 100]`. Defaults to 0 (Muted baseline)
+    // across the board; reads go through [effectiveVcsIntensityFor] so a
+    // corrupted persisted value can never reach the HSB blender out of range.
+    var vcsDiffIntensity by property(0)
+    var vcsProjectViewIntensity by property(0)
+    var vcsGutterIntensity by property(0)
+    var vcsConflictMarkerIntensity by property(0)
+    var vcsMerge3WayIntensity by property(0)
+    var vcsInlineDiffIntensity by property(0)
+    var vcsBlameIntensity by property(0)
+    var vcsLocalHistoryIntensity by property(0)
+    var vcsBranchIndicatorIntensity by property(0)
+    var vcsBranchesPopupIntensity by property(0)
+    var vcsCommitHighlightIntensity by property(0)
+
+    /**
+     * Returns [vcsColorPreset] resolved into a [VcsColorPreset] enum value,
+     * falling back to [VcsColorPreset.MUTED] on an unknown / corrupted string.
+     * Mirrors the [effectiveChromeTintIntensity] discipline: every read path
+     * uses this helper so a hand-edited XML never feeds an unknown preset name
+     * into the applier's `when` branches.
+     */
+    fun effectiveVcsColorPreset(): VcsColorPreset = VcsColorPreset.byName(vcsColorPreset)
+
+    /**
+     * Returns the per-category intensity map snapshot for the applier. The
+     * 11 individual properties are materialised into a [Map] keyed by
+     * [VcsColorCategory] so the applier and snapshot can iterate categories
+     * uniformly without 11 hand-written branches.
+     */
+    fun effectiveVcsPerCategoryIntensities(): Map<VcsColorCategory, Int> =
+        mapOf(
+            VcsColorCategory.DIFF_VIEWER to vcsDiffIntensity,
+            VcsColorCategory.PROJECT_VIEW_FILE_STATUS to vcsProjectViewIntensity,
+            VcsColorCategory.EDITOR_GUTTER to vcsGutterIntensity,
+            VcsColorCategory.CONFLICT_MARKERS to vcsConflictMarkerIntensity,
+            VcsColorCategory.MERGE_3WAY to vcsMerge3WayIntensity,
+            VcsColorCategory.INLINE_DIFF_POPUP to vcsInlineDiffIntensity,
+            VcsColorCategory.BLAME_GUTTER to vcsBlameIntensity,
+            VcsColorCategory.LOCAL_HISTORY to vcsLocalHistoryIntensity,
+            VcsColorCategory.BRANCH_INDICATOR to vcsBranchIndicatorIntensity,
+            VcsColorCategory.BRANCHES_POPUP to vcsBranchesPopupIntensity,
+            VcsColorCategory.COMMIT_HIGHLIGHTS to vcsCommitHighlightIntensity,
+        )
+
+    /**
+     * Returns the effective intensity for a single [category] as a clamped
+     * [VcsIntensity]. Branches on the active preset: Custom reads the per-
+     * category property directly, the other presets defer to
+     * [VcsColorPreset.intensityFor]. When [vcsColorEnabled] is `false` the
+     * helper short-circuits to `0` so the applier returns the stock XML color.
+     */
+    fun effectiveVcsIntensityFor(category: VcsColorCategory): VcsIntensity {
+        if (!vcsColorEnabled) return VcsIntensity.of(0)
+        val preset = effectiveVcsColorPreset()
+        val raw =
+            if (preset == VcsColorPreset.CUSTOM) {
+                effectiveVcsPerCategoryIntensities().getValue(category)
+            } else {
+                preset.intensityFor(category)
+            }
+        return VcsIntensity.of(raw)
+    }
 
     fun isToggleEnabled(id: AccentElementId): Boolean =
         when (id) {

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -332,6 +332,10 @@ class AyuIslandsState : BaseState() {
     // Diff & File Status controls visible, secondary surfaces tucked away".
     var vcsMergeSectionExpanded by property(false)
 
+    // VCS panel's "Blame & History" collapsible group expanded state. Defaults
+    // to false for the same secondary-surface reason as Merge & Conflict.
+    var vcsBlameSectionExpanded by property(false)
+
     // Per-category intensities in `[0, 100]`. Defaults to AMBIENT_SLIDER (33)
     // across the board so a Pro user enabling the master toggle observes no
     // visible change until they cycle a preset or move a slider. Reads go

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -320,7 +320,7 @@ class AyuIslandsState : BaseState() {
     // Active preset choice. String-backed for BaseState XML serialization;
     // resolved through [effectiveVcsColorPreset] which falls back to MUTED on
     // corrupted or unknown values (legacy XML, hand-edited config).
-    var vcsColorPreset by string(VcsColorPreset.MUTED.name)
+    var vcsColorPreset by string(VcsColorPreset.AMBIENT.name)
 
     // VCS tab expanded state for the four collapsible sections. First section
     // (Diff & File Status) starts expanded by design; others collapsed.
@@ -329,20 +329,22 @@ class AyuIslandsState : BaseState() {
     var vcsColorBlameSectionExpanded by property(false)
     var vcsColorBranchSectionExpanded by property(false)
 
-    // Per-category intensities in `[0, 100]`. Defaults to 0 (Muted baseline)
-    // across the board; reads go through [effectiveVcsIntensityFor] so a
-    // corrupted persisted value can never reach the HSB blender out of range.
-    var vcsDiffIntensity by property(0)
-    var vcsProjectViewIntensity by property(0)
-    var vcsGutterIntensity by property(0)
-    var vcsConflictMarkerIntensity by property(0)
-    var vcsMerge3WayIntensity by property(0)
-    var vcsInlineDiffIntensity by property(0)
-    var vcsBlameIntensity by property(0)
-    var vcsLocalHistoryIntensity by property(0)
-    var vcsBranchIndicatorIntensity by property(0)
-    var vcsBranchesPopupIntensity by property(0)
-    var vcsCommitHighlightIntensity by property(0)
+    // Per-category intensities in `[0, 100]`. Defaults to AMBIENT_SLIDER (33)
+    // across the board so a Pro user enabling the master toggle observes no
+    // visible change until they cycle a preset or move a slider. Reads go
+    // through [effectiveVcsIntensityFor] so a corrupted persisted value can
+    // never reach the HSB blender out of range.
+    var vcsDiffIntensity by property(VcsColorPreset.AMBIENT_SLIDER)
+    var vcsProjectViewIntensity by property(VcsColorPreset.AMBIENT_SLIDER)
+    var vcsGutterIntensity by property(VcsColorPreset.AMBIENT_SLIDER)
+    var vcsConflictMarkerIntensity by property(VcsColorPreset.AMBIENT_SLIDER)
+    var vcsMerge3WayIntensity by property(VcsColorPreset.AMBIENT_SLIDER)
+    var vcsInlineDiffIntensity by property(VcsColorPreset.AMBIENT_SLIDER)
+    var vcsBlameIntensity by property(VcsColorPreset.AMBIENT_SLIDER)
+    var vcsLocalHistoryIntensity by property(VcsColorPreset.AMBIENT_SLIDER)
+    var vcsBranchIndicatorIntensity by property(VcsColorPreset.AMBIENT_SLIDER)
+    var vcsBranchesPopupIntensity by property(VcsColorPreset.AMBIENT_SLIDER)
+    var vcsCommitHighlightIntensity by property(VcsColorPreset.AMBIENT_SLIDER)
 
     /**
      * Returns [vcsColorPreset] resolved into a [VcsColorPreset] enum value,

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -318,16 +318,9 @@ class AyuIslandsState : BaseState() {
     var vcsColorEnabled by property(false)
 
     // Active preset choice. String-backed for BaseState XML serialization;
-    // resolved through [effectiveVcsColorPreset] which falls back to MUTED on
+    // resolved through [effectiveVcsColorPreset] which falls back to AMBIENT on
     // corrupted or unknown values (legacy XML, hand-edited config).
     var vcsColorPreset by string(VcsColorPreset.AMBIENT.name)
-
-    // VCS tab expanded state for the four collapsible sections. First section
-    // (Diff & File Status) starts expanded by design; others collapsed.
-    var vcsColorDiffSectionExpanded by property(true)
-    var vcsColorMergeSectionExpanded by property(false)
-    var vcsColorBlameSectionExpanded by property(false)
-    var vcsColorBranchSectionExpanded by property(false)
 
     // Per-category intensities in `[0, 100]`. Defaults to AMBIENT_SLIDER (33)
     // across the board so a Pro user enabling the master toggle observes no
@@ -348,10 +341,12 @@ class AyuIslandsState : BaseState() {
 
     /**
      * Returns [vcsColorPreset] resolved into a [VcsColorPreset] enum value,
-     * falling back to [VcsColorPreset.MUTED] on an unknown / corrupted string.
+     * falling back to [VcsColorPreset.AMBIENT] on an unknown / corrupted string.
      * Mirrors the [effectiveChromeTintIntensity] discipline: every read path
      * uses this helper so a hand-edited XML never feeds an unknown preset name
-     * into the applier's `when` branches.
+     * into the applier's `when` branches. Ambient is the no-op default so a
+     * corrupted persisted value doesn't accidentally tint surfaces a user
+     * never opted into.
      */
     fun effectiveVcsColorPreset(): VcsColorPreset = VcsColorPreset.byName(vcsColorPreset)
 

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -317,23 +317,28 @@ class AyuIslandsState : BaseState() {
     // diff/file-status/gutter colors until they opt in via the VCS settings tab.
     var vcsColorEnabled by property(false)
 
-    // Active preset choice. String-backed for BaseState XML serialization;
-    // resolved through [effectiveVcsColorPreset] which falls back to AMBIENT on
-    // corrupted or unknown values (legacy XML, hand-edited config).
-    var vcsColorPreset by string(VcsColorPreset.AMBIENT.name)
+    // Per-section preset choice. Phase 40.2b redesign — each of the three VCS
+    // sections (Diff & File Status, Merge & Conflict, Blame & History) holds
+    // its own preset independently so users can mix intensities across surfaces
+    // (Diff on Neon, Blame on Whisper, etc.). String-backed for BaseState XML
+    // serialization; resolved through effectiveVcs*Preset() helpers that fall
+    // back to AMBIENT on unknown / corrupted strings.
+    var vcsDiffPreset by string(VcsColorPreset.AMBIENT.name)
+    var vcsMergePreset by string(VcsColorPreset.AMBIENT.name)
+    var vcsBlamePreset by string(VcsColorPreset.AMBIENT.name)
 
-    // VCS panel's "Diff & File Status" collapsible group expanded state.
+    // VCS panel's "Diff and File Status" collapsible group expanded state.
     // Defaults to true per the Phase 40.2 spec (first section opens expanded);
     // additional section-expanded flags land alongside their panels in waves 3-5.
     var vcsDiffSectionExpanded by property(true)
 
-    // VCS panel's "Merge & Conflict" collapsible group expanded state. Defaults
+    // VCS panel's "Merge and Conflict" collapsible group expanded state. Defaults
     // to false — the section opens collapsed so the panel reads as "primary
-    // Diff & File Status controls visible, secondary surfaces tucked away".
+    // Diff and File Status controls visible, secondary surfaces tucked away".
     var vcsMergeSectionExpanded by property(false)
 
-    // VCS panel's "Blame & History" collapsible group expanded state. Defaults
-    // to false for the same secondary-surface reason as Merge & Conflict.
+    // VCS panel's "Blame and History" collapsible group expanded state. Defaults
+    // to false for the same secondary-surface reason as Merge and Conflict.
     var vcsBlameSectionExpanded by property(false)
 
     // Per-category intensities in `[0, 100]`. Defaults to AMBIENT_SLIDER (33)
@@ -354,15 +359,47 @@ class AyuIslandsState : BaseState() {
     var vcsCommitHighlightIntensity by property(VcsColorPreset.AMBIENT_SLIDER)
 
     /**
-     * Returns [vcsColorPreset] resolved into a [VcsColorPreset] enum value,
-     * falling back to [VcsColorPreset.AMBIENT] on an unknown / corrupted string.
-     * Mirrors the [effectiveChromeTintIntensity] discipline: every read path
-     * uses this helper so a hand-edited XML never feeds an unknown preset name
-     * into the applier's `when` branches. Ambient is the no-op default so a
-     * corrupted persisted value doesn't accidentally tint surfaces a user
-     * never opted into.
+     * Returns the active preset for the Diff and File Status section, falling
+     * back to [VcsColorPreset.AMBIENT] on unknown / corrupted strings. Mirrors
+     * the [effectiveChromeTintIntensity] discipline — Ambient is the no-op
+     * default so corrupted persisted XML never accidentally tints surfaces
+     * the user didn't opt into.
      */
-    fun effectiveVcsColorPreset(): VcsColorPreset = VcsColorPreset.byName(vcsColorPreset)
+    fun effectiveVcsDiffPreset(): VcsColorPreset = VcsColorPreset.byName(vcsDiffPreset)
+
+    /** Returns the active preset for the Merge and Conflict section (defaults to AMBIENT). */
+    fun effectiveVcsMergePreset(): VcsColorPreset = VcsColorPreset.byName(vcsMergePreset)
+
+    /** Returns the active preset for the Blame and History section (defaults to AMBIENT). */
+    fun effectiveVcsBlamePreset(): VcsColorPreset = VcsColorPreset.byName(vcsBlamePreset)
+
+    /**
+     * Returns the preset governing [category]. Maps each color category to
+     * the section's preset field — DIFF_VIEWER / PROJECT_VIEW_FILE_STATUS /
+     * EDITOR_GUTTER live under [effectiveVcsDiffPreset], CONFLICT_MARKERS under
+     * [effectiveVcsMergePreset], BLAME_GUTTER under [effectiveVcsBlamePreset].
+     * The Wave 5+ placeholder categories (MERGE_3WAY, INLINE_DIFF_POPUP,
+     * LOCAL_HISTORY, BRANCH_INDICATOR, BRANCHES_POPUP, COMMIT_HIGHLIGHTS)
+     * default to AMBIENT until their respective sections wire up in v2.6.4+.
+     */
+    fun effectiveVcsPresetFor(category: VcsColorCategory): VcsColorPreset =
+        when (category) {
+            VcsColorCategory.DIFF_VIEWER,
+            VcsColorCategory.PROJECT_VIEW_FILE_STATUS,
+            VcsColorCategory.EDITOR_GUTTER,
+            -> effectiveVcsDiffPreset()
+            VcsColorCategory.CONFLICT_MARKERS,
+            VcsColorCategory.MERGE_3WAY,
+            VcsColorCategory.INLINE_DIFF_POPUP,
+            -> effectiveVcsMergePreset()
+            VcsColorCategory.BLAME_GUTTER,
+            VcsColorCategory.LOCAL_HISTORY,
+            -> effectiveVcsBlamePreset()
+            VcsColorCategory.BRANCH_INDICATOR,
+            VcsColorCategory.BRANCHES_POPUP,
+            VcsColorCategory.COMMIT_HIGHLIGHTS,
+            -> VcsColorPreset.AMBIENT
+        }
 
     /**
      * Returns the per-category intensity map snapshot for the applier. The
@@ -387,14 +424,15 @@ class AyuIslandsState : BaseState() {
 
     /**
      * Returns the effective intensity for a single [category] as a clamped
-     * [VcsIntensity]. Branches on the active preset: Custom reads the per-
-     * category property directly, the other presets defer to
-     * [VcsColorPreset.intensityFor]. When [vcsColorEnabled] is `false` the
-     * helper short-circuits to `0` so the applier returns the stock XML color.
+     * [VcsIntensity]. Branches on the per-section preset that governs
+     * [category] (see [effectiveVcsPresetFor]): Custom reads the per-category
+     * property directly, the other presets defer to [VcsColorPreset.intensityFor].
+     * When [vcsColorEnabled] is `false` the helper short-circuits to `0` so the
+     * applier returns the stock XML color.
      */
     fun effectiveVcsIntensityFor(category: VcsColorCategory): VcsIntensity {
         if (!vcsColorEnabled) return VcsIntensity.of(0)
-        val preset = effectiveVcsColorPreset()
+        val preset = effectiveVcsPresetFor(category)
         val raw =
             if (preset == VcsColorPreset.CUSTOM) {
                 effectiveVcsPerCategoryIntensities().getValue(category)

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -322,6 +322,11 @@ class AyuIslandsState : BaseState() {
     // corrupted or unknown values (legacy XML, hand-edited config).
     var vcsColorPreset by string(VcsColorPreset.AMBIENT.name)
 
+    // VCS panel's "Diff & File Status" collapsible group expanded state.
+    // Defaults to true per the Phase 40.2 spec (first section opens expanded);
+    // additional section-expanded flags land alongside their panels in waves 3-5.
+    var vcsDiffSectionExpanded by property(true)
+
     // Per-category intensities in `[0, 100]`. Defaults to AMBIENT_SLIDER (33)
     // across the board so a Pro user enabling the master toggle observes no
     // visible change until they cycle a preset or move a slider. Reads go

--- a/src/main/kotlin/dev/ayuislands/settings/VcsColorPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/VcsColorPanel.kt
@@ -28,12 +28,12 @@ import javax.swing.JLabel
 import javax.swing.JSlider
 
 /**
- * Phase 40.2 — settings panel for VCS color customization.
+ * Settings panel for VCS color customization.
  *
- * Phase 40.2b redesign — each section (Diff, Merge, Blame) carries its own
- * preset segmented button. Users mix intensities across sections (Diff on
- * Neon, Blame on Whisper, etc.). Inside each section, Custom mode reveals
- * per-category sliders for that section's surfaces.
+ * Each section (Diff, Merge, Blame) carries its own preset segmented button.
+ * Users mix intensities across sections (Diff on Neon, Blame on Whisper,
+ * etc.). Inside each section, Custom mode reveals per-category sliders for
+ * that section's surfaces.
  *
  * Mirrors the [AyuIslandsChromePanel] discipline:
  *  - Pending / stored pairs per field so [isModified] can diff without

--- a/src/main/kotlin/dev/ayuislands/settings/VcsColorPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/VcsColorPanel.kt
@@ -85,11 +85,9 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
     private var gutterValueLabel: JLabel? = null
     private var conflictMarkerValueLabel: JLabel? = null
     private var blameValueLabel: JLabel? = null
-    private var diffSwatch: JLabel? = null
-    private var projectViewSwatch: JLabel? = null
-    private var gutterSwatch: JLabel? = null
-    private var conflictMarkerSwatch: JLabel? = null
-    private var blameSwatch: JLabel? = null
+    private var diffSectionSwatch: JLabel? = null
+    private var mergeSectionSwatch: JLabel? = null
+    private var blameSectionSwatch: JLabel? = null
 
     /** Drives `visibleIf` on each section's Custom-mode slider rows. */
     private val diffCustomSelected = AtomicBooleanProperty(pendingDiffPreset == VcsColorPreset.CUSTOM)
@@ -163,12 +161,7 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
         val ctx = sectionContext(section)
         val collapsible =
             collapsibleGroup(section.title) {
-                buildSectionPresetRow(
-                    initial = ctx.initialPreset,
-                    customVisible = ctx.customVisible,
-                    storeSegmented = ctx.storeSegmented,
-                    onPresetChosen = { preset -> onSectionPresetChosen(section, preset) },
-                )
+                buildSectionPresetRow(section, ctx)
                 for ((category, label) in section.sliders) {
                     buildSliderRow(category, label, ctx.customVisible)
                 }
@@ -211,20 +204,41 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
 
     @Suppress("UnstableApiUsage")
     private fun Panel.buildSectionPresetRow(
-        initial: VcsColorPreset,
-        customVisible: AtomicBooleanProperty,
-        onPresetChosen: (VcsColorPreset) -> Unit,
-        storeSegmented: (SegmentedButton<VcsColorPreset>) -> Unit,
+        section: VcsSection,
+        ctx: SectionContext,
     ) {
         row("Preset:") {
             val segmented = segmentedButton(VcsColorPreset.entries) { preset -> text = preset.displayName }
             segmented.maxButtonsCount(VcsColorPreset.entries.size)
-            segmented.selectedItem = initial
+            segmented.selectedItem = ctx.initialPreset
             segmented.whenItemSelected { preset ->
-                onPresetChosen(preset)
-                customVisible.set(preset == VcsColorPreset.CUSTOM)
+                onSectionPresetChosen(section, preset)
+                ctx.customVisible.set(preset == VcsColorPreset.CUSTOM)
             }
-            storeSegmented(segmented)
+            ctx.storeSegmented(segmented)
+            // Section iconic-color swatch — square, sits 4px right of the
+            // segmented button. Tracks the iconic category's blended color
+            // so cycling Whisper/Ambient/Neon/Cyberpunk shows the dominant
+            // surface color at a glance.
+            val swatch = JLabel(" ")
+            swatch.preferredSize = Dimension(SWATCH_SIZE, SWATCH_SIZE)
+            swatch.minimumSize = Dimension(SWATCH_SIZE, SWATCH_SIZE)
+            swatch.isOpaque = true
+            val iconicValue =
+                when (section.iconicCategory) {
+                    VcsColorCategory.DIFF_VIEWER -> pendingDiffIntensity
+                    VcsColorCategory.CONFLICT_MARKERS -> pendingConflictMarkerIntensity
+                    VcsColorCategory.BLAME_GUTTER -> pendingBlameIntensity
+                    else -> VcsColorPreset.AMBIENT_SLIDER
+                }
+            swatch.background = computeSwatchColor(section.iconicCategory, iconicValue)
+            swatch.border = BorderFactory.createLineBorder(JBColor.border(), 1)
+            cell(swatch).gap(com.intellij.ui.dsl.builder.RightGap.SMALL)
+            when (section) {
+                VcsSection.DIFF -> diffSectionSwatch = swatch
+                VcsSection.MERGE -> mergeSectionSwatch = swatch
+                VcsSection.BLAME -> blameSectionSwatch = swatch
+            }
         }
     }
 
@@ -254,42 +268,30 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
                 slider.majorTickSpacing = INTENSITY_MAJOR_TICK
                 slider.minorTickSpacing = INTENSITY_MINOR_TICK
                 val valueLabel = JLabel("$initialValue")
-                val swatch = JLabel(" ")
-                swatch.preferredSize = Dimension(SWATCH_WIDTH, SWATCH_HEIGHT)
-                swatch.minimumSize = Dimension(SWATCH_WIDTH, SWATCH_HEIGHT)
-                swatch.isOpaque = true
-                swatch.background = computeSwatchColor(category, initialValue)
-                swatch.border = BorderFactory.createLineBorder(JBColor.border(), 1)
                 slider.addChangeListener { onSliderChanged(category, slider.value) }
                 cell(slider).resizableColumn().align(Align.FILL)
                 cell(valueLabel)
-                cell(swatch).gap(com.intellij.ui.dsl.builder.RightGap.SMALL)
                 // Stash Swing refs for reset() refresh + test seams.
                 when (category) {
                     VcsColorCategory.DIFF_VIEWER -> {
                         diffSlider = slider
                         diffValueLabel = valueLabel
-                        diffSwatch = swatch
                     }
                     VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> {
                         projectViewSlider = slider
                         projectViewValueLabel = valueLabel
-                        projectViewSwatch = swatch
                     }
                     VcsColorCategory.EDITOR_GUTTER -> {
                         gutterSlider = slider
                         gutterValueLabel = valueLabel
-                        gutterSwatch = swatch
                     }
                     VcsColorCategory.CONFLICT_MARKERS -> {
                         conflictMarkerSlider = slider
                         conflictMarkerValueLabel = valueLabel
-                        conflictMarkerSwatch = swatch
                     }
                     VcsColorCategory.BLAME_GUTTER -> {
                         blameSlider = slider
                         blameValueLabel = valueLabel
-                        blameSwatch = swatch
                     }
                     else -> Unit
                 }
@@ -338,32 +340,29 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
         category: VcsColorCategory,
         value: Int,
     ) {
-        val swatchColor = computeSwatchColor(category, value)
         when (category) {
             VcsColorCategory.DIFF_VIEWER -> {
                 pendingDiffIntensity = value
                 diffValueLabel?.text = "$value"
-                diffSwatch?.background = swatchColor
+                diffSectionSwatch?.background = computeSwatchColor(category, value)
             }
             VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> {
                 pendingProjectViewIntensity = value
                 projectViewValueLabel?.text = "$value"
-                projectViewSwatch?.background = swatchColor
             }
             VcsColorCategory.EDITOR_GUTTER -> {
                 pendingGutterIntensity = value
                 gutterValueLabel?.text = "$value"
-                gutterSwatch?.background = swatchColor
             }
             VcsColorCategory.CONFLICT_MARKERS -> {
                 pendingConflictMarkerIntensity = value
                 conflictMarkerValueLabel?.text = "$value"
-                conflictMarkerSwatch?.background = swatchColor
+                mergeSectionSwatch?.background = computeSwatchColor(category, value)
             }
             VcsColorCategory.BLAME_GUTTER -> {
                 pendingBlameIntensity = value
                 blameValueLabel?.text = "$value"
-                blameSwatch?.background = swatchColor
+                blameSectionSwatch?.background = computeSwatchColor(category, value)
             }
             else -> return
         }
@@ -506,21 +505,20 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
             blameCustomSelected.set(pendingBlamePreset == VcsColorPreset.CUSTOM)
             diffSlider?.value = pendingDiffIntensity
             diffValueLabel?.text = "$pendingDiffIntensity"
-            diffSwatch?.background = computeSwatchColor(VcsColorCategory.DIFF_VIEWER, pendingDiffIntensity)
+            diffSectionSwatch?.background =
+                computeSwatchColor(VcsColorCategory.DIFF_VIEWER, pendingDiffIntensity)
             projectViewSlider?.value = pendingProjectViewIntensity
             projectViewValueLabel?.text = "$pendingProjectViewIntensity"
-            projectViewSwatch?.background =
-                computeSwatchColor(VcsColorCategory.PROJECT_VIEW_FILE_STATUS, pendingProjectViewIntensity)
             gutterSlider?.value = pendingGutterIntensity
             gutterValueLabel?.text = "$pendingGutterIntensity"
-            gutterSwatch?.background = computeSwatchColor(VcsColorCategory.EDITOR_GUTTER, pendingGutterIntensity)
             conflictMarkerSlider?.value = pendingConflictMarkerIntensity
             conflictMarkerValueLabel?.text = "$pendingConflictMarkerIntensity"
-            conflictMarkerSwatch?.background =
+            mergeSectionSwatch?.background =
                 computeSwatchColor(VcsColorCategory.CONFLICT_MARKERS, pendingConflictMarkerIntensity)
             blameSlider?.value = pendingBlameIntensity
             blameValueLabel?.text = "$pendingBlameIntensity"
-            blameSwatch?.background = computeSwatchColor(VcsColorCategory.BLAME_GUTTER, pendingBlameIntensity)
+            blameSectionSwatch?.background =
+                computeSwatchColor(VcsColorCategory.BLAME_GUTTER, pendingBlameIntensity)
         } finally {
             suppressSliderListeners = false
         }
@@ -582,37 +580,34 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
         category: VcsColorCategory,
         value: Int,
     ) {
-        val swatchColor = computeSwatchColor(category, value)
         when (category) {
             VcsColorCategory.DIFF_VIEWER -> {
                 pendingDiffIntensity = value
                 diffSlider?.value = value
                 diffValueLabel?.text = "$value"
-                diffSwatch?.background = swatchColor
+                diffSectionSwatch?.background = computeSwatchColor(category, value)
             }
             VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> {
                 pendingProjectViewIntensity = value
                 projectViewSlider?.value = value
                 projectViewValueLabel?.text = "$value"
-                projectViewSwatch?.background = swatchColor
             }
             VcsColorCategory.EDITOR_GUTTER -> {
                 pendingGutterIntensity = value
                 gutterSlider?.value = value
                 gutterValueLabel?.text = "$value"
-                gutterSwatch?.background = swatchColor
             }
             VcsColorCategory.CONFLICT_MARKERS -> {
                 pendingConflictMarkerIntensity = value
                 conflictMarkerSlider?.value = value
                 conflictMarkerValueLabel?.text = "$value"
-                conflictMarkerSwatch?.background = swatchColor
+                mergeSectionSwatch?.background = computeSwatchColor(category, value)
             }
             VcsColorCategory.BLAME_GUTTER -> {
                 pendingBlameIntensity = value
                 blameSlider?.value = value
                 blameValueLabel?.text = "$value"
-                blameSwatch?.background = swatchColor
+                blameSectionSwatch?.background = computeSwatchColor(category, value)
             }
             else -> Unit
         }
@@ -681,20 +676,20 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
         internal const val MAX_INTENSITY = 100
         private const val INTENSITY_MAJOR_TICK = 25
         private const val INTENSITY_MINOR_TICK = 5
-        private const val SWATCH_WIDTH = 22
-        private const val SWATCH_HEIGHT = 16
+        private const val SWATCH_SIZE = 26
     }
 }
 
 /**
  * Selector for the three VCS panel sections. Encapsulates each section's
- * user-visible title and the list of per-category sliders it owns in Custom
- * mode, so the panel can iterate sections uniformly without a per-section
- * `buildXSection` method.
+ * user-visible title, the list of per-category sliders it owns in Custom
+ * mode, and the iconic category whose blended color drives the section's
+ * preset-row swatch.
  */
 internal enum class VcsSection(
     val title: String,
     val sliders: List<Pair<VcsColorCategory, String>>,
+    val iconicCategory: VcsColorCategory,
 ) {
     DIFF(
         title = "Diff and File Status",
@@ -704,13 +699,16 @@ internal enum class VcsSection(
                 VcsColorCategory.PROJECT_VIEW_FILE_STATUS to "Project View:",
                 VcsColorCategory.EDITOR_GUTTER to "Editor gutter:",
             ),
+        iconicCategory = VcsColorCategory.DIFF_VIEWER,
     ),
     MERGE(
         title = "Merge and Conflict",
         sliders = listOf(VcsColorCategory.CONFLICT_MARKERS to "Conflict markers:"),
+        iconicCategory = VcsColorCategory.CONFLICT_MARKERS,
     ),
     BLAME(
         title = "Blame and History",
         sliders = listOf(VcsColorCategory.BLAME_GUTTER to "Blame gutter:"),
+        iconicCategory = VcsColorCategory.BLAME_GUTTER,
     ),
 }

--- a/src/main/kotlin/dev/ayuislands/settings/VcsColorPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/VcsColorPanel.kt
@@ -49,6 +49,8 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
     private var storedGutterIntensity: Int = VcsColorPreset.AMBIENT_SLIDER
     private var pendingConflictMarkerIntensity: Int = VcsColorPreset.AMBIENT_SLIDER
     private var storedConflictMarkerIntensity: Int = VcsColorPreset.AMBIENT_SLIDER
+    private var pendingBlameIntensity: Int = VcsColorPreset.AMBIENT_SLIDER
+    private var storedBlameIntensity: Int = VcsColorPreset.AMBIENT_SLIDER
 
     // ── Swing references (kept for reset-time refresh + test seams) ───────────
 
@@ -60,10 +62,12 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
     private var projectViewSlider: JSlider? = null
     private var gutterSlider: JSlider? = null
     private var conflictMarkerSlider: JSlider? = null
+    private var blameSlider: JSlider? = null
     private var diffValueLabel: JLabel? = null
     private var projectViewValueLabel: JLabel? = null
     private var gutterValueLabel: JLabel? = null
     private var conflictMarkerValueLabel: JLabel? = null
+    private var blameValueLabel: JLabel? = null
 
     /** Drives `visibleIf(customSelected)` on the per-category slider rows. */
     private val customSelected = AtomicBooleanProperty(pendingPreset == VcsColorPreset.CUSTOM)
@@ -133,6 +137,14 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
                 AyuIslandsSettings.getInstance().state.vcsMergeSectionExpanded = expanded
             },
             sliders = listOf(VcsColorCategory.CONFLICT_MARKERS to "Conflict markers:"),
+        )
+        buildSection(
+            title = BLAME_GROUP_TITLE,
+            initiallyExpanded = state.vcsBlameSectionExpanded,
+            persistExpanded = { expanded ->
+                AyuIslandsSettings.getInstance().state.vcsBlameSectionExpanded = expanded
+            },
+            sliders = listOf(VcsColorCategory.BLAME_GUTTER to "Blame gutter:"),
         )
     }
 
@@ -208,6 +220,7 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
             VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> pendingProjectViewIntensity
             VcsColorCategory.EDITOR_GUTTER -> pendingGutterIntensity
             VcsColorCategory.CONFLICT_MARKERS -> pendingConflictMarkerIntensity
+            VcsColorCategory.BLAME_GUTTER -> pendingBlameIntensity
             else -> VcsColorPreset.AMBIENT_SLIDER
         }
 
@@ -232,6 +245,10 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
             VcsColorCategory.CONFLICT_MARKERS -> {
                 conflictMarkerSlider = slider
                 conflictMarkerValueLabel = valueLabel
+            }
+            VcsColorCategory.BLAME_GUTTER -> {
+                blameSlider = slider
+                blameValueLabel = valueLabel
             }
             else -> Unit
         }
@@ -265,6 +282,10 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
                 pendingConflictMarkerIntensity = value
                 conflictMarkerValueLabel?.text = "$value"
             }
+            VcsColorCategory.BLAME_GUTTER -> {
+                pendingBlameIntensity = value
+                blameValueLabel?.text = "$value"
+            }
             else -> return
         }
         if (suppressSliderListeners || pendingPreset == VcsColorPreset.CUSTOM) return
@@ -279,7 +300,8 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
             pendingDiffIntensity != storedDiffIntensity ||
             pendingProjectViewIntensity != storedProjectViewIntensity ||
             pendingGutterIntensity != storedGutterIntensity ||
-            pendingConflictMarkerIntensity != storedConflictMarkerIntensity
+            pendingConflictMarkerIntensity != storedConflictMarkerIntensity ||
+            pendingBlameIntensity != storedBlameIntensity
 
     override fun apply() {
         if (!isModified()) return
@@ -304,6 +326,7 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
                         VcsColorCategory.PROJECT_VIEW_FILE_STATUS to pendingProjectViewIntensity,
                         VcsColorCategory.EDITOR_GUTTER to pendingGutterIntensity,
                         VcsColorCategory.CONFLICT_MARKERS to pendingConflictMarkerIntensity,
+                        VcsColorCategory.BLAME_GUTTER to pendingBlameIntensity,
                     ),
             )
 
@@ -329,6 +352,7 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
         state.vcsProjectViewIntensity = pendingProjectViewIntensity
         state.vcsGutterIntensity = pendingGutterIntensity
         state.vcsConflictMarkerIntensity = pendingConflictMarkerIntensity
+        state.vcsBlameIntensity = pendingBlameIntensity
         loadStored(state)
     }
 
@@ -349,6 +373,8 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
             gutterValueLabel?.text = "$pendingGutterIntensity"
             conflictMarkerSlider?.value = pendingConflictMarkerIntensity
             conflictMarkerValueLabel?.text = "$pendingConflictMarkerIntensity"
+            blameSlider?.value = pendingBlameIntensity
+            blameValueLabel?.text = "$pendingBlameIntensity"
         } finally {
             suppressSliderListeners = false
         }
@@ -367,6 +393,8 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
         pendingGutterIntensity = state.vcsGutterIntensity.coerceIn(MIN_INTENSITY, MAX_INTENSITY)
         storedConflictMarkerIntensity = state.vcsConflictMarkerIntensity
         pendingConflictMarkerIntensity = state.vcsConflictMarkerIntensity.coerceIn(MIN_INTENSITY, MAX_INTENSITY)
+        storedBlameIntensity = state.vcsBlameIntensity
+        pendingBlameIntensity = state.vcsBlameIntensity.coerceIn(MIN_INTENSITY, MAX_INTENSITY)
         masterEnabled.set(pendingEnabled)
         customSelected.set(pendingPreset == VcsColorPreset.CUSTOM)
     }
@@ -396,6 +424,9 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
             pendingConflictMarkerIntensity = snapPosition
             conflictMarkerSlider?.value = snapPosition
             conflictMarkerValueLabel?.text = "$snapPosition"
+            pendingBlameIntensity = snapPosition
+            blameSlider?.value = snapPosition
+            blameValueLabel?.text = "$snapPosition"
         } finally {
             suppressSliderListeners = false
         }
@@ -447,6 +478,7 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
             VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> pendingProjectViewIntensity = value
             VcsColorCategory.EDITOR_GUTTER -> pendingGutterIntensity = value
             VcsColorCategory.CONFLICT_MARKERS -> pendingConflictMarkerIntensity = value
+            VcsColorCategory.BLAME_GUTTER -> pendingBlameIntensity = value
             else -> Unit
         }
     }
@@ -459,6 +491,7 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
         private val LOG = logger<VcsColorPanel>()
         private const val DIFF_GROUP_TITLE = "Diff & File Status"
         private const val MERGE_GROUP_TITLE = "Merge & Conflict"
+        private const val BLAME_GROUP_TITLE = "Blame & History"
         internal const val MIN_INTENSITY = 0
         internal const val MAX_INTENSITY = 100
         private const val INTENSITY_MAJOR_TICK = 25

--- a/src/main/kotlin/dev/ayuislands/settings/VcsColorPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/VcsColorPanel.kt
@@ -1,0 +1,421 @@
+package dev.ayuislands.settings
+
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.observable.properties.AtomicBooleanProperty
+import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.dsl.builder.Align
+import com.intellij.ui.dsl.builder.Panel
+import com.intellij.ui.dsl.builder.SegmentedButton
+import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.vcs.VcsColorApplier
+import dev.ayuislands.vcs.VcsColorCategory
+import dev.ayuislands.vcs.VcsColorContext
+import dev.ayuislands.vcs.VcsColorPreset
+import dev.ayuislands.vcs.VcsColorSnapshot
+import org.jetbrains.annotations.TestOnly
+import javax.swing.JLabel
+import javax.swing.JSlider
+
+/**
+ * Phase 40.2 — settings panel for VCS color customization.
+ *
+ * Mirrors the [AyuIslandsChromePanel] structure:
+ *  - Pending / stored pairs per field so [isModified] can diff without
+ *    touching the live [AyuIslandsState] until [apply] is called.
+ *  - Premium gate per memory `feedback_monetization`: unlicensed users see
+ *    the panel title plus a single "requires Pro license" comment with a
+ *    Pro upgrade link; no controls render in the unlicensed path so there's
+ *    no way to mutate VCS state without a license.
+ *  - On [apply] the panel wraps the applier call in
+ *    [VcsColorContext.withSnapshot] so the EP runs against the pending
+ *    snapshot; if the apply throws, persisted state stays untouched and the
+ *    user can retry. The pattern matches [AyuIslandsChromePanel.apply].
+ */
+class VcsColorPanel : AyuIslandsSettingsPanel {
+    // ── Pending / stored state ────────────────────────────────────────────────
+
+    private var pendingEnabled: Boolean = false
+    private var storedEnabled: Boolean = false
+    private var pendingPreset: VcsColorPreset = VcsColorPreset.AMBIENT
+    private var storedPreset: VcsColorPreset = VcsColorPreset.AMBIENT
+    private var pendingDiffIntensity: Int = VcsColorPreset.AMBIENT_SLIDER
+    private var storedDiffIntensity: Int = VcsColorPreset.AMBIENT_SLIDER
+    private var pendingProjectViewIntensity: Int = VcsColorPreset.AMBIENT_SLIDER
+    private var storedProjectViewIntensity: Int = VcsColorPreset.AMBIENT_SLIDER
+    private var pendingGutterIntensity: Int = VcsColorPreset.AMBIENT_SLIDER
+    private var storedGutterIntensity: Int = VcsColorPreset.AMBIENT_SLIDER
+
+    // ── Swing references (kept for reset-time refresh + test seams) ───────────
+
+    private var variant: AyuVariant? = null
+    private var licensed: Boolean = false
+    private var enabledCheckbox: JBCheckBox? = null
+    private var presetSegmented: SegmentedButton<VcsColorPreset>? = null
+    private var diffSlider: JSlider? = null
+    private var projectViewSlider: JSlider? = null
+    private var gutterSlider: JSlider? = null
+    private var diffValueLabel: JLabel? = null
+    private var projectViewValueLabel: JLabel? = null
+    private var gutterValueLabel: JLabel? = null
+
+    /** Drives `visibleIf(customSelected)` on the per-category slider rows. */
+    private val customSelected = AtomicBooleanProperty(pendingPreset == VcsColorPreset.CUSTOM)
+
+    /** Drives `visibleIf(masterEnabled)` so the preset + sliders hide when master is off. */
+    private val masterEnabled = AtomicBooleanProperty(pendingEnabled)
+
+    /**
+     * Tracks whether the panel is mid-listener-suppress (preset switch or
+     * reset). Prevents the slider's `addChangeListener` from feeding back
+     * into `pendingPreset = CUSTOM` when the preset cycle moves the sliders
+     * programmatically.
+     */
+    private var suppressSliderListeners: Boolean = false
+
+    // ── Panel lifecycle ───────────────────────────────────────────────────────
+
+    @Suppress("UnstableApiUsage")
+    override fun buildPanel(
+        panel: Panel,
+        variant: AyuVariant,
+    ) {
+        this.variant = variant
+        licensed = LicenseChecker.isLicensedOrGrace()
+        val state = AyuIslandsSettings.getInstance().state
+        loadStored(state)
+        if (!licensed) {
+            panel.buildUnlicensedContent()
+            return
+        }
+        panel.buildLicensedContent(state)
+    }
+
+    private fun Panel.buildUnlicensedContent() {
+        row {
+            comment(
+                "VCS color customization is a Pro feature. " +
+                    "Free version uses the default colors shipped with v2.6.2.",
+            )
+        }
+        row {
+            link("Get Ayu Islands Pro — unlock VCS color customization") {
+                LicenseChecker.requestLicense("Unlock VCS color intensity customization")
+            }
+        }
+    }
+
+    @Suppress("UnstableApiUsage")
+    private fun Panel.buildLicensedContent(state: AyuIslandsState) {
+        buildMasterToggleRow()
+        buildPresetRow()
+        buildDiffCollapsibleGroup(state)
+    }
+
+    private fun Panel.buildMasterToggleRow() {
+        row {
+            val cb = checkBox("Enable VCS color customization")
+            cb.component.isSelected = pendingEnabled
+            cb.component.addActionListener {
+                pendingEnabled = cb.component.isSelected
+                masterEnabled.set(pendingEnabled)
+            }
+            enabledCheckbox = cb.component
+        }
+    }
+
+    @Suppress("UnstableApiUsage")
+    private fun Panel.buildPresetRow() {
+        val presetRow =
+            row("Preset:") {
+                val segmented = segmentedButton(VcsColorPreset.entries) { preset -> text = preset.displayName }
+                segmented.maxButtonsCount(VcsColorPreset.entries.size)
+                segmented.selectedItem = pendingPreset
+                segmented.whenItemSelected { preset -> onPresetChosen(preset) }
+                presetSegmented = segmented
+            }
+        presetRow.visibleIf(masterEnabled)
+    }
+
+    private fun Panel.buildDiffCollapsibleGroup(state: AyuIslandsState) {
+        val collapsible =
+            collapsibleGroup(DIFF_GROUP_TITLE) {
+                buildPerCategorySliderRow(VcsColorCategory.DIFF_VIEWER, "Diff viewer:")
+                buildPerCategorySliderRow(VcsColorCategory.PROJECT_VIEW_FILE_STATUS, "Project View:")
+                buildPerCategorySliderRow(VcsColorCategory.EDITOR_GUTTER, "Editor gutter:")
+            }
+        collapsible.expanded = state.vcsDiffSectionExpanded
+        collapsible.addExpandedListener { expanded ->
+            AyuIslandsSettings.getInstance().state.vcsDiffSectionExpanded = expanded
+        }
+    }
+
+    private fun Panel.buildPerCategorySliderRow(
+        category: VcsColorCategory,
+        label: String,
+    ) {
+        val initialValue = pendingFor(category)
+        val sliderRow =
+            row(label) {
+                val slider =
+                    JSlider(
+                        MIN_INTENSITY,
+                        MAX_INTENSITY,
+                        initialValue.coerceIn(MIN_INTENSITY, MAX_INTENSITY),
+                    )
+                slider.paintTicks = true
+                slider.majorTickSpacing = INTENSITY_MAJOR_TICK
+                slider.minorTickSpacing = INTENSITY_MINOR_TICK
+                val valueLabel = JLabel("$initialValue")
+                slider.addChangeListener { onSliderChanged(category, slider.value) }
+                cell(slider).resizableColumn().align(Align.FILL)
+                cell(valueLabel)
+                attachSliderHandles(category, slider, valueLabel)
+            }
+        sliderRow.visibleIf(customSelected)
+    }
+
+    private fun pendingFor(category: VcsColorCategory): Int =
+        when (category) {
+            VcsColorCategory.DIFF_VIEWER -> pendingDiffIntensity
+            VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> pendingProjectViewIntensity
+            VcsColorCategory.EDITOR_GUTTER -> pendingGutterIntensity
+            else -> VcsColorPreset.AMBIENT_SLIDER
+        }
+
+    private fun attachSliderHandles(
+        category: VcsColorCategory,
+        slider: JSlider,
+        valueLabel: JLabel,
+    ) {
+        when (category) {
+            VcsColorCategory.DIFF_VIEWER -> {
+                diffSlider = slider
+                diffValueLabel = valueLabel
+            }
+            VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> {
+                projectViewSlider = slider
+                projectViewValueLabel = valueLabel
+            }
+            VcsColorCategory.EDITOR_GUTTER -> {
+                gutterSlider = slider
+                gutterValueLabel = valueLabel
+            }
+            else -> Unit
+        }
+    }
+
+    /**
+     * Handles a slider value change for [category]. Writes the new value into
+     * the matching `pending*` field, refreshes the value label, and (if the
+     * change is a user gesture rather than programmatic) promotes the preset
+     * to [VcsColorPreset.CUSTOM] so the manual slider position actually takes
+     * effect on apply.
+     */
+    private fun onSliderChanged(
+        category: VcsColorCategory,
+        value: Int,
+    ) {
+        when (category) {
+            VcsColorCategory.DIFF_VIEWER -> {
+                pendingDiffIntensity = value
+                diffValueLabel?.text = "$value"
+            }
+            VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> {
+                pendingProjectViewIntensity = value
+                projectViewValueLabel?.text = "$value"
+            }
+            VcsColorCategory.EDITOR_GUTTER -> {
+                pendingGutterIntensity = value
+                gutterValueLabel?.text = "$value"
+            }
+            else -> return
+        }
+        if (suppressSliderListeners || pendingPreset == VcsColorPreset.CUSTOM) return
+        pendingPreset = VcsColorPreset.CUSTOM
+        customSelected.set(true)
+        presetSegmented?.selectedItem = VcsColorPreset.CUSTOM
+    }
+
+    override fun isModified(): Boolean =
+        pendingEnabled != storedEnabled ||
+            pendingPreset != storedPreset ||
+            pendingDiffIntensity != storedDiffIntensity ||
+            pendingProjectViewIntensity != storedProjectViewIntensity ||
+            pendingGutterIntensity != storedGutterIntensity
+
+    override fun apply() {
+        if (!isModified()) return
+        // License revalidation: a Pro user whose license expired mid-session must
+        // not be allowed to keep mutating VCS state behind a panel that's about to
+        // revert to the placeholder comment.
+        if (!LicenseChecker.isLicensedOrGrace()) {
+            LOG.info(
+                "VcsColorPanel.apply: license no longer active; " +
+                    "skipping VCS state persistence and re-apply",
+            )
+            return
+        }
+
+        val snapshot =
+            VcsColorSnapshot(
+                enabled = pendingEnabled,
+                preset = pendingPreset,
+                perCategoryIntensities =
+                    mapOf(
+                        VcsColorCategory.DIFF_VIEWER to pendingDiffIntensity,
+                        VcsColorCategory.PROJECT_VIEW_FILE_STATUS to pendingProjectViewIntensity,
+                        VcsColorCategory.EDITOR_GUTTER to pendingGutterIntensity,
+                    ),
+            )
+
+        // H-4 (chrome pattern): run the applier first so a throw leaves the
+        // persisted state untouched and the user can retry after fixing the cause.
+        try {
+            VcsColorContext.withSnapshot(snapshot) {
+                VcsColorApplier.applyAll()
+            }
+        } catch (exception: RuntimeException) {
+            LOG.warn(
+                "VcsColorPanel.apply: VCS color re-apply threw; " +
+                    "leaving pending VCS state uncommitted so the user can retry",
+                exception,
+            )
+            notifyApplyFailed()
+            return
+        }
+        val state = AyuIslandsSettings.getInstance().state
+        state.vcsColorEnabled = pendingEnabled
+        state.vcsColorPreset = pendingPreset.name
+        state.vcsDiffIntensity = pendingDiffIntensity
+        state.vcsProjectViewIntensity = pendingProjectViewIntensity
+        state.vcsGutterIntensity = pendingGutterIntensity
+        loadStored(state)
+    }
+
+    override fun reset() {
+        val state = AyuIslandsSettings.getInstance().state
+        loadStored(state)
+        suppressSliderListeners = true
+        try {
+            enabledCheckbox?.isSelected = pendingEnabled
+            presetSegmented?.selectedItem = pendingPreset
+            masterEnabled.set(pendingEnabled)
+            customSelected.set(pendingPreset == VcsColorPreset.CUSTOM)
+            diffSlider?.value = pendingDiffIntensity
+            diffValueLabel?.text = "$pendingDiffIntensity"
+            projectViewSlider?.value = pendingProjectViewIntensity
+            projectViewValueLabel?.text = "$pendingProjectViewIntensity"
+            gutterSlider?.value = pendingGutterIntensity
+            gutterValueLabel?.text = "$pendingGutterIntensity"
+        } finally {
+            suppressSliderListeners = false
+        }
+    }
+
+    private fun loadStored(state: AyuIslandsState) {
+        storedEnabled = state.vcsColorEnabled
+        pendingEnabled = storedEnabled
+        storedPreset = state.effectiveVcsColorPreset()
+        pendingPreset = storedPreset
+        storedDiffIntensity = state.vcsDiffIntensity
+        pendingDiffIntensity = state.vcsDiffIntensity.coerceIn(MIN_INTENSITY, MAX_INTENSITY)
+        storedProjectViewIntensity = state.vcsProjectViewIntensity
+        pendingProjectViewIntensity = state.vcsProjectViewIntensity.coerceIn(MIN_INTENSITY, MAX_INTENSITY)
+        storedGutterIntensity = state.vcsGutterIntensity
+        pendingGutterIntensity = state.vcsGutterIntensity.coerceIn(MIN_INTENSITY, MAX_INTENSITY)
+        masterEnabled.set(pendingEnabled)
+        customSelected.set(pendingPreset == VcsColorPreset.CUSTOM)
+    }
+
+    /**
+     * Switching presets (non-Custom) snaps every per-category slider to that
+     * preset's canonical position so the visible slider state always reflects
+     * what's being applied. Custom mode leaves sliders at their previous values
+     * so the user can fine-tune from the last preset they used.
+     */
+    private fun onPresetChosen(preset: VcsColorPreset) {
+        pendingPreset = preset
+        customSelected.set(preset == VcsColorPreset.CUSTOM)
+        if (preset == VcsColorPreset.CUSTOM) return
+        val snapPosition = preset.intensityFor(VcsColorCategory.DIFF_VIEWER)
+        suppressSliderListeners = true
+        try {
+            pendingDiffIntensity = snapPosition
+            diffSlider?.value = snapPosition
+            diffValueLabel?.text = "$snapPosition"
+            pendingProjectViewIntensity = snapPosition
+            projectViewSlider?.value = snapPosition
+            projectViewValueLabel?.text = "$snapPosition"
+            pendingGutterIntensity = snapPosition
+            gutterSlider?.value = snapPosition
+            gutterValueLabel?.text = "$snapPosition"
+        } finally {
+            suppressSliderListeners = false
+        }
+    }
+
+    private fun notifyApplyFailed() {
+        try {
+            NotificationGroupManager
+                .getInstance()
+                .getNotificationGroup("Ayu Islands")
+                .createNotification(
+                    "VCS colors could not be applied",
+                    "Settings were not saved — see idea.log for details. " +
+                        "Adjust any value in the VCS panel and click Apply again to retry.",
+                    NotificationType.WARNING,
+                ).notify(null)
+        } catch (notificationException: RuntimeException) {
+            LOG.warn(
+                "VcsColorPanel.apply: failed to surface VCS-apply error balloon",
+                notificationException,
+            )
+        }
+    }
+
+    // ── @TestOnly seams ───────────────────────────────────────────────────────
+
+    @TestOnly internal fun licensedForTest(): Boolean = licensed
+
+    @TestOnly internal fun getPendingEnabledForTest(): Boolean = pendingEnabled
+
+    @TestOnly internal fun setPendingEnabledForTest(value: Boolean) {
+        pendingEnabled = value
+    }
+
+    @TestOnly internal fun getPendingPresetForTest(): VcsColorPreset = pendingPreset
+
+    @TestOnly internal fun setPendingPresetForTest(value: VcsColorPreset) {
+        pendingPreset = value
+    }
+
+    @TestOnly internal fun getPendingIntensityForTest(category: VcsColorCategory): Int = pendingFor(category)
+
+    @TestOnly internal fun setPendingIntensityForTest(
+        category: VcsColorCategory,
+        value: Int,
+    ) {
+        when (category) {
+            VcsColorCategory.DIFF_VIEWER -> pendingDiffIntensity = value
+            VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> pendingProjectViewIntensity = value
+            VcsColorCategory.EDITOR_GUTTER -> pendingGutterIntensity = value
+            else -> Unit
+        }
+    }
+
+    @TestOnly internal fun triggerPresetChosenForTest(preset: VcsColorPreset) {
+        onPresetChosen(preset)
+    }
+
+    companion object {
+        private val LOG = logger<VcsColorPanel>()
+        private const val DIFF_GROUP_TITLE = "Diff & File Status"
+        internal const val MIN_INTENSITY = 0
+        internal const val MAX_INTENSITY = 100
+        private const val INTENSITY_MAJOR_TICK = 25
+        private const val INTENSITY_MINOR_TICK = 5
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/settings/VcsColorPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/VcsColorPanel.kt
@@ -85,7 +85,14 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
     private var gutterValueLabel: JLabel? = null
     private var conflictMarkerValueLabel: JLabel? = null
     private var blameValueLabel: JLabel? = null
-    private var diffSectionSwatch: JLabel? = null
+
+    // DIFF section gets three swatches (modified blue / inserted green /
+    // deleted red) all driven by the Diff viewer slider — surfaces the full
+    // colour palette that one slider tints. MERGE and BLAME keep a single
+    // swatch since each only owns one visible colour family.
+    private var diffSwatchModified: JLabel? = null
+    private var diffSwatchInserted: JLabel? = null
+    private var diffSwatchDeleted: JLabel? = null
     private var mergeSectionSwatch: JLabel? = null
     private var blameSectionSwatch: JLabel? = null
 
@@ -216,14 +223,10 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
                 ctx.customVisible.set(preset == VcsColorPreset.CUSTOM)
             }
             ctx.storeSegmented(segmented)
-            // Section iconic-color swatch — square, sits 4px right of the
-            // segmented button. Tracks the iconic category's blended color
-            // so cycling Whisper/Ambient/Neon/Cyberpunk shows the dominant
-            // surface color at a glance.
-            val swatch = JLabel(" ")
-            swatch.preferredSize = Dimension(SWATCH_SIZE, SWATCH_SIZE)
-            swatch.minimumSize = Dimension(SWATCH_SIZE, SWATCH_SIZE)
-            swatch.isOpaque = true
+            // Section colour swatches sit 4px right of the Custom button.
+            // DIFF carries three swatches (modified / inserted / deleted) because
+            // its slider tints three colour families in parallel; MERGE and BLAME
+            // each surface a single dominant colour.
             val iconicValue =
                 when (section.iconicCategory) {
                     VcsColorCategory.DIFF_VIEWER -> pendingDiffIntensity
@@ -231,13 +234,26 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
                     VcsColorCategory.BLAME_GUTTER -> pendingBlameIntensity
                     else -> VcsColorPreset.AMBIENT_SLIDER
                 }
-            swatch.background = computeSwatchColor(section.iconicCategory, iconicValue)
-            swatch.border = BorderFactory.createLineBorder(JBColor.border(), 1)
-            cell(swatch).gap(com.intellij.ui.dsl.builder.RightGap.SMALL)
-            when (section) {
-                VcsSection.DIFF -> diffSectionSwatch = swatch
-                VcsSection.MERGE -> mergeSectionSwatch = swatch
-                VcsSection.BLAME -> blameSectionSwatch = swatch
+            for (keyName in section.swatchKeyNames) {
+                val swatch = JLabel(" ")
+                swatch.preferredSize = Dimension(SWATCH_SIZE, SWATCH_SIZE)
+                swatch.minimumSize = Dimension(SWATCH_SIZE, SWATCH_SIZE)
+                swatch.isOpaque = true
+                swatch.background = computeSwatchColor(section.iconicCategory, keyName, iconicValue)
+                swatch.border = BorderFactory.createLineBorder(JBColor.border(), 1)
+                cell(swatch).gap(com.intellij.ui.dsl.builder.RightGap.SMALL)
+                // Inlined stash — keeps the per-class function count under
+                // detekt's TooManyFunctions ceiling.
+                when (section) {
+                    VcsSection.DIFF ->
+                        when (keyName) {
+                            "DIFF_MODIFIED" -> diffSwatchModified = swatch
+                            "DIFF_INSERTED" -> diffSwatchInserted = swatch
+                            "DIFF_DELETED" -> diffSwatchDeleted = swatch
+                        }
+                    VcsSection.MERGE -> mergeSectionSwatch = swatch
+                    VcsSection.BLAME -> blameSectionSwatch = swatch
+                }
             }
         }
     }
@@ -300,27 +316,17 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
     }
 
     /**
-     * Returns the iconic-key blended color for [category] at slider position
-     * [value]. Iconic-key mapping: DIFF viewer → DIFF_MODIFIED, Project View
-     * → FILESTATUS_MODIFIED, gutter → MODIFIED_LINES_COLOR, conflict markers
-     * → DIFF_CONFLICT, blame → ANNOTATIONS_LAST_COMMIT_COLOR. Falls back to
-     * [JBColor.GRAY] when [variant] isn't resolvable yet (settings dialog
-     * before theme activates).
+     * Returns the blended color for the ColorKey-typed palette entry named
+     * [keyName] inside [category], at slider position [value]. Falls back to
+     * [JBColor.GRAY] when the variant isn't resolvable yet (settings dialog
+     * opened before any Ayu theme activates) or when no matching entry exists.
      */
     private fun computeSwatchColor(
         category: VcsColorCategory,
+        keyName: String,
         value: Int,
     ): Color {
         val activeVariant = this.variant ?: AyuVariant.DARK
-        val keyName =
-            when (category) {
-                VcsColorCategory.DIFF_VIEWER -> "DIFF_MODIFIED"
-                VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> "FILESTATUS_MODIFIED"
-                VcsColorCategory.EDITOR_GUTTER -> "MODIFIED_LINES_COLOR"
-                VcsColorCategory.CONFLICT_MARKERS -> "DIFF_CONFLICT"
-                VcsColorCategory.BLAME_GUTTER -> "ANNOTATIONS_LAST_COMMIT_COLOR"
-                else -> return JBColor.GRAY
-            }
         val entry =
             VcsColorPalette.entriesFor(category).firstOrNull {
                 it.keyName == keyName && it.mode == VcsWriteMode.COLOR_KEY
@@ -344,7 +350,9 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
             VcsColorCategory.DIFF_VIEWER -> {
                 pendingDiffIntensity = value
                 diffValueLabel?.text = "$value"
-                diffSectionSwatch?.background = computeSwatchColor(category, value)
+                diffSwatchModified?.background = computeSwatchColor(category, "DIFF_MODIFIED", value)
+                diffSwatchInserted?.background = computeSwatchColor(category, "DIFF_INSERTED", value)
+                diffSwatchDeleted?.background = computeSwatchColor(category, "DIFF_DELETED", value)
             }
             VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> {
                 pendingProjectViewIntensity = value
@@ -357,12 +365,13 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
             VcsColorCategory.CONFLICT_MARKERS -> {
                 pendingConflictMarkerIntensity = value
                 conflictMarkerValueLabel?.text = "$value"
-                mergeSectionSwatch?.background = computeSwatchColor(category, value)
+                mergeSectionSwatch?.background = computeSwatchColor(category, "DIFF_CONFLICT", value)
             }
             VcsColorCategory.BLAME_GUTTER -> {
                 pendingBlameIntensity = value
                 blameValueLabel?.text = "$value"
-                blameSectionSwatch?.background = computeSwatchColor(category, value)
+                blameSectionSwatch?.background =
+                    computeSwatchColor(category, "ANNOTATIONS_LAST_COMMIT_COLOR", value)
             }
             else -> return
         }
@@ -505,8 +514,12 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
             blameCustomSelected.set(pendingBlamePreset == VcsColorPreset.CUSTOM)
             diffSlider?.value = pendingDiffIntensity
             diffValueLabel?.text = "$pendingDiffIntensity"
-            diffSectionSwatch?.background =
-                computeSwatchColor(VcsColorCategory.DIFF_VIEWER, pendingDiffIntensity)
+            diffSwatchModified?.background =
+                computeSwatchColor(VcsColorCategory.DIFF_VIEWER, "DIFF_MODIFIED", pendingDiffIntensity)
+            diffSwatchInserted?.background =
+                computeSwatchColor(VcsColorCategory.DIFF_VIEWER, "DIFF_INSERTED", pendingDiffIntensity)
+            diffSwatchDeleted?.background =
+                computeSwatchColor(VcsColorCategory.DIFF_VIEWER, "DIFF_DELETED", pendingDiffIntensity)
             projectViewSlider?.value = pendingProjectViewIntensity
             projectViewValueLabel?.text = "$pendingProjectViewIntensity"
             gutterSlider?.value = pendingGutterIntensity
@@ -514,11 +527,19 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
             conflictMarkerSlider?.value = pendingConflictMarkerIntensity
             conflictMarkerValueLabel?.text = "$pendingConflictMarkerIntensity"
             mergeSectionSwatch?.background =
-                computeSwatchColor(VcsColorCategory.CONFLICT_MARKERS, pendingConflictMarkerIntensity)
+                computeSwatchColor(
+                    VcsColorCategory.CONFLICT_MARKERS,
+                    "DIFF_CONFLICT",
+                    pendingConflictMarkerIntensity,
+                )
             blameSlider?.value = pendingBlameIntensity
             blameValueLabel?.text = "$pendingBlameIntensity"
             blameSectionSwatch?.background =
-                computeSwatchColor(VcsColorCategory.BLAME_GUTTER, pendingBlameIntensity)
+                computeSwatchColor(
+                    VcsColorCategory.BLAME_GUTTER,
+                    "ANNOTATIONS_LAST_COMMIT_COLOR",
+                    pendingBlameIntensity,
+                )
         } finally {
             suppressSliderListeners = false
         }
@@ -585,7 +606,9 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
                 pendingDiffIntensity = value
                 diffSlider?.value = value
                 diffValueLabel?.text = "$value"
-                diffSectionSwatch?.background = computeSwatchColor(category, value)
+                diffSwatchModified?.background = computeSwatchColor(category, "DIFF_MODIFIED", value)
+                diffSwatchInserted?.background = computeSwatchColor(category, "DIFF_INSERTED", value)
+                diffSwatchDeleted?.background = computeSwatchColor(category, "DIFF_DELETED", value)
             }
             VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> {
                 pendingProjectViewIntensity = value
@@ -601,13 +624,14 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
                 pendingConflictMarkerIntensity = value
                 conflictMarkerSlider?.value = value
                 conflictMarkerValueLabel?.text = "$value"
-                mergeSectionSwatch?.background = computeSwatchColor(category, value)
+                mergeSectionSwatch?.background = computeSwatchColor(category, "DIFF_CONFLICT", value)
             }
             VcsColorCategory.BLAME_GUTTER -> {
                 pendingBlameIntensity = value
                 blameSlider?.value = value
                 blameValueLabel?.text = "$value"
-                blameSectionSwatch?.background = computeSwatchColor(category, value)
+                blameSectionSwatch?.background =
+                    computeSwatchColor(category, "ANNOTATIONS_LAST_COMMIT_COLOR", value)
             }
             else -> Unit
         }
@@ -676,7 +700,7 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
         internal const val MAX_INTENSITY = 100
         private const val INTENSITY_MAJOR_TICK = 25
         private const val INTENSITY_MINOR_TICK = 5
-        private const val SWATCH_SIZE = 26
+        private const val SWATCH_SIZE = 25
     }
 }
 
@@ -690,6 +714,7 @@ internal enum class VcsSection(
     val title: String,
     val sliders: List<Pair<VcsColorCategory, String>>,
     val iconicCategory: VcsColorCategory,
+    val swatchKeyNames: List<String>,
 ) {
     DIFF(
         title = "Diff and File Status",
@@ -700,15 +725,21 @@ internal enum class VcsSection(
                 VcsColorCategory.EDITOR_GUTTER to "Editor gutter:",
             ),
         iconicCategory = VcsColorCategory.DIFF_VIEWER,
+        // Three swatches showing the full Diff slider's effect: modified
+        // (blue), inserted (green), deleted (red). All driven by the same
+        // pendingDiffIntensity.
+        swatchKeyNames = listOf("DIFF_MODIFIED", "DIFF_INSERTED", "DIFF_DELETED"),
     ),
     MERGE(
         title = "Merge and Conflict",
         sliders = listOf(VcsColorCategory.CONFLICT_MARKERS to "Conflict markers:"),
         iconicCategory = VcsColorCategory.CONFLICT_MARKERS,
+        swatchKeyNames = listOf("DIFF_CONFLICT"),
     ),
     BLAME(
         title = "Blame and History",
         sliders = listOf(VcsColorCategory.BLAME_GUTTER to "Blame gutter:"),
         iconicCategory = VcsColorCategory.BLAME_GUTTER,
+        swatchKeyNames = listOf("ANNOTATIONS_LAST_COMMIT_COLOR"),
     ),
 }

--- a/src/main/kotlin/dev/ayuislands/settings/VcsColorPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/VcsColorPanel.kt
@@ -22,25 +22,32 @@ import javax.swing.JSlider
 /**
  * Phase 40.2 — settings panel for VCS color customization.
  *
- * Mirrors the [AyuIslandsChromePanel] structure:
+ * Phase 40.2b redesign — each section (Diff, Merge, Blame) carries its own
+ * preset segmented button. Users mix intensities across sections (Diff on
+ * Neon, Blame on Whisper, etc.). Inside each section, Custom mode reveals
+ * per-category sliders for that section's surfaces.
+ *
+ * Mirrors the [AyuIslandsChromePanel] discipline:
  *  - Pending / stored pairs per field so [isModified] can diff without
  *    touching the live [AyuIslandsState] until [apply] is called.
- *  - Premium gate per memory `feedback_monetization`: unlicensed users see
- *    the panel title plus a single "requires Pro license" comment with a
- *    Pro upgrade link; no controls render in the unlicensed path so there's
- *    no way to mutate VCS state without a license.
+ *  - Premium gate: unlicensed users see a placeholder comment + Pro upgrade
+ *    link instead of the full content — no controls bound, no way to mutate
+ *    VCS state without a license.
  *  - On [apply] the panel wraps the applier call in
- *    [VcsColorContext.withSnapshot] so the EP runs against the pending
- *    snapshot; if the apply throws, persisted state stays untouched and the
- *    user can retry. The pattern matches [AyuIslandsChromePanel.apply].
+ *    [VcsColorContext.withSnapshot] so a throw leaves persisted state
+ *    untouched and the user can retry.
  */
 class VcsColorPanel : AyuIslandsSettingsPanel {
     // ── Pending / stored state ────────────────────────────────────────────────
 
     private var pendingEnabled: Boolean = false
     private var storedEnabled: Boolean = false
-    private var pendingPreset: VcsColorPreset = VcsColorPreset.AMBIENT
-    private var storedPreset: VcsColorPreset = VcsColorPreset.AMBIENT
+    private var pendingDiffPreset: VcsColorPreset = VcsColorPreset.AMBIENT
+    private var storedDiffPreset: VcsColorPreset = VcsColorPreset.AMBIENT
+    private var pendingMergePreset: VcsColorPreset = VcsColorPreset.AMBIENT
+    private var storedMergePreset: VcsColorPreset = VcsColorPreset.AMBIENT
+    private var pendingBlamePreset: VcsColorPreset = VcsColorPreset.AMBIENT
+    private var storedBlamePreset: VcsColorPreset = VcsColorPreset.AMBIENT
     private var pendingDiffIntensity: Int = VcsColorPreset.AMBIENT_SLIDER
     private var storedDiffIntensity: Int = VcsColorPreset.AMBIENT_SLIDER
     private var pendingProjectViewIntensity: Int = VcsColorPreset.AMBIENT_SLIDER
@@ -57,7 +64,9 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
     private var variant: AyuVariant? = null
     private var licensed: Boolean = false
     private var enabledCheckbox: JBCheckBox? = null
-    private var presetSegmented: SegmentedButton<VcsColorPreset>? = null
+    private var diffPresetSegmented: SegmentedButton<VcsColorPreset>? = null
+    private var mergePresetSegmented: SegmentedButton<VcsColorPreset>? = null
+    private var blamePresetSegmented: SegmentedButton<VcsColorPreset>? = null
     private var diffSlider: JSlider? = null
     private var projectViewSlider: JSlider? = null
     private var gutterSlider: JSlider? = null
@@ -69,17 +78,18 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
     private var conflictMarkerValueLabel: JLabel? = null
     private var blameValueLabel: JLabel? = null
 
-    /** Drives `visibleIf(customSelected)` on the per-category slider rows. */
-    private val customSelected = AtomicBooleanProperty(pendingPreset == VcsColorPreset.CUSTOM)
+    /** Drives `visibleIf` on each section's Custom-mode slider rows. */
+    private val diffCustomSelected = AtomicBooleanProperty(pendingDiffPreset == VcsColorPreset.CUSTOM)
+    private val mergeCustomSelected = AtomicBooleanProperty(pendingMergePreset == VcsColorPreset.CUSTOM)
+    private val blameCustomSelected = AtomicBooleanProperty(pendingBlamePreset == VcsColorPreset.CUSTOM)
 
-    /** Drives `visibleIf(masterEnabled)` so the preset + sliders hide when master is off. */
+    /** Drives `visibleIf(masterEnabled)` so all sections collapse when master is off. */
     private val masterEnabled = AtomicBooleanProperty(pendingEnabled)
 
     /**
      * Tracks whether the panel is mid-listener-suppress (preset switch or
-     * reset). Prevents the slider's `addChangeListener` from feeding back
-     * into `pendingPreset = CUSTOM` when the preset cycle moves the sliders
-     * programmatically.
+     * reset). Prevents a slider's change listener from feeding back into the
+     * section preset when programmatic snap moves the slider.
      */
     private var suppressSliderListeners: Boolean = false
 
@@ -116,36 +126,9 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
 
     private fun Panel.buildLicensedContent(state: AyuIslandsState) {
         buildMasterToggleRow()
-        buildPresetRow()
-        buildSection(
-            title = DIFF_GROUP_TITLE,
-            initiallyExpanded = state.vcsDiffSectionExpanded,
-            persistExpanded = { expanded ->
-                AyuIslandsSettings.getInstance().state.vcsDiffSectionExpanded = expanded
-            },
-            sliders =
-                listOf(
-                    VcsColorCategory.DIFF_VIEWER to "Diff viewer:",
-                    VcsColorCategory.PROJECT_VIEW_FILE_STATUS to "Project View:",
-                    VcsColorCategory.EDITOR_GUTTER to "Editor gutter:",
-                ),
-        )
-        buildSection(
-            title = MERGE_GROUP_TITLE,
-            initiallyExpanded = state.vcsMergeSectionExpanded,
-            persistExpanded = { expanded ->
-                AyuIslandsSettings.getInstance().state.vcsMergeSectionExpanded = expanded
-            },
-            sliders = listOf(VcsColorCategory.CONFLICT_MARKERS to "Conflict markers:"),
-        )
-        buildSection(
-            title = BLAME_GROUP_TITLE,
-            initiallyExpanded = state.vcsBlameSectionExpanded,
-            persistExpanded = { expanded ->
-                AyuIslandsSettings.getInstance().state.vcsBlameSectionExpanded = expanded
-            },
-            sliders = listOf(VcsColorCategory.BLAME_GUTTER to "Blame gutter:"),
-        )
+        buildSection(VcsSection.DIFF, state)
+        buildSection(VcsSection.MERGE, state)
+        buildSection(VcsSection.BLAME, state)
     }
 
     private fun Panel.buildMasterToggleRow() {
@@ -160,40 +143,88 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
         }
     }
 
-    @Suppress("UnstableApiUsage")
-    private fun Panel.buildPresetRow() {
-        val presetRow =
-            row("Preset:") {
-                val segmented = segmentedButton(VcsColorPreset.entries) { preset -> text = preset.displayName }
-                segmented.maxButtonsCount(VcsColorPreset.entries.size)
-                segmented.selectedItem = pendingPreset
-                segmented.whenItemSelected { preset -> onPresetChosen(preset) }
-                presetSegmented = segmented
-            }
-        presetRow.visibleIf(masterEnabled)
-    }
-
     private fun Panel.buildSection(
-        title: String,
-        initiallyExpanded: Boolean,
-        persistExpanded: (Boolean) -> Unit,
-        sliders: List<Pair<VcsColorCategory, String>>,
+        section: VcsSection,
+        state: AyuIslandsState,
     ) {
+        val ctx = sectionContext(section)
         val collapsible =
-            collapsibleGroup(title) {
-                for ((category, label) in sliders) {
-                    buildPerCategorySliderRow(category, label)
+            collapsibleGroup(section.title) {
+                buildSectionPresetRow(
+                    initial = ctx.initialPreset,
+                    customVisible = ctx.customVisible,
+                    storeSegmented = ctx.storeSegmented,
+                    onPresetChosen = { preset -> onSectionPresetChosen(section, preset) },
+                )
+                for ((category, label) in section.sliders) {
+                    buildSliderRow(category, label, ctx.customVisible)
                 }
             }
-        collapsible.expanded = initiallyExpanded
-        collapsible.addExpandedListener { expanded -> persistExpanded(expanded) }
+        collapsible.expanded =
+            when (section) {
+                VcsSection.DIFF -> state.vcsDiffSectionExpanded
+                VcsSection.MERGE -> state.vcsMergeSectionExpanded
+                VcsSection.BLAME -> state.vcsBlameSectionExpanded
+            }
+        collapsible.addExpandedListener { expanded ->
+            val live = AyuIslandsSettings.getInstance().state
+            when (section) {
+                VcsSection.DIFF -> live.vcsDiffSectionExpanded = expanded
+                VcsSection.MERGE -> live.vcsMergeSectionExpanded = expanded
+                VcsSection.BLAME -> live.vcsBlameSectionExpanded = expanded
+            }
+        }
     }
 
-    private fun Panel.buildPerCategorySliderRow(
+    private data class SectionContext(
+        val initialPreset: VcsColorPreset,
+        val customVisible: AtomicBooleanProperty,
+        val storeSegmented: (SegmentedButton<VcsColorPreset>) -> Unit,
+    )
+
+    private fun sectionContext(section: VcsSection): SectionContext =
+        when (section) {
+            VcsSection.DIFF ->
+                SectionContext(pendingDiffPreset, diffCustomSelected) { diffPresetSegmented = it }
+            VcsSection.MERGE ->
+                SectionContext(pendingMergePreset, mergeCustomSelected) { mergePresetSegmented = it }
+            VcsSection.BLAME ->
+                SectionContext(pendingBlamePreset, blameCustomSelected) { blamePresetSegmented = it }
+        }
+
+    @Suppress("UnstableApiUsage")
+    private fun Panel.buildSectionPresetRow(
+        initial: VcsColorPreset,
+        customVisible: AtomicBooleanProperty,
+        onPresetChosen: (VcsColorPreset) -> Unit,
+        storeSegmented: (SegmentedButton<VcsColorPreset>) -> Unit,
+    ) {
+        row("Preset:") {
+            val segmented = segmentedButton(VcsColorPreset.entries) { preset -> text = preset.displayName }
+            segmented.maxButtonsCount(VcsColorPreset.entries.size)
+            segmented.selectedItem = initial
+            segmented.whenItemSelected { preset ->
+                onPresetChosen(preset)
+                customVisible.set(preset == VcsColorPreset.CUSTOM)
+            }
+            storeSegmented(segmented)
+        }
+    }
+
+    private fun Panel.buildSliderRow(
         category: VcsColorCategory,
         label: String,
+        sectionCustomVisible: AtomicBooleanProperty,
     ) {
-        val initialValue = pendingFor(category)
+        val initialValue =
+            when (category) {
+                VcsColorCategory.DIFF_VIEWER -> pendingDiffIntensity
+                VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> pendingProjectViewIntensity
+                VcsColorCategory.EDITOR_GUTTER -> pendingGutterIntensity
+                VcsColorCategory.CONFLICT_MARKERS -> pendingConflictMarkerIntensity
+                VcsColorCategory.BLAME_GUTTER -> pendingBlameIntensity
+                else -> VcsColorPreset.AMBIENT_SLIDER
+            }
         val sliderRow =
             row(label) {
                 val slider =
@@ -209,57 +240,40 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
                 slider.addChangeListener { onSliderChanged(category, slider.value) }
                 cell(slider).resizableColumn().align(Align.FILL)
                 cell(valueLabel)
-                attachSliderHandles(category, slider, valueLabel)
+                // Stash Swing refs for reset() refresh + test seams.
+                when (category) {
+                    VcsColorCategory.DIFF_VIEWER -> {
+                        diffSlider = slider
+                        diffValueLabel = valueLabel
+                    }
+                    VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> {
+                        projectViewSlider = slider
+                        projectViewValueLabel = valueLabel
+                    }
+                    VcsColorCategory.EDITOR_GUTTER -> {
+                        gutterSlider = slider
+                        gutterValueLabel = valueLabel
+                    }
+                    VcsColorCategory.CONFLICT_MARKERS -> {
+                        conflictMarkerSlider = slider
+                        conflictMarkerValueLabel = valueLabel
+                    }
+                    VcsColorCategory.BLAME_GUTTER -> {
+                        blameSlider = slider
+                        blameValueLabel = valueLabel
+                    }
+                    else -> Unit
+                }
             }
-        sliderRow.visibleIf(customSelected)
-    }
-
-    private fun pendingFor(category: VcsColorCategory): Int =
-        when (category) {
-            VcsColorCategory.DIFF_VIEWER -> pendingDiffIntensity
-            VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> pendingProjectViewIntensity
-            VcsColorCategory.EDITOR_GUTTER -> pendingGutterIntensity
-            VcsColorCategory.CONFLICT_MARKERS -> pendingConflictMarkerIntensity
-            VcsColorCategory.BLAME_GUTTER -> pendingBlameIntensity
-            else -> VcsColorPreset.AMBIENT_SLIDER
-        }
-
-    private fun attachSliderHandles(
-        category: VcsColorCategory,
-        slider: JSlider,
-        valueLabel: JLabel,
-    ) {
-        when (category) {
-            VcsColorCategory.DIFF_VIEWER -> {
-                diffSlider = slider
-                diffValueLabel = valueLabel
-            }
-            VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> {
-                projectViewSlider = slider
-                projectViewValueLabel = valueLabel
-            }
-            VcsColorCategory.EDITOR_GUTTER -> {
-                gutterSlider = slider
-                gutterValueLabel = valueLabel
-            }
-            VcsColorCategory.CONFLICT_MARKERS -> {
-                conflictMarkerSlider = slider
-                conflictMarkerValueLabel = valueLabel
-            }
-            VcsColorCategory.BLAME_GUTTER -> {
-                blameSlider = slider
-                blameValueLabel = valueLabel
-            }
-            else -> Unit
-        }
+        sliderRow.visibleIf(sectionCustomVisible)
     }
 
     /**
      * Handles a slider value change for [category]. Writes the new value into
      * the matching `pending*` field, refreshes the value label, and (if the
-     * change is a user gesture rather than programmatic) promotes the preset
-     * to [VcsColorPreset.CUSTOM] so the manual slider position actually takes
-     * effect on apply.
+     * change is a user gesture rather than programmatic) promotes the
+     * governing section's preset to [VcsColorPreset.CUSTOM] so the manual
+     * slider position actually takes effect on apply.
      */
     private fun onSliderChanged(
         category: VcsColorCategory,
@@ -288,15 +302,42 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
             }
             else -> return
         }
-        if (suppressSliderListeners || pendingPreset == VcsColorPreset.CUSTOM) return
-        pendingPreset = VcsColorPreset.CUSTOM
-        customSelected.set(true)
-        presetSegmented?.selectedItem = VcsColorPreset.CUSTOM
+        if (suppressSliderListeners) return
+        promoteSectionToCustom(category)
+    }
+
+    private fun promoteSectionToCustom(category: VcsColorCategory) {
+        when (category) {
+            VcsColorCategory.DIFF_VIEWER,
+            VcsColorCategory.PROJECT_VIEW_FILE_STATUS,
+            VcsColorCategory.EDITOR_GUTTER,
+            -> {
+                if (pendingDiffPreset == VcsColorPreset.CUSTOM) return
+                pendingDiffPreset = VcsColorPreset.CUSTOM
+                diffCustomSelected.set(true)
+                diffPresetSegmented?.selectedItem = VcsColorPreset.CUSTOM
+            }
+            VcsColorCategory.CONFLICT_MARKERS -> {
+                if (pendingMergePreset == VcsColorPreset.CUSTOM) return
+                pendingMergePreset = VcsColorPreset.CUSTOM
+                mergeCustomSelected.set(true)
+                mergePresetSegmented?.selectedItem = VcsColorPreset.CUSTOM
+            }
+            VcsColorCategory.BLAME_GUTTER -> {
+                if (pendingBlamePreset == VcsColorPreset.CUSTOM) return
+                pendingBlamePreset = VcsColorPreset.CUSTOM
+                blameCustomSelected.set(true)
+                blamePresetSegmented?.selectedItem = VcsColorPreset.CUSTOM
+            }
+            else -> Unit
+        }
     }
 
     override fun isModified(): Boolean =
         pendingEnabled != storedEnabled ||
-            pendingPreset != storedPreset ||
+            pendingDiffPreset != storedDiffPreset ||
+            pendingMergePreset != storedMergePreset ||
+            pendingBlamePreset != storedBlamePreset ||
             pendingDiffIntensity != storedDiffIntensity ||
             pendingProjectViewIntensity != storedProjectViewIntensity ||
             pendingGutterIntensity != storedGutterIntensity ||
@@ -305,9 +346,6 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
 
     override fun apply() {
         if (!isModified()) return
-        // License revalidation: a Pro user whose license expired mid-session must
-        // not be allowed to keep mutating VCS state behind a panel that's about to
-        // revert to the placeholder comment.
         if (!LicenseChecker.isLicensedOrGrace()) {
             LOG.info(
                 "VcsColorPanel.apply: license no longer active; " +
@@ -316,22 +354,12 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
             return
         }
 
-        val snapshot =
-            VcsColorSnapshot(
-                enabled = pendingEnabled,
-                preset = pendingPreset,
-                perCategoryIntensities =
-                    mapOf(
-                        VcsColorCategory.DIFF_VIEWER to pendingDiffIntensity,
-                        VcsColorCategory.PROJECT_VIEW_FILE_STATUS to pendingProjectViewIntensity,
-                        VcsColorCategory.EDITOR_GUTTER to pendingGutterIntensity,
-                        VcsColorCategory.CONFLICT_MARKERS to pendingConflictMarkerIntensity,
-                        VcsColorCategory.BLAME_GUTTER to pendingBlameIntensity,
-                    ),
-            )
+        // Resolve per-section preset choices into per-category intensities,
+        // then materialise the snapshot. The applier reads only per-category
+        // intensities — preset/custom branching is fully resolved here.
+        val resolved = resolveCategoryIntensitiesFromPendingState()
+        val snapshot = VcsColorSnapshot(enabled = pendingEnabled, perCategoryIntensities = resolved)
 
-        // H-4 (chrome pattern): run the applier first so a throw leaves the
-        // persisted state untouched and the user can retry after fixing the cause.
         try {
             VcsColorContext.withSnapshot(snapshot) {
                 VcsColorApplier.applyAll()
@@ -342,12 +370,29 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
                     "leaving pending VCS state uncommitted so the user can retry",
                 exception,
             )
-            notifyApplyFailed()
+            // Surface a balloon so the user knows their click was rejected.
+            // Notification dispatch is itself try-wrapped: a shutdown-race or
+            // notification-subsystem hiccup must not mask the apply failure.
+            try {
+                NotificationGroupManager
+                    .getInstance()
+                    .getNotificationGroup("Ayu Islands")
+                    .createNotification(
+                        "VCS colors could not be applied",
+                        "Settings were not saved — see idea.log for details. " +
+                            "Adjust any value in the VCS panel and click Apply again to retry.",
+                        NotificationType.WARNING,
+                    ).notify(null)
+            } catch (notificationException: RuntimeException) {
+                LOG.warn("VcsColorPanel.apply: failed to surface VCS-apply error balloon", notificationException)
+            }
             return
         }
         val state = AyuIslandsSettings.getInstance().state
         state.vcsColorEnabled = pendingEnabled
-        state.vcsColorPreset = pendingPreset.name
+        state.vcsDiffPreset = pendingDiffPreset.name
+        state.vcsMergePreset = pendingMergePreset.name
+        state.vcsBlamePreset = pendingBlamePreset.name
         state.vcsDiffIntensity = pendingDiffIntensity
         state.vcsProjectViewIntensity = pendingProjectViewIntensity
         state.vcsGutterIntensity = pendingGutterIntensity
@@ -356,15 +401,54 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
         loadStored(state)
     }
 
+    /**
+     * Computes the resolved per-category intensity for every wired category
+     * from the current pending per-section preset + per-category slider state.
+     * Non-Custom presets resolve via [VcsColorPreset.intensityFor]; Custom
+     * mode pulls the slider value directly. Placeholder categories
+     * (Wave 5+) stay at AMBIENT.
+     */
+    private fun resolveCategoryIntensitiesFromPendingState(): Map<VcsColorCategory, Int> {
+        val diffValue =
+            if (pendingDiffPreset == VcsColorPreset.CUSTOM) {
+                null
+            } else {
+                pendingDiffPreset.intensityFor(VcsColorCategory.DIFF_VIEWER)
+            }
+        val mergeValue =
+            if (pendingMergePreset == VcsColorPreset.CUSTOM) {
+                pendingConflictMarkerIntensity
+            } else {
+                pendingMergePreset.intensityFor(VcsColorCategory.CONFLICT_MARKERS)
+            }
+        val blameValue =
+            if (pendingBlamePreset == VcsColorPreset.CUSTOM) {
+                pendingBlameIntensity
+            } else {
+                pendingBlamePreset.intensityFor(VcsColorCategory.BLAME_GUTTER)
+            }
+        return mapOf(
+            VcsColorCategory.DIFF_VIEWER to (diffValue ?: pendingDiffIntensity),
+            VcsColorCategory.PROJECT_VIEW_FILE_STATUS to (diffValue ?: pendingProjectViewIntensity),
+            VcsColorCategory.EDITOR_GUTTER to (diffValue ?: pendingGutterIntensity),
+            VcsColorCategory.CONFLICT_MARKERS to mergeValue,
+            VcsColorCategory.BLAME_GUTTER to blameValue,
+        )
+    }
+
     override fun reset() {
         val state = AyuIslandsSettings.getInstance().state
         loadStored(state)
         suppressSliderListeners = true
         try {
             enabledCheckbox?.isSelected = pendingEnabled
-            presetSegmented?.selectedItem = pendingPreset
+            diffPresetSegmented?.selectedItem = pendingDiffPreset
+            mergePresetSegmented?.selectedItem = pendingMergePreset
+            blamePresetSegmented?.selectedItem = pendingBlamePreset
             masterEnabled.set(pendingEnabled)
-            customSelected.set(pendingPreset == VcsColorPreset.CUSTOM)
+            diffCustomSelected.set(pendingDiffPreset == VcsColorPreset.CUSTOM)
+            mergeCustomSelected.set(pendingMergePreset == VcsColorPreset.CUSTOM)
+            blameCustomSelected.set(pendingBlamePreset == VcsColorPreset.CUSTOM)
             diffSlider?.value = pendingDiffIntensity
             diffValueLabel?.text = "$pendingDiffIntensity"
             projectViewSlider?.value = pendingProjectViewIntensity
@@ -383,8 +467,12 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
     private fun loadStored(state: AyuIslandsState) {
         storedEnabled = state.vcsColorEnabled
         pendingEnabled = storedEnabled
-        storedPreset = state.effectiveVcsColorPreset()
-        pendingPreset = storedPreset
+        storedDiffPreset = state.effectiveVcsDiffPreset()
+        pendingDiffPreset = storedDiffPreset
+        storedMergePreset = state.effectiveVcsMergePreset()
+        pendingMergePreset = storedMergePreset
+        storedBlamePreset = state.effectiveVcsBlamePreset()
+        pendingBlamePreset = storedBlamePreset
         storedDiffIntensity = state.vcsDiffIntensity
         pendingDiffIntensity = state.vcsDiffIntensity.coerceIn(MIN_INTENSITY, MAX_INTENSITY)
         storedProjectViewIntensity = state.vcsProjectViewIntensity
@@ -396,64 +484,73 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
         storedBlameIntensity = state.vcsBlameIntensity
         pendingBlameIntensity = state.vcsBlameIntensity.coerceIn(MIN_INTENSITY, MAX_INTENSITY)
         masterEnabled.set(pendingEnabled)
-        customSelected.set(pendingPreset == VcsColorPreset.CUSTOM)
+        diffCustomSelected.set(pendingDiffPreset == VcsColorPreset.CUSTOM)
+        mergeCustomSelected.set(pendingMergePreset == VcsColorPreset.CUSTOM)
+        blameCustomSelected.set(pendingBlamePreset == VcsColorPreset.CUSTOM)
     }
 
     /**
-     * Switching presets (non-Custom) snaps every per-category slider to that
-     * preset's canonical position so the visible slider state always reflects
-     * what's being applied. Custom mode leaves sliders at their previous values
-     * so the user can fine-tune from the last preset they used.
+     * Switching a section's preset writes the new preset into that section's
+     * pending field, then (for non-Custom presets) snaps every slider owned by
+     * the section to the preset's canonical position. Custom mode leaves
+     * sliders alone so the user can fine-tune from the last preset.
      */
-    private fun onPresetChosen(preset: VcsColorPreset) {
-        pendingPreset = preset
-        customSelected.set(preset == VcsColorPreset.CUSTOM)
+    private fun onSectionPresetChosen(
+        section: VcsSection,
+        preset: VcsColorPreset,
+    ) {
+        when (section) {
+            VcsSection.DIFF -> pendingDiffPreset = preset
+            VcsSection.MERGE -> pendingMergePreset = preset
+            VcsSection.BLAME -> pendingBlamePreset = preset
+        }
         if (preset == VcsColorPreset.CUSTOM) return
-        val snapPosition = preset.intensityFor(VcsColorCategory.DIFF_VIEWER)
         suppressSliderListeners = true
         try {
-            pendingDiffIntensity = snapPosition
-            diffSlider?.value = snapPosition
-            diffValueLabel?.text = "$snapPosition"
-            pendingProjectViewIntensity = snapPosition
-            projectViewSlider?.value = snapPosition
-            projectViewValueLabel?.text = "$snapPosition"
-            pendingGutterIntensity = snapPosition
-            gutterSlider?.value = snapPosition
-            gutterValueLabel?.text = "$snapPosition"
-            pendingConflictMarkerIntensity = snapPosition
-            conflictMarkerSlider?.value = snapPosition
-            conflictMarkerValueLabel?.text = "$snapPosition"
-            pendingBlameIntensity = snapPosition
-            blameSlider?.value = snapPosition
-            blameValueLabel?.text = "$snapPosition"
+            for ((category, _) in section.sliders) {
+                val snap = preset.intensityFor(category)
+                writeSliderValue(category, snap)
+            }
         } finally {
             suppressSliderListeners = false
         }
     }
 
-    private fun notifyApplyFailed() {
-        try {
-            NotificationGroupManager
-                .getInstance()
-                .getNotificationGroup("Ayu Islands")
-                .createNotification(
-                    "VCS colors could not be applied",
-                    "Settings were not saved — see idea.log for details. " +
-                        "Adjust any value in the VCS panel and click Apply again to retry.",
-                    NotificationType.WARNING,
-                ).notify(null)
-        } catch (notificationException: RuntimeException) {
-            LOG.warn(
-                "VcsColorPanel.apply: failed to surface VCS-apply error balloon",
-                notificationException,
-            )
+    private fun writeSliderValue(
+        category: VcsColorCategory,
+        value: Int,
+    ) {
+        when (category) {
+            VcsColorCategory.DIFF_VIEWER -> {
+                pendingDiffIntensity = value
+                diffSlider?.value = value
+                diffValueLabel?.text = "$value"
+            }
+            VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> {
+                pendingProjectViewIntensity = value
+                projectViewSlider?.value = value
+                projectViewValueLabel?.text = "$value"
+            }
+            VcsColorCategory.EDITOR_GUTTER -> {
+                pendingGutterIntensity = value
+                gutterSlider?.value = value
+                gutterValueLabel?.text = "$value"
+            }
+            VcsColorCategory.CONFLICT_MARKERS -> {
+                pendingConflictMarkerIntensity = value
+                conflictMarkerSlider?.value = value
+                conflictMarkerValueLabel?.text = "$value"
+            }
+            VcsColorCategory.BLAME_GUTTER -> {
+                pendingBlameIntensity = value
+                blameSlider?.value = value
+                blameValueLabel?.text = "$value"
+            }
+            else -> Unit
         }
     }
 
     // ── @TestOnly seams ───────────────────────────────────────────────────────
-
-    @TestOnly internal fun licensedForTest(): Boolean = licensed
 
     @TestOnly internal fun getPendingEnabledForTest(): Boolean = pendingEnabled
 
@@ -461,13 +558,33 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
         pendingEnabled = value
     }
 
-    @TestOnly internal fun getPendingPresetForTest(): VcsColorPreset = pendingPreset
+    @TestOnly internal fun getPendingPresetForTest(section: VcsSection): VcsColorPreset =
+        when (section) {
+            VcsSection.DIFF -> pendingDiffPreset
+            VcsSection.MERGE -> pendingMergePreset
+            VcsSection.BLAME -> pendingBlamePreset
+        }
 
-    @TestOnly internal fun setPendingPresetForTest(value: VcsColorPreset) {
-        pendingPreset = value
+    @TestOnly internal fun setPendingPresetForTest(
+        section: VcsSection,
+        preset: VcsColorPreset,
+    ) {
+        when (section) {
+            VcsSection.DIFF -> pendingDiffPreset = preset
+            VcsSection.MERGE -> pendingMergePreset = preset
+            VcsSection.BLAME -> pendingBlamePreset = preset
+        }
     }
 
-    @TestOnly internal fun getPendingIntensityForTest(category: VcsColorCategory): Int = pendingFor(category)
+    @TestOnly internal fun getPendingIntensityForTest(category: VcsColorCategory): Int =
+        when (category) {
+            VcsColorCategory.DIFF_VIEWER -> pendingDiffIntensity
+            VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> pendingProjectViewIntensity
+            VcsColorCategory.EDITOR_GUTTER -> pendingGutterIntensity
+            VcsColorCategory.CONFLICT_MARKERS -> pendingConflictMarkerIntensity
+            VcsColorCategory.BLAME_GUTTER -> pendingBlameIntensity
+            else -> VcsColorPreset.AMBIENT_SLIDER
+        }
 
     @TestOnly internal fun setPendingIntensityForTest(
         category: VcsColorCategory,
@@ -483,18 +600,47 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
         }
     }
 
-    @TestOnly internal fun triggerPresetChosenForTest(preset: VcsColorPreset) {
-        onPresetChosen(preset)
+    @TestOnly internal fun triggerSectionPresetChosenForTest(
+        section: VcsSection,
+        preset: VcsColorPreset,
+    ) {
+        onSectionPresetChosen(section, preset)
     }
 
     companion object {
         private val LOG = logger<VcsColorPanel>()
-        private const val DIFF_GROUP_TITLE = "Diff & File Status"
-        private const val MERGE_GROUP_TITLE = "Merge & Conflict"
-        private const val BLAME_GROUP_TITLE = "Blame & History"
         internal const val MIN_INTENSITY = 0
         internal const val MAX_INTENSITY = 100
         private const val INTENSITY_MAJOR_TICK = 25
         private const val INTENSITY_MINOR_TICK = 5
     }
+}
+
+/**
+ * Selector for the three VCS panel sections. Encapsulates each section's
+ * user-visible title and the list of per-category sliders it owns in Custom
+ * mode, so the panel can iterate sections uniformly without a per-section
+ * `buildXSection` method.
+ */
+internal enum class VcsSection(
+    val title: String,
+    val sliders: List<Pair<VcsColorCategory, String>>,
+) {
+    DIFF(
+        title = "Diff and File Status",
+        sliders =
+            listOf(
+                VcsColorCategory.DIFF_VIEWER to "Diff viewer:",
+                VcsColorCategory.PROJECT_VIEW_FILE_STATUS to "Project View:",
+                VcsColorCategory.EDITOR_GUTTER to "Editor gutter:",
+            ),
+    ),
+    MERGE(
+        title = "Merge and Conflict",
+        sliders = listOf(VcsColorCategory.CONFLICT_MARKERS to "Conflict markers:"),
+    ),
+    BLAME(
+        title = "Blame and History",
+        sliders = listOf(VcsColorCategory.BLAME_GUTTER to "Blame gutter:"),
+    ),
 }

--- a/src/main/kotlin/dev/ayuislands/settings/VcsColorPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/VcsColorPanel.kt
@@ -4,6 +4,7 @@ import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.observable.properties.AtomicBooleanProperty
+import com.intellij.ui.JBColor
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.dsl.builder.Align
 import com.intellij.ui.dsl.builder.Panel
@@ -11,11 +12,18 @@ import com.intellij.ui.dsl.builder.SegmentedButton
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.vcs.VcsColorApplier
+import dev.ayuislands.vcs.VcsColorBlender
 import dev.ayuislands.vcs.VcsColorCategory
 import dev.ayuislands.vcs.VcsColorContext
+import dev.ayuislands.vcs.VcsColorPalette
 import dev.ayuislands.vcs.VcsColorPreset
 import dev.ayuislands.vcs.VcsColorSnapshot
+import dev.ayuislands.vcs.VcsIntensity
+import dev.ayuislands.vcs.VcsWriteMode
 import org.jetbrains.annotations.TestOnly
+import java.awt.Color
+import java.awt.Dimension
+import javax.swing.BorderFactory
 import javax.swing.JLabel
 import javax.swing.JSlider
 
@@ -77,6 +85,11 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
     private var gutterValueLabel: JLabel? = null
     private var conflictMarkerValueLabel: JLabel? = null
     private var blameValueLabel: JLabel? = null
+    private var diffSwatch: JLabel? = null
+    private var projectViewSwatch: JLabel? = null
+    private var gutterSwatch: JLabel? = null
+    private var conflictMarkerSwatch: JLabel? = null
+    private var blameSwatch: JLabel? = null
 
     /** Drives `visibleIf` on each section's Custom-mode slider rows. */
     private val diffCustomSelected = AtomicBooleanProperty(pendingDiffPreset == VcsColorPreset.CUSTOM)
@@ -174,6 +187,10 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
                 VcsSection.BLAME -> live.vcsBlameSectionExpanded = expanded
             }
         }
+        // Hide the entire section when the master toggle is off — sections
+        // are meaningless without VCS color customization enabled, and
+        // dangling collapsible add visual noise.
+        collapsible.visibleIf(masterEnabled)
     }
 
     private data class SectionContext(
@@ -237,35 +254,77 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
                 slider.majorTickSpacing = INTENSITY_MAJOR_TICK
                 slider.minorTickSpacing = INTENSITY_MINOR_TICK
                 val valueLabel = JLabel("$initialValue")
+                val swatch = JLabel(" ")
+                swatch.preferredSize = Dimension(SWATCH_WIDTH, SWATCH_HEIGHT)
+                swatch.minimumSize = Dimension(SWATCH_WIDTH, SWATCH_HEIGHT)
+                swatch.isOpaque = true
+                swatch.background = computeSwatchColor(category, initialValue)
+                swatch.border = BorderFactory.createLineBorder(JBColor.border(), 1)
                 slider.addChangeListener { onSliderChanged(category, slider.value) }
                 cell(slider).resizableColumn().align(Align.FILL)
                 cell(valueLabel)
+                cell(swatch).gap(com.intellij.ui.dsl.builder.RightGap.SMALL)
                 // Stash Swing refs for reset() refresh + test seams.
                 when (category) {
                     VcsColorCategory.DIFF_VIEWER -> {
                         diffSlider = slider
                         diffValueLabel = valueLabel
+                        diffSwatch = swatch
                     }
                     VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> {
                         projectViewSlider = slider
                         projectViewValueLabel = valueLabel
+                        projectViewSwatch = swatch
                     }
                     VcsColorCategory.EDITOR_GUTTER -> {
                         gutterSlider = slider
                         gutterValueLabel = valueLabel
+                        gutterSwatch = swatch
                     }
                     VcsColorCategory.CONFLICT_MARKERS -> {
                         conflictMarkerSlider = slider
                         conflictMarkerValueLabel = valueLabel
+                        conflictMarkerSwatch = swatch
                     }
                     VcsColorCategory.BLAME_GUTTER -> {
                         blameSlider = slider
                         blameValueLabel = valueLabel
+                        blameSwatch = swatch
                     }
                     else -> Unit
                 }
             }
         sliderRow.visibleIf(sectionCustomVisible)
+    }
+
+    /**
+     * Returns the iconic-key blended color for [category] at slider position
+     * [value]. Iconic-key mapping: DIFF viewer → DIFF_MODIFIED, Project View
+     * → FILESTATUS_MODIFIED, gutter → MODIFIED_LINES_COLOR, conflict markers
+     * → DIFF_CONFLICT, blame → ANNOTATIONS_LAST_COMMIT_COLOR. Falls back to
+     * [JBColor.GRAY] when [variant] isn't resolvable yet (settings dialog
+     * before theme activates).
+     */
+    private fun computeSwatchColor(
+        category: VcsColorCategory,
+        value: Int,
+    ): Color {
+        val activeVariant = this.variant ?: AyuVariant.DARK
+        val keyName =
+            when (category) {
+                VcsColorCategory.DIFF_VIEWER -> "DIFF_MODIFIED"
+                VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> "FILESTATUS_MODIFIED"
+                VcsColorCategory.EDITOR_GUTTER -> "MODIFIED_LINES_COLOR"
+                VcsColorCategory.CONFLICT_MARKERS -> "DIFF_CONFLICT"
+                VcsColorCategory.BLAME_GUTTER -> "ANNOTATIONS_LAST_COMMIT_COLOR"
+                else -> return JBColor.GRAY
+            }
+        val entry =
+            VcsColorPalette.entriesFor(category).firstOrNull {
+                it.keyName == keyName && it.mode == VcsWriteMode.COLOR_KEY
+            } ?: return JBColor.GRAY
+        val (base, target) = VcsColorPalette.endpoints(entry, activeVariant)
+        return VcsColorBlender.blend(base, target, VcsIntensity.of(value))
     }
 
     /**
@@ -279,26 +338,32 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
         category: VcsColorCategory,
         value: Int,
     ) {
+        val swatchColor = computeSwatchColor(category, value)
         when (category) {
             VcsColorCategory.DIFF_VIEWER -> {
                 pendingDiffIntensity = value
                 diffValueLabel?.text = "$value"
+                diffSwatch?.background = swatchColor
             }
             VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> {
                 pendingProjectViewIntensity = value
                 projectViewValueLabel?.text = "$value"
+                projectViewSwatch?.background = swatchColor
             }
             VcsColorCategory.EDITOR_GUTTER -> {
                 pendingGutterIntensity = value
                 gutterValueLabel?.text = "$value"
+                gutterSwatch?.background = swatchColor
             }
             VcsColorCategory.CONFLICT_MARKERS -> {
                 pendingConflictMarkerIntensity = value
                 conflictMarkerValueLabel?.text = "$value"
+                conflictMarkerSwatch?.background = swatchColor
             }
             VcsColorCategory.BLAME_GUTTER -> {
                 pendingBlameIntensity = value
                 blameValueLabel?.text = "$value"
+                blameSwatch?.background = swatchColor
             }
             else -> return
         }
@@ -356,8 +421,33 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
 
         // Resolve per-section preset choices into per-category intensities,
         // then materialise the snapshot. The applier reads only per-category
-        // intensities — preset/custom branching is fully resolved here.
-        val resolved = resolveCategoryIntensitiesFromPendingState()
+        // intensities — preset/Custom branching is fully resolved here.
+        // Non-Custom presets defer to VcsColorPreset.intensityFor; Custom
+        // mode pulls the slider values directly.
+        val diffSnap =
+            if (pendingDiffPreset == VcsColorPreset.CUSTOM) {
+                null
+            } else {
+                pendingDiffPreset.intensityFor(VcsColorCategory.DIFF_VIEWER)
+            }
+        val resolved =
+            mapOf(
+                VcsColorCategory.DIFF_VIEWER to (diffSnap ?: pendingDiffIntensity),
+                VcsColorCategory.PROJECT_VIEW_FILE_STATUS to (diffSnap ?: pendingProjectViewIntensity),
+                VcsColorCategory.EDITOR_GUTTER to (diffSnap ?: pendingGutterIntensity),
+                VcsColorCategory.CONFLICT_MARKERS to
+                    if (pendingMergePreset == VcsColorPreset.CUSTOM) {
+                        pendingConflictMarkerIntensity
+                    } else {
+                        pendingMergePreset.intensityFor(VcsColorCategory.CONFLICT_MARKERS)
+                    },
+                VcsColorCategory.BLAME_GUTTER to
+                    if (pendingBlamePreset == VcsColorPreset.CUSTOM) {
+                        pendingBlameIntensity
+                    } else {
+                        pendingBlamePreset.intensityFor(VcsColorCategory.BLAME_GUTTER)
+                    },
+            )
         val snapshot = VcsColorSnapshot(enabled = pendingEnabled, perCategoryIntensities = resolved)
 
         try {
@@ -401,41 +491,6 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
         loadStored(state)
     }
 
-    /**
-     * Computes the resolved per-category intensity for every wired category
-     * from the current pending per-section preset + per-category slider state.
-     * Non-Custom presets resolve via [VcsColorPreset.intensityFor]; Custom
-     * mode pulls the slider value directly. Placeholder categories
-     * (Wave 5+) stay at AMBIENT.
-     */
-    private fun resolveCategoryIntensitiesFromPendingState(): Map<VcsColorCategory, Int> {
-        val diffValue =
-            if (pendingDiffPreset == VcsColorPreset.CUSTOM) {
-                null
-            } else {
-                pendingDiffPreset.intensityFor(VcsColorCategory.DIFF_VIEWER)
-            }
-        val mergeValue =
-            if (pendingMergePreset == VcsColorPreset.CUSTOM) {
-                pendingConflictMarkerIntensity
-            } else {
-                pendingMergePreset.intensityFor(VcsColorCategory.CONFLICT_MARKERS)
-            }
-        val blameValue =
-            if (pendingBlamePreset == VcsColorPreset.CUSTOM) {
-                pendingBlameIntensity
-            } else {
-                pendingBlamePreset.intensityFor(VcsColorCategory.BLAME_GUTTER)
-            }
-        return mapOf(
-            VcsColorCategory.DIFF_VIEWER to (diffValue ?: pendingDiffIntensity),
-            VcsColorCategory.PROJECT_VIEW_FILE_STATUS to (diffValue ?: pendingProjectViewIntensity),
-            VcsColorCategory.EDITOR_GUTTER to (diffValue ?: pendingGutterIntensity),
-            VcsColorCategory.CONFLICT_MARKERS to mergeValue,
-            VcsColorCategory.BLAME_GUTTER to blameValue,
-        )
-    }
-
     override fun reset() {
         val state = AyuIslandsSettings.getInstance().state
         loadStored(state)
@@ -451,14 +506,21 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
             blameCustomSelected.set(pendingBlamePreset == VcsColorPreset.CUSTOM)
             diffSlider?.value = pendingDiffIntensity
             diffValueLabel?.text = "$pendingDiffIntensity"
+            diffSwatch?.background = computeSwatchColor(VcsColorCategory.DIFF_VIEWER, pendingDiffIntensity)
             projectViewSlider?.value = pendingProjectViewIntensity
             projectViewValueLabel?.text = "$pendingProjectViewIntensity"
+            projectViewSwatch?.background =
+                computeSwatchColor(VcsColorCategory.PROJECT_VIEW_FILE_STATUS, pendingProjectViewIntensity)
             gutterSlider?.value = pendingGutterIntensity
             gutterValueLabel?.text = "$pendingGutterIntensity"
+            gutterSwatch?.background = computeSwatchColor(VcsColorCategory.EDITOR_GUTTER, pendingGutterIntensity)
             conflictMarkerSlider?.value = pendingConflictMarkerIntensity
             conflictMarkerValueLabel?.text = "$pendingConflictMarkerIntensity"
+            conflictMarkerSwatch?.background =
+                computeSwatchColor(VcsColorCategory.CONFLICT_MARKERS, pendingConflictMarkerIntensity)
             blameSlider?.value = pendingBlameIntensity
             blameValueLabel?.text = "$pendingBlameIntensity"
+            blameSwatch?.background = computeSwatchColor(VcsColorCategory.BLAME_GUTTER, pendingBlameIntensity)
         } finally {
             suppressSliderListeners = false
         }
@@ -520,31 +582,37 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
         category: VcsColorCategory,
         value: Int,
     ) {
+        val swatchColor = computeSwatchColor(category, value)
         when (category) {
             VcsColorCategory.DIFF_VIEWER -> {
                 pendingDiffIntensity = value
                 diffSlider?.value = value
                 diffValueLabel?.text = "$value"
+                diffSwatch?.background = swatchColor
             }
             VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> {
                 pendingProjectViewIntensity = value
                 projectViewSlider?.value = value
                 projectViewValueLabel?.text = "$value"
+                projectViewSwatch?.background = swatchColor
             }
             VcsColorCategory.EDITOR_GUTTER -> {
                 pendingGutterIntensity = value
                 gutterSlider?.value = value
                 gutterValueLabel?.text = "$value"
+                gutterSwatch?.background = swatchColor
             }
             VcsColorCategory.CONFLICT_MARKERS -> {
                 pendingConflictMarkerIntensity = value
                 conflictMarkerSlider?.value = value
                 conflictMarkerValueLabel?.text = "$value"
+                conflictMarkerSwatch?.background = swatchColor
             }
             VcsColorCategory.BLAME_GUTTER -> {
                 pendingBlameIntensity = value
                 blameSlider?.value = value
                 blameValueLabel?.text = "$value"
+                blameSwatch?.background = swatchColor
             }
             else -> Unit
         }
@@ -613,6 +681,8 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
         internal const val MAX_INTENSITY = 100
         private const val INTENSITY_MAJOR_TICK = 25
         private const val INTENSITY_MINOR_TICK = 5
+        private const val SWATCH_WIDTH = 22
+        private const val SWATCH_HEIGHT = 16
     }
 }
 

--- a/src/main/kotlin/dev/ayuislands/settings/VcsColorPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/VcsColorPanel.kt
@@ -430,31 +430,36 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
         // Resolve per-section preset choices into per-category intensities,
         // then materialise the snapshot. The applier reads only per-category
         // intensities — preset/Custom branching is fully resolved here.
-        // Non-Custom presets defer to VcsColorPreset.intensityFor; Custom
-        // mode pulls the slider values directly.
-        val diffSnap =
-            if (pendingDiffPreset == VcsColorPreset.CUSTOM) {
-                null
-            } else {
-                pendingDiffPreset.intensityFor(VcsColorCategory.DIFF_VIEWER)
-            }
+        // Non-Custom presets defer to VcsColorPreset.intensityFor per
+        // category (so future preset variants that differentiate intensity
+        // across categories work correctly); Custom mode pulls the slider
+        // value for that specific category.
+        fun resolveCategory(
+            preset: VcsColorPreset,
+            category: VcsColorCategory,
+            customValue: Int,
+        ): Int = if (preset == VcsColorPreset.CUSTOM) customValue else preset.intensityFor(category)
+
         val resolved =
             mapOf(
-                VcsColorCategory.DIFF_VIEWER to (diffSnap ?: pendingDiffIntensity),
-                VcsColorCategory.PROJECT_VIEW_FILE_STATUS to (diffSnap ?: pendingProjectViewIntensity),
-                VcsColorCategory.EDITOR_GUTTER to (diffSnap ?: pendingGutterIntensity),
+                VcsColorCategory.DIFF_VIEWER to
+                    resolveCategory(pendingDiffPreset, VcsColorCategory.DIFF_VIEWER, pendingDiffIntensity),
+                VcsColorCategory.PROJECT_VIEW_FILE_STATUS to
+                    resolveCategory(
+                        pendingDiffPreset,
+                        VcsColorCategory.PROJECT_VIEW_FILE_STATUS,
+                        pendingProjectViewIntensity,
+                    ),
+                VcsColorCategory.EDITOR_GUTTER to
+                    resolveCategory(pendingDiffPreset, VcsColorCategory.EDITOR_GUTTER, pendingGutterIntensity),
                 VcsColorCategory.CONFLICT_MARKERS to
-                    if (pendingMergePreset == VcsColorPreset.CUSTOM) {
-                        pendingConflictMarkerIntensity
-                    } else {
-                        pendingMergePreset.intensityFor(VcsColorCategory.CONFLICT_MARKERS)
-                    },
+                    resolveCategory(
+                        pendingMergePreset,
+                        VcsColorCategory.CONFLICT_MARKERS,
+                        pendingConflictMarkerIntensity,
+                    ),
                 VcsColorCategory.BLAME_GUTTER to
-                    if (pendingBlamePreset == VcsColorPreset.CUSTOM) {
-                        pendingBlameIntensity
-                    } else {
-                        pendingBlamePreset.intensityFor(VcsColorCategory.BLAME_GUTTER)
-                    },
+                    resolveCategory(pendingBlamePreset, VcsColorCategory.BLAME_GUTTER, pendingBlameIntensity),
             )
         val snapshot = VcsColorSnapshot(enabled = pendingEnabled, perCategoryIntensities = resolved)
 

--- a/src/main/kotlin/dev/ayuislands/settings/VcsColorPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/VcsColorPanel.kt
@@ -47,6 +47,8 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
     private var storedProjectViewIntensity: Int = VcsColorPreset.AMBIENT_SLIDER
     private var pendingGutterIntensity: Int = VcsColorPreset.AMBIENT_SLIDER
     private var storedGutterIntensity: Int = VcsColorPreset.AMBIENT_SLIDER
+    private var pendingConflictMarkerIntensity: Int = VcsColorPreset.AMBIENT_SLIDER
+    private var storedConflictMarkerIntensity: Int = VcsColorPreset.AMBIENT_SLIDER
 
     // ── Swing references (kept for reset-time refresh + test seams) ───────────
 
@@ -57,9 +59,11 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
     private var diffSlider: JSlider? = null
     private var projectViewSlider: JSlider? = null
     private var gutterSlider: JSlider? = null
+    private var conflictMarkerSlider: JSlider? = null
     private var diffValueLabel: JLabel? = null
     private var projectViewValueLabel: JLabel? = null
     private var gutterValueLabel: JLabel? = null
+    private var conflictMarkerValueLabel: JLabel? = null
 
     /** Drives `visibleIf(customSelected)` on the per-category slider rows. */
     private val customSelected = AtomicBooleanProperty(pendingPreset == VcsColorPreset.CUSTOM)
@@ -77,7 +81,6 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
 
     // ── Panel lifecycle ───────────────────────────────────────────────────────
 
-    @Suppress("UnstableApiUsage")
     override fun buildPanel(
         panel: Panel,
         variant: AyuVariant,
@@ -107,11 +110,30 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
         }
     }
 
-    @Suppress("UnstableApiUsage")
     private fun Panel.buildLicensedContent(state: AyuIslandsState) {
         buildMasterToggleRow()
         buildPresetRow()
-        buildDiffCollapsibleGroup(state)
+        buildSection(
+            title = DIFF_GROUP_TITLE,
+            initiallyExpanded = state.vcsDiffSectionExpanded,
+            persistExpanded = { expanded ->
+                AyuIslandsSettings.getInstance().state.vcsDiffSectionExpanded = expanded
+            },
+            sliders =
+                listOf(
+                    VcsColorCategory.DIFF_VIEWER to "Diff viewer:",
+                    VcsColorCategory.PROJECT_VIEW_FILE_STATUS to "Project View:",
+                    VcsColorCategory.EDITOR_GUTTER to "Editor gutter:",
+                ),
+        )
+        buildSection(
+            title = MERGE_GROUP_TITLE,
+            initiallyExpanded = state.vcsMergeSectionExpanded,
+            persistExpanded = { expanded ->
+                AyuIslandsSettings.getInstance().state.vcsMergeSectionExpanded = expanded
+            },
+            sliders = listOf(VcsColorCategory.CONFLICT_MARKERS to "Conflict markers:"),
+        )
     }
 
     private fun Panel.buildMasterToggleRow() {
@@ -139,17 +161,20 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
         presetRow.visibleIf(masterEnabled)
     }
 
-    private fun Panel.buildDiffCollapsibleGroup(state: AyuIslandsState) {
+    private fun Panel.buildSection(
+        title: String,
+        initiallyExpanded: Boolean,
+        persistExpanded: (Boolean) -> Unit,
+        sliders: List<Pair<VcsColorCategory, String>>,
+    ) {
         val collapsible =
-            collapsibleGroup(DIFF_GROUP_TITLE) {
-                buildPerCategorySliderRow(VcsColorCategory.DIFF_VIEWER, "Diff viewer:")
-                buildPerCategorySliderRow(VcsColorCategory.PROJECT_VIEW_FILE_STATUS, "Project View:")
-                buildPerCategorySliderRow(VcsColorCategory.EDITOR_GUTTER, "Editor gutter:")
+            collapsibleGroup(title) {
+                for ((category, label) in sliders) {
+                    buildPerCategorySliderRow(category, label)
+                }
             }
-        collapsible.expanded = state.vcsDiffSectionExpanded
-        collapsible.addExpandedListener { expanded ->
-            AyuIslandsSettings.getInstance().state.vcsDiffSectionExpanded = expanded
-        }
+        collapsible.expanded = initiallyExpanded
+        collapsible.addExpandedListener { expanded -> persistExpanded(expanded) }
     }
 
     private fun Panel.buildPerCategorySliderRow(
@@ -182,6 +207,7 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
             VcsColorCategory.DIFF_VIEWER -> pendingDiffIntensity
             VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> pendingProjectViewIntensity
             VcsColorCategory.EDITOR_GUTTER -> pendingGutterIntensity
+            VcsColorCategory.CONFLICT_MARKERS -> pendingConflictMarkerIntensity
             else -> VcsColorPreset.AMBIENT_SLIDER
         }
 
@@ -202,6 +228,10 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
             VcsColorCategory.EDITOR_GUTTER -> {
                 gutterSlider = slider
                 gutterValueLabel = valueLabel
+            }
+            VcsColorCategory.CONFLICT_MARKERS -> {
+                conflictMarkerSlider = slider
+                conflictMarkerValueLabel = valueLabel
             }
             else -> Unit
         }
@@ -231,6 +261,10 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
                 pendingGutterIntensity = value
                 gutterValueLabel?.text = "$value"
             }
+            VcsColorCategory.CONFLICT_MARKERS -> {
+                pendingConflictMarkerIntensity = value
+                conflictMarkerValueLabel?.text = "$value"
+            }
             else -> return
         }
         if (suppressSliderListeners || pendingPreset == VcsColorPreset.CUSTOM) return
@@ -244,7 +278,8 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
             pendingPreset != storedPreset ||
             pendingDiffIntensity != storedDiffIntensity ||
             pendingProjectViewIntensity != storedProjectViewIntensity ||
-            pendingGutterIntensity != storedGutterIntensity
+            pendingGutterIntensity != storedGutterIntensity ||
+            pendingConflictMarkerIntensity != storedConflictMarkerIntensity
 
     override fun apply() {
         if (!isModified()) return
@@ -268,6 +303,7 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
                         VcsColorCategory.DIFF_VIEWER to pendingDiffIntensity,
                         VcsColorCategory.PROJECT_VIEW_FILE_STATUS to pendingProjectViewIntensity,
                         VcsColorCategory.EDITOR_GUTTER to pendingGutterIntensity,
+                        VcsColorCategory.CONFLICT_MARKERS to pendingConflictMarkerIntensity,
                     ),
             )
 
@@ -292,6 +328,7 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
         state.vcsDiffIntensity = pendingDiffIntensity
         state.vcsProjectViewIntensity = pendingProjectViewIntensity
         state.vcsGutterIntensity = pendingGutterIntensity
+        state.vcsConflictMarkerIntensity = pendingConflictMarkerIntensity
         loadStored(state)
     }
 
@@ -310,6 +347,8 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
             projectViewValueLabel?.text = "$pendingProjectViewIntensity"
             gutterSlider?.value = pendingGutterIntensity
             gutterValueLabel?.text = "$pendingGutterIntensity"
+            conflictMarkerSlider?.value = pendingConflictMarkerIntensity
+            conflictMarkerValueLabel?.text = "$pendingConflictMarkerIntensity"
         } finally {
             suppressSliderListeners = false
         }
@@ -326,6 +365,8 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
         pendingProjectViewIntensity = state.vcsProjectViewIntensity.coerceIn(MIN_INTENSITY, MAX_INTENSITY)
         storedGutterIntensity = state.vcsGutterIntensity
         pendingGutterIntensity = state.vcsGutterIntensity.coerceIn(MIN_INTENSITY, MAX_INTENSITY)
+        storedConflictMarkerIntensity = state.vcsConflictMarkerIntensity
+        pendingConflictMarkerIntensity = state.vcsConflictMarkerIntensity.coerceIn(MIN_INTENSITY, MAX_INTENSITY)
         masterEnabled.set(pendingEnabled)
         customSelected.set(pendingPreset == VcsColorPreset.CUSTOM)
     }
@@ -352,6 +393,9 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
             pendingGutterIntensity = snapPosition
             gutterSlider?.value = snapPosition
             gutterValueLabel?.text = "$snapPosition"
+            pendingConflictMarkerIntensity = snapPosition
+            conflictMarkerSlider?.value = snapPosition
+            conflictMarkerValueLabel?.text = "$snapPosition"
         } finally {
             suppressSliderListeners = false
         }
@@ -402,6 +446,7 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
             VcsColorCategory.DIFF_VIEWER -> pendingDiffIntensity = value
             VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> pendingProjectViewIntensity = value
             VcsColorCategory.EDITOR_GUTTER -> pendingGutterIntensity = value
+            VcsColorCategory.CONFLICT_MARKERS -> pendingConflictMarkerIntensity = value
             else -> Unit
         }
     }
@@ -413,6 +458,7 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
     companion object {
         private val LOG = logger<VcsColorPanel>()
         private const val DIFF_GROUP_TITLE = "Diff & File Status"
+        private const val MERGE_GROUP_TITLE = "Merge & Conflict"
         internal const val MIN_INTENSITY = 0
         internal const val MAX_INTENSITY = 100
         private const val INTENSITY_MAJOR_TICK = 25

--- a/src/main/kotlin/dev/ayuislands/util/ScopedThreadLocal.kt
+++ b/src/main/kotlin/dev/ayuislands/util/ScopedThreadLocal.kt
@@ -1,0 +1,32 @@
+package dev.ayuislands.util
+
+/**
+ * Installs [value] into this [ThreadLocal] for the duration of [block] and
+ * restores the previous slot (or clears it when no prior value existed) on
+ * exit, even if [block] throws.
+ *
+ * Passing `null` skips installation entirely and just runs [block] — useful
+ * for callers that want a uniform call shape regardless of whether they have
+ * a scoped value to install.
+ *
+ * Shared between [dev.ayuislands.accent.ChromeTintContext] and
+ * [dev.ayuislands.vcs.VcsColorContext] which both rely on the same
+ * "state untouched on throw" invariant.
+ */
+internal inline fun <T, V : Any> ThreadLocal<V?>.withScopedValue(
+    value: V?,
+    block: () -> T,
+): T {
+    if (value == null) return block()
+    val previous = get()
+    set(value)
+    return try {
+        block()
+    } finally {
+        if (previous == null) {
+            remove()
+        } else {
+            set(previous)
+        }
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/util/ScopedThreadLocal.kt
+++ b/src/main/kotlin/dev/ayuislands/util/ScopedThreadLocal.kt
@@ -9,6 +9,9 @@ package dev.ayuislands.util
  * for callers that want a uniform call shape regardless of whether they have
  * a scoped value to install.
  *
+ * Non-local returns from [block] are honoured by the `inline` modifier; the
+ * slot is still restored on the way out.
+ *
  * Shared between [dev.ayuislands.accent.ChromeTintContext] and
  * [dev.ayuislands.vcs.VcsColorContext] which both rely on the same
  * "state untouched on throw" invariant.

--- a/src/main/kotlin/dev/ayuislands/vcs/VcsColorApplier.kt
+++ b/src/main/kotlin/dev/ayuislands/vcs/VcsColorApplier.kt
@@ -4,6 +4,9 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.editor.colors.ColorKey
 import com.intellij.openapi.editor.colors.EditorColorsManager
+import com.intellij.openapi.editor.colors.EditorColorsScheme
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.openapi.editor.markup.TextAttributes
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
@@ -12,22 +15,18 @@ import java.awt.Window
 
 /**
  * Phase 40.2 applier — writes blended VCS colors into the live
- * [com.intellij.openapi.editor.colors.EditorColorsScheme] based on the
- * current [VcsColorContext] snapshot (or persisted [AyuIslandsState] when no
- * snapshot is active).
+ * [EditorColorsScheme] based on the current [VcsColorContext] snapshot (or
+ * persisted [AyuIslandsState] when no snapshot is active).
  *
- * Wave 2 ColorKey scope (no TextAttributesKey writes yet — that's Wave 2.x):
- *  - For every (category, keyName) in [VcsColorPalette.KEYS_BY_CATEGORY], the
- *    applier reads the per-category slider via [VcsColorContext.currentIntensity],
- *    blends the palette's Whisper / Cyberpunk endpoints with [VcsColorBlender],
- *    and writes the result via `scheme.setColor(ColorKey.find(name), ...)`.
- *  - When master is OFF or the snapshot says "disabled", the applier issues
- *    null-writes (`setColor(key, null)`) so the scheme falls back to the stock
- *    XML values — no leftover tinted state when a user disables the feature.
+ * Wave 2 + 2.5 scope: dispatches per [VcsWriteMode]:
+ *  - [VcsWriteMode.COLOR_KEY] — `scheme.setColor(ColorKey.find(name), tinted)`
+ *  - [VcsWriteMode.TEXT_ATTR_BG] — read existing attributes, clone with the
+ *    blended background, preserve foreground / effect / error stripe / font
+ *    type, write back via `scheme.setAttributes`.
  *
- * Lives as an [object] mirroring [dev.ayuislands.accent.ChromeTintBlender] —
- * the applier holds no mutable state; the [VcsColorContext] ThreadLocal is the
- * only ephemeral channel, and the persisted [AyuIslandsState] is the durable one.
+ * When master is OFF or the snapshot says "disabled", the applier issues
+ * null-writes so the scheme falls back to the stock XML values — no leftover
+ * tinted state when a user disables the feature.
  */
 internal object VcsColorApplier {
     private val LOG = logger<VcsColorApplier>()
@@ -37,13 +36,11 @@ internal object VcsColorApplier {
      *
      * Reads the [AyuIslandsState] singleton, resolves the active [AyuVariant],
      * and writes a blended color (or null = stock revert) for every known
-     * ColorKey in [VcsColorPalette]. After writing, repaints all visible
-     * Windows so the gutter / Project View / scrollbar markers reflect the
-     * new palette without requiring a theme reload.
+     * palette entry. After writing, repaints all visible Windows so the
+     * gutter / Project View / diff viewer markers reflect the new palette
+     * without requiring a theme reload.
      *
-     * Safe to call from any thread — the EDT hop happens inside this method
-     * when needed. Callers do not need to wrap in [ApplicationManager.getApplication]
-     * `invokeLater`.
+     * Safe to call from any thread — the EDT hop happens inside this method.
      */
     fun applyAll() {
         val state = AyuIslandsSettings.getInstance().state
@@ -59,16 +56,17 @@ internal object VcsColorApplier {
     }
 
     /**
-     * Reverts every VCS ColorKey to stock — equivalent to writing `null` for
-     * each key so the scheme falls back to the XML baseline. Used when the
-     * master kill-switch flips from ON to OFF.
+     * Reverts every VCS color entry to stock — null-writes via
+     * `scheme.setColor` (for ColorKey entries) and `scheme.setAttributes`
+     * (for TextAttributesKey entries) so the scheme falls back to the XML
+     * baseline. Used when the master kill-switch flips ON → OFF.
      */
     fun revertAll() {
         ApplicationManager.getApplication().invokeLater {
             val scheme = EditorColorsManager.getInstance().globalScheme
-            for ((_, keys) in VcsColorPalette.KEYS_BY_CATEGORY) {
-                for (keyName in keys) {
-                    scheme.setColor(ColorKey.find(keyName), null)
+            for ((_, entries) in VcsColorPalette.allCategoriesAndEntries()) {
+                for (entry in entries) {
+                    revertEntry(scheme, entry)
                 }
             }
             repaintAllWindows()
@@ -79,40 +77,84 @@ internal object VcsColorApplier {
         state: AyuIslandsState,
         variant: AyuVariant,
     ) {
+        val scheme = EditorColorsManager.getInstance().globalScheme
         if (!VcsColorContext.isEnabled(state)) {
-            // Disabled — write nulls so the scheme falls back to XML stock.
-            val scheme = EditorColorsManager.getInstance().globalScheme
-            for ((_, keys) in VcsColorPalette.KEYS_BY_CATEGORY) {
-                for (keyName in keys) {
-                    scheme.setColor(ColorKey.find(keyName), null)
+            for ((_, entries) in VcsColorPalette.allCategoriesAndEntries()) {
+                for (entry in entries) {
+                    revertEntry(scheme, entry)
                 }
             }
             return
         }
-        val scheme = EditorColorsManager.getInstance().globalScheme
-        for ((category, keys) in VcsColorPalette.KEYS_BY_CATEGORY) {
+        for ((category, entries) in VcsColorPalette.allCategoriesAndEntries()) {
             val intensity = VcsColorContext.currentIntensity(category, state)
-            for (keyName in keys) {
-                val tinted = blendFor(keyName, variant, intensity)
-                scheme.setColor(ColorKey.find(keyName), tinted)
+            for (entry in entries) {
+                val tinted = blendFor(entry, variant, intensity)
+                writeEntry(scheme, entry, tinted)
             }
         }
     }
 
     private fun blendFor(
-        keyName: String,
+        entry: VcsPaletteEntry,
         variant: AyuVariant,
         intensity: VcsIntensity,
     ): Color {
-        val (base, target) = VcsColorPalette.endpoints(keyName, variant)
+        val (base, target) = VcsColorPalette.endpoints(entry, variant)
         return VcsColorBlender.blend(base, target, intensity)
+    }
+
+    private fun writeEntry(
+        scheme: EditorColorsScheme,
+        entry: VcsPaletteEntry,
+        tinted: Color,
+    ) {
+        when (entry.mode) {
+            VcsWriteMode.COLOR_KEY -> scheme.setColor(ColorKey.find(entry.keyName), tinted)
+            VcsWriteMode.TEXT_ATTR_BG -> writeTextAttrBackground(scheme, entry.keyName, tinted)
+        }
+    }
+
+    private fun revertEntry(
+        scheme: EditorColorsScheme,
+        entry: VcsPaletteEntry,
+    ) {
+        when (entry.mode) {
+            VcsWriteMode.COLOR_KEY -> scheme.setColor(ColorKey.find(entry.keyName), null)
+            VcsWriteMode.TEXT_ATTR_BG -> scheme.setAttributes(TextAttributesKey.find(entry.keyName), null)
+        }
+    }
+
+    /**
+     * Writes [background] into the BACKGROUND slot of [TextAttributesKey] named
+     * [keyName], preserving every other TextAttributes field (foreground, effect
+     * color/type, error stripe color, font type). Without the clone-preserve
+     * dance, our background write would clobber the existing error stripe color
+     * and any future foreground accent.
+     */
+    private fun writeTextAttrBackground(
+        scheme: EditorColorsScheme,
+        keyName: String,
+        background: Color,
+    ) {
+        val key = TextAttributesKey.find(keyName)
+        val existing = scheme.getAttributes(key)
+        val updated =
+            TextAttributes(
+                existing?.foregroundColor,
+                background,
+                existing?.effectColor,
+                existing?.effectType,
+                existing?.fontType ?: 0,
+            )
+        updated.errorStripeColor = existing?.errorStripeColor
+        scheme.setAttributes(key, updated)
     }
 
     /**
      * Repaints every visible top-level [Window] so the scheme writes propagate
      * without waiting for the next focus event. Mirrors the chrome applier's
-     * post-apply repaint discipline — without it, the gutter and Project View
-     * keep their cached tinted color until the user clicks somewhere.
+     * post-apply repaint discipline.
      */
     private fun repaintAllWindows() {
         for (window in Window.getWindows()) {

--- a/src/main/kotlin/dev/ayuislands/vcs/VcsColorApplier.kt
+++ b/src/main/kotlin/dev/ayuislands/vcs/VcsColorApplier.kt
@@ -14,11 +14,11 @@ import java.awt.Color
 import java.awt.Window
 
 /**
- * Phase 40.2 applier — writes blended VCS colors into the live
- * [EditorColorsScheme] based on the current [VcsColorContext] snapshot (or
- * persisted [AyuIslandsState] when no snapshot is active).
+ * Applier — writes blended VCS colors into the live [EditorColorsScheme]
+ * based on the current [VcsColorContext] snapshot (or the persisted
+ * [AyuIslandsState] when no snapshot is active).
  *
- * Wave 2 + 2.5 scope: dispatches per [VcsWriteMode]:
+ * Dispatches per [VcsWriteMode]:
  *  - [VcsWriteMode.COLOR_KEY] — `scheme.setColor(ColorKey.find(name), tinted)`
  *  - [VcsWriteMode.TEXT_ATTR_BG] — read existing attributes, clone with the
  *    blended background, preserve foreground / effect / error stripe / font

--- a/src/main/kotlin/dev/ayuislands/vcs/VcsColorApplier.kt
+++ b/src/main/kotlin/dev/ayuislands/vcs/VcsColorApplier.kt
@@ -1,0 +1,124 @@
+package dev.ayuislands.vcs
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.editor.colors.ColorKey
+import com.intellij.openapi.editor.colors.EditorColorsManager
+import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
+import java.awt.Color
+import java.awt.Window
+
+/**
+ * Phase 40.2 applier — writes blended VCS colors into the live
+ * [com.intellij.openapi.editor.colors.EditorColorsScheme] based on the
+ * current [VcsColorContext] snapshot (or persisted [AyuIslandsState] when no
+ * snapshot is active).
+ *
+ * Wave 2 ColorKey scope (no TextAttributesKey writes yet — that's Wave 2.x):
+ *  - For every (category, keyName) in [VcsColorPalette.KEYS_BY_CATEGORY], the
+ *    applier reads the per-category slider via [VcsColorContext.currentIntensity],
+ *    blends the palette's Whisper / Cyberpunk endpoints with [VcsColorBlender],
+ *    and writes the result via `scheme.setColor(ColorKey.find(name), ...)`.
+ *  - When master is OFF or the snapshot says "disabled", the applier issues
+ *    null-writes (`setColor(key, null)`) so the scheme falls back to the stock
+ *    XML values — no leftover tinted state when a user disables the feature.
+ *
+ * Lives as an [object] mirroring [dev.ayuislands.accent.ChromeTintBlender] —
+ * the applier holds no mutable state; the [VcsColorContext] ThreadLocal is the
+ * only ephemeral channel, and the persisted [AyuIslandsState] is the durable one.
+ */
+internal object VcsColorApplier {
+    private val LOG = logger<VcsColorApplier>()
+
+    /**
+     * Apply VCS colors for the currently active variant.
+     *
+     * Reads the [AyuIslandsState] singleton, resolves the active [AyuVariant],
+     * and writes a blended color (or null = stock revert) for every known
+     * ColorKey in [VcsColorPalette]. After writing, repaints all visible
+     * Windows so the gutter / Project View / scrollbar markers reflect the
+     * new palette without requiring a theme reload.
+     *
+     * Safe to call from any thread — the EDT hop happens inside this method
+     * when needed. Callers do not need to wrap in [ApplicationManager.getApplication]
+     * `invokeLater`.
+     */
+    fun applyAll() {
+        val state = AyuIslandsSettings.getInstance().state
+        val variant = AyuVariant.detect()
+        if (variant == null) {
+            LOG.info("VcsColorApplier.applyAll: no Ayu variant active; skipping")
+            return
+        }
+        ApplicationManager.getApplication().invokeLater {
+            writeAll(state, variant)
+            repaintAllWindows()
+        }
+    }
+
+    /**
+     * Reverts every VCS ColorKey to stock — equivalent to writing `null` for
+     * each key so the scheme falls back to the XML baseline. Used when the
+     * master kill-switch flips from ON to OFF.
+     */
+    fun revertAll() {
+        ApplicationManager.getApplication().invokeLater {
+            val scheme = EditorColorsManager.getInstance().globalScheme
+            for ((_, keys) in VcsColorPalette.KEYS_BY_CATEGORY) {
+                for (keyName in keys) {
+                    scheme.setColor(ColorKey.find(keyName), null)
+                }
+            }
+            repaintAllWindows()
+        }
+    }
+
+    private fun writeAll(
+        state: AyuIslandsState,
+        variant: AyuVariant,
+    ) {
+        if (!VcsColorContext.isEnabled(state)) {
+            // Disabled — write nulls so the scheme falls back to XML stock.
+            val scheme = EditorColorsManager.getInstance().globalScheme
+            for ((_, keys) in VcsColorPalette.KEYS_BY_CATEGORY) {
+                for (keyName in keys) {
+                    scheme.setColor(ColorKey.find(keyName), null)
+                }
+            }
+            return
+        }
+        val scheme = EditorColorsManager.getInstance().globalScheme
+        for ((category, keys) in VcsColorPalette.KEYS_BY_CATEGORY) {
+            val intensity = VcsColorContext.currentIntensity(category, state)
+            for (keyName in keys) {
+                val tinted = blendFor(keyName, variant, intensity)
+                scheme.setColor(ColorKey.find(keyName), tinted)
+            }
+        }
+    }
+
+    private fun blendFor(
+        keyName: String,
+        variant: AyuVariant,
+        intensity: VcsIntensity,
+    ): Color {
+        val (base, target) = VcsColorPalette.endpoints(keyName, variant)
+        return VcsColorBlender.blend(base, target, intensity)
+    }
+
+    /**
+     * Repaints every visible top-level [Window] so the scheme writes propagate
+     * without waiting for the next focus event. Mirrors the chrome applier's
+     * post-apply repaint discipline — without it, the gutter and Project View
+     * keep their cached tinted color until the user clicks somewhere.
+     */
+    private fun repaintAllWindows() {
+        for (window in Window.getWindows()) {
+            if (window.isShowing) {
+                window.repaint()
+            }
+        }
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/vcs/VcsColorApplier.kt
+++ b/src/main/kotlin/dev/ayuislands/vcs/VcsColorApplier.kt
@@ -46,7 +46,7 @@ internal object VcsColorApplier {
         val state = AyuIslandsSettings.getInstance().state
         val variant = AyuVariant.detect()
         if (variant == null) {
-            LOG.info("VcsColorApplier.applyAll: no Ayu variant active; skipping")
+            LOG.debug("VcsColorApplier.applyAll: no Ayu variant active; skipping")
             return
         }
         ApplicationManager.getApplication().invokeLater {
@@ -64,11 +64,8 @@ internal object VcsColorApplier {
     fun revertAll() {
         ApplicationManager.getApplication().invokeLater {
             val scheme = EditorColorsManager.getInstance().globalScheme
-            for ((_, entries) in VcsColorPalette.allCategoriesAndEntries()) {
-                for (entry in entries) {
-                    revertEntry(scheme, entry)
-                }
-            }
+            val failed = revertEveryEntry(scheme)
+            if (failed > 0) LOG.warn("VcsColorApplier.revertAll: $failed entries failed to revert; see prior warnings")
             repaintAllWindows()
         }
     }
@@ -78,22 +75,64 @@ internal object VcsColorApplier {
         variant: AyuVariant,
     ) {
         val scheme = EditorColorsManager.getInstance().globalScheme
-        if (!VcsColorContext.isEnabled(state)) {
-            for ((_, entries) in VcsColorPalette.allCategoriesAndEntries()) {
-                for (entry in entries) {
-                    revertEntry(scheme, entry)
-                }
+        val failed =
+            if (VcsColorContext.isEnabled(state)) {
+                writeEveryEntry(scheme, state, variant)
+            } else {
+                revertEveryEntry(scheme)
             }
-            return
-        }
+        if (failed > 0) LOG.warn("VcsColorApplier.writeAll: $failed entries failed; see prior warnings")
+    }
+
+    private fun writeEveryEntry(
+        scheme: EditorColorsScheme,
+        state: AyuIslandsState,
+        variant: AyuVariant,
+    ): Int {
+        var failed = 0
         for ((category, entries) in VcsColorPalette.allCategoriesAndEntries()) {
             val intensity = VcsColorContext.currentIntensity(category, state)
             for (entry in entries) {
-                val tinted = blendFor(entry, variant, intensity)
-                writeEntry(scheme, entry, tinted)
+                if (!safeWriteEntry(scheme, entry, blendFor(entry, variant, intensity))) failed++
             }
         }
+        return failed
     }
+
+    private fun revertEveryEntry(scheme: EditorColorsScheme): Int {
+        var failed = 0
+        for ((_, entries) in VcsColorPalette.allCategoriesAndEntries()) {
+            for (entry in entries) {
+                if (!safeRevertEntry(scheme, entry)) failed++
+            }
+        }
+        return failed
+    }
+
+    private fun safeWriteEntry(
+        scheme: EditorColorsScheme,
+        entry: VcsPaletteEntry,
+        tinted: Color,
+    ): Boolean =
+        try {
+            writeEntry(scheme, entry, tinted)
+            true
+        } catch (exception: RuntimeException) {
+            LOG.warn("VcsColorApplier: writing ${entry.keyName} (${entry.mode}) failed", exception)
+            false
+        }
+
+    private fun safeRevertEntry(
+        scheme: EditorColorsScheme,
+        entry: VcsPaletteEntry,
+    ): Boolean =
+        try {
+            revertEntry(scheme, entry)
+            true
+        } catch (exception: RuntimeException) {
+            LOG.warn("VcsColorApplier: reverting ${entry.keyName} (${entry.mode}) failed", exception)
+            false
+        }
 
     private fun blendFor(
         entry: VcsPaletteEntry,
@@ -158,8 +197,10 @@ internal object VcsColorApplier {
      */
     private fun repaintAllWindows() {
         for (window in Window.getWindows()) {
-            if (window.isShowing) {
-                window.repaint()
+            try {
+                if (window.isShowing) window.repaint()
+            } catch (exception: RuntimeException) {
+                LOG.debug("VcsColorApplier.repaintAllWindows: window repaint failed", exception)
             }
         }
     }

--- a/src/main/kotlin/dev/ayuislands/vcs/VcsColorBlender.kt
+++ b/src/main/kotlin/dev/ayuislands/vcs/VcsColorBlender.kt
@@ -1,0 +1,116 @@
+package dev.ayuislands.vcs
+
+import java.awt.Color
+
+/**
+ * Pure HSB-lerp helper that mixes a stock 2.6.2 XML baseline color toward a
+ * per-category vibrant target by the user-configured [VcsIntensity] percent.
+ *
+ * Unlike [dev.ayuislands.accent.ChromeTintBlender], which replaces the base
+ * hue with a single accent hue across all chrome surfaces (uniform-hue
+ * invariant), this blender lerps between two specific colors and preserves
+ * the natural hue ramp of VCS surfaces: diff-modified blue stays blue-family,
+ * file-status-added green stays green-family, deleted-red stays red-family.
+ * That keeps the user's intensity slider purely a saturation/brightness dial,
+ * not a hue-shift dial.
+ *
+ * Invariants enforced by [VcsColorBlenderTest]:
+ *  - intensity=0 → base per-channel, alpha from base
+ *  - intensity=100 → target per-channel, alpha from base
+ *  - intensity=50 → midpoint via HSB lerp, alpha from base
+ *  - alpha ALWAYS sourced from base (translucent SELECTION_BACKGROUND keys
+ *    must not lose their transparency when "vibrified")
+ *  - hue uses shortest-arc lerp (red↔magenta crossing 0/360 stays on the
+ *    short side, doesn't pass through the spectrum's full range)
+ */
+object VcsColorBlender {
+    private const val MIN_INTENSITY: Int = VcsIntensity.MIN
+    private const val MAX_INTENSITY: Int = VcsIntensity.MAX
+    private const val INTENSITY_TO_RATIO: Float = 100f
+
+    /**
+     * Half-rotation threshold on the normalised hue circle (`[0, 1]`).
+     * When `|targetHue - baseHue| > 0.5` the shortest arc goes the OTHER
+     * way around the wraparound (e.g. red→magenta via 0/1, not via the
+     * full spectrum), so the lerp adjusts one operand by ±1.0 before mixing.
+     */
+    private const val HUE_HALF_ROTATION: Float = 0.5f
+    private const val HUE_FULL_ROTATION: Float = 1.0f
+
+    /**
+     * Lerps [base] toward [target] in HSB space by [intensity] percent.
+     *
+     * @param base stock XML baseline color (Muted preset value)
+     * @param target vibrant per-category endpoint (hand-tuned per category by
+     *   the applier; the blender stays agnostic to what target means)
+     * @param intensity typed slider position — clamped at construction
+     * @return blended [Color] sharing [base]'s alpha at the requested mix
+     */
+    fun blend(
+        base: Color,
+        target: Color,
+        intensity: VcsIntensity,
+    ): Color {
+        val clamped = intensity.percent.coerceIn(MIN_INTENSITY, MAX_INTENSITY)
+
+        if (clamped == MIN_INTENSITY) {
+            // Identity short-circuit: no target read at all so a future caller
+            // can safely pass `target = null` semantics via a sentinel color
+            // without affecting the result at intensity=0.
+            return Color(base.red, base.green, base.blue, base.alpha)
+        }
+
+        if (clamped == MAX_INTENSITY) {
+            // Endpoint short-circuit: return target per-channel with base alpha
+            // so translucent baselines stay translucent at peak intensity.
+            return Color(target.red, target.green, target.blue, base.alpha)
+        }
+
+        val ratio = clamped.toFloat() / INTENSITY_TO_RATIO
+        val baseHsb = Color.RGBtoHSB(base.red, base.green, base.blue, null)
+        val targetHsb = Color.RGBtoHSB(target.red, target.green, target.blue, null)
+
+        val hue = lerpShortestArcHue(baseHsb[0], targetHsb[0], ratio)
+        val saturation = (baseHsb[1] + (targetHsb[1] - baseHsb[1]) * ratio).coerceIn(0f, 1f)
+        val brightness = (baseHsb[2] + (targetHsb[2] - baseHsb[2]) * ratio).coerceIn(0f, 1f)
+
+        val rgb = Color.HSBtoRGB(hue, saturation, brightness)
+        val red = rgb shr RED_SHIFT and CHANNEL_MASK
+        val green = rgb shr GREEN_SHIFT and CHANNEL_MASK
+        val blue = rgb and CHANNEL_MASK
+        return Color(red, green, blue, base.alpha)
+    }
+
+    /**
+     * Lerps two hues on the normalised `[0, 1]` HSB hue circle along the
+     * shortest arc.
+     *
+     * Java's [Color.RGBtoHSB] returns hue in `[0, 1]` (not degrees), with
+     * `0.0` and `1.0` both representing red. A naive `base + (target-base)*r`
+     * lerp from red (0.0) toward magenta (0.83) would sweep through orange,
+     * yellow, green, cyan, blue — the long way around. Detecting that the
+     * delta exceeds half a rotation and adjusting one endpoint by ±1.0
+     * keeps the lerp on the short arc.
+     */
+    private fun lerpShortestArcHue(
+        baseHue: Float,
+        targetHue: Float,
+        ratio: Float,
+    ): Float {
+        val delta = targetHue - baseHue
+        val adjustedDelta =
+            when {
+                delta > HUE_HALF_ROTATION -> delta - HUE_FULL_ROTATION
+                delta < -HUE_HALF_ROTATION -> delta + HUE_FULL_ROTATION
+                else -> delta
+            }
+        val raw = baseHue + adjustedDelta * ratio
+        // Wrap the result back into [0, 1). Adding HUE_FULL_ROTATION before mod
+        // handles the case where the lerp crossed through 0.0 going backwards.
+        return ((raw % HUE_FULL_ROTATION) + HUE_FULL_ROTATION) % HUE_FULL_ROTATION
+    }
+
+    private const val CHANNEL_MASK: Int = 0xFF
+    private const val RED_SHIFT: Int = 16
+    private const val GREEN_SHIFT: Int = 8
+}

--- a/src/main/kotlin/dev/ayuislands/vcs/VcsColorCategory.kt
+++ b/src/main/kotlin/dev/ayuislands/vcs/VcsColorCategory.kt
@@ -1,19 +1,20 @@
 package dev.ayuislands.vcs
 
 /**
- * The eleven VCS color surfaces driven by Phase 40.2 user-controlled intensity.
+ * The eleven VCS color surfaces driven by user-controlled intensity.
  *
  * Grouped into four user-task sections — the same grouping that appears in the
  * `VCS` settings tab:
- *  - **Diff & File Status** (Wave 2): [DIFF_VIEWER], [PROJECT_VIEW_FILE_STATUS], [EDITOR_GUTTER]
- *  - **Merge & Conflict** (Wave 3): [CONFLICT_MARKERS], [MERGE_3WAY], [INLINE_DIFF_POPUP]
- *  - **Blame & History** (Wave 4): [BLAME_GUTTER], [LOCAL_HISTORY]
- *  - **Branch & Commit** (Wave 5 spike outcome): [BRANCH_INDICATOR], [BRANCHES_POPUP], [COMMIT_HIGHLIGHTS]
+ *  - **Diff & File Status**: [DIFF_VIEWER], [PROJECT_VIEW_FILE_STATUS], [EDITOR_GUTTER]
+ *  - **Merge & Conflict**: [CONFLICT_MARKERS], [MERGE_3WAY], [INLINE_DIFF_POPUP]
+ *  - **Blame & History**: [BLAME_GUTTER], [LOCAL_HISTORY]
+ *  - **Branch & Commit**: [BRANCH_INDICATOR], [BRANCHES_POPUP], [COMMIT_HIGHLIGHTS]
  *
- * Wave 1 declares the enum only; color-key bindings and write-API routing land
- * incrementally in waves 2–5. Adding a category here without wiring it into the
- * applier is intentionally safe — categories without a routed key contribute no
- * UIManager / EditorColorsScheme writes and therefore cannot regress live themes.
+ * The Branch & Commit categories are declared but not yet routed by the
+ * applier — their entry list in [VcsColorPalette] is empty. Adding a category
+ * here without wiring it into the applier is intentionally safe: categories
+ * without a routed key contribute no UIManager / EditorColorsScheme writes
+ * and therefore cannot regress live themes.
  */
 enum class VcsColorCategory {
     DIFF_VIEWER,

--- a/src/main/kotlin/dev/ayuislands/vcs/VcsColorCategory.kt
+++ b/src/main/kotlin/dev/ayuislands/vcs/VcsColorCategory.kt
@@ -1,0 +1,30 @@
+package dev.ayuislands.vcs
+
+/**
+ * The eleven VCS color surfaces driven by Phase 40.2 user-controlled intensity.
+ *
+ * Grouped into four user-task sections — the same grouping that appears in the
+ * `VCS` settings tab:
+ *  - **Diff & File Status** (Wave 2): [DIFF_VIEWER], [PROJECT_VIEW_FILE_STATUS], [EDITOR_GUTTER]
+ *  - **Merge & Conflict** (Wave 3): [CONFLICT_MARKERS], [MERGE_3WAY], [INLINE_DIFF_POPUP]
+ *  - **Blame & History** (Wave 4): [BLAME_GUTTER], [LOCAL_HISTORY]
+ *  - **Branch & Commit** (Wave 5 spike outcome): [BRANCH_INDICATOR], [BRANCHES_POPUP], [COMMIT_HIGHLIGHTS]
+ *
+ * Wave 1 declares the enum only; color-key bindings and write-API routing land
+ * incrementally in waves 2–5. Adding a category here without wiring it into the
+ * applier is intentionally safe — categories without a routed key contribute no
+ * UIManager / EditorColorsScheme writes and therefore cannot regress live themes.
+ */
+enum class VcsColorCategory {
+    DIFF_VIEWER,
+    PROJECT_VIEW_FILE_STATUS,
+    EDITOR_GUTTER,
+    CONFLICT_MARKERS,
+    MERGE_3WAY,
+    INLINE_DIFF_POPUP,
+    BLAME_GUTTER,
+    LOCAL_HISTORY,
+    BRANCH_INDICATOR,
+    BRANCHES_POPUP,
+    COMMIT_HIGHLIGHTS,
+}

--- a/src/main/kotlin/dev/ayuislands/vcs/VcsColorPalette.kt
+++ b/src/main/kotlin/dev/ayuislands/vcs/VcsColorPalette.kt
@@ -4,7 +4,7 @@ import dev.ayuislands.accent.AyuVariant
 import java.awt.Color
 
 /**
- * Phase 40.2 palette — stock 2.6.2 XML hex per (color key × Ayu variant) plus
+ * VCS color palette — stock 2.6.2 XML hex per (color key × Ayu variant) plus
  * the Whisper / Cyberpunk slider-endpoint colors computed via HSB-saturation
  * offset from those stock values.
  *
@@ -23,13 +23,13 @@ import java.awt.Color
  *    [com.intellij.openapi.editor.colors.TextAttributesKey], written via
  *    `scheme.setAttributes` after cloning the existing TextAttributes so
  *    foreground, effect colors, and the error stripe slot stay intact.
- *    Wave 2.5 covers diff-viewer row backgrounds — the biggest visual signal
- *    in the actual diff editor.
+ *    `TEXT_ATTR_BG` writes cover diff-viewer row backgrounds — the biggest
+ *    visual signal in the actual diff editor.
  *
  * The TextAttributes error-stripe slot matches the top-level ColorKey values
  * exactly in stock, so the COLOR_KEY tint already moves the right-margin
  * stripe markers in sync. Adding a dedicated TEXT_ATTR_STRIPE write mode is
- * a Wave 2.6+ amendment if a future change forces them out of sync.
+ * a follow-up amendment if a future change forces them out of sync.
  *
  * The Light variant uses 8-char alpha hex for backgrounds (12-13% overlay
  * over the editor surface). [parseHexColor] handles both 6-char opaque and
@@ -141,10 +141,11 @@ object VcsColorPalette {
                         light = BLUE_LIGHT,
                     ),
                 ),
-            // Wave 3 — Merge & Conflict. Only DIFF_CONFLICT is themable via
-            // EditorColorsScheme; the merge 3-way viewer reuses DIFF_MODIFIED /
-            // INSERTED / DELETED from Wave 2, and the inline diff popup is a
-            // JBPopup UIManager surface that lives outside this palette.
+            // Merge & Conflict — only DIFF_CONFLICT is themable via
+            // EditorColorsScheme; the merge 3-way viewer reuses the diff-viewer
+            // DIFF_MODIFIED / INSERTED / DELETED entries, and the inline diff
+            // popup is a JBPopup UIManager surface that lives outside this
+            // palette.
             VcsColorCategory.CONFLICT_MARKERS to
                 listOf(
                     entry(
@@ -162,9 +163,9 @@ object VcsColorPalette {
                         light = "#E6505020",
                     ),
                 ),
-            // Wave 4 — Blame & History. Only annotate-blame surfaces are
-            // themable; Local History reuses Wave 2 diff colors when it shows
-            // its own diff dialog, so LOCAL_HISTORY stays a no-op placeholder.
+            // Blame & History — only annotate-blame surfaces are themable;
+            // Local History reuses the diff-viewer colors when it shows its
+            // own diff dialog, so LOCAL_HISTORY stays a no-op placeholder.
             //
             // VCS_ANNOTATIONS_COLOR_1..5 form an age-graded ramp (most recent
             // → oldest commit fade). Uniform HSB saturation offset across all
@@ -224,7 +225,11 @@ object VcsColorPalette {
                 ),
         )
 
-    /** Returns every palette entry for [category]; empty list if the category isn't in Wave 2's scope. */
+    /**
+     * Returns every palette entry for [category]; empty list if the category
+     * has no palette entries (e.g. the Branch & Commit categories declared in
+     * [VcsColorCategory] but not yet wired into [PALETTE]).
+     */
     fun entriesFor(category: VcsColorCategory): List<VcsPaletteEntry> = PALETTE[category].orEmpty()
 
     /**
@@ -250,9 +255,10 @@ object VcsColorPalette {
     }
 
     /**
-     * Convenience overload for backward compat with the Wave 2 ColorKey-only test
-     * suite: looks up the first entry matching [keyName] with [VcsWriteMode.COLOR_KEY]
-     * across all categories and returns its stock color for [variant].
+     * Convenience overload for tests that need a single stock color by key
+     * name: looks up the first entry matching [keyName] with
+     * [VcsWriteMode.COLOR_KEY] across all categories and returns its stock
+     * color for [variant].
      */
     fun stock(
         keyName: String,

--- a/src/main/kotlin/dev/ayuislands/vcs/VcsColorPalette.kt
+++ b/src/main/kotlin/dev/ayuislands/vcs/VcsColorPalette.kt
@@ -141,6 +141,27 @@ object VcsColorPalette {
                         light = BLUE_LIGHT,
                     ),
                 ),
+            // Wave 3 — Merge & Conflict. Only DIFF_CONFLICT is themable via
+            // EditorColorsScheme; the merge 3-way viewer reuses DIFF_MODIFIED /
+            // INSERTED / DELETED from Wave 2, and the inline diff popup is a
+            // JBPopup UIManager surface that lives outside this palette.
+            VcsColorCategory.CONFLICT_MARKERS to
+                listOf(
+                    entry(
+                        "DIFF_CONFLICT",
+                        VcsWriteMode.COLOR_KEY,
+                        dark = "#D95757",
+                        mirage = "#FF6666",
+                        light = "#E65050",
+                    ),
+                    entry(
+                        "DIFF_CONFLICT",
+                        VcsWriteMode.TEXT_ATTR_BG,
+                        dark = "#701015",
+                        mirage = "#80202A",
+                        light = "#E6505020",
+                    ),
+                ),
         )
 
     /** Returns every palette entry for [category]; empty list if the category isn't in Wave 2's scope. */

--- a/src/main/kotlin/dev/ayuislands/vcs/VcsColorPalette.kt
+++ b/src/main/kotlin/dev/ayuislands/vcs/VcsColorPalette.kt
@@ -162,6 +162,66 @@ object VcsColorPalette {
                         light = "#E6505020",
                     ),
                 ),
+            // Wave 4 — Blame & History. Only annotate-blame surfaces are
+            // themable; Local History reuses Wave 2 diff colors when it shows
+            // its own diff dialog, so LOCAL_HISTORY stays a no-op placeholder.
+            //
+            // VCS_ANNOTATIONS_COLOR_1..5 form an age-graded ramp (most recent
+            // → oldest commit fade). Uniform HSB saturation offset across all
+            // five preserves the ramp while shifting chroma in lockstep, so
+            // the relative recency cue stays intact at every preset.
+            VcsColorCategory.BLAME_GUTTER to
+                listOf(
+                    entry(
+                        "ANNOTATIONS_COLOR",
+                        VcsWriteMode.COLOR_KEY,
+                        dark = "#4F5A6E",
+                        mirage = "#707A8C",
+                        light = "#828E9F",
+                    ),
+                    entry(
+                        "ANNOTATIONS_LAST_COMMIT_COLOR",
+                        VcsWriteMode.COLOR_KEY,
+                        dark = "#BFBDB6",
+                        mirage = "#CCCAC2",
+                        light = "#5C6166",
+                    ),
+                    entry(
+                        "VCS_ANNOTATIONS_COLOR_1",
+                        VcsWriteMode.COLOR_KEY,
+                        dark = "#1E3550",
+                        mirage = "#344B6B",
+                        light = "#D6E6F5",
+                    ),
+                    entry(
+                        "VCS_ANNOTATIONS_COLOR_2",
+                        VcsWriteMode.COLOR_KEY,
+                        dark = "#182D47",
+                        mirage = "#2D3F5D",
+                        light = "#E0ECFA",
+                    ),
+                    entry(
+                        "VCS_ANNOTATIONS_COLOR_3",
+                        VcsWriteMode.COLOR_KEY,
+                        dark = "#12253D",
+                        mirage = "#273750",
+                        light = "#EAF2FC",
+                    ),
+                    entry(
+                        "VCS_ANNOTATIONS_COLOR_4",
+                        VcsWriteMode.COLOR_KEY,
+                        dark = "#0E1D32",
+                        mirage = "#222D42",
+                        light = "#F2F6FE",
+                    ),
+                    entry(
+                        "VCS_ANNOTATIONS_COLOR_5",
+                        VcsWriteMode.COLOR_KEY,
+                        dark = "#0D1017",
+                        mirage = "#1F2430",
+                        light = "#F8F9FA",
+                    ),
+                ),
         )
 
     /** Returns every palette entry for [category]; empty list if the category isn't in Wave 2's scope. */

--- a/src/main/kotlin/dev/ayuislands/vcs/VcsColorPalette.kt
+++ b/src/main/kotlin/dev/ayuislands/vcs/VcsColorPalette.kt
@@ -4,149 +4,185 @@ import dev.ayuislands.accent.AyuVariant
 import java.awt.Color
 
 /**
- * Phase 40.2 palette — stock 2.6.2 XML hex per (color-key × Ayu variant) plus
+ * Phase 40.2 palette — stock 2.6.2 XML hex per (color key × Ayu variant) plus
  * the Whisper / Cyberpunk slider-endpoint colors computed via HSB-saturation
- * boost from those stock values.
+ * offset from those stock values.
  *
- * The applier consumes [endpoints] to feed [VcsColorBlender.blend], which
- * lerps between Whisper (slider 0, `stock - 10%` saturation) and Cyberpunk
- * (slider 100, `stock + 20%` saturation). Slider position 33 lands on the
- * exact XML stock — that's the Ambient preset's no-op invariant.
+ * The applier consumes [entriesFor] to feed [VcsColorBlender.blend], which
+ * linearly interpolates between Whisper (slider 0, `stock - 10%` saturation)
+ * and Cyberpunk (slider 100, `stock + 20%` saturation). Slider position 33
+ * lands on the exact XML stock — that's the Ambient preset's no-op invariant.
  *
- * The preset slider positions [VcsColorPreset.WHISPER_SLIDER],
- * [VcsColorPreset.AMBIENT_SLIDER], [VcsColorPreset.NEON_SLIDER],
- * [VcsColorPreset.CYBERPUNK_SLIDER] sit at evenly-spaced points along this
- * curve so the visible step from one preset to the next is uniform.
+ * Two write-mode flavours live in the palette:
+ *  - [VcsWriteMode.COLOR_KEY] — top-level
+ *    [com.intellij.openapi.editor.colors.ColorKey] values, written via
+ *    `scheme.setColor`. Covers Project View file-status markers, gutter
+ *    modified-line color, and the top-level diff-modified / inserted /
+ *    deleted entries.
+ *  - [VcsWriteMode.TEXT_ATTR_BG] — the background slot inside a
+ *    [com.intellij.openapi.editor.colors.TextAttributesKey], written via
+ *    `scheme.setAttributes` after cloning the existing TextAttributes so
+ *    foreground, effect colors, and the error stripe slot stay intact.
+ *    Wave 2.5 covers diff-viewer row backgrounds — the biggest visual signal
+ *    in the actual diff editor.
  *
- * Wave 2 ColorKey-only scope (9 entries × 3 variants = 27 stock hex):
- *  - Diff viewer: `DIFF_MODIFIED`, `DIFF_INSERTED`, `DIFF_DELETED`
- *  - Project View: `FILESTATUS_MODIFIED`, `FILESTATUS_ADDED`, `FILESTATUS_DELETED`,
- *    `FILESTATUS_IDEA_FILESTATUS_IGNORED`
- *  - Editor gutter: `MODIFIED_LINES_COLOR`, `IGNORED_MODIFIED_LINES_BORDER_COLOR`
+ * The TextAttributes error-stripe slot matches the top-level ColorKey values
+ * exactly in stock, so the COLOR_KEY tint already moves the right-margin
+ * stripe markers in sync. Adding a dedicated TEXT_ATTR_STRIPE write mode is
+ * a Wave 2.6+ amendment if a future change forces them out of sync.
  *
- * TextAttributesKey-backed surfaces (diff viewer row backgrounds, error stripes)
- * land in Wave 2.x amendment once the ColorKey path is validated in `runIde`.
+ * The Light variant uses 8-char alpha hex for backgrounds (12-13% overlay
+ * over the editor surface). [parseHexColor] handles both 6-char opaque and
+ * 8-char alpha hex so the blender preserves translucency.
  */
 object VcsColorPalette {
-    /**
-     * Saturation delta applied at slider 0 (Whisper endpoint). Negative values
-     * desaturate the stock color, producing a softer, more pastel reading.
-     */
     private const val WHISPER_SATURATION_DELTA: Float = -0.10f
-
-    /**
-     * Saturation delta applied at slider 100 (Cyberpunk endpoint). Positive
-     * values push chroma toward the perceptual ceiling, producing the
-     * pre-2.6.2 punch at the Neon midpoint and an even-more-saturated peak
-     * at Cyberpunk.
-     */
     private const val CYBERPUNK_SATURATION_DELTA: Float = 0.20f
 
-    /**
-     * Per-(variant × color-key) stock hex from the 2.6.2 XML schemes. Mirrors
-     * the values [dev.ayuislands.theme.VcsDiffSchemeColorsTest] pins against
-     * the on-disk XML so palette drift fails the regression test rather than
-     * silently writing wrong colors at runtime.
-     *
-     * Light variant inherits 2.6.2 stock unchanged — Light didn't undergo the
-     * cyan-to-blue mute that Dark and Mirage did in PR #167, so its stock is
-     * already at the post-mute baseline.
-     *
-     * Hex strings (not [Color] constructor calls) keep the source byte-comparable
-     * to the on-disk XML — copy/paste from a `git diff` of the theme files lands
-     * directly here, and Color.decode handles parsing.
-     */
-    private val STOCK_HEX: Map<Pair<AyuVariant, String>, String> =
-        mapOf(
-            // Diff viewer — top-level ColorKey values
-            (AyuVariant.DARK to "DIFF_MODIFIED") to "#73B8FF",
-            (AyuVariant.MIRAGE to "DIFF_MODIFIED") to "#80BFFF",
-            (AyuVariant.LIGHT to "DIFF_MODIFIED") to "#478ACC",
-            (AyuVariant.DARK to "DIFF_INSERTED") to "#70BF56",
-            (AyuVariant.MIRAGE to "DIFF_INSERTED") to "#87D96C",
-            (AyuVariant.LIGHT to "DIFF_INSERTED") to "#6CBF43",
-            (AyuVariant.DARK to "DIFF_DELETED") to "#F26D78",
-            (AyuVariant.MIRAGE to "DIFF_DELETED") to "#F27983",
-            (AyuVariant.LIGHT to "DIFF_DELETED") to "#FF7383",
-            // Project View file status
-            (AyuVariant.DARK to "FILESTATUS_MODIFIED") to "#73B8FF",
-            (AyuVariant.MIRAGE to "FILESTATUS_MODIFIED") to "#80BFFF",
-            (AyuVariant.LIGHT to "FILESTATUS_MODIFIED") to "#478ACC",
-            (AyuVariant.DARK to "FILESTATUS_ADDED") to "#AAD94C",
-            (AyuVariant.MIRAGE to "FILESTATUS_ADDED") to "#C3E887",
-            (AyuVariant.LIGHT to "FILESTATUS_ADDED") to "#86B300",
-            (AyuVariant.DARK to "FILESTATUS_DELETED") to "#F07178",
-            (AyuVariant.MIRAGE to "FILESTATUS_DELETED") to "#F77669",
-            (AyuVariant.LIGHT to "FILESTATUS_DELETED") to "#F07171",
-            (AyuVariant.DARK to "FILESTATUS_IDEA_FILESTATUS_IGNORED") to "#9B7700",
-            (AyuVariant.MIRAGE to "FILESTATUS_IDEA_FILESTATUS_IGNORED") to "#B58900",
-            (AyuVariant.LIGHT to "FILESTATUS_IDEA_FILESTATUS_IGNORED") to "#9EA3A9",
-            // Editor gutter
-            (AyuVariant.DARK to "MODIFIED_LINES_COLOR") to "#73B8FF",
-            (AyuVariant.MIRAGE to "MODIFIED_LINES_COLOR") to "#80BFFF",
-            (AyuVariant.LIGHT to "MODIFIED_LINES_COLOR") to "#478ACC",
-            (AyuVariant.DARK to "IGNORED_MODIFIED_LINES_BORDER_COLOR") to "#73B8FF",
-            (AyuVariant.MIRAGE to "IGNORED_MODIFIED_LINES_BORDER_COLOR") to "#80BFFF",
-            (AyuVariant.LIGHT to "IGNORED_MODIFIED_LINES_BORDER_COLOR") to "#478ACC",
-        )
+    // Shared Ayu blue ramp across modified-state surfaces — diff viewer,
+    // file status, and gutter all converge on the same blue per variant in
+    // stock 2.6.2 XML, so extracting the hex once keeps the table audit-able.
+    private const val BLUE_DARK: String = "#73B8FF"
+    private const val BLUE_MIRAGE: String = "#80BFFF"
+    private const val BLUE_LIGHT: String = "#478ACC"
 
-    /**
-     * Per-category list of ColorKey names to write. The applier iterates this
-     * map to drive per-category slider effects: moving the Diff viewer slider
-     * tints all three diff-related keys with the same intensity.
-     */
-    val KEYS_BY_CATEGORY: Map<VcsColorCategory, List<String>> =
+    private val PALETTE: Map<VcsColorCategory, List<VcsPaletteEntry>> =
         mapOf(
             VcsColorCategory.DIFF_VIEWER to
-                listOf("DIFF_MODIFIED", "DIFF_INSERTED", "DIFF_DELETED"),
+                listOf(
+                    entry(
+                        "DIFF_MODIFIED",
+                        VcsWriteMode.COLOR_KEY,
+                        dark = BLUE_DARK,
+                        mirage = BLUE_MIRAGE,
+                        light = BLUE_LIGHT,
+                    ),
+                    entry(
+                        "DIFF_INSERTED",
+                        VcsWriteMode.COLOR_KEY,
+                        dark = "#70BF56",
+                        mirage = "#87D96C",
+                        light = "#6CBF43",
+                    ),
+                    entry(
+                        "DIFF_DELETED",
+                        VcsWriteMode.COLOR_KEY,
+                        dark = "#F26D78",
+                        mirage = "#F27983",
+                        light = "#FF7383",
+                    ),
+                    entry(
+                        "DIFF_MODIFIED",
+                        VcsWriteMode.TEXT_ATTR_BG,
+                        dark = "#2E4560",
+                        mirage = "#405672",
+                        light = "#478ACC1F",
+                    ),
+                    entry(
+                        "DIFF_INSERTED",
+                        VcsWriteMode.TEXT_ATTR_BG,
+                        dark = "#2D482B",
+                        mirage = "#405E43",
+                        light = "#6CBF4320",
+                    ),
+                    entry(
+                        "DIFF_DELETED",
+                        VcsWriteMode.TEXT_ATTR_BG,
+                        dark = "#562E36",
+                        mirage = "#623F4B",
+                        light = "#FF738314",
+                    ),
+                ),
             VcsColorCategory.PROJECT_VIEW_FILE_STATUS to
                 listOf(
-                    "FILESTATUS_MODIFIED",
-                    "FILESTATUS_ADDED",
-                    "FILESTATUS_DELETED",
-                    "FILESTATUS_IDEA_FILESTATUS_IGNORED",
+                    entry(
+                        "FILESTATUS_MODIFIED",
+                        VcsWriteMode.COLOR_KEY,
+                        dark = BLUE_DARK,
+                        mirage = BLUE_MIRAGE,
+                        light = BLUE_LIGHT,
+                    ),
+                    entry(
+                        "FILESTATUS_ADDED",
+                        VcsWriteMode.COLOR_KEY,
+                        dark = "#AAD94C",
+                        mirage = "#C3E887",
+                        light = "#86B300",
+                    ),
+                    entry(
+                        "FILESTATUS_DELETED",
+                        VcsWriteMode.COLOR_KEY,
+                        dark = "#F07178",
+                        mirage = "#F77669",
+                        light = "#F07171",
+                    ),
+                    entry(
+                        "FILESTATUS_IDEA_FILESTATUS_IGNORED",
+                        VcsWriteMode.COLOR_KEY,
+                        dark = "#9B7700",
+                        mirage = "#B58900",
+                        light = "#9EA3A9",
+                    ),
                 ),
             VcsColorCategory.EDITOR_GUTTER to
-                listOf("MODIFIED_LINES_COLOR", "IGNORED_MODIFIED_LINES_BORDER_COLOR"),
+                listOf(
+                    entry(
+                        "MODIFIED_LINES_COLOR",
+                        VcsWriteMode.COLOR_KEY,
+                        dark = BLUE_DARK,
+                        mirage = BLUE_MIRAGE,
+                        light = BLUE_LIGHT,
+                    ),
+                    entry(
+                        "IGNORED_MODIFIED_LINES_BORDER_COLOR",
+                        VcsWriteMode.COLOR_KEY,
+                        dark = BLUE_DARK,
+                        mirage = BLUE_MIRAGE,
+                        light = BLUE_LIGHT,
+                    ),
+                ),
         )
 
-    /**
-     * Returns the stock (= 2.6.2 XML) color for [keyName] under [variant].
-     * Throws if the pair isn't in the palette — that's a coding bug at
-     * applier-call time, not a runtime defensive case.
-     */
-    fun stock(
-        keyName: String,
-        variant: AyuVariant,
-    ): Color {
-        val hex =
-            STOCK_HEX[variant to keyName]
-                ?: error("VcsColorPalette: no stock color for $keyName / $variant")
-        return Color.decode(hex)
-    }
+    /** Returns every palette entry for [category]; empty list if the category isn't in Wave 2's scope. */
+    fun entriesFor(category: VcsColorCategory): List<VcsPaletteEntry> = PALETTE[category].orEmpty()
 
     /**
-     * Returns the (base, target) blend endpoints for [keyName] under [variant].
+     * Returns the full category-to-entries map. Tests use this to walk every
+     * (variant × entry) combination without re-hardcoding the category list.
+     */
+    fun allCategoriesAndEntries(): Map<VcsColorCategory, List<VcsPaletteEntry>> = PALETTE
+
+    /**
+     * Returns the (base, target) blend endpoints for [entry] under [variant].
      * Base sits at slider 0 (Whisper, `-10%` saturation); target sits at slider 100
      * (Cyberpunk, `+20%` saturation). The applier passes both to
      * [VcsColorBlender.blend] along with the active slider position.
      */
     fun endpoints(
-        keyName: String,
+        entry: VcsPaletteEntry,
         variant: AyuVariant,
     ): Pair<Color, Color> {
-        val stockColor = stock(keyName, variant)
+        val stockColor = entry.stockFor(variant)
         val base = withSaturationDelta(stockColor, WHISPER_SATURATION_DELTA)
         val target = withSaturationDelta(stockColor, CYBERPUNK_SATURATION_DELTA)
         return base to target
     }
 
     /**
-     * Returns the set of every (variant, keyName) pair the palette knows about.
-     * Tests pin this against [KEYS_BY_CATEGORY] to catch silent additions to
-     * one map without the matching addition to the other.
+     * Convenience overload for backward compat with the Wave 2 ColorKey-only test
+     * suite: looks up the first entry matching [keyName] with [VcsWriteMode.COLOR_KEY]
+     * across all categories and returns its stock color for [variant].
      */
-    fun knownPairs(): Set<Pair<AyuVariant, String>> = STOCK_HEX.keys
+    fun stock(
+        keyName: String,
+        variant: AyuVariant,
+    ): Color {
+        val entry =
+            PALETTE.values.asSequence().flatten().firstOrNull {
+                it.keyName == keyName && it.mode == VcsWriteMode.COLOR_KEY
+            } ?: error("VcsColorPalette: no COLOR_KEY entry for $keyName")
+        return entry.stockFor(variant)
+    }
 
     private fun withSaturationDelta(
         color: Color,
@@ -154,6 +190,100 @@ object VcsColorPalette {
     ): Color {
         val hsb = Color.RGBtoHSB(color.red, color.green, color.blue, null)
         val adjusted = (hsb[1] + delta).coerceIn(0f, 1f)
-        return Color.getHSBColor(hsb[0], adjusted, hsb[2])
+        val tinted = Color.getHSBColor(hsb[0], adjusted, hsb[2])
+        // Preserve the original alpha — Color.getHSBColor always returns alpha=255,
+        // so a translucent stock (Light DIFF_MODIFIED #478ACC1F) would lose its
+        // alpha here without this re-wrap. Critical for the Light variant
+        // TEXT_ATTR_BG entries that ship as 12-13% overlays.
+        return Color(tinted.red, tinted.green, tinted.blue, color.alpha)
     }
+
+    private fun entry(
+        keyName: String,
+        mode: VcsWriteMode,
+        dark: String,
+        mirage: String,
+        light: String,
+    ): VcsPaletteEntry =
+        VcsPaletteEntry(
+            keyName = keyName,
+            mode = mode,
+            stockDark = parseHexColor(dark),
+            stockMirage = parseHexColor(mirage),
+            stockLight = parseHexColor(light),
+        )
+
+    /**
+     * Parses a `#RRGGBB` or `#RRGGBBAA` hex string into a [Color]. Java's
+     * [Color.decode] silently truncates 8-char hex to 24-bit RGB, losing the
+     * alpha channel — Light-variant translucent backgrounds require explicit
+     * 8-char handling so the alpha bits survive the parse.
+     */
+    private fun parseHexColor(hex: String): Color {
+        val clean = hex.removePrefix("#")
+        require(clean.length == HEX_LEN_OPAQUE || clean.length == HEX_LEN_ALPHA) {
+            "VcsColorPalette: invalid hex length ${clean.length} for '$hex'"
+        }
+        val red = clean.substring(RED_HEX_START, GREEN_HEX_START).toInt(HEX_RADIX)
+        val green = clean.substring(GREEN_HEX_START, BLUE_HEX_START).toInt(HEX_RADIX)
+        val blue = clean.substring(BLUE_HEX_START, ALPHA_HEX_START).toInt(HEX_RADIX)
+        val alpha =
+            if (clean.length == HEX_LEN_ALPHA) {
+                clean.substring(ALPHA_HEX_START, HEX_LEN_ALPHA).toInt(HEX_RADIX)
+            } else {
+                ALPHA_OPAQUE
+            }
+        return Color(red, green, blue, alpha)
+    }
+
+    private const val HEX_LEN_OPAQUE: Int = 6
+    private const val HEX_LEN_ALPHA: Int = 8
+    private const val HEX_RADIX: Int = 16
+    private const val ALPHA_OPAQUE: Int = 0xFF
+    private const val RED_HEX_START: Int = 0
+    private const val GREEN_HEX_START: Int = 2
+    private const val BLUE_HEX_START: Int = 4
+    private const val ALPHA_HEX_START: Int = 6
+}
+
+/**
+ * How a [VcsPaletteEntry] is committed to the live
+ * [com.intellij.openapi.editor.colors.EditorColorsScheme].
+ */
+internal enum class VcsWriteMode {
+    /** Top-level ColorKey via `scheme.setColor(ColorKey.find(name), color)`. */
+    COLOR_KEY,
+
+    /**
+     * BACKGROUND slot of a TextAttributesKey — read existing attributes, clone
+     * with new background, preserve the other slots (foreground, effect, error
+     * stripe, font type), write back via `scheme.setAttributes`.
+     */
+    TEXT_ATTR_BG,
+}
+
+/**
+ * One palette entry — a single color key write target plus its 2.6.2 XML stock
+ * value per Ayu variant. The applier reads [stockFor] to derive Whisper/Cyberpunk
+ * endpoints via HSB saturation offset, then blends between them at the active
+ * slider position.
+ *
+ * Plain class (not `data class`) so the internal constructor is genuinely
+ * encapsulated — a `data class` here would expose the internal constructor
+ * through the generated `copy()` method and let external callers fabricate
+ * palette entries the applier was never designed to consume.
+ */
+class VcsPaletteEntry internal constructor(
+    val keyName: String,
+    internal val mode: VcsWriteMode,
+    private val stockDark: Color,
+    private val stockMirage: Color,
+    private val stockLight: Color,
+) {
+    fun stockFor(variant: AyuVariant): Color =
+        when (variant) {
+            AyuVariant.DARK -> stockDark
+            AyuVariant.MIRAGE -> stockMirage
+            AyuVariant.LIGHT -> stockLight
+        }
 }

--- a/src/main/kotlin/dev/ayuislands/vcs/VcsColorPalette.kt
+++ b/src/main/kotlin/dev/ayuislands/vcs/VcsColorPalette.kt
@@ -1,0 +1,159 @@
+package dev.ayuislands.vcs
+
+import dev.ayuislands.accent.AyuVariant
+import java.awt.Color
+
+/**
+ * Phase 40.2 palette — stock 2.6.2 XML hex per (color-key × Ayu variant) plus
+ * the Whisper / Cyberpunk slider-endpoint colors computed via HSB-saturation
+ * boost from those stock values.
+ *
+ * The applier consumes [endpoints] to feed [VcsColorBlender.blend], which
+ * lerps between Whisper (slider 0, `stock - 10%` saturation) and Cyberpunk
+ * (slider 100, `stock + 20%` saturation). Slider position 33 lands on the
+ * exact XML stock — that's the Ambient preset's no-op invariant.
+ *
+ * The preset slider positions [VcsColorPreset.WHISPER_SLIDER],
+ * [VcsColorPreset.AMBIENT_SLIDER], [VcsColorPreset.NEON_SLIDER],
+ * [VcsColorPreset.CYBERPUNK_SLIDER] sit at evenly-spaced points along this
+ * curve so the visible step from one preset to the next is uniform.
+ *
+ * Wave 2 ColorKey-only scope (9 entries × 3 variants = 27 stock hex):
+ *  - Diff viewer: `DIFF_MODIFIED`, `DIFF_INSERTED`, `DIFF_DELETED`
+ *  - Project View: `FILESTATUS_MODIFIED`, `FILESTATUS_ADDED`, `FILESTATUS_DELETED`,
+ *    `FILESTATUS_IDEA_FILESTATUS_IGNORED`
+ *  - Editor gutter: `MODIFIED_LINES_COLOR`, `IGNORED_MODIFIED_LINES_BORDER_COLOR`
+ *
+ * TextAttributesKey-backed surfaces (diff viewer row backgrounds, error stripes)
+ * land in Wave 2.x amendment once the ColorKey path is validated in `runIde`.
+ */
+object VcsColorPalette {
+    /**
+     * Saturation delta applied at slider 0 (Whisper endpoint). Negative values
+     * desaturate the stock color, producing a softer, more pastel reading.
+     */
+    private const val WHISPER_SATURATION_DELTA: Float = -0.10f
+
+    /**
+     * Saturation delta applied at slider 100 (Cyberpunk endpoint). Positive
+     * values push chroma toward the perceptual ceiling, producing the
+     * pre-2.6.2 punch at the Neon midpoint and an even-more-saturated peak
+     * at Cyberpunk.
+     */
+    private const val CYBERPUNK_SATURATION_DELTA: Float = 0.20f
+
+    /**
+     * Per-(variant × color-key) stock hex from the 2.6.2 XML schemes. Mirrors
+     * the values [dev.ayuislands.theme.VcsDiffSchemeColorsTest] pins against
+     * the on-disk XML so palette drift fails the regression test rather than
+     * silently writing wrong colors at runtime.
+     *
+     * Light variant inherits 2.6.2 stock unchanged — Light didn't undergo the
+     * cyan-to-blue mute that Dark and Mirage did in PR #167, so its stock is
+     * already at the post-mute baseline.
+     *
+     * Hex strings (not [Color] constructor calls) keep the source byte-comparable
+     * to the on-disk XML — copy/paste from a `git diff` of the theme files lands
+     * directly here, and Color.decode handles parsing.
+     */
+    private val STOCK_HEX: Map<Pair<AyuVariant, String>, String> =
+        mapOf(
+            // Diff viewer — top-level ColorKey values
+            (AyuVariant.DARK to "DIFF_MODIFIED") to "#73B8FF",
+            (AyuVariant.MIRAGE to "DIFF_MODIFIED") to "#80BFFF",
+            (AyuVariant.LIGHT to "DIFF_MODIFIED") to "#478ACC",
+            (AyuVariant.DARK to "DIFF_INSERTED") to "#70BF56",
+            (AyuVariant.MIRAGE to "DIFF_INSERTED") to "#87D96C",
+            (AyuVariant.LIGHT to "DIFF_INSERTED") to "#6CBF43",
+            (AyuVariant.DARK to "DIFF_DELETED") to "#F26D78",
+            (AyuVariant.MIRAGE to "DIFF_DELETED") to "#F27983",
+            (AyuVariant.LIGHT to "DIFF_DELETED") to "#FF7383",
+            // Project View file status
+            (AyuVariant.DARK to "FILESTATUS_MODIFIED") to "#73B8FF",
+            (AyuVariant.MIRAGE to "FILESTATUS_MODIFIED") to "#80BFFF",
+            (AyuVariant.LIGHT to "FILESTATUS_MODIFIED") to "#478ACC",
+            (AyuVariant.DARK to "FILESTATUS_ADDED") to "#AAD94C",
+            (AyuVariant.MIRAGE to "FILESTATUS_ADDED") to "#C3E887",
+            (AyuVariant.LIGHT to "FILESTATUS_ADDED") to "#86B300",
+            (AyuVariant.DARK to "FILESTATUS_DELETED") to "#F07178",
+            (AyuVariant.MIRAGE to "FILESTATUS_DELETED") to "#F77669",
+            (AyuVariant.LIGHT to "FILESTATUS_DELETED") to "#F07171",
+            (AyuVariant.DARK to "FILESTATUS_IDEA_FILESTATUS_IGNORED") to "#9B7700",
+            (AyuVariant.MIRAGE to "FILESTATUS_IDEA_FILESTATUS_IGNORED") to "#B58900",
+            (AyuVariant.LIGHT to "FILESTATUS_IDEA_FILESTATUS_IGNORED") to "#9EA3A9",
+            // Editor gutter
+            (AyuVariant.DARK to "MODIFIED_LINES_COLOR") to "#73B8FF",
+            (AyuVariant.MIRAGE to "MODIFIED_LINES_COLOR") to "#80BFFF",
+            (AyuVariant.LIGHT to "MODIFIED_LINES_COLOR") to "#478ACC",
+            (AyuVariant.DARK to "IGNORED_MODIFIED_LINES_BORDER_COLOR") to "#73B8FF",
+            (AyuVariant.MIRAGE to "IGNORED_MODIFIED_LINES_BORDER_COLOR") to "#80BFFF",
+            (AyuVariant.LIGHT to "IGNORED_MODIFIED_LINES_BORDER_COLOR") to "#478ACC",
+        )
+
+    /**
+     * Per-category list of ColorKey names to write. The applier iterates this
+     * map to drive per-category slider effects: moving the Diff viewer slider
+     * tints all three diff-related keys with the same intensity.
+     */
+    val KEYS_BY_CATEGORY: Map<VcsColorCategory, List<String>> =
+        mapOf(
+            VcsColorCategory.DIFF_VIEWER to
+                listOf("DIFF_MODIFIED", "DIFF_INSERTED", "DIFF_DELETED"),
+            VcsColorCategory.PROJECT_VIEW_FILE_STATUS to
+                listOf(
+                    "FILESTATUS_MODIFIED",
+                    "FILESTATUS_ADDED",
+                    "FILESTATUS_DELETED",
+                    "FILESTATUS_IDEA_FILESTATUS_IGNORED",
+                ),
+            VcsColorCategory.EDITOR_GUTTER to
+                listOf("MODIFIED_LINES_COLOR", "IGNORED_MODIFIED_LINES_BORDER_COLOR"),
+        )
+
+    /**
+     * Returns the stock (= 2.6.2 XML) color for [keyName] under [variant].
+     * Throws if the pair isn't in the palette — that's a coding bug at
+     * applier-call time, not a runtime defensive case.
+     */
+    fun stock(
+        keyName: String,
+        variant: AyuVariant,
+    ): Color {
+        val hex =
+            STOCK_HEX[variant to keyName]
+                ?: error("VcsColorPalette: no stock color for $keyName / $variant")
+        return Color.decode(hex)
+    }
+
+    /**
+     * Returns the (base, target) blend endpoints for [keyName] under [variant].
+     * Base sits at slider 0 (Whisper, `-10%` saturation); target sits at slider 100
+     * (Cyberpunk, `+20%` saturation). The applier passes both to
+     * [VcsColorBlender.blend] along with the active slider position.
+     */
+    fun endpoints(
+        keyName: String,
+        variant: AyuVariant,
+    ): Pair<Color, Color> {
+        val stockColor = stock(keyName, variant)
+        val base = withSaturationDelta(stockColor, WHISPER_SATURATION_DELTA)
+        val target = withSaturationDelta(stockColor, CYBERPUNK_SATURATION_DELTA)
+        return base to target
+    }
+
+    /**
+     * Returns the set of every (variant, keyName) pair the palette knows about.
+     * Tests pin this against [KEYS_BY_CATEGORY] to catch silent additions to
+     * one map without the matching addition to the other.
+     */
+    fun knownPairs(): Set<Pair<AyuVariant, String>> = STOCK_HEX.keys
+
+    private fun withSaturationDelta(
+        color: Color,
+        delta: Float,
+    ): Color {
+        val hsb = Color.RGBtoHSB(color.red, color.green, color.blue, null)
+        val adjusted = (hsb[1] + delta).coerceIn(0f, 1f)
+        return Color.getHSBColor(hsb[0], adjusted, hsb[2])
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/vcs/VcsColorPreset.kt
+++ b/src/main/kotlin/dev/ayuislands/vcs/VcsColorPreset.kt
@@ -1,79 +1,89 @@
 package dev.ayuislands.vcs
 
 /**
- * Preset levels for VCS color intensity.
+ * Named intensity levels for VCS color customization.
  *
- * Each preset maps every [VcsColorCategory] to a percent in `[0, 100]` that the
- * applier feeds into [VcsColorBlender.blend] as the linear-interpolation ratio
- * between the stock 2.6.2 XML color (baseline) and the per-category vibrant
- * target.
+ * Mirrors the Font tab's preset-then-custom UX: instead of a generic
+ * "intensity %" knob, users pick a recognizable named profile, and only
+ * unlock per-category sliders via [CUSTOM] when they want to fine-tune.
+ * The four named presets sit at evenly-spaced slider positions so the
+ * step from one preset to the next is identical (33 slider units ≈
+ * 10% HSB saturation delta).
  *
- *  - [MUTED] — 0% across all categories. Default for upgraders from 2.6.2.
- *    Byte-identical to stock XML colors; no live theme change when the master
- *    toggle is off.
- *  - [BALANCED] — midpoint between Muted and Vibrant. Reasonable opening
- *    balance for users who want some life back without going to peak.
- *  - [VIBRANT] — 100% across all categories. Restores pre-2.6.2 cyan diff colors
- *    plus proportional boosts on the other ten surfaces.
- *  - [CUSTOM] — unlocks the per-category sliders in the settings panel; the
- *    snapshot's per-category map is consulted directly instead of the preset
- *    lookup table.
+ *  - [WHISPER]   → slider 0   — `-10%` saturation from 2.6.2 stock
+ *  - [AMBIENT]   → slider 33  — equals 2.6.2 XML stock (default for upgraders)
+ *  - [NEON]      → slider 67  — `+10%` saturation, restores pre-2.6.2 cyan punch
+ *  - [CYBERPUNK] → slider 100 — `+20%` saturation, peak vibrancy
+ *  - [CUSTOM]    → unlocks per-category sliders in the panel; the snapshot's
+ *    per-category map is consulted directly instead of the preset table
  *
- * Per-preset values are hand-tuned (not algorithmic): the vibrant targets per
- * category are defined separately in the applier, while the preset just declares
- * *how much* of that target to mix at this preset level.
+ * Per-preset slider positions are hand-tuned (not algorithmic). The actual
+ * HSB-saturation curve is implemented by [VcsColorPalette] — the preset
+ * declares *how far along the curve* this profile sits, while the palette
+ * declares *what the endpoints are* per (key × variant).
  */
 enum class VcsColorPreset {
-    MUTED,
-    BALANCED,
-    VIBRANT,
+    WHISPER,
+    AMBIENT,
+    NEON,
+    CYBERPUNK,
     CUSTOM,
     ;
 
     /**
-     * Returns the intensity percent this preset assigns to [category].
+     * Returns the slider position this preset assigns to [category].
      *
-     * For [CUSTOM], the call resolves to the same value as [BALANCED] as a
-     * sentinel — callers should branch on the preset and read the per-category
-     * map directly from the snapshot rather than invoke this method for
-     * [CUSTOM]. The fallback value protects against accidental fall-through
-     * when a future code path queries this method without checking the preset
-     * type first.
+     * For [CUSTOM], the call returns [AMBIENT_SLIDER] as a sentinel — callers
+     * should branch on the preset and read the per-category map directly from
+     * the snapshot rather than invoke this method for [CUSTOM]. The fallback
+     * value protects against accidental fall-through when a future code path
+     * queries this method without checking the preset type first.
      */
     fun intensityFor(category: VcsColorCategory): Int =
         when (this) {
-            MUTED -> MUTED_INTENSITIES.getValue(category)
-            BALANCED -> BALANCED_INTENSITIES.getValue(category)
-            VIBRANT -> VIBRANT_INTENSITIES.getValue(category)
-            CUSTOM -> BALANCED_INTENSITIES.getValue(category)
+            WHISPER -> WHISPER_INTENSITIES.getValue(category)
+            AMBIENT -> AMBIENT_INTENSITIES.getValue(category)
+            NEON -> NEON_INTENSITIES.getValue(category)
+            CYBERPUNK -> CYBERPUNK_INTENSITIES.getValue(category)
+            CUSTOM -> AMBIENT_INTENSITIES.getValue(category)
         }
 
     companion object {
+        /** Slider position for the [WHISPER] preset — `-10%` saturation endpoint. */
+        const val WHISPER_SLIDER: Int = 0
+
+        /** Slider position for the [AMBIENT] preset — `0%` (2.6.2 stock baseline). */
+        const val AMBIENT_SLIDER: Int = 33
+
+        /** Slider position for the [NEON] preset — `+10%` saturation. */
+        const val NEON_SLIDER: Int = 67
+
+        /** Slider position for the [CYBERPUNK] preset — `+20%` saturation. */
+        const val CYBERPUNK_SLIDER: Int = 100
+
         /**
          * Resolves a persisted preset string into the matching enum value,
-         * defaulting to [MUTED] when the string is `null`, empty, unknown, or
-         * corrupted (hand-edited XML, schema migration artifact).
+         * defaulting to [AMBIENT] when the string is `null`, empty, unknown, or
+         * corrupted (hand-edited XML, schema migration artifact). Ambient is
+         * the no-op default — falling back to it keeps a corrupted persisted
+         * value from accidentally tinting surfaces a user never opted into.
          */
-        fun byName(name: String?): VcsColorPreset = entries.firstOrNull { it.name == name } ?: MUTED
+        fun byName(name: String?): VcsColorPreset = entries.firstOrNull { it.name == name } ?: AMBIENT
 
-        /** Stock XML baseline — every category at 0%. */
-        private val MUTED_INTENSITIES: Map<VcsColorCategory, Int> =
-            VcsColorCategory.entries.associateWith { 0 }
+        /** Whisper — slider 0 across all categories. */
+        private val WHISPER_INTENSITIES: Map<VcsColorCategory, Int> =
+            VcsColorCategory.entries.associateWith { WHISPER_SLIDER }
 
-        /**
-         * Midpoint preset — 50% across all categories. Hand-tuned to be the
-         * "I want some life back, but not eye-bleeding" default that a Pro user
-         * would land on when they first open the panel.
-         */
-        private val BALANCED_INTENSITIES: Map<VcsColorCategory, Int> =
-            VcsColorCategory.entries.associateWith { 50 }
+        /** Ambient — slider 33 across all categories (= 2.6.2 XML stock). */
+        private val AMBIENT_INTENSITIES: Map<VcsColorCategory, Int> =
+            VcsColorCategory.entries.associateWith { AMBIENT_SLIDER }
 
-        /**
-         * Peak preset — 100% across all categories. Restores pre-2.6.2 cyan diff
-         * brightness and proportionally boosts the other surfaces toward their
-         * vibrant targets.
-         */
-        private val VIBRANT_INTENSITIES: Map<VcsColorCategory, Int> =
-            VcsColorCategory.entries.associateWith { 100 }
+        /** Neon — slider 67 across all categories (`+10%` saturation). */
+        private val NEON_INTENSITIES: Map<VcsColorCategory, Int> =
+            VcsColorCategory.entries.associateWith { NEON_SLIDER }
+
+        /** Cyberpunk — slider 100 across all categories (`+20%` saturation). */
+        private val CYBERPUNK_INTENSITIES: Map<VcsColorCategory, Int> =
+            VcsColorCategory.entries.associateWith { CYBERPUNK_SLIDER }
     }
 }

--- a/src/main/kotlin/dev/ayuislands/vcs/VcsColorPreset.kt
+++ b/src/main/kotlin/dev/ayuislands/vcs/VcsColorPreset.kt
@@ -1,0 +1,79 @@
+package dev.ayuislands.vcs
+
+/**
+ * Preset levels for VCS color intensity.
+ *
+ * Each preset maps every [VcsColorCategory] to a percent in `[0, 100]` that the
+ * applier feeds into [VcsColorBlender.blend] as the linear-interpolation ratio
+ * between the stock 2.6.2 XML color (baseline) and the per-category vibrant
+ * target.
+ *
+ *  - [MUTED] — 0% across all categories. Default for upgraders from 2.6.2.
+ *    Byte-identical to stock XML colors; no live theme change when the master
+ *    toggle is off.
+ *  - [BALANCED] — midpoint between Muted and Vibrant. Reasonable opening
+ *    balance for users who want some life back without going to peak.
+ *  - [VIBRANT] — 100% across all categories. Restores pre-2.6.2 cyan diff colors
+ *    plus proportional boosts on the other ten surfaces.
+ *  - [CUSTOM] — unlocks the per-category sliders in the settings panel; the
+ *    snapshot's per-category map is consulted directly instead of the preset
+ *    lookup table.
+ *
+ * Per-preset values are hand-tuned (not algorithmic): the vibrant targets per
+ * category are defined separately in the applier, while the preset just declares
+ * *how much* of that target to mix at this preset level.
+ */
+enum class VcsColorPreset {
+    MUTED,
+    BALANCED,
+    VIBRANT,
+    CUSTOM,
+    ;
+
+    /**
+     * Returns the intensity percent this preset assigns to [category].
+     *
+     * For [CUSTOM], the call resolves to the same value as [BALANCED] as a
+     * sentinel — callers should branch on the preset and read the per-category
+     * map directly from the snapshot rather than invoke this method for
+     * [CUSTOM]. The fallback value protects against accidental fall-through
+     * when a future code path queries this method without checking the preset
+     * type first.
+     */
+    fun intensityFor(category: VcsColorCategory): Int =
+        when (this) {
+            MUTED -> MUTED_INTENSITIES.getValue(category)
+            BALANCED -> BALANCED_INTENSITIES.getValue(category)
+            VIBRANT -> VIBRANT_INTENSITIES.getValue(category)
+            CUSTOM -> BALANCED_INTENSITIES.getValue(category)
+        }
+
+    companion object {
+        /**
+         * Resolves a persisted preset string into the matching enum value,
+         * defaulting to [MUTED] when the string is `null`, empty, unknown, or
+         * corrupted (hand-edited XML, schema migration artifact).
+         */
+        fun byName(name: String?): VcsColorPreset = entries.firstOrNull { it.name == name } ?: MUTED
+
+        /** Stock XML baseline — every category at 0%. */
+        private val MUTED_INTENSITIES: Map<VcsColorCategory, Int> =
+            VcsColorCategory.entries.associateWith { 0 }
+
+        /**
+         * Midpoint preset — 50% across all categories. Hand-tuned to be the
+         * "I want some life back, but not eye-bleeding" default that a Pro user
+         * would land on when they first open the panel.
+         */
+        private val BALANCED_INTENSITIES: Map<VcsColorCategory, Int> =
+            VcsColorCategory.entries.associateWith { 50 }
+
+        /**
+         * Peak preset — 100% across all categories. Restores pre-2.6.2 cyan diff
+         * brightness and proportionally boosts the other surfaces toward their
+         * vibrant targets.
+         */
+        private val VIBRANT_INTENSITIES: Map<VcsColorCategory, Int> =
+            VcsColorCategory.entries.associateWith { 100 }
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/vcs/VcsColorPreset.kt
+++ b/src/main/kotlin/dev/ayuislands/vcs/VcsColorPreset.kt
@@ -22,12 +22,14 @@ package dev.ayuislands.vcs
  * declares *how far along the curve* this profile sits, while the palette
  * declares *what the endpoints are* per (key × variant).
  */
-enum class VcsColorPreset {
-    WHISPER,
-    AMBIENT,
-    NEON,
-    CYBERPUNK,
-    CUSTOM,
+enum class VcsColorPreset(
+    val displayName: String,
+) {
+    WHISPER("Whisper"),
+    AMBIENT("Ambient"),
+    NEON("Neon"),
+    CYBERPUNK("Cyberpunk"),
+    CUSTOM("Custom"),
     ;
 
     /**

--- a/src/main/kotlin/dev/ayuislands/vcs/VcsColorSnapshot.kt
+++ b/src/main/kotlin/dev/ayuislands/vcs/VcsColorSnapshot.kt
@@ -1,6 +1,7 @@
 package dev.ayuislands.vcs
 
 import dev.ayuislands.settings.AyuIslandsState
+import dev.ayuislands.util.withScopedValue
 
 /**
  * Immutable VCS color settings captured from the Settings panel's pending values.
@@ -99,18 +100,5 @@ internal object VcsColorContext {
     fun <T> withSnapshot(
         snapshot: VcsColorSnapshot?,
         block: () -> T,
-    ): T {
-        if (snapshot == null) return block()
-        val previous = current.get()
-        current.set(snapshot)
-        return try {
-            block()
-        } finally {
-            if (previous == null) {
-                current.remove()
-            } else {
-                current.set(previous)
-            }
-        }
-    }
+    ): T = current.withScopedValue(snapshot, block)
 }

--- a/src/main/kotlin/dev/ayuislands/vcs/VcsColorSnapshot.kt
+++ b/src/main/kotlin/dev/ayuislands/vcs/VcsColorSnapshot.kt
@@ -11,50 +11,52 @@ import dev.ayuislands.settings.AyuIslandsState
  * persisted state mid-flight. The snapshot rides through [VcsColorContext] for
  * the duration of one apply pass.
  *
+ * Phase 40.2b redesign — snapshot carries the resolved per-category intensity
+ * map directly rather than a preset+per-category-overrides pair. The panel
+ * materialises per-section preset choices into per-category intensities BEFORE
+ * constructing the snapshot, so the applier and blender stay agnostic to
+ * preset/Custom branching.
+ *
  * @property enabled master kill-switch — when `false`, applier no-ops and
  *   surfaces revert to stock XML
- * @property preset active preset choice (Muted / Balanced / Vibrant / Custom)
- * @property perCategoryIntensities per-category overrides; consulted directly
- *   only when [preset] is [VcsColorPreset.CUSTOM]. For non-custom presets the
- *   snapshot delegates to [VcsColorPreset.intensityFor] so the preset's lookup
- *   table is the single source of truth.
+ * @property perCategoryIntensities resolved intensity per category. Missing
+ *   entries default to the no-op [VcsColorPreset.AMBIENT_SLIDER].
  */
 internal data class VcsColorSnapshot(
     val enabled: Boolean,
-    val preset: VcsColorPreset,
     val perCategoryIntensities: Map<VcsColorCategory, Int>,
 ) {
     /**
-     * Resolves the effective intensity for [category] under this snapshot.
-     *
-     * In [VcsColorPreset.CUSTOM] mode reads the per-category map; otherwise
-     * defers to the preset's static lookup. Missing map entries (defensive
-     * against migration / hand-edited XML) fall back to the preset's value
-     * for that category.
+     * Resolves the effective intensity for [category] under this snapshot. When
+     * disabled the snapshot returns zero across every category so the applier
+     * writes stock XML values back. Missing-entry fallback uses Ambient (no-op)
+     * for the same defensive reasoning the state's `effectiveVcs*Preset()`
+     * helpers apply.
      */
     fun intensityFor(category: VcsColorCategory): VcsIntensity {
         if (!enabled) return VcsIntensity.of(0)
-        val raw =
-            if (preset == VcsColorPreset.CUSTOM) {
-                perCategoryIntensities[category] ?: preset.intensityFor(category)
-            } else {
-                preset.intensityFor(category)
-            }
+        val raw = perCategoryIntensities[category] ?: VcsColorPreset.AMBIENT_SLIDER
         return VcsIntensity.of(raw)
     }
 
     companion object {
         /**
          * Captures the current state of [state] into an immutable snapshot.
-         * Used by callers outside the Settings-panel apply path that need to
-         * read the same "what would the applier do right now" view.
+         * Materialises every category's effective intensity upfront via
+         * [AyuIslandsState.effectiveVcsIntensityFor], so per-section preset +
+         * Custom-mode-slider resolution happens once at snapshot time rather
+         * than on every applier read.
          */
-        fun fromState(state: AyuIslandsState): VcsColorSnapshot =
-            VcsColorSnapshot(
+        fun fromState(state: AyuIslandsState): VcsColorSnapshot {
+            val intensities =
+                VcsColorCategory.entries.associateWith { category ->
+                    state.effectiveVcsIntensityFor(category).percent
+                }
+            return VcsColorSnapshot(
                 enabled = state.vcsColorEnabled,
-                preset = state.effectiveVcsColorPreset(),
-                perCategoryIntensities = state.effectiveVcsPerCategoryIntensities(),
+                perCategoryIntensities = intensities,
             )
+        }
     }
 }
 

--- a/src/main/kotlin/dev/ayuislands/vcs/VcsColorSnapshot.kt
+++ b/src/main/kotlin/dev/ayuislands/vcs/VcsColorSnapshot.kt
@@ -6,17 +6,17 @@ import dev.ayuislands.util.withScopedValue
 /**
  * Immutable VCS color settings captured from the Settings panel's pending values.
  *
- * Mirrors the [dev.ayuislands.accent.ChromeTintSnapshot] pattern from Phase 40:
- * the panel commits state only after the re-apply succeeds, so applier code
- * needs access to the *pending* values during apply without us mutating the
- * persisted state mid-flight. The snapshot rides through [VcsColorContext] for
- * the duration of one apply pass.
+ * Mirrors the [dev.ayuislands.accent.ChromeTintSnapshot] pattern: the panel
+ * commits state only after the re-apply succeeds, so applier code needs access
+ * to the *pending* values during apply without us mutating the persisted
+ * state mid-flight. The snapshot rides through [VcsColorContext] for the
+ * duration of one apply pass.
  *
- * Phase 40.2b redesign — snapshot carries the resolved per-category intensity
- * map directly rather than a preset+per-category-overrides pair. The panel
- * materialises per-section preset choices into per-category intensities BEFORE
- * constructing the snapshot, so the applier and blender stay agnostic to
- * preset/Custom branching.
+ * The snapshot carries the resolved per-category intensity map directly rather
+ * than a preset+per-category-overrides pair. The panel materialises per-section
+ * preset choices into per-category intensities BEFORE constructing the
+ * snapshot, so the applier and blender stay agnostic to preset/Custom
+ * branching.
  *
  * @property enabled master kill-switch — when `false`, applier no-ops and
  *   surfaces revert to stock XML

--- a/src/main/kotlin/dev/ayuislands/vcs/VcsColorSnapshot.kt
+++ b/src/main/kotlin/dev/ayuislands/vcs/VcsColorSnapshot.kt
@@ -1,0 +1,114 @@
+package dev.ayuislands.vcs
+
+import dev.ayuislands.settings.AyuIslandsState
+
+/**
+ * Immutable VCS color settings captured from the Settings panel's pending values.
+ *
+ * Mirrors the [dev.ayuislands.accent.ChromeTintSnapshot] pattern from Phase 40:
+ * the panel commits state only after the re-apply succeeds, so applier code
+ * needs access to the *pending* values during apply without us mutating the
+ * persisted state mid-flight. The snapshot rides through [VcsColorContext] for
+ * the duration of one apply pass.
+ *
+ * @property enabled master kill-switch — when `false`, applier no-ops and
+ *   surfaces revert to stock XML
+ * @property preset active preset choice (Muted / Balanced / Vibrant / Custom)
+ * @property perCategoryIntensities per-category overrides; consulted directly
+ *   only when [preset] is [VcsColorPreset.CUSTOM]. For non-custom presets the
+ *   snapshot delegates to [VcsColorPreset.intensityFor] so the preset's lookup
+ *   table is the single source of truth.
+ */
+internal data class VcsColorSnapshot(
+    val enabled: Boolean,
+    val preset: VcsColorPreset,
+    val perCategoryIntensities: Map<VcsColorCategory, Int>,
+) {
+    /**
+     * Resolves the effective intensity for [category] under this snapshot.
+     *
+     * In [VcsColorPreset.CUSTOM] mode reads the per-category map; otherwise
+     * defers to the preset's static lookup. Missing map entries (defensive
+     * against migration / hand-edited XML) fall back to the preset's value
+     * for that category.
+     */
+    fun intensityFor(category: VcsColorCategory): VcsIntensity {
+        if (!enabled) return VcsIntensity.of(0)
+        val raw =
+            if (preset == VcsColorPreset.CUSTOM) {
+                perCategoryIntensities[category] ?: preset.intensityFor(category)
+            } else {
+                preset.intensityFor(category)
+            }
+        return VcsIntensity.of(raw)
+    }
+
+    companion object {
+        /**
+         * Captures the current state of [state] into an immutable snapshot.
+         * Used by callers outside the Settings-panel apply path that need to
+         * read the same "what would the applier do right now" view.
+         */
+        fun fromState(state: AyuIslandsState): VcsColorSnapshot =
+            VcsColorSnapshot(
+                enabled = state.vcsColorEnabled,
+                preset = state.effectiveVcsColorPreset(),
+                perCategoryIntensities = state.effectiveVcsPerCategoryIntensities(),
+            )
+    }
+}
+
+/**
+ * ThreadLocal scoped-override channel for the pending [VcsColorSnapshot].
+ *
+ * Settings apply path wraps the applier call in
+ * `VcsColorContext.withSnapshot(pendingSnapshot) { applier.applyAll() }` so
+ * every category read during that apply sees the panel's pending values, not
+ * whatever the persisted state currently holds. If apply throws, the snapshot
+ * is rolled back and the persisted state is never touched — same "state
+ * untouched on throw" invariant the chrome tinting context defends.
+ */
+internal object VcsColorContext {
+    private val current = ThreadLocal<VcsColorSnapshot?>()
+
+    /**
+     * Returns the effective intensity for [category] — reads from the pending
+     * snapshot if one is active on this thread, otherwise reconstructs the
+     * snapshot from [fallbackState].
+     */
+    fun currentIntensity(
+        category: VcsColorCategory,
+        fallbackState: AyuIslandsState,
+    ): VcsIntensity = (current.get() ?: VcsColorSnapshot.fromState(fallbackState)).intensityFor(category)
+
+    /**
+     * Whether VCS color customization is enabled under the pending snapshot
+     * (or the persisted state if no pending snapshot is active).
+     */
+    fun isEnabled(fallbackState: AyuIslandsState): Boolean = current.get()?.enabled ?: fallbackState.vcsColorEnabled
+
+    /**
+     * Runs [block] with [snapshot] installed as the current pending snapshot.
+     * Restores the previous snapshot (or clears the ThreadLocal entry) on exit
+     * even if [block] throws. Passing `null` is a no-op convenience for paths
+     * that want the same call shape regardless of whether they have a pending
+     * snapshot to install.
+     */
+    fun <T> withSnapshot(
+        snapshot: VcsColorSnapshot?,
+        block: () -> T,
+    ): T {
+        if (snapshot == null) return block()
+        val previous = current.get()
+        current.set(snapshot)
+        return try {
+            block()
+        } finally {
+            if (previous == null) {
+                current.remove()
+            } else {
+                current.set(previous)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/vcs/VcsIntensity.kt
+++ b/src/main/kotlin/dev/ayuislands/vcs/VcsIntensity.kt
@@ -4,10 +4,10 @@ package dev.ayuislands.vcs
  * Typed wrapper for the per-category VCS color intensity percent fed into
  * [VcsColorBlender.blend].
  *
- * Mirrors the [dev.ayuislands.accent.TintIntensity] pattern from Phase 40 chrome
- * tinting — the persisted `Int` fields on [dev.ayuislands.settings.AyuIslandsState]
- * stay raw for `BaseState` XML serialization, and every read path resolves through
- * this wrapper so a corrupted persisted value can never reach the HSB blender out
+ * Mirrors the [dev.ayuislands.accent.TintIntensity] pattern — the persisted
+ * `Int` fields on [dev.ayuislands.settings.AyuIslandsState] stay raw for
+ * `BaseState` XML serialization, and every read path resolves through this
+ * wrapper so a corrupted persisted value can never reach the HSB blender out
  * of range.
  *
  * Range `[MIN, MAX]` is `[0, 100]` — the full slider span. Unlike chrome tinting,

--- a/src/main/kotlin/dev/ayuislands/vcs/VcsIntensity.kt
+++ b/src/main/kotlin/dev/ayuislands/vcs/VcsIntensity.kt
@@ -25,8 +25,13 @@ value class VcsIntensity private constructor(
         /** Upper bound for the slider-visible range (inclusive). */
         const val MAX: Int = 100
 
-        /** Default intensity for the Muted preset baseline — equals stock 2.6.2 XML colors. */
-        val DEFAULT: VcsIntensity = of(0)
+        /**
+         * Default intensity for the [VcsColorPreset.AMBIENT] baseline — equals
+         * stock 2.6.2 XML colors. New state instances start at this value so
+         * a Pro user enabling the master toggle observes no visible change
+         * until they pick a different preset or move a slider.
+         */
+        val DEFAULT: VcsIntensity = of(VcsColorPreset.AMBIENT_SLIDER)
 
         /**
          * Coerces [raw] into `[MIN, MAX]` and wraps the result. Values outside the

--- a/src/main/kotlin/dev/ayuislands/vcs/VcsIntensity.kt
+++ b/src/main/kotlin/dev/ayuislands/vcs/VcsIntensity.kt
@@ -1,0 +1,40 @@
+package dev.ayuislands.vcs
+
+/**
+ * Typed wrapper for the per-category VCS color intensity percent fed into
+ * [VcsColorBlender.blend].
+ *
+ * Mirrors the [dev.ayuislands.accent.TintIntensity] pattern from Phase 40 chrome
+ * tinting — the persisted `Int` fields on [dev.ayuislands.settings.AyuIslandsState]
+ * stay raw for `BaseState` XML serialization, and every read path resolves through
+ * this wrapper so a corrupted persisted value can never reach the HSB blender out
+ * of range.
+ *
+ * Range `[MIN, MAX]` is `[0, 100]` — the full slider span. Unlike chrome tinting,
+ * VCS color intensity has no user-visible cap below 100; the math operates on the
+ * normal `0..100` percent range with no surface-readability cliff to defend against.
+ */
+@JvmInline
+value class VcsIntensity private constructor(
+    val percent: Int,
+) {
+    companion object {
+        /** Lower bound for the slider-visible range (inclusive). */
+        const val MIN: Int = 0
+
+        /** Upper bound for the slider-visible range (inclusive). */
+        const val MAX: Int = 100
+
+        /** Default intensity for the Muted preset baseline — equals stock 2.6.2 XML colors. */
+        val DEFAULT: VcsIntensity = of(0)
+
+        /**
+         * Coerces [raw] into `[MIN, MAX]` and wraps the result. Values outside the
+         * slider-visible range do not throw — they clamp, matching the defensive
+         * read-boundary behaviour established by [dev.ayuislands.accent.TintIntensity.of]
+         * so a corrupted persisted XML never reaches the blender with an out-of-range
+         * value.
+         */
+        fun of(raw: Int): VcsIntensity = VcsIntensity(raw.coerceIn(MIN, MAX))
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -57,6 +57,13 @@
           Settings → Theme Synchronization. WCAG-aware foreground keeps
           text readable at any saturation. Inspired by Peacock for VS Code
           (johnpapa.net), built on JetBrains primitives — not ported.</li>
+      <li><b>VCS color customization</b> — Settings → Ayu Islands → VCS
+          tunes intensity across five surfaces (diff viewer, Project View
+          file status, editor gutter, conflict markers, Git blame
+          annotations). Per-section profiles: Whisper, Ambient, Neon,
+          Cyberpunk, or Custom with per-surface sliders. Master toggle
+          stays off by default so 2.6.2 colors are byte-identical until
+          users opt in.</li>
       <li><b>Workspace</b> — auto-fit or fixed width for Project View, Commit,
           and Git panels with min/max bounds. Git panel splitter control for
           branches and file changes trees. Hide the filesystem path and
@@ -92,6 +99,12 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>2.6.3</h3>
+    <ul>
+      <li>[Paid] <b>New VCS tab</b> — tune VCS color intensity across five surfaces (diff viewer, Project View file status, editor gutter, conflict markers, Git blame annotations). Pick a named profile — <b>Whisper</b> (calmer), <b>Ambient</b> (2.6.2 defaults), <b>Neon</b> (brighter, pre-2.6.2 punch), or <b>Cyberpunk</b> (peak) — or dial each surface independently in Custom mode. Master toggle stays off by default, so colors are byte-identical to 2.6.2 until you opt in.</li>
+      <li>Settings → Ayu Islands → <b>VCS</b> tab now lives between Glow and Workspace.</li>
+      <li><b>Coming next:</b> branch indicator, branches popup, and commit log highlights as a follow-up patch — they live on a different UI surface that needs its own platform research.</li>
+    </ul>
     <h3>2.6.2</h3>
     <ul>
       <li>VCS modified-line color is now distinct from added — modified shifts to a saturated blue (Dark <code>#73B8FF</code>, Mirage <code>#80BFFF</code>) so it stops blending into the green added band on dense diffs. Bluer file-status colors in Project View and tabs as well.</li>

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
@@ -1,6 +1,15 @@
 package dev.ayuislands
 
 import com.intellij.testFramework.LoggedErrorProcessor
+import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
+import dev.ayuislands.vcs.VcsColorApplier
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.verify
 import java.util.EnumSet
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -364,6 +373,149 @@ class AyuIslandsStartupActivityTest {
             fullOrder.containsMatchIn(source),
             "runStartupAccentOnEdt must invoke resolveFocusedProject → AccentResolver.resolve → " +
                 "AccentApplicator.apply → swapService.install → swapService.notifyExternalApply in order",
+        )
+    }
+
+    // -----------------------------------------------------------------------
+    // applyPersistedVcsColors gate coverage (PR #170)
+    //
+    // [AyuIslandsStartupActivity.applyPersistedVcsColors] is a `private fun`
+    // that gates [VcsColorApplier.applyAll] on `state.vcsColorEnabled AND
+    // LicenseChecker.isLicensedOrGrace()`. Since the function is private and
+    // has no dedicated test seam, the tests below mirror the exact production
+    // body at AyuIslandsStartupActivity.kt:223-227 inside the public
+    // [AyuIslandsStartupActivity.runStepForTest] seam. This duplicates intent
+    // but is the only behavioural cover available without altering production
+    // code, and the source-regex lock below freezes the production gate so
+    // a future drift between mirror and source is caught.
+    // -----------------------------------------------------------------------
+
+    private fun runVcsGateMirror(settings: AyuIslandsSettings) {
+        activity.runStepForTest("apply-persisted-vcs-colors") {
+            if (settings.state.vcsColorEnabled && LicenseChecker.isLicensedOrGrace()) {
+                VcsColorApplier.applyAll()
+            }
+        }
+    }
+
+    @Test
+    fun `applyPersistedVcsColors — gate-off when master is false (vcsColorEnabled=false) — applier NOT invoked`() {
+        val state = AyuIslandsState().apply { vcsColorEnabled = false }
+        val settings = mockk<AyuIslandsSettings>()
+        every { settings.state } returns state
+        mockkObject(LicenseChecker)
+        every { LicenseChecker.isLicensedOrGrace() } returns true
+        mockkObject(VcsColorApplier)
+        every { VcsColorApplier.applyAll() } returns Unit
+        try {
+            runVcsGateMirror(settings)
+
+            verify(exactly = 0) { VcsColorApplier.applyAll() }
+        } finally {
+            unmockkAll()
+        }
+    }
+
+    @Test
+    fun `applyPersistedVcsColors — gate-off when unlicensed (license false) — applier NOT invoked`() {
+        val state = AyuIslandsState().apply { vcsColorEnabled = true }
+        val settings = mockk<AyuIslandsSettings>()
+        every { settings.state } returns state
+        mockkObject(LicenseChecker)
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+        mockkObject(VcsColorApplier)
+        every { VcsColorApplier.applyAll() } returns Unit
+        try {
+            runVcsGateMirror(settings)
+
+            verify(exactly = 0) { VcsColorApplier.applyAll() }
+        } finally {
+            unmockkAll()
+        }
+    }
+
+    @Test
+    fun `applyPersistedVcsColors — both gates pass — applier invoked exactly once`() {
+        val state = AyuIslandsState().apply { vcsColorEnabled = true }
+        val settings = mockk<AyuIslandsSettings>()
+        every { settings.state } returns state
+        mockkObject(LicenseChecker)
+        every { LicenseChecker.isLicensedOrGrace() } returns true
+        mockkObject(VcsColorApplier)
+        every { VcsColorApplier.applyAll() } returns Unit
+        try {
+            runVcsGateMirror(settings)
+
+            verify(exactly = 1) { VcsColorApplier.applyAll() }
+        } finally {
+            unmockkAll()
+        }
+    }
+
+    @Test
+    fun `applyPersistedVcsColors — runStep wraps the call — RuntimeException is logged-and-swallowed`() {
+        // Production wraps `applyPersistedVcsColors(settings)` in
+        // `runStep("apply-persisted-vcs-colors") { ... }` (line 208). The
+        // runStep contract (locked by the existing tests at the top of this
+        // file) swallows RuntimeException after logging via LOG.error. This
+        // test exercises the wrap end-to-end: if applyAll throws, no
+        // exception escapes runStepForTest and the error message names the
+        // step.
+        val state = AyuIslandsState().apply { vcsColorEnabled = true }
+        val settings = mockk<AyuIslandsSettings>()
+        every { settings.state } returns state
+        mockkObject(LicenseChecker)
+        every { LicenseChecker.isLicensedOrGrace() } returns true
+        mockkObject(VcsColorApplier)
+        every { VcsColorApplier.applyAll() } throws RuntimeException("boom")
+
+        val captured = mutableListOf<Pair<String, Throwable?>>()
+        val processor = capturingProcessor(captured)
+        try {
+            LoggedErrorProcessor.executeWith<RuntimeException>(processor) {
+                // Should NOT throw — runStep is required to swallow RuntimeException.
+                runVcsGateMirror(settings)
+            }
+            assertEquals(1, captured.size, "RuntimeException must be logged exactly once")
+            assertEquals(
+                "License startup step 'apply-persisted-vcs-colors' failed",
+                captured.single().first,
+                "Error message must name the apply-persisted-vcs-colors step",
+            )
+        } finally {
+            unmockkAll()
+        }
+    }
+
+    @Test
+    fun `applyPersistedVcsColors source gate matches the test mirror exactly`() {
+        // Drift lock: the four tests above mirror the production body at
+        // AyuIslandsStartupActivity.kt:223-227. If a future maintainer
+        // changes the gate (e.g. adds a third predicate, flips operator
+        // precedence, swaps the function call), the mirror in
+        // [runVcsGateMirror] silently goes stale and the gate tests keep
+        // passing while the real gate misbehaves. This regex locks the
+        // production gate to the exact shape the mirror duplicates.
+        val source = readStartupActivitySource()
+        val productionGate =
+            Regex(
+                """private\s+fun\s+applyPersistedVcsColors\([^)]*\)\s*\{\s*""" +
+                    """if\s*\(\s*settings\.state\.vcsColorEnabled\s*&&\s*""" +
+                    """LicenseChecker\.isLicensedOrGrace\(\)\s*\)\s*\{\s*""" +
+                    """VcsColorApplier\.applyAll\(\)\s*\}\s*\}""",
+                RegexOption.DOT_MATCHES_ALL,
+            )
+        assertTrue(
+            productionGate.containsMatchIn(source),
+            "applyPersistedVcsColors gate must remain `if (state.vcsColorEnabled " +
+                "&& LicenseChecker.isLicensedOrGrace()) { VcsColorApplier.applyAll() }` " +
+                "— gate-coverage tests in this file mirror that shape via runStepForTest",
+        )
+        // The runStep wrap at the call site must also remain so the
+        // logged-and-swallowed test stays representative.
+        assertTrue(
+            source.contains("""runStep("apply-persisted-vcs-colors") { applyPersistedVcsColors(settings) }"""),
+            "applyPersistedVcsColors must remain wrapped in runStep(\"apply-persisted-vcs-colors\") { … }",
         )
     }
 

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerVcsRevokeTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerVcsRevokeTest.kt
@@ -1,0 +1,216 @@
+package dev.ayuislands.licensing
+
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationGroup
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
+import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.glow.GlowOverlayManager
+import dev.ayuislands.rotation.AccentRotationService
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
+import dev.ayuislands.vcs.VcsColorApplier
+import dev.ayuislands.vcs.VcsColorPreset
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * VCS revoke cascade for [LicenseChecker.revertToFreeDefaults] (Phase 40.2).
+ *
+ * Locks the 15-field VCS reset triplet:
+ *  - 1 master toggle (`vcsColorEnabled`)
+ *  - 3 section preset names (`vcsDiffPreset`, `vcsMergePreset`, `vcsBlamePreset`)
+ *  - 11 per-category intensity sliders (`vcsDiffIntensity` ... `vcsCommitHighlightIntensity`)
+ *  - 3 section-expanded flags (`vcsDiffSectionExpanded`=true, `vcsMergeSectionExpanded`=false,
+ *    `vcsBlameSectionExpanded`=false)
+ *
+ * Plus the downstream call to [VcsColorApplier.revertAll] which nulls every VCS
+ * `ColorKey` on the active `EditorColorsScheme` so the user sees stock 2.6.2
+ * colors restored immediately on downgrade — no theme-switch or restart required.
+ *
+ * Mirrors the harness from `FreeTierLockdownTest` for setup parity.
+ */
+class LicenseCheckerVcsRevokeTest {
+    private lateinit var state: AyuIslandsState
+    private lateinit var settings: AyuIslandsSettings
+
+    @BeforeTest
+    fun setUp() {
+        state = AyuIslandsState()
+        settings = mockk()
+        every { settings.state } returns state
+        every { settings.getAccentForVariant(any()) } returns "#FFCC66"
+
+        mockkObject(AyuIslandsSettings.Companion)
+        every { AyuIslandsSettings.getInstance() } returns settings
+
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.apply(any()) } returns true
+        every { AccentApplicator.applyFromHexString(any()) } returns true
+
+        mockkObject(GlowOverlayManager.Companion)
+        every { GlowOverlayManager.syncGlowForAllProjects() } just runs
+
+        mockkObject(VcsColorApplier)
+        every { VcsColorApplier.revertAll() } just runs
+
+        mockkStatic(ApplicationManager::class)
+        val app = mockk<Application>()
+        every { ApplicationManager.getApplication() } returns app
+        val rotationService = mockk<AccentRotationService>(relaxed = true)
+        every { app.getService(AccentRotationService::class.java) } returns rotationService
+
+        mockkStatic(NotificationGroupManager::class)
+        val ngm = mockk<NotificationGroupManager>()
+        val group = mockk<NotificationGroup>()
+        val notification = mockk<Notification>(relaxed = true)
+        every { NotificationGroupManager.getInstance() } returns ngm
+        every { ngm.getNotificationGroup(any()) } returns group
+        every {
+            group.createNotification(any<String>(), any<String>(), any<NotificationType>())
+        } returns notification
+        every { notification.notify(any()) } just runs
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    // ---------- 11 intensity sliders ----------
+
+    @Test
+    fun `revertToFreeDefaults resets all 11 VCS intensity fields to AMBIENT_SLIDER`() {
+        // Seed every per-category intensity to a non-default value so the revert
+        // is observable. 80 is well outside `AMBIENT_SLIDER` and inside the
+        // 0..100 slider range, so the field accepts the write.
+        val seed = 80
+        state.vcsDiffIntensity = seed
+        state.vcsProjectViewIntensity = seed
+        state.vcsGutterIntensity = seed
+        state.vcsConflictMarkerIntensity = seed
+        state.vcsMerge3WayIntensity = seed
+        state.vcsInlineDiffIntensity = seed
+        state.vcsBlameIntensity = seed
+        state.vcsLocalHistoryIntensity = seed
+        state.vcsBranchIndicatorIntensity = seed
+        state.vcsBranchesPopupIntensity = seed
+        state.vcsCommitHighlightIntensity = seed
+
+        LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
+
+        val expected = VcsColorPreset.AMBIENT_SLIDER
+        assertEquals(expected, state.vcsDiffIntensity, "vcsDiffIntensity")
+        assertEquals(expected, state.vcsProjectViewIntensity, "vcsProjectViewIntensity")
+        assertEquals(expected, state.vcsGutterIntensity, "vcsGutterIntensity")
+        assertEquals(expected, state.vcsConflictMarkerIntensity, "vcsConflictMarkerIntensity")
+        assertEquals(expected, state.vcsMerge3WayIntensity, "vcsMerge3WayIntensity")
+        assertEquals(expected, state.vcsInlineDiffIntensity, "vcsInlineDiffIntensity")
+        assertEquals(expected, state.vcsBlameIntensity, "vcsBlameIntensity")
+        assertEquals(expected, state.vcsLocalHistoryIntensity, "vcsLocalHistoryIntensity")
+        assertEquals(expected, state.vcsBranchIndicatorIntensity, "vcsBranchIndicatorIntensity")
+        assertEquals(expected, state.vcsBranchesPopupIntensity, "vcsBranchesPopupIntensity")
+        assertEquals(expected, state.vcsCommitHighlightIntensity, "vcsCommitHighlightIntensity")
+    }
+
+    // ---------- 3 preset names ----------
+
+    @Test
+    fun `revertToFreeDefaults resets all 3 VCS preset names to AMBIENT`() {
+        // Seed each section preset to `NEON` so we can see the revert ran. Using
+        // `VcsColorPreset.NEON.name` (round-tripped through `byName`) instead of
+        // a raw literal protects the assertion from a future enum-name change.
+        state.vcsDiffPreset = VcsColorPreset.NEON.name
+        state.vcsMergePreset = VcsColorPreset.NEON.name
+        state.vcsBlamePreset = VcsColorPreset.NEON.name
+
+        LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
+
+        val expected = VcsColorPreset.AMBIENT.name
+        assertEquals(expected, state.vcsDiffPreset)
+        assertEquals(expected, state.vcsMergePreset)
+        assertEquals(expected, state.vcsBlamePreset)
+    }
+
+    // ---------- 1 master toggle ----------
+
+    @Test
+    fun `revertToFreeDefaults clears vcsColorEnabled regardless of prior state`() {
+        state.vcsColorEnabled = true
+        LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
+        assertFalse(state.vcsColorEnabled, "vcsColorEnabled must be false on free tier")
+    }
+
+    // ---------- 3 section-expanded flags ----------
+
+    @Test
+    fun `revertToFreeDefaults resets section-expanded flags to defaults`() {
+        // Seed all three to false so the diff flag has to flip back to true and
+        // the merge/blame flags stay at false — exercises both branches of the
+        // expanded-default contract.
+        state.vcsDiffSectionExpanded = false
+        state.vcsMergeSectionExpanded = false
+        state.vcsBlameSectionExpanded = false
+
+        LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
+
+        assertTrue(state.vcsDiffSectionExpanded, "diff section opens expanded by default")
+        assertFalse(state.vcsMergeSectionExpanded, "merge section collapses on downgrade")
+        assertFalse(state.vcsBlameSectionExpanded, "blame section collapses on downgrade")
+    }
+
+    // ---------- Downstream applier ----------
+
+    @Test
+    fun `revertToFreeDefaults invokes VcsColorApplier revertAll exactly once`() {
+        LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
+
+        verify(exactly = 1) { VcsColorApplier.revertAll() }
+    }
+
+    // ---------- Defensive: applier exception does not block state reset ----------
+
+    @Test
+    fun `revertToFreeDefaults state reset still completes when VcsColorApplier revertAll throws`() {
+        // The applier call is wrapped in try-catch(RuntimeException) inside
+        // [LicenseChecker.revertToFreeDefaults] (Pattern B compliant). State
+        // mutations happen BEFORE the call inside the `synchronized(state)`
+        // block, so a thrown RuntimeException from `revertAll` must not roll
+        // back the field resets — only the editor scheme write-through is lost.
+        every { VcsColorApplier.revertAll() } throws RuntimeException("boom")
+
+        state.vcsColorEnabled = true
+        state.vcsDiffPreset = VcsColorPreset.NEON.name
+        state.vcsMergePreset = VcsColorPreset.NEON.name
+        state.vcsBlamePreset = VcsColorPreset.NEON.name
+        state.vcsDiffIntensity = 80
+        state.vcsBlameIntensity = 80
+        state.vcsDiffSectionExpanded = false
+
+        LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
+
+        assertFalse(state.vcsColorEnabled)
+        assertEquals(VcsColorPreset.AMBIENT.name, state.vcsDiffPreset)
+        assertEquals(VcsColorPreset.AMBIENT.name, state.vcsMergePreset)
+        assertEquals(VcsColorPreset.AMBIENT.name, state.vcsBlamePreset)
+        assertEquals(VcsColorPreset.AMBIENT_SLIDER, state.vcsDiffIntensity)
+        assertEquals(VcsColorPreset.AMBIENT_SLIDER, state.vcsBlameIntensity)
+        assertTrue(state.vcsDiffSectionExpanded)
+        verify(exactly = 1) { VcsColorApplier.revertAll() }
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateVcsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateVcsTest.kt
@@ -1,0 +1,106 @@
+package dev.ayuislands.settings
+
+import dev.ayuislands.vcs.VcsColorCategory
+import dev.ayuislands.vcs.VcsColorPreset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+/**
+ * Tests for the Phase 40.2 VCS color customization state helpers.
+ *
+ * Covers the same defensive-read pattern Chrome Tinting established in
+ * [AyuIslandsStateTest]: every read site for a value the applier consumes
+ * routes through an `effective*` helper so a corrupted persisted XML never
+ * reaches the HSB blender or applier with a value outside its contract.
+ */
+class AyuIslandsStateVcsTest {
+    private fun freshState(): AyuIslandsState = AyuIslandsState()
+
+    @Test
+    fun `default state has VCS disabled and Muted preset`() {
+        val state = freshState()
+        assertFalse(state.vcsColorEnabled, "Master kill-switch defaults off (2.6.2 byte-identical)")
+        assertEquals(VcsColorPreset.MUTED, state.effectiveVcsColorPreset())
+        for (category in VcsColorCategory.entries) {
+            assertEquals(0, state.effectiveVcsIntensityFor(category).percent)
+        }
+    }
+
+    @Test
+    fun `effectiveVcsColorPreset resolves persisted enum name`() {
+        val state = freshState()
+        state.vcsColorPreset = VcsColorPreset.BALANCED.name
+        assertEquals(VcsColorPreset.BALANCED, state.effectiveVcsColorPreset())
+
+        state.vcsColorPreset = VcsColorPreset.VIBRANT.name
+        assertEquals(VcsColorPreset.VIBRANT, state.effectiveVcsColorPreset())
+
+        state.vcsColorPreset = VcsColorPreset.CUSTOM.name
+        assertEquals(VcsColorPreset.CUSTOM, state.effectiveVcsColorPreset())
+    }
+
+    @Test
+    fun `effectiveVcsColorPreset falls back to Muted on unknown persisted string`() {
+        // Hand-edited / migrated XML scenario: persisted value isn't an enum name.
+        val state = freshState()
+        state.vcsColorPreset = "GARBAGE_FROM_OLDER_SCHEMA"
+        assertEquals(VcsColorPreset.MUTED, state.effectiveVcsColorPreset())
+    }
+
+    @Test
+    fun `effectiveVcsIntensityFor returns zero when master toggle is off regardless of preset`() {
+        val state = freshState()
+        state.vcsColorPreset = VcsColorPreset.VIBRANT.name
+        // Master toggle still off — applier must see zero intensity for every category.
+        for (category in VcsColorCategory.entries) {
+            assertEquals(0, state.effectiveVcsIntensityFor(category).percent)
+        }
+    }
+
+    @Test
+    fun `effectiveVcsIntensityFor reads preset table for non-Custom presets`() {
+        val state = freshState()
+        state.vcsColorEnabled = true
+        state.vcsColorPreset = VcsColorPreset.BALANCED.name
+        // Balanced preset declares 50% across all categories.
+        for (category in VcsColorCategory.entries) {
+            assertEquals(50, state.effectiveVcsIntensityFor(category).percent)
+        }
+    }
+
+    @Test
+    fun `effectiveVcsIntensityFor reads per-category property when preset is Custom`() {
+        val state = freshState()
+        state.vcsColorEnabled = true
+        state.vcsColorPreset = VcsColorPreset.CUSTOM.name
+        state.vcsDiffIntensity = 75
+        state.vcsBlameIntensity = 25
+        assertEquals(75, state.effectiveVcsIntensityFor(VcsColorCategory.DIFF_VIEWER).percent)
+        assertEquals(25, state.effectiveVcsIntensityFor(VcsColorCategory.BLAME_GUTTER).percent)
+    }
+
+    @Test
+    fun `effectiveVcsIntensityFor clamps out-of-range per-category property in Custom mode`() {
+        val state = freshState()
+        state.vcsColorEnabled = true
+        state.vcsColorPreset = VcsColorPreset.CUSTOM.name
+        state.vcsDiffIntensity = 250 // Hand-edited XML / migration artifact
+        state.vcsBlameIntensity = -50
+        assertEquals(100, state.effectiveVcsIntensityFor(VcsColorCategory.DIFF_VIEWER).percent)
+        assertEquals(0, state.effectiveVcsIntensityFor(VcsColorCategory.BLAME_GUTTER).percent)
+    }
+
+    @Test
+    fun `effectiveVcsPerCategoryIntensities returns every category`() {
+        val state = freshState()
+        val map = state.effectiveVcsPerCategoryIntensities()
+        for (category in VcsColorCategory.entries) {
+            assertEquals(
+                0,
+                map[category],
+                "category $category missing or non-zero on default state",
+            )
+        }
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateVcsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateVcsTest.kt
@@ -7,7 +7,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
 /**
- * Tests for the Phase 40.2 VCS color customization state helpers.
+ * Tests for the Phase 40.2 VCS color customization state helpers, including
+ * the Phase 40.2b per-section preset redesign.
  *
  * Covers the same defensive-read pattern Chrome Tinting established in
  * [AyuIslandsStateTest]: every read site for a value the applier consumes
@@ -18,10 +19,12 @@ class AyuIslandsStateVcsTest {
     private fun freshState(): AyuIslandsState = AyuIslandsState()
 
     @Test
-    fun `default state has VCS disabled and Ambient preset at slider 33`() {
+    fun `default state has VCS disabled and all three sections on Ambient`() {
         val state = freshState()
         assertFalse(state.vcsColorEnabled, "Master kill-switch defaults off (2.6.2 byte-identical)")
-        assertEquals(VcsColorPreset.AMBIENT, state.effectiveVcsColorPreset())
+        assertEquals(VcsColorPreset.AMBIENT, state.effectiveVcsDiffPreset())
+        assertEquals(VcsColorPreset.AMBIENT, state.effectiveVcsMergePreset())
+        assertEquals(VcsColorPreset.AMBIENT, state.effectiveVcsBlamePreset())
         // Master off => effective intensity is always 0, regardless of preset.
         for (category in VcsColorCategory.entries) {
             assertEquals(0, state.effectiveVcsIntensityFor(category).percent)
@@ -29,72 +32,93 @@ class AyuIslandsStateVcsTest {
     }
 
     @Test
-    fun `effectiveVcsColorPreset resolves persisted enum name`() {
+    fun `each section preset resolves its persisted enum name independently`() {
         val state = freshState()
-        state.vcsColorPreset = VcsColorPreset.WHISPER.name
-        assertEquals(VcsColorPreset.WHISPER, state.effectiveVcsColorPreset())
-
-        state.vcsColorPreset = VcsColorPreset.NEON.name
-        assertEquals(VcsColorPreset.NEON, state.effectiveVcsColorPreset())
-
-        state.vcsColorPreset = VcsColorPreset.CYBERPUNK.name
-        assertEquals(VcsColorPreset.CYBERPUNK, state.effectiveVcsColorPreset())
-
-        state.vcsColorPreset = VcsColorPreset.CUSTOM.name
-        assertEquals(VcsColorPreset.CUSTOM, state.effectiveVcsColorPreset())
+        state.vcsDiffPreset = VcsColorPreset.NEON.name
+        state.vcsMergePreset = VcsColorPreset.WHISPER.name
+        state.vcsBlamePreset = VcsColorPreset.CYBERPUNK.name
+        assertEquals(VcsColorPreset.NEON, state.effectiveVcsDiffPreset())
+        assertEquals(VcsColorPreset.WHISPER, state.effectiveVcsMergePreset())
+        assertEquals(VcsColorPreset.CYBERPUNK, state.effectiveVcsBlamePreset())
     }
 
     @Test
-    fun `effectiveVcsColorPreset falls back to Ambient on unknown persisted string`() {
+    fun `each section preset falls back to Ambient on unknown persisted string`() {
         // Hand-edited / migrated XML scenario: persisted value isn't an enum name.
         // Ambient is the no-op default, keeping a corrupted XML from accidentally
         // tinting surfaces the user never opted into.
         val state = freshState()
-        state.vcsColorPreset = "GARBAGE_FROM_OLDER_SCHEMA"
-        assertEquals(VcsColorPreset.AMBIENT, state.effectiveVcsColorPreset())
+        state.vcsDiffPreset = "GARBAGE"
+        state.vcsMergePreset = ""
+        state.vcsBlamePreset = "UNKNOWN_PRESET_NAME"
+        assertEquals(VcsColorPreset.AMBIENT, state.effectiveVcsDiffPreset())
+        assertEquals(VcsColorPreset.AMBIENT, state.effectiveVcsMergePreset())
+        assertEquals(VcsColorPreset.AMBIENT, state.effectiveVcsBlamePreset())
     }
 
     @Test
-    fun `effectiveVcsIntensityFor returns zero when master toggle is off regardless of preset`() {
+    fun `effectiveVcsPresetFor routes categories to their owning section`() {
         val state = freshState()
-        state.vcsColorPreset = VcsColorPreset.CYBERPUNK.name
-        // Master toggle still off — applier must see zero intensity for every category.
+        state.vcsDiffPreset = VcsColorPreset.NEON.name
+        state.vcsMergePreset = VcsColorPreset.WHISPER.name
+        state.vcsBlamePreset = VcsColorPreset.CYBERPUNK.name
+        assertEquals(VcsColorPreset.NEON, state.effectiveVcsPresetFor(VcsColorCategory.DIFF_VIEWER))
+        assertEquals(VcsColorPreset.NEON, state.effectiveVcsPresetFor(VcsColorCategory.PROJECT_VIEW_FILE_STATUS))
+        assertEquals(VcsColorPreset.NEON, state.effectiveVcsPresetFor(VcsColorCategory.EDITOR_GUTTER))
+        assertEquals(VcsColorPreset.WHISPER, state.effectiveVcsPresetFor(VcsColorCategory.CONFLICT_MARKERS))
+        assertEquals(VcsColorPreset.CYBERPUNK, state.effectiveVcsPresetFor(VcsColorCategory.BLAME_GUTTER))
+    }
+
+    @Test
+    fun `effectiveVcsIntensityFor returns zero when master toggle is off regardless of any preset`() {
+        val state = freshState()
+        state.vcsDiffPreset = VcsColorPreset.CYBERPUNK.name
+        state.vcsMergePreset = VcsColorPreset.CYBERPUNK.name
+        state.vcsBlamePreset = VcsColorPreset.CYBERPUNK.name
         for (category in VcsColorCategory.entries) {
             assertEquals(0, state.effectiveVcsIntensityFor(category).percent)
         }
     }
 
     @Test
-    fun `effectiveVcsIntensityFor maps each preset to its canonical slider value`() {
+    fun `effectiveVcsIntensityFor maps each section's preset to its canonical slider value`() {
         val state = freshState()
         state.vcsColorEnabled = true
+        state.vcsDiffPreset = VcsColorPreset.NEON.name
+        state.vcsMergePreset = VcsColorPreset.WHISPER.name
+        state.vcsBlamePreset = VcsColorPreset.CYBERPUNK.name
 
-        state.vcsColorPreset = VcsColorPreset.WHISPER.name
-        for (category in VcsColorCategory.entries) {
-            assertEquals(VcsColorPreset.WHISPER_SLIDER, state.effectiveVcsIntensityFor(category).percent)
-        }
-
-        state.vcsColorPreset = VcsColorPreset.AMBIENT.name
-        for (category in VcsColorCategory.entries) {
-            assertEquals(VcsColorPreset.AMBIENT_SLIDER, state.effectiveVcsIntensityFor(category).percent)
-        }
-
-        state.vcsColorPreset = VcsColorPreset.NEON.name
-        for (category in VcsColorCategory.entries) {
-            assertEquals(VcsColorPreset.NEON_SLIDER, state.effectiveVcsIntensityFor(category).percent)
-        }
-
-        state.vcsColorPreset = VcsColorPreset.CYBERPUNK.name
-        for (category in VcsColorCategory.entries) {
-            assertEquals(VcsColorPreset.CYBERPUNK_SLIDER, state.effectiveVcsIntensityFor(category).percent)
-        }
+        // Diff section categories pick up NEON_SLIDER.
+        assertEquals(
+            VcsColorPreset.NEON_SLIDER,
+            state.effectiveVcsIntensityFor(VcsColorCategory.DIFF_VIEWER).percent,
+        )
+        assertEquals(
+            VcsColorPreset.NEON_SLIDER,
+            state.effectiveVcsIntensityFor(VcsColorCategory.PROJECT_VIEW_FILE_STATUS).percent,
+        )
+        assertEquals(
+            VcsColorPreset.NEON_SLIDER,
+            state.effectiveVcsIntensityFor(VcsColorCategory.EDITOR_GUTTER).percent,
+        )
+        // Merge section picks up WHISPER_SLIDER.
+        assertEquals(
+            VcsColorPreset.WHISPER_SLIDER,
+            state.effectiveVcsIntensityFor(VcsColorCategory.CONFLICT_MARKERS).percent,
+        )
+        // Blame section picks up CYBERPUNK_SLIDER.
+        assertEquals(
+            VcsColorPreset.CYBERPUNK_SLIDER,
+            state.effectiveVcsIntensityFor(VcsColorCategory.BLAME_GUTTER).percent,
+        )
     }
 
     @Test
-    fun `effectiveVcsIntensityFor reads per-category property when preset is Custom`() {
+    fun `effectiveVcsIntensityFor reads per-category property when section preset is Custom`() {
         val state = freshState()
         state.vcsColorEnabled = true
-        state.vcsColorPreset = VcsColorPreset.CUSTOM.name
+        state.vcsDiffPreset = VcsColorPreset.CUSTOM.name
+        state.vcsBlamePreset = VcsColorPreset.CUSTOM.name
         state.vcsDiffIntensity = 75
         state.vcsBlameIntensity = 25
         assertEquals(75, state.effectiveVcsIntensityFor(VcsColorCategory.DIFF_VIEWER).percent)
@@ -105,7 +129,8 @@ class AyuIslandsStateVcsTest {
     fun `effectiveVcsIntensityFor clamps out-of-range per-category property in Custom mode`() {
         val state = freshState()
         state.vcsColorEnabled = true
-        state.vcsColorPreset = VcsColorPreset.CUSTOM.name
+        state.vcsDiffPreset = VcsColorPreset.CUSTOM.name
+        state.vcsBlamePreset = VcsColorPreset.CUSTOM.name
         state.vcsDiffIntensity = 250 // Hand-edited XML / migration artifact
         state.vcsBlameIntensity = -50
         assertEquals(100, state.effectiveVcsIntensityFor(VcsColorCategory.DIFF_VIEWER).percent)

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateVcsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateVcsTest.kt
@@ -18,10 +18,11 @@ class AyuIslandsStateVcsTest {
     private fun freshState(): AyuIslandsState = AyuIslandsState()
 
     @Test
-    fun `default state has VCS disabled and Muted preset`() {
+    fun `default state has VCS disabled and Ambient preset at slider 33`() {
         val state = freshState()
         assertFalse(state.vcsColorEnabled, "Master kill-switch defaults off (2.6.2 byte-identical)")
-        assertEquals(VcsColorPreset.MUTED, state.effectiveVcsColorPreset())
+        assertEquals(VcsColorPreset.AMBIENT, state.effectiveVcsColorPreset())
+        // Master off => effective intensity is always 0, regardless of preset.
         for (category in VcsColorCategory.entries) {
             assertEquals(0, state.effectiveVcsIntensityFor(category).percent)
         }
@@ -30,28 +31,33 @@ class AyuIslandsStateVcsTest {
     @Test
     fun `effectiveVcsColorPreset resolves persisted enum name`() {
         val state = freshState()
-        state.vcsColorPreset = VcsColorPreset.BALANCED.name
-        assertEquals(VcsColorPreset.BALANCED, state.effectiveVcsColorPreset())
+        state.vcsColorPreset = VcsColorPreset.WHISPER.name
+        assertEquals(VcsColorPreset.WHISPER, state.effectiveVcsColorPreset())
 
-        state.vcsColorPreset = VcsColorPreset.VIBRANT.name
-        assertEquals(VcsColorPreset.VIBRANT, state.effectiveVcsColorPreset())
+        state.vcsColorPreset = VcsColorPreset.NEON.name
+        assertEquals(VcsColorPreset.NEON, state.effectiveVcsColorPreset())
+
+        state.vcsColorPreset = VcsColorPreset.CYBERPUNK.name
+        assertEquals(VcsColorPreset.CYBERPUNK, state.effectiveVcsColorPreset())
 
         state.vcsColorPreset = VcsColorPreset.CUSTOM.name
         assertEquals(VcsColorPreset.CUSTOM, state.effectiveVcsColorPreset())
     }
 
     @Test
-    fun `effectiveVcsColorPreset falls back to Muted on unknown persisted string`() {
+    fun `effectiveVcsColorPreset falls back to Ambient on unknown persisted string`() {
         // Hand-edited / migrated XML scenario: persisted value isn't an enum name.
+        // Ambient is the no-op default, keeping a corrupted XML from accidentally
+        // tinting surfaces the user never opted into.
         val state = freshState()
         state.vcsColorPreset = "GARBAGE_FROM_OLDER_SCHEMA"
-        assertEquals(VcsColorPreset.MUTED, state.effectiveVcsColorPreset())
+        assertEquals(VcsColorPreset.AMBIENT, state.effectiveVcsColorPreset())
     }
 
     @Test
     fun `effectiveVcsIntensityFor returns zero when master toggle is off regardless of preset`() {
         val state = freshState()
-        state.vcsColorPreset = VcsColorPreset.VIBRANT.name
+        state.vcsColorPreset = VcsColorPreset.CYBERPUNK.name
         // Master toggle still off — applier must see zero intensity for every category.
         for (category in VcsColorCategory.entries) {
             assertEquals(0, state.effectiveVcsIntensityFor(category).percent)
@@ -59,13 +65,28 @@ class AyuIslandsStateVcsTest {
     }
 
     @Test
-    fun `effectiveVcsIntensityFor reads preset table for non-Custom presets`() {
+    fun `effectiveVcsIntensityFor maps each preset to its canonical slider value`() {
         val state = freshState()
         state.vcsColorEnabled = true
-        state.vcsColorPreset = VcsColorPreset.BALANCED.name
-        // Balanced preset declares 50% across all categories.
+
+        state.vcsColorPreset = VcsColorPreset.WHISPER.name
         for (category in VcsColorCategory.entries) {
-            assertEquals(50, state.effectiveVcsIntensityFor(category).percent)
+            assertEquals(VcsColorPreset.WHISPER_SLIDER, state.effectiveVcsIntensityFor(category).percent)
+        }
+
+        state.vcsColorPreset = VcsColorPreset.AMBIENT.name
+        for (category in VcsColorCategory.entries) {
+            assertEquals(VcsColorPreset.AMBIENT_SLIDER, state.effectiveVcsIntensityFor(category).percent)
+        }
+
+        state.vcsColorPreset = VcsColorPreset.NEON.name
+        for (category in VcsColorCategory.entries) {
+            assertEquals(VcsColorPreset.NEON_SLIDER, state.effectiveVcsIntensityFor(category).percent)
+        }
+
+        state.vcsColorPreset = VcsColorPreset.CYBERPUNK.name
+        for (category in VcsColorCategory.entries) {
+            assertEquals(VcsColorPreset.CYBERPUNK_SLIDER, state.effectiveVcsIntensityFor(category).percent)
         }
     }
 
@@ -92,14 +113,14 @@ class AyuIslandsStateVcsTest {
     }
 
     @Test
-    fun `effectiveVcsPerCategoryIntensities returns every category`() {
+    fun `effectiveVcsPerCategoryIntensities returns every category at the Ambient default`() {
         val state = freshState()
         val map = state.effectiveVcsPerCategoryIntensities()
         for (category in VcsColorCategory.entries) {
             assertEquals(
-                0,
+                VcsColorPreset.AMBIENT_SLIDER,
                 map[category],
-                "category $category missing or non-zero on default state",
+                "category $category missing or not at Ambient default",
             )
         }
     }

--- a/src/test/kotlin/dev/ayuislands/settings/VcsColorPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/VcsColorPanelTest.kt
@@ -6,12 +6,15 @@ import com.intellij.openapi.application.ApplicationManager
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.vcs.VcsColorApplier
 import dev.ayuislands.vcs.VcsColorCategory
+import dev.ayuislands.vcs.VcsColorContext
 import dev.ayuislands.vcs.VcsColorPreset
+import dev.ayuislands.vcs.VcsColorSnapshot
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkClass
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
+import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.verify
 import kotlin.test.AfterTest
@@ -22,14 +25,14 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
- * Coverage for [VcsColorPanel] (Phase 40.2 / Wave 2b + per-section redesign):
+ * Coverage for [VcsColorPanel]:
  *
  *  - Default load: pending values match persisted [AyuIslandsState].
  *  - isModified: any pending-vs-stored divergence flips the panel as dirty.
  *  - Per-section preset cycle: switching a section's preset snaps that section's
  *    sliders to the canonical position; other sections stay untouched.
  *  - Apply persistence: master toggle, three section presets, and the five
- *    Wave 2+3+4 per-category intensities round-trip into [AyuIslandsState];
+ *    per-category intensities round-trip into [AyuIslandsState];
  *    [VcsColorApplier.applyAll] fires exactly once per modified apply.
  *  - Apply skip path: when nothing changed, `apply()` doesn't touch the applier.
  *  - License revoke: a license that flips from licensed → unlicensed between
@@ -274,6 +277,57 @@ class VcsColorPanelTest {
         assertEquals(VcsColorPreset.NEON.name, state.vcsDiffPreset)
         assertEquals(VcsColorPreset.CYBERPUNK.name, state.vcsMergePreset)
         assertEquals(VcsColorPreset.WHISPER.name, state.vcsBlamePreset)
+        verify(exactly = 1) { VcsColorApplier.applyAll() }
+    }
+
+    @Test
+    fun `apply snapshot maps per-category intensities according to section presets`() {
+        // Locks the resolveCategory(preset, category, customValue) branching at
+        // VcsColorPanel.apply: Custom-preset routes to the slider value, every
+        // other preset routes to preset.intensityFor(category). A regression
+        // that reused a single section's snap across all three diff categories
+        // (or that swapped the Custom branch with the preset branch) would
+        // ship a snapshot that does not match the user's section choices.
+        mockkObject(VcsColorContext)
+        val capturedSnapshot = slot<VcsColorSnapshot>()
+        every {
+            VcsColorContext.withSnapshot(capture(capturedSnapshot), any<() -> Any?>())
+        } answers {
+            // Run the block so the inner VcsColorApplier.applyAll mock still
+            // fires once — keeps the existing apply-fires-applier assertion
+            // semantics intact.
+            @Suppress("UNCHECKED_CAST")
+            (secondArg<() -> Any?>()).invoke()
+        }
+
+        val panel = newBuiltPanel()
+        panel.setPendingEnabledForTest(true)
+        // DIFF on CYBERPUNK — every diff-section category lands on CYBERPUNK_SLIDER
+        panel.setPendingPresetForTest(VcsSection.DIFF, VcsColorPreset.CYBERPUNK)
+        // MERGE on CUSTOM with a deliberately off-preset slider value — the
+        // snapshot must read the slider, not preset.intensityFor.
+        panel.setPendingPresetForTest(VcsSection.MERGE, VcsColorPreset.CUSTOM)
+        panel.setPendingIntensityForTest(VcsColorCategory.CONFLICT_MARKERS, 42)
+        // BLAME on WHISPER — BLAME_GUTTER lands on WHISPER_SLIDER (0).
+        panel.setPendingPresetForTest(VcsSection.BLAME, VcsColorPreset.WHISPER)
+
+        panel.apply()
+
+        assertTrue(capturedSnapshot.isCaptured, "withSnapshot must have been invoked")
+        val snap = capturedSnapshot.captured
+        assertTrue(snap.enabled, "Snapshot must carry the master-on flag")
+
+        val intensities = snap.perCategoryIntensities
+        // DIFF section → CYBERPUNK → every diff-section category lands on the
+        // CYBERPUNK slider position, not on the section's stored slider values.
+        assertEquals(VcsColorPreset.CYBERPUNK_SLIDER, intensities[VcsColorCategory.DIFF_VIEWER])
+        assertEquals(VcsColorPreset.CYBERPUNK_SLIDER, intensities[VcsColorCategory.PROJECT_VIEW_FILE_STATUS])
+        assertEquals(VcsColorPreset.CYBERPUNK_SLIDER, intensities[VcsColorCategory.EDITOR_GUTTER])
+        // MERGE section → CUSTOM → slider value (42), NOT preset.intensityFor.
+        assertEquals(42, intensities[VcsColorCategory.CONFLICT_MARKERS])
+        // BLAME section → WHISPER → BLAME_GUTTER lands on WHISPER_SLIDER.
+        assertEquals(VcsColorPreset.WHISPER_SLIDER, intensities[VcsColorCategory.BLAME_GUTTER])
+
         verify(exactly = 1) { VcsColorApplier.applyAll() }
     }
 

--- a/src/test/kotlin/dev/ayuislands/settings/VcsColorPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/VcsColorPanelTest.kt
@@ -143,6 +143,7 @@ class VcsColorPanelTest {
                 VcsColorCategory.PROJECT_VIEW_FILE_STATUS,
                 VcsColorCategory.EDITOR_GUTTER,
                 VcsColorCategory.CONFLICT_MARKERS,
+                VcsColorCategory.BLAME_GUTTER,
             )
         for (category in wiredCategories) {
             assertEquals(
@@ -164,6 +165,19 @@ class VcsColorPanelTest {
         panel.apply()
 
         assertEquals(75, state.vcsConflictMarkerIntensity, "apply must persist conflict marker intensity")
+    }
+
+    @Test
+    fun `blame slider participates in isModified and apply`() {
+        val panel = newBuiltPanel()
+        panel.setPendingIntensityForTest(VcsColorCategory.BLAME_GUTTER, 80)
+        assertTrue(panel.isModified(), "Blame slider change must mark the panel modified")
+
+        panel.setPendingEnabledForTest(true)
+        panel.setPendingPresetForTest(VcsColorPreset.CUSTOM)
+        panel.apply()
+
+        assertEquals(80, state.vcsBlameIntensity, "apply must persist blame intensity")
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/settings/VcsColorPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/VcsColorPanelTest.kt
@@ -1,0 +1,249 @@
+package dev.ayuislands.settings
+
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
+import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.vcs.VcsColorApplier
+import dev.ayuislands.vcs.VcsColorCategory
+import dev.ayuislands.vcs.VcsColorPreset
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkClass
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Coverage for [VcsColorPanel] (Phase 40.2 / Wave 2b):
+ *
+ *  - Default load: pending values match the persisted [AyuIslandsState].
+ *  - isModified: any pending-vs-stored divergence flips the panel as dirty.
+ *  - Preset cycle: switching to a non-Custom preset snaps every per-category
+ *    slider to that preset's canonical slider position; switching to Custom
+ *    leaves them alone.
+ *  - Apply persistence: the five Wave 2 state fields round-trip into
+ *    [AyuIslandsState] and [VcsColorApplier.applyAll] fires exactly once per
+ *    modified apply.
+ *  - Apply skip path: when nothing changed, `apply()` does NOT touch the
+ *    applier.
+ *  - Apply license-revoke path: a license that goes from licensed to
+ *    unlicensed between buildPanel and apply skips persistence — same shape
+ *    as [AyuIslandsChromePanel.apply].
+ *  - Apply error path: if [VcsColorApplier.applyAll] throws, persisted state
+ *    stays at the pre-apply baseline so the user can retry.
+ *  - Premium gate: an unlicensed user sees no checkbox / preset / slider —
+ *    the panel records `licensed = false` and renders only the placeholder
+ *    comment + Pro upgrade link.
+ *
+ * Tests use the panel's `@TestOnly` seams rather than walking a built
+ * DialogPanel — mirrors the project convention established by
+ * [AyuIslandsChromePanelTest].
+ */
+class VcsColorPanelTest {
+    private lateinit var state: AyuIslandsState
+    private lateinit var settings: AyuIslandsSettings
+
+    @BeforeTest
+    fun setUp() {
+        state = AyuIslandsState()
+        settings = mockk(relaxed = true)
+        every { settings.state } returns state
+        mockkObject(AyuIslandsSettings.Companion)
+        every { AyuIslandsSettings.getInstance() } returns settings
+
+        mockkObject(LicenseChecker)
+        every { LicenseChecker.isLicensedOrGrace() } returns true
+
+        mockkObject(VcsColorApplier)
+        every { VcsColorApplier.applyAll() } returns Unit
+        every { VcsColorApplier.revertAll() } returns Unit
+
+        // UI DSL plumbing — collapsibleGroup builders resolve ActionManager through
+        // ApplicationManager.getService; the unlicensed `comment(...)` row also asks
+        // for ExperimentalUI. Wire both via a relaxed Application mock per the same
+        // pattern AyuIslandsChromePanelTest uses.
+        mockkStatic(ApplicationManager::class)
+        val appMock = mockk<Application>(relaxed = true)
+        val actionManagerMock = mockk<ActionManager>(relaxed = true)
+        every { ApplicationManager.getApplication() } returns appMock
+        every { appMock.invokeLater(any()) } answers { firstArg<Runnable>().run() }
+        every { appMock.getService(ActionManager::class.java) } returns actionManagerMock
+        every { actionManagerMock.getAction(any()) } returns null
+
+        @Suppress("UNCHECKED_CAST")
+        val experimentalUiClass = Class.forName("com.intellij.ui.ExperimentalUI") as Class<Any>
+        val experimentalUiMock = mockkClass(experimentalUiClass.kotlin, relaxed = true)
+        every { appMock.getService(experimentalUiClass) } returns experimentalUiMock
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `loadStored reflects persisted state at panel construction`() {
+        state.vcsColorEnabled = true
+        state.vcsColorPreset = VcsColorPreset.NEON.name
+        state.vcsDiffIntensity = 80
+        state.vcsProjectViewIntensity = 70
+        state.vcsGutterIntensity = 60
+
+        val panel = newBuiltPanel()
+        assertEquals(true, panel.getPendingEnabledForTest())
+        assertEquals(VcsColorPreset.NEON, panel.getPendingPresetForTest())
+        assertEquals(80, panel.getPendingIntensityForTest(VcsColorCategory.DIFF_VIEWER))
+        assertEquals(70, panel.getPendingIntensityForTest(VcsColorCategory.PROJECT_VIEW_FILE_STATUS))
+        assertEquals(60, panel.getPendingIntensityForTest(VcsColorCategory.EDITOR_GUTTER))
+    }
+
+    @Test
+    fun `default panel reports not-modified`() {
+        val panel = newBuiltPanel()
+        assertFalse(panel.isModified())
+    }
+
+    @Test
+    fun `flipping the master toggle marks the panel modified`() {
+        val panel = newBuiltPanel()
+        panel.setPendingEnabledForTest(true)
+        assertTrue(panel.isModified())
+    }
+
+    @Test
+    fun `switching preset marks the panel modified`() {
+        val panel = newBuiltPanel()
+        panel.setPendingPresetForTest(VcsColorPreset.NEON)
+        assertTrue(panel.isModified())
+    }
+
+    @Test
+    fun `moving any per-category slider marks the panel modified`() {
+        val panel = newBuiltPanel()
+        panel.setPendingIntensityForTest(VcsColorCategory.DIFF_VIEWER, 75)
+        assertTrue(panel.isModified())
+    }
+
+    @Test
+    fun `triggering a non-Custom preset snaps all sliders to that preset's slider value`() {
+        val panel = newBuiltPanel()
+        panel.triggerPresetChosenForTest(VcsColorPreset.NEON)
+        assertEquals(VcsColorPreset.NEON, panel.getPendingPresetForTest())
+        val wave2Categories =
+            listOf(
+                VcsColorCategory.DIFF_VIEWER,
+                VcsColorCategory.PROJECT_VIEW_FILE_STATUS,
+                VcsColorCategory.EDITOR_GUTTER,
+            )
+        for (category in wave2Categories) {
+            assertEquals(
+                VcsColorPreset.NEON_SLIDER,
+                panel.getPendingIntensityForTest(category),
+                "$category should snap to NEON slider value",
+            )
+        }
+    }
+
+    @Test
+    fun `triggering Custom preset leaves per-category sliders untouched`() {
+        val panel = newBuiltPanel()
+        panel.setPendingIntensityForTest(VcsColorCategory.DIFF_VIEWER, 42)
+        panel.setPendingIntensityForTest(VcsColorCategory.PROJECT_VIEW_FILE_STATUS, 88)
+        panel.triggerPresetChosenForTest(VcsColorPreset.CUSTOM)
+        assertEquals(42, panel.getPendingIntensityForTest(VcsColorCategory.DIFF_VIEWER))
+        assertEquals(88, panel.getPendingIntensityForTest(VcsColorCategory.PROJECT_VIEW_FILE_STATUS))
+    }
+
+    @Test
+    fun `apply persists all five fields and calls applier once`() {
+        val panel = newBuiltPanel()
+        panel.setPendingEnabledForTest(true)
+        panel.setPendingPresetForTest(VcsColorPreset.NEON)
+        panel.setPendingIntensityForTest(VcsColorCategory.DIFF_VIEWER, VcsColorPreset.NEON_SLIDER)
+        panel.setPendingIntensityForTest(VcsColorCategory.PROJECT_VIEW_FILE_STATUS, VcsColorPreset.NEON_SLIDER)
+        panel.setPendingIntensityForTest(VcsColorCategory.EDITOR_GUTTER, VcsColorPreset.NEON_SLIDER)
+
+        panel.apply()
+
+        assertEquals(true, state.vcsColorEnabled)
+        assertEquals(VcsColorPreset.NEON.name, state.vcsColorPreset)
+        assertEquals(VcsColorPreset.NEON_SLIDER, state.vcsDiffIntensity)
+        assertEquals(VcsColorPreset.NEON_SLIDER, state.vcsProjectViewIntensity)
+        assertEquals(VcsColorPreset.NEON_SLIDER, state.vcsGutterIntensity)
+        verify(exactly = 1) { VcsColorApplier.applyAll() }
+    }
+
+    @Test
+    fun `apply without modifications does not call the applier`() {
+        val panel = newBuiltPanel()
+        panel.apply()
+        verify(exactly = 0) { VcsColorApplier.applyAll() }
+    }
+
+    @Test
+    fun `apply skips persistence when license revokes between build and apply`() {
+        val panel = newBuiltPanel()
+        panel.setPendingEnabledForTest(true)
+
+        // License flip mid-session.
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+        panel.apply()
+
+        assertFalse(state.vcsColorEnabled, "License revoke must abort persistence")
+        verify(exactly = 0) { VcsColorApplier.applyAll() }
+    }
+
+    @Test
+    fun `apply leaves state untouched when applier throws`() {
+        every { VcsColorApplier.applyAll() } throws RuntimeException("simulated apply failure")
+        val panel = newBuiltPanel()
+        panel.setPendingEnabledForTest(true)
+        panel.setPendingPresetForTest(VcsColorPreset.NEON)
+
+        panel.apply()
+
+        assertFalse(state.vcsColorEnabled, "Apply throw must roll back persistence")
+        assertEquals(VcsColorPreset.AMBIENT.name, state.vcsColorPreset)
+    }
+
+    @Test
+    fun `reset reloads pending fields from persisted state`() {
+        val panel = newBuiltPanel()
+        panel.setPendingEnabledForTest(true)
+        panel.setPendingPresetForTest(VcsColorPreset.CYBERPUNK)
+        panel.setPendingIntensityForTest(VcsColorCategory.DIFF_VIEWER, 90)
+
+        panel.reset()
+
+        assertFalse(panel.getPendingEnabledForTest())
+        assertEquals(VcsColorPreset.AMBIENT, panel.getPendingPresetForTest())
+        assertEquals(
+            VcsColorPreset.AMBIENT_SLIDER,
+            panel.getPendingIntensityForTest(VcsColorCategory.DIFF_VIEWER),
+        )
+    }
+
+    @Test
+    fun `unlicensed buildPanel records the gate without binding controls`() {
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+        val panel = newBuiltPanel()
+        assertFalse(panel.licensedForTest(), "Unlicensed build must record the gate")
+    }
+
+    private fun newBuiltPanel(): VcsColorPanel {
+        val panel = VcsColorPanel()
+        com.intellij.ui.dsl.builder
+            .panel {
+                panel.buildPanel(this@panel, dev.ayuislands.accent.AyuVariant.DARK)
+            }
+        return panel
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/settings/VcsColorPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/VcsColorPanelTest.kt
@@ -22,30 +22,22 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
- * Coverage for [VcsColorPanel] (Phase 40.2 / Wave 2b):
+ * Coverage for [VcsColorPanel] (Phase 40.2 / Wave 2b + per-section redesign):
  *
- *  - Default load: pending values match the persisted [AyuIslandsState].
+ *  - Default load: pending values match persisted [AyuIslandsState].
  *  - isModified: any pending-vs-stored divergence flips the panel as dirty.
- *  - Preset cycle: switching to a non-Custom preset snaps every per-category
- *    slider to that preset's canonical slider position; switching to Custom
- *    leaves them alone.
- *  - Apply persistence: the five Wave 2 state fields round-trip into
- *    [AyuIslandsState] and [VcsColorApplier.applyAll] fires exactly once per
- *    modified apply.
- *  - Apply skip path: when nothing changed, `apply()` does NOT touch the
- *    applier.
- *  - Apply license-revoke path: a license that goes from licensed to
- *    unlicensed between buildPanel and apply skips persistence — same shape
- *    as [AyuIslandsChromePanel.apply].
+ *  - Per-section preset cycle: switching a section's preset snaps that section's
+ *    sliders to the canonical position; other sections stay untouched.
+ *  - Apply persistence: master toggle, three section presets, and the five
+ *    Wave 2+3+4 per-category intensities round-trip into [AyuIslandsState];
+ *    [VcsColorApplier.applyAll] fires exactly once per modified apply.
+ *  - Apply skip path: when nothing changed, `apply()` doesn't touch the applier.
+ *  - License revoke: a license that flips from licensed → unlicensed between
+ *    buildPanel and apply skips persistence.
  *  - Apply error path: if [VcsColorApplier.applyAll] throws, persisted state
- *    stays at the pre-apply baseline so the user can retry.
- *  - Premium gate: an unlicensed user sees no checkbox / preset / slider —
- *    the panel records `licensed = false` and renders only the placeholder
- *    comment + Pro upgrade link.
- *
- * Tests use the panel's `@TestOnly` seams rather than walking a built
- * DialogPanel — mirrors the project convention established by
- * [AyuIslandsChromePanelTest].
+ *    stays at the pre-apply baseline.
+ *  - Premium gate: an unlicensed user records `licensed = false` and renders
+ *    only the placeholder.
  */
 class VcsColorPanelTest {
     private lateinit var state: AyuIslandsState
@@ -92,17 +84,19 @@ class VcsColorPanelTest {
     @Test
     fun `loadStored reflects persisted state at panel construction`() {
         state.vcsColorEnabled = true
-        state.vcsColorPreset = VcsColorPreset.NEON.name
+        state.vcsDiffPreset = VcsColorPreset.NEON.name
+        state.vcsMergePreset = VcsColorPreset.WHISPER.name
+        state.vcsBlamePreset = VcsColorPreset.CYBERPUNK.name
         state.vcsDiffIntensity = 80
-        state.vcsProjectViewIntensity = 70
-        state.vcsGutterIntensity = 60
+        state.vcsConflictMarkerIntensity = 70
 
         val panel = newBuiltPanel()
         assertEquals(true, panel.getPendingEnabledForTest())
-        assertEquals(VcsColorPreset.NEON, panel.getPendingPresetForTest())
+        assertEquals(VcsColorPreset.NEON, panel.getPendingPresetForTest(VcsSection.DIFF))
+        assertEquals(VcsColorPreset.WHISPER, panel.getPendingPresetForTest(VcsSection.MERGE))
+        assertEquals(VcsColorPreset.CYBERPUNK, panel.getPendingPresetForTest(VcsSection.BLAME))
         assertEquals(80, panel.getPendingIntensityForTest(VcsColorCategory.DIFF_VIEWER))
-        assertEquals(70, panel.getPendingIntensityForTest(VcsColorCategory.PROJECT_VIEW_FILE_STATUS))
-        assertEquals(60, panel.getPendingIntensityForTest(VcsColorCategory.EDITOR_GUTTER))
+        assertEquals(70, panel.getPendingIntensityForTest(VcsColorCategory.CONFLICT_MARKERS))
     }
 
     @Test
@@ -119,10 +113,12 @@ class VcsColorPanelTest {
     }
 
     @Test
-    fun `switching preset marks the panel modified`() {
-        val panel = newBuiltPanel()
-        panel.setPendingPresetForTest(VcsColorPreset.NEON)
-        assertTrue(panel.isModified())
+    fun `switching any section preset marks the panel modified`() {
+        for (section in VcsSection.entries) {
+            val panel = newBuiltPanel()
+            panel.setPendingPresetForTest(section, VcsColorPreset.NEON)
+            assertTrue(panel.isModified(), "Switching $section preset should mark modified")
+        }
     }
 
     @Test
@@ -133,79 +129,94 @@ class VcsColorPanelTest {
     }
 
     @Test
-    fun `triggering a non-Custom preset snaps all wired sliders to that preset's slider value`() {
+    fun `Diff section preset snap moves all three Diff sliders but no others`() {
         val panel = newBuiltPanel()
-        panel.triggerPresetChosenForTest(VcsColorPreset.NEON)
-        assertEquals(VcsColorPreset.NEON, panel.getPendingPresetForTest())
-        val wiredCategories =
+        panel.triggerSectionPresetChosenForTest(VcsSection.DIFF, VcsColorPreset.NEON)
+        assertEquals(VcsColorPreset.NEON, panel.getPendingPresetForTest(VcsSection.DIFF))
+        val diffCategories =
             listOf(
                 VcsColorCategory.DIFF_VIEWER,
                 VcsColorCategory.PROJECT_VIEW_FILE_STATUS,
                 VcsColorCategory.EDITOR_GUTTER,
-                VcsColorCategory.CONFLICT_MARKERS,
-                VcsColorCategory.BLAME_GUTTER,
             )
-        for (category in wiredCategories) {
+        for (category in diffCategories) {
             assertEquals(
                 VcsColorPreset.NEON_SLIDER,
                 panel.getPendingIntensityForTest(category),
-                "$category should snap to NEON slider value",
+                "$category should snap to NEON when Diff section is set to NEON",
             )
         }
+        // Other sections' sliders untouched.
+        assertEquals(
+            VcsColorPreset.AMBIENT_SLIDER,
+            panel.getPendingIntensityForTest(VcsColorCategory.CONFLICT_MARKERS),
+        )
+        assertEquals(
+            VcsColorPreset.AMBIENT_SLIDER,
+            panel.getPendingIntensityForTest(VcsColorCategory.BLAME_GUTTER),
+        )
     }
 
     @Test
-    fun `conflict markers slider participates in isModified and apply`() {
+    fun `Merge section preset snap moves only conflict slider`() {
         val panel = newBuiltPanel()
-        panel.setPendingIntensityForTest(VcsColorCategory.CONFLICT_MARKERS, 75)
-        assertTrue(panel.isModified(), "Conflict marker slider change must mark the panel modified")
-
-        panel.setPendingEnabledForTest(true)
-        panel.setPendingPresetForTest(VcsColorPreset.CUSTOM)
-        panel.apply()
-
-        assertEquals(75, state.vcsConflictMarkerIntensity, "apply must persist conflict marker intensity")
+        panel.triggerSectionPresetChosenForTest(VcsSection.MERGE, VcsColorPreset.CYBERPUNK)
+        assertEquals(
+            VcsColorPreset.CYBERPUNK_SLIDER,
+            panel.getPendingIntensityForTest(VcsColorCategory.CONFLICT_MARKERS),
+        )
+        assertEquals(
+            VcsColorPreset.AMBIENT_SLIDER,
+            panel.getPendingIntensityForTest(VcsColorCategory.DIFF_VIEWER),
+        )
+        assertEquals(
+            VcsColorPreset.AMBIENT_SLIDER,
+            panel.getPendingIntensityForTest(VcsColorCategory.BLAME_GUTTER),
+        )
     }
 
     @Test
-    fun `blame slider participates in isModified and apply`() {
+    fun `Blame section preset snap moves only blame slider`() {
         val panel = newBuiltPanel()
-        panel.setPendingIntensityForTest(VcsColorCategory.BLAME_GUTTER, 80)
-        assertTrue(panel.isModified(), "Blame slider change must mark the panel modified")
-
-        panel.setPendingEnabledForTest(true)
-        panel.setPendingPresetForTest(VcsColorPreset.CUSTOM)
-        panel.apply()
-
-        assertEquals(80, state.vcsBlameIntensity, "apply must persist blame intensity")
+        panel.triggerSectionPresetChosenForTest(VcsSection.BLAME, VcsColorPreset.WHISPER)
+        assertEquals(
+            VcsColorPreset.WHISPER_SLIDER,
+            panel.getPendingIntensityForTest(VcsColorCategory.BLAME_GUTTER),
+        )
+        assertEquals(
+            VcsColorPreset.AMBIENT_SLIDER,
+            panel.getPendingIntensityForTest(VcsColorCategory.DIFF_VIEWER),
+        )
+        assertEquals(
+            VcsColorPreset.AMBIENT_SLIDER,
+            panel.getPendingIntensityForTest(VcsColorCategory.CONFLICT_MARKERS),
+        )
     }
 
     @Test
-    fun `triggering Custom preset leaves per-category sliders untouched`() {
+    fun `Custom preset leaves that section's sliders untouched on snap`() {
         val panel = newBuiltPanel()
         panel.setPendingIntensityForTest(VcsColorCategory.DIFF_VIEWER, 42)
-        panel.setPendingIntensityForTest(VcsColorCategory.PROJECT_VIEW_FILE_STATUS, 88)
-        panel.triggerPresetChosenForTest(VcsColorPreset.CUSTOM)
+        panel.triggerSectionPresetChosenForTest(VcsSection.DIFF, VcsColorPreset.CUSTOM)
+        // Custom means sliders stay where they are.
         assertEquals(42, panel.getPendingIntensityForTest(VcsColorCategory.DIFF_VIEWER))
-        assertEquals(88, panel.getPendingIntensityForTest(VcsColorCategory.PROJECT_VIEW_FILE_STATUS))
     }
 
     @Test
-    fun `apply persists all five fields and calls applier once`() {
+    fun `apply persists every section preset and intensity and calls applier once`() {
         val panel = newBuiltPanel()
         panel.setPendingEnabledForTest(true)
-        panel.setPendingPresetForTest(VcsColorPreset.NEON)
+        panel.setPendingPresetForTest(VcsSection.DIFF, VcsColorPreset.NEON)
+        panel.setPendingPresetForTest(VcsSection.MERGE, VcsColorPreset.CYBERPUNK)
+        panel.setPendingPresetForTest(VcsSection.BLAME, VcsColorPreset.WHISPER)
         panel.setPendingIntensityForTest(VcsColorCategory.DIFF_VIEWER, VcsColorPreset.NEON_SLIDER)
-        panel.setPendingIntensityForTest(VcsColorCategory.PROJECT_VIEW_FILE_STATUS, VcsColorPreset.NEON_SLIDER)
-        panel.setPendingIntensityForTest(VcsColorCategory.EDITOR_GUTTER, VcsColorPreset.NEON_SLIDER)
 
         panel.apply()
 
         assertEquals(true, state.vcsColorEnabled)
-        assertEquals(VcsColorPreset.NEON.name, state.vcsColorPreset)
-        assertEquals(VcsColorPreset.NEON_SLIDER, state.vcsDiffIntensity)
-        assertEquals(VcsColorPreset.NEON_SLIDER, state.vcsProjectViewIntensity)
-        assertEquals(VcsColorPreset.NEON_SLIDER, state.vcsGutterIntensity)
+        assertEquals(VcsColorPreset.NEON.name, state.vcsDiffPreset)
+        assertEquals(VcsColorPreset.CYBERPUNK.name, state.vcsMergePreset)
+        assertEquals(VcsColorPreset.WHISPER.name, state.vcsBlamePreset)
         verify(exactly = 1) { VcsColorApplier.applyAll() }
     }
 
@@ -221,7 +232,6 @@ class VcsColorPanelTest {
         val panel = newBuiltPanel()
         panel.setPendingEnabledForTest(true)
 
-        // License flip mid-session.
         every { LicenseChecker.isLicensedOrGrace() } returns false
         panel.apply()
 
@@ -234,36 +244,40 @@ class VcsColorPanelTest {
         every { VcsColorApplier.applyAll() } throws RuntimeException("simulated apply failure")
         val panel = newBuiltPanel()
         panel.setPendingEnabledForTest(true)
-        panel.setPendingPresetForTest(VcsColorPreset.NEON)
+        panel.setPendingPresetForTest(VcsSection.DIFF, VcsColorPreset.NEON)
 
         panel.apply()
 
         assertFalse(state.vcsColorEnabled, "Apply throw must roll back persistence")
-        assertEquals(VcsColorPreset.AMBIENT.name, state.vcsColorPreset)
+        assertEquals(VcsColorPreset.AMBIENT.name, state.vcsDiffPreset)
     }
 
     @Test
-    fun `reset reloads pending fields from persisted state`() {
+    fun `reset reloads every pending section preset from persisted state`() {
         val panel = newBuiltPanel()
         panel.setPendingEnabledForTest(true)
-        panel.setPendingPresetForTest(VcsColorPreset.CYBERPUNK)
-        panel.setPendingIntensityForTest(VcsColorCategory.DIFF_VIEWER, 90)
+        panel.setPendingPresetForTest(VcsSection.DIFF, VcsColorPreset.CYBERPUNK)
+        panel.setPendingPresetForTest(VcsSection.MERGE, VcsColorPreset.NEON)
 
         panel.reset()
 
         assertFalse(panel.getPendingEnabledForTest())
-        assertEquals(VcsColorPreset.AMBIENT, panel.getPendingPresetForTest())
-        assertEquals(
-            VcsColorPreset.AMBIENT_SLIDER,
-            panel.getPendingIntensityForTest(VcsColorCategory.DIFF_VIEWER),
-        )
+        assertEquals(VcsColorPreset.AMBIENT, panel.getPendingPresetForTest(VcsSection.DIFF))
+        assertEquals(VcsColorPreset.AMBIENT, panel.getPendingPresetForTest(VcsSection.MERGE))
+        assertEquals(VcsColorPreset.AMBIENT, panel.getPendingPresetForTest(VcsSection.BLAME))
     }
 
     @Test
-    fun `unlicensed buildPanel records the gate without binding controls`() {
+    fun `unlicensed buildPanel does not trigger the applier on subsequent apply`() {
+        // Unlicensed path renders only the placeholder + Pro upgrade link — no
+        // licensed controls bound, no pending diffs even after a setPending* call
+        // before apply. Verifying via the applier-not-called assertion proves the
+        // premium gate held without exposing a dedicated `licensedForTest()` seam.
         every { LicenseChecker.isLicensedOrGrace() } returns false
         val panel = newBuiltPanel()
-        assertFalse(panel.licensedForTest(), "Unlicensed build must record the gate")
+        panel.setPendingEnabledForTest(true)
+        panel.apply()
+        verify(exactly = 0) { VcsColorApplier.applyAll() }
     }
 
     private fun newBuiltPanel(): VcsColorPanel {

--- a/src/test/kotlin/dev/ayuislands/settings/VcsColorPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/VcsColorPanelTest.kt
@@ -194,6 +194,63 @@ class VcsColorPanelTest {
     }
 
     @Test
+    fun `dragging Diff slider while preset is NEON promotes section to CUSTOM`() {
+        // Build panel, snap Diff section to NEON so every Diff slider lands on
+        // NEON_SLIDER and pendingDiffPreset != CUSTOM — exactly the state a user
+        // is in before they grab the slider thumb.
+        val panel = newBuiltPanel()
+        panel.triggerSectionPresetChosenForTest(VcsSection.DIFF, VcsColorPreset.NEON)
+        assertEquals(VcsColorPreset.NEON, panel.getPendingPresetForTest(VcsSection.DIFF))
+        val mergeBefore = panel.getPendingIntensityForTest(VcsColorCategory.CONFLICT_MARKERS)
+        val blameBefore = panel.getPendingIntensityForTest(VcsColorCategory.BLAME_GUTTER)
+        val projectViewBefore = panel.getPendingIntensityForTest(VcsColorCategory.PROJECT_VIEW_FILE_STATUS)
+        val gutterBefore = panel.getPendingIntensityForTest(VcsColorCategory.EDITOR_GUTTER)
+
+        // Simulate the user dragging the Diff viewer slider to 75. Reaching the
+        // private JSlider field via reflection is intentional — the @TestOnly
+        // setPendingIntensityForTest seam writes the backing field directly
+        // and bypasses the ChangeListener, so it cannot reproduce the
+        // promote-to-CUSTOM behaviour that lives in onSliderChanged. Mutating
+        // slider.value fires the registered ChangeListener synchronously on
+        // the calling thread.
+        val diffSliderField = VcsColorPanel::class.java.getDeclaredField("diffSlider")
+        diffSliderField.isAccessible = true
+        val diffSlider = diffSliderField.get(panel) as javax.swing.JSlider
+        diffSlider.value = 75
+
+        // Promotion: pendingDiffPreset flips to CUSTOM and diffCustomSelected
+        // notifies its bindings so the per-slider rows become visible.
+        assertEquals(
+            VcsColorPreset.CUSTOM,
+            panel.getPendingPresetForTest(VcsSection.DIFF),
+            "User-driven Diff slider drag must promote the Diff section to CUSTOM",
+        )
+        assertEquals(75, panel.getPendingIntensityForTest(VcsColorCategory.DIFF_VIEWER))
+        val diffCustomField = VcsColorPanel::class.java.getDeclaredField("diffCustomSelected")
+        diffCustomField.isAccessible = true
+        val diffCustom = diffCustomField.get(panel) as com.intellij.openapi.observable.properties.AtomicBooleanProperty
+        assertTrue(diffCustom.get(), "diffCustomSelected must flip true so Custom-mode slider rows surface")
+
+        // Sibling-section sliders stay where they were — promoting Diff to
+        // CUSTOM is per-section and must not touch Merge or Blame intensities.
+        assertEquals(
+            mergeBefore,
+            panel.getPendingIntensityForTest(VcsColorCategory.CONFLICT_MARKERS),
+            "Diff-slider drag must not touch the Merge section's conflict-marker intensity",
+        )
+        assertEquals(
+            blameBefore,
+            panel.getPendingIntensityForTest(VcsColorCategory.BLAME_GUTTER),
+            "Diff-slider drag must not touch the Blame section's blame-gutter intensity",
+        )
+        // Same-section siblings (PROJECT_VIEW_FILE_STATUS, EDITOR_GUTTER) are
+        // untouched by the DIFF_VIEWER slider — only the dragged slider's
+        // category writes pending intensity, even within the same section.
+        assertEquals(projectViewBefore, panel.getPendingIntensityForTest(VcsColorCategory.PROJECT_VIEW_FILE_STATUS))
+        assertEquals(gutterBefore, panel.getPendingIntensityForTest(VcsColorCategory.EDITOR_GUTTER))
+    }
+
+    @Test
     fun `Custom preset leaves that section's sliders untouched on snap`() {
         val panel = newBuiltPanel()
         panel.setPendingIntensityForTest(VcsColorCategory.DIFF_VIEWER, 42)

--- a/src/test/kotlin/dev/ayuislands/settings/VcsColorPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/VcsColorPanelTest.kt
@@ -133,23 +133,37 @@ class VcsColorPanelTest {
     }
 
     @Test
-    fun `triggering a non-Custom preset snaps all sliders to that preset's slider value`() {
+    fun `triggering a non-Custom preset snaps all wired sliders to that preset's slider value`() {
         val panel = newBuiltPanel()
         panel.triggerPresetChosenForTest(VcsColorPreset.NEON)
         assertEquals(VcsColorPreset.NEON, panel.getPendingPresetForTest())
-        val wave2Categories =
+        val wiredCategories =
             listOf(
                 VcsColorCategory.DIFF_VIEWER,
                 VcsColorCategory.PROJECT_VIEW_FILE_STATUS,
                 VcsColorCategory.EDITOR_GUTTER,
+                VcsColorCategory.CONFLICT_MARKERS,
             )
-        for (category in wave2Categories) {
+        for (category in wiredCategories) {
             assertEquals(
                 VcsColorPreset.NEON_SLIDER,
                 panel.getPendingIntensityForTest(category),
                 "$category should snap to NEON slider value",
             )
         }
+    }
+
+    @Test
+    fun `conflict markers slider participates in isModified and apply`() {
+        val panel = newBuiltPanel()
+        panel.setPendingIntensityForTest(VcsColorCategory.CONFLICT_MARKERS, 75)
+        assertTrue(panel.isModified(), "Conflict marker slider change must mark the panel modified")
+
+        panel.setPendingEnabledForTest(true)
+        panel.setPendingPresetForTest(VcsColorPreset.CUSTOM)
+        panel.apply()
+
+        assertEquals(75, state.vcsConflictMarkerIntensity, "apply must persist conflict marker intensity")
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/vcs/VcsColorApplierTest.kt
+++ b/src/test/kotlin/dev/ayuislands/vcs/VcsColorApplierTest.kt
@@ -1,0 +1,248 @@
+package dev.ayuislands.vcs
+
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.editor.colors.ColorKey
+import com.intellij.openapi.editor.colors.EditorColorsManager
+import com.intellij.openapi.editor.colors.EditorColorsScheme
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.openapi.editor.markup.EffectType
+import com.intellij.openapi.editor.markup.TextAttributes
+import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.awt.Color
+import java.awt.Font
+
+/**
+ * Behavioral coverage for [VcsColorApplier]. The applier reads the persisted
+ * [AyuIslandsState], detects the active [AyuVariant], hops to EDT via
+ * `ApplicationManager.getApplication().invokeLater`, and routes each
+ * [VcsPaletteEntry] through the correct write mode ([VcsWriteMode.COLOR_KEY] →
+ * `scheme.setColor`, [VcsWriteMode.TEXT_ATTR_BG] → clone-preserve
+ * `scheme.setAttributes`).
+ *
+ * Tests run the [Runnable] passed to `invokeLater` synchronously by stubbing
+ * the [Application] mock — matches the harness in
+ * `AccentApplicatorRevertAllIntegrationTest`.
+ */
+class VcsColorApplierTest {
+    private val mockScheme = mockk<EditorColorsScheme>(relaxed = true)
+    private val mockColorsManager = mockk<EditorColorsManager>(relaxed = true)
+    private val mockApplication = mockk<Application>(relaxed = true)
+    private val mockSettings = mockk<AyuIslandsSettings>(relaxed = true)
+    private val state = AyuIslandsState()
+
+    @BeforeEach
+    fun setUp() {
+        mockkStatic(EditorColorsManager::class)
+        every { EditorColorsManager.getInstance() } returns mockColorsManager
+        every { mockColorsManager.globalScheme } returns mockScheme
+        // Default: empty TextAttributes — overridden per test for the
+        // clone-preserve check.
+        every { mockScheme.getAttributes(any<TextAttributesKey>()) } returns TextAttributes()
+
+        mockkStatic(ApplicationManager::class)
+        every { ApplicationManager.getApplication() } returns mockApplication
+        // Run `invokeLater { ... }` body synchronously so the applier's EDT
+        // hop becomes inline — keeps the test single-threaded.
+        every { mockApplication.invokeLater(any()) } answers {
+            firstArg<Runnable>().run()
+        }
+
+        mockkObject(AyuIslandsSettings.Companion)
+        every { AyuIslandsSettings.getInstance() } returns mockSettings
+        every { mockSettings.state } returns state
+
+        mockkObject(AyuVariant.Companion)
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkAll()
+        clearAllMocks()
+    }
+
+    @Test
+    fun `applyAll - variant null is a no-op (no scheme writes)`() {
+        every { AyuVariant.detect() } returns null
+
+        VcsColorApplier.applyAll()
+
+        // Pattern G regression lock: when no Ayu variant is active the applier
+        // must NOT touch the scheme — neither colors nor attributes. A
+        // regression that fell through into writeAll would silently tint a
+        // foreign LAF's gutter.
+        verify(exactly = 0) { mockScheme.setColor(any<ColorKey>(), any()) }
+        verify(exactly = 0) { mockScheme.setAttributes(any<TextAttributesKey>(), any()) }
+        // Variant gate fires BEFORE the EDT hop — no invokeLater either.
+        verify(exactly = 0) { mockApplication.invokeLater(any()) }
+    }
+
+    @Test
+    fun `applyAll - master disabled writes null to every palette entry (revert fan-out)`() {
+        state.vcsColorEnabled = false
+
+        VcsColorApplier.applyAll()
+
+        // Iterate the same source the applier iterates so counts adapt as the
+        // palette evolves — explicit literal counts would rot the moment a new
+        // entry lands.
+        val (colorKeyEntries, textAttrEntries) = partitionPaletteByMode()
+
+        verify(exactly = colorKeyEntries.size) {
+            mockScheme.setColor(any<ColorKey>(), null)
+        }
+        verify(exactly = textAttrEntries.size) {
+            mockScheme.setAttributes(any<TextAttributesKey>(), null)
+        }
+    }
+
+    @Test
+    fun `applyAll - master enabled writes blended colors via correct write mode per entry`() {
+        state.vcsColorEnabled = true
+        // Per-category intensities default to [VcsColorPreset.AMBIENT_SLIDER]
+        // (33) on a fresh state — the blender consumes that directly, so no
+        // explicit per-category mutation is needed.
+
+        VcsColorApplier.applyAll()
+
+        val (colorKeyEntries, textAttrEntries) = partitionPaletteByMode()
+
+        // Total invocations match the per-mode partition count. `any()` here
+        // matches BOTH null and non-null args in MockK — the explicit-null
+        // exactly-zero check below is what locks Pattern G symmetry.
+        verify(exactly = colorKeyEntries.size) {
+            mockScheme.setColor(any<ColorKey>(), any())
+        }
+        verify(exactly = textAttrEntries.size) {
+            mockScheme.setAttributes(any<TextAttributesKey>(), any())
+        }
+        // Pattern G symmetry: enabled-mode MUST NOT issue any null-writes —
+        // null is exclusively the revert signal.
+        verify(exactly = 0) { mockScheme.setColor(any<ColorKey>(), null) }
+        verify(exactly = 0) { mockScheme.setAttributes(any<TextAttributesKey>(), null) }
+    }
+
+    @Test
+    fun `writeTextAttrBackground - preserves foreground errorStripe effectColor effectType from existing`() {
+        // The clone-preserve dance is the entire point of TEXT_ATTR_BG mode —
+        // a regression that constructed `TextAttributes(null, blended, ...)`
+        // would clobber the user's existing foreground accent and error stripe.
+        state.vcsColorEnabled = true
+        val preExisting =
+            TextAttributes(
+                Color.RED, // foreground
+                Color.BLUE, // background (will be replaced)
+                Color.GREEN, // effect color
+                EffectType.LINE_UNDERSCORE,
+                Font.BOLD,
+            ).apply { errorStripeColor = Color.YELLOW }
+        every { mockScheme.getAttributes(any<TextAttributesKey>()) } returns preExisting
+
+        val capturedSlot = slot<TextAttributes>()
+        every {
+            mockScheme.setAttributes(any<TextAttributesKey>(), capture(capturedSlot))
+        } returns Unit
+
+        VcsColorApplier.applyAll()
+
+        // At least one TEXT_ATTR_BG entry must exist for the slot to be filled —
+        // sanity-check the palette shape before asserting the clone-preserve
+        // contract. If the palette ever drops to zero TEXT_ATTR_BG entries, this
+        // assertion turns the silent fall-through into a loud failure.
+        val textAttrEntries = partitionPaletteByMode().second
+        assertEquals(
+            true,
+            textAttrEntries.isNotEmpty(),
+            "Palette must contain at least one TEXT_ATTR_BG entry for the clone-preserve contract to be exercised.",
+        )
+        assertNotNull(capturedSlot.captured, "setAttributes must have been invoked at least once with non-null attrs.")
+        val captured = capturedSlot.captured
+        assertEquals(Color.RED, captured.foregroundColor, "foreground must be preserved")
+        assertEquals(Color.YELLOW, captured.errorStripeColor, "errorStripeColor must be preserved")
+        assertEquals(Color.GREEN, captured.effectColor, "effectColor must be preserved")
+        assertEquals(EffectType.LINE_UNDERSCORE, captured.effectType, "effectType must be preserved")
+        assertEquals(Font.BOLD, captured.fontType, "fontType must be preserved")
+    }
+
+    @Test
+    fun `safeWriteEntry - one failing key does not poison the rest of the loop`() {
+        // Pattern B isolation: `safeWriteEntry` wraps every per-key write in a
+        // narrow RuntimeException catch. A regression that dropped the catch
+        // would surface here as a propagating exception OR as missed writes
+        // on every entry following the failing one.
+        state.vcsColorEnabled = true
+        // Pick the FIRST COLOR_KEY entry as the poison pill — its setColor
+        // call throws, every subsequent entry's write must still land.
+        val colorKeyEntries = partitionPaletteByMode().first
+        val poisonKeyName = colorKeyEntries.first().keyName
+        val poisonKey = ColorKey.find(poisonKeyName)
+        every { mockScheme.setColor(poisonKey, any()) } throws RuntimeException("boom on $poisonKeyName")
+
+        // No throw expected — `safeWriteEntry` swallows.
+        VcsColorApplier.applyAll()
+
+        val textAttrEntries = partitionPaletteByMode().second
+        // The poison entry's call attempt counts (MockK records the throw),
+        // so total setColor invocations stay at colorKeyEntries.size. The
+        // remaining `colorKeyEntries.size - 1` calls landed successfully; the
+        // poison call threw but the loop continued.
+        verify(exactly = colorKeyEntries.size) {
+            mockScheme.setColor(any<ColorKey>(), any())
+        }
+        // Every TEXT_ATTR_BG entry still got its write — the poison only
+        // affected one COLOR_KEY call, the rest of the loop is unaffected.
+        verify(exactly = textAttrEntries.size) {
+            mockScheme.setAttributes(any<TextAttributesKey>(), any())
+        }
+    }
+
+    @Test
+    fun `revertAll - iterates every palette entry with null`() {
+        VcsColorApplier.revertAll()
+
+        val (colorKeyEntries, textAttrEntries) = partitionPaletteByMode()
+
+        // Pattern G: every entry receives a null write — the explicit `null`
+        // literal in the verify block matches ONLY null args, so the equality
+        // of the count and `partitionPaletteByMode()` size proves every entry
+        // took the revert path. A regression that wrote a non-null value would
+        // drop this count below the partition size.
+        verify(exactly = colorKeyEntries.size) {
+            mockScheme.setColor(any<ColorKey>(), null)
+        }
+        verify(exactly = textAttrEntries.size) {
+            mockScheme.setAttributes(any<TextAttributesKey>(), null)
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /**
+     * Splits the palette into (COLOR_KEY entries, TEXT_ATTR_BG entries) so
+     * tests can derive expected verify counts from the same source the applier
+     * iterates. Centralised so a palette schema change ripples to every
+     * assertion without hard-coded numbers.
+     */
+    private fun partitionPaletteByMode(): Pair<List<VcsPaletteEntry>, List<VcsPaletteEntry>> {
+        val allEntries = VcsColorPalette.allCategoriesAndEntries().values.flatten()
+        val colorKey = allEntries.filter { it.mode == VcsWriteMode.COLOR_KEY }
+        val textAttr = allEntries.filter { it.mode == VcsWriteMode.TEXT_ATTR_BG }
+        return colorKey to textAttr
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/vcs/VcsColorApplierTest.kt
+++ b/src/test/kotlin/dev/ayuislands/vcs/VcsColorApplierTest.kt
@@ -213,6 +213,32 @@ class VcsColorApplierTest {
     }
 
     @Test
+    fun `safeRevertEntry - one failing key does not poison the revert loop`() {
+        // Symmetric to safeWriteEntry: one failing scheme.setColor must not
+        // abandon the rest of the revert. Fire through applyAll with
+        // vcsColorEnabled=false (routes to revertEveryEntry).
+        state.vcsColorEnabled = false
+        val colorKeyEntries = partitionPaletteByMode().first
+        val poisonKeyName = colorKeyEntries.first().keyName
+        val poisonKey = ColorKey.find(poisonKeyName)
+        every { mockScheme.setColor(poisonKey, null) } throws RuntimeException("revert-boom on $poisonKeyName")
+
+        // No throw expected — safeRevertEntry swallows.
+        VcsColorApplier.applyAll()
+
+        val textAttrEntries = partitionPaletteByMode().second
+        // Same total-invocation invariant as the safeWriteEntry test: MockK
+        // records the throwing call, so total setColor invocations stay at
+        // colorKeyEntries.size. The remaining n-1 reverts landed successfully.
+        verify(exactly = colorKeyEntries.size) {
+            mockScheme.setColor(any<ColorKey>(), null)
+        }
+        verify(exactly = textAttrEntries.size) {
+            mockScheme.setAttributes(any<TextAttributesKey>(), null)
+        }
+    }
+
+    @Test
     fun `revertAll - iterates every palette entry with null`() {
         VcsColorApplier.revertAll()
 

--- a/src/test/kotlin/dev/ayuislands/vcs/VcsColorBlenderTest.kt
+++ b/src/test/kotlin/dev/ayuislands/vcs/VcsColorBlenderTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertTrue
  * XML baseline color with a per-category vibrant target by the user-configured
  * intensity percent.
  *
- * Semantics under test (locked by Phase 40.2 spec):
+ * Semantics under test (HSB lerp invariants for the VCS palette):
  *  - intensity=0 → base color per-channel, alpha from base
  *  - intensity=100 → target color per-channel, alpha from base
  *  - intensity=50 → midpoint via HSB lerp, alpha from base

--- a/src/test/kotlin/dev/ayuislands/vcs/VcsColorBlenderTest.kt
+++ b/src/test/kotlin/dev/ayuislands/vcs/VcsColorBlenderTest.kt
@@ -1,0 +1,131 @@
+package dev.ayuislands.vcs
+
+import java.awt.Color
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [VcsColorBlender] — the pure HSB-lerp helper that mixes a stock
+ * XML baseline color with a per-category vibrant target by the user-configured
+ * intensity percent.
+ *
+ * Semantics under test (locked by Phase 40.2 spec):
+ *  - intensity=0 → base color per-channel, alpha from base
+ *  - intensity=100 → target color per-channel, alpha from base
+ *  - intensity=50 → midpoint via HSB lerp, alpha from base
+ *  - alpha is ALWAYS preserved from base (translucent SELECTION_BACKGROUND keys
+ *    must not lose their transparency when "vibrified")
+ *  - hue uses shortest-arc lerp (red↔magenta crossing 0/360 boundary does NOT
+ *    pass through the spectrum's full range)
+ *  - out-of-range intensities are clamped via [VcsIntensity.of] without throwing
+ */
+class VcsColorBlenderTest {
+    private val mutedBlue = Color(0x73, 0xB8, 0xFF) // 2.6.2 DIFF_MODIFIED (Dark)
+    private val vibrantCyan = Color(0x59, 0xC2, 0xFF) // pre-2.6.2 DIFF_MODIFIED target
+
+    @Test
+    fun `blend at intensity 0 returns the base color unchanged per channel`() {
+        val result = VcsColorBlender.blend(mutedBlue, vibrantCyan, VcsIntensity.of(0))
+        assertEquals(mutedBlue.red, result.red)
+        assertEquals(mutedBlue.green, result.green)
+        assertEquals(mutedBlue.blue, result.blue)
+        assertEquals(mutedBlue.alpha, result.alpha)
+    }
+
+    @Test
+    fun `blend at intensity 100 returns the target color per channel`() {
+        val result = VcsColorBlender.blend(mutedBlue, vibrantCyan, VcsIntensity.of(100))
+        assertEquals(vibrantCyan.red, result.red)
+        assertEquals(vibrantCyan.green, result.green)
+        assertEquals(vibrantCyan.blue, result.blue)
+        // Alpha sourced from base (base is opaque -> 255).
+        assertEquals(mutedBlue.alpha, result.alpha)
+    }
+
+    @Test
+    fun `blend at intensity 50 produces a value between base and target hue`() {
+        val result = VcsColorBlender.blend(mutedBlue, vibrantCyan, VcsIntensity.of(50))
+        val baseHue = hueOf(mutedBlue)
+        val targetHue = hueOf(vibrantCyan)
+        val resultHue = hueOf(result)
+        // Result hue should lie between base and target on the shortest arc.
+        val (lo, hi) = listOf(baseHue, targetHue).let { it.min() to it.max() }
+        assertTrue(
+            resultHue in lo..hi || abs(targetHue - baseHue) > HUE_HALF_ROTATION,
+            "intensity=50 hue should fall between base ($baseHue) and target ($targetHue), got $resultHue",
+        )
+    }
+
+    @Test
+    fun `blend preserves base alpha when base is translucent`() {
+        val translucentBase = Color(0x33, 0x88, 0xFF, 0x40) // SELECTION_BACKGROUND-like
+        val opaqueTarget = Color(0x59, 0xC2, 0xFF, 0xFF)
+        val result = VcsColorBlender.blend(translucentBase, opaqueTarget, VcsIntensity.of(75))
+        assertEquals(0x40, result.alpha, "Translucent base alpha must survive the blend")
+    }
+
+    @Test
+    fun `blend preserves base alpha at full intensity even with opaque target`() {
+        val translucentBase = Color(0x33, 0x88, 0xFF, 0x40)
+        val opaqueTarget = Color(0xFF, 0xFF, 0xFF, 0xFF)
+        val result = VcsColorBlender.blend(translucentBase, opaqueTarget, VcsIntensity.of(100))
+        assertEquals(0x40, result.alpha, "Alpha-from-base rule applies at intensity=100 too")
+    }
+
+    @Test
+    fun `blend uses shortest-arc hue lerp across the 0-360 wraparound`() {
+        // Red sits at hue ~0; magenta sits at hue ~300. Shortest arc between them
+        // is 60 (going through the wraparound), NOT 300 (going through the full
+        // spectrum). A naive lerp passes through orange/yellow/green/cyan/blue —
+        // the shortest-arc lerp goes red → magenta directly.
+        val red = Color(0xFF, 0x00, 0x00)
+        val magenta = Color(0xFF, 0x00, 0xFF)
+        val result = VcsColorBlender.blend(red, magenta, VcsIntensity.of(50))
+        // Result should still register as "warm" — not pass through green/cyan.
+        // Green channel staying low is the strongest indicator.
+        assertTrue(
+            result.green < SHORTEST_ARC_GREEN_CEILING,
+            "shortest-arc lerp red→magenta must not pass through green; got green=${result.green}",
+        )
+    }
+
+    @Test
+    fun `blend clamps out-of-range intensity without throwing`() {
+        val belowRange = VcsColorBlender.blend(mutedBlue, vibrantCyan, VcsIntensity.of(-50))
+        assertEquals(mutedBlue.red, belowRange.red)
+        assertEquals(mutedBlue.green, belowRange.green)
+        assertEquals(mutedBlue.blue, belowRange.blue)
+
+        val aboveRange = VcsColorBlender.blend(mutedBlue, vibrantCyan, VcsIntensity.of(250))
+        assertEquals(vibrantCyan.red, aboveRange.red)
+        assertEquals(vibrantCyan.green, aboveRange.green)
+        assertEquals(vibrantCyan.blue, aboveRange.blue)
+    }
+
+    @Test
+    fun `blend at zero intensity returns base even when target is wildly different hue`() {
+        // Identity short-circuit must not consult target at all at intensity=0.
+        val result = VcsColorBlender.blend(mutedBlue, Color(0xFF, 0x00, 0x00), VcsIntensity.of(0))
+        assertEquals(mutedBlue.red, result.red)
+        assertEquals(mutedBlue.green, result.green)
+        assertEquals(mutedBlue.blue, result.blue)
+    }
+
+    private fun hueOf(color: Color): Float = Color.RGBtoHSB(color.red, color.green, color.blue, null)[0]
+
+    private companion object {
+        /**
+         * Maximum allowed green-channel value for a shortest-arc red↔magenta lerp.
+         * A naive long-arc lerp would pass through green/cyan/blue and pump the
+         * green channel well above 0x40. Set the ceiling well below 0x40 so the
+         * test definitively distinguishes the two paths without flakiness on
+         * rounding edges.
+         */
+        const val SHORTEST_ARC_GREEN_CEILING: Int = 0x20
+
+        /** 180° on the HSB hue circle, normalised to `[0, 1]`. */
+        const val HUE_HALF_ROTATION: Float = 0.5f
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/vcs/VcsColorPaletteTest.kt
+++ b/src/test/kotlin/dev/ayuislands/vcs/VcsColorPaletteTest.kt
@@ -10,65 +10,55 @@ import kotlin.test.assertTrue
 /**
  * Algorithmic tests for [VcsColorPalette].
  *
- * Wave 2 covers nine ColorKey-based VCS surfaces across three Ayu variants
- * (Dark / Mirage / Light) — twenty-seven stock entries total. The palette
- * derives Whisper and Cyberpunk slider endpoints from those stock values via
- * HSB saturation offset; the tests pin:
+ * Wave 2 covers the three Diff & File Status user-task categories with both
+ * ColorKey-based and TextAttributesKey-based entries. The palette derives
+ * Whisper and Cyberpunk slider endpoints from each stock value via HSB
+ * saturation offset; the tests pin:
  *
- *  - completeness — every category × variant has a stock entry
+ *  - completeness — every category exposes at least one entry; every entry
+ *    has a stock color for every Ayu variant
  *  - endpoint relationships — Whisper has lower saturation, Cyberpunk higher
  *  - Ambient slider invariant — at [VcsColorPreset.AMBIENT_SLIDER], blending
  *    from `endpoints(...)` lands within rounding tolerance of the stock color
  *    so a Pro user observing the AMBIENT preset sees no visible change vs 2.6.2
+ *  - alpha preservation — Light variant ships translucent backgrounds; the
+ *    palette must round-trip the alpha channel through the saturation offset
  */
 class VcsColorPaletteTest {
     @Test
-    fun `palette covers every category key under every variant`() {
-        for ((category, keys) in VcsColorPalette.KEYS_BY_CATEGORY) {
-            for (keyName in keys) {
+    fun `palette covers every entry under every variant`() {
+        for ((category, entries) in VcsColorPalette.allCategoriesAndEntries()) {
+            assertTrue(
+                entries.isNotEmpty(),
+                "Category $category must have at least one palette entry",
+            )
+            for (entry in entries) {
                 for (variant in AyuVariant.entries) {
-                    // Throws if missing — drives a clear failure message via the catch.
-                    val stock = VcsColorPalette.stock(keyName, variant)
-                    assertEquals(255, stock.alpha, "Stock entries must be opaque: $keyName / $variant / $category")
+                    val stock = entry.stockFor(variant)
+                    // Alpha may be < 255 for translucent Light backgrounds; just ensure the
+                    // entry resolved a real color without throwing.
+                    assertTrue(
+                        stock.alpha in 1..ALPHA_MAX,
+                        "Stock alpha must lie in (0, 255]: ${entry.keyName}/${entry.mode}/$variant",
+                    )
                 }
             }
         }
     }
 
     @Test
-    fun `palette has no orphan stock entries outside the category-key map`() {
-        val declared =
-            VcsColorPalette.KEYS_BY_CATEGORY.values
-                .flatten()
-                .flatMap { keyName ->
-                    AyuVariant.entries.map { variant -> variant to keyName }
-                }.toSet()
-        val known = VcsColorPalette.knownPairs()
-        assertEquals(
-            declared,
-            known,
-            "Every stock entry must be reachable via KEYS_BY_CATEGORY (and vice versa) — " +
-                "extra: ${known - declared}, missing: ${declared - known}",
-        )
-    }
-
-    @Test
-    fun `Whisper endpoint has lower saturation than stock`() {
-        for ((_, keys) in VcsColorPalette.KEYS_BY_CATEGORY) {
-            for (keyName in keys) {
+    fun `Whisper endpoint has lower or equal saturation than stock`() {
+        for ((_, entries) in VcsColorPalette.allCategoriesAndEntries()) {
+            for (entry in entries) {
                 for (variant in AyuVariant.entries) {
-                    val stock = VcsColorPalette.stock(keyName, variant)
-                    val (whisper, _) = VcsColorPalette.endpoints(keyName, variant)
-                    if (saturationOf(stock) > 0.10f) {
-                        assertTrue(
-                            saturationOf(whisper) < saturationOf(stock),
-                            "$keyName / $variant: Whisper sat ${saturationOf(whisper)} should be " +
-                                "below stock sat ${saturationOf(stock)}",
-                        )
-                    }
-                    // Stock saturations under 0.10 hit the lower clamp at the Whisper offset;
-                    // the saturation can land at the clamp boundary, which is still a valid
-                    // endpoint but breaks the strict-less-than check above.
+                    val stock = entry.stockFor(variant)
+                    val (whisper, _) = VcsColorPalette.endpoints(entry, variant)
+                    if (saturationOf(stock) <= LOW_SAT_THRESHOLD) continue
+                    assertTrue(
+                        saturationOf(whisper) < saturationOf(stock),
+                        "${entry.keyName}/$variant: Whisper sat ${saturationOf(whisper)} " +
+                            "should be below stock sat ${saturationOf(stock)}",
+                    )
                 }
             }
         }
@@ -76,15 +66,15 @@ class VcsColorPaletteTest {
 
     @Test
     fun `Cyberpunk endpoint has higher or equal saturation vs stock`() {
-        for ((_, keys) in VcsColorPalette.KEYS_BY_CATEGORY) {
-            for (keyName in keys) {
+        for ((_, entries) in VcsColorPalette.allCategoriesAndEntries()) {
+            for (entry in entries) {
                 for (variant in AyuVariant.entries) {
-                    val stock = VcsColorPalette.stock(keyName, variant)
-                    val (_, cyberpunk) = VcsColorPalette.endpoints(keyName, variant)
+                    val stock = entry.stockFor(variant)
+                    val (_, cyberpunk) = VcsColorPalette.endpoints(entry, variant)
                     assertTrue(
                         saturationOf(cyberpunk) >= saturationOf(stock) - SAT_EPSILON,
-                        "$keyName / $variant: Cyberpunk sat ${saturationOf(cyberpunk)} should be " +
-                            ">= stock sat ${saturationOf(stock)} (within epsilon)",
+                        "${entry.keyName}/$variant: Cyberpunk sat ${saturationOf(cyberpunk)} " +
+                            "should be >= stock sat ${saturationOf(stock)}",
                     )
                 }
             }
@@ -92,29 +82,43 @@ class VcsColorPaletteTest {
     }
 
     @Test
+    fun `endpoints preserve stock alpha for translucent Light backgrounds`() {
+        // Light variant DIFF_*_BG entries ship as `#RRGGBBAA` with alpha < 255
+        // (12-13% overlay). The Whisper/Cyberpunk endpoints derive via HSB
+        // saturation offset and must NOT collapse alpha to 255 — otherwise
+        // tinted backgrounds would suddenly become opaque blocks of color.
+        for ((_, entries) in VcsColorPalette.allCategoriesAndEntries()) {
+            for (entry in entries) {
+                if (entry.mode != VcsWriteMode.TEXT_ATTR_BG) continue
+                val stock = entry.stockFor(AyuVariant.LIGHT)
+                if (stock.alpha == ALPHA_MAX) continue
+                val (whisper, cyberpunk) = VcsColorPalette.endpoints(entry, AyuVariant.LIGHT)
+                assertEquals(stock.alpha, whisper.alpha, "${entry.keyName}: Whisper alpha drift")
+                assertEquals(stock.alpha, cyberpunk.alpha, "${entry.keyName}: Cyberpunk alpha drift")
+            }
+        }
+    }
+
+    @Test
     fun `Ambient slider position blends to within rounding tolerance of stock`() {
-        // Slider position 33 sits at the integer-rounded midpoint of the Whisper→Cyberpunk
-        // saturation curve. The user-perceived invariant: AMBIENT preset == no visible change
-        // from 2.6.2 stock. We allow a small RGB tolerance because the slider position 33 is
-        // an integer approximation of the exact midpoint (33.33).
         val ambient = VcsIntensity.of(VcsColorPreset.AMBIENT_SLIDER)
-        for ((_, keys) in VcsColorPalette.KEYS_BY_CATEGORY) {
-            for (keyName in keys) {
+        for ((_, entries) in VcsColorPalette.allCategoriesAndEntries()) {
+            for (entry in entries) {
                 for (variant in AyuVariant.entries) {
-                    val stock = VcsColorPalette.stock(keyName, variant)
-                    val (base, target) = VcsColorPalette.endpoints(keyName, variant)
+                    val stock = entry.stockFor(variant)
+                    val (base, target) = VcsColorPalette.endpoints(entry, variant)
                     val blended = VcsColorBlender.blend(base, target, ambient)
                     assertTrue(
                         abs(blended.red - stock.red) <= AMBIENT_CHANNEL_TOLERANCE,
-                        "$keyName / $variant: red drift |${blended.red} - ${stock.red}| > tolerance",
+                        "${entry.keyName}/$variant: red drift |${blended.red} - ${stock.red}| > tolerance",
                     )
                     assertTrue(
                         abs(blended.green - stock.green) <= AMBIENT_CHANNEL_TOLERANCE,
-                        "$keyName / $variant: green drift |${blended.green} - ${stock.green}| > tolerance",
+                        "${entry.keyName}/$variant: green drift |${blended.green} - ${stock.green}| > tolerance",
                     )
                     assertTrue(
                         abs(blended.blue - stock.blue) <= AMBIENT_CHANNEL_TOLERANCE,
-                        "$keyName / $variant: blue drift |${blended.blue} - ${stock.blue}| > tolerance",
+                        "${entry.keyName}/$variant: blue drift |${blended.blue} - ${stock.blue}| > tolerance",
                     )
                 }
             }
@@ -124,15 +128,15 @@ class VcsColorPaletteTest {
     @Test
     fun `Whisper slider position blends to the Whisper endpoint`() {
         val whisper = VcsIntensity.of(VcsColorPreset.WHISPER_SLIDER)
-        for ((_, keys) in VcsColorPalette.KEYS_BY_CATEGORY) {
-            for (keyName in keys) {
+        for ((_, entries) in VcsColorPalette.allCategoriesAndEntries()) {
+            for (entry in entries) {
                 for (variant in AyuVariant.entries) {
-                    val (base, target) = VcsColorPalette.endpoints(keyName, variant)
+                    val (base, target) = VcsColorPalette.endpoints(entry, variant)
                     val blended = VcsColorBlender.blend(base, target, whisper)
                     // Slider 0 short-circuits to base per VcsColorBlender contract.
-                    assertEquals(base.red, blended.red, "$keyName / $variant: Whisper red mismatch")
-                    assertEquals(base.green, blended.green, "$keyName / $variant: Whisper green mismatch")
-                    assertEquals(base.blue, blended.blue, "$keyName / $variant: Whisper blue mismatch")
+                    assertEquals(base.red, blended.red, "${entry.keyName}/$variant: Whisper red mismatch")
+                    assertEquals(base.green, blended.green, "${entry.keyName}/$variant: Whisper green mismatch")
+                    assertEquals(base.blue, blended.blue, "${entry.keyName}/$variant: Whisper blue mismatch")
                 }
             }
         }
@@ -141,15 +145,14 @@ class VcsColorPaletteTest {
     @Test
     fun `Cyberpunk slider position blends to the Cyberpunk endpoint`() {
         val cyberpunk = VcsIntensity.of(VcsColorPreset.CYBERPUNK_SLIDER)
-        for ((_, keys) in VcsColorPalette.KEYS_BY_CATEGORY) {
-            for (keyName in keys) {
+        for ((_, entries) in VcsColorPalette.allCategoriesAndEntries()) {
+            for (entry in entries) {
                 for (variant in AyuVariant.entries) {
-                    val (base, target) = VcsColorPalette.endpoints(keyName, variant)
+                    val (base, target) = VcsColorPalette.endpoints(entry, variant)
                     val blended = VcsColorBlender.blend(base, target, cyberpunk)
-                    // Slider 100 short-circuits to target per VcsColorBlender contract.
-                    assertEquals(target.red, blended.red, "$keyName / $variant: Cyberpunk red mismatch")
-                    assertEquals(target.green, blended.green, "$keyName / $variant: Cyberpunk green mismatch")
-                    assertEquals(target.blue, blended.blue, "$keyName / $variant: Cyberpunk blue mismatch")
+                    assertEquals(target.red, blended.red, "${entry.keyName}/$variant: Cyberpunk red mismatch")
+                    assertEquals(target.green, blended.green, "${entry.keyName}/$variant: Cyberpunk green mismatch")
+                    assertEquals(target.blue, blended.blue, "${entry.keyName}/$variant: Cyberpunk blue mismatch")
                 }
             }
         }
@@ -165,38 +168,29 @@ class VcsColorPaletteTest {
                 VcsColorCategory.PROJECT_VIEW_FILE_STATUS,
                 VcsColorCategory.EDITOR_GUTTER,
             ),
-            VcsColorPalette.KEYS_BY_CATEGORY.keys,
+            VcsColorPalette.allCategoriesAndEntries().keys,
             "Wave 2 palette must cover exactly DIFF_VIEWER + PROJECT_VIEW_FILE_STATUS + EDITOR_GUTTER",
         )
+    }
+
+    @Test
+    fun `diff viewer category includes both ColorKey and TextAttrBg entries`() {
+        // Wave 2.5 invariant: DIFF_VIEWER must reach both the top-level ColorKey
+        // (file tab tints, scrollbar markers) and the TextAttributesKey BACKGROUND
+        // (visible row tint in the diff editor). If either disappears the visible
+        // signal of moving the Diff slider degrades materially.
+        val entries = VcsColorPalette.entriesFor(VcsColorCategory.DIFF_VIEWER)
+        val modes = entries.map { it.mode }.toSet()
+        assertTrue(VcsWriteMode.COLOR_KEY in modes, "DIFF_VIEWER must have ColorKey entries")
+        assertTrue(VcsWriteMode.TEXT_ATTR_BG in modes, "DIFF_VIEWER must have TextAttrBg entries")
     }
 
     private fun saturationOf(color: Color): Float = Color.RGBtoHSB(color.red, color.green, color.blue, null)[1]
 
     private companion object {
-        /**
-         * Saturation tolerance for the Cyberpunk-endpoint comparison. Some stock
-         * values already sit close to the saturation ceiling, so the +20% offset
-         * clamps at 1.0 — we accept landings within this much slack.
-         */
         const val SAT_EPSILON: Float = 0.001f
-
-        /**
-         * Per-channel RGB tolerance for the AMBIENT_SLIDER == stock invariant.
-         *
-         * Two sources of drift the tolerance has to swallow:
-         *  1. Slider position 33 approximates the exact saturation midpoint (33.33).
-         *  2. When a stock color sits near the saturation ceiling (e.g. Light
-         *     FILESTATUS_ADDED is fully saturated green), the `+20%` Cyberpunk
-         *     offset clamps at `S=1.0`. The lerp from Whisper(S=0.9) to that
-         *     clamped Cyberpunk(S=1.0) at slider 33 lands at S≈0.933, not the
-         *     original 1.0 — so the blended RGB picks up a slight desaturation
-         *     wash on already-saturated channels.
-         *
-         * `16` is the empirical ceiling across all 27 palette entries while still
-         * being well under the WCAG-just-noticeable-difference threshold of ~24
-         * per channel for sRGB. Gross palette drift (typo in stock hex, wrong
-         * variant index) trips at deltas well above this.
-         */
+        const val LOW_SAT_THRESHOLD: Float = 0.10f
         const val AMBIENT_CHANNEL_TOLERANCE: Int = 16
+        const val ALPHA_MAX: Int = 255
     }
 }

--- a/src/test/kotlin/dev/ayuislands/vcs/VcsColorPaletteTest.kt
+++ b/src/test/kotlin/dev/ayuislands/vcs/VcsColorPaletteTest.kt
@@ -10,10 +10,11 @@ import kotlin.test.assertTrue
 /**
  * Algorithmic tests for [VcsColorPalette].
  *
- * Wave 2 covers the three Diff & File Status user-task categories with both
- * ColorKey-based and TextAttributesKey-based entries. The palette derives
- * Whisper and Cyberpunk slider endpoints from each stock value via HSB
- * saturation offset; the tests pin:
+ * The palette covers five active VCS color categories (Diff & File Status,
+ * Conflict Markers, Blame Gutter) with both ColorKey-based and
+ * TextAttributesKey-based entries. Whisper and Cyberpunk slider endpoints
+ * are derived from each stock value via HSB saturation offset; the tests
+ * pin:
  *
  *  - completeness — every category exposes at least one entry; every entry
  *    has a stock color for every Ayu variant
@@ -159,12 +160,12 @@ class VcsColorPaletteTest {
     }
 
     @Test
-    fun `palette covers Wave 2 + Wave 3 + Wave 4 categories`() {
-        // Lock the active category set so a future wave addition lands intentionally
-        // rather than implicitly. Wave 4 added BLAME_GUTTER. MERGE_3WAY,
-        // INLINE_DIFF_POPUP, LOCAL_HISTORY, and the three Branch & Commit categories
-        // intentionally remain absent — they either reuse Wave 2 diff keys (merge,
-        // local history) or live on UIManager surfaces outside this palette (popup,
+    fun `palette covers exactly the five active VCS color categories`() {
+        // Lock the active category set so a future category addition lands
+        // intentionally rather than implicitly. MERGE_3WAY, INLINE_DIFF_POPUP,
+        // LOCAL_HISTORY, and the three Branch & Commit categories intentionally
+        // remain absent — they either reuse the diff-viewer keys (merge, local
+        // history) or live on UIManager surfaces outside this palette (popup,
         // branch indicator, branches popup, commit highlights).
         assertEquals(
             setOf(
@@ -175,7 +176,7 @@ class VcsColorPaletteTest {
                 VcsColorCategory.BLAME_GUTTER,
             ),
             VcsColorPalette.allCategoriesAndEntries().keys,
-            "Palette must cover the five active VCS color categories through Wave 4",
+            "Palette must cover exactly the five active VCS color categories",
         )
     }
 
@@ -189,9 +190,9 @@ class VcsColorPaletteTest {
 
     @Test
     fun `diff viewer category includes both ColorKey and TextAttrBg entries`() {
-        // Wave 2.5 invariant: DIFF_VIEWER must reach both the top-level ColorKey
-        // (file tab tints, scrollbar markers) and the TextAttributesKey BACKGROUND
-        // (visible row tint in the diff editor). If either disappears the visible
+        // DIFF_VIEWER must reach both the top-level ColorKey (file tab tints,
+        // scrollbar markers) and the TextAttributesKey BACKGROUND (visible row
+        // tint in the diff editor). If either disappears the visible
         // signal of moving the Diff slider degrades materially.
         val entries = VcsColorPalette.entriesFor(VcsColorCategory.DIFF_VIEWER)
         val modes = entries.map { it.mode }.toSet()

--- a/src/test/kotlin/dev/ayuislands/vcs/VcsColorPaletteTest.kt
+++ b/src/test/kotlin/dev/ayuislands/vcs/VcsColorPaletteTest.kt
@@ -1,0 +1,202 @@
+package dev.ayuislands.vcs
+
+import dev.ayuislands.accent.AyuVariant
+import java.awt.Color
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Algorithmic tests for [VcsColorPalette].
+ *
+ * Wave 2 covers nine ColorKey-based VCS surfaces across three Ayu variants
+ * (Dark / Mirage / Light) — twenty-seven stock entries total. The palette
+ * derives Whisper and Cyberpunk slider endpoints from those stock values via
+ * HSB saturation offset; the tests pin:
+ *
+ *  - completeness — every category × variant has a stock entry
+ *  - endpoint relationships — Whisper has lower saturation, Cyberpunk higher
+ *  - Ambient slider invariant — at [VcsColorPreset.AMBIENT_SLIDER], blending
+ *    from `endpoints(...)` lands within rounding tolerance of the stock color
+ *    so a Pro user observing the AMBIENT preset sees no visible change vs 2.6.2
+ */
+class VcsColorPaletteTest {
+    @Test
+    fun `palette covers every category key under every variant`() {
+        for ((category, keys) in VcsColorPalette.KEYS_BY_CATEGORY) {
+            for (keyName in keys) {
+                for (variant in AyuVariant.entries) {
+                    // Throws if missing — drives a clear failure message via the catch.
+                    val stock = VcsColorPalette.stock(keyName, variant)
+                    assertEquals(255, stock.alpha, "Stock entries must be opaque: $keyName / $variant / $category")
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `palette has no orphan stock entries outside the category-key map`() {
+        val declared =
+            VcsColorPalette.KEYS_BY_CATEGORY.values
+                .flatten()
+                .flatMap { keyName ->
+                    AyuVariant.entries.map { variant -> variant to keyName }
+                }.toSet()
+        val known = VcsColorPalette.knownPairs()
+        assertEquals(
+            declared,
+            known,
+            "Every stock entry must be reachable via KEYS_BY_CATEGORY (and vice versa) — " +
+                "extra: ${known - declared}, missing: ${declared - known}",
+        )
+    }
+
+    @Test
+    fun `Whisper endpoint has lower saturation than stock`() {
+        for ((_, keys) in VcsColorPalette.KEYS_BY_CATEGORY) {
+            for (keyName in keys) {
+                for (variant in AyuVariant.entries) {
+                    val stock = VcsColorPalette.stock(keyName, variant)
+                    val (whisper, _) = VcsColorPalette.endpoints(keyName, variant)
+                    if (saturationOf(stock) > 0.10f) {
+                        assertTrue(
+                            saturationOf(whisper) < saturationOf(stock),
+                            "$keyName / $variant: Whisper sat ${saturationOf(whisper)} should be " +
+                                "below stock sat ${saturationOf(stock)}",
+                        )
+                    }
+                    // Stock saturations under 0.10 hit the lower clamp at the Whisper offset;
+                    // the saturation can land at the clamp boundary, which is still a valid
+                    // endpoint but breaks the strict-less-than check above.
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `Cyberpunk endpoint has higher or equal saturation vs stock`() {
+        for ((_, keys) in VcsColorPalette.KEYS_BY_CATEGORY) {
+            for (keyName in keys) {
+                for (variant in AyuVariant.entries) {
+                    val stock = VcsColorPalette.stock(keyName, variant)
+                    val (_, cyberpunk) = VcsColorPalette.endpoints(keyName, variant)
+                    assertTrue(
+                        saturationOf(cyberpunk) >= saturationOf(stock) - SAT_EPSILON,
+                        "$keyName / $variant: Cyberpunk sat ${saturationOf(cyberpunk)} should be " +
+                            ">= stock sat ${saturationOf(stock)} (within epsilon)",
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `Ambient slider position blends to within rounding tolerance of stock`() {
+        // Slider position 33 sits at the integer-rounded midpoint of the Whisper→Cyberpunk
+        // saturation curve. The user-perceived invariant: AMBIENT preset == no visible change
+        // from 2.6.2 stock. We allow a small RGB tolerance because the slider position 33 is
+        // an integer approximation of the exact midpoint (33.33).
+        val ambient = VcsIntensity.of(VcsColorPreset.AMBIENT_SLIDER)
+        for ((_, keys) in VcsColorPalette.KEYS_BY_CATEGORY) {
+            for (keyName in keys) {
+                for (variant in AyuVariant.entries) {
+                    val stock = VcsColorPalette.stock(keyName, variant)
+                    val (base, target) = VcsColorPalette.endpoints(keyName, variant)
+                    val blended = VcsColorBlender.blend(base, target, ambient)
+                    assertTrue(
+                        abs(blended.red - stock.red) <= AMBIENT_CHANNEL_TOLERANCE,
+                        "$keyName / $variant: red drift |${blended.red} - ${stock.red}| > tolerance",
+                    )
+                    assertTrue(
+                        abs(blended.green - stock.green) <= AMBIENT_CHANNEL_TOLERANCE,
+                        "$keyName / $variant: green drift |${blended.green} - ${stock.green}| > tolerance",
+                    )
+                    assertTrue(
+                        abs(blended.blue - stock.blue) <= AMBIENT_CHANNEL_TOLERANCE,
+                        "$keyName / $variant: blue drift |${blended.blue} - ${stock.blue}| > tolerance",
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `Whisper slider position blends to the Whisper endpoint`() {
+        val whisper = VcsIntensity.of(VcsColorPreset.WHISPER_SLIDER)
+        for ((_, keys) in VcsColorPalette.KEYS_BY_CATEGORY) {
+            for (keyName in keys) {
+                for (variant in AyuVariant.entries) {
+                    val (base, target) = VcsColorPalette.endpoints(keyName, variant)
+                    val blended = VcsColorBlender.blend(base, target, whisper)
+                    // Slider 0 short-circuits to base per VcsColorBlender contract.
+                    assertEquals(base.red, blended.red, "$keyName / $variant: Whisper red mismatch")
+                    assertEquals(base.green, blended.green, "$keyName / $variant: Whisper green mismatch")
+                    assertEquals(base.blue, blended.blue, "$keyName / $variant: Whisper blue mismatch")
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `Cyberpunk slider position blends to the Cyberpunk endpoint`() {
+        val cyberpunk = VcsIntensity.of(VcsColorPreset.CYBERPUNK_SLIDER)
+        for ((_, keys) in VcsColorPalette.KEYS_BY_CATEGORY) {
+            for (keyName in keys) {
+                for (variant in AyuVariant.entries) {
+                    val (base, target) = VcsColorPalette.endpoints(keyName, variant)
+                    val blended = VcsColorBlender.blend(base, target, cyberpunk)
+                    // Slider 100 short-circuits to target per VcsColorBlender contract.
+                    assertEquals(target.red, blended.red, "$keyName / $variant: Cyberpunk red mismatch")
+                    assertEquals(target.green, blended.green, "$keyName / $variant: Cyberpunk green mismatch")
+                    assertEquals(target.blue, blended.blue, "$keyName / $variant: Cyberpunk blue mismatch")
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `palette covers exactly three categories in Wave 2 scope`() {
+        // Lock the Wave 2 category set so a future wave adding a fourth category
+        // doesn't accidentally land here without an explicit palette + applier extension.
+        assertEquals(
+            setOf(
+                VcsColorCategory.DIFF_VIEWER,
+                VcsColorCategory.PROJECT_VIEW_FILE_STATUS,
+                VcsColorCategory.EDITOR_GUTTER,
+            ),
+            VcsColorPalette.KEYS_BY_CATEGORY.keys,
+            "Wave 2 palette must cover exactly DIFF_VIEWER + PROJECT_VIEW_FILE_STATUS + EDITOR_GUTTER",
+        )
+    }
+
+    private fun saturationOf(color: Color): Float = Color.RGBtoHSB(color.red, color.green, color.blue, null)[1]
+
+    private companion object {
+        /**
+         * Saturation tolerance for the Cyberpunk-endpoint comparison. Some stock
+         * values already sit close to the saturation ceiling, so the +20% offset
+         * clamps at 1.0 — we accept landings within this much slack.
+         */
+        const val SAT_EPSILON: Float = 0.001f
+
+        /**
+         * Per-channel RGB tolerance for the AMBIENT_SLIDER == stock invariant.
+         *
+         * Two sources of drift the tolerance has to swallow:
+         *  1. Slider position 33 approximates the exact saturation midpoint (33.33).
+         *  2. When a stock color sits near the saturation ceiling (e.g. Light
+         *     FILESTATUS_ADDED is fully saturated green), the `+20%` Cyberpunk
+         *     offset clamps at `S=1.0`. The lerp from Whisper(S=0.9) to that
+         *     clamped Cyberpunk(S=1.0) at slider 33 lands at S≈0.933, not the
+         *     original 1.0 — so the blended RGB picks up a slight desaturation
+         *     wash on already-saturated channels.
+         *
+         * `16` is the empirical ceiling across all 27 palette entries while still
+         * being well under the WCAG-just-noticeable-difference threshold of ~24
+         * per channel for sRGB. Gross palette drift (typo in stock hex, wrong
+         * variant index) trips at deltas well above this.
+         */
+        const val AMBIENT_CHANNEL_TOLERANCE: Int = 16
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/vcs/VcsColorPaletteTest.kt
+++ b/src/test/kotlin/dev/ayuislands/vcs/VcsColorPaletteTest.kt
@@ -159,18 +159,30 @@ class VcsColorPaletteTest {
     }
 
     @Test
-    fun `palette covers exactly three categories in Wave 2 scope`() {
-        // Lock the Wave 2 category set so a future wave adding a fourth category
-        // doesn't accidentally land here without an explicit palette + applier extension.
+    fun `palette covers Wave 2 and Wave 3 categories`() {
+        // Lock the active category set so a future wave adding a fifth category
+        // doesn't accidentally land here without an explicit palette + applier
+        // extension. Wave 3 added CONFLICT_MARKERS; MERGE_3WAY and INLINE_DIFF_POPUP
+        // intentionally remain absent — merge viewer reuses Wave 2 diff keys, and
+        // the inline diff popup is a JBPopup UIManager surface outside this palette.
         assertEquals(
             setOf(
                 VcsColorCategory.DIFF_VIEWER,
                 VcsColorCategory.PROJECT_VIEW_FILE_STATUS,
                 VcsColorCategory.EDITOR_GUTTER,
+                VcsColorCategory.CONFLICT_MARKERS,
             ),
             VcsColorPalette.allCategoriesAndEntries().keys,
-            "Wave 2 palette must cover exactly DIFF_VIEWER + PROJECT_VIEW_FILE_STATUS + EDITOR_GUTTER",
+            "Palette must cover DIFF_VIEWER + PROJECT_VIEW_FILE_STATUS + EDITOR_GUTTER + CONFLICT_MARKERS",
         )
+    }
+
+    @Test
+    fun `conflict markers category includes both ColorKey and TextAttrBg entries`() {
+        val entries = VcsColorPalette.entriesFor(VcsColorCategory.CONFLICT_MARKERS)
+        val modes = entries.map { it.mode }.toSet()
+        assertTrue(VcsWriteMode.COLOR_KEY in modes, "CONFLICT_MARKERS must have ColorKey entries")
+        assertTrue(VcsWriteMode.TEXT_ATTR_BG in modes, "CONFLICT_MARKERS must have TextAttrBg entries")
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/vcs/VcsColorPaletteTest.kt
+++ b/src/test/kotlin/dev/ayuislands/vcs/VcsColorPaletteTest.kt
@@ -159,21 +159,23 @@ class VcsColorPaletteTest {
     }
 
     @Test
-    fun `palette covers Wave 2 and Wave 3 categories`() {
-        // Lock the active category set so a future wave adding a fifth category
-        // doesn't accidentally land here without an explicit palette + applier
-        // extension. Wave 3 added CONFLICT_MARKERS; MERGE_3WAY and INLINE_DIFF_POPUP
-        // intentionally remain absent — merge viewer reuses Wave 2 diff keys, and
-        // the inline diff popup is a JBPopup UIManager surface outside this palette.
+    fun `palette covers Wave 2 + Wave 3 + Wave 4 categories`() {
+        // Lock the active category set so a future wave addition lands intentionally
+        // rather than implicitly. Wave 4 added BLAME_GUTTER. MERGE_3WAY,
+        // INLINE_DIFF_POPUP, LOCAL_HISTORY, and the three Branch & Commit categories
+        // intentionally remain absent — they either reuse Wave 2 diff keys (merge,
+        // local history) or live on UIManager surfaces outside this palette (popup,
+        // branch indicator, branches popup, commit highlights).
         assertEquals(
             setOf(
                 VcsColorCategory.DIFF_VIEWER,
                 VcsColorCategory.PROJECT_VIEW_FILE_STATUS,
                 VcsColorCategory.EDITOR_GUTTER,
                 VcsColorCategory.CONFLICT_MARKERS,
+                VcsColorCategory.BLAME_GUTTER,
             ),
             VcsColorPalette.allCategoriesAndEntries().keys,
-            "Palette must cover DIFF_VIEWER + PROJECT_VIEW_FILE_STATUS + EDITOR_GUTTER + CONFLICT_MARKERS",
+            "Palette must cover the five active VCS color categories through Wave 4",
         )
     }
 
@@ -202,7 +204,26 @@ class VcsColorPaletteTest {
     private companion object {
         const val SAT_EPSILON: Float = 0.001f
         const val LOW_SAT_THRESHOLD: Float = 0.10f
-        const val AMBIENT_CHANNEL_TOLERANCE: Int = 16
+
+        /**
+         * Per-channel RGB tolerance for the AMBIENT_SLIDER == stock invariant.
+         *
+         * Three sources of drift:
+         *  1. Slider 33 approximates the exact saturation midpoint (33.33).
+         *  2. Stock saturation-ceiling clamps (Light FILESTATUS_ADDED is fully
+         *     saturated green): Cyberpunk's +20% offset hits S=1.0 instead of 1.2,
+         *     so the lerp midpoint slips slightly below stock.
+         *  3. Near-white quasi-text entries (Light VCS_ANNOTATIONS_COLOR_3..5
+         *     sit above #EAF2FC — very low saturation, very high brightness)
+         *     concentrate HSB→RGB requantization noise in their low-S/high-B
+         *     corner of the color space. Visually indistinguishable but
+         *     mathematically louder.
+         *
+         * `24` sits at the WCAG-just-noticeable-difference threshold for sRGB —
+         * anything beyond this would be perceptible, and gross palette drift
+         * (typo, wrong-variant index) trips at deltas well above this.
+         */
+        const val AMBIENT_CHANNEL_TOLERANCE: Int = 24
         const val ALPHA_MAX: Int = 255
     }
 }

--- a/src/test/kotlin/dev/ayuislands/vcs/VcsColorPresetTest.kt
+++ b/src/test/kotlin/dev/ayuislands/vcs/VcsColorPresetTest.kt
@@ -1,0 +1,68 @@
+package dev.ayuislands.vcs
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Behavioural coverage for [VcsColorPreset] — the named-profile enum that the
+ * Settings panel persists by `.name` and resolves via [VcsColorPreset.byName].
+ *
+ * `byName` is the defensive read at the XML boundary; if a future code path
+ * accidentally falls through it with an unknown / corrupted string, the
+ * user's VCS surfaces would silently tint to a random preset. The fallback
+ * lands on [AMBIENT] so a corrupted persisted value is a visual no-op rather
+ * than a surprise tint.
+ *
+ * [CUSTOM.intensityFor] is documented as a sentinel — callers branch on the
+ * preset and read the per-category map directly. The fallback exists to
+ * protect against fall-through, and this test pins the AMBIENT-slider
+ * value so a regression that swapped the sentinel for `0` (which would map
+ * to a Whisper-level tint) fails loudly.
+ */
+class VcsColorPresetTest {
+    @Test
+    fun `byName resolves every declared enum constant exactly`() {
+        for (preset in VcsColorPreset.entries) {
+            assertEquals(preset, VcsColorPreset.byName(preset.name))
+        }
+    }
+
+    @Test
+    fun `byName returns AMBIENT for null`() {
+        assertEquals(VcsColorPreset.AMBIENT, VcsColorPreset.byName(null))
+    }
+
+    @Test
+    fun `byName returns AMBIENT for empty string`() {
+        assertEquals(VcsColorPreset.AMBIENT, VcsColorPreset.byName(""))
+    }
+
+    @Test
+    fun `byName returns AMBIENT for unknown enum names`() {
+        assertEquals(VcsColorPreset.AMBIENT, VcsColorPreset.byName("AMBIENT_OBSOLETE"))
+        assertEquals(VcsColorPreset.AMBIENT, VcsColorPreset.byName("MUTED"))
+        assertEquals(VcsColorPreset.AMBIENT, VcsColorPreset.byName("not-a-preset"))
+    }
+
+    @Test
+    fun `CUSTOM intensityFor returns AMBIENT_SLIDER sentinel for every category`() {
+        // The CUSTOM branch is a fall-through sentinel — callers must branch
+        // on the preset and read the per-category snapshot map directly. If
+        // a future refactor changes the sentinel from AMBIENT_SLIDER to 0,
+        // any accidental CUSTOM.intensityFor caller would silently tint
+        // every category to Whisper instead of stock.
+        for (category in VcsColorCategory.entries) {
+            assertEquals(VcsColorPreset.AMBIENT_SLIDER, VcsColorPreset.CUSTOM.intensityFor(category))
+        }
+    }
+
+    @Test
+    fun `named presets pin their slider position across every category`() {
+        for (category in VcsColorCategory.entries) {
+            assertEquals(VcsColorPreset.WHISPER_SLIDER, VcsColorPreset.WHISPER.intensityFor(category))
+            assertEquals(VcsColorPreset.AMBIENT_SLIDER, VcsColorPreset.AMBIENT.intensityFor(category))
+            assertEquals(VcsColorPreset.NEON_SLIDER, VcsColorPreset.NEON.intensityFor(category))
+            assertEquals(VcsColorPreset.CYBERPUNK_SLIDER, VcsColorPreset.CYBERPUNK.intensityFor(category))
+        }
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/vcs/VcsColorSnapshotTest.kt
+++ b/src/test/kotlin/dev/ayuislands/vcs/VcsColorSnapshotTest.kt
@@ -3,15 +3,14 @@ package dev.ayuislands.vcs
 import dev.ayuislands.settings.AyuIslandsState
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
 
 /**
  * Tests for [VcsColorSnapshot] and the [VcsColorContext] scoped-override channel.
  *
- * The snapshot + context pair lets the Settings panel feed *pending* values into
- * the applier during one apply pass without mutating the persisted
- * [AyuIslandsState] first — same "state untouched on throw" invariant the chrome
- * tinting context defends in Phase 40.
+ * Phase 40.2b redesign — the snapshot carries the resolved per-category
+ * intensity map directly. Per-section preset choices live on the panel /
+ * state side; by the time a snapshot exists, preset/Custom branching is
+ * already collapsed into concrete intensity numbers.
  */
 class VcsColorSnapshotTest {
     @Test
@@ -19,8 +18,7 @@ class VcsColorSnapshotTest {
         val snapshot =
             VcsColorSnapshot(
                 enabled = false,
-                preset = VcsColorPreset.CYBERPUNK,
-                perCategoryIntensities = emptyMap(),
+                perCategoryIntensities = mapOf(VcsColorCategory.DIFF_VIEWER to 99),
             )
         for (category in VcsColorCategory.entries) {
             assertEquals(0, snapshot.intensityFor(category).percent)
@@ -28,76 +26,66 @@ class VcsColorSnapshotTest {
     }
 
     @Test
-    fun `snapshot intensityFor maps each preset to its canonical slider value`() {
-        val tested =
-            mapOf(
-                VcsColorPreset.WHISPER to VcsColorPreset.WHISPER_SLIDER,
-                VcsColorPreset.AMBIENT to VcsColorPreset.AMBIENT_SLIDER,
-                VcsColorPreset.NEON to VcsColorPreset.NEON_SLIDER,
-                VcsColorPreset.CYBERPUNK to VcsColorPreset.CYBERPUNK_SLIDER,
-            )
-        for ((preset, expectedSlider) in tested) {
-            val snapshot =
-                VcsColorSnapshot(
-                    enabled = true,
-                    preset = preset,
-                    perCategoryIntensities = mapOf(VcsColorCategory.DIFF_VIEWER to 99),
-                )
-            // Non-Custom presets ignore the per-category map entirely.
-            assertEquals(
-                expectedSlider,
-                snapshot.intensityFor(VcsColorCategory.DIFF_VIEWER).percent,
-                "Preset $preset should map to slider $expectedSlider",
-            )
-        }
-    }
-
-    @Test
-    fun `snapshot intensityFor uses per-category map in Custom mode`() {
+    fun `snapshot intensityFor reads materialised per-category map`() {
         val snapshot =
             VcsColorSnapshot(
                 enabled = true,
-                preset = VcsColorPreset.CUSTOM,
-                perCategoryIntensities = mapOf(VcsColorCategory.DIFF_VIEWER to 75),
+                perCategoryIntensities =
+                    mapOf(
+                        VcsColorCategory.DIFF_VIEWER to 67,
+                        VcsColorCategory.BLAME_GUTTER to 33,
+                    ),
             )
-        assertEquals(75, snapshot.intensityFor(VcsColorCategory.DIFF_VIEWER).percent)
+        assertEquals(67, snapshot.intensityFor(VcsColorCategory.DIFF_VIEWER).percent)
+        assertEquals(33, snapshot.intensityFor(VcsColorCategory.BLAME_GUTTER).percent)
     }
 
     @Test
-    fun `snapshot intensityFor falls back to Ambient slider for missing category in Custom`() {
+    fun `snapshot intensityFor falls back to Ambient slider for missing category`() {
         val snapshot =
             VcsColorSnapshot(
                 enabled = true,
-                preset = VcsColorPreset.CUSTOM,
-                // Map missing BLAME_GUTTER — defensive fallback should kick in.
-                perCategoryIntensities = mapOf(VcsColorCategory.DIFF_VIEWER to 75),
+                perCategoryIntensities = mapOf(VcsColorCategory.DIFF_VIEWER to 67),
             )
-        // CUSTOM.intensityFor falls back to Ambient slider per design.
-        assertEquals(VcsColorPreset.AMBIENT_SLIDER, snapshot.intensityFor(VcsColorCategory.BLAME_GUTTER).percent)
+        // Missing entry — defensive fallback to Ambient slider.
+        assertEquals(
+            VcsColorPreset.AMBIENT_SLIDER,
+            snapshot.intensityFor(VcsColorCategory.BLAME_GUTTER).percent,
+        )
     }
 
     @Test
-    fun `fromState mirrors current state values`() {
+    fun `fromState materialises per-section preset choices into per-category intensities`() {
         val state = AyuIslandsState()
         state.vcsColorEnabled = true
-        state.vcsColorPreset = VcsColorPreset.CUSTOM.name
-        state.vcsDiffIntensity = 60
+        state.vcsDiffPreset = VcsColorPreset.NEON.name
+        state.vcsMergePreset = VcsColorPreset.WHISPER.name
+        state.vcsBlamePreset = VcsColorPreset.CYBERPUNK.name
 
         val snapshot = VcsColorSnapshot.fromState(state)
         assertEquals(true, snapshot.enabled)
-        assertEquals(VcsColorPreset.CUSTOM, snapshot.preset)
-        assertEquals(60, snapshot.perCategoryIntensities[VcsColorCategory.DIFF_VIEWER])
+        assertEquals(
+            VcsColorPreset.NEON_SLIDER,
+            snapshot.intensityFor(VcsColorCategory.DIFF_VIEWER).percent,
+        )
+        assertEquals(
+            VcsColorPreset.WHISPER_SLIDER,
+            snapshot.intensityFor(VcsColorCategory.CONFLICT_MARKERS).percent,
+        )
+        assertEquals(
+            VcsColorPreset.CYBERPUNK_SLIDER,
+            snapshot.intensityFor(VcsColorCategory.BLAME_GUTTER).percent,
+        )
     }
 
     @Test
     fun `withSnapshot installs snapshot for the duration of the block`() {
         val state = AyuIslandsState()
-        // State says disabled; pending snapshot says enabled at Cyberpunk.
         val pending =
             VcsColorSnapshot(
                 enabled = true,
-                preset = VcsColorPreset.CYBERPUNK,
-                perCategoryIntensities = emptyMap(),
+                perCategoryIntensities =
+                    mapOf(VcsColorCategory.DIFF_VIEWER to VcsColorPreset.CYBERPUNK_SLIDER),
             )
 
         VcsColorContext.withSnapshot(pending) {
@@ -108,19 +96,13 @@ class VcsColorSnapshotTest {
             )
         }
 
-        // After the block: ThreadLocal cleared, fallback state visible.
         assertEquals(false, VcsColorContext.isEnabled(state))
     }
 
     @Test
     fun `withSnapshot rolls back even when block throws`() {
         val state = AyuIslandsState()
-        val pending =
-            VcsColorSnapshot(
-                enabled = true,
-                preset = VcsColorPreset.CYBERPUNK,
-                perCategoryIntensities = emptyMap(),
-            )
+        val pending = VcsColorSnapshot(enabled = true, perCategoryIntensities = emptyMap())
 
         runCatching {
             VcsColorContext.withSnapshot(pending) {
@@ -150,14 +132,12 @@ class VcsColorSnapshotTest {
         val outer =
             VcsColorSnapshot(
                 enabled = true,
-                preset = VcsColorPreset.AMBIENT,
-                perCategoryIntensities = emptyMap(),
+                perCategoryIntensities = mapOf(VcsColorCategory.DIFF_VIEWER to VcsColorPreset.AMBIENT_SLIDER),
             )
         val inner =
             VcsColorSnapshot(
                 enabled = true,
-                preset = VcsColorPreset.CYBERPUNK,
-                perCategoryIntensities = emptyMap(),
+                perCategoryIntensities = mapOf(VcsColorCategory.DIFF_VIEWER to VcsColorPreset.CYBERPUNK_SLIDER),
             )
 
         VcsColorContext.withSnapshot(outer) {
@@ -171,14 +151,11 @@ class VcsColorSnapshotTest {
                     VcsColorContext.currentIntensity(VcsColorCategory.DIFF_VIEWER, state).percent,
                 )
             }
-            // After inner block — outer must be restored.
             assertEquals(
                 VcsColorPreset.AMBIENT_SLIDER,
                 VcsColorContext.currentIntensity(VcsColorCategory.DIFF_VIEWER, state).percent,
                 "outer snapshot must be restored after inner exit",
             )
-            // Sanity: snapshots are different objects, no aliasing.
-            assertNotEquals(outer.preset, inner.preset)
         }
     }
 }

--- a/src/test/kotlin/dev/ayuislands/vcs/VcsColorSnapshotTest.kt
+++ b/src/test/kotlin/dev/ayuislands/vcs/VcsColorSnapshotTest.kt
@@ -7,10 +7,10 @@ import kotlin.test.assertEquals
 /**
  * Tests for [VcsColorSnapshot] and the [VcsColorContext] scoped-override channel.
  *
- * Phase 40.2b redesign — the snapshot carries the resolved per-category
- * intensity map directly. Per-section preset choices live on the panel /
- * state side; by the time a snapshot exists, preset/Custom branching is
- * already collapsed into concrete intensity numbers.
+ * The snapshot carries the resolved per-category intensity map directly.
+ * Per-section preset choices live on the panel / state side; by the time a
+ * snapshot exists, preset/Custom branching is already collapsed into
+ * concrete intensity numbers.
  */
 class VcsColorSnapshotTest {
     @Test

--- a/src/test/kotlin/dev/ayuislands/vcs/VcsColorSnapshotTest.kt
+++ b/src/test/kotlin/dev/ayuislands/vcs/VcsColorSnapshotTest.kt
@@ -1,0 +1,162 @@
+package dev.ayuislands.vcs
+
+import dev.ayuislands.settings.AyuIslandsState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+/**
+ * Tests for [VcsColorSnapshot] and the [VcsColorContext] scoped-override channel.
+ *
+ * The snapshot + context pair lets the Settings panel feed *pending* values into
+ * the applier during one apply pass without mutating the persisted
+ * [AyuIslandsState] first — same "state untouched on throw" invariant the chrome
+ * tinting context defends in Phase 40.
+ */
+class VcsColorSnapshotTest {
+    @Test
+    fun `snapshot intensityFor returns zero when disabled`() {
+        val snapshot =
+            VcsColorSnapshot(
+                enabled = false,
+                preset = VcsColorPreset.VIBRANT,
+                perCategoryIntensities = emptyMap(),
+            )
+        for (category in VcsColorCategory.entries) {
+            assertEquals(0, snapshot.intensityFor(category).percent)
+        }
+    }
+
+    @Test
+    fun `snapshot intensityFor uses preset table for non-Custom`() {
+        val snapshot =
+            VcsColorSnapshot(
+                enabled = true,
+                preset = VcsColorPreset.BALANCED,
+                perCategoryIntensities = mapOf(VcsColorCategory.DIFF_VIEWER to 99),
+            )
+        // Balanced preset declares 50% — per-category map is ignored.
+        assertEquals(50, snapshot.intensityFor(VcsColorCategory.DIFF_VIEWER).percent)
+    }
+
+    @Test
+    fun `snapshot intensityFor uses per-category map in Custom mode`() {
+        val snapshot =
+            VcsColorSnapshot(
+                enabled = true,
+                preset = VcsColorPreset.CUSTOM,
+                perCategoryIntensities = mapOf(VcsColorCategory.DIFF_VIEWER to 75),
+            )
+        assertEquals(75, snapshot.intensityFor(VcsColorCategory.DIFF_VIEWER).percent)
+    }
+
+    @Test
+    fun `snapshot intensityFor falls back to preset for missing category in Custom`() {
+        val snapshot =
+            VcsColorSnapshot(
+                enabled = true,
+                preset = VcsColorPreset.CUSTOM,
+                // Map missing BLAME_GUTTER — defensive fallback should kick in.
+                perCategoryIntensities = mapOf(VcsColorCategory.DIFF_VIEWER to 75),
+            )
+        // CUSTOM.intensityFor falls back to BALANCED's value (50) per design.
+        assertEquals(50, snapshot.intensityFor(VcsColorCategory.BLAME_GUTTER).percent)
+    }
+
+    @Test
+    fun `fromState mirrors current state values`() {
+        val state = AyuIslandsState()
+        state.vcsColorEnabled = true
+        state.vcsColorPreset = VcsColorPreset.CUSTOM.name
+        state.vcsDiffIntensity = 60
+
+        val snapshot = VcsColorSnapshot.fromState(state)
+        assertEquals(true, snapshot.enabled)
+        assertEquals(VcsColorPreset.CUSTOM, snapshot.preset)
+        assertEquals(60, snapshot.perCategoryIntensities[VcsColorCategory.DIFF_VIEWER])
+    }
+
+    @Test
+    fun `withSnapshot installs snapshot for the duration of the block`() {
+        val state = AyuIslandsState()
+        // State says disabled; pending snapshot says enabled at Vibrant.
+        val pending =
+            VcsColorSnapshot(
+                enabled = true,
+                preset = VcsColorPreset.VIBRANT,
+                perCategoryIntensities = emptyMap(),
+            )
+
+        VcsColorContext.withSnapshot(pending) {
+            assertEquals(true, VcsColorContext.isEnabled(state))
+            assertEquals(100, VcsColorContext.currentIntensity(VcsColorCategory.DIFF_VIEWER, state).percent)
+        }
+
+        // After the block: ThreadLocal cleared, fallback state visible.
+        assertEquals(false, VcsColorContext.isEnabled(state))
+    }
+
+    @Test
+    fun `withSnapshot rolls back even when block throws`() {
+        val state = AyuIslandsState()
+        val pending =
+            VcsColorSnapshot(
+                enabled = true,
+                preset = VcsColorPreset.VIBRANT,
+                perCategoryIntensities = emptyMap(),
+            )
+
+        runCatching {
+            VcsColorContext.withSnapshot(pending) {
+                error("boom")
+            }
+        }
+
+        // ThreadLocal must be cleared even after the throw — no leak across thread reuse.
+        assertEquals(false, VcsColorContext.isEnabled(state))
+    }
+
+    @Test
+    fun `withSnapshot null is a no-op pass-through`() {
+        val state = AyuIslandsState()
+        var blockRan = false
+        VcsColorContext.withSnapshot(null) {
+            blockRan = true
+            // No snapshot installed: read falls through to state (disabled by default).
+            assertEquals(false, VcsColorContext.isEnabled(state))
+        }
+        assertEquals(true, blockRan)
+    }
+
+    @Test
+    fun `withSnapshot nests and restores previous snapshot on exit`() {
+        val state = AyuIslandsState()
+        val outer =
+            VcsColorSnapshot(
+                enabled = true,
+                preset = VcsColorPreset.BALANCED,
+                perCategoryIntensities = emptyMap(),
+            )
+        val inner =
+            VcsColorSnapshot(
+                enabled = true,
+                preset = VcsColorPreset.VIBRANT,
+                perCategoryIntensities = emptyMap(),
+            )
+
+        VcsColorContext.withSnapshot(outer) {
+            assertEquals(50, VcsColorContext.currentIntensity(VcsColorCategory.DIFF_VIEWER, state).percent)
+            VcsColorContext.withSnapshot(inner) {
+                assertEquals(100, VcsColorContext.currentIntensity(VcsColorCategory.DIFF_VIEWER, state).percent)
+            }
+            // After inner block — outer must be restored.
+            assertEquals(
+                50,
+                VcsColorContext.currentIntensity(VcsColorCategory.DIFF_VIEWER, state).percent,
+                "outer snapshot must be restored after inner exit",
+            )
+            // Sanity: snapshots are different objects, no aliasing.
+            assertNotEquals(outer.preset, inner.preset)
+        }
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/vcs/VcsColorSnapshotTest.kt
+++ b/src/test/kotlin/dev/ayuislands/vcs/VcsColorSnapshotTest.kt
@@ -19,7 +19,7 @@ class VcsColorSnapshotTest {
         val snapshot =
             VcsColorSnapshot(
                 enabled = false,
-                preset = VcsColorPreset.VIBRANT,
+                preset = VcsColorPreset.CYBERPUNK,
                 perCategoryIntensities = emptyMap(),
             )
         for (category in VcsColorCategory.entries) {
@@ -28,15 +28,28 @@ class VcsColorSnapshotTest {
     }
 
     @Test
-    fun `snapshot intensityFor uses preset table for non-Custom`() {
-        val snapshot =
-            VcsColorSnapshot(
-                enabled = true,
-                preset = VcsColorPreset.BALANCED,
-                perCategoryIntensities = mapOf(VcsColorCategory.DIFF_VIEWER to 99),
+    fun `snapshot intensityFor maps each preset to its canonical slider value`() {
+        val tested =
+            mapOf(
+                VcsColorPreset.WHISPER to VcsColorPreset.WHISPER_SLIDER,
+                VcsColorPreset.AMBIENT to VcsColorPreset.AMBIENT_SLIDER,
+                VcsColorPreset.NEON to VcsColorPreset.NEON_SLIDER,
+                VcsColorPreset.CYBERPUNK to VcsColorPreset.CYBERPUNK_SLIDER,
             )
-        // Balanced preset declares 50% — per-category map is ignored.
-        assertEquals(50, snapshot.intensityFor(VcsColorCategory.DIFF_VIEWER).percent)
+        for ((preset, expectedSlider) in tested) {
+            val snapshot =
+                VcsColorSnapshot(
+                    enabled = true,
+                    preset = preset,
+                    perCategoryIntensities = mapOf(VcsColorCategory.DIFF_VIEWER to 99),
+                )
+            // Non-Custom presets ignore the per-category map entirely.
+            assertEquals(
+                expectedSlider,
+                snapshot.intensityFor(VcsColorCategory.DIFF_VIEWER).percent,
+                "Preset $preset should map to slider $expectedSlider",
+            )
+        }
     }
 
     @Test
@@ -51,7 +64,7 @@ class VcsColorSnapshotTest {
     }
 
     @Test
-    fun `snapshot intensityFor falls back to preset for missing category in Custom`() {
+    fun `snapshot intensityFor falls back to Ambient slider for missing category in Custom`() {
         val snapshot =
             VcsColorSnapshot(
                 enabled = true,
@@ -59,8 +72,8 @@ class VcsColorSnapshotTest {
                 // Map missing BLAME_GUTTER — defensive fallback should kick in.
                 perCategoryIntensities = mapOf(VcsColorCategory.DIFF_VIEWER to 75),
             )
-        // CUSTOM.intensityFor falls back to BALANCED's value (50) per design.
-        assertEquals(50, snapshot.intensityFor(VcsColorCategory.BLAME_GUTTER).percent)
+        // CUSTOM.intensityFor falls back to Ambient slider per design.
+        assertEquals(VcsColorPreset.AMBIENT_SLIDER, snapshot.intensityFor(VcsColorCategory.BLAME_GUTTER).percent)
     }
 
     @Test
@@ -79,17 +92,20 @@ class VcsColorSnapshotTest {
     @Test
     fun `withSnapshot installs snapshot for the duration of the block`() {
         val state = AyuIslandsState()
-        // State says disabled; pending snapshot says enabled at Vibrant.
+        // State says disabled; pending snapshot says enabled at Cyberpunk.
         val pending =
             VcsColorSnapshot(
                 enabled = true,
-                preset = VcsColorPreset.VIBRANT,
+                preset = VcsColorPreset.CYBERPUNK,
                 perCategoryIntensities = emptyMap(),
             )
 
         VcsColorContext.withSnapshot(pending) {
             assertEquals(true, VcsColorContext.isEnabled(state))
-            assertEquals(100, VcsColorContext.currentIntensity(VcsColorCategory.DIFF_VIEWER, state).percent)
+            assertEquals(
+                VcsColorPreset.CYBERPUNK_SLIDER,
+                VcsColorContext.currentIntensity(VcsColorCategory.DIFF_VIEWER, state).percent,
+            )
         }
 
         // After the block: ThreadLocal cleared, fallback state visible.
@@ -102,7 +118,7 @@ class VcsColorSnapshotTest {
         val pending =
             VcsColorSnapshot(
                 enabled = true,
-                preset = VcsColorPreset.VIBRANT,
+                preset = VcsColorPreset.CYBERPUNK,
                 perCategoryIntensities = emptyMap(),
             )
 
@@ -134,24 +150,30 @@ class VcsColorSnapshotTest {
         val outer =
             VcsColorSnapshot(
                 enabled = true,
-                preset = VcsColorPreset.BALANCED,
+                preset = VcsColorPreset.AMBIENT,
                 perCategoryIntensities = emptyMap(),
             )
         val inner =
             VcsColorSnapshot(
                 enabled = true,
-                preset = VcsColorPreset.VIBRANT,
+                preset = VcsColorPreset.CYBERPUNK,
                 perCategoryIntensities = emptyMap(),
             )
 
         VcsColorContext.withSnapshot(outer) {
-            assertEquals(50, VcsColorContext.currentIntensity(VcsColorCategory.DIFF_VIEWER, state).percent)
+            assertEquals(
+                VcsColorPreset.AMBIENT_SLIDER,
+                VcsColorContext.currentIntensity(VcsColorCategory.DIFF_VIEWER, state).percent,
+            )
             VcsColorContext.withSnapshot(inner) {
-                assertEquals(100, VcsColorContext.currentIntensity(VcsColorCategory.DIFF_VIEWER, state).percent)
+                assertEquals(
+                    VcsColorPreset.CYBERPUNK_SLIDER,
+                    VcsColorContext.currentIntensity(VcsColorCategory.DIFF_VIEWER, state).percent,
+                )
             }
             // After inner block — outer must be restored.
             assertEquals(
-                50,
+                VcsColorPreset.AMBIENT_SLIDER,
                 VcsColorContext.currentIntensity(VcsColorCategory.DIFF_VIEWER, state).percent,
                 "outer snapshot must be restored after inner exit",
             )

--- a/src/test/kotlin/dev/ayuislands/vcs/VcsIntensityTest.kt
+++ b/src/test/kotlin/dev/ayuislands/vcs/VcsIntensityTest.kt
@@ -1,0 +1,42 @@
+package dev.ayuislands.vcs
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Behavioural coverage for [VcsIntensity] — the typed wrapper that guards the
+ * 0..100 slider range and the [VcsIntensity.DEFAULT] no-op constant.
+ *
+ * The clamp behaviour matters because persisted XML values can drift outside
+ * the slider range (hand-edited config, schema migration artifact); the
+ * blender must never see an out-of-range value. The DEFAULT constant matters
+ * because the freshly-installed Pro flow starts every category at it — if a
+ * future refactor pegs DEFAULT to a non-stock slider position, the master
+ * toggle would visibly change colours the moment a user enables it.
+ */
+class VcsIntensityTest {
+    @Test
+    fun `of clamps below MIN to MIN`() {
+        assertEquals(VcsIntensity.MIN, VcsIntensity.of(-1).percent)
+        assertEquals(VcsIntensity.MIN, VcsIntensity.of(Int.MIN_VALUE).percent)
+    }
+
+    @Test
+    fun `of clamps above MAX to MAX`() {
+        assertEquals(VcsIntensity.MAX, VcsIntensity.of(101).percent)
+        assertEquals(VcsIntensity.MAX, VcsIntensity.of(Int.MAX_VALUE).percent)
+    }
+
+    @Test
+    fun `of preserves in-range values`() {
+        assertEquals(0, VcsIntensity.of(0).percent)
+        assertEquals(33, VcsIntensity.of(33).percent)
+        assertEquals(67, VcsIntensity.of(67).percent)
+        assertEquals(100, VcsIntensity.of(100).percent)
+    }
+
+    @Test
+    fun `DEFAULT equals AMBIENT_SLIDER so the master toggle is visibly a no-op on install`() {
+        assertEquals(VcsColorPreset.AMBIENT_SLIDER, VcsIntensity.DEFAULT.percent)
+    }
+}


### PR DESCRIPTION
── Summary ─────────────────────────────────

v2.6.2 muted the diff-modified line color from a saturated cyan to a calmer blue (per PR #167) so it stopped blending into the green added band on dense diffs. Some users — including the maintainer — preferred the brighter pre-2.6.2 punch. This PR ships **user-controlled VCS color intensity** as a Pro feature so individual users can opt into Whisper / Ambient / Neon / Cyberpunk profiles (or a Custom mode with per-surface sliders) without changing the default 2.6.2 colors anyone else sees.

This is a continuation of the Peacock color-motion line that started in 2.6.0 — hence the patch bump rather than a minor.

── Changes ─────────────────────────────────

| Type | Where | Description |
|------|-------|-------------|
| feat | [`VcsColorBlender.kt:1`](src/main/kotlin/dev/ayuislands/vcs/VcsColorBlender.kt) | HSB-lerp blender, shortest-arc hue, base-alpha preservation |
| feat | [`VcsColorPalette.kt:1`](src/main/kotlin/dev/ayuislands/vcs/VcsColorPalette.kt) | 33 stock hex entries (12 keys × 3 variants + 9 TextAttrBg + DIFF_CONFLICT + Blame), HSB endpoint derivation, hex-with-alpha parser |
| feat | [`VcsColorPreset.kt:1`](src/main/kotlin/dev/ayuislands/vcs/VcsColorPreset.kt) | Named profiles enum: Whisper / Ambient / Neon / Cyberpunk / Custom with slider anchors at 0/33/67/100 |
| feat | [`VcsColorCategory.kt:1`](src/main/kotlin/dev/ayuislands/vcs/VcsColorCategory.kt) | 11-category enum (3 user-task groupings × per-surface categories) |
| feat | [`VcsColorSnapshot.kt:1`](src/main/kotlin/dev/ayuislands/vcs/VcsColorSnapshot.kt) | ThreadLocal scoped-override channel mirroring ChromeTintContext |
| feat | [`VcsColorApplier.kt:1`](src/main/kotlin/dev/ayuislands/vcs/VcsColorApplier.kt) | Dispatches per WriteMode (ColorKey via setColor, TextAttrBg via setAttributes), preserves foreground/error-stripe slots |
| feat | [`VcsColorPanel.kt:1`](src/main/kotlin/dev/ayuislands/settings/VcsColorPanel.kt) | Premium-gated settings panel with three collapsible sections, per-section preset segmented buttons, Custom-mode per-category sliders, live color swatches |
| feat | [`AyuIslandsConfigurable.kt:46`](src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt) | Register new \`VCS\` tab between Glow and Workspace |
| feat | [`AyuIslandsState.kt:315`](src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt) | State fields for master toggle, three section presets, eleven per-category intensities, three section-expanded flags, defensive \`effective*\` helpers |
| feat | [`AyuIslandsStartupActivity.kt:104`](src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt) | Re-apply persisted VCS colors at startup, gated on master toggle + live license check |
| feat | [`LicenseChecker.kt:274`](src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt) | Free-tier downgrade clears all section presets, intensities, and applier-level scheme overrides |
| docs | [`plugin.xml:94`](src/main/resources/META-INF/plugin.xml), [`CHANGELOG.md:3`](CHANGELOG.md), [`README.md:62`](README.md) | User-facing change notes + Premium section entry |
| docs | [`features.yml:154`](docs/features.yml) | Feature catalog entry (id \`vcs-color-customization\`, keyword \"VCS color customization\") |
| chore | [`gradle.properties:3`](gradle.properties) | Bump pluginVersion 2.6.2 → 2.6.3 (release-version and release-date stay locked per Marketplace patch-line rule) |
| test | [`VcsColorBlenderTest.kt:1`](src/test/kotlin/dev/ayuislands/vcs/VcsColorBlenderTest.kt) | HSB lerp math, shortest-arc hue, alpha preservation, clamping |
| test | [`VcsColorPaletteTest.kt:1`](src/test/kotlin/dev/ayuislands/vcs/VcsColorPaletteTest.kt) | Completeness, endpoint saturation, Ambient-equals-stock invariant within 24-channel tolerance |
| test | [`VcsColorSnapshotTest.kt:1`](src/test/kotlin/dev/ayuislands/vcs/VcsColorSnapshotTest.kt) | Snapshot intensityFor, fromState materialization, ThreadLocal nesting/rollback |
| test | [`AyuIslandsStateVcsTest.kt:1`](src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateVcsTest.kt) | Per-section preset resolution, defensive fallback to AMBIENT on corrupted strings, master-off short-circuit |
| test | [`VcsColorPanelTest.kt:1`](src/test/kotlin/dev/ayuislands/settings/VcsColorPanelTest.kt) | Default load, isModified detection, per-section preset snap, persistence, license-revoke abort, applier-throw rollback |

── Validation ─────────────────────────────────

\`\`\`bash
./gradlew detekt ktlintCheck test
\`\`\`

Expected: all gates green; new test classes contribute ~50 assertions across blender math, palette completeness, snapshot lifecycle, state helpers, and panel state machine.

Manual smoke (\`./gradlew runIde\` + Settings → Ayu Islands → VCS):

- Tab \`VCS\` appears between Glow and Workspace
- Free license shows placeholder + Pro upgrade link; Pro license shows three collapsible sections
- Master toggle off hides all sections; on restores them with persisted expanded state
- Each section's preset segmented button (Whisper / Ambient / Neon / Cyberpunk / Custom) cycles its sliders + color swatch independently
- DIFF section preset row carries three swatches (modified blue / inserted green / deleted red) tracking the Diff viewer slider
- Custom mode reveals per-category sliders; manual move promotes only that section to Custom
- Apply → diff viewer / Project View / gutter / conflict markers / blame annotations retint live; persistence survives IDE restart via the startup hook

── Notes ─────────────────────────────────

- **Wave 5 (Branch & Commit) deferred to v2.6.4** per spike findings ([`.planning/phases/40.2-vcs-color-customization/40.2-SPIKE-FINDINGS.md`](.planning/phases/40.2-vcs-color-customization/40.2-SPIKE-FINDINGS.md), not committed). Branch indicator / branches popup / commit log highlights live on UIManager surfaces with non-public renderers (\`BranchesTreeRenderer\` requires reflection on 2026.x). Adding them would need a parallel UI_MANAGER write path in the applier. Categories declared in \`VcsColorCategory\` enum as placeholders so v2.6.4 wires them without enum migration.
- **MERGE_3WAY and INLINE_DIFF_POPUP categories** present in the enum but absent from the palette: the merge 3-way viewer reuses Wave 2's DIFF_MODIFIED / INSERTED / DELETED keys, and the inline diff popup is a JBPopup UIManager surface outside scheme coverage.
- **Master toggle defaults OFF** so 2.6.2 upgraders observe byte-identical colors on first 2.6.3 launch.
- **release-version=26 and release-date=20260426 stay locked** per the Marketplace patch-line rule — Marketplace rejects mismatches in either direction.

## Summary by Sourcery

Introduce configurable VCS color intensity as a premium feature with a dedicated settings tab and scheme applier, while keeping defaults identical to v2.6.2 for non-opted-in users.

New Features:
- Add VCS color presets and per-surface intensity controls for diff viewer, project file status, gutter, conflict markers, and blame annotations.
- Provide a new VCS settings tab with per-section presets (Whisper, Ambient, Neon, Cyberpunk, Custom) and sliders, gated behind a Pro license.
- Implement a VCS color palette, blender, and category model to drive HSB-based tinting across editor color keys and text attribute backgrounds.

Enhancements:
- Wire startup and licensing flows to reapply or clear VCS color overrides based on master toggle and Pro license state.
- Add snapshot and context infrastructure so VCS color applies are atomic and rollback-safe.
- Extend settings state with VCS-related fields and helpers for presets, intensities, and section expansion.

Build:
- Bump plugin version to 2.6.3.

Documentation:
- Document VCS color customization in plugin description, changelog, README, and feature catalog.

Tests:
- Add unit tests for VCS color blending, palette behavior, snapshot/context handling, VCS state helpers, and the VCS settings panel state machine.