### PR TITLE
docs(changelog): note auto-fit fix in 2.6.3 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - [Paid] **Custom mode** — unlocks per-surface sliders inside each section for fine-grained control.
 
 ### Fixed
-- Project tool window no longer jumps width when toggled on/off in Mirage Islands UI under auto-fit mode (issue #169). Project View, Commit, and Git panel auto-fit managers now ignore show-toggle events that don't change content.
+- Project tool window no longer changes width when toggled on/off in Mirage Islands UI under auto-fit mode (issue #169). Project View, Commit, and Git panel auto-fit managers now ignore show-toggle events that don't change content.
 
 ### Compatibility
 - Master toggle stays off by default — 2.6.2 colors are **byte-identical** until you opt in. No surprise tints on upgrade.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - [Paid] **Four named profiles** — pick **Whisper** (calmer), **Ambient** (2.6.2 defaults), **Neon** (brighter, restores the pre-2.6.2 punch), or **Cyberpunk** (peak vibrancy). Each section (Diff, Merge, Blame) carries its own profile, so you can mix — Neon diffs with Whisper blame, for example.
 - [Paid] **Custom mode** — unlocks per-surface sliders inside each section for fine-grained control.
 
+### Fixed
+- Project tool window no longer jumps width when toggled on/off in Mirage Islands UI under auto-fit mode (issue #169). Project View, Commit, and Git panel auto-fit managers now ignore show-toggle events that don't change content.
+
 ### Compatibility
 - Master toggle stays off by default — 2.6.2 colors are **byte-identical** until you opt in. No surprise tints on upgrade.
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -103,6 +103,7 @@
     <ul>
       <li>[Paid] <b>New VCS tab</b> — tune VCS color intensity across five surfaces (diff viewer, Project View file status, editor gutter, conflict markers, Git blame annotations). Pick a named profile — <b>Whisper</b> (calmer), <b>Ambient</b> (2.6.2 defaults), <b>Neon</b> (brighter, pre-2.6.2 punch), or <b>Cyberpunk</b> (peak) — or dial each surface independently in Custom mode. Master toggle stays off by default, so colors are byte-identical to 2.6.2 until you opt in.</li>
       <li>Settings → Ayu Islands → <b>VCS</b> tab now lives between Glow and Workspace.</li>
+      <li>Project tool window no longer jumps width when toggled on/off in Mirage Islands UI under auto-fit mode (issue #169).</li>
     </ul>
     <h3>2.6.2</h3>
     <ul>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -103,7 +103,7 @@
     <ul>
       <li>[Paid] <b>New VCS tab</b> — tune VCS color intensity across five surfaces (diff viewer, Project View file status, editor gutter, conflict markers, Git blame annotations). Pick a named profile — <b>Whisper</b> (calmer), <b>Ambient</b> (2.6.2 defaults), <b>Neon</b> (brighter, pre-2.6.2 punch), or <b>Cyberpunk</b> (peak) — or dial each surface independently in Custom mode. Master toggle stays off by default, so colors are byte-identical to 2.6.2 until you opt in.</li>
       <li>Settings → Ayu Islands → <b>VCS</b> tab now lives between Glow and Workspace.</li>
-      <li>Project tool window no longer jumps width when toggled on/off in Mirage Islands UI under auto-fit mode (issue #169).</li>
+      <li>Project tool window no longer changes width when toggled on/off in Mirage Islands UI under auto-fit mode (issue #169).</li>
     </ul>
     <h3>2.6.2</h3>
     <ul>


### PR DESCRIPTION
## Summary

PR #173 landed the Project tool window width-oscillation fix (issue #169) on main, but the 2.6.3 release entry only listed the VCS feature. Adding a one-bullet \`### Fixed\` section so users updating from 2.6.2 see the fix called out alongside the VCS feature.

## Changes

| Type | File | Description |
|---|---|---|
| Docs | [CHANGELOG.md](CHANGELOG.md) | New \`### Fixed\` block under 2.6.3 with the auto-fit fix bullet |
| Docs | [src/main/resources/META-INF/plugin.xml](src/main/resources/META-INF/plugin.xml) | Matching \`<li>\` in 2.6.3 change-notes for Marketplace listing |

## Notes

- Sourcery refactor (\`AutoFitTriggers.kt\` + \`computeFingerprint()\` helper) intentionally NOT in user-facing changelog — internal code structure, not user-visible
- Version stays at 2.6.3. Tag will be re-pointed to new main HEAD after merge; prior release.yml attempts never completed Marketplace upload (still on 2.6.2 publicly)

## Validation

\`\`\`
./gradlew ktlintCheck detekt   # green (no source changes)
\`\`\`

Pre-commit \`verify-docs\` hook passes.

## Summary by Sourcery

Document the 2.6.3 auto-fit Project tool window fix in both the changelog and plugin change notes.

Documentation:
- Add a 2.6.3 'Fixed' entry to the changelog describing the Project tool window width auto-fit fix.
- Update the plugin.xml change notes for 2.6.3 to include the Project tool window width auto-fit fix.