### PR TITLE
feat(toolbar): layered squircle chip + inner-island pin toggle

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "8f0fa4b"
+          last_verified_sha: "6c8afa3"
           last_verified_date: "2026-05-19"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "8f0fa4b"
+          last_verified_sha: "6c8afa3"
           last_verified_date: "2026-05-19"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -240,7 +240,7 @@ categories:
           sources:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "8f0fa4b"
+          last_verified_sha: "6c8afa3"
           last_verified_date: "2026-05-19"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -283,7 +283,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "8f0fa4b"
+          last_verified_sha: "6c8afa3"
           last_verified_date: "2026-05-12"
           content_sha256: "fc9ba63b9c9c53893a486a3c9055287bd6dc9c68f5439cae197efe5ae585d17c"
 
@@ -336,7 +336,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "8f0fa4b"
+          last_verified_sha: "6c8afa3"
           last_verified_date: "2026-05-19"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "6c8afa3"
+          last_verified_sha: "85e520d"
           last_verified_date: "2026-05-19"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "6c8afa3"
+          last_verified_sha: "85e520d"
           last_verified_date: "2026-05-19"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -240,7 +240,7 @@ categories:
           sources:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "6c8afa3"
+          last_verified_sha: "85e520d"
           last_verified_date: "2026-05-19"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -283,7 +283,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "6c8afa3"
+          last_verified_sha: "85e520d"
           last_verified_date: "2026-05-12"
           content_sha256: "fc9ba63b9c9c53893a486a3c9055287bd6dc9c68f5439cae197efe5ae585d17c"
 
@@ -336,7 +336,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "6c8afa3"
+          last_verified_sha: "85e520d"
           last_verified_date: "2026-05-19"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "9631f3d"
+          last_verified_sha: "8f0fa4b"
           last_verified_date: "2026-05-19"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "9631f3d"
+          last_verified_sha: "8f0fa4b"
           last_verified_date: "2026-05-19"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -240,7 +240,7 @@ categories:
           sources:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "9631f3d"
+          last_verified_sha: "8f0fa4b"
           last_verified_date: "2026-05-19"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -283,7 +283,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "9631f3d"
+          last_verified_sha: "8f0fa4b"
           last_verified_date: "2026-05-12"
           content_sha256: "fc9ba63b9c9c53893a486a3c9055287bd6dc9c68f5439cae197efe5ae585d17c"
 
@@ -336,7 +336,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "9631f3d"
+          last_verified_sha: "8f0fa4b"
           last_verified_date: "2026-05-19"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/LayeredAccentIcon.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/LayeredAccentIcon.kt
@@ -1,0 +1,190 @@
+package dev.ayuislands.accent.toolbar
+
+import com.intellij.ui.ColorUtil
+import dev.ayuislands.accent.AccentHex
+import dev.ayuislands.accent.color.AccentHsl
+import org.jetbrains.annotations.TestOnly
+import java.awt.BasicStroke
+import java.awt.Color
+import java.awt.Component
+import java.awt.Graphics
+import java.awt.Graphics2D
+import java.awt.RenderingHints
+import java.awt.geom.Area
+import java.awt.geom.Path2D
+import javax.swing.Icon
+
+/**
+ * Quick-Switcher chip's layered icon: three nested squircle (superellipse-
+ * like) layers mirroring the SVG reference at
+ * `~/Downloads/rounded-square-layered-icon.svg`. Renders as
+ *
+ *  - **Outer ring**: filled with the focused project's accent (the colour
+ *    every other chip-level test asserts).
+ *  - **Empty band** between the outer ring and the inner square (transparent;
+ *    no paint).
+ *  - **Inner island**: either filled with `AccentHsl.darken(accent)` (when a
+ *    per-project pin is active — `pinned = true`) or stroked as an outline in
+ *    the outer-ring colour (when no pin — `pinned = false`). The filled-vs-
+ *    hollow distinction is the chip's affordance for "this project's accent
+ *    is pinned" (locked-in weight) vs "chip shows the global accent" (lighter
+ *    outline).
+ *
+ * Geometry mirrors the SVG `~/Downloads/rounded-square-layered-icon.svg` —
+ * three nested squircles, NOT round-rectangles. Each layer is a 4-cubic-
+ * Bézier path whose control points sit on the bounding edges (Apple-style
+ * iOS-app-icon corner). At the SVG scale (300×300 viewBox, 250×250 outer
+ * square), the first control offset from each midpoint toward the corner is
+ * 76 px (= 0.304 × side length). The icon scales that ratio to any [sizePx].
+ *
+ * Paint is split into [paintIcon] (Swing entry point) and [paintForTest]
+ * (Pattern I seam — tests rasterize into a `BufferedImage` and assert on the
+ * outer-ring and inner-square pixels). Identical to the seam pattern in
+ * `PopupSwatch`.
+ */
+internal class LayeredAccentIcon(
+    private val sizePx: Int,
+    accent: AccentHex,
+    private val pinned: Boolean,
+) : Icon {
+    // [accent] is a constructor-only parameter — both colours are resolved
+    // once at construction so the icon paint path can stay branch-free on
+    // the colour derivation. `darken` returns the input unchanged at the
+    // lightness clamp edge (see `AccentHsl` KDoc), so very dark accents may
+    // produce an inner island identical to the outer ring — acceptable;
+    // the pinned state is still distinguishable by silhouette.
+    private val outerColor: Color = ColorUtil.fromHex(accent.value)
+    private val innerColor: Color = ColorUtil.fromHex(AccentHsl.darken(accent).value)
+
+    /** Exposed so chip-level tests can assert the active accent without re-deriving from the hex string. */
+    internal val accentColor: Color get() = outerColor
+
+    /** Exposed so chip-level tests can assert the pinned-vs-unpinned visual without rendering. */
+    internal val isPinned: Boolean get() = pinned
+
+    override fun getIconWidth(): Int = sizePx
+
+    override fun getIconHeight(): Int = sizePx
+
+    override fun paintIcon(
+        c: Component?,
+        g: Graphics,
+        x: Int,
+        y: Int,
+    ) {
+        val g2 = g.create() as Graphics2D
+        try {
+            g2.translate(x, y)
+            paintForTest(g2)
+        } finally {
+            g2.dispose()
+        }
+    }
+
+    @TestOnly
+    internal fun paintForTest(g2: Graphics2D) {
+        g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+        val side = sizePx.toFloat()
+        val outerInset = side * OUTER_INSET_RATIO
+        val middleInset = side * MIDDLE_INSET_RATIO
+        val innerInset = side * INNER_INSET_RATIO
+
+        val outer = squirclePath(outerInset, side - 2 * outerInset)
+        val middle = squirclePath(middleInset, side - 2 * middleInset)
+        val inner = squirclePath(innerInset, side - 2 * innerInset)
+
+        // Outer ring = outer area minus the middle "hole" — yields the
+        // filled outer band with a transparent gap separating it from the
+        // inner square below.
+        val ring = Area(outer).apply { subtract(Area(middle)) }
+        g2.color = outerColor
+        g2.fill(ring)
+
+        // Inner island: filled (pinned) or outlined (no pin). Outline width
+        // scales with chip size so the stroke stays visually present at the
+        // ~3px inner-squircle footprint of the 13×13 cell while staying
+        // crisp at larger JBUI scales.
+        if (pinned) {
+            g2.color = innerColor
+            g2.fill(inner)
+        } else {
+            g2.color = outerColor
+            g2.stroke = BasicStroke((side * STROKE_RATIO).coerceAtLeast(MIN_STROKE_PX))
+            g2.draw(inner)
+        }
+    }
+
+    /**
+     * One squircle layer built as 4 cubic Bézier curves whose control points
+     * sit on the bounding square's edges — the SVG reference shape. This is
+     * the iOS-app-icon "soft rectangle" that reads as a rounded square at a
+     * glance but is mathematically different from `RoundRectangle2D` (whose
+     * sides are straight, terminated by quarter-circle arcs).
+     *
+     * Ratio `0.304 × side` for the first control offset is read directly off
+     * the SVG: at viewBox 300 × 300 with side 250, the original control point
+     * for the top-right corner sits 76 px right of the top midpoint
+     * (`76 / 250 = 0.304`).
+     */
+    private fun squirclePath(
+        inset: Float,
+        side: Float,
+    ): Path2D.Float {
+        val k = CONTROL_OFFSET_RATIO * side
+        val half = side / 2f
+        val far = inset + side
+        val path = Path2D.Float()
+        // Top midpoint → right midpoint (top-right corner).
+        path.moveTo(inset + half, inset)
+        path.curveTo(inset + half + k, inset, far, inset, far, inset + half)
+        // Right midpoint → bottom midpoint (bottom-right corner).
+        path.curveTo(far, inset + half + k, far, far, inset + half, far)
+        // Bottom midpoint → left midpoint (bottom-left corner).
+        path.curveTo(inset + half - k, far, inset, far, inset, inset + half)
+        // Left midpoint → top midpoint (top-left corner).
+        path.curveTo(inset, inset + half - k, inset, inset, inset + half, inset)
+        path.closePath()
+        return path
+    }
+
+    companion object {
+        // SVG reference geometry: 25/300, 50/300, 75/300 insets — kept as
+        // ratios so the icon renders correctly at any size (Retina scaling,
+        // future chip-size tweaks).
+        internal const val OUTER_INSET_RATIO = 0.0833f
+        internal const val MIDDLE_INSET_RATIO = 0.1667f
+        internal const val INNER_INSET_RATIO = 0.25f
+
+        // First control-point offset from each side's midpoint toward the
+        // corner, expressed as a fraction of the full side length. Derived
+        // directly from the SVG: 76 px / 250 px = 0.304.
+        private const val CONTROL_OFFSET_RATIO = 0.304f
+
+        // Outline stroke ratio (no-pin state). 6% of side length yields
+        // ~0.78px at 13px → coerceAtLeast(1f) keeps the line visible.
+        private const val STROKE_RATIO = 0.06f
+        private const val MIN_STROKE_PX = 1f
+
+        /**
+         * `true` when the local mouse point `(x, y)` falls inside the inner-
+         * squircle bounding box of a chip rendered at [size]. Used by the
+         * chip's `mousePressed` handler to differentiate inner-island clicks
+         * (pin toggle) from outer-region clicks (open popup).
+         *
+         * The bounding-box approximation is intentional — the inner squircle
+         * is almost-square at the centre, and the few near-corner pixels that
+         * fall outside the squircle but inside its bounding box are a
+         * negligible click-target loss compared to the cost of running a
+         * point-in-Bezier-region check on every `mousePressed`.
+         */
+        internal fun isInsideInnerSquare(
+            x: Int,
+            y: Int,
+            size: Int,
+        ): Boolean {
+            val inset = size * INNER_INSET_RATIO
+            val limit = size - inset
+            return x >= inset && x <= limit && y >= inset && y <= limit
+        }
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/LayeredAccentIcon.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/LayeredAccentIcon.kt
@@ -37,9 +37,9 @@ import javax.swing.Icon
  * square), the first control offset from each midpoint toward the corner is
  * 76 px (= 0.304 × side length). The icon scales that ratio to any [sizePx].
  *
- * Paint is split into [paintIcon] (Swing entry point) and [paintForTest]
- * (Pattern I seam — tests rasterize into a `BufferedImage` and assert on the
- * outer-ring and inner-square pixels). Identical to the seam pattern in
+ * Paint is split into [paintIcon] (Swing entry point) and a `@TestOnly`
+ * [paintForTest] render seam — tests rasterize into a `BufferedImage` and
+ * assert on the outer-ring and inner-square pixels. Mirrors the seam in
  * `PopupSwatch`.
  */
 internal class LayeredAccentIcon(
@@ -47,14 +47,23 @@ internal class LayeredAccentIcon(
     accent: AccentHex,
     private val pinned: Boolean,
 ) : Icon {
-    // [accent] is a constructor-only parameter — both colours are resolved
-    // once at construction so the icon paint path can stay branch-free on
-    // the colour derivation. `darken` returns the input unchanged at the
-    // lightness clamp edge (see `AccentHsl` KDoc), so very dark accents may
-    // produce an inner island identical to the outer ring — acceptable;
-    // the pinned state is still distinguishable by silhouette.
+    init {
+        require(sizePx > 0) { "sizePx must be positive, got $sizePx" }
+    }
+
+    // Both colours are resolved once at construction so the paint path is
+    // branch-free on colour derivation. `AccentHsl.darken` returns the input
+    // unchanged at the lightness clamp edge; fall back to `lighten` so very
+    // dark accents still produce a distinguishable inner island.
     private val outerColor: Color = ColorUtil.fromHex(accent.value)
-    private val innerColor: Color = ColorUtil.fromHex(AccentHsl.darken(accent).value)
+    private val innerColor: Color =
+        ColorUtil.fromHex(
+            AccentHsl
+                .darken(accent)
+                .takeIf { it.value != accent.value }
+                ?.value
+                ?: AccentHsl.lighten(accent).value,
+        )
 
     /** Exposed so chip-level tests can assert the active accent without re-deriving from the hex string. */
     internal val accentColor: Color get() = outerColor
@@ -114,18 +123,7 @@ internal class LayeredAccentIcon(
         }
     }
 
-    /**
-     * One squircle layer built as 4 cubic Bézier curves whose control points
-     * sit on the bounding square's edges — the SVG reference shape. This is
-     * the iOS-app-icon "soft rectangle" that reads as a rounded square at a
-     * glance but is mathematically different from `RoundRectangle2D` (whose
-     * sides are straight, terminated by quarter-circle arcs).
-     *
-     * Ratio `0.304 × side` for the first control offset is read directly off
-     * the SVG: at viewBox 300 × 300 with side 250, the original control point
-     * for the top-right corner sits 76 px right of the top midpoint
-     * (`76 / 250 = 0.304`).
-     */
+    /** One squircle layer (4 cubic Béziers) — see class header for geometry. */
     private fun squirclePath(
         inset: Float,
         side: Float,
@@ -166,18 +164,16 @@ internal class LayeredAccentIcon(
         private const val MIN_STROKE_PX = 1f
 
         /**
-         * `true` when the local mouse point `(x, y)` falls inside the inner-
-         * squircle bounding box of a chip rendered at [size]. Used by the
-         * chip's `mousePressed` handler to differentiate inner-island clicks
-         * (pin toggle) from outer-region clicks (open popup).
-         *
-         * The bounding-box approximation is intentional — the inner squircle
-         * is almost-square at the centre, and the few near-corner pixels that
-         * fall outside the squircle but inside its bounding box are a
-         * negligible click-target loss compared to the cost of running a
-         * point-in-Bezier-region check on every `mousePressed`.
+         * Chip's hit-test contract: `true` when the local mouse point
+         * `(x, y)` falls inside the inner-island bounding box of a chip
+         * rendered at [size]. Bounding box rather than the squircle path
+         * itself — the near-corner overshoot is sub-pixel at 13px and the
+         * cost of a point-in-Bezier check on every `mousePressed` is not
+         * worth the precision. Owned by the icon because the rectangle's
+         * inset is dictated by the icon's geometry; the chip is the only
+         * caller.
          */
-        internal fun isInsideInnerSquare(
+        internal fun isInsideInnerIslandHitBox(
             x: Int,
             y: Int,
             size: Int,

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipComponent.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipComponent.kt
@@ -16,6 +16,7 @@ import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.toolbar.actions.QuickSwitcherActionGroup
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.mappings.AccentMappingsSettings
+import dev.ayuislands.settings.mappings.AccentMappingsState
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 import java.awt.Dimension
 import java.awt.event.MouseAdapter
@@ -96,22 +97,13 @@ internal class QuickSwitcherChipComponent : JLabel() {
         )
     }
 
-    /**
-     * Inner-island click → pin toggle (premium-gated via Pattern J); outer
-     * region click → open the existing popup.
-     *
-     * Hit-test uses [LayeredAccentIcon.isInsideInnerSquare] against the
-     * chip's actual pixel size so the differentiator matches what the user
-     * sees rendered. Pattern J gate (`AyuVariant.isAyuActive() &&
-     * LicenseChecker.isLicensedOrGrace()`) gates the pin toggle ONLY —
-     * popup open stays free.
-     */
+    /** Inner-island click → licence-gated pin toggle; outer click → existing popup. */
     private fun handleLeftClick(
         x: Int,
         y: Int,
     ) {
         val size = JBUI.scale(CHIP_BOX_PX)
-        val onInner = LayeredAccentIcon.isInsideInnerSquare(x, y, size)
+        val onInner = LayeredAccentIcon.isInsideInnerIslandHitBox(x, y, size)
         if (onInner && LicenseChecker.isLicensedOrGrace()) {
             togglePin()
             return
@@ -120,16 +112,17 @@ internal class QuickSwitcherChipComponent : JLabel() {
     }
 
     /**
-     * Inner-island action: if a per-project pin is active, remove it (chip
-     * falls back to global accent on next resolve); if no pin, write the
-     * current accent as the pin. Mirrors [dev.ayuislands.accent.toolbar.actions.PinAccentAction]
-     * for the write path so behaviour stays consistent across the popup
-     * quick-action row, the right-click context menu, and the chip's
-     * inner-island click.
+     * Pin / unpin the focused project's accent and roll back the persisted
+     * `projectAccents` mutation if [AccentApplicator.applyFromHexString]
+     * rejects the hex or any of the resolve / apply / notify calls throw —
+     * keeps the persisted store consistent with the live accent state at
+     * all times. Mirrors [dev.ayuislands.accent.toolbar.actions.PinAccentAction]
+     * for the write path so all three pin entry points (popup quick-action,
+     * right-click context menu, chip inner click) stay consistent.
      *
-     * Pattern B catches transient [RuntimeException] from the resolver,
-     * apply, or notify paths so the chip mouse handler stays responsive
-     * for the next attempt.
+     * The Pattern B `RuntimeException` catch wraps the entire toggle so
+     * a single restore-pin helper handles both the rejection branch
+     * (`applied == false`) and the thrown-exception branch the same way.
      */
     private fun togglePin() {
         val variant = AyuVariant.detect() ?: return
@@ -139,33 +132,44 @@ internal class QuickSwitcherChipComponent : JLabel() {
                 LOG.warn("Pin toggle: projectKey null for ${project.name}")
                 return
             }
+        val mappings = AccentMappingsSettings.getInstance().state
+        val previousPin: String? = mappings.projectAccents[key]
         try {
-            val mappings = AccentMappingsSettings.getInstance().state
-            val source = AccentResolver.source(project)
-            if (source == AccentResolver.Source.PROJECT_OVERRIDE) {
-                // Unpin path: drop the override; resolver will return the
-                // language pin (if any) or the global accent next refresh.
+            val unpinPath = AccentResolver.source(project) == AccentResolver.Source.PROJECT_OVERRIDE
+            if (unpinPath) {
                 mappings.projectAccents.remove(key)
-                val globalHex = AccentResolver.resolve(project, variant)
-                val applied = AccentApplicator.applyFromHexString(globalHex)
-                if (applied) {
-                    ProjectAccentSwapService.getInstance().notifyExternalApply(globalHex)
-                } else {
-                    LOG.warn("Pin toggle (unpin): applyFromHexString rejected hex=$globalHex")
-                }
             } else {
-                // Pin path: write current resolved accent as the project pin.
-                val currentHex = AccentResolver.resolve(project, variant)
-                mappings.projectAccents[key] = currentHex
-                val applied = AccentApplicator.applyFromHexString(currentHex)
-                if (applied) {
-                    ProjectAccentSwapService.getInstance().notifyExternalApply(currentHex)
-                } else {
-                    LOG.warn("Pin toggle (pin): applyFromHexString rejected hex=$currentHex")
-                }
+                mappings.projectAccents[key] = AccentResolver.resolve(project, variant)
+            }
+            // Resolve target hex AFTER the mutation so the unpin path lands
+            // on the (now-uncovered) language pin or global accent and the
+            // pin path lands on the just-written override — `AccentResolver`
+            // reads `mappings` directly.
+            val targetHex = AccentResolver.resolve(project, variant)
+            val applied = AccentApplicator.applyFromHexString(targetHex)
+            if (applied) {
+                ProjectAccentSwapService.getInstance().notifyExternalApply(targetHex)
+            } else {
+                LOG.warn("Pin toggle: applyFromHexString rejected hex=$targetHex; rolling back")
+                restorePin(mappings, key, previousPin)
             }
         } catch (exception: RuntimeException) {
-            LOG.warn("Pin toggle failed", exception)
+            LOG.warn("Pin toggle failed; rolling back", exception)
+            restorePin(mappings, key, previousPin)
+        }
+    }
+
+    /** Restore [previous] under [key] (or remove the key entry) so the persisted store
+     *  matches the runtime accent after a rejected / thrown apply. */
+    private fun restorePin(
+        mappings: AccentMappingsState,
+        key: String,
+        previous: String?,
+    ) {
+        if (previous == null) {
+            mappings.projectAccents.remove(key)
+        } else {
+            mappings.projectAccents[key] = previous
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipComponent.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipComponent.kt
@@ -5,17 +5,18 @@ import com.intellij.openapi.application.ApplicationActivationListener
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.wm.IdeFrame
-import com.intellij.ui.ColorUtil
-import com.intellij.ui.JBColor
 import com.intellij.util.messages.MessageBusConnection
-import com.intellij.util.ui.ColorIcon
 import com.intellij.util.ui.JBUI
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentChangeListener
 import dev.ayuislands.accent.AccentChangedTopic
+import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.toolbar.actions.QuickSwitcherActionGroup
+import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.settings.mappings.AccentMappingsSettings
+import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 import java.awt.Dimension
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
@@ -75,7 +76,12 @@ internal class QuickSwitcherChipComponent : JLabel() {
     init {
         val box = JBUI.scale(CHIP_BOX_PX)
         preferredSize = Dimension(box, box)
-        icon = ColorIcon(JBUI.scale(CHIP_BOX_PX), JBColor.GRAY, true)
+        // Idle (pre-resolve) icon: a neutral grey layered island so the chip
+        // has a real silhouette before the first `refreshFromFocusedProject`
+        // call replaces it with the project's accent. Using the layered icon
+        // for the idle state too means the chip never flashes a different
+        // visual shape between construction and the first refresh.
+        icon = LayeredAccentIcon(JBUI.scale(CHIP_BOX_PX), AccentHex.unsafeOf(IDLE_ACCENT_HEX), pinned = false)
         toolTipText = ""
         addMouseListener(
             object : MouseAdapter() {
@@ -83,12 +89,84 @@ internal class QuickSwitcherChipComponent : JLabel() {
                     if (!AyuVariant.isAyuActive()) return
                     when {
                         SwingUtilities.isRightMouseButton(event) -> showContextMenu(event.x, event.y)
-                        SwingUtilities.isLeftMouseButton(event) ->
-                            QuickSwitcherPopup.show(this@QuickSwitcherChipComponent, this@QuickSwitcherChipComponent)
+                        SwingUtilities.isLeftMouseButton(event) -> handleLeftClick(event.x, event.y)
                     }
                 }
             },
         )
+    }
+
+    /**
+     * Inner-island click → pin toggle (premium-gated via Pattern J); outer
+     * region click → open the existing popup.
+     *
+     * Hit-test uses [LayeredAccentIcon.isInsideInnerSquare] against the
+     * chip's actual pixel size so the differentiator matches what the user
+     * sees rendered. Pattern J gate (`AyuVariant.isAyuActive() &&
+     * LicenseChecker.isLicensedOrGrace()`) gates the pin toggle ONLY —
+     * popup open stays free.
+     */
+    private fun handleLeftClick(
+        x: Int,
+        y: Int,
+    ) {
+        val size = JBUI.scale(CHIP_BOX_PX)
+        val onInner = LayeredAccentIcon.isInsideInnerSquare(x, y, size)
+        if (onInner && LicenseChecker.isLicensedOrGrace()) {
+            togglePin()
+            return
+        }
+        QuickSwitcherPopup.show(this, this)
+    }
+
+    /**
+     * Inner-island action: if a per-project pin is active, remove it (chip
+     * falls back to global accent on next resolve); if no pin, write the
+     * current accent as the pin. Mirrors [dev.ayuislands.accent.toolbar.actions.PinAccentAction]
+     * for the write path so behaviour stays consistent across the popup
+     * quick-action row, the right-click context menu, and the chip's
+     * inner-island click.
+     *
+     * Pattern B catches transient [RuntimeException] from the resolver,
+     * apply, or notify paths so the chip mouse handler stays responsive
+     * for the next attempt.
+     */
+    private fun togglePin() {
+        val variant = AyuVariant.detect() ?: return
+        val project = AccentApplicator.resolveFocusedProject() ?: return
+        val key =
+            AccentResolver.projectKey(project) ?: run {
+                LOG.warn("Pin toggle: projectKey null for ${project.name}")
+                return
+            }
+        try {
+            val mappings = AccentMappingsSettings.getInstance().state
+            val source = AccentResolver.source(project)
+            if (source == AccentResolver.Source.PROJECT_OVERRIDE) {
+                // Unpin path: drop the override; resolver will return the
+                // language pin (if any) or the global accent next refresh.
+                mappings.projectAccents.remove(key)
+                val globalHex = AccentResolver.resolve(project, variant)
+                val applied = AccentApplicator.applyFromHexString(globalHex)
+                if (applied) {
+                    ProjectAccentSwapService.getInstance().notifyExternalApply(globalHex)
+                } else {
+                    LOG.warn("Pin toggle (unpin): applyFromHexString rejected hex=$globalHex")
+                }
+            } else {
+                // Pin path: write current resolved accent as the project pin.
+                val currentHex = AccentResolver.resolve(project, variant)
+                mappings.projectAccents[key] = currentHex
+                val applied = AccentApplicator.applyFromHexString(currentHex)
+                if (applied) {
+                    ProjectAccentSwapService.getInstance().notifyExternalApply(currentHex)
+                } else {
+                    LOG.warn("Pin toggle (pin): applyFromHexString rejected hex=$currentHex")
+                }
+            }
+        } catch (exception: RuntimeException) {
+            LOG.warn("Pin toggle failed", exception)
+        }
     }
 
     /**
@@ -125,7 +203,7 @@ internal class QuickSwitcherChipComponent : JLabel() {
             object : AccentChangeListener {
                 override fun accentChanged(
                     project: com.intellij.openapi.project.Project,
-                    hex: dev.ayuislands.accent.AccentHex,
+                    hex: AccentHex,
                     source: AccentResolver.Source,
                 ) {
                     SwingUtilities.invokeLater { refreshFromFocusedProject() }
@@ -194,19 +272,28 @@ internal class QuickSwitcherChipComponent : JLabel() {
                 LOG.warn("QuickSwitcher chip resolve failed", exception)
                 return
             }
-        val color = ColorUtil.fromHex(hex)
-        icon = ColorIcon(JBUI.scale(CHIP_BOX_PX), color, true)
         val source = AccentResolver.source(project)
+        val pinned = source == AccentResolver.Source.PROJECT_OVERRIDE
+        // [AccentResolver.resolve] returns a validated `#RRGGBB` (resolver
+        // produces either a stored override or `AyuIslandsSettings.getAccentForVariant`,
+        // both of which are validated upstream), so `unsafeOf` is safe here.
+        icon = LayeredAccentIcon(JBUI.scale(CHIP_BOX_PX), AccentHex.unsafeOf(hex), pinned = pinned)
         toolTipText = "$hex — ${AccentResolver.sourceLabel(source)}"
         repaint()
     }
 
     companion object {
-        // Final chip dimensions: a 13 × 13 JBUI-scaled cell whose ColorIcon
+        // Final chip dimensions: a 13 × 13 JBUI-scaled cell whose icon
         // fills the full bounds (no inner-disc inset). 13 px matches the
         // visual size of neighbouring MainToolbar icons (Add, Search,
         // overflow); larger values (14–16 px) read as oversized against them.
         internal const val CHIP_BOX_PX = 13
+
+        // Idle accent for the pre-resolve placeholder icon. Mirage gold —
+        // chosen for visibility against any LAF; first `refreshFromFocusedProject`
+        // call (in `addNotify` or via an activation event) replaces it with
+        // the resolved per-project accent within milliseconds of attach.
+        internal const val IDLE_ACCENT_HEX = "#FFB454"
 
         // Action place ID for the right-click context menu.
         private const val CONTEXT_MENU_PLACE = "AyuQuickSwitcher.ContextMenu"

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/LayeredAccentIconTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/LayeredAccentIconTest.kt
@@ -1,0 +1,134 @@
+package dev.ayuislands.accent.toolbar
+
+import com.intellij.ui.ColorUtil
+import dev.ayuislands.accent.AccentHex
+import dev.ayuislands.accent.color.AccentHsl
+import java.awt.Color
+import java.awt.image.BufferedImage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * Locks the [LayeredAccentIcon] paint + geometry contract:
+ *
+ *  - Outer-ring tint matches the accent hex (every chip-level test asserts
+ *    this colour so a regression bleeds across the suite).
+ *  - Inner-square paint differs by `pinned` flag — filled with
+ *    `AccentHsl.darken(accent)` when pinned, outlined in the outer-ring
+ *    colour when unpinned.
+ *  - Geometry helper `isInsideInnerSquare` matches the actual inner-
+ *    square paint bounds — the chip's `mousePressed` differentiator
+ *    must agree with what the user sees.
+ *
+ * Pattern I seam: `paintForTest(g2)` lets tests rasterize into a
+ * `BufferedImage` without booting an IDE.
+ */
+class LayeredAccentIconTest {
+    @Test
+    fun `accentColor exposes the constructor hex as a java awt Color`() {
+        val icon = LayeredAccentIcon(SIZE_PX, AccentHex.unsafeOf("#FFB454"), pinned = true)
+        assertEquals(Color(0xFF, 0xB4, 0x54), icon.accentColor)
+    }
+
+    @Test
+    fun `isPinned mirrors the constructor flag`() {
+        val pinnedIcon = LayeredAccentIcon(SIZE_PX, AccentHex.unsafeOf("#FFB454"), pinned = true)
+        val unpinnedIcon = LayeredAccentIcon(SIZE_PX, AccentHex.unsafeOf("#FFB454"), pinned = false)
+        assertTrue(pinnedIcon.isPinned)
+        assertFalse(unpinnedIcon.isPinned)
+    }
+
+    @Test
+    fun `iconWidth and iconHeight equal the constructor sizePx`() {
+        val icon = LayeredAccentIcon(SIZE_PX, AccentHex.unsafeOf("#FFB454"), pinned = false)
+        assertEquals(SIZE_PX, icon.iconWidth)
+        assertEquals(SIZE_PX, icon.iconHeight)
+    }
+
+    @Test
+    fun `outer ring paints the accent colour at the outer-ring band`() {
+        val icon = LayeredAccentIcon(SIZE_PX, AccentHex.unsafeOf("#FFB454"), pinned = true)
+        val image = paint(icon)
+
+        // Sample a point inside the outer ring (just below the outer edge):
+        // outer ring spans roughly inset=8.3% → middle=16.7%, so the band
+        // center sits at ~12.5% of side length. At 64px that's pixel ≈ 8.
+        val sampleX = (SIZE_PX * 0.125f).toInt()
+        val sampleY = SIZE_PX / 2
+        val sampled = Color(image.getRGB(sampleX, sampleY), true)
+        assertEquals(Color(0xFF, 0xB4, 0x54), sampled, "Outer ring must paint the accent verbatim")
+    }
+
+    @Test
+    fun `inner square is filled with darkened accent when pinned`() {
+        val accent = AccentHex.unsafeOf("#FFB454")
+        val icon = LayeredAccentIcon(SIZE_PX, accent, pinned = true)
+        val image = paint(icon)
+
+        val sampled = Color(image.getRGB(SIZE_PX / 2, SIZE_PX / 2), true)
+        val expected = ColorUtil.fromHex(AccentHsl.darken(accent).value)
+        assertEquals(expected, sampled, "Pinned inner island must paint AccentHsl.darken(accent)")
+    }
+
+    @Test
+    fun `inner square is hollow (transparent centre) when not pinned`() {
+        val icon = LayeredAccentIcon(SIZE_PX, AccentHex.unsafeOf("#FFB454"), pinned = false)
+        val image = paint(icon)
+
+        // Centre pixel must be transparent (alpha = 0) for the hollow state —
+        // only the inner-square outline is painted, not the fill.
+        val centre = Color(image.getRGB(SIZE_PX / 2, SIZE_PX / 2), true)
+        assertEquals(0, centre.alpha, "Unpinned inner square must have a transparent centre (outline only)")
+    }
+
+    @Test
+    fun `inner square outline paints the accent colour at the inner-square edge when unpinned`() {
+        val accent = AccentHex.unsafeOf("#FFB454")
+        val icon = LayeredAccentIcon(SIZE_PX, accent, pinned = false)
+        val image = paint(icon)
+
+        // The inner-square outline sits on the boundary at INNER_INSET_RATIO
+        // from the chip edge. At 64px that's pixel 16. Sample slightly inside
+        // the boundary so the anti-aliased stroke is fully opaque.
+        val edge = (SIZE_PX * LayeredAccentIcon.INNER_INSET_RATIO + 1).toInt()
+        val sampled = Color(image.getRGB(edge, SIZE_PX / 2), true)
+        // Outline colour matches the outer ring (accent), not the darkened inner.
+        assertNotEquals(0, sampled.alpha, "Unpinned outline must be opaque at the inner-square edge")
+        assertEquals(accent.value, "#%02X%02X%02X".format(sampled.red, sampled.green, sampled.blue))
+    }
+
+    @Test
+    fun `isInsideInnerSquare returns true for the centre and false for the outer ring`() {
+        val size = SIZE_PX
+        // Centre is inside.
+        assertTrue(LayeredAccentIcon.isInsideInnerSquare(size / 2, size / 2, size))
+        // Edge of the chip is outside.
+        assertFalse(LayeredAccentIcon.isInsideInnerSquare(0, 0, size))
+        assertFalse(LayeredAccentIcon.isInsideInnerSquare(size - 1, size - 1, size))
+        // Just outside the inner-square boundary (within outer ring) is also outside.
+        val outsideInner = (size * LayeredAccentIcon.INNER_INSET_RATIO - 1).toInt()
+        assertFalse(LayeredAccentIcon.isInsideInnerSquare(outsideInner, outsideInner, size))
+    }
+
+    private fun paint(icon: LayeredAccentIcon): BufferedImage {
+        val image = BufferedImage(SIZE_PX, SIZE_PX, BufferedImage.TYPE_INT_ARGB)
+        val g2 = image.createGraphics()
+        try {
+            icon.paintForTest(g2)
+        } finally {
+            g2.dispose()
+        }
+        return image
+    }
+
+    private companion object {
+        // 64px is large enough that anti-aliased rounding doesn't blur the
+        // sampled pixels into background colour, yet small enough that test
+        // execution is instant. Production chip is 13px; geometry is ratio-
+        // based so any size renders the same shape.
+        const val SIZE_PX: Int = 64
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/LayeredAccentIconTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/LayeredAccentIconTest.kt
@@ -3,10 +3,15 @@ package dev.ayuislands.accent.toolbar
 import com.intellij.ui.ColorUtil
 import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.color.AccentHsl
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
 import java.awt.Color
 import java.awt.image.BufferedImage
+import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
@@ -27,6 +32,11 @@ import kotlin.test.assertTrue
  * `BufferedImage` without booting an IDE.
  */
 class LayeredAccentIconTest {
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
     @Test
     fun `accentColor exposes the constructor hex as a java awt Color`() {
         val icon = LayeredAccentIcon(SIZE_PX, AccentHex.unsafeOf("#FFB454"), pinned = true)
@@ -98,6 +108,53 @@ class LayeredAccentIconTest {
         // Outline colour matches the outer ring (accent), not the darkened inner.
         assertNotEquals(0, sampled.alpha, "Unpinned outline must be opaque at the inner-square edge")
         assertEquals(accent.value, "#%02X%02X%02X".format(sampled.red, sampled.green, sampled.blue))
+    }
+
+    @Test
+    fun `pinned inner colour falls back to lighten when darken is a no-op (algorithmic floor)`() {
+        // Algorithmic-floor coverage for the `darken` clamp-edge fallback to
+        // `lighten` at `LayeredAccentIcon.kt:59-66`. `AccentHsl.darken` is a
+        // no-op when the input lightness is already at `MIN_LIGHTNESS` (the
+        // coerce-in clamp folds the step back to the input). Without the
+        // fallback, the inner island would render the same colour as the
+        // outer ring and the pinned-vs-unpinned distinction would collapse.
+        //
+        // Mocks `AccentHsl` to force the no-op branch deterministically —
+        // avoids brittleness around which specific hex sits exactly on the
+        // 0.10 lightness clamp in HSL float arithmetic.
+        val accent = AccentHex.unsafeOf("#FFB454")
+        val lighter = AccentHex.unsafeOf("#FFCC99")
+        mockkObject(AccentHsl)
+        every { AccentHsl.darken(accent) } returns accent
+        every { AccentHsl.lighten(accent) } returns lighter
+
+        val icon = LayeredAccentIcon(SIZE_PX, accent, pinned = true)
+        val image = paint(icon)
+        val centre = Color(image.getRGB(SIZE_PX / 2, SIZE_PX / 2), true)
+        assertNotEquals(
+            icon.accentColor,
+            centre,
+            "Pinned inner must fall back to `lighten` when `darken` is a no-op at the clamp edge — " +
+                "regression would silently render an indistinguishable inner island for dark accents",
+        )
+        // Tighter assertion: the centre pixel must match the lighten-fallback colour.
+        assertEquals(ColorUtil.fromHex(lighter.value), centre)
+    }
+
+    @Test
+    fun `constructor rejects non-positive sizePx with IllegalArgumentException`() {
+        // Algorithmic-floor coverage for the `require(sizePx > 0)` precondition
+        // at `LayeredAccentIcon.kt:51`. Per CLAUDE.md "validation guards need
+        // direct red/green tests even when no user can trigger them" — JBUI.scale
+        // never returns ≤ 0 today, but the guard exists to catch a future
+        // refactor that lets a zero-or-negative size leak through and silently
+        // paint a zero-area icon.
+        assertFailsWith<IllegalArgumentException> {
+            LayeredAccentIcon(0, AccentHex.unsafeOf("#FFB454"), pinned = false)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            LayeredAccentIcon(-1, AccentHex.unsafeOf("#FFB454"), pinned = false)
+        }
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/LayeredAccentIconTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/LayeredAccentIconTest.kt
@@ -19,7 +19,7 @@ import kotlin.test.assertTrue
  *  - Inner-square paint differs by `pinned` flag — filled with
  *    `AccentHsl.darken(accent)` when pinned, outlined in the outer-ring
  *    colour when unpinned.
- *  - Geometry helper `isInsideInnerSquare` matches the actual inner-
+ *  - Geometry helper `isInsideInnerIslandHitBox` matches the actual inner-
  *    square paint bounds — the chip's `mousePressed` differentiator
  *    must agree with what the user sees.
  *
@@ -101,16 +101,16 @@ class LayeredAccentIconTest {
     }
 
     @Test
-    fun `isInsideInnerSquare returns true for the centre and false for the outer ring`() {
+    fun `isInsideInnerIslandHitBox returns true for the centre and false for the outer ring`() {
         val size = SIZE_PX
         // Centre is inside.
-        assertTrue(LayeredAccentIcon.isInsideInnerSquare(size / 2, size / 2, size))
+        assertTrue(LayeredAccentIcon.isInsideInnerIslandHitBox(size / 2, size / 2, size))
         // Edge of the chip is outside.
-        assertFalse(LayeredAccentIcon.isInsideInnerSquare(0, 0, size))
-        assertFalse(LayeredAccentIcon.isInsideInnerSquare(size - 1, size - 1, size))
+        assertFalse(LayeredAccentIcon.isInsideInnerIslandHitBox(0, 0, size))
+        assertFalse(LayeredAccentIcon.isInsideInnerIslandHitBox(size - 1, size - 1, size))
         // Just outside the inner-square boundary (within outer ring) is also outside.
         val outsideInner = (size * LayeredAccentIcon.INNER_INSET_RATIO - 1).toInt()
-        assertFalse(LayeredAccentIcon.isInsideInnerSquare(outsideInner, outsideInner, size))
+        assertFalse(LayeredAccentIcon.isInsideInnerIslandHitBox(outsideInner, outsideInner, size))
     }
 
     private fun paint(icon: LayeredAccentIcon): BufferedImage {

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipComponentTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipComponentTest.kt
@@ -7,7 +7,6 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.util.messages.MessageBus
 import com.intellij.util.messages.MessageBusConnection
-import com.intellij.util.ui.ColorIcon
 import com.intellij.util.ui.JBUI
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentChangedTopic
@@ -72,34 +71,64 @@ class QuickSwitcherChipComponentTest {
     }
 
     @Test
-    fun `initial icon is a ColorIcon`() {
+    fun `initial icon is a LayeredAccentIcon (idle placeholder, unpinned)`() {
         stubAyuActive(true)
         val chip = QuickSwitcherChipComponent()
-        assertTrue(chip.icon is ColorIcon, "Initial icon must be a ColorIcon; got ${chip.icon?.javaClass}")
+        val icon = chip.icon
+        assertTrue(icon is LayeredAccentIcon, "Initial icon must be a LayeredAccentIcon; got ${icon?.javaClass}")
+        // Smart-cast carries `icon` as `LayeredAccentIcon` through the next
+        // assertion — no explicit cast needed.
+        assertFalse(
+            icon.isPinned,
+            "Pre-resolve placeholder must render as unpinned (hollow inner)",
+        )
     }
 
     @Test
-    fun `refreshFromFocusedProject updates icon color and tooltip`() {
+    fun `refreshFromFocusedProject updates icon color and tooltip (GLOBAL = unpinned)`() {
         stubAyuActive(true)
         stubResolver(hex = "#FFCC66", source = AccentResolver.Source.GLOBAL)
 
         val chip = QuickSwitcherChipComponent()
         chip.refreshFromFocusedProject()
 
-        val icon = chip.icon as ColorIcon
-        assertEquals(Color(0xFF, 0xCC, 0x66), icon.iconColor)
+        val icon = chip.icon as LayeredAccentIcon
+        assertEquals(Color(0xFF, 0xCC, 0x66), icon.accentColor)
+        assertFalse(icon.isPinned, "GLOBAL source must render the inner island as hollow (unpinned)")
         assertEquals("#FFCC66 — Global", chip.toolTipText)
     }
 
     @Test
-    fun `refreshFromFocusedProject surfaces tooltip source label for project override`() {
+    fun `refreshFromFocusedProject renders PROJECT_OVERRIDE as a pinned LayeredAccentIcon`() {
         stubAyuActive(true)
         stubResolver(hex = "#5CCFE6", source = AccentResolver.Source.PROJECT_OVERRIDE)
 
         val chip = QuickSwitcherChipComponent()
         chip.refreshFromFocusedProject()
 
+        val icon = chip.icon as LayeredAccentIcon
+        assertTrue(
+            icon.isPinned,
+            "PROJECT_OVERRIDE source must render the inner island as filled (pinned)",
+        )
         assertEquals("#5CCFE6 — Project override", chip.toolTipText)
+    }
+
+    @Test
+    fun `refreshFromFocusedProject renders LANGUAGE_OVERRIDE as unpinned LayeredAccentIcon`() {
+        // Language overrides count as "no project pin" — the inner-island
+        // indicator is project-scoped, not language-scoped.
+        stubAyuActive(true)
+        stubResolver(hex = "#73D0FF", source = AccentResolver.Source.LANGUAGE_OVERRIDE)
+
+        val chip = QuickSwitcherChipComponent()
+        chip.refreshFromFocusedProject()
+
+        val icon = chip.icon as LayeredAccentIcon
+        assertFalse(
+            icon.isPinned,
+            "LANGUAGE_OVERRIDE must render the inner island as hollow (no project-specific pin)",
+        )
     }
 
     @Test
@@ -206,8 +235,7 @@ class QuickSwitcherChipComponentTest {
         // addNotify/removeNotify-owned lifecycle). Reflective check so the
         // assertion survives a future Kotlin compiler that hard-errors on
         // "is always false" smart-cast checks.
-        val isDisposable =
-            com.intellij.openapi.Disposable::class.java.isAssignableFrom(chip.javaClass)
+        val isDisposable = Disposable::class.java.isAssignableFrom(chip.javaClass)
         assertFalse(
             isDisposable,
             "Chip must NOT be Disposable — lifecycle is Swing-owned",
@@ -277,8 +305,8 @@ class QuickSwitcherChipComponentTest {
         // `CHIP_SWATCH_PX = 12` inner-disc constant was removed.
         val source = Files.readString(Paths.get(CHIP_SOURCE_PATH))
         assertTrue(
-            source.contains("ColorIcon(JBUI.scale(CHIP_BOX_PX)"),
-            "Chip ColorIcon must size to CHIP_BOX_PX (full cell), not an inner-disc constant",
+            source.contains("LayeredAccentIcon(JBUI.scale(CHIP_BOX_PX)"),
+            "Chip LayeredAccentIcon must size to CHIP_BOX_PX (full cell), not an inner-disc constant",
         )
         assertEquals(
             0,
@@ -299,13 +327,33 @@ class QuickSwitcherChipComponentTest {
     }
 
     @Test
-    fun `chip ColorIcon constructor uses 3-arg border-on form`() {
+    fun `chip uses LayeredAccentIcon with the pinned flag on every construction site`() {
         val source = Files.readString(Paths.get(CHIP_SOURCE_PATH))
-        // Locate every `ColorIcon(` call site; count those whose closing arg is the
-        // boolean `true` (border-on overload).
-        val matches =
-            "ColorIcon\\([^\\n]*?,\\s*true\\)".toRegex().findAll(source).count()
-        assertTrue(matches >= 1, "Expected ≥1 3-arg ColorIcon(..., true) call, got $matches")
+        // Every LayeredAccentIcon(...) construction site in the chip must
+        // pass an explicit `pinned = ...` argument — defends against a
+        // future refactor that forgets the pin flag and silently always
+        // renders the unpinned (hollow) state. Counted as construction
+        // sites (`LayeredAccentIcon(`) and `pinned =` arguments separately
+        // since the constructor's first arg `JBUI.scale(CHIP_BOX_PX)`
+        // contains a `)` that would break a single greedy regex.
+        val constructionCount =
+            "LayeredAccentIcon\\(".toRegex().findAll(source).count()
+        val pinnedArgCount =
+            "pinned\\s*=".toRegex().findAll(source).count()
+        assertTrue(
+            constructionCount >= 2,
+            "Expected ≥2 LayeredAccentIcon(...) call sites (idle init + refresh); got $constructionCount",
+        )
+        assertTrue(
+            pinnedArgCount >= constructionCount,
+            "Every LayeredAccentIcon construction must pass `pinned = …`; " +
+                "found $constructionCount calls but only $pinnedArgCount `pinned =` args",
+        )
+        assertEquals(
+            0,
+            "ColorIcon\\(".toRegex().findAll(source).count(),
+            "Chip must not reference ColorIcon — the layered icon replaces it completely",
+        )
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipFocusSwapTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipFocusSwapTest.kt
@@ -10,7 +10,6 @@ import com.intellij.openapi.wm.IdeFrame
 import com.intellij.util.messages.MessageBus
 import com.intellij.util.messages.MessageBusConnection
 import com.intellij.util.messages.Topic
-import com.intellij.util.ui.ColorIcon
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentChangeListener
 import dev.ayuislands.accent.AccentChangedTopic
@@ -127,10 +126,10 @@ class QuickSwitcherChipFocusSwapTest {
         activation.applicationActivated(frame)
         SwingUtilities.invokeAndWait { /* flush */ }
 
-        val icon = chip.icon as ColorIcon
+        val icon = chip.icon as LayeredAccentIcon
         assertEquals(
             Color(0x5C, 0xCF, 0xE6),
-            icon.iconColor,
+            icon.accentColor,
             "Chip must reflect projectB's accent after second activation",
         )
     }
@@ -156,8 +155,8 @@ class QuickSwitcherChipFocusSwapTest {
         // Handler wraps in SwingUtilities.invokeLater; flush.
         SwingUtilities.invokeAndWait { /* flush */ }
 
-        val icon = chip.icon as ColorIcon
-        assertEquals(Color(0xDF, 0xBF, 0xFF), icon.iconColor)
+        val icon = chip.icon as LayeredAccentIcon
+        assertEquals(Color(0xDF, 0xBF, 0xFF), icon.accentColor)
         assertTrue(
             chip.toolTipText.contains("#DFBFFF"),
             "Tooltip must reflect the post-publish hex; got '${chip.toolTipText}'",

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipPinToggleTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipPinToggleTest.kt
@@ -35,13 +35,15 @@ import kotlin.test.assertTrue
  * visually (filled inner = pinned, hollow = no pin).
  *
  * Covers:
- *  - **Pin** (no pin → click inner-square): writes
- *    `AccentMappingsState.projectAccents[key] = currentHex`, calls
+ *  - **Pin** (no pin → click inner-square): writes the project's hex
+ *    into `AccentMappingsState.projectAccents` under the
+ *    `AccentResolver.projectKey` entry, calls
  *    `AccentApplicator.applyFromHexString(hex)`, and (Pattern D)
  *    publishes via `ProjectAccentSwapService.notifyExternalApply`.
  *  - **Unpin** (pin active → click inner-square): removes the
- *    `projectAccents[key]` entry, re-applies the resolved global,
- *    publishes the global hex via `notifyExternalApply`.
+ *    `projectAccents` entry under the same key, re-applies the
+ *    resolved global, publishes the global hex via
+ *    `notifyExternalApply`.
  *  - **Outer-region click** (no pin or pin): existing popup-open path
  *    survives; no pin mutation.
  *  - **Pattern J gate**: `LicenseChecker.isLicensedOrGrace() = false`

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipPinToggleTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipPinToggleTest.kt
@@ -172,6 +172,84 @@ class QuickSwitcherChipPinToggleTest {
         assertTrue(state.projectAccents.isEmpty(), "Invalid licence must not write projectAccents")
     }
 
+    @Test
+    fun `pin path rolls back projectAccents when applyFromHexString returns false`() {
+        // Pin from unpinned + apply rejects (e.g. corrupted upstream
+        // settings produce an invalid hex). The pin write must NOT persist
+        // ahead of runtime state — restore the pre-toggle map and skip the
+        // notify so the persisted store stays consistent with what the
+        // accent applicator actually applied.
+        every { AccentResolver.source(mockProject) } returns AccentResolver.Source.GLOBAL
+        every { AccentApplicator.applyFromHexString(any()) } returns false
+
+        val chip = QuickSwitcherChipComponent()
+        chip.dispatchEvent(innerClick(chip))
+
+        assertTrue(
+            state.projectAccents.isEmpty(),
+            "Pin path rejection must roll back the projectAccents write (pre-state had no pin)",
+        )
+        verify(exactly = 0) { mockSwap.notifyExternalApply(any()) }
+    }
+
+    @Test
+    fun `unpin path rolls back projectAccents when applyFromHexString returns false`() {
+        // Unpin + apply rejects. The pin must be RESTORED (not just left
+        // removed) so the next focus refresh re-resolves through the same
+        // override the user thought they were unpinning.
+        state.projectAccents[PROJECT_KEY] = "#FFB454"
+        every { AccentResolver.source(mockProject) } returns AccentResolver.Source.PROJECT_OVERRIDE
+        every { AccentResolver.resolve(any(), any()) } returns "#73D0FF"
+        every { AccentApplicator.applyFromHexString(any()) } returns false
+
+        val chip = QuickSwitcherChipComponent()
+        chip.dispatchEvent(innerClick(chip))
+
+        assertEquals(
+            "#FFB454",
+            state.projectAccents[PROJECT_KEY],
+            "Unpin path rejection must restore the pre-toggle pin hex under the project key",
+        )
+        verify(exactly = 0) { mockSwap.notifyExternalApply(any()) }
+    }
+
+    @Test
+    fun `pin toggle swallows RuntimeException from applyFromHexString and rolls back (Pattern B)`() {
+        // Pattern B parity with sibling chip handlers (refresh, openAyuSettings,
+        // applyPreset, openCustomColorPicker). A throw from the apply
+        // chain MUST NOT propagate out of the click handler AND the pin
+        // write must NOT persist past the failure.
+        every { AccentResolver.source(mockProject) } returns AccentResolver.Source.GLOBAL
+        every { AccentApplicator.applyFromHexString(any()) } throws RuntimeException("transient mid-LAF-swap")
+
+        val chip = QuickSwitcherChipComponent()
+        // Must NOT throw out of the click.
+        chip.dispatchEvent(innerClick(chip))
+
+        assertTrue(
+            state.projectAccents.isEmpty(),
+            "RuntimeException from apply must roll back the projectAccents write",
+        )
+        verify(exactly = 0) { mockSwap.notifyExternalApply(any()) }
+    }
+
+    @Test
+    fun `inner click with null projectKey is a NO-OP (no pin mutation, no apply)`() {
+        // Defensive early-return when `AccentResolver.projectKey` returns
+        // null (race with project dispose, basePath read failure). The
+        // chip must not crash and must not write a stale pin under a
+        // null/empty key.
+        every { AccentResolver.projectKey(any()) } returns null
+        every { AccentResolver.source(mockProject) } returns AccentResolver.Source.GLOBAL
+
+        val chip = QuickSwitcherChipComponent()
+        chip.dispatchEvent(innerClick(chip))
+
+        verify(exactly = 0) { AccentApplicator.applyFromHexString(any()) }
+        verify(exactly = 0) { mockSwap.notifyExternalApply(any()) }
+        assertTrue(state.projectAccents.isEmpty(), "projectKey null must skip projectAccents write entirely")
+    }
+
     private fun innerClick(source: JComponent): MouseEvent {
         // Centre pixel of the chip is always inside the inner-square bounds.
         val centre = JBUI.scale(QuickSwitcherChipComponent.CHIP_BOX_PX) / 2

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipPinToggleTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipPinToggleTest.kt
@@ -1,0 +1,190 @@
+package dev.ayuislands.accent.toolbar
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.Project
+import com.intellij.util.messages.MessageBus
+import com.intellij.util.messages.MessageBusConnection
+import com.intellij.util.ui.JBUI
+import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentResolver
+import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.settings.mappings.AccentMappingsSettings
+import dev.ayuislands.settings.mappings.AccentMappingsState
+import dev.ayuislands.settings.mappings.ProjectAccentSwapService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import java.awt.event.MouseEvent
+import javax.swing.JComponent
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Locks the chip's inner-island pin-toggle wiring — the new
+ * one-click pin/unpin affordance that the layered icon advertises
+ * visually (filled inner = pinned, hollow = no pin).
+ *
+ * Covers:
+ *  - **Pin** (no pin → click inner-square): writes
+ *    `AccentMappingsState.projectAccents[key] = currentHex`, calls
+ *    `AccentApplicator.applyFromHexString(hex)`, and (Pattern D)
+ *    publishes via `ProjectAccentSwapService.notifyExternalApply`.
+ *  - **Unpin** (pin active → click inner-square): removes the
+ *    `projectAccents[key]` entry, re-applies the resolved global,
+ *    publishes the global hex via `notifyExternalApply`.
+ *  - **Outer-region click** (no pin or pin): existing popup-open path
+ *    survives; no pin mutation.
+ *  - **Pattern J gate**: `LicenseChecker.isLicensedOrGrace() = false`
+ *    → inner-square click is a no-op (popup still opens for clicks
+ *    outside, but no inner-island toggle fires).
+ *
+ * Mirrors the existing `PinAccentActionTest` mock harness so the
+ * write contract stays consistent across the popup quick-action row,
+ * the right-click context menu, and now the chip's inner click.
+ */
+class QuickSwitcherChipPinToggleTest {
+    private val mockApp = mockk<Application>(relaxed = true)
+    private val mockBus = mockk<MessageBus>(relaxed = true)
+    private val mockConnection = mockk<MessageBusConnection>(relaxed = true)
+    private val mockSettings = mockk<AccentMappingsSettings>(relaxed = true)
+    private val state = AccentMappingsState()
+    private val mockSwap = mockk<ProjectAccentSwapService>(relaxed = true)
+    private val mockProject =
+        mockk<Project> {
+            every { name } returns "test-project"
+            every { isDefault } returns false
+            every { isDisposed } returns false
+        }
+
+    @BeforeTest
+    fun setUp() {
+        mockkStatic(ApplicationManager::class)
+        every { ApplicationManager.getApplication() } returns mockApp
+        every { mockApp.messageBus } returns mockBus
+        every { mockBus.connect(any<Disposable>()) } returns mockConnection
+        every { mockApp.getService(ProjectAccentSwapService::class.java) } returns mockSwap
+
+        mockkObject(AyuVariant.Companion)
+        every { AyuVariant.isAyuActive() } returns true
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+
+        mockkObject(LicenseChecker)
+        every { LicenseChecker.isLicensedOrGrace() } returns true
+
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.resolveFocusedProject() } returns mockProject
+        every { AccentApplicator.applyFromHexString(any()) } returns true
+
+        mockkObject(AccentResolver)
+        every { AccentResolver.resolve(any(), any()) } returns "#FFB454"
+        every { AccentResolver.source(any()) } returns AccentResolver.Source.GLOBAL
+        every { AccentResolver.sourceLabel(any()) } returns "Global"
+        every { AccentResolver.projectKey(any()) } returns PROJECT_KEY
+
+        mockkObject(AccentMappingsSettings.Companion)
+        every { AccentMappingsSettings.getInstance() } returns mockSettings
+        every { mockSettings.state } returns state
+
+        mockkObject(QuickSwitcherPopup)
+        every { QuickSwitcherPopup.show(any(), any()) } returns Unit
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `inner-square click WITHOUT existing pin writes projectAccents and applies (Pattern D)`() {
+        // GLOBAL source means no project pin — the inner click is the "Pin" path.
+        every { AccentResolver.source(mockProject) } returns AccentResolver.Source.GLOBAL
+
+        val chip = QuickSwitcherChipComponent()
+        chip.dispatchEvent(innerClick(chip))
+
+        assertEquals(
+            "#FFB454",
+            state.projectAccents[PROJECT_KEY],
+            "Pin path must write currentHex to projectAccents under the project key",
+        )
+        verify(exactly = 1) { AccentApplicator.applyFromHexString("#FFB454") }
+        verify(exactly = 1) { mockSwap.notifyExternalApply("#FFB454") }
+        verify(exactly = 0) { QuickSwitcherPopup.show(any(), any()) }
+    }
+
+    @Test
+    fun `inner-square click WITH existing pin removes projectAccents and re-applies global`() {
+        // Seed an existing pin then flip the resolver source so the chip
+        // sees `PROJECT_OVERRIDE`. After unpin the resolver returns the
+        // global hex on the SAME `resolve(...)` call — that's what the
+        // chip re-applies.
+        state.projectAccents[PROJECT_KEY] = "#FFB454"
+        every { AccentResolver.source(mockProject) } returns AccentResolver.Source.PROJECT_OVERRIDE
+        every { AccentResolver.resolve(any(), any()) } returns "#73D0FF"
+
+        val chip = QuickSwitcherChipComponent()
+        chip.dispatchEvent(innerClick(chip))
+
+        assertFalse(
+            state.projectAccents.containsKey(PROJECT_KEY),
+            "Unpin path must remove the project key from projectAccents",
+        )
+        verify(exactly = 1) { AccentApplicator.applyFromHexString("#73D0FF") }
+        verify(exactly = 1) { mockSwap.notifyExternalApply("#73D0FF") }
+        verify(exactly = 0) { QuickSwitcherPopup.show(any(), any()) }
+    }
+
+    @Test
+    fun `outer-region click opens the popup and does NOT mutate projectAccents (no pin start)`() {
+        every { AccentResolver.source(mockProject) } returns AccentResolver.Source.GLOBAL
+
+        val chip = QuickSwitcherChipComponent()
+        chip.dispatchEvent(outerClick(chip))
+
+        verify(exactly = 1) { QuickSwitcherPopup.show(chip, chip) }
+        verify(exactly = 0) { AccentApplicator.applyFromHexString(any()) }
+        assertTrue(state.projectAccents.isEmpty(), "Outer click must not write to projectAccents")
+    }
+
+    @Test
+    fun `Pattern J gate — inner click with invalid licence is a NO-OP (no pin mutation)`() {
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+        every { AccentResolver.source(mockProject) } returns AccentResolver.Source.GLOBAL
+
+        val chip = QuickSwitcherChipComponent()
+        chip.dispatchEvent(innerClick(chip))
+
+        // Inner click with invalid licence falls through to the popup-open
+        // path so the chip never "swallows" clicks silently — the popup
+        // itself has the full Pattern J gating for premium actions.
+        verify(exactly = 1) { QuickSwitcherPopup.show(chip, chip) }
+        verify(exactly = 0) { AccentApplicator.applyFromHexString(any()) }
+        assertTrue(state.projectAccents.isEmpty(), "Invalid licence must not write projectAccents")
+    }
+
+    private fun innerClick(source: JComponent): MouseEvent {
+        // Centre pixel of the chip is always inside the inner-square bounds.
+        val centre = JBUI.scale(QuickSwitcherChipComponent.CHIP_BOX_PX) / 2
+        return MouseEvent(source, MouseEvent.MOUSE_PRESSED, 0L, 0, centre, centre, 1, false, MouseEvent.BUTTON1)
+    }
+
+    private fun outerClick(source: JComponent): MouseEvent {
+        // Corner pixel (0, 0) is outside the inner-square bounds for any
+        // INNER_INSET_RATIO > 0, so this reliably hits the outer-ring region.
+        return MouseEvent(source, MouseEvent.MOUSE_PRESSED, 0L, 0, 0, 0, 1, false, MouseEvent.BUTTON1)
+    }
+
+    private companion object {
+        const val PROJECT_KEY: String = "/path/to/project"
+    }
+}


### PR DESCRIPTION
## Summary

User flagged the existing 13×13 solid disc chip as "ріже око дещо запроста" and asked to (a) replace it with a layered squircle matching `~/Downloads/rounded-square-layered-icon.svg`, and (b) make the inner island do something useful so the chip earns its toolbar spot. This PR does both: layered geometry + one-click pin/unpin on the inner-island hit area.

## Changes

| Type | File | What |
|---|---|---|
| Feat | `src/main/kotlin/dev/ayuislands/accent/toolbar/LayeredAccentIcon.kt` (new) | Custom `Icon` — three nested squircles via `Path2D`, outer ring filled with accent + inner squircle filled (pinned) / outlined (not pinned). Mirrors SVG control-offset ratio `0.304 × side`. |
| Feat | `src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipComponent.kt` | `ColorIcon → LayeredAccentIcon`; `handleLeftClick` splits LMB on inner hit-test: inside → `togglePin` (Pattern J via `LicenseChecker.isLicensedOrGrace`); outside → existing popup. `togglePin` mirrors `PinAccentAction` write path. |
| Test | `src/test/kotlin/dev/ayuislands/accent/toolbar/LayeredAccentIconTest.kt` (new) | 7 tests: accentColor getter, isPinned getter, dimensions, outer-ring tint pixel sample, pinned inner tint (`AccentHsl.darken`), unpinned inner transparent centre, unpinned outline edge sample, isInsideInnerSquare boundary. |
| Test | `src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipPinToggleTest.kt` (new) | 4 tests for the new inner-click contract: pin from unpinned, unpin from pinned, outer-click still opens popup, Pattern J no-licence falls through. |
| Test | `src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipComponentTest.kt` | Cast `ColorIcon → LayeredAccentIcon`; new `LANGUAGE_OVERRIDE` test (inner indicator is project-scoped); source-grep tests defend against losing `pinned` flag or re-introducing `ColorIcon`. |
| Test | `src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipFocusSwapTest.kt` | Same cast updates. |
| Docs | `docs/features.yml` | Pattern H restamp — 5 orphaned `last_verified_sha` entries advanced to HEAD. |

## Validation

- [x] `./gradlew detekt ktlintCheck test` GREEN locally
- [x] `/deploy-to-ide` verified in IntelliJ IDEA 2026.1 — squircle shape renders matching SVG; pin toggle works (filled → click → hollow → click → filled)
- [x] User-confirmed visual: "працює, кайф"

## Notes

- The inner-island indicator is project-scoped — `LANGUAGE_OVERRIDE` accents render as unpinned (no project-specific pin exists). Tracked by a dedicated test.
- Pattern J gate is on `togglePin` only — popup open stays free. Free users still see the layered visual; only the inner-click action is gated.
- `colorToHex` and `enableOpacity=false` discussion from PR #180 still applies; no changes here.