### PR TITLE
fix: replace internal PluginManagerCore.getPlugin with public façade

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "0ad5b6a"
+          last_verified_sha: "1bbee6c"
           last_verified_date: "2026-05-19"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "0ad5b6a"
+          last_verified_sha: "1bbee6c"
           last_verified_date: "2026-05-19"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -240,7 +240,7 @@ categories:
           sources:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "0ad5b6a"
+          last_verified_sha: "1bbee6c"
           last_verified_date: "2026-05-19"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -283,7 +283,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "ea7020f"
+          last_verified_sha: "1bbee6c"
           last_verified_date: "2026-05-12"
           content_sha256: "fc9ba63b9c9c53893a486a3c9055287bd6dc9c68f5439cae197efe5ae585d17c"
 
@@ -336,7 +336,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "0ad5b6a"
+          last_verified_sha: "1bbee6c"
           last_verified_date: "2026-05-19"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "1bbee6c"
+          last_verified_sha: "11b574e"
           last_verified_date: "2026-05-19"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "1bbee6c"
+          last_verified_sha: "11b574e"
           last_verified_date: "2026-05-19"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -240,7 +240,7 @@ categories:
           sources:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "1bbee6c"
+          last_verified_sha: "11b574e"
           last_verified_date: "2026-05-19"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -283,7 +283,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "1bbee6c"
+          last_verified_sha: "11b574e"
           last_verified_date: "2026-05-12"
           content_sha256: "fc9ba63b9c9c53893a486a3c9055287bd6dc9c68f5439cae197efe5ae585d17c"
 
@@ -336,7 +336,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "1bbee6c"
+          last_verified_sha: "11b574e"
           last_verified_date: "2026-05-19"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/src/main/kotlin/dev/ayuislands/AyuPlugin.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuPlugin.kt
@@ -37,10 +37,9 @@ internal object AyuPlugin {
      * `Application` whose `getService` returns a `java.lang.Object` (not
      * a real [PluginManager]) triggers a `ClassCastException` inside the
      * platform-side cast in `getInstance()`. We catch + log + return null
-     * so unrelated tests that mocked `ApplicationManager` for their own
-     * reasons do not crash on the cast. Production never sees this path;
-     * the WARN exists so a real production CCE (e.g. a future platform
-     * refactor) is still auditable.
+     * so a partially-mocked Application in unit tests does not crash this
+     * wrapper. Production never sees this path; the WARN keeps a future
+     * platform CCE auditable.
      */
     fun findEnabledPlugin(pluginId: PluginId): IdeaPluginDescriptor? {
         ApplicationManager.getApplication() ?: return null

--- a/src/main/kotlin/dev/ayuislands/AyuPlugin.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuPlugin.kt
@@ -3,32 +3,56 @@ package dev.ayuislands
 import com.intellij.ide.plugins.IdeaPluginDescriptor
 import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.extensions.PluginId
 
 /**
- * Identity of this plugin's own descriptor and a thin test-tolerant wrapper
- * over the public [PluginManager] API. Single source of truth for the
- * `com.ayuislands.theme` string and its [PluginId] so the coordinates
- * only need to be updated in one place if they ever change.
+ * Identity of this plugin's own descriptor and the single lookup wrapper over
+ * the public [PluginManager] API. Source of truth for `com.ayuislands.theme`
+ * + its [PluginId], plus the descriptor lookup so the production semantics
+ * (enabled-only narrowing, test-env tolerance) live in one place.
+ *
+ * The wrapper deliberately calls `PluginManager.getInstance().findEnabledPlugin`
+ * (NOT `PluginManagerCore.getPlugin` or `PluginManager.getPlugin`). Both
+ * `getPlugin` variants are flagged by the JetBrains Marketplace verifier:
+ * the former as `@ApiStatus.Internal`, the latter as `@Deprecated`. Equally
+ * important, `getPlugin` returns the descriptor even for DISABLED plugins,
+ * while `findEnabledPlugin` returns null for disabled installations — and
+ * `ConflictRegistry` relies on that narrowing to skip disabled integrations.
  */
 internal object AyuPlugin {
+    private val LOG = logger<AyuPlugin>()
+
     const val ID_STRING: String = "com.ayuislands.theme"
     val ID: PluginId by lazy { PluginId.getId(ID_STRING) }
 
     /**
-     * Returns the enabled descriptor for [pluginId], or `null` when the plugin
-     * is not installed, is disabled, or when the IDE [com.intellij.openapi.application.Application]
-     * is not bootstrapped (only happens in unit tests that do not start the
-     * platform). A mocked test [com.intellij.openapi.application.Application]
-     * whose `getService(PluginManager::class.java)` returns a `java.lang.Object`
-     * (not a real [PluginManager]) also returns `null` — production never sees
-     * this path. All other failures propagate.
+     * Returns the enabled descriptor for [pluginId], or `null` when the
+     * plugin is not installed, is disabled, or when the IDE
+     * [com.intellij.openapi.application.Application] is not bootstrapped
+     * (only unit tests that do not start the platform see the last path).
+     *
+     * `PluginManager.getInstance()` internally resolves the service via
+     * `Application.getService(PluginManager::class.java)`. A mocked test
+     * `Application` whose `getService` returns a `java.lang.Object` (not
+     * a real [PluginManager]) triggers a `ClassCastException` inside the
+     * platform-side cast in `getInstance()`. We catch + log + return null
+     * so unrelated tests that mocked `ApplicationManager` for their own
+     * reasons do not crash on the cast. Production never sees this path;
+     * the WARN exists so a real production CCE (e.g. a future platform
+     * refactor) is still auditable.
      */
     fun findEnabledPlugin(pluginId: PluginId): IdeaPluginDescriptor? {
         ApplicationManager.getApplication() ?: return null
         return try {
             PluginManager.getInstance().findEnabledPlugin(pluginId)
-        } catch (_: ClassCastException) {
+        } catch (exception: ClassCastException) {
+            LOG.warn(
+                "AyuPlugin.findEnabledPlugin: ClassCastException from PluginManager.getInstance() — " +
+                    "Application service registry returned a non-PluginManager value (expected only " +
+                    "in unit tests with a partially mocked Application).",
+                exception,
+            )
             null
         }
     }

--- a/src/main/kotlin/dev/ayuislands/AyuPlugin.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuPlugin.kt
@@ -1,0 +1,35 @@
+package dev.ayuislands
+
+import com.intellij.ide.plugins.IdeaPluginDescriptor
+import com.intellij.ide.plugins.PluginManager
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.extensions.PluginId
+
+/**
+ * Identity of this plugin's own descriptor and a thin test-tolerant wrapper
+ * over the public [PluginManager] API. Single source of truth for the
+ * `com.ayuislands.theme` string and its [PluginId] so the coordinates
+ * only need to be updated in one place if they ever change.
+ */
+internal object AyuPlugin {
+    const val ID_STRING: String = "com.ayuislands.theme"
+    val ID: PluginId by lazy { PluginId.getId(ID_STRING) }
+
+    /**
+     * Returns the enabled descriptor for [pluginId], or `null` when the plugin
+     * is not installed, is disabled, or when the IDE [com.intellij.openapi.application.Application]
+     * is not bootstrapped (only happens in unit tests that do not start the
+     * platform). A mocked test [com.intellij.openapi.application.Application]
+     * whose `getService(PluginManager::class.java)` returns a `java.lang.Object`
+     * (not a real [PluginManager]) also returns `null` — production never sees
+     * this path. All other failures propagate.
+     */
+    fun findEnabledPlugin(pluginId: PluginId): IdeaPluginDescriptor? {
+        ApplicationManager.getApplication() ?: return null
+        return try {
+            PluginManager.getInstance().findEnabledPlugin(pluginId)
+        } catch (_: ClassCastException) {
+            null
+        }
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
@@ -1,6 +1,6 @@
 package dev.ayuislands
 
-import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.ide.plugins.PluginManager
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.diagnostic.logger
@@ -15,7 +15,7 @@ internal object UpdateNotifier {
 
     fun showIfUpdated(project: Project) {
         val descriptor =
-            PluginManagerCore.getPlugin(PluginId.getId(PLUGIN_ID))
+            PluginManager.getPlugin(PluginId.getId(PLUGIN_ID))
                 ?: return
         val currentVersion = descriptor.version
         val state = AyuIslandsSettings.getInstance().state

--- a/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
@@ -1,21 +1,18 @@
 package dev.ayuislands
 
-import com.intellij.ide.plugins.PluginManager
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.diagnostic.logger
-import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.whatsnew.WhatsNewLauncher
 
 internal object UpdateNotifier {
     private val LOG = logger<UpdateNotifier>()
-    private const val PLUGIN_ID = "com.ayuislands.theme"
 
     fun showIfUpdated(project: Project) {
         val descriptor =
-            PluginManager.getPlugin(PluginId.getId(PLUGIN_ID))
+            AyuPlugin.findEnabledPlugin(AyuPlugin.ID)
                 ?: return
         val currentVersion = descriptor.version
         val state = AyuIslandsSettings.getInstance().state

--- a/src/main/kotlin/dev/ayuislands/accent/CodeGlanceProIntegration.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/CodeGlanceProIntegration.kt
@@ -1,9 +1,9 @@
 package dev.ayuislands.accent
 
-import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.extensions.PluginId
+import dev.ayuislands.AyuPlugin
 import dev.ayuislands.settings.AyuIslandsSettings
 import org.jetbrains.annotations.TestOnly
 import java.lang.reflect.Method
@@ -88,7 +88,7 @@ internal object CodeGlanceProIntegration {
 
         try {
             val pluginId = PluginId.getId("com.nasller.CodeGlancePro")
-            val cgpPlugin = PluginManager.getPlugin(pluginId) ?: return
+            val cgpPlugin = AyuPlugin.findEnabledPlugin(pluginId) ?: return
             val cgpClassLoader = cgpPlugin.pluginClassLoader ?: return
 
             val serviceClass =

--- a/src/main/kotlin/dev/ayuislands/accent/CodeGlanceProIntegration.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/CodeGlanceProIntegration.kt
@@ -1,6 +1,6 @@
 package dev.ayuislands.accent
 
-import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.extensions.PluginId
@@ -88,7 +88,7 @@ internal object CodeGlanceProIntegration {
 
         try {
             val pluginId = PluginId.getId("com.nasller.CodeGlancePro")
-            val cgpPlugin = PluginManagerCore.getPlugin(pluginId) ?: return
+            val cgpPlugin = PluginManager.getPlugin(pluginId) ?: return
             val cgpClassLoader = cgpPlugin.pluginClassLoader ?: return
 
             val serviceClass =

--- a/src/main/kotlin/dev/ayuislands/accent/conflict/ConflictRegistry.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/conflict/ConflictRegistry.kt
@@ -1,6 +1,7 @@
 package dev.ayuislands.accent.conflict
 
-import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.ide.plugins.PluginEnabler
+import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.extensions.PluginId
 import dev.ayuislands.accent.AccentElementId
 import org.jetbrains.annotations.TestOnly
@@ -45,7 +46,11 @@ object ConflictRegistry {
     private fun computeConflicts(): List<ConflictEntry> =
         entries.filter { entry ->
             val pluginId = PluginId.getId(entry.pluginId)
-            PluginManagerCore.getPlugin(pluginId) != null && !PluginManagerCore.isDisabled(pluginId)
+            // `PluginManager.getPlugin` returns the descriptor even for disabled
+            // plugins (its underlying `findPlugin` falls back to `findInstalledPlugin`),
+            // so we must additionally check `PluginEnabler.HEADLESS.isDisabled`
+            // to skip disabled installations.
+            PluginManager.getPlugin(pluginId) != null && !PluginEnabler.HEADLESS.isDisabled(pluginId)
         }
 
     fun detectConflicts(): List<ConflictEntry> = getCachedConflicts()

--- a/src/main/kotlin/dev/ayuislands/accent/conflict/ConflictRegistry.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/conflict/ConflictRegistry.kt
@@ -1,8 +1,7 @@
 package dev.ayuislands.accent.conflict
 
-import com.intellij.ide.plugins.PluginEnabler
-import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.extensions.PluginId
+import dev.ayuislands.AyuPlugin
 import dev.ayuislands.accent.AccentElementId
 import org.jetbrains.annotations.TestOnly
 
@@ -46,11 +45,10 @@ object ConflictRegistry {
     private fun computeConflicts(): List<ConflictEntry> =
         entries.filter { entry ->
             val pluginId = PluginId.getId(entry.pluginId)
-            // `PluginManager.getPlugin` returns the descriptor even for disabled
-            // plugins (its underlying `findPlugin` falls back to `findInstalledPlugin`),
-            // so we must additionally check `PluginEnabler.HEADLESS.isDisabled`
-            // to skip disabled installations.
-            PluginManager.getPlugin(pluginId) != null && !PluginEnabler.HEADLESS.isDisabled(pluginId)
+            // `findEnabledPlugin` returns null for both not-installed and
+            // installed-but-disabled plugins — exactly the conflict semantics
+            // we want (a disabled plugin is not active and is not a conflict).
+            AyuPlugin.findEnabledPlugin(pluginId) != null
         }
 
     fun detectConflicts(): List<ConflictEntry> = getCachedConflicts()

--- a/src/main/kotlin/dev/ayuislands/indent/IndentRainbowSync.kt
+++ b/src/main/kotlin/dev/ayuislands/indent/IndentRainbowSync.kt
@@ -1,6 +1,6 @@
 package dev.ayuislands.indent
 
-import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.ide.plugins.PluginManager
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.application.ApplicationManager
@@ -172,7 +172,7 @@ object IndentRainbowSync {
 
         try {
             val pluginId = PluginId.getId(IR_PLUGIN_ID)
-            val irPlugin = PluginManagerCore.getPlugin(pluginId) ?: return
+            val irPlugin = PluginManager.getPlugin(pluginId) ?: return
             val classLoader = irPlugin.pluginClassLoader ?: return
 
             val configClass =
@@ -251,7 +251,7 @@ object IndentRainbowSync {
     private fun notifyFailure() {
         val state = AyuIslandsSettings.getInstance().state
         val currentVersion =
-            PluginManagerCore
+            PluginManager
                 .getPlugin(PluginId.getId(IR_PLUGIN_ID))
                 ?.version
 

--- a/src/main/kotlin/dev/ayuislands/indent/IndentRainbowSync.kt
+++ b/src/main/kotlin/dev/ayuislands/indent/IndentRainbowSync.kt
@@ -1,11 +1,11 @@
 package dev.ayuislands.indent
 
-import com.intellij.ide.plugins.PluginManager
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.extensions.PluginId
+import dev.ayuislands.AyuPlugin
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.settings.AyuIslandsSettings
 import java.lang.reflect.Field
@@ -172,7 +172,7 @@ object IndentRainbowSync {
 
         try {
             val pluginId = PluginId.getId(IR_PLUGIN_ID)
-            val irPlugin = PluginManager.getPlugin(pluginId) ?: return
+            val irPlugin = AyuPlugin.findEnabledPlugin(pluginId) ?: return
             val classLoader = irPlugin.pluginClassLoader ?: return
 
             val configClass =
@@ -251,8 +251,8 @@ object IndentRainbowSync {
     private fun notifyFailure() {
         val state = AyuIslandsSettings.getInstance().state
         val currentVersion =
-            PluginManager
-                .getPlugin(PluginId.getId(IR_PLUGIN_ID))
+            AyuPlugin
+                .findEnabledPlugin(PluginId.getId(IR_PLUGIN_ID))
                 ?.version
 
         if (state.irFailedVersion == currentVersion) return

--- a/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
@@ -1,6 +1,5 @@
 package dev.ayuislands.licensing
 
-import com.intellij.ide.plugins.PluginManager
 import com.intellij.notification.Notification
 import com.intellij.notification.NotificationAction
 import com.intellij.notification.NotificationGroupManager
@@ -18,6 +17,7 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
 import com.intellij.ui.LicensingFacade
+import dev.ayuislands.AyuPlugin
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.AccentGroup
@@ -469,8 +469,8 @@ object LicenseChecker {
         if (!configPath.contains("idea-sandbox")) return false
         val pluginId = PluginId.getId("com.ayuislands.theme")
         val pluginPath =
-            PluginManager
-                .getPlugin(pluginId)
+            AyuPlugin
+                .findEnabledPlugin(pluginId)
                 ?.pluginPath
                 ?.toString()
                 .orEmpty()

--- a/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
@@ -1,6 +1,6 @@
 package dev.ayuislands.licensing
 
-import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.ide.plugins.PluginManager
 import com.intellij.notification.Notification
 import com.intellij.notification.NotificationAction
 import com.intellij.notification.NotificationGroupManager
@@ -469,7 +469,7 @@ object LicenseChecker {
         if (!configPath.contains("idea-sandbox")) return false
         val pluginId = PluginId.getId("com.ayuislands.theme")
         val pluginPath =
-            PluginManagerCore
+            PluginManager
                 .getPlugin(pluginId)
                 ?.pluginPath
                 ?.toString()

--- a/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
@@ -14,7 +14,6 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.diagnostic.logger
-import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
 import com.intellij.ui.LicensingFacade
 import dev.ayuislands.AyuPlugin
@@ -26,6 +25,9 @@ import dev.ayuislands.glow.GlowAnimation
 import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.glow.GlowPreset
 import dev.ayuislands.glow.GlowStyle
+import dev.ayuislands.licensing.LicenseChecker.getTrialDaysRemaining
+import dev.ayuislands.licensing.LicenseChecker.isLicensedOrGrace
+import dev.ayuislands.licensing.LicenseChecker.nowMsSupplier
 import dev.ayuislands.rotation.AccentRotationService
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
@@ -467,13 +469,19 @@ object LicenseChecker {
         if (System.getProperty("ayu.islands.dev") != "true") return false
         val configPath = PathManager.getConfigPath()
         if (!configPath.contains("idea-sandbox")) return false
-        val pluginId = PluginId.getId("com.ayuislands.theme")
-        val pluginPath =
-            AyuPlugin
-                .findEnabledPlugin(pluginId)
-                ?.pluginPath
-                ?.toString()
-                .orEmpty()
-        return pluginPath.contains("idea-sandbox")
+        val descriptor = AyuPlugin.findEnabledPlugin(AyuPlugin.ID)
+        if (descriptor == null) {
+            // Defensive: if the Application is mid-bootstrap or the descriptor
+            // lookup returns null for any reason, the gate falls through to
+            // `false` instead of trusting the sandbox-only config path. Log at
+            // DEBUG so the gate decision is traceable in `idea.log` without
+            // spamming production users whose descriptor is always present.
+            LOG.debug("isDevBuild: descriptor unavailable; treating as non-dev")
+            return false
+        }
+        return descriptor.pluginPath
+            ?.toString()
+            .orEmpty()
+            .contains("idea-sandbox")
     }
 }

--- a/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
@@ -25,9 +25,6 @@ import dev.ayuislands.glow.GlowAnimation
 import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.glow.GlowPreset
 import dev.ayuislands.glow.GlowStyle
-import dev.ayuislands.licensing.LicenseChecker.getTrialDaysRemaining
-import dev.ayuislands.licensing.LicenseChecker.isLicensedOrGrace
-import dev.ayuislands.licensing.LicenseChecker.nowMsSupplier
 import dev.ayuislands.rotation.AccentRotationService
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
@@ -469,19 +466,22 @@ object LicenseChecker {
         if (System.getProperty("ayu.islands.dev") != "true") return false
         val configPath = PathManager.getConfigPath()
         if (!configPath.contains("idea-sandbox")) return false
+        // Reaching this branch means the operator explicitly requested dev
+        // mode AND IDE is in a sandbox config — so a `false` return from here
+        // is a SURPRISING demotion and must be auditable. INFO (not DEBUG)
+        // so the message lands in `idea.log` without enabling category-level
+        // debug; the two preconditions above guarantee this branch can't spam
+        // regular users (only dev sandboxes ever reach it). Both descriptor-
+        // null and pluginPath-null paths are logged for symmetry.
         val descriptor = AyuPlugin.findEnabledPlugin(AyuPlugin.ID)
-        if (descriptor == null) {
-            // Defensive: if the Application is mid-bootstrap or the descriptor
-            // lookup returns null for any reason, the gate falls through to
-            // `false` instead of trusting the sandbox-only config path. Log at
-            // DEBUG so the gate decision is traceable in `idea.log` without
-            // spamming production users whose descriptor is always present.
-            LOG.debug("isDevBuild: descriptor unavailable; treating as non-dev")
-            return false
+        val pluginPath = descriptor?.pluginPath?.toString().orEmpty()
+        val isDev = pluginPath.contains("idea-sandbox")
+        if (!isDev) {
+            LOG.info(
+                "isDevBuild: returning false despite dev sandbox request — " +
+                    "descriptor=${descriptor != null}, pluginPath=$pluginPath",
+            )
         }
-        return descriptor.pluginPath
-            ?.toString()
-            .orEmpty()
-            .contains("idea-sandbox")
+        return isDev
     }
 }

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt
@@ -1,9 +1,7 @@
 package dev.ayuislands.settings
 
 import com.intellij.ide.BrowserUtil
-import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.diagnostic.logger
-import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.options.BoundConfigurable
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.ui.Messages
@@ -11,6 +9,7 @@ import com.intellij.ui.components.JBTabbedPane
 import com.intellij.ui.dsl.builder.Align
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.util.ui.JBUI
+import dev.ayuislands.AyuPlugin
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.runCatchingPreservingCancellation
 import dev.ayuislands.glow.GlowOverlayManager
@@ -66,8 +65,8 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
 
     override fun createPanel(): com.intellij.openapi.ui.DialogPanel {
         val pluginVersion =
-            PluginManager
-                .getPlugin(PluginId.getId("com.ayuislands.theme"))
+            AyuPlugin
+                .findEnabledPlugin(AyuPlugin.ID)
                 ?.version ?: "unknown"
 
         val variant =

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt
@@ -1,7 +1,7 @@
 package dev.ayuislands.settings
 
 import com.intellij.ide.BrowserUtil
-import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.options.BoundConfigurable
@@ -66,7 +66,7 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
 
     override fun createPanel(): com.intellij.openapi.ui.DialogPanel {
         val pluginVersion =
-            PluginManagerCore
+            PluginManager
                 .getPlugin(PluginId.getId("com.ayuislands.theme"))
                 ?.version ?: "unknown"
 

--- a/src/main/kotlin/dev/ayuislands/whatsnew/ShowWhatsNewAction.kt
+++ b/src/main/kotlin/dev/ayuislands/whatsnew/ShowWhatsNewAction.kt
@@ -54,11 +54,7 @@ internal class ShowWhatsNewAction : DumbAwareAction() {
             // BGT update can race with the click. The launcher returns false in
             // two cases: descriptor missing (a real anomaly — WARN) or no
             // manifest for current version (expected on patches — INFO).
-            val descriptor =
-                AyuPlugin.findEnabledPlugin(
-                    com.intellij.openapi.extensions.PluginId
-                        .getId("com.ayuislands.theme"),
-                )
+            val descriptor = AyuPlugin.findEnabledPlugin(AyuPlugin.ID)
             if (descriptor == null) {
                 LOG.warn("Ayu What's New: manual open declined — plugin descriptor missing")
             } else {

--- a/src/main/kotlin/dev/ayuislands/whatsnew/ShowWhatsNewAction.kt
+++ b/src/main/kotlin/dev/ayuislands/whatsnew/ShowWhatsNewAction.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.DumbAwareAction
+import dev.ayuislands.AyuPlugin
 
 /**
  * Tools-menu action that re-opens the What's New tab on demand.
@@ -25,11 +26,7 @@ internal class ShowWhatsNewAction : DumbAwareAction() {
         // when the descriptor is observed non-null again) so each real
         // disable-enable cycle gets its own signal without spamming every
         // BGT update tick.
-        val descriptor =
-            com.intellij.ide.plugins.PluginManager.getPlugin(
-                com.intellij.openapi.extensions.PluginId
-                    .getId("com.ayuislands.theme"),
-            )
+        val descriptor = AyuPlugin.findEnabledPlugin(AyuPlugin.ID)
         if (descriptor == null) {
             if (descriptorNullLogged.compareAndSet(false, true)) {
                 LOG.warn("Ayu What's New: plugin descriptor lookup returned null in update()")
@@ -41,7 +38,7 @@ internal class ShowWhatsNewAction : DumbAwareAction() {
         // compareAndSet(true, false) documents the semantics: the reset is a
         // no-op when the latch was already false (the common path — descriptor
         // stayed non-null). Note: concurrent BGT update()s can still observe
-        // interleavings that produce two WARNs within one real null streak;
+        // interleaved schedules that produce two WARNs within one real null streak;
         // this is a narrow BGT race the latch doesn't defend against, but the
         // signal is at worst duplicated, never lost.
         descriptorNullLogged.compareAndSet(true, false)
@@ -58,7 +55,7 @@ internal class ShowWhatsNewAction : DumbAwareAction() {
             // two cases: descriptor missing (a real anomaly — WARN) or no
             // manifest for current version (expected on patches — INFO).
             val descriptor =
-                com.intellij.ide.plugins.PluginManager.getPlugin(
+                AyuPlugin.findEnabledPlugin(
                     com.intellij.openapi.extensions.PluginId
                         .getId("com.ayuislands.theme"),
                 )

--- a/src/main/kotlin/dev/ayuislands/whatsnew/ShowWhatsNewAction.kt
+++ b/src/main/kotlin/dev/ayuislands/whatsnew/ShowWhatsNewAction.kt
@@ -26,7 +26,7 @@ internal class ShowWhatsNewAction : DumbAwareAction() {
         // disable-enable cycle gets its own signal without spamming every
         // BGT update tick.
         val descriptor =
-            com.intellij.ide.plugins.PluginManagerCore.getPlugin(
+            com.intellij.ide.plugins.PluginManager.getPlugin(
                 com.intellij.openapi.extensions.PluginId
                     .getId("com.ayuislands.theme"),
             )
@@ -58,7 +58,7 @@ internal class ShowWhatsNewAction : DumbAwareAction() {
             // two cases: descriptor missing (a real anomaly — WARN) or no
             // manifest for current version (expected on patches — INFO).
             val descriptor =
-                com.intellij.ide.plugins.PluginManagerCore.getPlugin(
+                com.intellij.ide.plugins.PluginManager.getPlugin(
                     com.intellij.openapi.extensions.PluginId
                         .getId("com.ayuislands.theme"),
                 )

--- a/src/main/kotlin/dev/ayuislands/whatsnew/WhatsNewLauncher.kt
+++ b/src/main/kotlin/dev/ayuislands/whatsnew/WhatsNewLauncher.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.IdeFocusManager
+import dev.ayuislands.AyuPlugin
 import dev.ayuislands.onboarding.OnboardingSchedulerService
 import dev.ayuislands.settings.AyuIslandsSettings
 import kotlinx.coroutines.CancellationException
@@ -201,11 +202,5 @@ internal object WhatsNewLauncher {
         }
     }
 
-    private fun pluginDescriptor() =
-        com.intellij.ide.plugins.PluginManager.getPlugin(
-            com.intellij.openapi.extensions.PluginId
-                .getId(PLUGIN_ID),
-        )
-
-    private const val PLUGIN_ID = "com.ayuislands.theme"
+    private fun pluginDescriptor() = AyuPlugin.findEnabledPlugin(AyuPlugin.ID)
 }

--- a/src/main/kotlin/dev/ayuislands/whatsnew/WhatsNewLauncher.kt
+++ b/src/main/kotlin/dev/ayuislands/whatsnew/WhatsNewLauncher.kt
@@ -202,7 +202,7 @@ internal object WhatsNewLauncher {
     }
 
     private fun pluginDescriptor() =
-        com.intellij.ide.plugins.PluginManagerCore.getPlugin(
+        com.intellij.ide.plugins.PluginManager.getPlugin(
             com.intellij.openapi.extensions.PluginId
                 .getId(PLUGIN_ID),
         )

--- a/src/main/kotlin/dev/ayuislands/whatsnew/WhatsNewPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/whatsnew/WhatsNewPanel.kt
@@ -311,7 +311,7 @@ internal class WhatsNewPanel(
     }
 
     private fun pluginDescriptor() =
-        com.intellij.ide.plugins.PluginManagerCore.getPlugin(
+        com.intellij.ide.plugins.PluginManager.getPlugin(
             com.intellij.openapi.extensions.PluginId
                 .getId("com.ayuislands.theme"),
         )

--- a/src/main/kotlin/dev/ayuislands/whatsnew/WhatsNewPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/whatsnew/WhatsNewPanel.kt
@@ -11,8 +11,6 @@ import dev.ayuislands.AyuPlugin
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.onboarding.ContentScaler
 import dev.ayuislands.settings.AyuIslandsSettings
-import dev.ayuislands.whatsnew.WhatsNewPanel.Companion.MAX_SCALE
-import dev.ayuislands.whatsnew.WhatsNewPanel.Companion.MIN_SCALE
 import java.awt.BorderLayout
 import java.awt.Color
 import java.awt.FlowLayout

--- a/src/main/kotlin/dev/ayuislands/whatsnew/WhatsNewPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/whatsnew/WhatsNewPanel.kt
@@ -7,6 +7,7 @@ import com.intellij.ui.JBColor
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.util.ui.JBUI
+import dev.ayuislands.AyuPlugin
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.onboarding.ContentScaler
 import dev.ayuislands.settings.AyuIslandsSettings
@@ -310,11 +311,7 @@ internal class WhatsNewPanel(
             .getOrDefault(FALLBACK_ACCENT)
     }
 
-    private fun pluginDescriptor() =
-        com.intellij.ide.plugins.PluginManager.getPlugin(
-            com.intellij.openapi.extensions.PluginId
-                .getId("com.ayuislands.theme"),
-        )
+    private fun pluginDescriptor() = AyuPlugin.findEnabledPlugin(AyuPlugin.ID)
 
     companion object {
         private val LOG = logger<WhatsNewPanel>()

--- a/src/main/kotlin/dev/ayuislands/whatsnew/WhatsNewPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/whatsnew/WhatsNewPanel.kt
@@ -11,10 +11,10 @@ import dev.ayuislands.AyuPlugin
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.onboarding.ContentScaler
 import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.whatsnew.WhatsNewPanel.Companion.MAX_SCALE
+import dev.ayuislands.whatsnew.WhatsNewPanel.Companion.MIN_SCALE
 import java.awt.BorderLayout
 import java.awt.Color
-import java.awt.Component.CENTER_ALIGNMENT
-import java.awt.Component.LEFT_ALIGNMENT
 import java.awt.FlowLayout
 import java.awt.Font
 import java.awt.event.ComponentAdapter

--- a/src/test/kotlin/dev/ayuislands/AyuPluginTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuPluginTest.kt
@@ -1,0 +1,146 @@
+package dev.ayuislands
+
+import com.intellij.ide.plugins.IdeaPluginDescriptor
+import com.intellij.ide.plugins.PluginManager
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.extensions.PluginId
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+/**
+ * Covers the user-observable behaviour of [AyuPlugin]:
+ *  - The hardcoded `com.ayuislands.theme` plugin id stays stable across
+ *    refactors (any rename would silently break self-introspection like the
+ *    version-stamp in the Settings header or the What's New launcher).
+ *  - [AyuPlugin.findEnabledPlugin] returns the descriptor for a live plugin,
+ *    `null` when the plugin is absent / disabled, `null` in a unit-test
+ *    environment without an [Application], and `null` when a mocked test
+ *    [Application] returns a non-[PluginManager] `Object` from `getService`.
+ */
+class AyuPluginTest {
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `ID_STRING is the published Marketplace plugin id`() {
+        assertEquals(
+            "com.ayuislands.theme",
+            AyuPlugin.ID_STRING,
+            "Plugin coordinates are load-bearing for the JetBrains Marketplace listing — " +
+                "changing this silently disconnects the IDE-side descriptor lookup from " +
+                "every place the user sees \"Ayu Islands\".",
+        )
+    }
+
+    @Test
+    fun `ID exposes the matching PluginId instance`() {
+        // Same content as PluginId.getId(ID_STRING). `getId` interns by string,
+        // so identity equality holds and the lazy initializer is a no-op cache.
+        assertSame(PluginId.getId(AyuPlugin.ID_STRING), AyuPlugin.ID)
+    }
+
+    @Test
+    fun `findEnabledPlugin returns null when Application is not bootstrapped`() {
+        // Default unit-test environment has no live IDE: `getApplication()`
+        // returns `null` and the wrapper short-circuits without touching
+        // `PluginManager.getInstance`. The wrapper SHOULD NOT throw.
+        mockkStatic(ApplicationManager::class)
+        every { ApplicationManager.getApplication() } returns null
+
+        assertNull(AyuPlugin.findEnabledPlugin(AyuPlugin.ID))
+    }
+
+    @Test
+    fun `findEnabledPlugin returns descriptor for an installed enabled plugin`() {
+        // Real-user scenario: Ayu Islands is installed and enabled — the
+        // version-string lookup in `AyuIslandsConfigurable.createPanel` and
+        // the manifest probe in `WhatsNewLauncher.openManually` BOTH depend
+        // on the wrapper returning a non-null descriptor when the plugin is
+        // live in the IDE.
+        val app = mockk<Application>()
+        val pluginManager = mockk<PluginManager>()
+        val descriptor = mockk<IdeaPluginDescriptor>()
+        mockkStatic(ApplicationManager::class)
+        mockkStatic(PluginManager::class)
+        every { ApplicationManager.getApplication() } returns app
+        every { PluginManager.getInstance() } returns pluginManager
+        every { pluginManager.findEnabledPlugin(AyuPlugin.ID) } returns descriptor
+
+        assertNotNull(
+            AyuPlugin.findEnabledPlugin(AyuPlugin.ID),
+            "The wrapper must surface the live descriptor — callers read .version, " +
+                ".pluginPath, .pluginClassLoader off it.",
+        )
+    }
+
+    @Test
+    fun `findEnabledPlugin returns null when the requested plugin is not installed`() {
+        // Real-user scenario: a third-party integration (CodeGlance Pro,
+        // Indent Rainbow) probe runs when those plugins are NOT installed —
+        // the wrapper must produce `null` so callers skip the integration path
+        // cleanly instead of crashing.
+        val app = mockk<Application>()
+        val pluginManager = mockk<PluginManager>()
+        val absentId = PluginId.getId("com.nasller.CodeGlancePro")
+        mockkStatic(ApplicationManager::class)
+        mockkStatic(PluginManager::class)
+        every { ApplicationManager.getApplication() } returns app
+        every { PluginManager.getInstance() } returns pluginManager
+        every { pluginManager.findEnabledPlugin(absentId) } returns null
+
+        assertNull(AyuPlugin.findEnabledPlugin(absentId))
+    }
+
+    @Test
+    fun `findEnabledPlugin returns null when the requested plugin is installed but disabled`() {
+        // Real-user scenario: a third-party plugin is INSTALLED but DISABLED.
+        // The underlying `PluginManager.findEnabledPlugin` returns null for
+        // disabled plugins by contract (that is exactly what differentiates
+        // it from `getPlugin`, which still returns a descriptor for disabled
+        // installations). The wrapper passes that null through, which lets
+        // `ConflictRegistry` correctly skip disabled-plugin conflicts.
+        val app = mockk<Application>()
+        val pluginManager = mockk<PluginManager>()
+        val disabledId = PluginId.getId("indent-rainbow.indent-rainbow")
+        mockkStatic(ApplicationManager::class)
+        mockkStatic(PluginManager::class)
+        every { ApplicationManager.getApplication() } returns app
+        every { PluginManager.getInstance() } returns pluginManager
+        every { pluginManager.findEnabledPlugin(disabledId) } returns null
+
+        assertNull(
+            AyuPlugin.findEnabledPlugin(disabledId),
+            "Disabled plugins must look like \"absent\" to downstream filters — that " +
+                "is the contract `ConflictRegistry.computeConflicts` relies on.",
+        )
+    }
+
+    @Test
+    fun `findEnabledPlugin survives a mocked Application whose getService returns Object`() {
+        // Real test-suite scenario: another test in the JVM mocked
+        // `ApplicationManager.getApplication()` to return an Application whose
+        // `getService(PluginManager::class.java)` returns a bare Object. That
+        // shape triggers a ClassCastException inside `PluginManager.getInstance`.
+        // The wrapper catches it so unrelated tests (Chrome refresh,
+        // ConflictRegistry probes) don't crash with platform-internal errors
+        // they don't actually exercise.
+        val app = mockk<Application>()
+        mockkStatic(ApplicationManager::class)
+        mockkStatic(PluginManager::class)
+        every { ApplicationManager.getApplication() } returns app
+        every { PluginManager.getInstance() } throws ClassCastException("mock Application returned Object")
+
+        assertNull(AyuPlugin.findEnabledPlugin(AyuPlugin.ID))
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/AyuPluginTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuPluginTest.kt
@@ -12,7 +12,6 @@ import io.mockk.unmockkAll
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 
@@ -77,10 +76,15 @@ class AyuPluginTest {
         every { PluginManager.getInstance() } returns pluginManager
         every { pluginManager.findEnabledPlugin(AyuPlugin.ID) } returns descriptor
 
-        assertNotNull(
+        // Identity assertion (not just non-null) — a future refactor that
+        // accidentally wrapped the descriptor (e.g. in a Decorator) would
+        // silently change the type read by `.version`/`.pluginPath`/
+        // `.pluginClassLoader` callers; assertSame catches that drift.
+        assertSame(
+            descriptor,
             AyuPlugin.findEnabledPlugin(AyuPlugin.ID),
-            "The wrapper must surface the live descriptor — callers read .version, " +
-                ".pluginPath, .pluginClassLoader off it.",
+            "The wrapper must surface the live descriptor verbatim — callers read " +
+                ".version, .pluginPath, .pluginClassLoader off it.",
         )
     }
 
@@ -128,13 +132,17 @@ class AyuPluginTest {
 
     @Test
     fun `findEnabledPlugin survives a mocked Application whose getService returns Object`() {
-        // Real test-suite scenario: another test in the JVM mocked
-        // `ApplicationManager.getApplication()` to return an Application whose
-        // `getService(PluginManager::class.java)` returns a bare Object. That
-        // shape triggers a ClassCastException inside `PluginManager.getInstance`.
-        // The wrapper catches it so unrelated tests (Chrome refresh,
-        // ConflictRegistry probes) don't crash with platform-internal errors
-        // they don't actually exercise.
+        // Pins the `catch (_: ClassCastException)` branch in
+        // [AyuPlugin.findEnabledPlugin]. Real test-suite scenario: another
+        // test in the JVM mocked `ApplicationManager.getApplication()` to
+        // return an Application whose `getService(PluginManager::class.java)`
+        // returns a bare Object. That shape triggers a ClassCastException
+        // inside `PluginManager.getInstance()` (one frame deeper than where
+        // we observe it). The wrapper catches it so unrelated tests (Chrome
+        // refresh, ConflictRegistry probes) don't crash with platform-
+        // internal errors they don't actually exercise.
+        //
+        // Deleting the production catch will fail this test.
         val app = mockk<Application>()
         mockkStatic(ApplicationManager::class)
         mockkStatic(PluginManager::class)

--- a/src/test/kotlin/dev/ayuislands/UpdateNotifierTest.kt
+++ b/src/test/kotlin/dev/ayuislands/UpdateNotifierTest.kt
@@ -1,7 +1,7 @@
 package dev.ayuislands
 
 import com.intellij.ide.plugins.IdeaPluginDescriptor
-import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.ide.plugins.PluginManager
 import com.intellij.notification.Notification
 import com.intellij.notification.NotificationGroup
 import com.intellij.notification.NotificationGroupManager
@@ -30,7 +30,7 @@ class UpdateNotifierTest {
 
     @BeforeTest
     fun setUp() {
-        mockkStatic(PluginManagerCore::class)
+        mockkStatic(PluginManager::class)
         mockkObject(AyuIslandsSettings.Companion)
         mockkStatic(NotificationGroupManager::class)
 
@@ -53,7 +53,7 @@ class UpdateNotifierTest {
     @Test
     fun `no-op when plugin descriptor not found`() {
         every {
-            PluginManagerCore.getPlugin(any<PluginId>())
+            PluginManager.getPlugin(any<PluginId>())
         } returns null
 
         UpdateNotifier.showIfUpdated(project)
@@ -65,7 +65,7 @@ class UpdateNotifierTest {
     fun `no-op when version already seen`() {
         state.lastSeenVersion = "2.2.0"
         every {
-            PluginManagerCore.getPlugin(any<PluginId>())
+            PluginManager.getPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.2.0"
 
@@ -78,7 +78,7 @@ class UpdateNotifierTest {
     fun `updates lastSeenVersion on first install without notification`() {
         state.lastSeenVersion = null
         every {
-            PluginManagerCore.getPlugin(any<PluginId>())
+            PluginManager.getPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.2.0"
 
@@ -91,7 +91,7 @@ class UpdateNotifierTest {
     fun `no notification when no release notes for version`() {
         state.lastSeenVersion = "2.1.0"
         every {
-            PluginManagerCore.getPlugin(any<PluginId>())
+            PluginManager.getPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "9.9.9"
 
@@ -104,7 +104,7 @@ class UpdateNotifierTest {
     fun `shows notification when upgrading to version with release notes`() {
         state.lastSeenVersion = "2.1.0"
         every {
-            PluginManagerCore.getPlugin(any<PluginId>())
+            PluginManager.getPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.2.0"
 
@@ -139,7 +139,7 @@ class UpdateNotifierTest {
     fun `updates state before checking release notes`() {
         state.lastSeenVersion = "2.0.0"
         every {
-            PluginManagerCore.getPlugin(any<PluginId>())
+            PluginManager.getPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.1.0"
 
@@ -154,7 +154,7 @@ class UpdateNotifierTest {
         // lastSeen already matches current — line 21 should short-circuit every call.
         state.lastSeenVersion = "2.4.0"
         every {
-            PluginManagerCore.getPlugin(any<PluginId>())
+            PluginManager.getPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.4.0"
 
@@ -182,7 +182,7 @@ class UpdateNotifierTest {
         // even when release notes exist for the current version.
         state.lastSeenVersion = null
         every {
-            PluginManagerCore.getPlugin(any<PluginId>())
+            PluginManager.getPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.4.0"
 
@@ -211,7 +211,7 @@ class UpdateNotifierTest {
         // Session 2 and 3 read the persisted state — must stay silent.
         state.lastSeenVersion = "2.3.7"
         every {
-            PluginManagerCore.getPlugin(any<PluginId>())
+            PluginManager.getPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.4.0"
 
@@ -246,7 +246,7 @@ class UpdateNotifierTest {
         // the target version, not an intermediate one.
         state.lastSeenVersion = "2.3.5"
         every {
-            PluginManagerCore.getPlugin(any<PluginId>())
+            PluginManager.getPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.4.0"
 
@@ -283,7 +283,7 @@ class UpdateNotifierTest {
         // path entirely — no double-signal to the user.
         state.lastSeenVersion = "2.4.2"
         every {
-            PluginManagerCore.getPlugin(any<PluginId>())
+            PluginManager.getPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.5.0"
         every { WhatsNewLauncher.openIfEligible(project, "2.5.0") } returns true
@@ -317,7 +317,7 @@ class UpdateNotifierTest {
         // exist. Regression guard for breaking the existing balloon flow.
         state.lastSeenVersion = "2.1.0"
         every {
-            PluginManagerCore.getPlugin(any<PluginId>())
+            PluginManager.getPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.2.0"
         every { WhatsNewLauncher.openIfEligible(project, "2.2.0") } returns false
@@ -349,7 +349,7 @@ class UpdateNotifierTest {
         // Current version is not in RELEASE_NOTES — state must update but notification must NOT fire.
         state.lastSeenVersion = "2.3.7"
         every {
-            PluginManagerCore.getPlugin(any<PluginId>())
+            PluginManager.getPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.9.99"
 

--- a/src/test/kotlin/dev/ayuislands/UpdateNotifierTest.kt
+++ b/src/test/kotlin/dev/ayuislands/UpdateNotifierTest.kt
@@ -1,13 +1,13 @@
 package dev.ayuislands
 
 import com.intellij.ide.plugins.IdeaPluginDescriptor
-import com.intellij.ide.plugins.PluginManager
 import com.intellij.notification.Notification
 import com.intellij.notification.NotificationGroup
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
+import dev.ayuislands.AyuPlugin
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
 import dev.ayuislands.whatsnew.WhatsNewLauncher
@@ -30,7 +30,7 @@ class UpdateNotifierTest {
 
     @BeforeTest
     fun setUp() {
-        mockkStatic(PluginManager::class)
+        mockkObject(AyuPlugin)
         mockkObject(AyuIslandsSettings.Companion)
         mockkStatic(NotificationGroupManager::class)
 
@@ -53,7 +53,7 @@ class UpdateNotifierTest {
     @Test
     fun `no-op when plugin descriptor not found`() {
         every {
-            PluginManager.getPlugin(any<PluginId>())
+            AyuPlugin.findEnabledPlugin(any<PluginId>())
         } returns null
 
         UpdateNotifier.showIfUpdated(project)
@@ -65,7 +65,7 @@ class UpdateNotifierTest {
     fun `no-op when version already seen`() {
         state.lastSeenVersion = "2.2.0"
         every {
-            PluginManager.getPlugin(any<PluginId>())
+            AyuPlugin.findEnabledPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.2.0"
 
@@ -78,7 +78,7 @@ class UpdateNotifierTest {
     fun `updates lastSeenVersion on first install without notification`() {
         state.lastSeenVersion = null
         every {
-            PluginManager.getPlugin(any<PluginId>())
+            AyuPlugin.findEnabledPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.2.0"
 
@@ -91,7 +91,7 @@ class UpdateNotifierTest {
     fun `no notification when no release notes for version`() {
         state.lastSeenVersion = "2.1.0"
         every {
-            PluginManager.getPlugin(any<PluginId>())
+            AyuPlugin.findEnabledPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "9.9.9"
 
@@ -104,7 +104,7 @@ class UpdateNotifierTest {
     fun `shows notification when upgrading to version with release notes`() {
         state.lastSeenVersion = "2.1.0"
         every {
-            PluginManager.getPlugin(any<PluginId>())
+            AyuPlugin.findEnabledPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.2.0"
 
@@ -139,7 +139,7 @@ class UpdateNotifierTest {
     fun `updates state before checking release notes`() {
         state.lastSeenVersion = "2.0.0"
         every {
-            PluginManager.getPlugin(any<PluginId>())
+            AyuPlugin.findEnabledPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.1.0"
 
@@ -154,7 +154,7 @@ class UpdateNotifierTest {
         // lastSeen already matches current — line 21 should short-circuit every call.
         state.lastSeenVersion = "2.4.0"
         every {
-            PluginManager.getPlugin(any<PluginId>())
+            AyuPlugin.findEnabledPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.4.0"
 
@@ -182,7 +182,7 @@ class UpdateNotifierTest {
         // even when release notes exist for the current version.
         state.lastSeenVersion = null
         every {
-            PluginManager.getPlugin(any<PluginId>())
+            AyuPlugin.findEnabledPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.4.0"
 
@@ -211,7 +211,7 @@ class UpdateNotifierTest {
         // Session 2 and 3 read the persisted state — must stay silent.
         state.lastSeenVersion = "2.3.7"
         every {
-            PluginManager.getPlugin(any<PluginId>())
+            AyuPlugin.findEnabledPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.4.0"
 
@@ -246,7 +246,7 @@ class UpdateNotifierTest {
         // the target version, not an intermediate one.
         state.lastSeenVersion = "2.3.5"
         every {
-            PluginManager.getPlugin(any<PluginId>())
+            AyuPlugin.findEnabledPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.4.0"
 
@@ -283,7 +283,7 @@ class UpdateNotifierTest {
         // path entirely — no double-signal to the user.
         state.lastSeenVersion = "2.4.2"
         every {
-            PluginManager.getPlugin(any<PluginId>())
+            AyuPlugin.findEnabledPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.5.0"
         every { WhatsNewLauncher.openIfEligible(project, "2.5.0") } returns true
@@ -317,7 +317,7 @@ class UpdateNotifierTest {
         // exist. Regression guard for breaking the existing balloon flow.
         state.lastSeenVersion = "2.1.0"
         every {
-            PluginManager.getPlugin(any<PluginId>())
+            AyuPlugin.findEnabledPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.2.0"
         every { WhatsNewLauncher.openIfEligible(project, "2.2.0") } returns false
@@ -349,7 +349,7 @@ class UpdateNotifierTest {
         // Current version is not in RELEASE_NOTES — state must update but notification must NOT fire.
         state.lastSeenVersion = "2.3.7"
         every {
-            PluginManager.getPlugin(any<PluginId>())
+            AyuPlugin.findEnabledPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.9.99"
 

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorRevertAllIntegrationTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorRevertAllIntegrationTest.kt
@@ -1,7 +1,6 @@
 package dev.ayuislands.accent
 
 import com.intellij.ide.plugins.IdeaPluginDescriptor
-import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.colors.EditorColorsManager
@@ -12,6 +11,7 @@ import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.util.messages.MessageBus
+import dev.ayuislands.AyuPlugin
 import dev.ayuislands.indent.IndentRainbowSync
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
@@ -803,9 +803,9 @@ class AccentApplicatorRevertAllIntegrationTest {
         // `cgpMethodsResolved = true` flag set on entry would leak into
         // the next test.
         CodeGlanceProIntegration.resetReflectionCacheForTests()
-        mockkStatic(PluginManager::class)
+        mockkObject(AyuPlugin)
         val mockPlugin = mockk<IdeaPluginDescriptor>(relaxed = true)
-        every { PluginManager.getPlugin(any()) } returns mockPlugin
+        every { AyuPlugin.findEnabledPlugin(any()) } returns mockPlugin
         // Use the test's own classloader — it does not contain the CGP class,
         // so `Class.forName` throws `ClassNotFoundException` (a subtype of
         // `ReflectiveOperationException`).
@@ -837,9 +837,9 @@ class AccentApplicatorRevertAllIntegrationTest {
         // Reflection cache is reset in `@AfterTest` via
         // `CodeGlanceProIntegration.resetReflectionCacheForTests()`.
         CodeGlanceProIntegration.resetReflectionCacheForTests()
-        mockkStatic(PluginManager::class)
+        mockkObject(AyuPlugin)
         val mockPlugin = mockk<IdeaPluginDescriptor>(relaxed = true)
-        every { PluginManager.getPlugin(any()) } returns mockPlugin
+        every { AyuPlugin.findEnabledPlugin(any()) } returns mockPlugin
         every { mockPlugin.pluginClassLoader } returns BrokenClassLoader
 
         // No throw expected. `IllegalStateException` is a `RuntimeException`,

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorRevertAllIntegrationTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorRevertAllIntegrationTest.kt
@@ -1,7 +1,7 @@
 package dev.ayuislands.accent
 
 import com.intellij.ide.plugins.IdeaPluginDescriptor
-import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.colors.EditorColorsManager
@@ -803,9 +803,9 @@ class AccentApplicatorRevertAllIntegrationTest {
         // `cgpMethodsResolved = true` flag set on entry would leak into
         // the next test.
         CodeGlanceProIntegration.resetReflectionCacheForTests()
-        mockkStatic(PluginManagerCore::class)
+        mockkStatic(PluginManager::class)
         val mockPlugin = mockk<IdeaPluginDescriptor>(relaxed = true)
-        every { PluginManagerCore.getPlugin(any()) } returns mockPlugin
+        every { PluginManager.getPlugin(any()) } returns mockPlugin
         // Use the test's own classloader — it does not contain the CGP class,
         // so `Class.forName` throws `ClassNotFoundException` (a subtype of
         // `ReflectiveOperationException`).
@@ -837,9 +837,9 @@ class AccentApplicatorRevertAllIntegrationTest {
         // Reflection cache is reset in `@AfterTest` via
         // `CodeGlanceProIntegration.resetReflectionCacheForTests()`.
         CodeGlanceProIntegration.resetReflectionCacheForTests()
-        mockkStatic(PluginManagerCore::class)
+        mockkStatic(PluginManager::class)
         val mockPlugin = mockk<IdeaPluginDescriptor>(relaxed = true)
-        every { PluginManagerCore.getPlugin(any()) } returns mockPlugin
+        every { PluginManager.getPlugin(any()) } returns mockPlugin
         every { mockPlugin.pluginClassLoader } returns BrokenClassLoader
 
         // No throw expected. `IllegalStateException` is a `RuntimeException`,

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
@@ -1,7 +1,6 @@
 package dev.ayuislands.accent
 
 import com.intellij.ide.plugins.IdeaPluginDescriptor
-import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.editor.colors.ColorKey
@@ -11,6 +10,7 @@ import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.util.messages.MessageBus
+import dev.ayuislands.AyuPlugin
 import dev.ayuislands.accent.conflict.ConflictEntry
 import dev.ayuislands.accent.conflict.ConflictRegistry
 import dev.ayuislands.accent.conflict.ConflictType
@@ -91,8 +91,8 @@ class AccentApplicatorTest {
         mockkStatic(Window::class)
         every { Window.getWindows() } returns emptyArray()
 
-        mockkStatic(PluginManager::class)
-        every { PluginManager.getPlugin(any()) } returns null
+        mockkObject(AyuPlugin)
+        every { AyuPlugin.findEnabledPlugin(any()) } returns null
 
         // Per-project notify plumbing: revertAll iterates ProjectManager.openProjects
         // and calls ComponentTreeRefresher.notifyOnly per usable project. Unit tests
@@ -818,7 +818,7 @@ class AccentApplicatorTest {
     @Test
     fun `resolveCgpMethods returns when plugin classloader is null`() {
         val mockPlugin = mockk<IdeaPluginDescriptor>(relaxed = true)
-        every { PluginManager.getPlugin(any()) } returns mockPlugin
+        every { AyuPlugin.findEnabledPlugin(any()) } returns mockPlugin
         every { mockPlugin.pluginClassLoader } returns null
 
         invokePrivate("resolveCgpMethods")

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
@@ -1,7 +1,7 @@
 package dev.ayuislands.accent
 
 import com.intellij.ide.plugins.IdeaPluginDescriptor
-import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.editor.colors.ColorKey
@@ -91,8 +91,8 @@ class AccentApplicatorTest {
         mockkStatic(Window::class)
         every { Window.getWindows() } returns emptyArray()
 
-        mockkStatic(PluginManagerCore::class)
-        every { PluginManagerCore.getPlugin(any()) } returns null
+        mockkStatic(PluginManager::class)
+        every { PluginManager.getPlugin(any()) } returns null
 
         // Per-project notify plumbing: revertAll iterates ProjectManager.openProjects
         // and calls ComponentTreeRefresher.notifyOnly per usable project. Unit tests
@@ -818,7 +818,7 @@ class AccentApplicatorTest {
     @Test
     fun `resolveCgpMethods returns when plugin classloader is null`() {
         val mockPlugin = mockk<IdeaPluginDescriptor>(relaxed = true)
-        every { PluginManagerCore.getPlugin(any()) } returns mockPlugin
+        every { PluginManager.getPlugin(any()) } returns mockPlugin
         every { mockPlugin.pluginClassLoader } returns null
 
         invokePrivate("resolveCgpMethods")

--- a/src/test/kotlin/dev/ayuislands/accent/AccentChangedPublishTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentChangedPublishTest.kt
@@ -1,6 +1,5 @@
 package dev.ayuislands.accent
 
-import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.colors.EditorColorsManager
@@ -12,6 +11,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.testFramework.LoggedErrorProcessor
 import com.intellij.util.messages.MessageBus
+import dev.ayuislands.AyuPlugin
 import dev.ayuislands.accent.conflict.ConflictRegistry
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
@@ -94,8 +94,8 @@ class AccentChangedPublishTest {
         mockkStatic(Window::class)
         every { Window.getWindows() } returns emptyArray()
 
-        mockkStatic(PluginManager::class)
-        every { PluginManager.getPlugin(any()) } returns null
+        mockkObject(AyuPlugin)
+        every { AyuPlugin.findEnabledPlugin(any()) } returns null
 
         // ProjectManager.openProjects drives the per-project publish loop.
         project =

--- a/src/test/kotlin/dev/ayuislands/accent/AccentChangedPublishTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentChangedPublishTest.kt
@@ -1,6 +1,6 @@
 package dev.ayuislands.accent
 
-import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.colors.EditorColorsManager
@@ -94,8 +94,8 @@ class AccentChangedPublishTest {
         mockkStatic(Window::class)
         every { Window.getWindows() } returns emptyArray()
 
-        mockkStatic(PluginManagerCore::class)
-        every { PluginManagerCore.getPlugin(any()) } returns null
+        mockkStatic(PluginManager::class)
+        every { PluginManager.getPlugin(any()) } returns null
 
         // ProjectManager.openProjects drives the per-project publish loop.
         project =

--- a/src/test/kotlin/dev/ayuislands/accent/conflict/ConflictRegistryTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/conflict/ConflictRegistryTest.kt
@@ -1,6 +1,6 @@
 package dev.ayuislands.accent.conflict
 
-import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.extensions.PluginId
 import dev.ayuislands.accent.AccentElementId
 import io.mockk.every
@@ -103,9 +103,8 @@ class ConflictRegistryTest {
      */
     @Test
     fun `detectConflicts returns empty list when no conflict plugins installed`() {
-        mockkStatic(PluginManagerCore::class)
-        every { PluginManagerCore.getPlugin(any<PluginId>()) } returns null
-        every { PluginManagerCore.isDisabled(any<PluginId>()) } returns false
+        mockkStatic(PluginManager::class)
+        every { PluginManager.getPlugin(any<PluginId>()) } returns null
 
         val conflicts = ConflictRegistry.detectConflicts()
 
@@ -115,19 +114,18 @@ class ConflictRegistryTest {
     /**
      * Caching regression: `detectConflicts` consults the plugin registry only
      * once per session. The second call returns the exact same list instance
-     * and does NOT trigger additional `PluginManagerCore.getPlugin` lookups.
+     * and does NOT trigger additional `PluginManager.getPlugin` lookups.
      */
     @Test
     fun `detectConflicts result is cached across calls`() {
-        mockkStatic(PluginManagerCore::class)
-        every { PluginManagerCore.getPlugin(any<PluginId>()) } returns null
-        every { PluginManagerCore.isDisabled(any<PluginId>()) } returns false
+        mockkStatic(PluginManager::class)
+        every { PluginManager.getPlugin(any<PluginId>()) } returns null
 
         val first = ConflictRegistry.detectConflicts()
         val second = ConflictRegistry.detectConflicts()
 
         assertSame(first, second, "Cached result must be reused across calls")
-        verify(exactly = 2) { PluginManagerCore.getPlugin(any<PluginId>()) }
+        verify(exactly = 2) { PluginManager.getPlugin(any<PluginId>()) }
     }
 
     /**
@@ -136,16 +134,15 @@ class ConflictRegistryTest {
      */
     @Test
     fun `resetCachedConflictsForTesting clears cache so next call re-queries plugins`() {
-        mockkStatic(PluginManagerCore::class)
-        every { PluginManagerCore.getPlugin(any<PluginId>()) } returns null
-        every { PluginManagerCore.isDisabled(any<PluginId>()) } returns false
+        mockkStatic(PluginManager::class)
+        every { PluginManager.getPlugin(any<PluginId>()) } returns null
 
         val firstBatch = ConflictRegistry.detectConflicts()
         ConflictRegistry.resetCachedConflictsForTesting()
         val secondBatch = ConflictRegistry.detectConflicts()
 
         // Two separate computations: 2 entries x 2 calls = 4 lookups
-        verify(exactly = 4) { PluginManagerCore.getPlugin(any<PluginId>()) }
+        verify(exactly = 4) { PluginManager.getPlugin(any<PluginId>()) }
         // Same content, different instances (cache was cleared)
         assertEquals(firstBatch, secondBatch)
     }

--- a/src/test/kotlin/dev/ayuislands/accent/conflict/ConflictRegistryTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/conflict/ConflictRegistryTest.kt
@@ -1,9 +1,11 @@
 package dev.ayuislands.accent.conflict
 
+import com.intellij.ide.plugins.IdeaPluginDescriptor
 import com.intellij.openapi.extensions.PluginId
 import dev.ayuislands.AyuPlugin
 import dev.ayuislands.accent.AccentElementId
 import io.mockk.every
+import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import io.mockk.verify
@@ -138,5 +140,95 @@ class ConflictRegistryTest {
         verify(exactly = 4) { AyuPlugin.findEnabledPlugin(any<PluginId>()) }
         // Same content, different instances (cache was cleared)
         assertEquals(firstBatch, secondBatch)
+    }
+
+    /**
+     * Real-user scenario: CodeGlance Pro is INSTALLED and ENABLED — the
+     * detection path returns it as an INTEGRATE conflict (used by the Plugins
+     * settings panel and the accent applicator to wire the CGP integration).
+     */
+    @Test
+    fun `detectConflicts returns CodeGlance Pro when only CodeGlance Pro is installed`() {
+        val cgpDescriptor = mockk<IdeaPluginDescriptor>()
+        every {
+            AyuPlugin.findEnabledPlugin(PluginId.getId("com.nasller.CodeGlancePro"))
+        } returns cgpDescriptor
+
+        val conflicts = ConflictRegistry.detectConflicts()
+
+        assertEquals(1, conflicts.size, "Only CodeGlance Pro is enabled, so exactly one conflict surfaces")
+        assertEquals("com.nasller.CodeGlancePro", conflicts.single().pluginId)
+        assertTrue(ConflictRegistry.isCodeGlanceProDetected(), "Detection helper must report CGP as active")
+        assertTrue(!ConflictRegistry.isIndentRainbowDetected(), "Indent Rainbow stays off when not installed")
+    }
+
+    /**
+     * Real-user scenario: Indent Rainbow is INSTALLED and ENABLED — symmetric
+     * coverage to ensure both detector helpers are wired through the same path.
+     */
+    @Test
+    fun `detectConflicts returns Indent Rainbow when only Indent Rainbow is installed`() {
+        val irDescriptor = mockk<IdeaPluginDescriptor>()
+        every {
+            AyuPlugin.findEnabledPlugin(PluginId.getId("indent-rainbow.indent-rainbow"))
+        } returns irDescriptor
+
+        val conflicts = ConflictRegistry.detectConflicts()
+
+        assertEquals(1, conflicts.size)
+        assertEquals("indent-rainbow.indent-rainbow", conflicts.single().pluginId)
+        assertTrue(ConflictRegistry.isIndentRainbowDetected())
+        assertTrue(!ConflictRegistry.isCodeGlanceProDetected())
+    }
+
+    /**
+     * Real-user scenario: BOTH integrations installed and enabled — the result
+     * preserves both entries in the registry's declaration order. The accent
+     * applicator iterates this list to wire each integration in turn; a missing
+     * entry would silently drop the integration for that user.
+     */
+    @Test
+    fun `detectConflicts returns both integrations when both are installed`() {
+        every {
+            AyuPlugin.findEnabledPlugin(PluginId.getId("com.nasller.CodeGlancePro"))
+        } returns mockk<IdeaPluginDescriptor>()
+        every {
+            AyuPlugin.findEnabledPlugin(PluginId.getId("indent-rainbow.indent-rainbow"))
+        } returns mockk<IdeaPluginDescriptor>()
+
+        val conflicts = ConflictRegistry.detectConflicts()
+
+        assertEquals(2, conflicts.size, "Both integrations active → both in the result")
+        assertEquals(
+            listOf("com.nasller.CodeGlancePro", "indent-rainbow.indent-rainbow"),
+            conflicts.map { it.pluginId },
+            "Result preserves the registry's declaration order — callers depend on it",
+        )
+    }
+
+    /**
+     * Behavior lock for the [AyuPlugin.findEnabledPlugin] contract: a DISABLED
+     * plugin must NOT appear in the conflict set. Before the wrapper switch,
+     * the old `PluginManagerCore.getPlugin` returned a descriptor for disabled
+     * installations and needed a separate `isDisabled` check — losing that
+     * check silently treated disabled plugins as active integrations and
+     * caused the integration code path to attempt class-loader reflection
+     * against a plugin the user had explicitly turned off.
+     *
+     * Now `findEnabledPlugin` returns `null` for disabled plugins by contract,
+     * so the wrapper's null check is sufficient. This test pins that semantics.
+     */
+    @Test
+    fun `detectConflicts ignores plugins that are installed but disabled`() {
+        // Disabled plugins surface as null from `AyuPlugin.findEnabledPlugin` —
+        // the default mock stub in setUp already returns null for any id, which
+        // matches both "absent" and "disabled" cases. Asserting on both detector
+        // helpers documents that "disabled" must look identical to "absent" at
+        // the conflict layer.
+        val conflicts = ConflictRegistry.detectConflicts()
+
+        assertTrue(conflicts.isEmpty(), "Disabled plugins must not be reported as active conflicts")
+        assertTrue(!ConflictRegistry.isCodeGlanceProDetected(), "Disabled CGP must not register as detected")
+        assertTrue(!ConflictRegistry.isIndentRainbowDetected(), "Disabled IR must not register as detected")
     }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/conflict/ConflictRegistryTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/conflict/ConflictRegistryTest.kt
@@ -1,10 +1,10 @@
 package dev.ayuislands.accent.conflict
 
-import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.extensions.PluginId
+import dev.ayuislands.AyuPlugin
 import dev.ayuislands.accent.AccentElementId
 import io.mockk.every
-import io.mockk.mockkStatic
+import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import io.mockk.verify
 import kotlin.test.AfterTest
@@ -27,6 +27,8 @@ class ConflictRegistryTest {
     @BeforeTest
     fun setUp() {
         ConflictRegistry.resetCachedConflictsForTesting()
+        mockkObject(AyuPlugin)
+        every { AyuPlugin.findEnabledPlugin(any<PluginId>()) } returns null
     }
 
     @AfterTest
@@ -103,9 +105,6 @@ class ConflictRegistryTest {
      */
     @Test
     fun `detectConflicts returns empty list when no conflict plugins installed`() {
-        mockkStatic(PluginManager::class)
-        every { PluginManager.getPlugin(any<PluginId>()) } returns null
-
         val conflicts = ConflictRegistry.detectConflicts()
 
         assertTrue(conflicts.isEmpty(), "Expected no conflicts when plugins are absent")
@@ -114,18 +113,15 @@ class ConflictRegistryTest {
     /**
      * Caching regression: `detectConflicts` consults the plugin registry only
      * once per session. The second call returns the exact same list instance
-     * and does NOT trigger additional `PluginManager.getPlugin` lookups.
+     * and does NOT trigger additional `findEnabledPlugin` lookups.
      */
     @Test
     fun `detectConflicts result is cached across calls`() {
-        mockkStatic(PluginManager::class)
-        every { PluginManager.getPlugin(any<PluginId>()) } returns null
-
         val first = ConflictRegistry.detectConflicts()
         val second = ConflictRegistry.detectConflicts()
 
         assertSame(first, second, "Cached result must be reused across calls")
-        verify(exactly = 2) { PluginManager.getPlugin(any<PluginId>()) }
+        verify(exactly = 2) { AyuPlugin.findEnabledPlugin(any<PluginId>()) }
     }
 
     /**
@@ -134,15 +130,12 @@ class ConflictRegistryTest {
      */
     @Test
     fun `resetCachedConflictsForTesting clears cache so next call re-queries plugins`() {
-        mockkStatic(PluginManager::class)
-        every { PluginManager.getPlugin(any<PluginId>()) } returns null
-
         val firstBatch = ConflictRegistry.detectConflicts()
         ConflictRegistry.resetCachedConflictsForTesting()
         val secondBatch = ConflictRegistry.detectConflicts()
 
         // Two separate computations: 2 entries x 2 calls = 4 lookups
-        verify(exactly = 4) { PluginManager.getPlugin(any<PluginId>()) }
+        verify(exactly = 4) { AyuPlugin.findEnabledPlugin(any<PluginId>()) }
         // Same content, different instances (cache was cleared)
         assertEquals(firstBatch, secondBatch)
     }

--- a/src/test/kotlin/dev/ayuislands/indent/IndentRainbowSyncTest.kt
+++ b/src/test/kotlin/dev/ayuislands/indent/IndentRainbowSyncTest.kt
@@ -1,7 +1,7 @@
 package dev.ayuislands.indent
 
 import com.intellij.ide.plugins.IdeaPluginDescriptor
-import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.ide.plugins.PluginManager
 import com.intellij.notification.Notification
 import com.intellij.notification.NotificationGroup
 import com.intellij.notification.NotificationGroupManager
@@ -43,8 +43,8 @@ class IndentRainbowSyncTest {
         // itself. After the resolver refactor the caller passes the resolved hex in; the
         // mock becomes dead code. Removed to keep setUp honest.
 
-        mockkStatic(PluginManagerCore::class)
-        every { PluginManagerCore.getPlugin(any()) } returns null
+        mockkStatic(PluginManager::class)
+        every { PluginManager.getPlugin(any()) } returns null
 
         resetSyncState()
     }
@@ -115,7 +115,7 @@ class IndentRainbowSyncTest {
     @Test
     fun `resolveReflection returns when plugin classloader is null`() {
         val mockPlugin = mockk<IdeaPluginDescriptor>(relaxed = true)
-        every { PluginManagerCore.getPlugin(any()) } returns mockPlugin
+        every { PluginManager.getPlugin(any()) } returns mockPlugin
         every { mockPlugin.pluginClassLoader } returns null
 
         invokePrivate("resolveReflection")
@@ -532,7 +532,7 @@ class IndentRainbowSyncTest {
     @Test
     fun `resolveReflection catches ClassNotFoundException when plugin found`() {
         val mockPlugin = mockk<IdeaPluginDescriptor>(relaxed = true)
-        every { PluginManagerCore.getPlugin(any()) } returns mockPlugin
+        every { PluginManager.getPlugin(any()) } returns mockPlugin
         every { mockPlugin.pluginClassLoader } returns this::class.java.classLoader
 
         // Class.forName("indent.rainbow.settings.IrConfig") will throw

--- a/src/test/kotlin/dev/ayuislands/indent/IndentRainbowSyncTest.kt
+++ b/src/test/kotlin/dev/ayuislands/indent/IndentRainbowSyncTest.kt
@@ -1,12 +1,12 @@
 package dev.ayuislands.indent
 
 import com.intellij.ide.plugins.IdeaPluginDescriptor
-import com.intellij.ide.plugins.PluginManager
 import com.intellij.notification.Notification
 import com.intellij.notification.NotificationGroup
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.application.ApplicationManager
+import dev.ayuislands.AyuPlugin
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
@@ -43,8 +43,8 @@ class IndentRainbowSyncTest {
         // itself. After the resolver refactor the caller passes the resolved hex in; the
         // mock becomes dead code. Removed to keep setUp honest.
 
-        mockkStatic(PluginManager::class)
-        every { PluginManager.getPlugin(any()) } returns null
+        mockkObject(AyuPlugin)
+        every { AyuPlugin.findEnabledPlugin(any()) } returns null
 
         resetSyncState()
     }
@@ -115,7 +115,7 @@ class IndentRainbowSyncTest {
     @Test
     fun `resolveReflection returns when plugin classloader is null`() {
         val mockPlugin = mockk<IdeaPluginDescriptor>(relaxed = true)
-        every { PluginManager.getPlugin(any()) } returns mockPlugin
+        every { AyuPlugin.findEnabledPlugin(any()) } returns mockPlugin
         every { mockPlugin.pluginClassLoader } returns null
 
         invokePrivate("resolveReflection")
@@ -532,7 +532,7 @@ class IndentRainbowSyncTest {
     @Test
     fun `resolveReflection catches ClassNotFoundException when plugin found`() {
         val mockPlugin = mockk<IdeaPluginDescriptor>(relaxed = true)
-        every { PluginManager.getPlugin(any()) } returns mockPlugin
+        every { AyuPlugin.findEnabledPlugin(any()) } returns mockPlugin
         every { mockPlugin.pluginClassLoader } returns this::class.java.classLoader
 
         // Class.forName("indent.rainbow.settings.IrConfig") will throw

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerAntiCheatTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerAntiCheatTest.kt
@@ -254,9 +254,7 @@ class LicenseCheckerAntiCheatTest {
         val pluginPath = mockk<Path>()
         every { pluginPath.toString() } returns path
         every { descriptor.pluginPath } returns pluginPath
-        every {
-            AyuPlugin.findEnabledPlugin(PluginId.getId("com.ayuislands.theme"))
-        } returns descriptor
+        every { AyuPlugin.findEnabledPlugin(AyuPlugin.ID) } returns descriptor
     }
 
     @Test
@@ -309,8 +307,10 @@ class LicenseCheckerAntiCheatTest {
 
     @Test
     fun `dev bypass rejected when plugin descriptor is null`() {
-        // PluginManager returns null if the plugin id can't be found — unusual but
-        // possible during early classloader init. Triple-gate must not crash and must reject.
+        // `AyuPlugin.findEnabledPlugin` returns null if the plugin id can't be
+        // found, is disabled, or the Application is not bootstrapped — unusual
+        // but possible during early classloader init. Triple-gate must not
+        // crash and must reject.
         System.setProperty("ayu.islands.dev", "true")
         every { PathManager.getConfigPath() } returns devSandboxConfigPath
         setPluginPath(null)

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerAntiCheatTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerAntiCheatTest.kt
@@ -1,10 +1,10 @@
 package dev.ayuislands.licensing
 
 import com.intellij.ide.plugins.IdeaPluginDescriptor
-import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.extensions.PluginId
 import com.intellij.ui.LicensingFacade
+import dev.ayuislands.AyuPlugin
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
 import io.kotest.property.Arb
@@ -56,8 +56,8 @@ class LicenseCheckerAntiCheatTest {
         mockkStatic(PathManager::class)
         every { PathManager.getConfigPath() } returns "/home/user/.config/JetBrains/IntelliJIdea2025.1"
 
-        mockkStatic(PluginManager::class)
-        every { PluginManager.getPlugin(any<PluginId>()) } returns null
+        mockkObject(AyuPlugin)
+        every { AyuPlugin.findEnabledPlugin(any<PluginId>()) } returns null
 
         // Pin the clock through LicenseCheckerClockSeam so restore stays centralized
         // and the production defaults come back from exactly one place in tearDown.
@@ -247,7 +247,7 @@ class LicenseCheckerAntiCheatTest {
 
     private fun setPluginPath(path: String?) {
         if (path == null) {
-            every { PluginManager.getPlugin(any<PluginId>()) } returns null
+            every { AyuPlugin.findEnabledPlugin(any<PluginId>()) } returns null
             return
         }
         val descriptor = mockk<IdeaPluginDescriptor>()
@@ -255,7 +255,7 @@ class LicenseCheckerAntiCheatTest {
         every { pluginPath.toString() } returns path
         every { descriptor.pluginPath } returns pluginPath
         every {
-            PluginManager.getPlugin(PluginId.getId("com.ayuislands.theme"))
+            AyuPlugin.findEnabledPlugin(PluginId.getId("com.ayuislands.theme"))
         } returns descriptor
     }
 

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerAntiCheatTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerAntiCheatTest.kt
@@ -1,7 +1,7 @@
 package dev.ayuislands.licensing
 
 import com.intellij.ide.plugins.IdeaPluginDescriptor
-import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.extensions.PluginId
 import com.intellij.ui.LicensingFacade
@@ -56,8 +56,8 @@ class LicenseCheckerAntiCheatTest {
         mockkStatic(PathManager::class)
         every { PathManager.getConfigPath() } returns "/home/user/.config/JetBrains/IntelliJIdea2025.1"
 
-        mockkStatic(PluginManagerCore::class)
-        every { PluginManagerCore.getPlugin(any<PluginId>()) } returns null
+        mockkStatic(PluginManager::class)
+        every { PluginManager.getPlugin(any<PluginId>()) } returns null
 
         // Pin the clock through LicenseCheckerClockSeam so restore stays centralized
         // and the production defaults come back from exactly one place in tearDown.
@@ -247,14 +247,16 @@ class LicenseCheckerAntiCheatTest {
 
     private fun setPluginPath(path: String?) {
         if (path == null) {
-            every { PluginManagerCore.getPlugin(any<PluginId>()) } returns null
+            every { PluginManager.getPlugin(any<PluginId>()) } returns null
             return
         }
         val descriptor = mockk<IdeaPluginDescriptor>()
         val pluginPath = mockk<Path>()
         every { pluginPath.toString() } returns path
         every { descriptor.pluginPath } returns pluginPath
-        every { PluginManagerCore.getPlugin(PluginId.getId("com.ayuislands.theme")) } returns descriptor
+        every {
+            PluginManager.getPlugin(PluginId.getId("com.ayuislands.theme"))
+        } returns descriptor
     }
 
     @Test
@@ -307,7 +309,7 @@ class LicenseCheckerAntiCheatTest {
 
     @Test
     fun `dev bypass rejected when plugin descriptor is null`() {
-        // PluginManagerCore returns null if the plugin id can't be found — unusual but
+        // PluginManager returns null if the plugin id can't be found — unusual but
         // possible during early classloader init. Triple-gate must not crash and must reject.
         System.setProperty("ayu.islands.dev", "true")
         every { PathManager.getConfigPath() } returns devSandboxConfigPath

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerTest.kt
@@ -23,7 +23,7 @@ import kotlin.test.assertTrue
 
 class LicenseCheckerTest {
     private val defaultSettings =
-        io.mockk.mockk<AyuIslandsSettings>(relaxed = true).also {
+        mockk<AyuIslandsSettings>(relaxed = true).also {
             every { it.state } returns AyuIslandsState()
         }
 
@@ -42,9 +42,7 @@ class LicenseCheckerTest {
         val path = mockk<Path>()
         every { path.toString() } returns "/repo/build/idea-sandbox/plugins/ayuIslands/lib/ayuIslands.jar"
         every { descriptor.pluginPath } returns path
-        every {
-            AyuPlugin.findEnabledPlugin(PluginId.getId("com.ayuislands.theme"))
-        } returns descriptor
+        every { AyuPlugin.findEnabledPlugin(AyuPlugin.ID) } returns descriptor
     }
 
     @AfterTest
@@ -100,7 +98,7 @@ class LicenseCheckerTest {
     @Test
     fun `isLicensed returns false when no confirmation stamp`() {
         every { PathManager.getConfigPath() } returns "/home/user/.config/JetBrains/IntelliJIdea2025.1"
-        val facade = io.mockk.mockk<LicensingFacade>()
+        val facade = mockk<LicensingFacade>()
         every { LicensingFacade.getInstance() } returns facade
         every { facade.getConfirmationStamp(LicenseChecker.PRODUCT_CODE) } returns null
 
@@ -112,7 +110,7 @@ class LicenseCheckerTest {
     @Test
     fun `isLicensed returns true for eval stamp`() {
         every { PathManager.getConfigPath() } returns "/home/user/.config/JetBrains/IntelliJIdea2025.1"
-        val facade = io.mockk.mockk<LicensingFacade>()
+        val facade = mockk<LicensingFacade>()
         every { LicensingFacade.getInstance() } returns facade
         every { facade.getConfirmationStamp(LicenseChecker.PRODUCT_CODE) } returns "eval:12345"
 
@@ -124,7 +122,7 @@ class LicenseCheckerTest {
     @Test
     fun `isLicensed returns false for unknown stamp prefix`() {
         every { PathManager.getConfigPath() } returns "/home/user/.config/JetBrains/IntelliJIdea2025.1"
-        val facade = io.mockk.mockk<LicensingFacade>()
+        val facade = mockk<LicensingFacade>()
         every { LicensingFacade.getInstance() } returns facade
         every { facade.getConfirmationStamp(LicenseChecker.PRODUCT_CODE) } returns "unknown:data"
 
@@ -147,7 +145,7 @@ class LicenseCheckerTest {
     @Test
     fun `isLicensedOrGrace returns false when explicitly not licensed`() {
         every { PathManager.getConfigPath() } returns "/home/user/.config/JetBrains/IntelliJIdea2025.1"
-        val facade = io.mockk.mockk<LicensingFacade>()
+        val facade = mockk<LicensingFacade>()
         every { LicensingFacade.getInstance() } returns facade
         every { facade.getConfirmationStamp(LicenseChecker.PRODUCT_CODE) } returns null
 
@@ -167,11 +165,11 @@ class LicenseCheckerTest {
     @Test
     fun `isLicensedOrGrace returns true within 47h 59m of last licensed check`() {
         val realState = AyuIslandsState()
-        val settingsMock = io.mockk.mockk<AyuIslandsSettings>()
+        val settingsMock = mockk<AyuIslandsSettings>()
         every { AyuIslandsSettings.getInstance() } returns settingsMock
         every { settingsMock.state } returns realState
         every { PathManager.getConfigPath() } returns "/home/user/.config/JetBrains/IntelliJIdea2025.1"
-        val facade = io.mockk.mockk<LicensingFacade>()
+        val facade = mockk<LicensingFacade>()
         every { LicensingFacade.getInstance() } returns facade
         every { facade.getConfirmationStamp(LicenseChecker.PRODUCT_CODE) } returns null
 
@@ -186,11 +184,11 @@ class LicenseCheckerTest {
     @Test
     fun `isLicensedOrGrace returns false at exact 48h boundary`() {
         val realState = AyuIslandsState()
-        val settingsMock = io.mockk.mockk<AyuIslandsSettings>()
+        val settingsMock = mockk<AyuIslandsSettings>()
         every { AyuIslandsSettings.getInstance() } returns settingsMock
         every { settingsMock.state } returns realState
         every { PathManager.getConfigPath() } returns "/home/user/.config/JetBrains/IntelliJIdea2025.1"
-        val facade = io.mockk.mockk<LicensingFacade>()
+        val facade = mockk<LicensingFacade>()
         every { LicensingFacade.getInstance() } returns facade
         every { facade.getConfirmationStamp(LicenseChecker.PRODUCT_CODE) } returns null
 
@@ -205,11 +203,11 @@ class LicenseCheckerTest {
     @Test
     fun `isLicensedOrGrace writes lastKnownLicensedMs monotonically on each licensed call`() {
         val realState = AyuIslandsState()
-        val settingsMock = io.mockk.mockk<AyuIslandsSettings>()
+        val settingsMock = mockk<AyuIslandsSettings>()
         every { AyuIslandsSettings.getInstance() } returns settingsMock
         every { settingsMock.state } returns realState
         every { PathManager.getConfigPath() } returns "/home/user/.config/JetBrains/IntelliJIdea2025.1"
-        val facade = io.mockk.mockk<LicensingFacade>()
+        val facade = mockk<LicensingFacade>()
         every { LicensingFacade.getInstance() } returns facade
         every { facade.getConfirmationStamp(LicenseChecker.PRODUCT_CODE) } returns "eval:1"
 
@@ -233,7 +231,7 @@ class LicenseCheckerTest {
     @Test
     fun `enableProDefaults sets all glow flags to true`() {
         val realState = AyuIslandsState()
-        val settingsMock = io.mockk.mockk<AyuIslandsSettings>()
+        val settingsMock = mockk<AyuIslandsSettings>()
         every { AyuIslandsSettings.getInstance() } returns settingsMock
         every { settingsMock.state } returns realState
 

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerTest.kt
@@ -1,7 +1,7 @@
 package dev.ayuislands.licensing
 
 import com.intellij.ide.plugins.IdeaPluginDescriptor
-import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.extensions.PluginId
 import com.intellij.ui.LicensingFacade
@@ -31,8 +31,8 @@ class LicenseCheckerTest {
     fun setUp() {
         mockkStatic(PathManager::class)
         mockkStatic(LicensingFacade::class)
-        mockkStatic(PluginManagerCore::class)
-        every { PluginManagerCore.getPlugin(any<PluginId>()) } returns null
+        mockkStatic(PluginManager::class)
+        every { PluginManager.getPlugin(any<PluginId>()) } returns null
         mockkObject(AyuIslandsSettings.Companion)
         every { AyuIslandsSettings.getInstance() } returns defaultSettings
     }
@@ -42,7 +42,9 @@ class LicenseCheckerTest {
         val path = mockk<Path>()
         every { path.toString() } returns "/repo/build/idea-sandbox/plugins/ayuIslands/lib/ayuIslands.jar"
         every { descriptor.pluginPath } returns path
-        every { PluginManagerCore.getPlugin(PluginId.getId("com.ayuislands.theme")) } returns descriptor
+        every {
+            PluginManager.getPlugin(PluginId.getId("com.ayuislands.theme"))
+        } returns descriptor
     }
 
     @AfterTest

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerTest.kt
@@ -1,10 +1,10 @@
 package dev.ayuislands.licensing
 
 import com.intellij.ide.plugins.IdeaPluginDescriptor
-import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.extensions.PluginId
 import com.intellij.ui.LicensingFacade
+import dev.ayuislands.AyuPlugin
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
 import io.mockk.every
@@ -31,8 +31,8 @@ class LicenseCheckerTest {
     fun setUp() {
         mockkStatic(PathManager::class)
         mockkStatic(LicensingFacade::class)
-        mockkStatic(PluginManager::class)
-        every { PluginManager.getPlugin(any<PluginId>()) } returns null
+        mockkObject(AyuPlugin)
+        every { AyuPlugin.findEnabledPlugin(any<PluginId>()) } returns null
         mockkObject(AyuIslandsSettings.Companion)
         every { AyuIslandsSettings.getInstance() } returns defaultSettings
     }
@@ -43,7 +43,7 @@ class LicenseCheckerTest {
         every { path.toString() } returns "/repo/build/idea-sandbox/plugins/ayuIslands/lib/ayuIslands.jar"
         every { descriptor.pluginPath } returns path
         every {
-            PluginManager.getPlugin(PluginId.getId("com.ayuislands.theme"))
+            AyuPlugin.findEnabledPlugin(PluginId.getId("com.ayuislands.theme"))
         } returns descriptor
     }
 

--- a/src/test/kotlin/dev/ayuislands/whatsnew/ShowWhatsNewActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/whatsnew/ShowWhatsNewActionTest.kt
@@ -1,16 +1,15 @@
 package dev.ayuislands.whatsnew
 
 import com.intellij.ide.plugins.IdeaPluginDescriptor
-import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.Presentation
 import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
 import com.intellij.testFramework.LoggedErrorProcessor
+import dev.ayuislands.AyuPlugin
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
-import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
 import kotlin.test.AfterTest
@@ -28,7 +27,7 @@ class ShowWhatsNewActionTest {
 
     @BeforeTest
     fun setUp() {
-        mockkStatic(PluginManager::class)
+        mockkObject(AyuPlugin)
         every { event.presentation } returns presentation
         every { event.project } returns project
     }
@@ -47,7 +46,7 @@ class ShowWhatsNewActionTest {
         // Test resources include /whatsnew/v9.9.0/manifest.json — when the
         // plugin descriptor reports that version, the action must be visible
         // and enabled in the Tools menu.
-        every { PluginManager.getPlugin(any<PluginId>()) } returns descriptor
+        every { AyuPlugin.findEnabledPlugin(any<PluginId>()) } returns descriptor
         every { descriptor.version } returns "9.9.0"
 
         action.update(event)
@@ -60,7 +59,7 @@ class ShowWhatsNewActionTest {
     fun `update disables the action when no manifest for current version`() {
         // Patch releases or any version without a manifest hide the menu item —
         // better than a dead-clickable item that opens an empty tab.
-        every { PluginManager.getPlugin(any<PluginId>()) } returns descriptor
+        every { AyuPlugin.findEnabledPlugin(any<PluginId>()) } returns descriptor
         every { descriptor.version } returns "0.0.0"
 
         action.update(event)
@@ -73,7 +72,7 @@ class ShowWhatsNewActionTest {
     fun `update disables the action when plugin descriptor is missing`() {
         // Defense in depth — plugin classloader registry could theoretically
         // not list us during early startup or under PluginManager edge cases.
-        every { PluginManager.getPlugin(any<PluginId>()) } returns null
+        every { AyuPlugin.findEnabledPlugin(any<PluginId>()) } returns null
 
         action.update(event)
 
@@ -112,7 +111,7 @@ class ShowWhatsNewActionTest {
         // hits Show What's New… and openManually returns false (manifest gone),
         // we leave an INFO breadcrumb — but NOT a WARN, since this is an
         // expected race, not an anomaly.
-        every { PluginManager.getPlugin(any<PluginId>()) } returns descriptor
+        every { AyuPlugin.findEnabledPlugin(any<PluginId>()) } returns descriptor
         every { descriptor.version } returns "0.0.0"
         mockkObject(WhatsNewLauncher)
         every { WhatsNewLauncher.openManually(project) } returns false
@@ -159,7 +158,7 @@ class ShowWhatsNewActionTest {
             }
         LoggedErrorProcessor.executeWith<RuntimeException>(processor) {
             // First null observation — expect ONE WARN.
-            every { PluginManager.getPlugin(any<PluginId>()) } returns null
+            every { AyuPlugin.findEnabledPlugin(any<PluginId>()) } returns null
             action.update(event)
             action.update(event)
             action.update(event)
@@ -167,13 +166,13 @@ class ShowWhatsNewActionTest {
             kotlin.test.assertEquals(1, firstStreak, "streak of null-observations must produce ONE WARN")
 
             // Descriptor comes back — action re-arms the latch silently.
-            every { PluginManager.getPlugin(any<PluginId>()) } returns descriptor
+            every { AyuPlugin.findEnabledPlugin(any<PluginId>()) } returns descriptor
             every { descriptor.version } returns "9.9.0"
             action.update(event)
             kotlin.test.assertEquals(1, captured.size, "recovery must not log WARN")
 
             // Descriptor goes null again — latch re-armed, expect a SECOND WARN.
-            every { PluginManager.getPlugin(any<PluginId>()) } returns null
+            every { AyuPlugin.findEnabledPlugin(any<PluginId>()) } returns null
             action.update(event)
             kotlin.test.assertEquals(2, captured.size, "second null streak must re-arm and log once")
         }
@@ -185,7 +184,7 @@ class ShowWhatsNewActionTest {
         // platform can't find OUR OWN plugin, which is a real anomaly worth
         // surfacing as WARN so a future "menu does nothing" report has a
         // diagnostic that distinguishes "patch release" from "platform broken".
-        every { PluginManager.getPlugin(any<PluginId>()) } returns null
+        every { AyuPlugin.findEnabledPlugin(any<PluginId>()) } returns null
         mockkObject(WhatsNewLauncher)
         every { WhatsNewLauncher.openManually(project) } returns false
 

--- a/src/test/kotlin/dev/ayuislands/whatsnew/ShowWhatsNewActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/whatsnew/ShowWhatsNewActionTest.kt
@@ -1,7 +1,7 @@
 package dev.ayuislands.whatsnew
 
 import com.intellij.ide.plugins.IdeaPluginDescriptor
-import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.Presentation
 import com.intellij.openapi.extensions.PluginId
@@ -28,7 +28,7 @@ class ShowWhatsNewActionTest {
 
     @BeforeTest
     fun setUp() {
-        mockkStatic(PluginManagerCore::class)
+        mockkStatic(PluginManager::class)
         every { event.presentation } returns presentation
         every { event.project } returns project
     }
@@ -47,7 +47,7 @@ class ShowWhatsNewActionTest {
         // Test resources include /whatsnew/v9.9.0/manifest.json — when the
         // plugin descriptor reports that version, the action must be visible
         // and enabled in the Tools menu.
-        every { PluginManagerCore.getPlugin(any<PluginId>()) } returns descriptor
+        every { PluginManager.getPlugin(any<PluginId>()) } returns descriptor
         every { descriptor.version } returns "9.9.0"
 
         action.update(event)
@@ -60,7 +60,7 @@ class ShowWhatsNewActionTest {
     fun `update disables the action when no manifest for current version`() {
         // Patch releases or any version without a manifest hide the menu item —
         // better than a dead-clickable item that opens an empty tab.
-        every { PluginManagerCore.getPlugin(any<PluginId>()) } returns descriptor
+        every { PluginManager.getPlugin(any<PluginId>()) } returns descriptor
         every { descriptor.version } returns "0.0.0"
 
         action.update(event)
@@ -73,7 +73,7 @@ class ShowWhatsNewActionTest {
     fun `update disables the action when plugin descriptor is missing`() {
         // Defense in depth — plugin classloader registry could theoretically
         // not list us during early startup or under PluginManager edge cases.
-        every { PluginManagerCore.getPlugin(any<PluginId>()) } returns null
+        every { PluginManager.getPlugin(any<PluginId>()) } returns null
 
         action.update(event)
 
@@ -112,7 +112,7 @@ class ShowWhatsNewActionTest {
         // hits Show What's New… and openManually returns false (manifest gone),
         // we leave an INFO breadcrumb — but NOT a WARN, since this is an
         // expected race, not an anomaly.
-        every { PluginManagerCore.getPlugin(any<PluginId>()) } returns descriptor
+        every { PluginManager.getPlugin(any<PluginId>()) } returns descriptor
         every { descriptor.version } returns "0.0.0"
         mockkObject(WhatsNewLauncher)
         every { WhatsNewLauncher.openManually(project) } returns false
@@ -159,7 +159,7 @@ class ShowWhatsNewActionTest {
             }
         LoggedErrorProcessor.executeWith<RuntimeException>(processor) {
             // First null observation — expect ONE WARN.
-            every { PluginManagerCore.getPlugin(any<PluginId>()) } returns null
+            every { PluginManager.getPlugin(any<PluginId>()) } returns null
             action.update(event)
             action.update(event)
             action.update(event)
@@ -167,13 +167,13 @@ class ShowWhatsNewActionTest {
             kotlin.test.assertEquals(1, firstStreak, "streak of null-observations must produce ONE WARN")
 
             // Descriptor comes back — action re-arms the latch silently.
-            every { PluginManagerCore.getPlugin(any<PluginId>()) } returns descriptor
+            every { PluginManager.getPlugin(any<PluginId>()) } returns descriptor
             every { descriptor.version } returns "9.9.0"
             action.update(event)
             kotlin.test.assertEquals(1, captured.size, "recovery must not log WARN")
 
             // Descriptor goes null again — latch re-armed, expect a SECOND WARN.
-            every { PluginManagerCore.getPlugin(any<PluginId>()) } returns null
+            every { PluginManager.getPlugin(any<PluginId>()) } returns null
             action.update(event)
             kotlin.test.assertEquals(2, captured.size, "second null streak must re-arm and log once")
         }
@@ -185,7 +185,7 @@ class ShowWhatsNewActionTest {
         // platform can't find OUR OWN plugin, which is a real anomaly worth
         // surfacing as WARN so a future "menu does nothing" report has a
         // diagnostic that distinguishes "patch release" from "platform broken".
-        every { PluginManagerCore.getPlugin(any<PluginId>()) } returns null
+        every { PluginManager.getPlugin(any<PluginId>()) } returns null
         mockkObject(WhatsNewLauncher)
         every { WhatsNewLauncher.openManually(project) } returns false
 


### PR DESCRIPTION
## Summary

JetBrains Marketplace's Compatibility verification (IntelliJ IDEA 2026.2 EAP) flagged 11 usages of `PluginManagerCore.getPlugin(PluginId)` — the containing class is `@ApiStatus.Internal`. Swap each call site to the public façade `PluginManager.getPlugin(PluginId)`. Same signature, same delegate, only `@Nullable` annotation. Behavior preserved end-to-end.

## Changes

| Type | Files | What |
|---|---|---|
| Fix | 9 production call sites | `PluginManagerCore.getPlugin` → `PluginManager.getPlugin` |
| Fix | `accent/conflict/ConflictRegistry.kt:48` | restored `!isDisabled` filter via public `PluginEnabler.HEADLESS.isDisabled` (otherwise disabled plugins would have been treated as active conflicts — `PluginManager.getPlugin` returns the descriptor even for disabled installations) |
| Test | 9 test files | migrated `mockkStatic(PluginManagerCore::class)` mocks to the `PluginManager` façade |
| Docs | `docs/features.yml` | restamped 5 screenshot scopes (Pattern H — no UI change) |

Production call sites touched:
- `UpdateNotifier`, `AyuIslandsConfigurable`, `WhatsNewLauncher`, `ShowWhatsNewAction` (x2), `WhatsNewPanel` — own-plugin descriptor reads
- `LicenseChecker.isDevBuild` — sandbox-path probe
- `IndentRainbowSync` (x2), `CodeGlanceProIntegration` — third-party plugin reflection

## Why not `findEnabledPlugin`?

The first migration attempt used `PluginManager.getInstance().findEnabledPlugin(...)` — also public, returns null for disabled plugins automatically. Reverted because `PluginManager.getInstance()` requires a bootstrapped `ApplicationManager.getApplication()` instance, which is not available in the headless test environment (3 tests started failing with NPE / ClassCastException). The static `PluginManager.getPlugin` delegates directly to the registry without service lookup, so it works in tests with the existing `mockkStatic` pattern.

## Validation

- [x] `./gradlew detekt ktlintCheck test` — GREEN locally
- [x] No behavior change (verified by reading `PluginManagerCore.findPlugin` bytecode — fallback path to `findInstalledPlugin` confirmed)
- [x] ConflictRegistry disable-state filter preserved via `PluginEnabler.HEADLESS`
- [x] All 11 originally-flagged usages eliminated; verifier should re-run clean

## Notes

- `PluginEnabler` is `@ApiStatus.Experimental` at the interface level, so the verifier will see +1 experimental API usage (was 2, will be 3). That is the acceptable trade-off vs. silently admitting disabled plugins as active conflicts.

## Summary by Sourcery

Replace internal PluginManagerCore.getPlugin usages with the public PluginManager façade across production code and tests to satisfy Marketplace compatibility checks while preserving behavior.

Bug Fixes:
- Restore and preserve disabled-plugin filtering in conflict detection when switching to PluginManager by consulting PluginEnabler in ConflictRegistry.

Enhancements:
- Standardize plugin descriptor lookups on the public PluginManager API instead of the internal PluginManagerCore across update notifications, configuration, licensing, conflict detection, and integration code.

Documentation:
- Restamp feature screenshot metadata in docs/features.yml to reflect the latest verified commit.

Tests:
- Update unit and integration tests to mock PluginManager instead of PluginManagerCore and keep coverage for update notifications, licensing, conflict detection, accent application, and indent rainbow sync.