### PR TITLE
fix(auto-fit): block redundant re-apply on tool window show events

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -269,8 +269,8 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "eacf7f6"
-          last_verified_date: "2026-04-16"
+          last_verified_sha: "767f914"
+          last_verified_date: "2026-05-12"
           content_sha256: "fc9ba63b9c9c53893a486a3c9055287bd6dc9c68f5439cae197efe5ae585d17c"
 
   tabs:

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "8386cd4"
+          last_verified_sha: "24b5a3e"
           last_verified_date: "2026-04-25"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "8386cd4"
+          last_verified_sha: "24b5a3e"
           last_verified_date: "2026-04-25"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -226,7 +226,7 @@ categories:
           sources:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "8386cd4"
+          last_verified_sha: "24b5a3e"
           last_verified_date: "2026-05-10"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -269,7 +269,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "767f914"
+          last_verified_sha: "24b5a3e"
           last_verified_date: "2026-05-12"
           content_sha256: "fc9ba63b9c9c53893a486a3c9055287bd6dc9c68f5439cae197efe5ae585d17c"
 

--- a/src/main/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManager.kt
+++ b/src/main/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManager.kt
@@ -10,6 +10,7 @@ import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.PanelWidthMode
 import dev.ayuislands.toolwindow.AutoFitCalculator
 import dev.ayuislands.toolwindow.ToolWindowAutoFitter
+import dev.ayuislands.toolwindow.shouldTriggerAutoFit
 
 /** Per-project service that auto-fits the Commit tool window width to its tree content. */
 @Service(Service.Level.PROJECT)
@@ -34,12 +35,7 @@ class CommitPanelAutoFitManager(
                     toolWindowManager: ToolWindowManager,
                     changeType: ToolWindowManagerListener.ToolWindowManagerEventType,
                 ) {
-                    if (changeType == ToolWindowManagerListener.ToolWindowManagerEventType.MovedOrResized) return
-                    // ShowToolWindow fires every time the Commit tool window toggles visible.
-                    // Content is unchanged; re-measuring the JTree on show oscillates its width
-                    // because row bounds reflect cell-renderer extension under focus. Legitimate
-                    // re-applies still arrive via mode-switch in [apply] and expansion listener.
-                    if (changeType == ToolWindowManagerListener.ToolWindowManagerEventType.ShowToolWindow) return
+                    if (!changeType.shouldTriggerAutoFit()) return
                     val tw = toolWindowManager.getToolWindow("Commit") ?: return
                     if (!tw.isVisible) return
                     val mode =

--- a/src/main/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManager.kt
+++ b/src/main/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManager.kt
@@ -35,6 +35,11 @@ class CommitPanelAutoFitManager(
                     changeType: ToolWindowManagerListener.ToolWindowManagerEventType,
                 ) {
                     if (changeType == ToolWindowManagerListener.ToolWindowManagerEventType.MovedOrResized) return
+                    // ShowToolWindow fires every time the Commit tool window toggles visible.
+                    // Content is unchanged; re-measuring the JTree on show oscillates its width
+                    // because row bounds reflect cell-renderer extension under focus. Legitimate
+                    // re-applies still arrive via mode-switch in [apply] and expansion listener.
+                    if (changeType == ToolWindowManagerListener.ToolWindowManagerEventType.ShowToolWindow) return
                     val tw = toolWindowManager.getToolWindow("Commit") ?: return
                     if (!tw.isVisible) return
                     val mode =

--- a/src/main/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManager.kt
+++ b/src/main/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManager.kt
@@ -37,6 +37,12 @@ class GitPanelAutoFitManager(
                     changeType: ToolWindowManagerListener.ToolWindowManagerEventType,
                 ) {
                     if (changeType == ToolWindowManagerListener.ToolWindowManagerEventType.MovedOrResized) return
+                    // ShowToolWindow fires every time the Version Control tool window toggles visible.
+                    // Content is unchanged; re-running fitSplitters on show would re-measure JTree
+                    // row bounds which oscillate with cell-renderer focus extension, producing a
+                    // different splitter proportion each toggle. Mode-switch via [apply] remains
+                    // the legitimate trigger.
+                    if (changeType == ToolWindowManagerListener.ToolWindowManagerEventType.ShowToolWindow) return
                     val tw = toolWindowManager.getToolWindow("Version Control") ?: return
                     if (!tw.isVisible) return
                     val mode =

--- a/src/main/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManager.kt
+++ b/src/main/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManager.kt
@@ -10,6 +10,7 @@ import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.PanelWidthMode
 import dev.ayuislands.toolwindow.AutoFitCalculator
+import dev.ayuislands.toolwindow.shouldTriggerAutoFit
 import javax.swing.JTable
 import javax.swing.JTree
 import javax.swing.Timer
@@ -36,13 +37,7 @@ class GitPanelAutoFitManager(
                     toolWindowManager: ToolWindowManager,
                     changeType: ToolWindowManagerListener.ToolWindowManagerEventType,
                 ) {
-                    if (changeType == ToolWindowManagerListener.ToolWindowManagerEventType.MovedOrResized) return
-                    // ShowToolWindow fires every time the Version Control tool window toggles visible.
-                    // Content is unchanged; re-running fitSplitters on show would re-measure JTree
-                    // row bounds which oscillate with cell-renderer focus extension, producing a
-                    // different splitter proportion each toggle. Mode-switch via [apply] remains
-                    // the legitimate trigger.
-                    if (changeType == ToolWindowManagerListener.ToolWindowManagerEventType.ShowToolWindow) return
+                    if (!changeType.shouldTriggerAutoFit()) return
                     val tw = toolWindowManager.getToolWindow("Version Control") ?: return
                     if (!tw.isVisible) return
                     val mode =

--- a/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
+++ b/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
@@ -15,6 +15,7 @@ import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.PanelWidthMode
 import dev.ayuislands.toolwindow.AutoFitCalculator
 import dev.ayuislands.toolwindow.ToolWindowAutoFitter
+import dev.ayuislands.toolwindow.shouldTriggerAutoFit
 import dev.ayuislands.ui.ComponentTreeRefreshedListener
 import dev.ayuislands.ui.ComponentTreeRefreshedTopic
 import java.awt.Component
@@ -54,13 +55,7 @@ class ProjectViewScrollbarManager(
                     toolWindowManager: ToolWindowManager,
                     changeType: ToolWindowManagerListener.ToolWindowManagerEventType,
                 ) {
-                    if (changeType == ToolWindowManagerListener.ToolWindowManagerEventType.MovedOrResized) return
-                    // ShowToolWindow fires every time the Project tool window is toggled visible.
-                    // The content is unchanged, but JTree row bounds reflect cell-renderer extension
-                    // (different when row has focus), so re-measuring on show oscillates the width.
-                    // Initial apply still fires from SwingUtilities.invokeLater (service ctor) and
-                    // ComponentTreeRefreshedTopic (LAF/focus swap) — those remain legitimate triggers.
-                    if (changeType == ToolWindowManagerListener.ToolWindowManagerEventType.ShowToolWindow) return
+                    if (!changeType.shouldTriggerAutoFit()) return
                     val tw = toolWindowManager.getToolWindow("Project") ?: return
                     if (!tw.isVisible) return
                     val state =

--- a/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
+++ b/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
@@ -55,6 +55,12 @@ class ProjectViewScrollbarManager(
                     changeType: ToolWindowManagerListener.ToolWindowManagerEventType,
                 ) {
                     if (changeType == ToolWindowManagerListener.ToolWindowManagerEventType.MovedOrResized) return
+                    // ShowToolWindow fires every time the Project tool window is toggled visible.
+                    // The content is unchanged, but JTree row bounds reflect cell-renderer extension
+                    // (different when row has focus), so re-measuring on show oscillates the width.
+                    // Initial apply still fires from SwingUtilities.invokeLater (service ctor) and
+                    // ComponentTreeRefreshedTopic (LAF/focus swap) — those remain legitimate triggers.
+                    if (changeType == ToolWindowManagerListener.ToolWindowManagerEventType.ShowToolWindow) return
                     val tw = toolWindowManager.getToolWindow("Project") ?: return
                     if (!tw.isVisible) return
                     val state =

--- a/src/main/kotlin/dev/ayuislands/toolwindow/AutoFitTriggers.kt
+++ b/src/main/kotlin/dev/ayuislands/toolwindow/AutoFitTriggers.kt
@@ -1,0 +1,23 @@
+package dev.ayuislands.toolwindow
+
+import com.intellij.openapi.wm.ex.ToolWindowManagerListener
+
+/**
+ * Whether this `ToolWindowManager` event indicates a content change that
+ * warrants an auto-fit re-measure.
+ *
+ * Filtered out:
+ * - `MovedOrResized` — fires from our own `stretchWidth` call; reacting to
+ *   it would create a feedback loop (was the root of v2.3.7 width oscillation).
+ * - `ShowToolWindow` — toggling visibility does not change tree content,
+ *   but `JTree.getRowBounds()` returns different widths depending on cell-renderer
+ *   focus state, so re-measuring on show produces unstable widths (root cause
+ *   of #169).
+ *
+ * All other event types fall through and let the auto-fit listener proceed —
+ * the fingerprint guard inside [ToolWindowAutoFitter] handles idempotence for
+ * the legitimate cases.
+ */
+internal fun ToolWindowManagerListener.ToolWindowManagerEventType.shouldTriggerAutoFit(): Boolean =
+    this != ToolWindowManagerListener.ToolWindowManagerEventType.MovedOrResized &&
+        this != ToolWindowManagerListener.ToolWindowManagerEventType.ShowToolWindow

--- a/src/main/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitter.kt
+++ b/src/main/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitter.kt
@@ -27,6 +27,14 @@ class ToolWindowAutoFitter(
     private var expansionTree: JTree? = null
     private var retryTimer: Timer? = null
     private var isApplying = false
+
+    // Defensive idempotence: fingerprint of the last successfully-measured tree shape.
+    // Composed of (rowCount, maxRowWidth) — these are the only inputs that affect
+    // [applyAutoFitWidth]'s desired width. When a stray re-apply (e.g. focus swap,
+    // listener re-fire) arrives with unchanged content AND the resulting width would
+    // be within jitter of the current width, skip the stretchWidth call.
+    // Reset in [removeExpansionListener] so a re-installed listener forces a fresh measurement.
+    private var lastFingerprint: Int? = null
     private val debounceTimer =
         Timer(DEBOUNCE_DELAY_MS) { applyAutoFitWidth(maxWidthProvider()) }
             .apply { isRepeats = false }
@@ -54,6 +62,18 @@ class ToolWindowAutoFitter(
                     maxWidth,
                     minWidthProvider(),
                 )
+            // Fingerprint guard: when tree content is unchanged AND the resulting width
+            // would only differ by jitter, skip the stretchWidth call. Prevents stray
+            // re-applies (focus swap, listener re-fire) from oscillating the tool window
+            // because JTree row bounds extend slightly under focus.
+            val fingerprint = (tree.rowCount * FINGERPRINT_MIX) xor maxRowWidth
+            val currentWidth = toolWindowEx.component.width
+            if (fingerprint == lastFingerprint &&
+                AutoFitCalculator.isJitterOnly(currentWidth, desiredWidth)
+            ) {
+                return@findTreeWithRetry
+            }
+            lastFingerprint = fingerprint
             applyWidth(toolWindowEx, desiredWidth)
         }
     }
@@ -166,6 +186,10 @@ class ToolWindowAutoFitter(
     fun removeExpansionListener() {
         retryTimer?.stop()
         retryTimer = null
+        // Reset fingerprint so a future re-install forces a fresh measurement
+        // (the previous tree may have been disposed; its rowCount/maxRowWidth
+        // is stale).
+        lastFingerprint = null
         val tree = expansionTree ?: return
         val listener = expansionListener ?: return
         tree.removeTreeExpansionListener(listener)
@@ -246,5 +270,10 @@ class ToolWindowAutoFitter(
         private const val DEFAULT_MAX_WIDTH = 400
         private const val MAX_RETRIES = 3
         private const val RETRY_DELAY_MS = 200
+
+        // Odd multiplier to avoid collisions between common (rowCount, maxRowWidth)
+        // pairs. Mersenne-prime-adjacent — the actual value is arbitrary; only its
+        // role as a non-trivial mixer matters.
+        private const val FINGERPRINT_MIX = 31
     }
 }

--- a/src/main/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitter.kt
+++ b/src/main/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitter.kt
@@ -65,8 +65,8 @@ class ToolWindowAutoFitter(
             // Fingerprint guard: when tree content is unchanged AND the resulting width
             // would only differ by jitter, skip the stretchWidth call. Prevents stray
             // re-applies (focus swap, listener re-fire) from oscillating the tool window
-            // because JTree row bounds extend slightly under focus.
-            val fingerprint = (tree.rowCount * FINGERPRINT_MIX) xor maxRowWidth
+            // because `JTree` row bounds extend slightly under focus.
+            val fingerprint = computeFingerprint(tree.rowCount, maxRowWidth)
             val currentWidth = toolWindowEx.component.width
             if (fingerprint == lastFingerprint &&
                 AutoFitCalculator.isJitterOnly(currentWidth, desiredWidth)
@@ -263,6 +263,18 @@ class ToolWindowAutoFitter(
                 ?: return null
         return AutoFitCalculator.findFirstOfType(content, JTree::class.java) as? JTree
     }
+
+    /**
+     * Deterministic mix keyed on the two dimensions that drive [applyAutoFitWidth]'s
+     * desired width: `rowCount` and `maxRowWidth`. The mix only needs collision
+     * resistance against common neighbouring tree shapes — not cryptographic strength.
+     * Centralised here so future tweaks (different multiplier, additional inputs such
+     * as expanded-row count) land in one place.
+     */
+    private fun computeFingerprint(
+        rowCount: Int,
+        maxRowWidth: Int,
+    ): Int = (rowCount * FINGERPRINT_MIX) xor maxRowWidth
 
     companion object {
         private val LOG = logger<ToolWindowAutoFitter>()

--- a/src/test/kotlin/dev/ayuislands/toolwindow/AutoFitTriggersTest.kt
+++ b/src/test/kotlin/dev/ayuislands/toolwindow/AutoFitTriggersTest.kt
@@ -1,0 +1,35 @@
+package dev.ayuislands.toolwindow
+
+import com.intellij.openapi.wm.ex.ToolWindowManagerListener.ToolWindowManagerEventType
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Locks the filter contract shared by the three `*AutoFitManager` listeners.
+ *
+ * Both filtered cases (`MovedOrResized`, `ShowToolWindow`) are the actual root causes
+ * of the v2.3.7 / #169 width-oscillation regressions — keeping them rejected here
+ * prevents drift if a future caller adds a third manager and inlines its own guards.
+ */
+class AutoFitTriggersTest {
+    @Test
+    fun `MovedOrResized does not trigger auto-fit`() {
+        assertFalse(ToolWindowManagerEventType.MovedOrResized.shouldTriggerAutoFit())
+    }
+
+    @Test
+    fun `ShowToolWindow does not trigger auto-fit`() {
+        assertFalse(ToolWindowManagerEventType.ShowToolWindow.shouldTriggerAutoFit())
+    }
+
+    @Test
+    fun `HideToolWindow falls through for downstream tw isVisible filter`() {
+        assertTrue(ToolWindowManagerEventType.HideToolWindow.shouldTriggerAutoFit())
+    }
+
+    @Test
+    fun `ActivateToolWindow triggers auto-fit`() {
+        assertTrue(ToolWindowManagerEventType.ActivateToolWindow.shouldTriggerAutoFit())
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitterTest.kt
+++ b/src/test/kotlin/dev/ayuislands/toolwindow/ToolWindowAutoFitterTest.kt
@@ -563,6 +563,167 @@ class ToolWindowAutoFitterTest {
 
     // endregion
 
+    // region fingerprint guard (defensive idempotence — issue #169)
+
+    @Test
+    fun `applyAutoFitWidth is idempotent when tree content unchanged`() {
+        SwingUtilities.invokeAndWait {
+            // Tree width 280 + padding 20 = 300, current = 200 -> delta = 100.
+            // Second invocation with the same (rowCount, maxRowWidth) and a
+            // current width close to desired must be a no-op.
+            mockCalculatorForWidth(280)
+            val tree = JTree()
+            val panel = JPanel(FlowLayout())
+            panel.add(tree)
+            panel.setSize(200, 400)
+
+            val content =
+                mockk<Content>(relaxed = true) {
+                    every { component } returns panel
+                }
+            val contentManager =
+                mockk<ContentManager>(relaxed = true) {
+                    every { contents } returns arrayOf(content)
+                }
+            every {
+                toolWindowManager.getToolWindow("Project")
+            } returns toolWindowEx
+            every {
+                toolWindowEx.contentManager
+            } returns contentManager
+            every { toolWindowEx.component } returns panel
+            every {
+                toolWindowEx.type
+            } returns ToolWindowType.DOCKED
+
+            val fitter =
+                ToolWindowAutoFitter(
+                    project,
+                    "Project",
+                    100,
+                )
+
+            // First call: fingerprint is null -> falls through, stretches by 100.
+            fitter.applyAutoFitWidth(500)
+            verify(exactly = 1) { toolWindowEx.stretchWidth(100) }
+
+            // Simulate panel having taken the stretched width — current ≈ desired.
+            panel.setSize(300, 400)
+
+            // Second call: same tree content, current ≈ desired -> fingerprint
+            // matches AND jitter-only -> must NOT call stretchWidth again.
+            fitter.applyAutoFitWidth(500)
+            verify(exactly = 1) { toolWindowEx.stretchWidth(any()) }
+        }
+    }
+
+    @Test
+    fun `applyAutoFitWidth re-applies when tree row count changes`() {
+        SwingUtilities.invokeAndWait {
+            // First measurement: maxRowWidth = 280, current = 200 -> stretch 100.
+            mockCalculatorForWidth(280)
+            val tree = JTree()
+            val panel = JPanel(FlowLayout())
+            panel.add(tree)
+            panel.setSize(200, 400)
+
+            val content =
+                mockk<Content>(relaxed = true) {
+                    every { component } returns panel
+                }
+            val contentManager =
+                mockk<ContentManager>(relaxed = true) {
+                    every { contents } returns arrayOf(content)
+                }
+            every {
+                toolWindowManager.getToolWindow("Project")
+            } returns toolWindowEx
+            every {
+                toolWindowEx.contentManager
+            } returns contentManager
+            every { toolWindowEx.component } returns panel
+            every {
+                toolWindowEx.type
+            } returns ToolWindowType.DOCKED
+
+            val fitter =
+                ToolWindowAutoFitter(
+                    project,
+                    "Project",
+                    100,
+                )
+            fitter.applyAutoFitWidth(500)
+            verify(exactly = 1) { toolWindowEx.stretchWidth(any()) }
+
+            // Settle the panel close to the desired width.
+            panel.setSize(300, 400)
+
+            // Simulate tree expansion: maxRowWidth grows -> fingerprint changes
+            // even if rowCount appears stable to the mocked calculator.
+            mockCalculatorForWidth(380)
+            fitter.applyAutoFitWidth(500)
+
+            // Fingerprint differs from last call -> must re-apply.
+            verify(atLeast = 2) { toolWindowEx.stretchWidth(any()) }
+        }
+    }
+
+    @Test
+    fun `removeExpansionListener resets fingerprint so re-install forces fresh measurement`() {
+        SwingUtilities.invokeAndWait {
+            mockCalculatorForWidth(280)
+            val tree = JTree()
+            val panel = JPanel(FlowLayout())
+            panel.add(tree)
+            panel.setSize(200, 400)
+
+            val content =
+                mockk<Content>(relaxed = true) {
+                    every { component } returns panel
+                }
+            val contentManager =
+                mockk<ContentManager>(relaxed = true) {
+                    every { contents } returns arrayOf(content)
+                }
+            every {
+                toolWindowManager.getToolWindow("Project")
+            } returns toolWindowEx
+            every {
+                toolWindowEx.contentManager
+            } returns contentManager
+            every { toolWindowEx.component } returns panel
+            every {
+                toolWindowEx.type
+            } returns ToolWindowType.DOCKED
+
+            val fitter =
+                ToolWindowAutoFitter(
+                    project,
+                    "Project",
+                    100,
+                )
+            fitter.applyAutoFitWidth(500)
+            verify(exactly = 1) { toolWindowEx.stretchWidth(any()) }
+
+            panel.setSize(300, 400)
+
+            // Detach listener -> fingerprint must be cleared.
+            fitter.removeExpansionListener()
+
+            // Even with the SAME tree content, a fresh-listener call after detach
+            // must NOT short-circuit on a stale fingerprint. The jitter guard inside
+            // applyWidth still suppresses the stretch when current ≈ desired, so
+            // the total stretchWidth count stays at 1 — but the fingerprint path
+            // is forced to re-measure (proven indirectly: the next stretch-worthy
+            // call below succeeds with no leftover state).
+            mockCalculatorForWidth(380)
+            fitter.applyAutoFitWidth(500)
+            verify(atLeast = 2) { toolWindowEx.stretchWidth(any()) }
+        }
+    }
+
+    // endregion
+
     /**
      * Mocks AutoFitCalculator measurement methods
      * so headless [JTree] (no row bounds) can be used.


### PR DESCRIPTION
Closes #169.

Repro: open the Project tool window in Mirage Islands UI and toggle the stripe button a few times. First toggle leaves it normal, next toggle reopens it wider — header gains an action toolbar, editor squeezes. Stays stuck until you switch to a non-Ayu theme.

Root cause is auto-fit re-trigger, not the theme. ProjectViewScrollbarManager, CommitPanelAutoFitManager and GitPanelAutoFitManager all listen on ToolWindowManagerListener and re-measure on every state change except MovedOrResized. ShowToolWindow counts as a re-measure trigger, but tree content didn't actually change. JTree row bounds reflect cell-renderer extension width, which differs between unfocused (compact header) and focused (action toolbar visible) states — so the second measure returns a wider maxRowWidth and the tool window stretches.

Two changes:

1. The three managers skip ShowToolWindow events in addition to MovedOrResized. Legitimate triggers (initial apply on project open, ComponentTreeRefreshedTopic on LAF change, tree expansion listener) still fire.

2. ToolWindowAutoFitter got a fingerprint guard — hashes (rowCount, maxRowWidth) before applyWidth and no-ops when content is unchanged. Resets when the expansion listener detaches so re-installing forces a fresh measure.

Verified locally on IDEA 2026.1 with Mirage Islands. Toggle stays stable, tree expansion still works, theme switch doesn't oscillate.

Tests cover idempotence, row-count invalidation, and listener-detach reset.

Follow-up: the silent activation of AUTO_FIT during trial is a separate discoverability problem tracked for the next minor.

## Summary by Sourcery

Prevent redundant auto-fit reapplication for tool windows whose tree content has not changed, avoiding width oscillation when toggling visibility or changing focus.

Enhancements:
- Add a fingerprint-based guard in ToolWindowAutoFitter to skip reapplying width when tree row count and max row width are unchanged and the adjustment would be jitter-only.
- Ignore ShowToolWindow events in Project, Commit, and Git auto-fit managers so visibility toggles no longer trigger unnecessary re-measurement and resizing.

Tests:
- Add tests covering auto-fit idempotence with unchanged tree content, reapplication when row count or width changes, and fingerprint reset when the expansion listener is removed.