### PR TITLE
docs(changelog): structure 2.6.3 VCS bullets, drop forward roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@
 ## [2.6.3] - 2026-05-12
 
 ### Added
-- [Paid] **New VCS tab** in Settings (between Glow and Workspace) — tune VCS color intensity across five surfaces: diff viewer, Project View file status, editor gutter, conflict markers, and Git blame annotations. Four named profiles — Whisper, Ambient, Neon, Cyberpunk — plus a Custom mode with per-surface sliders. Master toggle stays off by default, so 2.6.2 colors are byte-identical until you opt in.
+- [Paid] **New VCS tab in Settings** — *Settings → Ayu Islands → VCS*, between Glow and Workspace. Tune VCS color intensity across five surfaces: **diff viewer**, **Project View file status**, **editor gutter**, **conflict markers**, and **Git blame annotations**.
+- [Paid] **Four named profiles** — pick **Whisper** (calmer), **Ambient** (2.6.2 defaults), **Neon** (brighter, restores the pre-2.6.2 punch), or **Cyberpunk** (peak vibrancy). Each section (Diff, Merge, Blame) carries its own profile, so you can mix — Neon diffs with Whisper blame, for example.
+- [Paid] **Custom mode** — unlocks per-surface sliders inside each section for fine-grained control.
 
-### Roadmap
-Next patch wires the same intensity profile into the branch indicator, branches popup, and commit log highlights — they live on a different UI surface that needs its own platform research.
+### Compatibility
+- Master toggle stays off by default — 2.6.2 colors are **byte-identical** until you opt in. No surprise tints on upgrade.
 
 ## [2.6.2] - 2026-05-10
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -103,7 +103,6 @@
     <ul>
       <li>[Paid] <b>New VCS tab</b> — tune VCS color intensity across five surfaces (diff viewer, Project View file status, editor gutter, conflict markers, Git blame annotations). Pick a named profile — <b>Whisper</b> (calmer), <b>Ambient</b> (2.6.2 defaults), <b>Neon</b> (brighter, pre-2.6.2 punch), or <b>Cyberpunk</b> (peak) — or dial each surface independently in Custom mode. Master toggle stays off by default, so colors are byte-identical to 2.6.2 until you opt in.</li>
       <li>Settings → Ayu Islands → <b>VCS</b> tab now lives between Glow and Workspace.</li>
-      <li><b>Coming next:</b> branch indicator, branches popup, and commit log highlights as a follow-up patch — they live on a different UI surface that needs its own platform research.</li>
     </ul>
     <h3>2.6.2</h3>
     <ul>


### PR DESCRIPTION
## Summary

Pre-release docs polish for the 2.6.3 entry that already merged in PR #170. Two reasons:

1. **Visibility** — the original 2.6.3 entry was one dense paragraph; restructured into three `[Paid]` bullets so users skimming the Marketplace change-notes can see the four profile names and the Custom mode in a glance.
2. **Honesty** — dropped the forward-looking \"Next patch wires branch indicator / branches popup / commit log highlights\" line. Those surfaces live on UIManager / non-public BranchesTreeRenderer reflection (not EditorColorsScheme), the Wave 5 platform spike returned DEFER, no concrete delivery timeline — public delivery promises without line-of-sight is a credibility hazard.

## Changes

| Type | File | Description |
|---|---|---|
| Docs | [CHANGELOG.md](CHANGELOG.md) | 2.6.3 entry restructured into three \`[Paid]\` bullets + Compatibility note; Roadmap section removed |
| Docs | [src/main/resources/META-INF/plugin.xml](src/main/resources/META-INF/plugin.xml) | Matching \"Coming next\" change-notes bullet removed |

## Validation

\`\`\`
./gradlew ktlintCheck detekt buildPlugin   # all green
./gradlew verifyPlugin                      # 12 IDE targets pass
\`\`\`

No code changes. No new deprecations. Pre-existing experimental APIs (LafManager.getInstalledThemes) unchanged.

## Summary by Sourcery

Polish the 2.6.3 changelog and plugin change-notes to clarify current VCS customization features and remove forward-looking roadmap promises.

Documentation:
- Restructure the 2.6.3 changelog entry into separate bullets for the VCS settings tab, named profiles, and Custom mode, plus a compatibility note about unchanged defaults.
- Remove the forward-looking roadmap section from the changelog and the matching "Coming next" bullet from the plugin change-notes.