### PR TITLE
refactor(scripts): adopt PEP 585 generics + pyright strict

### DIFF
--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -27,6 +27,9 @@ package = false
 # script's directory to sys.path at runtime, but pyright's static analyzer
 # needs an explicit hint. `.` = the scripts/ dir (where pyproject.toml lives).
 extraPaths = ["."]
+# Strict mode catches partially-unknown types (YAML `dict.get()` returning
+# `Any | str` etc.) so docs-lint stays type-safe end-to-end.
+typeCheckingMode = "strict"
 # types-defusedxml ships stubs only (no source) — suppress the spurious
 # "source not found" warning that would otherwise fire on every import.
 reportMissingModuleSource = "none"

--- a/scripts/verify-theme-json.py
+++ b/scripts/verify-theme-json.py
@@ -66,7 +66,7 @@ def extract_block(data: dict[str, Any], keys: list[str]) -> dict[str, Any] | Non
         value = node.get(key)
         if not isinstance(value, dict):
             return None
-        node = cast("dict[str, Any]", value)
+        node = cast(dict[str, Any], value)
     return node
 
 

--- a/scripts/verify-theme-json.py
+++ b/scripts/verify-theme-json.py
@@ -10,11 +10,13 @@ Usage: python3 scripts/verify-theme-json.py
 Exit code 0 = all checks pass, 1 = mismatches found
 """
 
+from __future__ import annotations
+
 import json
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, cast
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 THEMES = REPO_ROOT / "src" / "main" / "resources" / "themes"
@@ -30,7 +32,7 @@ class ThemePair:
 @dataclass(frozen=True)
 class BlockPath:
     label: str
-    keys: List[str]
+    keys: list[str]
 
 
 PAIRS = [
@@ -57,18 +59,18 @@ BLOCKS_TO_CHECK = [
 ]
 
 
-def extract_block(data: Dict[str, Any], keys: List[str]) -> Optional[Dict[str, Any]]:
+def extract_block(data: dict[str, Any], keys: list[str]) -> dict[str, Any] | None:
     """Walk nested keys, return the sub-dict or None."""
-    node: Dict[str, Any] = data
+    node: dict[str, Any] = data
     for key in keys:
         value = node.get(key)
         if not isinstance(value, dict):
             return None
-        node = cast(Dict[str, Any], value)
+        node = cast("dict[str, Any]", value)
     return node
 
 
-def diff_dicts(base: Dict[str, Any], islands: Dict[str, Any]) -> List[str]:
+def diff_dicts(base: dict[str, Any], islands: dict[str, Any]) -> list[str]:
     """Return formatted lines for each differing key between the two dicts."""
     all_keys = sorted(set(base) | set(islands))
     return [

--- a/scripts/verify-theme-json.py
+++ b/scripts/verify-theme-json.py
@@ -14,7 +14,7 @@ import json
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 THEMES = REPO_ROOT / "src" / "main" / "resources" / "themes"
@@ -59,13 +59,13 @@ BLOCKS_TO_CHECK = [
 
 def extract_block(data: Dict[str, Any], keys: List[str]) -> Optional[Dict[str, Any]]:
     """Walk nested keys, return the sub-dict or None."""
-    node = data  # type: Any
+    node: Dict[str, Any] = data
     for key in keys:
-        if isinstance(node, dict) and key in node:
-            node = node[key]
-        else:
+        value = node.get(key)
+        if not isinstance(value, dict):
             return None
-    return node if isinstance(node, dict) else None
+        node = cast(Dict[str, Any], value)
+    return node
 
 
 def diff_dicts(base: Dict[str, Any], islands: Dict[str, Any]) -> List[str]:
@@ -89,9 +89,9 @@ def check_pair(pair: ThemePair) -> int:
             return 1
 
     with open(base_path) as f:
-        base_data = json.load(f)  # type: Dict[str, Any]
+        base_data = json.load(f)
     with open(islands_path) as f:
-        islands_data = json.load(f)  # type: Dict[str, Any]
+        islands_data = json.load(f)
 
     errors = 0
 

--- a/scripts/verify-theme-xml.py
+++ b/scripts/verify-theme-xml.py
@@ -120,7 +120,9 @@ def compare_values(
     data: Dict[str, Dict[str, str]],
 ) -> Tuple[int, int]:
     """Compare key-value maps across variants, return (checked, mismatches)."""
-    all_keys = sorted(set().union(*data.values()))
+    all_keys: List[str] = sorted(
+        {key for variant_map in data.values() for key in variant_map}
+    )
     names = list(data.keys())
     mismatches = 0
 

--- a/scripts/verify-theme-xml.py
+++ b/scripts/verify-theme-xml.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Set, Tuple
+from typing import TYPE_CHECKING
 
 # The defusedxml package replaces the stdlib xml.etree parser with a hardened
 # variant that rejects entity expansion and XML-bomb attacks. Our inputs are
@@ -32,14 +32,14 @@ if TYPE_CHECKING:
 REPO_ROOT = Path(__file__).resolve().parent.parent
 THEMES = REPO_ROOT / "src" / "main" / "resources" / "themes"
 
-VARIANTS: Dict[str, Path] = {
+VARIANTS: dict[str, Path] = {
     "Mirage": THEMES / "AyuIslandsMirage.xml",
     "Dark": THEMES / "AyuIslandsDark.xml",
     "Light": THEMES / "AyuIslandsLight.xml",
 }
 
 
-def parse_attributes(path: Path) -> Dict[str, Element]:
+def parse_attributes(path: Path) -> dict[str, Element]:
     """Return {name: <option> element} for top-level attributes."""
     tree = parse_xml(path)
     attrs_elem = tree.find(".//attributes")
@@ -52,9 +52,9 @@ def parse_attributes(path: Path) -> Dict[str, Element]:
     }
 
 
-def get_font_types(attrs: Dict[str, Element]) -> Dict[str, str]:
+def get_font_types(attrs: dict[str, Element]) -> dict[str, str]:
     """Extract FONT_TYPE value per attribute."""
-    result: Dict[str, str] = {}
+    result: dict[str, str] = {}
     for name, elem in attrs.items():
         value_elem = elem.find("value")
         if value_elem is None:
@@ -65,7 +65,7 @@ def get_font_types(attrs: Dict[str, Element]) -> Dict[str, str]:
     return result
 
 
-def get_base_attributes(attrs: Dict[str, Element]) -> Dict[str, str]:
+def get_base_attributes(attrs: dict[str, Element]) -> dict[str, str]:
     """Extract baseAttributes value per attribute."""
     return {
         name: elem.get("baseAttributes", "")
@@ -77,11 +77,11 @@ def get_base_attributes(attrs: Dict[str, Element]) -> Dict[str, str]:
 def format_set_diff(
     ref_name: str,
     other_name: str,
-    only_ref: Set[str],
-    only_other: Set[str],
-) -> List[str]:
+    only_ref: set[str],
+    only_other: set[str],
+) -> list[str]:
     """Format the diff between two attribute name sets as output lines."""
-    lines: List[str] = []
+    lines: list[str] = []
     if only_ref:
         lines.append(f"\nOnly in {ref_name} (not {other_name}):")
         lines.extend(f"  {attr}" for attr in sorted(only_ref))
@@ -91,7 +91,7 @@ def format_set_diff(
     return lines
 
 
-def compare_sets(data: Dict[str, Set[str]]) -> int:
+def compare_sets(data: dict[str, set[str]]) -> int:
     """Compare sets across variants, return error count."""
     names = list(data.keys())
     ref_name = names[0]
@@ -117,10 +117,10 @@ def compare_sets(data: Dict[str, Set[str]]) -> int:
 
 def compare_values(
     check_name: str,
-    data: Dict[str, Dict[str, str]],
-) -> Tuple[int, int]:
+    data: dict[str, dict[str, str]],
+) -> tuple[int, int]:
     """Compare key-value maps across variants, return (checked, mismatches)."""
-    all_keys: List[str] = sorted(
+    all_keys: list[str] = sorted(
         {key for variant_map in data.values() for key in variant_map}
     )
     names = list(data.keys())
@@ -142,7 +142,7 @@ def compare_values(
 def run_check(
     title: str,
     check_name: str,
-    data: Dict[str, Dict[str, str]],
+    data: dict[str, dict[str, str]],
 ) -> int:
     """Run a value-comparison check and print results."""
     print(f"--- {title} ---")

--- a/scripts/verify_docs/changelog.py
+++ b/scripts/verify_docs/changelog.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from typing import Any
 
 from .features import iter_features
 from .paths import CHANGELOG
@@ -25,7 +26,7 @@ def extract_latest_changelog_section() -> tuple[str, list[tuple[str, str]]]:
     return version, bullets
 
 
-def check_changelog_cross_ref(data: dict, report: Report) -> None:
+def check_changelog_cross_ref(data: dict[str, Any], report: Report) -> None:
     """Invariant 2: tier-tagged bullets in latest changelog map to features with matching `introduced`."""
     version, bullets = extract_latest_changelog_section()
     if not bullets:

--- a/scripts/verify_docs/features.py
+++ b/scripts/verify_docs/features.py
@@ -2,19 +2,19 @@
 
 from __future__ import annotations
 
-from typing import Iterator
+from typing import Any, Iterator, cast
 
 import yaml
 
 from .paths import FEATURES_YAML
 
 
-def load_features() -> dict:
+def load_features() -> dict[str, Any]:
     with FEATURES_YAML.open() as fh:
-        return yaml.safe_load(fh)
+        return cast(dict[str, Any], yaml.safe_load(fh))
 
 
-def iter_features(data: dict) -> Iterator[dict]:
+def iter_features(data: dict[str, Any]) -> Iterator[dict[str, Any]]:
     """Yield every feature dict, flattening across categories.
 
     Category metadata (id, title) isn't currently consumed by any check —

--- a/scripts/verify_docs/inventory.py
+++ b/scripts/verify_docs/inventory.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from .paths import REPO_ROOT
 from .report import Report
@@ -11,7 +12,7 @@ _ASSET_EXTENSIONS = (".png", ".gif", ".svg", ".jpg", ".jpeg", ".webp")
 _ASSET_SEARCH_ROOTS = ("assets", "src/main/resources/whatsnew")
 
 
-def check_asset_inventory(data: dict, report: Report) -> None:
+def check_asset_inventory(data: dict[str, Any], report: Report) -> None:
     """Invariant 5: every on-disk image under the tracked roots is inventoried,
     and every inventory entry's `referenced_by` files actually mention the path.
 
@@ -22,17 +23,17 @@ def check_asset_inventory(data: dict, report: Report) -> None:
       - Missing justification: inventory entry has referenced_by=[] AND no
                                `justification` explaining why it's unused
     """
-    inventory = data.get("asset_inventory") or []
+    inventory: list[dict[str, Any]] = data.get("asset_inventory") or []
     _check_inventory_entries(inventory, report)
     _check_filesystem_orphans(inventory, report)
 
 
-def _check_inventory_entries(inventory: list[dict], report: Report) -> None:
+def _check_inventory_entries(inventory: list[dict[str, Any]], report: Report) -> None:
     for entry in inventory:
         _check_one_inventory_entry(entry, report)
 
 
-def _check_one_inventory_entry(entry: dict, report: Report) -> None:
+def _check_one_inventory_entry(entry: dict[str, Any], report: Report) -> None:
     path = (entry.get("path") or "").strip()
     if not path:
         report.error("_asset_inventory_", "inventory entry missing `path`")
@@ -44,7 +45,7 @@ def _check_one_inventory_entry(entry: dict, report: Report) -> None:
     # `referenced_by: [""]` would otherwise resolve to REPO_ROOT itself
     # (`Path / ""` == `Path`) and produce nonsense errors about the repo
     # root not containing the asset path.
-    raw_referenced_by = entry.get("referenced_by") or []
+    raw_referenced_by: list[Any] = entry.get("referenced_by") or []
     referenced_by = [
         ref.strip() for ref in raw_referenced_by if isinstance(ref, str) and ref.strip()
     ]
@@ -80,7 +81,7 @@ def _check_reference_in_file(
         )
 
 
-def _check_filesystem_orphans(inventory: list[dict], report: Report) -> None:
+def _check_filesystem_orphans(inventory: list[dict[str, Any]], report: Report) -> None:
     inventoried = {(entry.get("path") or "").strip() for entry in inventory}
     for root_rel in _ASSET_SEARCH_ROOTS:
         root = REPO_ROOT / root_rel

--- a/scripts/verify_docs/keywords.py
+++ b/scripts/verify_docs/keywords.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from .features import iter_features
 from .paths import README
 from .plugin_xml import extract_plugin_xml_description
 from .report import Report
 
 
-def check_keywords(data: dict, report: Report) -> None:
+def check_keywords(data: dict[str, Any], report: Report) -> None:
     """Invariant 1: every feature keyword is present in README + plugin.xml description."""
     readme_text = README.read_text(encoding="utf-8").lower()
     description_text = extract_plugin_xml_description().lower()

--- a/scripts/verify_docs/marketplace.py
+++ b/scripts/verify_docs/marketplace.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import functools
 import hashlib
+from typing import Any
 
 from .paths import GRADLE_PROPERTIES
 from .plugin_xml import extract_plugin_xml_description
@@ -27,7 +28,7 @@ def _read_plugin_version() -> str | None:
     return None
 
 
-def check_marketplace_sync(data: dict, report: Report) -> None:
+def check_marketplace_sync(data: dict[str, Any], report: Report) -> None:
     """Invariant 6: when gradle pluginVersion matches the last-published version,
     the current plugin.xml <description> hash must match what shipped.
 
@@ -38,9 +39,9 @@ def check_marketplace_sync(data: dict, report: Report) -> None:
     `release_sync.last_published_description_sha256` so this check stays
     silent during the window the published version == the on-disk version.
     """
-    sync = data.get("release_sync") or {}
-    expected_version = (sync.get("last_published_version") or "").strip()
-    expected_sha = (sync.get("last_published_description_sha256") or "").strip()
+    sync: dict[str, Any] = data.get("release_sync") or {}
+    expected_version: str = (sync.get("last_published_version") or "").strip()
+    expected_sha: str = (sync.get("last_published_description_sha256") or "").strip()
     if not expected_version or not expected_sha:
         return  # Bootstrap mode — no last-published state recorded yet.
 

--- a/scripts/verify_docs/report.py
+++ b/scripts/verify_docs/report.py
@@ -12,9 +12,13 @@ class Finding:
     message: str
 
 
+def _empty_findings() -> list[Finding]:
+    return []
+
+
 @dataclass
 class Report:
-    findings: list[Finding] = field(default_factory=list)
+    findings: list[Finding] = field(default_factory=_empty_findings)
 
     def error(self, feature_id: str, message: str) -> None:
         self.findings.append(Finding("error", feature_id, message))

--- a/scripts/verify_docs/required_links.py
+++ b/scripts/verify_docs/required_links.py
@@ -2,20 +2,23 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from .paths import REPO_ROOT
 from .report import Report
 
 
-def check_required_links(data: dict, report: Report) -> None:
+def check_required_links(data: dict[str, Any], report: Report) -> None:
     """Invariant 4: every required_links entry's substring appears in its `in` file.
 
     Catches "someone refactored the Community section and dropped the
     GitHub Discussions links", or "removed the Marketplace install badge".
     """
-    for entry in data.get("required_links") or []:
-        name = entry.get("name", "<unnamed>")
-        needle = (entry.get("substring") or "").strip().lower()
-        target_rel = (entry.get("in") or "").strip()
+    entries: list[dict[str, Any]] = data.get("required_links") or []
+    for entry in entries:
+        name: str = entry.get("name", "<unnamed>") or "<unnamed>"
+        needle: str = (entry.get("substring") or "").strip().lower()
+        target_rel: str = (entry.get("in") or "").strip()
         if not needle or not target_rel:
             report.error(name, "required_links entry missing `substring` or `in`")
             continue

--- a/scripts/verify_docs/screenshots.py
+++ b/scripts/verify_docs/screenshots.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any, cast
 
 from .features import iter_features
 from .git_utils import (
@@ -17,7 +18,7 @@ from .paths import REPO_ROOT
 from .report import Report
 
 
-def check_screenshots(data: dict, report: Report) -> None:
+def check_screenshots(data: dict[str, Any], report: Report) -> None:
     """Invariant 3: screenshot freshness via source stamp + byte hash.
 
     Split into per-check helpers so the orchestrator stays straight-line
@@ -25,14 +26,14 @@ def check_screenshots(data: dict, report: Report) -> None:
     """
     for feat in iter_features(data):
         if shot := feat.get("screenshot"):
-            _check_one_screenshot(feat["id"], shot, report)
+            _check_one_screenshot(feat["id"], cast(dict[str, Any], shot), report)
 
 
-def _check_one_screenshot(fid: str, shot: dict, report: Report) -> None:
-    path = shot.get("path", "").strip()
-    sha = shot.get("last_verified_sha", "").strip()
-    sources = shot.get("sources") or []
-    stored_hash = (shot.get("content_sha256") or "").strip()
+def _check_one_screenshot(fid: str, shot: dict[str, Any], report: Report) -> None:
+    path: str = (shot.get("path") or "").strip()
+    sha: str = (shot.get("last_verified_sha") or "").strip()
+    sources: list[str] = shot.get("sources") or []
+    stored_hash: str = (shot.get("content_sha256") or "").strip()
 
     if not path or not sha or not sources:
         report.error(

--- a/scripts/verify_docs/screenshots.py
+++ b/scripts/verify_docs/screenshots.py
@@ -27,7 +27,7 @@ def check_screenshots(data: dict[str, Any], report: Report) -> None:
     for feat in iter_features(data):
         shot = feat.get("screenshot")
         if isinstance(shot, dict):
-            _check_one_screenshot(feat["id"], cast("dict[str, Any]", shot), report)
+            _check_one_screenshot(feat["id"], cast(dict[str, Any], shot), report)
 
 
 def _check_one_screenshot(fid: str, shot: dict[str, Any], report: Report) -> None:

--- a/scripts/verify_docs/screenshots.py
+++ b/scripts/verify_docs/screenshots.py
@@ -25,8 +25,9 @@ def check_screenshots(data: dict[str, Any], report: Report) -> None:
     and individual guards are testable in isolation.
     """
     for feat in iter_features(data):
-        if shot := feat.get("screenshot"):
-            _check_one_screenshot(feat["id"], cast(dict[str, Any], shot), report)
+        shot = feat.get("screenshot")
+        if isinstance(shot, dict):
+            _check_one_screenshot(feat["id"], cast("dict[str, Any]", shot), report)
 
 
 def _check_one_screenshot(fid: str, shot: dict[str, Any], report: Report) -> None:

--- a/scripts/verify_docs/stamps.py
+++ b/scripts/verify_docs/stamps.py
@@ -11,13 +11,14 @@ from __future__ import annotations
 
 import re
 import sys
+from typing import Any
 
 from .features import iter_features
 from .git_utils import file_sha256, head_short_sha, is_ancestor_of_head
 from .paths import FEATURES_YAML, REPO_ROOT
 
 
-def update_hashes(data: dict) -> int:
+def update_hashes(data: dict[str, Any]) -> int:
     """Update content_sha256 values in-place, preserving the file's comments.
 
     PyYAML's safe_dump would rewrite the whole document and drop the header
@@ -28,8 +29,8 @@ def update_hashes(data: dict) -> int:
     text = FEATURES_YAML.read_text(encoding="utf-8")
     updated = 0
     for feat in iter_features(data):
-        shot = feat.get("screenshot") or {}
-        path = (shot.get("path") or "").strip()
+        shot: dict[str, Any] = feat.get("screenshot") or {}
+        path: str = (shot.get("path") or "").strip()
         if not path:
             continue
         screenshot_file = REPO_ROOT / path
@@ -45,7 +46,7 @@ def update_hashes(data: dict) -> int:
     return updated
 
 
-def restamp_orphaned(data: dict) -> int:
+def restamp_orphaned(data: dict[str, Any]) -> int:
     """Rewrite every orphaned `last_verified_sha` in features.yml to HEAD.
 
     "Orphaned" = `git merge-base --is-ancestor sha HEAD` returns non-zero.
@@ -66,9 +67,9 @@ def restamp_orphaned(data: dict) -> int:
     text = FEATURES_YAML.read_text(encoding="utf-8")
     updated = 0
     for feat in iter_features(data):
-        shot = feat.get("screenshot") or {}
-        stored_sha = (shot.get("last_verified_sha") or "").strip()
-        path = (shot.get("path") or "").strip()
+        shot: dict[str, Any] = feat.get("screenshot") or {}
+        stored_sha: str = (shot.get("last_verified_sha") or "").strip()
+        path: str = (shot.get("path") or "").strip()
         if not stored_sha or not path:
             continue
         if is_ancestor_of_head(stored_sha):


### PR DESCRIPTION
## Summary

- Migrate `Dict[...]` / `List[...]` to PEP 585 `dict[...]` / `list[...]` across `scripts/verify_docs/` so pyright stops seeing `dict[Unknown, Unknown]` returns.
- Enable `typeCheckingMode = "strict"` in `scripts/pyproject.toml` (replaces a temporary standalone `pyrightconfig.json` I removed) — Pylance and CLI now see the same diagnostics.
- Add explicit local annotations on YAML `.get()` chains so `Any | str` / `Any | list[Unknown]` resolve to concrete types under strict.
- Replace `field(default_factory=list)` with a named `_empty_findings` factory so pyright can infer `list[Finding]`.
- Fix two standalone scripts (`verify-theme-json.py`, `verify-theme-xml.py`) that had the same partial-unknown issues — guard clause + `cast` in `extract_block`, typed set comprehension instead of `set().union(*data.values())`.

## Test plan

- [x] `cd scripts && uv run pyright` — 0 errors, 0 warnings, 0 informations
- [x] `scripts/verify-docs.py` — EXIT 0, no errors, 4 expected orphan-stamp warnings on `main`
- [x] `python3 scripts/verify-theme-json.py` — PASS for all 3 theme pairs
- [x] `scripts/verify-theme-xml.py` — PASS, 603 attributes × 3 variants consistent

## Summary by Sourcery

Adopt stricter static typing for documentation and theme verification scripts to eliminate partially-unknown types and align Pyright configuration with PEP 585 generics.

Enhancements:
- Tighten type annotations across verify_docs and theme verification scripts, including explicit dict/list element types and casts on YAML access patterns, to ensure type safety under strict checking.
- Introduce a dedicated empty-findings factory for Report to improve list[Finding] inference.
- Refine key aggregation logic in XML theme comparison to use a typed set comprehension instead of set().union(*values).

Build:
- Enable Pyright strict type checking in scripts/pyproject.toml so scripts share a consistent, stricter analysis configuration.