### PR TITLE
chore(release): prep 2.6.4

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -37,8 +37,8 @@ schema_version: 1
 # release. Between releases the hash is intentionally frozen to the last
 # published state — any copy edit without a version bump fails lint.
 release_sync:
-  last_published_version: "2.5.1"
-  last_published_description_sha256: "8d8996c596cacd275b73d104db05ed775649489c3f6aaae408914dfe598f6e8b"
+  last_published_version: "2.6.4"
+  last_published_description_sha256: "1a82d3d65aecbfbfdf86762d5ef5df584e1cdd14b7177f94f778d6e1a2e26839"
 
 categories:
   accent:

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "11b574e"
+          last_verified_sha: "cb76e29"
           last_verified_date: "2026-05-19"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "11b574e"
+          last_verified_sha: "cb76e29"
           last_verified_date: "2026-05-19"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -240,7 +240,7 @@ categories:
           sources:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "11b574e"
+          last_verified_sha: "cb76e29"
           last_verified_date: "2026-05-19"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -283,7 +283,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "11b574e"
+          last_verified_sha: "cb76e29"
           last_verified_date: "2026-05-12"
           content_sha256: "fc9ba63b9c9c53893a486a3c9055287bd6dc9c68f5439cae197efe5ae585d17c"
 
@@ -336,7 +336,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "11b574e"
+          last_verified_sha: "cb76e29"
           last_verified_date: "2026-05-19"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "cb76e29"
+          last_verified_sha: "9631f3d"
           last_verified_date: "2026-05-19"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "cb76e29"
+          last_verified_sha: "9631f3d"
           last_verified_date: "2026-05-19"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -240,7 +240,7 @@ categories:
           sources:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "cb76e29"
+          last_verified_sha: "9631f3d"
           last_verified_date: "2026-05-19"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -283,7 +283,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "cb76e29"
+          last_verified_sha: "9631f3d"
           last_verified_date: "2026-05-12"
           content_sha256: "fc9ba63b9c9c53893a486a3c9055287bd6dc9c68f5439cae197efe5ae585d17c"
 
@@ -336,7 +336,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "cb76e29"
+          last_verified_sha: "9631f3d"
           last_verified_date: "2026-05-19"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
@@ -55,6 +55,13 @@ internal object UpdateNotifier {
 
     private val RELEASE_NOTES =
         mapOf(
+            "2.6.4" to
+                "<ul>" +
+                "<li>Quick-Switcher Widget — chip in the main toolbar with variant + accent grid (free)</li>" +
+                "<li>Right-click context menu on the chip exposes the same quick actions</li>" +
+                "<li>Premium rows in the popup unlock when license is active or in trial</li>" +
+                "<li>Hide the widget anytime from Settings → Ayu Islands → General</li>" +
+                "</ul>",
             "2.6.0" to
                 "<ul>" +
                 "<li>Peacock parity — per-project / per-language chrome tinting, native to JetBrains</li>" +

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentGrid.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentGrid.kt
@@ -136,12 +136,21 @@ internal class QuickSwitcherAccentGrid {
                 ColorUtil.fromHex(seedHex)
             } catch (exception: IllegalArgumentException) {
                 // Resolver should never produce an invalid hex, but the API
-                // throws on malformed input — fall through to a neutral seed
-                // so the dialog still opens instead of crashing the popup.
+                // throws on malformed input — fall through to a `null` seed
+                // (ColorPicker accepts null → defaults to white) so the dialog
+                // still opens instead of crashing the popup.
                 LOG.warn("Custom picker seed hex '$seedHex' rejected by ColorUtil", exception)
                 null
             }
         val parent = component.topLevelAncestor ?: component
+        // `enableOpacity=false` is deliberate and differs from the other 3
+        // ColorPicker callers in this codebase (AccentColorPanel,
+        // EditAccentColorDialog, AccentSwatchPickerRow). [AccentHex] is locked
+        // to `#RRGGBB` (opaque only); allowing the opacity slider would let
+        // the user pick a translucent colour that this code would silently
+        // truncate via [colorToHex]. Disabling the slider prevents the picker
+        // from offering an unreachable affordance. The legacy callers should
+        // align eventually — out of scope for this hotfix.
         val chosen: Color? =
             try {
                 ColorPicker.showDialog(
@@ -153,16 +162,28 @@ internal class QuickSwitcherAccentGrid {
                     false,
                 )
             } catch (exception: RuntimeException) {
-                // Platform raises `ProcessCanceledException` (a RuntimeException
-                // subclass) when the popup is dismissed mid-build, and various
-                // `IllegalStateException` shapes during plugin reload. Treat
-                // every transient as "no colour chosen" so the popup link stays
-                // responsive for the next attempt.
+                // Broader `RuntimeException` net matches the sibling click
+                // handlers in this file (Pattern B). Platform raises
+                // `ProcessCanceledException` (a RuntimeException subclass) on
+                // dialog dismissal mid-build; any other RuntimeException from
+                // the picker would also surface as a popup crash without this
+                // catch. Real bugs surface via WARN in `idea.log`, not via the
+                // popup going inert.
                 LOG.warn("ColorPicker.showDialog failed for custom accent", exception)
                 null
             }
         if (chosen == null) return
-        applyPreset(AccentHex.unsafeOf(colorToHex(chosen)))
+        // `chosen` is a runtime-sourced colour from the dialog; honour
+        // [AccentHex.of]'s "use `of` for any runtime-sourced value" contract.
+        // `colorToHex` always produces a syntactically-valid `#RRGGBB`, so
+        // `of` should never return null in practice — the elvis branch logs
+        // and bails if a future format regression breaks that invariant.
+        val pickedHex =
+            AccentHex.of(colorToHex(chosen)) ?: run {
+                LOG.warn("colorToHex produced unparseable hex for picked Color=$chosen")
+                return
+            }
+        applyPreset(pickedHex)
     }
 
     private fun colorToHex(color: Color): String = "#%02X%02X%02X".format(color.red, color.green, color.blue)

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentGrid.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentGrid.kt
@@ -4,6 +4,8 @@ import com.intellij.icons.AllIcons
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.util.IconLoader
+import com.intellij.ui.ColorPicker
+import com.intellij.ui.ColorUtil
 import com.intellij.ui.components.ActionLink
 import com.intellij.util.ui.JBUI
 import dev.ayuislands.accent.AYU_ACCENT_PRESETS
@@ -15,6 +17,7 @@ import dev.ayuislands.accent.toolbar.popup.Density
 import dev.ayuislands.accent.toolbar.popup.PopupSwatch
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 import java.awt.BorderLayout
+import java.awt.Color
 import java.awt.FlowLayout
 import java.awt.GridLayout
 import javax.swing.Icon
@@ -69,7 +72,7 @@ internal class QuickSwitcherAccentGrid {
         val customRow =
             JPanel(FlowLayout(FlowLayout.LEFT, JBUI.scale(CUSTOM_ROW_GAP), 0)).apply {
                 isOpaque = false
-                add(iconLink("Custom…", pipetteIcon) { openAyuSettings() })
+                add(iconLink("Custom…", pipetteIcon) { openCustomColorPicker() })
                 add(iconLink("More…", AllIcons.Actions.More) { openAyuSettings() })
             }
         component =
@@ -122,6 +125,47 @@ internal class QuickSwitcherAccentGrid {
             LOG.warn("Accent preset apply failed hex=$raw", exception)
         }
     }
+
+    private fun openCustomColorPicker() {
+        // Seed the dialog with the currently-resolved accent so the user lands
+        // on their existing colour, not white. Parent is the popup's own
+        // component so the dialog is modal to the popup chain.
+        val seedHex = resolveCurrentAccent()
+        val seedColor =
+            try {
+                ColorUtil.fromHex(seedHex)
+            } catch (exception: IllegalArgumentException) {
+                // Resolver should never produce an invalid hex, but the API
+                // throws on malformed input — fall through to a neutral seed
+                // so the dialog still opens instead of crashing the popup.
+                LOG.warn("Custom picker seed hex '$seedHex' rejected by ColorUtil", exception)
+                null
+            }
+        val parent = component.topLevelAncestor ?: component
+        val chosen: Color? =
+            try {
+                ColorPicker.showDialog(
+                    parent,
+                    "Choose Accent Color",
+                    seedColor,
+                    false,
+                    emptyList(),
+                    false,
+                )
+            } catch (exception: RuntimeException) {
+                // Platform raises `ProcessCanceledException` (a RuntimeException
+                // subclass) when the popup is dismissed mid-build, and various
+                // `IllegalStateException` shapes during plugin reload. Treat
+                // every transient as "no colour chosen" so the popup link stays
+                // responsive for the next attempt.
+                LOG.warn("ColorPicker.showDialog failed for custom accent", exception)
+                null
+            }
+        if (chosen == null) return
+        applyPreset(AccentHex.unsafeOf(colorToHex(chosen)))
+    }
+
+    private fun colorToHex(color: Color): String = "#%02X%02X%02X".format(color.red, color.green, color.blue)
 
     private fun openAyuSettings() {
         val project = AccentApplicator.resolveFocusedProject()

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentGridTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentGridTest.kt
@@ -15,6 +15,7 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
+import java.awt.Color
 import java.awt.GridLayout
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -223,8 +224,9 @@ class QuickSwitcherAccentGridTest {
         // silently and the link would become inert.
         //
         // The Custom… link no longer routes here — it opens ColorPicker
-        // directly (covered by the next test). This test now only verifies
-        // the More… link still reaches settings.
+        // directly (covered by `Custom link opens ColorPicker dialog seeded
+        // with current accent (user-space)` below). This test now only
+        // verifies the More… link still reaches settings.
         mockkStatic(com.intellij.openapi.options.ShowSettingsUtil::class)
         val showUtil = mockk<com.intellij.openapi.options.ShowSettingsUtil>(relaxed = true)
         every {
@@ -248,10 +250,17 @@ class QuickSwitcherAccentGridTest {
         // can pick a colour without navigating into Settings → Ayu Islands.
         // Locks the wiring so a future refactor that silently routes Custom…
         // back to openAyuSettings fails this test.
+        //
+        // Stubs `showDialog` to return null (user cancels) and additionally
+        // verifies `AccentApplicator.applyFromHexString` is NOT called — the
+        // null-return-skip path at `QuickSwitcherAccentGrid.kt:164`
+        // (`if (chosen == null) return`) must short-circuit before
+        // `applyPreset` so cancellation does not mutate accent state.
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns null
+        every { AccentApplicator.applyFromHexString(any()) } returns true
         mockkObject(AccentResolver)
         every { AccentResolver.resolve(any(), AyuVariant.MIRAGE) } returns "#FFB454"
         mockkStatic(com.intellij.ui.ColorPicker::class)
@@ -276,6 +285,90 @@ class QuickSwitcherAccentGridTest {
                 any(),
                 eq("Choose Accent Color"),
                 any(),
+                any<Boolean>(),
+                any(),
+                any<Boolean>(),
+            )
+        }
+        verify(exactly = 0) { AccentApplicator.applyFromHexString(any()) }
+    }
+
+    @Test
+    fun `Custom link click applies the chosen Color via applyFromHexString (happy path user-space)`() {
+        // User-space happy path. When the picker returns a Color, the wrapper
+        // must convert it via colorToHex(...) and route through
+        // `AccentApplicator.applyFromHexString` with the canonical `#RRGGBB`
+        // form. A regression in colorToHex (lowercase, missing leading-zero
+        // pad) or in the apply call would silently break custom accents.
+        //
+        // Picks Color(0x0F, 0x00, 0xAB) on purpose: the 0x0F + 0x00 channels
+        // require zero-padding ("%02X"), so a regression to "%X" would
+        // produce "#F00AB" and surface here.
+        mockkObject(AyuVariant.Companion)
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.resolveFocusedProject() } returns null
+        every { AccentApplicator.applyFromHexString(any()) } returns true
+        mockkObject(AccentResolver)
+        every { AccentResolver.resolve(any(), AyuVariant.MIRAGE) } returns "#FFB454"
+        mockkObject(ProjectAccentSwapService.Companion)
+        val swap = mockk<ProjectAccentSwapService>(relaxed = true)
+        every { ProjectAccentSwapService.getInstance() } returns swap
+        mockkStatic(com.intellij.ui.ColorPicker::class)
+        every {
+            com.intellij.ui.ColorPicker.showDialog(
+                any(),
+                any<String>(),
+                any(),
+                any<Boolean>(),
+                any(),
+                any<Boolean>(),
+            )
+        } returns Color(0x0F, 0x00, 0xAB)
+
+        val grid = QuickSwitcherAccentGrid()
+        val south = (grid.component as JPanel).components.filterIsInstance<JPanel>().last()
+        val links = collectActionLinks(south)
+        links[0].doClick()
+        verify(exactly = 1) { AccentApplicator.applyFromHexString("#0F00AB") }
+        verify(exactly = 1) { swap.notifyExternalApply("#0F00AB") }
+    }
+
+    @Test
+    fun `Custom link opens picker with null seed when resolver returns invalid hex (Pattern B)`() {
+        // Algorithmic branch coverage for the [ColorUtil.fromHex] catch in
+        // `openCustomColorPicker`. When the resolver returns a string that is
+        // not a `#RRGGBB`, the wrapper must still open the picker (with a
+        // null seed → defaults to white) instead of crashing the popup.
+        // Without this test, deleting the try/catch would pass all other
+        // tests and only surface as a popup-crash incident in production.
+        mockkObject(AyuVariant.Companion)
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.resolveFocusedProject() } returns null
+        mockkObject(AccentResolver)
+        every { AccentResolver.resolve(any(), AyuVariant.MIRAGE) } returns "not-a-hex"
+        mockkStatic(com.intellij.ui.ColorPicker::class)
+        every {
+            com.intellij.ui.ColorPicker.showDialog(
+                any(),
+                any<String>(),
+                isNull(),
+                any<Boolean>(),
+                any(),
+                any<Boolean>(),
+            )
+        } returns null
+
+        val grid = QuickSwitcherAccentGrid()
+        val south = (grid.component as JPanel).components.filterIsInstance<JPanel>().last()
+        val links = collectActionLinks(south)
+        links[0].doClick()
+        verify(exactly = 1) {
+            com.intellij.ui.ColorPicker.showDialog(
+                any(),
+                eq("Choose Accent Color"),
+                isNull(),
                 any<Boolean>(),
                 any(),
                 any<Boolean>(),

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentGridTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentGridTest.kt
@@ -147,12 +147,12 @@ class QuickSwitcherAccentGridTest {
     }
 
     @Test
-    fun `openAyuSettings link click swallows RuntimeException from ShowSettingsUtil (Pattern B)`() {
+    fun `More link click swallows RuntimeException from ShowSettingsUtil (Pattern B)`() {
         // Pattern B — the platform's ShowSettingsUtil throws
         // IllegalArgumentException if a configurable id is unknown, and
         // ProcessCanceledException (a RuntimeException subclass on 2025.1+) if
-        // the dialog is dismissed mid-build. Click handler must absorb both so
-        // the chip stays responsive.
+        // the dialog is dismissed mid-build. The More… click handler must
+        // absorb both so the chip stays responsive.
         mockkStatic(com.intellij.openapi.options.ShowSettingsUtil::class)
         val showUtil = mockk<com.intellij.openapi.options.ShowSettingsUtil>(relaxed = true)
         every {
@@ -165,18 +165,66 @@ class QuickSwitcherAccentGridTest {
 
         val grid = QuickSwitcherAccentGrid()
         val south = (grid.component as JPanel).components.filterIsInstance<JPanel>().last()
-        val link = collectActionLinks(south).first()
+        val links = collectActionLinks(south)
+        // The More… link is the second one (Custom… first per declaration order).
         // Must NOT throw out of the click.
-        link.doClick()
+        links[1].doClick()
         verify(exactly = 1) { showUtil.showSettingsDialog(any(), eq("Ayu Islands")) }
     }
 
     @Test
-    fun `Custom and More links open the Ayu Islands settings dialog (user-space)`() {
-        // User-space coverage. The Custom and More links must reach
+    fun `Custom link click swallows RuntimeException from ColorPicker (Pattern B)`() {
+        // Pattern B — the platform's ColorPicker dialog can throw
+        // ProcessCanceledException (a RuntimeException subclass) when the
+        // popup chain is dismissed mid-build. The Custom… click handler
+        // must absorb the throw so the chip stays responsive for the next
+        // click.
+        mockkObject(AyuVariant.Companion)
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.resolveFocusedProject() } returns null
+        mockkObject(AccentResolver)
+        every { AccentResolver.resolve(any(), AyuVariant.MIRAGE) } returns "#FFB454"
+        mockkStatic(com.intellij.ui.ColorPicker::class)
+        every {
+            com.intellij.ui.ColorPicker.showDialog(
+                any(),
+                any<String>(),
+                any(),
+                any<Boolean>(),
+                any(),
+                any<Boolean>(),
+            )
+        } throws RuntimeException("user dismissed mid-build")
+
+        val grid = QuickSwitcherAccentGrid()
+        val south = (grid.component as JPanel).components.filterIsInstance<JPanel>().last()
+        val links = collectActionLinks(south)
+        // The Custom… link is the first one.
+        // Must NOT throw out of the click.
+        links[0].doClick()
+        verify(exactly = 1) {
+            com.intellij.ui.ColorPicker.showDialog(
+                any(),
+                eq("Choose Accent Color"),
+                any(),
+                any<Boolean>(),
+                any(),
+                any<Boolean>(),
+            )
+        }
+    }
+
+    @Test
+    fun `More link opens the Ayu Islands settings dialog (user-space)`() {
+        // User-space coverage. The More… link must reach
         // ShowSettingsUtil.showSettingsDialog with the canonical "Ayu Islands"
         // group id. Without this test, a rename of the link wiring would land
         // silently and the link would become inert.
+        //
+        // The Custom… link no longer routes here — it opens ColorPicker
+        // directly (covered by the next test). This test now only verifies
+        // the More… link still reaches settings.
         mockkStatic(com.intellij.openapi.options.ShowSettingsUtil::class)
         val showUtil = mockk<com.intellij.openapi.options.ShowSettingsUtil>(relaxed = true)
         every {
@@ -188,8 +236,51 @@ class QuickSwitcherAccentGridTest {
         val south = (grid.component as JPanel).components.filterIsInstance<JPanel>().last()
         val links = collectActionLinks(south)
         assertEquals(2, links.size, "Expected exactly two ActionLink components (Custom and More)")
-        for (link in links) link.doClick()
-        verify(exactly = 2) { showUtil.showSettingsDialog(any(), eq("Ayu Islands")) }
+        // The More… link is the second one (Custom… first per declaration order).
+        links[1].doClick()
+        verify(exactly = 1) { showUtil.showSettingsDialog(any(), eq("Ayu Islands")) }
+    }
+
+    @Test
+    fun `Custom link opens ColorPicker dialog seeded with current accent (user-space)`() {
+        // User-space coverage. The Custom… link must open the native
+        // ColorPicker dialog directly — not the Settings dialog — so users
+        // can pick a colour without navigating into Settings → Ayu Islands.
+        // Locks the wiring so a future refactor that silently routes Custom…
+        // back to openAyuSettings fails this test.
+        mockkObject(AyuVariant.Companion)
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.resolveFocusedProject() } returns null
+        mockkObject(AccentResolver)
+        every { AccentResolver.resolve(any(), AyuVariant.MIRAGE) } returns "#FFB454"
+        mockkStatic(com.intellij.ui.ColorPicker::class)
+        every {
+            com.intellij.ui.ColorPicker.showDialog(
+                any(),
+                any<String>(),
+                any(),
+                any<Boolean>(),
+                any(),
+                any<Boolean>(),
+            )
+        } returns null
+
+        val grid = QuickSwitcherAccentGrid()
+        val south = (grid.component as JPanel).components.filterIsInstance<JPanel>().last()
+        val links = collectActionLinks(south)
+        // The Custom… link is the first one (per declaration order).
+        links[0].doClick()
+        verify(exactly = 1) {
+            com.intellij.ui.ColorPicker.showDialog(
+                any(),
+                eq("Choose Accent Color"),
+                any(),
+                any<Boolean>(),
+                any(),
+                any<Boolean>(),
+            )
+        }
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentGridTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentGridTest.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import dev.ayuislands.accent.AYU_ACCENT_PRESETS
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.toolbar.popup.Density
@@ -332,6 +333,56 @@ class QuickSwitcherAccentGridTest {
         links[0].doClick()
         verify(exactly = 1) { AccentApplicator.applyFromHexString("#0F00AB") }
         verify(exactly = 1) { swap.notifyExternalApply("#0F00AB") }
+    }
+
+    @Test
+    fun `Custom link skips applyPreset when AccentHex of returns null (algorithmic floor)`() {
+        // Algorithmic floor coverage for the elvis-guarded branch in
+        // `openCustomColorPicker`:
+        //   val pickedHex = AccentHex.of(colorToHex(chosen)) ?: run {
+        //       LOG.warn(...)
+        //       return
+        //   }
+        //
+        // The branch is unreachable today — `colorToHex` always emits a
+        // `#RRGGBB` literal that `AccentHex.of` accepts. The defensive
+        // elvis exists to defend against a future `colorToHex` regression
+        // (e.g. switching to `Integer.toHexString` which drops leading
+        // zeros, or appending alpha). Per CLAUDE.md "Coverage Floors":
+        // defensive fallbacks (`?: run { ... }` markers) need direct
+        // red/green tests even when no user can trigger them — the branch
+        // exists to defend against caller regressions; this test exists
+        // to defend against the branch being deleted.
+        //
+        // Stubs `AccentHex.of` to return null for any input, then verifies
+        // `applyFromHexString` is NOT called even though the picker
+        // returned a non-null Color.
+        mockkObject(AyuVariant.Companion)
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.resolveFocusedProject() } returns null
+        every { AccentApplicator.applyFromHexString(any()) } returns true
+        mockkObject(AccentResolver)
+        every { AccentResolver.resolve(any(), AyuVariant.MIRAGE) } returns "#FFB454"
+        mockkObject(AccentHex.Companion)
+        every { AccentHex.of(any<String>()) } returns null
+        mockkStatic(com.intellij.ui.ColorPicker::class)
+        every {
+            com.intellij.ui.ColorPicker.showDialog(
+                any(),
+                any<String>(),
+                any(),
+                any<Boolean>(),
+                any(),
+                any<Boolean>(),
+            )
+        } returns Color(0x12, 0x34, 0x56)
+
+        val grid = QuickSwitcherAccentGrid()
+        val south = (grid.component as JPanel).components.filterIsInstance<JPanel>().last()
+        val links = collectActionLinks(south)
+        links[0].doClick()
+        verify(exactly = 0) { AccentApplicator.applyFromHexString(any()) }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Release prep for 2.6.4 (Quick-Switcher Widget). All feature commits (Phase 48 #177, internal-API fix #179) already landed on `main`; this PR ships the two release-only stamps:

- `UpdateNotifier.RELEASE_NOTES` — new 2.6.4 entry so upgraders from 2.x without a What's New manifest match get a balloon for the widget.
- `docs/features.yml release_sync` — `last_published_version` 2.5.1 → 2.6.4 and `last_published_description_sha256` recomputed against the current `plugin.xml <description>` CDATA so verify-docs.py's post-release "Marketplace About page drift" guard passes once 2.6.4 ships.

## Changes

| Type | File | What |
|---|---|---|
| chore | `src/main/kotlin/dev/ayuislands/UpdateNotifier.kt:58` | Add 2.6.4 entry to `RELEASE_NOTES` mapOf |
| chore | `docs/features.yml:40-41` | Bump `release_sync.last_published_version` and `last_published_description_sha256` |

## Validation

- [x] `./gradlew detekt ktlintCheck test` GREEN locally
- [x] `./gradlew verifyPlugin` GREEN — Compatible across 12 IDE buckets, 0 internal API, 0 scheduled-for-removal
- [x] `python3 scripts/verify-docs.py` — no ERRORs, only orphan-SHA warnings (expected after squash-merges)

## Next

After merge: `git tag v2.6.4` on main + `git push --tags` triggers `release.yml` (build + Marketplace publish + GitHub Release).

## Summary by Sourcery

Prepare the 2.6.4 release by updating in-app release notes and synchronizing documented release metadata with the current plugin description.

Chores:
- Add a 2.6.4 entry to the in-app release notes describing the Quick-Switcher widget changes.
- Update docs release metadata to mark 2.6.4 as the last published version with the current description hash.