### PR TITLE
refactor(scripts): apply code-conventions findings across verify_docs

### DIFF
--- a/scripts/verify-bytecode.py
+++ b/scripts/verify-bytecode.py
@@ -32,17 +32,16 @@ def find_composed_jar() -> Path | None:
     dist-output layout changes — the composed JAR is always the biggest one
     (it bundles obfuscated classes + resources that the -base jar lacks).
     """
-    if candidates := [
-        p
-        for p in BUILD_LIBS.glob("ayu-jetbrains-*.jar")
-        if not any(p.stem.endswith(sfx) for sfx in _EXCLUDED_SUFFIXES)
-    ]:
-        return max(candidates, key=lambda p: p.stat().st_size)
-    else:
-        return None
+    candidates = [
+        path
+        for path in BUILD_LIBS.glob("ayu-jetbrains-*.jar")
+        if not any(path.stem.endswith(sfx) for sfx in _EXCLUDED_SUFFIXES)
+    ]
+    return max(candidates, key=lambda path: path.stat().st_size, default=None)
 
 
 def class_in_jar(jar: Path, fqn: str) -> bool:
+    """Return True if `fqn` is a public class inside `jar` (checked via javap)."""
     result = subprocess.run(
         ["javap", "-public", "-cp", str(jar), fqn],
         capture_output=True,
@@ -53,20 +52,20 @@ def class_in_jar(jar: Path, fqn: str) -> bool:
 
 
 def main() -> int:
-    ap = argparse.ArgumentParser(
+    """Entry point: locate the composed JAR and verify every plugin.xml class is in it."""
+    parser = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    ap.add_argument("jar", nargs="?", type=Path, help="Optional explicit JAR path")
-    args = ap.parse_args()
+    parser.add_argument("jar", nargs="?", type=Path, help="Optional explicit JAR path")
+    args = parser.parse_args()
 
     jar: Path | None = args.jar
     if jar is None:
         jar = find_composed_jar()
     if jar is None:
         print(
-            "ERROR: No composed JAR in build/libs/. "
-            "Run ./gradlew buildPlugin first.",
+            "ERROR: No composed JAR in build/libs/. Run ./gradlew buildPlugin first.",
             file=sys.stderr,
         )
         return 1

--- a/scripts/verify-theme-json.py
+++ b/scripts/verify-theme-json.py
@@ -74,9 +74,9 @@ def diff_dicts(base: dict[str, Any], islands: dict[str, Any]) -> list[str]:
     """Return formatted lines for each differing key between the two dicts."""
     all_keys = sorted(set(base) | set(islands))
     return [
-        f"    {k}: base={base.get(k)!r}  islands={islands.get(k)!r}"
-        for k in all_keys
-        if base.get(k) != islands.get(k)
+        f"    {key}: base={base.get(key)!r}  islands={islands.get(key)!r}"
+        for key in all_keys
+        if base.get(key) != islands.get(key)
     ]
 
 
@@ -90,10 +90,8 @@ def check_pair(pair: ThemePair) -> int:
             print(f"MISSING: {path!s}")
             return 1
 
-    with open(base_path) as f:
-        base_data = json.load(f)
-    with open(islands_path) as f:
-        islands_data = json.load(f)
+    base_data = json.loads(base_path.read_text(encoding="utf-8"))
+    islands_data = json.loads(islands_path.read_text(encoding="utf-8"))
 
     errors = 0
 

--- a/scripts/verify_docs/changelog.py
+++ b/scripts/verify_docs/changelog.py
@@ -3,26 +3,32 @@
 from __future__ import annotations
 
 import re
-from typing import Any
+from typing import Any, cast
 
 from .features import iter_features
 from .paths import CHANGELOG
 from .report import Report
 
+_VERSION_HEADER = re.compile(r"^##\s*\[(\d+\.\d+\.\d+)]", re.MULTILINE)
+_NEXT_HEADER = re.compile(r"^##\s*\[", re.MULTILINE)
+# `[^\n]+` instead of `.+` — `.+` plus surrounding `\s*` is what static
+# analysers flag as polynomial backtracking. `[^\n]+` is a single-char class
+# with no overlap, so the matcher is linear.
+_TIER_BULLET = re.compile(r"^\s*-\s*\[(Paid|Free)]\s*([^\n]+)$", re.MULTILINE)
+
 
 def extract_latest_changelog_section() -> tuple[str, list[tuple[str, str]]]:
     """Return (version, [(tier, bullet_text), ...]) for the latest CHANGELOG section."""
     text = CHANGELOG.read_text(encoding="utf-8")
-    m = re.search(r"^##\s*\[(\d+\.\d+\.\d+)]", text, re.MULTILINE)
-    if not m:
+    match = _VERSION_HEADER.search(text)
+    if not match:
         raise SystemExit("Could not find latest version header in CHANGELOG.md")
-    version = m[1]
-    start = m.end()
-    next_m = re.search(r"^##\s*\[", text[start:], re.MULTILINE)
-    end = start + (next_m.start() if next_m else len(text) - start)
+    version: str = match[1]
+    start = match.end()
+    next_match = _NEXT_HEADER.search(text, pos=start)
+    end = next_match.start() if next_match else len(text)
     section = text[start:end]
-    # Match bullets that start with [Paid] or [Free] (tier-tagged, user-facing).
-    bullets = re.findall(r"^\s*-\s*\[(Paid|Free)]\s*(.+)$", section, re.MULTILINE)
+    bullets = cast(list[tuple[str, str]], _TIER_BULLET.findall(section))
     return version, bullets
 
 
@@ -33,7 +39,9 @@ def check_changelog_cross_ref(data: dict[str, Any], report: Report) -> None:
         # No tier-tagged bullets — could be a fix-only patch release. OK.
         return
     matching_features = [
-        f for f in iter_features(data) if f.get("introduced") == version
+        feature
+        for feature in iter_features(data)
+        if feature.get("introduced") == version
     ]
     if not matching_features:
         report.error(

--- a/scripts/verify_docs/cli.py
+++ b/scripts/verify_docs/cli.py
@@ -17,18 +17,19 @@ from .stamps import restamp_orphaned, update_hashes
 
 
 def main() -> int:
-    ap = argparse.ArgumentParser(
+    """Run the orchestrator: parse args, either run invariant checks or mutate features.yml."""
+    parser = argparse.ArgumentParser(
         description=(
             "Verify that docs/features.yml stays in sync with README + plugin.xml + CHANGELOG."
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    ap.add_argument(
+    parser.add_argument(
         "--update-hashes",
         action="store_true",
         help="Recompute content_sha256 for every screenshot and rewrite features.yml",
     )
-    ap.add_argument(
+    parser.add_argument(
         "--restamp",
         action="store_true",
         help="Rewrite every screenshot's last_verified_sha to the current HEAD "
@@ -36,7 +37,7 @@ def main() -> int:
         "Use after a squash-merge rebase or when adopting the inherited "
         "stamp from main onto a fresh feature branch.",
     )
-    args = ap.parse_args()
+    args = parser.parse_args()
 
     data = load_features()
 

--- a/scripts/verify_docs/features.py
+++ b/scripts/verify_docs/features.py
@@ -10,7 +10,10 @@ from .paths import FEATURES_YAML
 
 
 def load_features() -> dict[str, Any]:
+    """Read and parse features.yml as a top-level mapping."""
     with FEATURES_YAML.open() as fh:
+        # YAML root in features.yml is always a top-level mapping by schema —
+        # the cast tells pyright strict that, since yaml.safe_load is `Any`.
         return cast(dict[str, Any], yaml.safe_load(fh))
 
 

--- a/scripts/verify_docs/git_utils.py
+++ b/scripts/verify_docs/git_utils.py
@@ -108,6 +108,7 @@ def merge_base_with_primary() -> str | None:
 
 
 def commit_exists(sha: str) -> bool:
+    """Return True when `sha` resolves to a commit object in the local repo."""
     result = subprocess.run(
         ["git", "rev-parse", "--verify", f"{sha}^{{commit}}"],
         cwd=REPO_ROOT,
@@ -151,8 +152,6 @@ def head_short_sha() -> str | None:
 
 
 def file_sha256(path: Path) -> str:
-    h = hashlib.sha256()
+    """Return hex-encoded SHA-256 digest of `path`'s bytes (streamed, no full read)."""
     with path.open("rb") as fh:
-        for chunk in iter(lambda: fh.read(65536), b""):
-            h.update(chunk)
-    return h.hexdigest()
+        return hashlib.file_digest(fh, "sha256").hexdigest()

--- a/scripts/verify_docs/keywords.py
+++ b/scripts/verify_docs/keywords.py
@@ -16,20 +16,20 @@ def check_keywords(data: dict[str, Any], report: Report) -> None:
     description_text = extract_plugin_xml_description().lower()
 
     for feat in iter_features(data):
-        kw = feat.get("keyword", "").strip().lower()
-        fid = feat.get("id", "<missing-id>")
-        if not kw:
-            report.error(fid, "missing `keyword` field (feature.yml schema)")
+        keyword = feat.get("keyword", "").strip().lower()
+        feature_id = feat.get("id", "<missing-id>")
+        if not keyword:
+            report.error(feature_id, "missing `keyword` field (feature.yml schema)")
             continue
-        if kw not in readme_text:
+        if keyword not in readme_text:
             report.error(
-                fid,
+                feature_id,
                 f"keyword '{feat['keyword']}' not found in README.md — "
                 f"the feature is declared in features.yml but not mentioned in marketing copy",
             )
-        if kw not in description_text:
+        if keyword not in description_text:
             report.error(
-                fid,
+                feature_id,
                 f"keyword '{feat['keyword']}' not found in plugin.xml <description> — "
                 f"Marketplace 'About' page will not mention this feature",
             )

--- a/scripts/verify_docs/report.py
+++ b/scripts/verify_docs/report.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 
-@dataclass
+@dataclass(frozen=True)
 class Finding:
     severity: str  # "error" or "warn"
     feature_id: str
@@ -28,12 +28,12 @@ class Report:
 
     @property
     def has_errors(self) -> bool:
-        return any(f.severity == "error" for f in self.findings)
+        return any(finding.severity == "error" for finding in self.findings)
 
     def print(self) -> None:
         if not self.findings:
             print("docs/features.yml in sync with README + plugin.xml + CHANGELOG")
             return
-        for f in self.findings:
-            prefix = "ERROR" if f.severity == "error" else "warn "
-            print(f"  [{prefix}] {f.feature_id}: {f.message}")
+        for finding in self.findings:
+            prefix = "ERROR" if finding.severity == "error" else "warn "
+            print(f"  [{prefix}] {finding.feature_id}: {finding.message}")

--- a/scripts/verify_docs/screenshots.py
+++ b/scripts/verify_docs/screenshots.py
@@ -30,7 +30,7 @@ def check_screenshots(data: dict[str, Any], report: Report) -> None:
             _check_one_screenshot(feat["id"], cast(dict[str, Any], shot), report)
 
 
-def _check_one_screenshot(fid: str, shot: dict[str, Any], report: Report) -> None:
+def _check_one_screenshot(feature_id: str, shot: dict[str, Any], report: Report) -> None:
     path: str = (shot.get("path") or "").strip()
     sha: str = (shot.get("last_verified_sha") or "").strip()
     sources: list[str] = shot.get("sources") or []
@@ -38,31 +38,31 @@ def _check_one_screenshot(fid: str, shot: dict[str, Any], report: Report) -> Non
 
     if not path or not sha or not sources:
         report.error(
-            fid,
+            feature_id,
             "screenshot block incomplete — required: path, last_verified_sha, sources",
         )
         return
 
     screenshot_file = REPO_ROOT / path
     if not screenshot_file.exists():
-        report.error(fid, f"screenshot path '{path}' does not exist")
+        report.error(feature_id, f"screenshot path '{path}' does not exist")
         return
 
-    _check_source_paths_exist(fid, sources, report)
-    _check_freshness_by_state(fid, path, sha, sources, report)
-    _check_content_hash(fid, screenshot_file, stored_hash, report)
+    _check_source_paths_exist(feature_id, sources, report)
+    _check_freshness_by_state(feature_id, path, sha, sources, report)
+    _check_content_hash(feature_id, screenshot_file, stored_hash, report)
 
 
-def _check_source_paths_exist(fid: str, sources: list[str], report: Report) -> None:
+def _check_source_paths_exist(feature_id: str, sources: list[str], report: Report) -> None:
     for src in sources:
         if not (REPO_ROOT / src).exists():
             report.error(
-                fid, f"screenshot source '{src}' does not exist (renamed or deleted?)"
+                feature_id, f"screenshot source '{src}' does not exist (renamed or deleted?)"
             )
 
 
 def _check_freshness_by_state(
-    fid: str, path: str, sha: str, sources: list[str], report: Report
+    feature_id: str, path: str, sha: str, sources: list[str], report: Report
 ) -> None:
     """Dispatch source-freshness check based on how the stamp relates to HEAD.
 
@@ -80,19 +80,19 @@ def _check_freshness_by_state(
     """
     if not commit_exists(sha):
         _handle_orphan_stamp(
-            fid, path, sha, sources, report, reason="not in local git object db"
+            feature_id, path, sha, sources, report, reason="not in local git object db"
         )
         return
     if is_ancestor_of_head(sha):
-        _check_source_freshness_since(fid, path, sha, sources, report, strict_msg=True)
+        _check_source_freshness_since(feature_id, path, sha, sources, report, strict_msg=True)
         return
     _handle_orphan_stamp(
-        fid, path, sha, sources, report, reason="not an ancestor of HEAD"
+        feature_id, path, sha, sources, report, reason="not an ancestor of HEAD"
     )
 
 
 def _handle_orphan_stamp(
-    fid: str, path: str, sha: str, sources: list[str], report: Report, *, reason: str
+    feature_id: str, path: str, sha: str, sources: list[str], report: Report, *, reason: str
 ) -> None:
     # SHA-identity check instead of branch-name equality so the main path also
     # covers CI runs that check out `origin/main` in detached-HEAD state —
@@ -100,7 +100,7 @@ def _handle_orphan_stamp(
     # there and would misroute us into the feature-branch diff logic.
     if head_points_at_primary():
         report.warn(
-            fid,
+            feature_id,
             f"last_verified_sha '{sha[:8]}' is orphaned ({reason}) — expected on "
             f"the primary branch after a squash-merge + branch delete. "
             f"content_sha256 remains the pixel-drift guard; the next PR that "
@@ -110,19 +110,19 @@ def _handle_orphan_stamp(
     base = merge_base_with_primary()
     if base is None:
         report.warn(
-            fid,
+            feature_id,
             f"last_verified_sha '{sha[:8]}' is orphaned ({reason}) and the "
             f"primary branch ref is not fetched — cannot diff branch changes; "
             f"re-fetch or re-stamp.",
         )
         return
     _check_source_freshness_since(
-        fid, path, base, sources, report, strict_msg=False, orphan_sha=sha
+        feature_id, path, base, sources, report, strict_msg=False, orphan_sha=sha
     )
 
 
 def _check_source_freshness_since(
-    fid: str,
+    feature_id: str,
     path: str,
     since_ref: str,
     sources: list[str],
@@ -134,7 +134,7 @@ def _check_source_freshness_since(
     try:
         changed = changed_since(since_ref, sources)
     except RuntimeError as exc:
-        report.error(fid, f"git freshness check failed for {path}: {exc}")
+        report.error(feature_id, f"git freshness check failed for {path}: {exc}")
         return
     if not changed:
         return
@@ -142,7 +142,7 @@ def _check_source_freshness_since(
     more = f" (+{len(changed) - 3} more)" if len(changed) > 3 else ""
     if strict_msg:
         report.error(
-            fid,
+            feature_id,
             f"sources changed since last_verified_sha {since_ref[:8]}: {preview}{more}. "
             f"Re-capture {path} and bump last_verified_sha + content_sha256, "
             f"OR if the UI didn't visually change, re-stamp last_verified_sha "
@@ -150,7 +150,7 @@ def _check_source_freshness_since(
         )
     else:
         report.error(
-            fid,
+            feature_id,
             f"last_verified_sha '{(orphan_sha or since_ref)[:8]}' is orphaned AND "
             f"this branch touches tracked sources: {preview}{more}. Re-stamp to "
             f"current HEAD before pushing (`scripts/verify-docs.py --restamp`).",
@@ -158,19 +158,19 @@ def _check_source_freshness_since(
 
 
 def _check_content_hash(
-    fid: str, screenshot_file: Path, stored_hash: str, report: Report
+    feature_id: str, screenshot_file: Path, stored_hash: str, report: Report
 ) -> None:
     actual_hash = file_sha256(screenshot_file)
     if stored_hash and actual_hash != stored_hash:
         report.warn(
-            fid,
+            feature_id,
             f"content_sha256 in features.yml is '{stored_hash[:12]}...' but the "
             f"file hashes to '{actual_hash[:12]}...'. Run "
             f"`scripts/verify-docs.py --update-hashes` to sync.",
         )
     if not stored_hash:
         report.warn(
-            fid,
+            feature_id,
             "content_sha256 is empty (seed state). "
             "Run `scripts/verify-docs.py --update-hashes` after capturing.",
         )

--- a/scripts/verify_docs/stamps.py
+++ b/scripts/verify_docs/stamps.py
@@ -83,49 +83,52 @@ def restamp_orphaned(data: dict[str, Any]) -> int:
     return updated
 
 
-def _replace_last_verified_sha(text: str, path: str, new_sha: str) -> tuple[str, bool]:
-    """Replace `last_verified_sha:` immediately following a given `path:` line.
+def _replace_field_after_path(
+    text: str,
+    path: str,
+    field_name: str,
+    new_value: str,
+    *,
+    preserve_quotes: bool,
+) -> tuple[str, bool]:
+    """Replace `{field_name}:` immediately following a given `path:` line.
 
-    Mirrors `_replace_content_hash`: regex anchor on the path to scope the
-    rewrite to one screenshot block, preserve surrounding YAML comments
-    and formatting. Returns (new_text, changed).
+    Regex anchors on the path so the rewrite stays scoped to one screenshot
+    block, preserving surrounding YAML comments and formatting. Returns
+    (new_text, changed). `changed` is False when the value already matches
+    (no-op) or the pattern didn't match (block not found).
+
+    When `preserve_quotes` is True the existing quote style is kept: an
+    existing `"abcdef1"` stays quoted, a bare `abcdef1` stays bare.
     """
     escaped = re.escape(path)
     pattern = re.compile(
-        rf"(path:\s*{escaped}\s*\n(?:.*\n){{0,40}}?\s*last_verified_sha:\s*)"
+        rf"(path:\s*{escaped}\s*\n(?:.*\n){{0,40}}?\s*{field_name}:\s*)"
         rf"\"?(?P<old>[0-9a-fA-F]*)\"?",
         re.MULTILINE,
     )
     match = pattern.search(text)
     if not match:
         return text, False
-    if match["old"] == new_sha:
+    if match["old"] == new_value:
         return text, False
-    # Preserve the quoted form: existing "abcdef1" stays quoted, bare abcdef1 stays bare.
-    quoted = match[0].rstrip().endswith('"')
-    replacement = f'"{new_sha}"' if quoted else new_sha
+    if preserve_quotes and match[0].rstrip().endswith('"'):
+        replacement = f'"{new_value}"'
+    else:
+        replacement = new_value
     new_text = text[: match.start()] + match[1] + replacement + text[match.end() :]
     return new_text, True
 
 
-def _replace_content_hash(text: str, path: str, new_hash: str) -> tuple[str, bool]:
-    """Replace the content_sha256 immediately following a given path: line.
-
-    Returns (new_text, changed). `changed` is False when the hash already
-    matches (no-op) or the pattern didn't match (block not found).
-    """
-    escaped = re.escape(path)
-    # Match: `path: <escaped>` followed within ~40 lines by `content_sha256:`.
-    # Capture the existing hash so we can detect no-op updates.
-    pattern = re.compile(
-        rf"(path:\s*{escaped}\s*\n(?:.*\n){{0,40}}?\s*content_sha256:\s*)"
-        rf"\"?(?P<old>[0-9a-fA-F]*)\"?",
-        re.MULTILINE,
+def _replace_last_verified_sha(text: str, path: str, new_sha: str) -> tuple[str, bool]:
+    """Replace `last_verified_sha:` for the given screenshot path; keep quote style."""
+    return _replace_field_after_path(
+        text, path, "last_verified_sha", new_sha, preserve_quotes=True
     )
-    match = pattern.search(text)
-    if not match:
-        return text, False
-    if match["old"] == new_hash:
-        return text, False
-    new_text = text[: match.start()] + match[1] + new_hash + text[match.end() :]
-    return new_text, True
+
+
+def _replace_content_hash(text: str, path: str, new_hash: str) -> tuple[str, bool]:
+    """Replace `content_sha256:` for the given screenshot path; emit bare value."""
+    return _replace_field_after_path(
+        text, path, "content_sha256", new_hash, preserve_quotes=False
+    )


### PR DESCRIPTION
## Summary

Result of running the `/code-conventions` skill on `scripts/` (naming + typing + errors + docstrings + python-pro idioms + ruff). All findings — HIGH, MEDIUM, LOW — fixed in a single cleanup pass.

### Naming
- Drop `ap` argparse short → `parser` (`verify-bytecode.py`, `verify_docs/cli.py`).
- `kw` → `keyword`, `fid` → `feature_id` (cross-module rename through `keywords.py`, `screenshots.py` parameter chain).
- `m` → `match`, `f` → `finding`/`feature`, `k` → `key`, `p` → `path` in loops/comprehensions.

### Pythonic idioms
- `verify-bytecode.py`: walrus + if/else returning `None` → `max(..., default=None)`.
- `verify-theme-json.py`: drop `open() as f` mix-in for pathlib style — `Path.read_text()` + `json.loads(...)`.
- `git_utils.file_sha256`: use Python 3.11's `hashlib.file_digest` instead of pre-3.8 `iter(lambda)` chunk loop.
- `changelog.py`: compile regexes once at module level, use `pos=` instead of slicing, tighten the bullet regex (`[^\n]+` instead of `.+`) to satisfy ReDoS analysers, and `cast(...)` the `findall` result for pyright.
- `report.Finding` → `@dataclass(frozen=True)` (value object only appended to a list).

### Docstrings (public surface)
- Add summary line to `cli.main`, `features.load_features`, `git_utils.commit_exists`, `git_utils.file_sha256`, `verify-bytecode.main`, `verify-bytecode.class_in_jar`.
- Inline comment in `features.load_features` explaining the YAML root cast.

### DRY
- `stamps.py`: merge `_replace_last_verified_sha` + `_replace_content_hash` into `_replace_field_after_path(...)` with `preserve_quotes` flag. Behaviour identical (quoted SHAs stay quoted, bare hashes stay bare).

## Test plan

- [x] `uv run pyright` (strict) — 0 errors, 0 warnings, 0 informations
- [x] `ruff check` — clean
- [x] `scripts/verify-docs.py` — 0 ERROR, 4 expected orphan-stamp warnings
- [x] `scripts/verify-theme-json.py` — PASS for all 3 theme pairs
- [x] `scripts/verify-theme-xml.py` — PASS, 603 attributes × 3 variants
- [x] `scripts/verify-bytecode.py` — 36/36 classes verified in JAR

## Summary by Sourcery

Refine verify_docs and related scripts for clearer naming, safer regexes, and more Pythonic patterns while consolidating duplicate YAML stamp update logic.

Enhancements:
- Deduplicate YAML stamp rewriting in stamps.py by introducing a generic helper for updating fields after a screenshot path with optional quote preservation.
- Improve readability and consistency across verify_docs modules by renaming short variables like fid/kw to descriptive names and tightening list comprehensions.
- Make changelog parsing more robust and static-analyser-friendly by compiling regexes once, constraining bullet patterns, and using typed casts.
- Adopt more Pythonic I/O and hashing by switching to pathlib-based JSON loading and hashlib.file_digest for streaming SHA-256 computation.
- Mark report.Finding as an immutable dataclass and streamline report aggregation and printing logic.
- Clarify CLI entry points and utilities by adding concise docstrings and renaming argparse parsers for verify-bytecode and verify_docs CLI.