### PR TITLE
ci: split Verify matrix to A1/A2/B + free disk in release.yml

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,0 +1,18 @@
+name: Free disk space
+description: >
+  Prune large pre-installed toolchains on GitHub-hosted ubuntu runners so the
+  Plugin Verifier has room to download + extract 11 IDE builds (~20 GB)
+  without hitting ClosedByInterruptException during JAR extraction.
+
+runs:
+  using: composite
+  steps:
+    - name: Prune unused toolchains
+      shell: bash
+      run: |
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /usr/local/share/boost
+        df -h /

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -229,7 +229,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [A, B]
+        # Split into 3 groups of 3+3+5 IDEs each so per-runner disk + I/O budget
+        # stays below the ClosedByInterruptException threshold that the unsplit
+        # 6-IDE Group A kept hitting.
+        group: [A1, A2, B]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -254,7 +257,7 @@ jobs:
       - name: Verify plugin (group ${{ matrix.group }})
         run: ./gradlew verifyPlugin -DverifyGroup=${{ matrix.group }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: matrix.group == 'A'
+        if: matrix.group == 'A1'
         with:
           name: ayu-islands-plugin
           path: build/distributions/*.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -237,18 +237,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      # GitHub-hosted runners ship with ~25 GB of pre-installed toolchains we don't need.
-      # Plugin Verifier downloads + extracts 5-6 IDE builds per group (~10-12 GB) and the
-      # Group B job has hit "No space left on device" on the runner diag log partition.
-      # Prune the large toolchains we don't touch so the IDE extraction window has room.
-      - name: Free disk space
-        run: |
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /usr/local/share/boost
-          df -h /
+      - uses: ./.github/actions/free-disk-space
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: temurin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,19 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+      # Plugin Verifier downloads + extracts 11 IDE builds (~20 GB) when called
+      # without -DverifyGroup. Hosted runners ship with ~25 GB of pre-installed
+      # toolchains we do not touch; pruning them gives the verifier room to
+      # extract every JAR without ClosedByInterruptException on full-disk.
+      # Same step is in build.yml's verify job — keep them in sync.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/boost
+          df -h /
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: temurin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,19 +17,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-      # Plugin Verifier downloads + extracts 11 IDE builds (~20 GB) when called
-      # without -DverifyGroup. Hosted runners ship with ~25 GB of pre-installed
-      # toolchains we do not touch; pruning them gives the verifier room to
-      # extract every JAR without ClosedByInterruptException on full-disk.
-      # Same step is in build.yml's verify job — keep them in sync.
-      - name: Free disk space
-        run: |
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /usr/local/share/boost
-          df -h /
+      - uses: ./.github/actions/free-disk-space
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: temurin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,18 +87,36 @@ intellijPlatform {
                 "ReleaseVersionAndPluginVersionMismatch,ExperimentalApiUsage",
             )
         ides {
+            // verifyGroup splits the 11 IDE targets across hosted runners to keep
+            // the per-runner disk and I/O budget under what GitHub Actions can
+            // sustain. A1/A2 split prevents the 6-way verifier-thread fan-out
+            // from saturating one runner's I/O and hitting ClosedByInterruptException
+            // on JAR extraction (observed three times on the unsplit Group A).
+            //
+            //   null  → every target (local dev: `./gradlew verifyPlugin`)
+            //   "A"   → A1 + A2 (back-compat with earlier matrix shape)
+            //   "A1"  → IntelliJ family (3 IDEs)
+            //   "A2"  → JetBrains pro IDEs on 2025.3 (3 IDEs)
+            //   "B"   → Language-specific IDEs on 2025.1 (5 IDEs)
             val group = providers.systemProperty("verifyGroup").orNull
-            if (group != "B") {
-                // Group A: IC/IU + major IDEs
+            val wanted =
+                when (group) {
+                    null -> setOf("A1", "A2", "B")
+                    "A" -> setOf("A1", "A2")
+                    "A1", "A2", "B" -> setOf(group)
+                    else -> error("Unknown verifyGroup '$group' — expected A1, A2, A, B, or unset")
+                }
+            if ("A1" in wanted) {
                 create(IntelliJPlatformType.IntellijIdeaCommunity, "2025.1")
                 create(IntelliJPlatformType.IntellijIdeaCommunity, "2025.2.3")
                 create(IntelliJPlatformType.IntellijIdea, "2025.3.3")
+            }
+            if ("A2" in wanted) {
                 create(IntelliJPlatformType.PhpStorm, "2025.3.3")
                 create(IntelliJPlatformType.WebStorm, "2025.3.3")
                 create(IntelliJPlatformType.CLion, "2025.3.3")
             }
-            if (group != "A") {
-                // Group B: Language-specific IDEs
+            if ("B" in wanted) {
                 // RustRover 2025.1.3 excluded: corrupted CDN artifact (InvalidIdeException: missing Core plugin)
                 create(IntelliJPlatformType.GoLand, "2025.1.3")
                 create(IntelliJPlatformType.PyCharm, "2025.1.3")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,7 +89,7 @@ intellijPlatform {
         ides {
             // verifyGroup splits the 11 IDE targets across hosted runners to keep
             // the per-runner disk and I/O budget under what GitHub Actions can
-            // sustain. A1/A2 split prevents the 6-way verifier-thread fan-out
+            // sustain. The A1/A2 split prevents the 6-way verifier-thread fan-out
             // from saturating one runner's I/O and hitting ClosedByInterruptException
             // on JAR extraction (observed three times on the unsplit Group A).
             //
@@ -98,31 +98,42 @@ intellijPlatform {
             //   "A1"  → IntelliJ family (3 IDEs)
             //   "A2"  → JetBrains pro IDEs on 2025.3 (3 IDEs)
             //   "B"   → Language-specific IDEs on 2025.1 (5 IDEs)
+            //
+            // RustRover 2025.1.3 excluded from Group B: corrupted CDN artifact
+            // (InvalidIdeException: missing Core plugin).
+            val ideGroups: Map<String, List<Pair<IntelliJPlatformType, String>>> =
+                mapOf(
+                    "A1" to
+                        listOf(
+                            IntelliJPlatformType.IntellijIdeaCommunity to "2025.1",
+                            IntelliJPlatformType.IntellijIdeaCommunity to "2025.2.3",
+                            IntelliJPlatformType.IntellijIdea to "2025.3.3",
+                        ),
+                    "A2" to
+                        listOf(
+                            IntelliJPlatformType.PhpStorm to "2025.3.3",
+                            IntelliJPlatformType.WebStorm to "2025.3.3",
+                            IntelliJPlatformType.CLion to "2025.3.3",
+                        ),
+                    "B" to
+                        listOf(
+                            IntelliJPlatformType.GoLand to "2025.1.3",
+                            IntelliJPlatformType.PyCharm to "2025.1.3",
+                            IntelliJPlatformType.DataGrip to "2025.1.3",
+                            IntelliJPlatformType.Rider to "2025.1.3",
+                            IntelliJPlatformType.RubyMine to "2025.1.3",
+                        ),
+                )
             val group = providers.systemProperty("verifyGroup").orNull
             val wanted =
                 when (group) {
-                    null -> setOf("A1", "A2", "B")
+                    null -> ideGroups.keys
                     "A" -> setOf("A1", "A2")
-                    "A1", "A2", "B" -> setOf(group)
+                    in ideGroups.keys -> setOf(group)
                     else -> error("Unknown verifyGroup '$group' — expected A1, A2, A, B, or unset")
                 }
-            if ("A1" in wanted) {
-                create(IntelliJPlatformType.IntellijIdeaCommunity, "2025.1")
-                create(IntelliJPlatformType.IntellijIdeaCommunity, "2025.2.3")
-                create(IntelliJPlatformType.IntellijIdea, "2025.3.3")
-            }
-            if ("A2" in wanted) {
-                create(IntelliJPlatformType.PhpStorm, "2025.3.3")
-                create(IntelliJPlatformType.WebStorm, "2025.3.3")
-                create(IntelliJPlatformType.CLion, "2025.3.3")
-            }
-            if ("B" in wanted) {
-                // RustRover 2025.1.3 excluded: corrupted CDN artifact (InvalidIdeException: missing Core plugin)
-                create(IntelliJPlatformType.GoLand, "2025.1.3")
-                create(IntelliJPlatformType.PyCharm, "2025.1.3")
-                create(IntelliJPlatformType.DataGrip, "2025.1.3")
-                create(IntelliJPlatformType.Rider, "2025.1.3")
-                create(IntelliJPlatformType.RubyMine, "2025.1.3")
+            wanted.flatMap { ideGroups.getValue(it) }.forEach { (type, version) ->
+                create(type, version)
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -124,9 +124,8 @@ intellijPlatform {
                             IntelliJPlatformType.RubyMine to "2025.1.3",
                         ),
                 )
-            val group = providers.systemProperty("verifyGroup").orNull
             val wanted =
-                when (group) {
+                when (val group = providers.systemProperty("verifyGroup").orNull) {
                     null -> ideGroups.keys
                     "A" -> setOf("A1", "A2")
                     in ideGroups.keys -> setOf(group)


### PR DESCRIPTION
## Summary

Three failed CI attempts (PR #170 Round 1 Verify A, PR #171 Verify A, v2.6.3 release Publish) hit the same flake: \`JarArchiveCannotBeOpenException\` caused by \`ClosedByInterruptException\` during plugin-verifier JAR extraction. Same runner OS, same step, same root cause — disk pressure on \`ubuntu-latest\`.

## Root cause

- GitHub-hosted runners ship with ~25 GB of pre-installed toolchains (CodeQL, dotnet, Android SDK, GHC, Boost)
- Plugin Verifier downloads + extracts 11 IDE builds (~20 GB)
- One worker times out → \`Thread.interrupt()\` → every concurrent \`ZipFile.open\` in flight aborts → cascading \`ClosedByInterruptException\` → verifyPlugin fails

\`build.yml\` already had a \`Free disk space\` step prunning those toolchains. \`release.yml\` did not. The remaining flake on PR Verify A was the 6-IDE Group A on a single runner — too much I/O concurrency for one disk to handle.

## Changes

| Type | File | Description |
|---|---|---|
| CI | [.github/workflows/release.yml](.github/workflows/release.yml) | Add the same \`Free disk space\` step that build.yml uses before \`buildPlugin verifyPlugin publishPlugin\` |
| Build | [build.gradle.kts](build.gradle.kts) | Split Group A into A1 (IC 25.1, IC 25.2.3, IU 25.3.3) + A2 (PhpStorm/WebStorm/CLion 25.3.3) — 3+3 IDEs per runner; \`A\` kept as back-compat alias |
| CI | [.github/workflows/build.yml](.github/workflows/build.yml) | Matrix \`[A, B]\` → \`[A1, A2, B]\`; artifact upload \`matrix.group == 'A1'\` |

## Validation

\`\`\`
./gradlew ktlintCheck detekt   # local — green
./gradlew verifyPlugin -DverifyGroup=A1 --dry-run   # DSL valid, no errors
\`\`\`

This PR's own CI will be the first run on the new \`[A1, A2, B]\` matrix — that itself validates the split end-to-end.

## Notes

- Local-dev \`./gradlew verifyPlugin\` without \`-DverifyGroup\` still resolves all 11 IDEs (wanted=A1+A2+B)
- \`-DverifyGroup=A\` keeps working for any scripts that hard-coded the old name

## Summary by Sourcery

Adjust plugin verification configuration and CI workflows to reduce disk pressure and flakiness on GitHub-hosted runners.

Bug Fixes:
- Prevent plugin verification failures caused by disk exhaustion and ClosedByInterruptException during IDE JAR extraction on CI runners.

Enhancements:
- Split the verifyGroup configuration into A1, A2, and B subsets, keeping A as a backward-compatible alias while allowing selective verification of IDE groups.
- Update verifyPlugin target selection logic to map verifyGroup values to the appropriate IDE subsets and validate unknown group values with a clear error.

CI:
- Expand the build workflow verification matrix from [A, B] to [A1, A2, B] and adjust artifact upload to run on the A1 group only.
- Add a disk space reclamation step to the release workflow to remove unused pre-installed toolchains before running plugin verification.