### PR TITLE
feat(syntax): add readability controls

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "8a04aaa"
+          last_verified_sha: "a8f9312"
           last_verified_date: "2026-05-28"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "8a04aaa"
+          last_verified_sha: "a8f9312"
           last_verified_date: "2026-05-28"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "4f4d90e"
+          last_verified_sha: "8a04aaa"
           last_verified_date: "2026-05-28"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "4f4d90e"
+          last_verified_sha: "8a04aaa"
           last_verified_date: "2026-05-28"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/src/main/kotlin/dev/ayuislands/accent/ChromeBaseColors.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ChromeBaseColors.kt
@@ -18,6 +18,14 @@ import javax.swing.UIManager
  * reads return the cached value. Resets on LAF change so theme switches pick up the
  * new base palette.
  *
+ * The cache also remembers the last color this plugin wrote for each key. Some
+ * platform startup paths fire several LAF events after the first accent apply; if
+ * a late cache refresh is followed by another apply before the platform restores
+ * stock UIDefaults, a naive read would capture our own tinted value as the new
+ * base and compound the status bar toward bright cyan. When the current
+ * UIManager value equals the last plugin tint, [get] recovers the last stock
+ * value instead of treating the tinted value as stock.
+ *
  * Thread-safe — ConcurrentHashMap; access is primarily EDT but may be touched from
  * background threads in tests. The cache is intentionally pessimistic — it captures
  * on first read, not at class load, so the snapshot takes the UIManager state AFTER
@@ -45,6 +53,16 @@ object ChromeBaseColors {
      * `.add(key)` returns the log-once gate in a single atomic step.
      */
     private val missingKeyLogged: MutableSet<String> = ConcurrentHashMap.newKeySet()
+
+    /**
+     * Last confirmed stock value per key. Kept across [refresh] so a late LAF
+     * event cannot make the next [get] recapture this plugin's own tint as the
+     * stock baseline.
+     */
+    private val lastStockSnapshot = ConcurrentHashMap<String, Color>()
+
+    /** Last tinted color written by this plugin per key. */
+    private val lastPluginTint = ConcurrentHashMap<String, Color>()
 
     init {
         // Tests that exercise ChromeBaseColors without an IDE container (no
@@ -114,14 +132,36 @@ object ChromeBaseColors {
                 }
                 return null
             }
+            val stock = recoverStockIfCurrentIsPluginTint(key, current)
+            lastStockSnapshot[key] = stock
             // Retain first captured value even under concurrent first access.
-            return snapshot.putIfAbsent(key, current) ?: current
+            return snapshot.putIfAbsent(key, stock) ?: stock
         }
+    }
+
+    /**
+     * Records a UIManager color this plugin just wrote so a later cache refresh
+     * can distinguish plugin tint from platform stock.
+     */
+    fun rememberPluginTint(
+        key: String,
+        color: Color,
+    ) {
+        lastPluginTint[key] = color
+    }
+
+    /** Clears the remembered plugin tint for [key] after the matching revert. */
+    fun forgetPluginTint(key: String) {
+        lastPluginTint.remove(key)
     }
 
     /**
      * Clears the snapshot so the next `get` call re-captures from UIManager.
      * Invoked by the LAF listener; exposed for tests.
+     *
+     * [lastStockSnapshot] and [lastPluginTint] intentionally survive this clear:
+     * listener ordering can refresh the cache after this plugin already wrote a
+     * tint, and the next [get] must still be able to recover the true stock base.
      *
      * The clear pair runs inside `synchronized(snapshot)` so a `get()` in
      * first-capture mode cannot interleave its read-UIManager-putIfAbsent
@@ -139,6 +179,15 @@ object ChromeBaseColors {
             missingKeyLogged.clear()
             snapshot.clear()
         }
+    }
+
+    private fun recoverStockIfCurrentIsPluginTint(
+        key: String,
+        current: Color,
+    ): Color {
+        val lastTint = lastPluginTint[key] ?: return current
+        val lastStock = lastStockSnapshot[key] ?: return current
+        return if (current == lastTint) lastStock else current
     }
 }
 

--- a/src/main/kotlin/dev/ayuislands/accent/ChromeTintBlender.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ChromeTintBlender.kt
@@ -57,10 +57,15 @@ object ChromeTintBlender {
     private const val GREEN_SHIFT = 8
 
     /**
-     * Luma-preserving hue replacement between [baseColor] and [accent].
+     * Luma-preserving hue blend between [baseColor] and [accent].
      *
-     * HSB-space blend rather than per-channel RGB lerp so every chrome surface
-     * receives the SAME accent hue regardless of how its stock base hue drifts:
+     * HSB-space blend rather than per-channel RGB lerp so high-intensity chrome
+     * surfaces converge on the same accent hue without flattening their original
+     * luminance hierarchy. The hue itself ramps faster than saturation /
+     * brightness because the user-visible slider caps at [TintIntensity.MAX]:
+     * a low value (10) stays visually close to stock, while max visible intensity
+     * reaches the accent hue.
+     *
      *  1. Read `intensity.percent` — already clamped to the user-visible
      *     slider range by the [TintIntensity] constructor. The blender still
      *     coerces into `[0, 100]` as a math-safety floor in case the wrapper
@@ -69,7 +74,8 @@ object ChromeTintBlender {
      *     the base's hue + saturation + brightness (`base.H`, `base.S`,
      *     `base.B`) via [Color.RGBtoHSB].
      *  3. Synthesise the output via [Color.getHSBColor]:
-     *       - **H** replaced outright by `accent.H` (uniform hue across surfaces)
+     *       - **H** circular-lerped from `base.H` to `accent.H` by
+     *         `intensity / TintIntensity.MAX`
      *       - **S** lerped from `base.S` toward `accent.S × SATURATION_DAMP`
      *         by `intensity / 100` (ramps chroma with the slider)
      *       - **B** lerped from `base.B` toward `accent.B` by
@@ -120,7 +126,8 @@ object ChromeTintBlender {
         // brightness (weighted by BRIGHTNESS_PULL_RATIO) — restores slider
         // visibility on dark Mirage bases while mostly preserving the luma
         // hierarchy at default intensity ≤ 40.
-        val outputHue = accentHsb[0]
+        val hueRatio = clamped.toFloat() / TintIntensity.MAX
+        val outputHue = lerpHue(baseHsb[0], accentHsb[0], hueRatio.coerceIn(0f, 1f))
         val outputSaturation = baseHsb[1] + (accentHsb[1] * SATURATION_DAMP - baseHsb[1]) * ratio
         val outputBrightness =
             baseHsb[2] + (accentHsb[2] - baseHsb[2]) * ratio * BRIGHTNESS_PULL_RATIO
@@ -137,4 +144,22 @@ object ChromeTintBlender {
             outputBrightness.coerceIn(0f, 1f),
         )
     }
+
+    private fun lerpHue(
+        from: Float,
+        to: Float,
+        ratio: Float,
+    ): Float {
+        var delta = to - from
+        if (delta > HUE_HALF_TURN) {
+            delta -= HUE_FULL_TURN
+        } else if (delta < -HUE_HALF_TURN) {
+            delta += HUE_FULL_TURN
+        }
+        val hue = from + delta * ratio
+        return (hue % HUE_FULL_TURN + HUE_FULL_TURN) % HUE_FULL_TURN
+    }
+
+    private const val HUE_HALF_TURN = 0.5f
+    private const val HUE_FULL_TURN = 1.0f
 }

--- a/src/main/kotlin/dev/ayuislands/accent/WcagForeground.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/WcagForeground.kt
@@ -41,7 +41,15 @@ object WcagForeground {
     // agree on the canonical dark foreground without a cross-import. Black is
     // the last-resort high-contrast candidate for unusually light tinted
     // surfaces.
-    private val palette = listOf(JBColor.WHITE, JBColor(DARK_FOREGROUND_HEX, DARK_FOREGROUND_HEX), JBColor.BLACK)
+    //
+    // Do not use JBColor.WHITE / JBColor.BLACK here: those are semantic UI
+    // colors. In dark LAFs JBColor.WHITE resolves to JBColor.background(), which
+    // makes the contrast math treat "white" as a dark panel color and can pick
+    // #1F2430 for status-bar text. Same-light/same-dark JBColor instances keep
+    // the IntelliJ color type while preserving literal contrast candidates.
+    private val literalWhite = JBColor(WHITE_HEX, WHITE_HEX)
+    private val literalBlack = JBColor(BLACK_HEX, BLACK_HEX)
+    private val palette = listOf(literalWhite, JBColor(DARK_FOREGROUND_HEX, DARK_FOREGROUND_HEX), literalBlack)
 
     // Light-family palette (no BLACK) for chrome surfaces the plugin
     // semantically owns as "tinted dark bands" (status bar foregrounds). Without
@@ -50,7 +58,7 @@ object WcagForeground {
     // passes 4.5:1 there while WHITE drops to ~4:1 — the picker is doing its job,
     // but on a chrome surface meant to read as dark the user expects light text.
     // Restricting the palette preserves the "always-light" contract.
-    private val lightFamilyPalette = listOf(JBColor.WHITE, JBColor(DARK_FOREGROUND_HEX, DARK_FOREGROUND_HEX))
+    private val lightFamilyPalette = listOf(literalWhite, JBColor(DARK_FOREGROUND_HEX, DARK_FOREGROUND_HEX))
 
     /**
      * Returns the first palette color whose WCAG 2.1 contrast ratio against
@@ -160,4 +168,7 @@ object WcagForeground {
 
     /** Ayu dark-foreground literal (shared with AccentApplicator's contrast-foreground pick). */
     private const val DARK_FOREGROUND_HEX = 0x1F2430
+
+    private const val WHITE_HEX = 0xFFFFFF
+    private const val BLACK_HEX = 0x000000
 }

--- a/src/main/kotlin/dev/ayuislands/accent/elements/AbstractChromeElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/AbstractChromeElement.kt
@@ -75,6 +75,7 @@ abstract class AbstractChromeElement : AccentElement {
             val baseColor = ChromeBaseColors[key] ?: continue
             val tinted = ChromeTintBlender.blend(color, baseColor, intensity)
             UIManager.put(key, tinted)
+            ChromeBaseColors.rememberPluginTint(key, tinted)
             tintedBackgrounds[key] = tinted
         }
         onBackgroundsTinted(tintedBackgrounds)
@@ -88,6 +89,7 @@ abstract class AbstractChromeElement : AccentElement {
     override fun revert() {
         for (key in backgroundKeys) {
             UIManager.put(key, null)
+            ChromeBaseColors.forgetPluginTint(key)
         }
         for (key in foregroundKeys) {
             UIManager.put(key, null)

--- a/src/main/kotlin/dev/ayuislands/accent/elements/StatusBarElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/StatusBarElement.kt
@@ -25,6 +25,10 @@ import javax.swing.UIManager
  * Foreground states receive the status-bar contrast color. Background states are
  * translucent overlays in the LAF, so this element clears any stale plugin override
  * and lets them render over the directly-tinted `NewNavBarPanel` background.
+ * Plain status-bar text widgets use `TextPanel.paintComponent()`, which resolves
+ * `JBUI.CurrentTheme.StatusBar.Widget` foregrounds across normal / hover /
+ * pressed states. These keys use the same light-family contrast pick as the
+ * breadcrumbs so clicking a widget cannot fall through to stock dark text.
  *
  * Foreground contrast uses [WcagForeground.pickLightFamilyForeground] (palette WHITE
  * + Ayu dark fg, NO black). The standard 3-color WCAG sweep correctly picks BLACK on
@@ -55,6 +59,7 @@ class StatusBarElement : AbstractChromeElement() {
     private val overlayBackgroundKeys =
         listOf(
             "StatusBar.Widget.hoverBackground",
+            "StatusBar.Widget.pressedBackground",
             "StatusBar.Breadcrumbs.hoverBackground",
             "StatusBar.Breadcrumbs.selectionBackground",
             "StatusBar.Breadcrumbs.selectionInactiveBackground",
@@ -91,14 +96,15 @@ class StatusBarElement : AbstractChromeElement() {
             "StatusBar.Breadcrumbs.selectionInactiveForeground",
         )
 
-    private val hoverForegroundKeys =
+    private val stateForegroundKeys =
         listOf(
             "StatusBar.Widget.hoverForeground",
+            "StatusBar.Widget.pressedForeground",
             "StatusBar.Breadcrumbs.hoverForeground",
         )
 
     /** Flat aggregation used by the base class's revert(); writes happen via [writeForegrounds]. */
-    override val foregroundKeys: List<String> = normalForegroundKeys + hoverForegroundKeys
+    override val foregroundKeys: List<String> = normalForegroundKeys + stateForegroundKeys
 
     override val foregroundTextTarget = WcagForeground.TextTarget.PRIMARY_TEXT
 

--- a/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
@@ -28,6 +28,7 @@ import dev.ayuislands.settings.PanelWidthMode
 import dev.ayuislands.syntax.SyntaxIntensityService
 import dev.ayuislands.syntax.SyntaxIntensityState
 import dev.ayuislands.syntax.SyntaxPreset
+import dev.ayuislands.syntax.SyntaxReadabilityOptions
 import dev.ayuislands.vcs.VcsColorApplier
 import dev.ayuislands.vcs.VcsColorPreset
 import org.jetbrains.annotations.VisibleForTesting
@@ -367,7 +368,19 @@ object LicenseChecker {
             syntaxState.subordinatePreset = SyntaxPreset.AMBIENT.name
             syntaxState.customOverrides.clear()
             syntaxState.customStyles.clear()
-            SyntaxIntensityService.getInstance().apply(SyntaxPreset.AMBIENT, emptyMap())
+            syntaxState.dimComments = false
+            syntaxState.softenDocumentation = false
+            syntaxState.quietOperators = false
+            syntaxState.emphasizeDeclarations = false
+            SyntaxIntensityService
+                .getInstance()
+                .apply(
+                    SyntaxPreset.AMBIENT,
+                    emptyMap(),
+                    SyntaxPreset.AMBIENT,
+                    emptyMap(),
+                    SyntaxReadabilityOptions.DEFAULT,
+                )
         } catch (exception: RuntimeException) {
             LOG.warn("Syntax intensity revert after license downgrade failed", exception)
         }

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanel.kt
@@ -15,10 +15,12 @@ import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.syntax.FontStyleOverride
 import dev.ayuislands.syntax.PrimitiveCategory
+import dev.ayuislands.syntax.SYNTAX_INTENSITY_SCHEMA_VERSION
 import dev.ayuislands.syntax.SyntaxIntensityService
 import dev.ayuislands.syntax.SyntaxIntensityState
 import dev.ayuislands.syntax.SyntaxLanguageRegistry
 import dev.ayuislands.syntax.SyntaxPreset
+import dev.ayuislands.syntax.SyntaxReadabilityOptions
 import java.awt.Component
 import java.awt.Container
 import java.awt.Dimension
@@ -26,6 +28,7 @@ import java.awt.Font
 import java.awt.GridLayout
 import javax.swing.AbstractButton
 import javax.swing.JButton
+import javax.swing.JCheckBox
 import javax.swing.JComponent
 import javax.swing.JLabel
 import javax.swing.JPanel
@@ -81,6 +84,14 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
     private var suppressSliderListeners: Boolean = false
     private var pendingSubordinate: SyntaxPreset = SyntaxPreset.AMBIENT
     private var storedSubordinate: SyntaxPreset = SyntaxPreset.AMBIENT
+    private var pendingDimComments: Boolean = false
+    private var storedDimComments: Boolean = false
+    private var pendingSoftenDocumentation: Boolean = false
+    private var storedSoftenDocumentation: Boolean = false
+    private var pendingQuietOperators: Boolean = false
+    private var storedQuietOperators: Boolean = false
+    private var pendingEmphasizeDeclarations: Boolean = false
+    private var storedEmphasizeDeclarations: Boolean = false
     private val pendingOverrides: MutableMap<String, String> = mutableMapOf()
     private val storedOverrides: MutableMap<String, String> = mutableMapOf()
 
@@ -95,6 +106,10 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
     private val resetButtons: MutableMap<PrimitiveCategory, InplaceButton> = mutableMapOf()
     private val boldToggles: MutableMap<PrimitiveCategory, InplaceButton> = mutableMapOf()
     private val italicToggles: MutableMap<PrimitiveCategory, InplaceButton> = mutableMapOf()
+    private var dimCommentsCheckbox: JCheckBox? = null
+    private var softenDocumentationCheckbox: JCheckBox? = null
+    private var quietOperatorsCheckbox: JCheckBox? = null
+    private var emphasizeDeclarationsCheckbox: JCheckBox? = null
     private var masterResetButton: JButton? = null
     private var currentLanguage: String = ""
 
@@ -145,6 +160,8 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
                     "Custom provides per-language fine tuning. Pick one of the 4 presets to apply instantly.",
                 )
             }
+
+            buildReadabilityBlock()
 
             row {
                 browserLink(
@@ -200,6 +217,52 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
 
         rebindSlidersFor(currentLanguage)
         refreshMasterResetButton()
+    }
+
+    private fun Panel.buildReadabilityBlock() {
+        row("Readability:") {
+            panel {
+                row {
+                    dimCommentsCheckbox =
+                        checkBox("Dim comments").component.apply {
+                            isSelected = pendingDimComments
+                            addActionListener {
+                                pendingDimComments = isSelected
+                                preview()
+                            }
+                        }
+                    softenDocumentationCheckbox =
+                        checkBox("Soften documentation").component.apply {
+                            isSelected = pendingSoftenDocumentation
+                            addActionListener {
+                                pendingSoftenDocumentation = isSelected
+                                preview()
+                            }
+                        }
+                }
+                row {
+                    quietOperatorsCheckbox =
+                        checkBox("Quiet operators").component.apply {
+                            isSelected = pendingQuietOperators
+                            addActionListener {
+                                pendingQuietOperators = isSelected
+                                preview()
+                            }
+                        }
+                    emphasizeDeclarationsCheckbox =
+                        checkBox("Emphasize declarations").component.apply {
+                            isSelected = pendingEmphasizeDeclarations
+                            addActionListener {
+                                pendingEmphasizeDeclarations = isSelected
+                                preview()
+                            }
+                        }
+                }
+            }
+        }
+        row {
+            comment("Applies on top of the selected preset. Use Custom for per-language tuning.")
+        }
     }
 
     private fun Panel.buildCategoryGroup(categoryGroup: CategoryGroup) {
@@ -448,7 +511,11 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
         pendingPreset != storedPreset ||
             pendingOverrides != storedOverrides ||
             pendingStyles != storedStyles ||
-            pendingSubordinate != storedSubordinate
+            pendingSubordinate != storedSubordinate ||
+            pendingDimComments != storedDimComments ||
+            pendingSoftenDocumentation != storedSoftenDocumentation ||
+            pendingQuietOperators != storedQuietOperators ||
+            pendingEmphasizeDeclarations != storedEmphasizeDeclarations
 
     override fun apply() {
         if (!isModified()) return
@@ -466,12 +533,21 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
         state.customOverrides.putAll(pendingOverrides)
         state.customStyles.clear()
         state.customStyles.putAll(pendingStyles)
+        state.dimComments = pendingDimComments
+        state.softenDocumentation = pendingSoftenDocumentation
+        state.quietOperators = pendingQuietOperators
+        state.emphasizeDeclarations = pendingEmphasizeDeclarations
+        state.schemaVersion = SYNTAX_INTENSITY_SCHEMA_VERSION
         storedPreset = pendingPreset
         storedSubordinate = pendingSubordinate
         storedOverrides.clear()
         storedOverrides.putAll(pendingOverrides)
         storedStyles.clear()
         storedStyles.putAll(pendingStyles)
+        storedDimComments = pendingDimComments
+        storedSoftenDocumentation = pendingSoftenDocumentation
+        storedQuietOperators = pendingQuietOperators
+        storedEmphasizeDeclarations = pendingEmphasizeDeclarations
     }
 
     override fun reset() {
@@ -483,6 +559,7 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
             suppressListeners = false
         }
         customSelected.set(pendingPreset == SyntaxPreset.CUSTOM)
+        refreshReadabilityCheckboxes()
         rebindSlidersFor(currentLanguage)
         refreshMasterResetButton()
     }
@@ -495,6 +572,14 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
         pendingPreset = storedPreset
         storedSubordinate = SyntaxPreset.fromName(state.subordinatePreset)
         pendingSubordinate = storedSubordinate
+        storedDimComments = state.dimComments
+        pendingDimComments = storedDimComments
+        storedSoftenDocumentation = state.softenDocumentation
+        pendingSoftenDocumentation = storedSoftenDocumentation
+        storedQuietOperators = state.quietOperators
+        pendingQuietOperators = storedQuietOperators
+        storedEmphasizeDeclarations = state.emphasizeDeclarations
+        pendingEmphasizeDeclarations = storedEmphasizeDeclarations
         storedOverrides.clear()
         if (canUseCustom) {
             storedOverrides.putAll(state.customOverrides)
@@ -507,6 +592,13 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
         }
         pendingStyles.clear()
         pendingStyles.putAll(storedStyles)
+    }
+
+    private fun refreshReadabilityCheckboxes() {
+        dimCommentsCheckbox?.isSelected = pendingDimComments
+        softenDocumentationCheckbox?.isSelected = pendingSoftenDocumentation
+        quietOperatorsCheckbox?.isSelected = pendingQuietOperators
+        emphasizeDeclarationsCheckbox?.isSelected = pendingEmphasizeDeclarations
     }
 
     private fun rebindSlidersFor(language: String) {
@@ -608,8 +700,18 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
     private fun preview() {
         val nested = buildNested(pendingOverrides) { it.toIntOrNull() }
         val nestedStyles = buildNested(pendingStyles) { FontStyleOverride.fromName(it)?.fontType }
-        SyntaxIntensityService.getInstance().apply(pendingPreset, nested, pendingSubordinate, nestedStyles)
+        SyntaxIntensityService
+            .getInstance()
+            .apply(pendingPreset, nested, pendingSubordinate, nestedStyles, readabilityOptions())
     }
+
+    private fun readabilityOptions(): SyntaxReadabilityOptions =
+        SyntaxReadabilityOptions(
+            dimComments = pendingDimComments,
+            softenDocumentation = pendingSoftenDocumentation,
+            quietOperators = pendingQuietOperators,
+            emphasizeDeclarations = pendingEmphasizeDeclarations,
+        )
 
     /**
      * Walk the [presetSegmented]'s rendered Swing subtree and set a

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanel.kt
@@ -4,7 +4,6 @@ import com.intellij.icons.AllIcons
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.observable.properties.AtomicBooleanProperty
 import com.intellij.ui.InplaceButton
-import com.intellij.ui.JBColor
 import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.dsl.builder.RightGap
@@ -24,7 +23,6 @@ import dev.ayuislands.syntax.SyntaxReadabilityOptions
 import java.awt.Component
 import java.awt.Container
 import java.awt.Dimension
-import java.awt.Font
 import java.awt.GridLayout
 import javax.swing.AbstractButton
 import javax.swing.JButton
@@ -60,14 +58,13 @@ import javax.swing.Timer
  *
  * Custom drill-down layout: the 16 [PrimitiveCategory] controls are arranged
  * as four semantic groups in two column-level grids. Each row keeps the same
- * fixed cells — category, tick-free slider, signed readout, and a fixed
- * reset / Bold / Italic slot zone — so controls line up without a long empty
- * single table. The slider value model (0..100, 50 = identity, sparse store
- * keyed by `language|category.name`) is unchanged — the signed string lives only in the
- * readout [JLabel] and is never parsed back. The font-style model is an
- * orthogonal sparse store keyed by the same composite key, mapping to a
- * [FontStyleOverride] enum `name`; both stores thread through [apply] in
- * parallel.
+ * fixed cells — category, tick-free slider, signed readout, and a reset slot —
+ * so controls line up without a long empty single table. The slider value
+ * model (0..100, 50 = identity, sparse store keyed by
+ * `language|category.name`) is unchanged — the signed string lives only in the
+ * readout [JLabel] and is never parsed back. The legacy font-style sparse map
+ * still threads through [apply] for stored configurations, but row-level B/I
+ * controls are intentionally not part of this compact grid.
  */
 @Suppress("TooManyFunctions", "UnstableApiUsage") // Settings panel with focused UI lifecycle helpers.
 class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
@@ -95,17 +92,14 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
     private val pendingOverrides: MutableMap<String, String> = mutableMapOf()
     private val storedOverrides: MutableMap<String, String> = mutableMapOf()
 
-    // Font-style store: flat "language|category" -> FontStyleOverride enum name.
-    // Orthogonal to pendingOverrides — a cell may carry a style with no slider
-    // move, or a slider move with no style. Both diff into [isModified] and
-    // both thread through [apply].
+    // Legacy font-style store: flat "language|category" -> FontStyleOverride
+    // enum name. It still round-trips stored configurations, but no longer has
+    // row-level controls in the compact Custom grid.
     private val pendingStyles: MutableMap<String, String> = mutableMapOf()
     private val storedStyles: MutableMap<String, String> = mutableMapOf()
     private val sliders: MutableMap<PrimitiveCategory, JSlider> = mutableMapOf()
     private val sliderLabels: MutableMap<PrimitiveCategory, JLabel> = mutableMapOf()
     private val resetButtons: MutableMap<PrimitiveCategory, InplaceButton> = mutableMapOf()
-    private val boldToggles: MutableMap<PrimitiveCategory, InplaceButton> = mutableMapOf()
-    private val italicToggles: MutableMap<PrimitiveCategory, InplaceButton> = mutableMapOf()
     private var dimCommentsCheckbox: JCheckBox? = null
     private var softenDocumentationCheckbox: JCheckBox? = null
     private var quietOperatorsCheckbox: JCheckBox? = null
@@ -221,44 +215,38 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
 
     private fun Panel.buildReadabilityBlock() {
         row("Readability:") {
-            panel {
-                row {
-                    dimCommentsCheckbox =
-                        checkBox("Dim comments").component.apply {
-                            isSelected = pendingDimComments
-                            addActionListener {
-                                pendingDimComments = isSelected
-                                preview()
-                            }
-                        }
-                    softenDocumentationCheckbox =
-                        checkBox("Soften documentation").component.apply {
-                            isSelected = pendingSoftenDocumentation
-                            addActionListener {
-                                pendingSoftenDocumentation = isSelected
-                                preview()
-                            }
-                        }
+            dimCommentsCheckbox =
+                checkBox("Dim comments").component.apply {
+                    isSelected = pendingDimComments
+                    addActionListener {
+                        pendingDimComments = isSelected
+                        preview()
+                    }
                 }
-                row {
-                    quietOperatorsCheckbox =
-                        checkBox("Quiet operators").component.apply {
-                            isSelected = pendingQuietOperators
-                            addActionListener {
-                                pendingQuietOperators = isSelected
-                                preview()
-                            }
-                        }
-                    emphasizeDeclarationsCheckbox =
-                        checkBox("Emphasize declarations").component.apply {
-                            isSelected = pendingEmphasizeDeclarations
-                            addActionListener {
-                                pendingEmphasizeDeclarations = isSelected
-                                preview()
-                            }
-                        }
+            softenDocumentationCheckbox =
+                checkBox("Soften documentation").component.apply {
+                    isSelected = pendingSoftenDocumentation
+                    addActionListener {
+                        pendingSoftenDocumentation = isSelected
+                        preview()
+                    }
                 }
-            }
+            quietOperatorsCheckbox =
+                checkBox("Quiet operators").component.apply {
+                    isSelected = pendingQuietOperators
+                    addActionListener {
+                        pendingQuietOperators = isSelected
+                        preview()
+                    }
+                }
+            emphasizeDeclarationsCheckbox =
+                checkBox("Emphasize declarations").component.apply {
+                    isSelected = pendingEmphasizeDeclarations
+                    addActionListener {
+                        pendingEmphasizeDeclarations = isSelected
+                        preview()
+                    }
+                }
         }
         row {
             comment("Applies on top of the selected preset. Use Custom for per-language tuning.")
@@ -311,93 +299,21 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
                     isFocusable = true
                     accessibleContext.accessibleName = "Reset ${category.displayName} to default"
                 }
-            val boldToggle =
-                InplaceButton("Bold ${category.displayName}", styleGlyphIcon("B", Font.BOLD, engaged = false)) {
-                    onStyleToggle(category, Font.BOLD)
-                }.apply {
-                    isFocusable = true
-                    accessibleContext.accessibleName = "Bold ${category.displayName}"
-                }
-            val italicToggle =
-                InplaceButton("Italic ${category.displayName}", styleGlyphIcon("I", Font.ITALIC, engaged = false)) {
-                    onStyleToggle(category, Font.ITALIC)
-                }.apply {
-                    isFocusable = true
-                    accessibleContext.accessibleName = "Italic ${category.displayName}"
-                }
             resetButtons[category] = resetButton
-            boldToggles[category] = boldToggle
-            italicToggles[category] = italicToggle
             val trailingZone =
-                JPanel(GridLayout(1, TRAILING_SLOT_COUNT, JBUI.scale(TRAILING_GAP), 0)).apply {
+                JPanel(GridLayout(1, TRAILING_SLOT_COUNT, 0, 0)).apply {
                     isOpaque = false
                     val zoneWidth = JBUI.scale(TRAILING_ZONE_WIDTH)
                     val zoneHeight = JBUI.scale(TRAILING_SLOT_SIDE)
                     preferredSize = Dimension(zoneWidth, zoneHeight)
                     minimumSize = Dimension(zoneWidth, zoneHeight)
                     add(resetButton)
-                    add(boldToggle)
-                    add(italicToggle)
                 }
             cell(trailingZone)
             sliders[category] = intensitySlider
             sliderLabels[category] = valueLabel
-            refreshStyleVisuals(category)
         }
     }
-
-    private fun onStyleToggle(
-        category: PrimitiveCategory,
-        bit: Int,
-    ) {
-        val key = compositeKey(currentLanguage, category)
-        val current = FontStyleOverride.fromName(pendingStyles[key])?.fontType ?: Font.PLAIN
-        val next = current xor bit
-        val nextStyle = FontStyleOverride.entries.firstOrNull { it.fontType == next }
-        if (nextStyle == null || nextStyle == FontStyleOverride.PLAIN) {
-            pendingStyles.remove(key)
-        } else {
-            pendingStyles[key] = nextStyle.name
-        }
-        refreshStyleVisuals(category)
-        refreshResetVisibility(category)
-        refreshMasterResetButton()
-        applyTimer.restart()
-    }
-
-    private fun refreshStyleVisuals(category: PrimitiveCategory) {
-        val key = compositeKey(currentLanguage, category)
-        val fontType = FontStyleOverride.fromName(pendingStyles[key])?.fontType ?: Font.PLAIN
-        boldToggles[category]?.let { button ->
-            button.icon = styleGlyphIcon("B", Font.BOLD, fontType and Font.BOLD != 0)
-            button.repaint()
-        }
-        italicToggles[category]?.let { button ->
-            button.icon = styleGlyphIcon("I", Font.ITALIC, fontType and Font.ITALIC != 0)
-            button.repaint()
-        }
-    }
-
-    private fun styleGlyphIcon(
-        glyph: String,
-        style: Int,
-        engaged: Boolean,
-    ): StyleGlyphIcon {
-        val foreground = if (engaged) UIUtil.getLabelForeground() else UIUtil.getContextHelpForeground()
-        val background =
-            if (engaged) {
-                JBUI.CurrentTheme.ActionButton.pressedBackground()
-            } else {
-                JBUI.CurrentTheme.ActionButton.hoverBackground()
-            }
-        return StyleGlyphIcon(glyph, style, foreground, background, border = styleGlyphBorder())
-    }
-
-    private fun styleGlyphBorder(): JBColor =
-        JBColor.namedColor(
-            "Popup.innerBorderColor",
-            JBColor.namedColor("Popup.borderColor", JBColor.GRAY),
-        )
 
     private fun refreshResetVisibility(category: PrimitiveCategory) {
         val key = compositeKey(currentLanguage, category)
@@ -418,7 +334,6 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
         val key = compositeKey(currentLanguage, category)
         pendingOverrides.remove(key)
         pendingStyles.remove(key)
-        refreshStyleVisuals(category)
         refreshResetVisibility(category)
         refreshMasterResetButton()
         applyTimer.restart()
@@ -533,10 +448,11 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
         state.customOverrides.putAll(pendingOverrides)
         state.customStyles.clear()
         state.customStyles.putAll(pendingStyles)
-        state.dimComments = pendingDimComments
-        state.softenDocumentation = pendingSoftenDocumentation
-        state.quietOperators = pendingQuietOperators
-        state.emphasizeDeclarations = pendingEmphasizeDeclarations
+        val appliedReadabilityOptions = readabilityOptions()
+        state.dimComments = appliedReadabilityOptions.dimComments
+        state.softenDocumentation = appliedReadabilityOptions.softenDocumentation
+        state.quietOperators = appliedReadabilityOptions.quietOperators
+        state.emphasizeDeclarations = appliedReadabilityOptions.emphasizeDeclarations
         state.schemaVersion = SYNTAX_INTENSITY_SCHEMA_VERSION
         storedPreset = pendingPreset
         storedSubordinate = pendingSubordinate
@@ -544,10 +460,7 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
         storedOverrides.putAll(pendingOverrides)
         storedStyles.clear()
         storedStyles.putAll(pendingStyles)
-        storedDimComments = pendingDimComments
-        storedSoftenDocumentation = pendingSoftenDocumentation
-        storedQuietOperators = pendingQuietOperators
-        storedEmphasizeDeclarations = pendingEmphasizeDeclarations
+        rememberReadabilityOptions(appliedReadabilityOptions)
     }
 
     override fun reset() {
@@ -572,14 +485,14 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
         pendingPreset = storedPreset
         storedSubordinate = SyntaxPreset.fromName(state.subordinatePreset)
         pendingSubordinate = storedSubordinate
-        storedDimComments = state.dimComments
-        pendingDimComments = storedDimComments
-        storedSoftenDocumentation = state.softenDocumentation
-        pendingSoftenDocumentation = storedSoftenDocumentation
-        storedQuietOperators = state.quietOperators
-        pendingQuietOperators = storedQuietOperators
-        storedEmphasizeDeclarations = state.emphasizeDeclarations
-        pendingEmphasizeDeclarations = storedEmphasizeDeclarations
+        rememberReadabilityOptions(
+            SyntaxReadabilityOptions(
+                dimComments = state.dimComments,
+                softenDocumentation = state.softenDocumentation,
+                quietOperators = state.quietOperators,
+                emphasizeDeclarations = state.emphasizeDeclarations,
+            ),
+        )
         storedOverrides.clear()
         if (canUseCustom) {
             storedOverrides.putAll(state.customOverrides)
@@ -601,6 +514,17 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
         emphasizeDeclarationsCheckbox?.isSelected = pendingEmphasizeDeclarations
     }
 
+    private fun rememberReadabilityOptions(options: SyntaxReadabilityOptions) {
+        storedDimComments = options.dimComments
+        pendingDimComments = options.dimComments
+        storedSoftenDocumentation = options.softenDocumentation
+        pendingSoftenDocumentation = options.softenDocumentation
+        storedQuietOperators = options.quietOperators
+        pendingQuietOperators = options.quietOperators
+        storedEmphasizeDeclarations = options.emphasizeDeclarations
+        pendingEmphasizeDeclarations = options.emphasizeDeclarations
+    }
+
     private fun rebindSlidersFor(language: String) {
         suppressSliderListeners = true
         try {
@@ -609,7 +533,6 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
                 sliders[category]?.value = value
                 sliderLabels[category]?.let { applyReadout(it, value) }
                 sliders[category]?.accessibleContext?.accessibleName = intensityAccessibleName(category, value)
-                refreshStyleVisuals(category)
                 refreshResetVisibility(category)
             }
         } finally {
@@ -635,7 +558,7 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
 
     /**
      * Single update site for a readout [JLabel]'s text AND foreground so the
-     * three callers ([onSliderChanged], [setSliderValue], [rebindSlidersFor])
+     * three callers ([onSliderChanged], [resetCategorySlider], [rebindSlidersFor])
      * stay in lock-step. At the [SLIDER_MID] identity the readout is visually
      * empty and dimmed to reduce noise; once the cell diverges the signed delta
      * switches to the stronger
@@ -780,10 +703,9 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
 
         private const val SLIDER_TRACK_WIDTH = 140
         private const val READOUT_WIDTH = 28
-        private const val TRAILING_SLOT_COUNT = 3
+        private const val TRAILING_SLOT_COUNT = 1
         private const val TRAILING_SLOT_SIDE = 20
-        private const val TRAILING_ZONE_WIDTH = 64
-        private const val TRAILING_GAP = 2
+        private const val TRAILING_ZONE_WIDTH = 20
         private const val LABEL_PADDING = 8
         private const val LABEL_FALLBACK_WIDTH = 170
         private const val CUSTOM_PILL_TOOLTIP = "Pro Feature"

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanel.kt
@@ -20,6 +20,7 @@ import dev.ayuislands.syntax.SyntaxIntensityState
 import dev.ayuislands.syntax.SyntaxLanguageRegistry
 import dev.ayuislands.syntax.SyntaxPreset
 import dev.ayuislands.syntax.SyntaxReadabilityOptions
+import org.jetbrains.annotations.TestOnly
 import java.awt.Component
 import java.awt.Container
 import java.awt.Dimension
@@ -50,11 +51,9 @@ import javax.swing.Timer
  * the on-disk `selectedPreset` is mutated; persist runs SECOND so the next
  * `reapplyForActiveLaf` call sees a consistent preset name.
  *
- * The free-pill apply path NEVER touches [LicenseChecker]. The only license
- * call sites in this class are the Custom-rejection guard in [onPresetChosen]
- * and the short-circuit at the top of [applyCustomPillTooltipIfFree]; both
- * paths are confined to the Custom branch. A source-regex regression lock in
- * `AyuIslandsSyntaxPanelTest` keeps this invariant honest.
+ * The free-pill apply path does not gate the four named presets. [LicenseChecker]
+ * is consulted only while loading premium state, disabling premium controls,
+ * and rejecting the Custom pill for free users.
  *
  * Custom drill-down layout: the 16 [PrimitiveCategory] controls are arranged
  * as four semantic groups in two column-level grids. Each row keeps the same
@@ -81,6 +80,7 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
     private var suppressSliderListeners: Boolean = false
     private var pendingSubordinate: SyntaxPreset = SyntaxPreset.AMBIENT
     private var storedSubordinate: SyntaxPreset = SyntaxPreset.AMBIENT
+    private var premiumSyntaxControlsEnabled: Boolean = true
     private var pendingDimComments: Boolean = false
     private var storedDimComments: Boolean = false
     private var pendingSoftenDocumentation: Boolean = false
@@ -217,40 +217,54 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
         row("Readability:") {
             dimCommentsCheckbox =
                 checkBox("Dim comments").component.apply {
-                    isSelected = pendingDimComments
-                    addActionListener {
-                        pendingDimComments = isSelected
-                        preview()
+                    configureReadabilityCheckbox(pendingDimComments) {
+                        pendingDimComments = it
                     }
                 }
             softenDocumentationCheckbox =
                 checkBox("Soften documentation").component.apply {
-                    isSelected = pendingSoftenDocumentation
-                    addActionListener {
-                        pendingSoftenDocumentation = isSelected
-                        preview()
+                    configureReadabilityCheckbox(pendingSoftenDocumentation) {
+                        pendingSoftenDocumentation = it
                     }
                 }
+        }
+        row {
             quietOperatorsCheckbox =
                 checkBox("Quiet operators").component.apply {
-                    isSelected = pendingQuietOperators
-                    addActionListener {
-                        pendingQuietOperators = isSelected
-                        preview()
+                    configureReadabilityCheckbox(pendingQuietOperators) {
+                        pendingQuietOperators = it
                     }
                 }
             emphasizeDeclarationsCheckbox =
                 checkBox("Emphasize declarations").component.apply {
-                    isSelected = pendingEmphasizeDeclarations
-                    addActionListener {
-                        pendingEmphasizeDeclarations = isSelected
-                        preview()
+                    configureReadabilityCheckbox(pendingEmphasizeDeclarations) {
+                        pendingEmphasizeDeclarations = it
                     }
                 }
         }
         row {
             comment("Applies on top of the selected preset. Use Custom for per-language tuning.")
         }
+    }
+
+    private fun JCheckBox.configureReadabilityCheckbox(
+        selected: Boolean,
+        updatePending: (Boolean) -> Unit,
+    ) {
+        isSelected = selected
+        isEnabled = premiumSyntaxControlsEnabled
+        toolTipText = if (premiumSyntaxControlsEnabled) null else PREMIUM_CONTROL_TOOLTIP
+        addActionListener {
+            if (!isEnabled) return@addActionListener
+            updatePending(isSelected)
+            preview()
+        }
+    }
+
+    @TestOnly
+    internal fun buildReadabilityBlockForTest(panel: Panel) {
+        loadStateIntoPending()
+        panel.buildReadabilityBlock()
     }
 
     private fun Panel.buildCategoryGroup(categoryGroup: CategoryGroup) {
@@ -475,23 +489,29 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
         refreshReadabilityCheckboxes()
         rebindSlidersFor(currentLanguage)
         refreshMasterResetButton()
+        preview()
     }
 
     private fun loadStateIntoPending() {
         val state = SyntaxIntensityState.getInstance().state
         val loadedPreset = SyntaxPreset.fromName(state.selectedPreset)
-        val canUseCustom = loadedPreset != SyntaxPreset.CUSTOM || LicenseChecker.isLicensedOrGrace()
+        premiumSyntaxControlsEnabled = LicenseChecker.isLicensedOrGrace()
+        val canUseCustom = loadedPreset != SyntaxPreset.CUSTOM || premiumSyntaxControlsEnabled
         storedPreset = if (canUseCustom) loadedPreset else SyntaxPreset.AMBIENT
         pendingPreset = storedPreset
         storedSubordinate = SyntaxPreset.fromName(state.subordinatePreset)
         pendingSubordinate = storedSubordinate
         rememberReadabilityOptions(
-            SyntaxReadabilityOptions(
-                dimComments = state.dimComments,
-                softenDocumentation = state.softenDocumentation,
-                quietOperators = state.quietOperators,
-                emphasizeDeclarations = state.emphasizeDeclarations,
-            ),
+            if (premiumSyntaxControlsEnabled) {
+                SyntaxReadabilityOptions(
+                    dimComments = state.dimComments,
+                    softenDocumentation = state.softenDocumentation,
+                    quietOperators = state.quietOperators,
+                    emphasizeDeclarations = state.emphasizeDeclarations,
+                )
+            } else {
+                SyntaxReadabilityOptions.DEFAULT
+            },
         )
         storedOverrides.clear()
         if (canUseCustom) {
@@ -655,7 +675,10 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
         if (LicenseChecker.isLicensedOrGrace()) return
         try {
             val root = renderedSegmentedComponent() ?: return
-            findCustomPresetButton(root)?.toolTipText = CUSTOM_PILL_TOOLTIP
+            findCustomPresetButton(root)?.apply {
+                isEnabled = false
+                toolTipText = PREMIUM_CONTROL_TOOLTIP
+            }
         } catch (runtime: RuntimeException) {
             LOG.warn("AyuIslandsSyntaxPanel: tooltip pre-placement on Custom pill failed", runtime)
         }
@@ -708,7 +731,7 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
         private const val TRAILING_ZONE_WIDTH = 20
         private const val LABEL_PADDING = 8
         private const val LABEL_FALLBACK_WIDTH = 170
-        private const val CUSTOM_PILL_TOOLTIP = "Pro Feature"
+        private const val PREMIUM_CONTROL_TOOLTIP = "Pro Feature"
 
         /**
          * The 16 [PrimitiveCategory] entries grouped by syntactic role and

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanel.kt
@@ -1,13 +1,13 @@
 package dev.ayuislands.settings
 
 import com.intellij.icons.AllIcons
-import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.observable.properties.AtomicBooleanProperty
 import com.intellij.ui.InplaceButton
 import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.dsl.builder.RightGap
 import com.intellij.ui.dsl.builder.SegmentedButton
+import com.intellij.ui.dsl.builder.SegmentedButton.ItemPresentation
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
 import dev.ayuislands.accent.AyuVariant
@@ -21,19 +21,14 @@ import dev.ayuislands.syntax.SyntaxLanguageRegistry
 import dev.ayuislands.syntax.SyntaxPreset
 import dev.ayuislands.syntax.SyntaxReadabilityOptions
 import org.jetbrains.annotations.TestOnly
-import java.awt.Component
-import java.awt.Container
 import java.awt.Dimension
 import java.awt.GridLayout
-import javax.swing.AbstractButton
 import javax.swing.JButton
 import javax.swing.JCheckBox
-import javax.swing.JComponent
 import javax.swing.JLabel
 import javax.swing.JPanel
 import javax.swing.JSlider
 import javax.swing.SwingConstants
-import javax.swing.SwingUtilities
 import javax.swing.Timer
 
 /**
@@ -41,10 +36,9 @@ import javax.swing.Timer
  *
  * Free tier: the 4 named pills (Whisper / Ambient / Neon / Cyberpunk) apply
  * immediately on click and persist to the syntax-intensity state. The Custom
- * pill is reserved for Pro — selecting it as an unlicensed user reverts the
- * pill selection and opens the upgrade flow. A pre-placed tooltip on the
- * Custom button surfaces the gate before the click whenever the platform's
- * `SegmentedButton` Swing subtree exposes the per-item button widget.
+ * pill is reserved for Pro — free users see it disabled with a Pro tooltip,
+ * and any programmatic selection still reverts to the previous preset and
+ * opens the upgrade flow.
  *
  * Apply-before-persist ordering follows Anti-Pattern #4 (Phase 40.4 lesson):
  * [SyntaxIntensityService.apply] runs FIRST so any failure surfaces before
@@ -133,17 +127,7 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
         loadStateIntoPending()
         customSelected.set(pendingPreset == SyntaxPreset.CUSTOM)
         with(panel) {
-            row("Preset:") {
-                val segmented =
-                    segmentedButton(SyntaxPreset.entries) { preset -> text = preset.displayName }
-                segmented.maxButtonsCount(SyntaxPreset.entries.size)
-                segmented.selectedItem = pendingPreset
-                segmented.whenItemSelected { preset ->
-                    if (suppressListeners) return@whenItemSelected
-                    onPresetChosen(preset)
-                }
-                presetSegmented = segmented
-            }
+            buildPresetBlock()
 
             // The 4 named pills apply immediately. The Custom pill opens the
             // per-language drill-down available on the Pro tier. Free users
@@ -166,12 +150,29 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
 
             buildCustomFoldOut()
         }
+    }
 
-        // SegmentedButton's internal JButton instances are not realised until
-        // the DSL panel renders, so the tooltip pre-placement walks the
-        // subtree on the EDT after the DSL build completes. Best-effort —
-        // see [applyCustomPillTooltipIfFree] for the fallback contract.
-        SwingUtilities.invokeLater { applyCustomPillTooltipIfFree() }
+    private fun Panel.buildPresetBlock() {
+        row("Preset:") {
+            val segmented =
+                segmentedButton(SyntaxPreset.entries) { preset ->
+                    configurePresetPresentation(preset)
+                }
+            segmented.maxButtonsCount(SyntaxPreset.entries.size)
+            segmented.selectedItem = pendingPreset
+            segmented.whenItemSelected { preset ->
+                if (suppressListeners) return@whenItemSelected
+                onPresetChosen(preset)
+            }
+            presetSegmented = segmented
+        }
+    }
+
+    private fun ItemPresentation.configurePresetPresentation(preset: SyntaxPreset) {
+        text = preset.displayName
+        val isPremiumPreset = preset == SyntaxPreset.CUSTOM
+        enabled = !isPremiumPreset || premiumSyntaxControlsEnabled
+        toolTipText = if (isPremiumPreset && !premiumSyntaxControlsEnabled) PREMIUM_CONTROL_TOOLTIP else null
     }
 
     /** Build the premium Custom drill-down as two grouped, aligned columns. */
@@ -251,9 +252,7 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
         selected: Boolean,
         updatePending: (Boolean) -> Unit,
     ) {
-        isSelected = selected
-        isEnabled = premiumSyntaxControlsEnabled
-        toolTipText = if (premiumSyntaxControlsEnabled) null else PREMIUM_CONTROL_TOOLTIP
+        applyReadabilityCheckboxState(selected)
         addActionListener {
             if (!isEnabled) return@addActionListener
             updatePending(isSelected)
@@ -261,11 +260,28 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
         }
     }
 
+    private fun JCheckBox.applyReadabilityCheckboxState(selected: Boolean) {
+        isSelected = selected
+        isEnabled = premiumSyntaxControlsEnabled
+        toolTipText = if (premiumSyntaxControlsEnabled) null else PREMIUM_CONTROL_TOOLTIP
+    }
+
     @TestOnly
     internal fun buildReadabilityBlockForTest(panel: Panel) {
         loadStateIntoPending()
         panel.buildReadabilityBlock()
     }
+
+    @TestOnly
+    internal fun buildPresetBlockForTest(panel: Panel) {
+        loadStateIntoPending()
+        customSelected.set(pendingPreset == SyntaxPreset.CUSTOM)
+        panel.buildPresetBlock()
+        refreshPresetPillAffordance()
+    }
+
+    @TestOnly
+    internal fun customPresetPresentationForTest(): ItemPresentation? = customPresetPresentation()
 
     private fun Panel.buildCategoryGroup(categoryGroup: CategoryGroup) {
         group(categoryGroup.title) {
@@ -410,11 +426,9 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
     }
 
     private fun onPresetChosen(preset: SyntaxPreset) {
-        // SegmentedButton has no per-item disable API in 2025.1, so the
-        // unlicensed Custom selection is intercepted here: revert the UI to
-        // the previous preset and open the upgrade flow. This is the ONLY
-        // free-pill call path that touches the license checker — the four
-        // named pills below never reach the gate.
+        // The Custom pill is disabled through the SegmentedButton item
+        // presentation, but direct calls and future programmatic selection
+        // paths still need the service-level gate.
         if (preset == SyntaxPreset.CUSTOM && !LicenseChecker.isLicensedOrGrace()) {
             suppressListeners = true
             try {
@@ -487,6 +501,7 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
         }
         customSelected.set(pendingPreset == SyntaxPreset.CUSTOM)
         refreshReadabilityCheckboxes()
+        refreshPresetPillAffordance()
         rebindSlidersFor(currentLanguage)
         refreshMasterResetButton()
         preview()
@@ -528,10 +543,17 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
     }
 
     private fun refreshReadabilityCheckboxes() {
-        dimCommentsCheckbox?.isSelected = pendingDimComments
-        softenDocumentationCheckbox?.isSelected = pendingSoftenDocumentation
-        quietOperatorsCheckbox?.isSelected = pendingQuietOperators
-        emphasizeDeclarationsCheckbox?.isSelected = pendingEmphasizeDeclarations
+        dimCommentsCheckbox?.applyReadabilityCheckboxState(pendingDimComments)
+        softenDocumentationCheckbox?.applyReadabilityCheckboxState(pendingSoftenDocumentation)
+        quietOperatorsCheckbox?.applyReadabilityCheckboxState(pendingQuietOperators)
+        emphasizeDeclarationsCheckbox?.applyReadabilityCheckboxState(pendingEmphasizeDeclarations)
+    }
+
+    private fun refreshPresetPillAffordance() {
+        val segmented = presetSegmented ?: return
+        for (preset in SyntaxPreset.entries) {
+            segmented.update(preset)
+        }
     }
 
     private fun rememberReadabilityOptions(options: SyntaxReadabilityOptions) {
@@ -656,53 +678,14 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
             emphasizeDeclarations = pendingEmphasizeDeclarations,
         )
 
-    /**
-     * Walk the [presetSegmented]'s rendered Swing subtree and set a
-     * "Pro Feature" tooltip on the button corresponding to
-     * [SyntaxPreset.CUSTOM] when the user is unlicensed. Best-effort:
-     * `SegmentedButton`'s internal widget tree is not API-stable across
-     * platform versions. If the tooltip cannot be applied, the
-     * click-then-revert fallback in [onPresetChosen] still surfaces the
-     * upgrade prompt — the tooltip is the pre-click affordance, not the
-     * gate itself.
-     *
-     * Pattern B: only `RuntimeException` is caught — narrower exceptions
-     * propagate. The runIde smoke test on the follow-up plan finalises the
-     * concrete Swing widget lookup; this method is the wire site for that
-     * verified path.
-     */
-    private fun applyCustomPillTooltipIfFree() {
-        if (LicenseChecker.isLicensedOrGrace()) return
-        try {
-            val root = renderedSegmentedComponent() ?: return
-            findCustomPresetButton(root)?.apply {
-                isEnabled = false
-                toolTipText = PREMIUM_CONTROL_TOOLTIP
-            }
-        } catch (runtime: RuntimeException) {
-            LOG.warn("AyuIslandsSyntaxPanel: tooltip pre-placement on Custom pill failed", runtime)
-        }
-    }
-
-    private fun renderedSegmentedComponent(): Component? {
+    private fun customPresetPresentation(): ItemPresentation? {
         val segmented = presetSegmented ?: return null
-        val getComponent =
+        val getPresentations =
             segmented.javaClass.methods.firstOrNull { method ->
-                method.name == "getComponent" && method.parameterCount == 0
+                method.name == SEGMENTED_PRESENTATIONS_METHOD && method.parameterCount == 0
             } ?: return null
-        return getComponent.invoke(segmented) as? Component
-    }
-
-    private fun findCustomPresetButton(component: Component): JComponent? {
-        if (component is AbstractButton && component.text == SyntaxPreset.CUSTOM.displayName) {
-            return component
-        }
-        val container = component as? Container ?: return null
-        for (child in container.components) {
-            val match = findCustomPresetButton(child)
-            if (match != null) return match
-        }
-        return null
+        val presentationMap = getPresentations.invoke(segmented) as? Map<*, *> ?: return null
+        return presentationMap[SyntaxPreset.CUSTOM] as? ItemPresentation
     }
 
     /**
@@ -718,7 +701,6 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
     )
 
     private companion object {
-        private val LOG = logger<AyuIslandsSyntaxPanel>()
         private const val DEBOUNCE_MS = 100
         private const val SLIDER_MIN = 0
         private const val SLIDER_MAX = 100
@@ -732,6 +714,8 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
         private const val LABEL_PADDING = 8
         private const val LABEL_FALLBACK_WIDTH = 170
         private const val PREMIUM_CONTROL_TOOLTIP = "Pro Feature"
+        private const val SEGMENTED_PRESENTATIONS_METHOD =
+            "getPresentations" + "$" + "intellij_platform_ide_impl"
 
         /**
          * The 16 [PrimitiveCategory] entries grouped by syntactic role and

--- a/src/main/kotlin/dev/ayuislands/syntax/SyntaxIntensityApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/syntax/SyntaxIntensityApplicator.kt
@@ -360,7 +360,7 @@ object SyntaxIntensityApplicator {
 
     private const val MAX_RGB_CHANNEL = 255
 
-    private const val DIM_COMMENTS_INTENSITY = 70
+    private const val DIM_COMMENTS_INTENSITY = 60
     private const val SOFTEN_DOCUMENTATION_INTENSITY = 82
     private const val QUIET_OPERATORS_INTENSITY = 78
     private const val EMPHASIZE_DECLARATIONS_SATURATION_DELTA = 0.08f

--- a/src/main/kotlin/dev/ayuislands/syntax/SyntaxIntensityApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/syntax/SyntaxIntensityApplicator.kt
@@ -48,6 +48,12 @@ import kotlin.math.abs
  * no style. Sparse: an absent cell leaves `fontType` untouched (inherits the
  * source style). Named / AMBIENT presets never read `customStyles`.
  *
+ * Readability modifiers are a second semantic layer after the selected preset
+ * has resolved. They never write Custom slider cells: comments, docs, and
+ * operators recede by blending toward `editorBg`, while declarations get a
+ * small chroma-intent boost. The user's Custom sparse map stays manual
+ * per-language tuning only.
+ *
  * Pattern B clone discipline: baseline / overlay `TextAttributes` instances
  * are NEVER mutated. Every output value is a fresh clone obtained via
  * `source.clone()` and the cloned instance is the only thing the applicator
@@ -90,6 +96,7 @@ object SyntaxIntensityApplicator {
         val customOverrides: Map<String, Map<String, Int>> = emptyMap(),
         val subordinatePreset: SyntaxPreset = SyntaxPreset.AMBIENT,
         val customStyles: Map<String, Map<String, Int>> = emptyMap(),
+        val readabilityOptions: SyntaxReadabilityOptions = SyntaxReadabilityOptions.DEFAULT,
     )
 
     fun compute(request: Request): Map<TextAttributesKey, TextAttributes> {
@@ -101,7 +108,15 @@ object SyntaxIntensityApplicator {
         warnOnceIfWhiteBgOnDarkVariant(request.variantName, request.editorBg)
 
         val result = linkedMapOf<TextAttributesKey, TextAttributes>()
-        val context = TransformContext(preset, customOverrides, subordinatePreset, request.customStyles)
+        val context =
+            TransformContext(
+                preset = preset,
+                customOverrides = customOverrides,
+                subordinatePreset = subordinatePreset,
+                customStyles = request.customStyles,
+                readabilityOptions = request.readabilityOptions,
+                editorBg = request.editorBg,
+            )
         val sources = AttributeSources(baseline, overlay)
         val keys = LinkedHashSet<TextAttributesKey>()
         keys.addAll(baseline.keys)
@@ -143,6 +158,8 @@ object SyntaxIntensityApplicator {
         val customOverrides: Map<String, Map<String, Int>>,
         val subordinatePreset: SyntaxPreset,
         val customStyles: Map<String, Map<String, Int>>,
+        val readabilityOptions: SyntaxReadabilityOptions,
+        val editorBg: Color,
     )
 
     private data class AttributeSources(
@@ -165,7 +182,14 @@ object SyntaxIntensityApplicator {
     ): TextAttributes? {
         val sourceForeground = source.foregroundColor ?: return null
         val clone = source.clone()
-        clone.foregroundColor = transformForeground(sourceForeground, curve)
+        clone.foregroundColor =
+            transformForeground(
+                fg = sourceForeground,
+                curve = curve,
+                readabilityOptions = context.readabilityOptions,
+                category = category,
+                editorBg = context.editorBg,
+            )
         // Sparse per-category font style — gated to the Custom drill-down.
         // fontType and foregroundColor are independent TextAttributes fields,
         // so the style set is orthogonal to the hue/color transform above.
@@ -250,6 +274,17 @@ object SyntaxIntensityApplicator {
     private fun transformForeground(
         fg: Color,
         curve: CategoryCurve,
+        readabilityOptions: SyntaxReadabilityOptions,
+        category: PrimitiveCategory,
+        editorBg: Color,
+    ): Color {
+        val color = transformForeground(fg, curve)
+        return applyReadabilityModifiers(color, category, readabilityOptions, editorBg)
+    }
+
+    private fun transformForeground(
+        fg: Color,
+        curve: CategoryCurve,
     ): Color {
         if (curve.saturationDelta == 0f && curve.lightnessDelta == 0f) return fg
         val hsl = HslColor.fromColor(fg)
@@ -275,6 +310,39 @@ object SyntaxIntensityApplicator {
         return HslColor.toColor(hsl.hue, newSat, newLight)
     }
 
+    private fun applyReadabilityModifiers(
+        color: Color,
+        category: PrimitiveCategory,
+        options: SyntaxReadabilityOptions,
+        editorBg: Color,
+    ): Color =
+        when (category) {
+            PrimitiveCategory.COMMENT ->
+                if (options.dimComments) {
+                    RgbBlend.blend(color, editorBg, DIM_COMMENTS_INTENSITY)
+                } else {
+                    color
+                }
+            PrimitiveCategory.DOCUMENTATION ->
+                if (options.softenDocumentation) {
+                    RgbBlend.blend(color, editorBg, SOFTEN_DOCUMENTATION_INTENSITY)
+                } else {
+                    color
+                }
+            PrimitiveCategory.OPERATOR ->
+                if (options.quietOperators) {
+                    RgbBlend.blend(color, editorBg, QUIET_OPERATORS_INTENSITY)
+                } else {
+                    color
+                }
+            PrimitiveCategory.FUNCTION_DECL,
+            PrimitiveCategory.CLASS_DECL,
+            PrimitiveCategory.INTERFACE_DECL,
+            ->
+                if (options.emphasizeDeclarations) transformForeground(color, EMPHASIZE_DECLARATIONS_CURVE) else color
+            else -> color
+        }
+
     private fun warnOnceIfWhiteBgOnDarkVariant(
         variantName: String,
         editorBg: Color,
@@ -291,6 +359,15 @@ object SyntaxIntensityApplicator {
     }
 
     private const val MAX_RGB_CHANNEL = 255
+
+    private const val DIM_COMMENTS_INTENSITY = 70
+    private const val SOFTEN_DOCUMENTATION_INTENSITY = 82
+    private const val QUIET_OPERATORS_INTENSITY = 78
+    private const val EMPHASIZE_DECLARATIONS_SATURATION_DELTA = 0.08f
+    private const val EMPHASIZE_DECLARATIONS_LIGHTNESS_DELTA = 0.06f
+
+    private val EMPHASIZE_DECLARATIONS_CURVE =
+        CategoryCurve(EMPHASIZE_DECLARATIONS_SATURATION_DELTA, EMPHASIZE_DECLARATIONS_LIGHTNESS_DELTA)
 
     // The flank pivot for the signed chroma intent: tokens at or above this L
     // are pushed DOWN toward it by a positive intent, tokens below are pushed UP.

--- a/src/main/kotlin/dev/ayuislands/syntax/SyntaxIntensityService.kt
+++ b/src/main/kotlin/dev/ayuislands/syntax/SyntaxIntensityService.kt
@@ -80,6 +80,7 @@ class SyntaxIntensityService {
         customOverrides: Map<String, Map<String, Int>>,
         subordinatePreset: SyntaxPreset = SyntaxPreset.AMBIENT,
         customStyles: Map<String, Map<String, Int>> = emptyMap(),
+        readabilityOptions: SyntaxReadabilityOptions = SyntaxReadabilityOptions.DEFAULT,
     ) {
         val effectivePreset = enforceCustomGate(preset)
         val context =
@@ -88,6 +89,7 @@ class SyntaxIntensityService {
                 customOverrides = customOverrides,
                 subordinatePreset = subordinatePreset,
                 customStyles = customStyles,
+                readabilityOptions = readabilityOptions,
             )
         val manager = EditorColorsManager.getInstance()
         val touched = mutableSetOf<EditorColorsScheme>()
@@ -117,7 +119,7 @@ class SyntaxIntensityService {
         val config = state.toPresetConfig()
         val preset = SyntaxPreset.fromName(config.selectedPreset)
         val subordinate = SyntaxPreset.fromName(config.subordinatePreset)
-        apply(preset, config.customOverrides, subordinate, config.customStyles)
+        apply(preset, config.customOverrides, subordinate, config.customStyles, config.readabilityOptions)
     }
 
     private data class ApplyContext(
@@ -125,6 +127,7 @@ class SyntaxIntensityService {
         val customOverrides: Map<String, Map<String, Int>>,
         val subordinatePreset: SyntaxPreset,
         val customStyles: Map<String, Map<String, Int>>,
+        val readabilityOptions: SyntaxReadabilityOptions,
     )
 
     /**
@@ -250,6 +253,7 @@ class SyntaxIntensityService {
                 customOverrides = context.customOverrides,
                 subordinatePreset = context.subordinatePreset,
                 customStyles = context.customStyles,
+                readabilityOptions = context.readabilityOptions,
             ),
         )
     }

--- a/src/main/kotlin/dev/ayuislands/syntax/SyntaxIntensityService.kt
+++ b/src/main/kotlin/dev/ayuislands/syntax/SyntaxIntensityService.kt
@@ -48,13 +48,13 @@ import java.util.concurrent.atomic.AtomicBoolean
  *    names is intentionally avoided here: a future scheme name like
  *    "Ayu Islands Darkroom" would otherwise silently capture the "Dark"
  *    branch.
- *  - Service-layer `CUSTOM` premium gate: [enforceCustomGate] normalises
- *    an unlicensed `CUSTOM` request down to `AMBIENT` and logs WARN once
- *    per session. The Settings panel performs UI-level gating, but that
- *    gate is bypass-able from future actions, tests, or settings imports
- *    that call this service directly. The service-layer normalisation is
- *    the defense-in-depth so the applicator never sees `CUSTOM` from an
- *    unlicensed call path.
+ *  - Service-layer premium gates: [enforceCustomGate] normalises an unlicensed
+ *    `CUSTOM` request down to `AMBIENT`, and [enforceReadabilityGate] drops
+ *    premium readability modifiers for unlicensed callers. The Settings panel
+ *    performs UI-level gating, but that gate is bypass-able from future
+ *    actions, tests, or settings imports that call this service directly.
+ *    Service-layer normalisation is the defense-in-depth so the applicator
+ *    never sees premium syntax inputs from an unlicensed call path.
  *
  * The language tag for each baseline key is derived inside
  * [SyntaxIntensityApplicator.compute] via [SyntaxLanguageRegistry.classify].
@@ -83,13 +83,14 @@ class SyntaxIntensityService {
         readabilityOptions: SyntaxReadabilityOptions = SyntaxReadabilityOptions.DEFAULT,
     ) {
         val effectivePreset = enforceCustomGate(preset)
+        val effectiveReadabilityOptions = enforceReadabilityGate(readabilityOptions)
         val context =
             ApplyContext(
                 preset = effectivePreset,
                 customOverrides = customOverrides,
                 subordinatePreset = subordinatePreset,
                 customStyles = customStyles,
-                readabilityOptions = readabilityOptions,
+                readabilityOptions = effectiveReadabilityOptions,
             )
         val manager = EditorColorsManager.getInstance()
         val touched = mutableSetOf<EditorColorsScheme>()
@@ -151,6 +152,11 @@ class SyntaxIntensityService {
             )
         }
         return SyntaxPreset.AMBIENT
+    }
+
+    private fun enforceReadabilityGate(readabilityOptions: SyntaxReadabilityOptions): SyntaxReadabilityOptions {
+        if (readabilityOptions == SyntaxReadabilityOptions.DEFAULT) return readabilityOptions
+        return if (LicenseChecker.isLicensedOrGrace()) readabilityOptions else SyntaxReadabilityOptions.DEFAULT
     }
 
     /**

--- a/src/main/kotlin/dev/ayuislands/syntax/SyntaxIntensityState.kt
+++ b/src/main/kotlin/dev/ayuislands/syntax/SyntaxIntensityState.kt
@@ -8,6 +8,8 @@ import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import java.awt.Font
 
+internal const val SYNTAX_INTENSITY_SCHEMA_VERSION = 3
+
 /**
  * Per-category font style for the Custom drill-down (Part A backend).
  *
@@ -57,9 +59,9 @@ enum class FontStyleOverride(
  *    is skipped — both reviewers independently flagged BaseState's nested-map
  *    delegate as unreliable for XML round-trip.
  *  - OpenCode suggestion: `schemaVersion` field added for forward migration
- *    safety; now `2` since [SyntaxIntensityBaseState.customStyles] was added.
- *    A v1 config (no `customStyles` element) reads as an empty map and
- *    inherits the source font, so the bump needs no read-time migration.
+ *    safety; now `3` since the global readability booleans were added. A v2
+ *    config (no readability elements) reads as all false, so the bump needs no
+ *    read-time migration.
  *  - Codex HIGH #1 continuation: [toPresetConfig] is the one-way bridge
  *    that adapts the flat composite-key map back into the nested
  *    `Map<String, Map<String, Int>>` shape consumed by
@@ -109,6 +111,13 @@ class SyntaxIntensityState : SimplePersistentStateComponent<SyntaxIntensityBaseS
             // into TextAttributes.fontType; a tampered token decodes to null
             // and the cell is dropped, mirroring the toIntOrNull discipline.
             customStyles = reshapeFlatMap(state.customStyles) { FontStyleOverride.fromName(it)?.fontType },
+            readabilityOptions =
+                SyntaxReadabilityOptions(
+                    dimComments = state.dimComments,
+                    softenDocumentation = state.softenDocumentation,
+                    quietOperators = state.quietOperators,
+                    emphasizeDeclarations = state.emphasizeDeclarations,
+                ),
         )
 
     /**
@@ -169,11 +178,14 @@ class SyntaxIntensityState : SimplePersistentStateComponent<SyntaxIntensityBaseS
  *    materialise; an absent cell inherits the source attribute's font style.
  *    Independent of the intensity slider — a cell may carry a style override
  *    with no slider, or a slider with no style.
- *  - [schemaVersion]: forward-compat sentinel; default `2` since the
- *    [customStyles] map was introduced. A v1 config (no `customStyles`
- *    element) deserialises with an empty `customStyles` map via the BaseState
- *    `map` delegate, so the bump needs NO read-time migration — absent styles
- *    simply inherit the source font.
+ *  - [dimComments], [softenDocumentation], [quietOperators], and
+ *    [emphasizeDeclarations]: global readability modifiers layered on top of
+ *    any selected preset. Defaults are false, so existing XML with no elements
+ *    stays byte-identical until the user opts in.
+ *  - [schemaVersion]: forward-compat sentinel; default `3` since readability
+ *    modifiers were introduced. A v2 config (no readability elements)
+ *    deserialises with all booleans false through the BaseState delegates, so
+ *    the bump needs NO read-time migration.
  *
  * The free tier never writes to [customOverrides] / [customStyles] — the
  * premium Custom drill-down is the only writer.
@@ -183,5 +195,9 @@ class SyntaxIntensityBaseState : BaseState() {
     var subordinatePreset by string("AMBIENT")
     var customOverrides by map<String, String>()
     var customStyles by map<String, String>()
-    var schemaVersion by property(2)
+    var dimComments by property(false)
+    var softenDocumentation by property(false)
+    var quietOperators by property(false)
+    var emphasizeDeclarations by property(false)
+    var schemaVersion by property(SYNTAX_INTENSITY_SCHEMA_VERSION)
 }

--- a/src/main/kotlin/dev/ayuislands/syntax/SyntaxPresetConfig.kt
+++ b/src/main/kotlin/dev/ayuislands/syntax/SyntaxPresetConfig.kt
@@ -29,10 +29,34 @@ package dev.ayuislands.syntax
  *    an absent cell inherits the source attribute's font style. Defaults to
  *    `emptyMap()` so callers predating the font-style feature compile
  *    unchanged.
+ *  - [readabilityOptions]: global semantic modifiers layered on top of the
+ *    selected preset. Defaults to [SyntaxReadabilityOptions.DEFAULT] so old
+ *    callers and old XML preserve the previous byte-identical output.
  */
 data class SyntaxPresetConfig(
     val selectedPreset: String,
     val customOverrides: Map<String, Map<String, Int>>,
     val subordinatePreset: String = "AMBIENT",
     val customStyles: Map<String, Map<String, Int>> = emptyMap(),
+    val readabilityOptions: SyntaxReadabilityOptions = SyntaxReadabilityOptions.DEFAULT,
 )
+
+/**
+ * Global readability modifiers layered on top of the selected syntax preset.
+ *
+ * These switches are intentionally separate from Custom's per-language sparse
+ * cells: Custom answers "which language/category should I tune manually?",
+ * while readability answers "which semantic noise should recede everywhere?".
+ * Defaults are all false so existing installs keep byte-identical syntax until
+ * a user opts in.
+ */
+data class SyntaxReadabilityOptions(
+    val dimComments: Boolean = false,
+    val softenDocumentation: Boolean = false,
+    val quietOperators: Boolean = false,
+    val emphasizeDeclarations: Boolean = false,
+) {
+    companion object {
+        val DEFAULT: SyntaxReadabilityOptions = SyntaxReadabilityOptions()
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/accent/ChromeBaseColorsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ChromeBaseColorsTest.kt
@@ -100,6 +100,38 @@ class ChromeBaseColorsTest {
     }
 
     @Test
+    fun `refresh does not recapture plugin tint as the stock baseline`() {
+        val pluginTint = Color(0x43, 0x86, 0x93)
+
+        assertEquals(statusBarStock, ChromeBaseColors["StatusBar.background"])
+        ChromeBaseColors.rememberPluginTint("StatusBar.background", pluginTint)
+
+        // Listener-order regression: a late LAF event clears the cache after
+        // this plugin already wrote the tint. The next apply must recover the
+        // original stock base, not compound from the tinted value.
+        every { UIManager.getColor("StatusBar.background") } returns pluginTint
+        ChromeBaseColors.refresh()
+
+        val reCaptured = ChromeBaseColors["StatusBar.background"]
+        assertEquals(statusBarStock, reCaptured)
+    }
+
+    @Test
+    fun `refresh captures new stock when current color differs from plugin tint`() {
+        val pluginTint = Color(0x43, 0x86, 0x93)
+        val newThemeStock = Color(0x2E, 0x35, 0x44)
+
+        assertEquals(statusBarStock, ChromeBaseColors["StatusBar.background"])
+        ChromeBaseColors.rememberPluginTint("StatusBar.background", pluginTint)
+
+        every { UIManager.getColor("StatusBar.background") } returns newThemeStock
+        ChromeBaseColors.refresh()
+
+        val reCaptured = ChromeBaseColors["StatusBar.background"]
+        assertEquals(newThemeStock, reCaptured)
+    }
+
+    @Test
     fun `get returns null when UIManager has no entry for the key`() {
         assertNull(ChromeBaseColors["Missing.key"])
     }

--- a/src/test/kotlin/dev/ayuislands/accent/ChromeTintBlenderHueUniformityTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ChromeTintBlenderHueUniformityTest.kt
@@ -7,10 +7,11 @@ import kotlin.test.assertTrue
 
 /**
  * Algorithmic lock on the uniform-hue invariant:
- * `ChromeTintBlender.blend` must produce the SAME hue across the five real
- * chrome base colors at any intensity value, while preserving each base's
+ * `ChromeTintBlender.blend` must converge to the SAME hue across the five real
+ * chrome base colors at max visible intensity, while preserving each base's
  * original luminance so the existing visual hierarchy (status bar darker than
- * toolbar, etc.) survives the rework.
+ * toolbar, etc.) survives the rework. Low intensity intentionally stays close
+ * to stock chrome instead of snapping immediately to the accent hue.
  *
  * A runIde smoke previously surfaced a regression — at intensity=20 each
  * surface rendered as a visibly different color because per-channel RGB lerp
@@ -43,23 +44,33 @@ class ChromeTintBlenderHueUniformityTest {
         )
 
     @Test
-    fun `blend produces the same hue across all 5 chrome bases at intensity 20`() {
-        accents.forEach { accent ->
-            assertUniformHue(accent, intensity = 20)
-        }
+    fun `blend keeps low intensity status bar tint visually close to stock`() {
+        val accent = Color(0x5C, 0xCF, 0xE6)
+        val base = Color(0x2E, 0x35, 0x44)
+
+        val tinted = ChromeTintBlender.blend(accent, base, TintIntensity.of(10))
+
+        assertTrue(
+            tinted.green - base.green <= LOW_INTENSITY_GREEN_DELTA_MAX,
+            "StatusBar at intensity=10 must be a slight accent, not a saturated teal: tinted=$tinted",
+        )
+        assertTrue(
+            hueDelta(hueOf(tinted), hueOf(base)) < hueDelta(hueOf(tinted), hueOf(accent)),
+            "StatusBar at intensity=10 must remain closer to the stock hue than the accent hue",
+        )
     }
 
     @Test
     fun `blend produces the same hue across all 5 chrome bases at intensity 50`() {
         accents.forEach { accent ->
-            assertUniformHue(accent, intensity = 50)
+            assertUniformHue(accent, intensity = 50, epsilon = HUE_EPSILON)
         }
     }
 
     @Test
     fun `blend produces the same hue across all 5 chrome bases at intensity 80`() {
         accents.forEach { accent ->
-            assertUniformHue(accent, intensity = 80)
+            assertUniformHue(accent, intensity = 80, epsilon = HUE_EPSILON)
         }
     }
 
@@ -150,6 +161,7 @@ class ChromeTintBlenderHueUniformityTest {
     private fun assertUniformHue(
         accent: Color,
         intensity: Int,
+        epsilon: Float,
     ) {
         val wrapped = TintIntensity.of(intensity)
         val tintedByKey =
@@ -160,8 +172,8 @@ class ChromeTintBlenderHueUniformityTest {
             val delta = hueDelta(h, reference)
             val ref = hues.keys.first()
             assertTrue(
-                delta <= HUE_EPSILON,
-                "hue spread exceeds ε=$HUE_EPSILON at intensity=$intensity accent=$accent: " +
+                delta <= epsilon,
+                "hue spread exceeds ε=$epsilon at intensity=$intensity accent=$accent: " +
                     "reference=$ref(h=$reference) vs $key(h=$h) Δ=$delta; " +
                     "tintedByKey=$tintedByKey",
             )
@@ -204,6 +216,7 @@ class ChromeTintBlenderHueUniformityTest {
         // base hue differences (StatusBar luminance lower than NavBar) drift through
         // the lerp; the HSB-replacement rework holds well within this band.
         private const val HUE_EPSILON = 0.01f
+        private const val LOW_INTENSITY_GREEN_DELTA_MAX = 10
         private const val OPAQUE_ALPHA = 255
         private const val LUMA_R = 0.299
         private const val LUMA_G = 0.587

--- a/src/test/kotlin/dev/ayuislands/accent/ChromeTintBlenderTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ChromeTintBlenderTest.kt
@@ -61,6 +61,32 @@ class ChromeTintBlenderTest {
     }
 
     @Test
+    fun `blend crosses the red hue seam by the shortest path`() {
+        val scenarios =
+            listOf(
+                HueSeamScenario(baseHue = 0.95f, accentHue = 0.05f),
+                HueSeamScenario(baseHue = 0.05f, accentHue = 0.95f),
+            )
+
+        for (scenario in scenarios) {
+            val base = Color.getHSBColor(scenario.baseHue, 0.45f, 0.35f)
+            val accent = Color.getHSBColor(scenario.accentHue, 0.90f, 0.80f)
+            val result = ChromeTintBlender.blend(accent, base, TintIntensity.of(25))
+            val resultHue = hueOf(result)
+
+            assertTrue(
+                hueDelta(resultHue, RED_SEAM_HUE) <= HUE_SEAM_EPSILON,
+                "mid-intensity hue must cross the red seam, not detour through cyan: " +
+                    "baseHue=${scenario.baseHue}, accentHue=${scenario.accentHue}, resultHue=$resultHue",
+            )
+            assertTrue(
+                hueDelta(resultHue, CYAN_DETOUR_HUE) > CYAN_DETOUR_MIN_DELTA,
+                "red-seam blend must stay away from the opposite cyan hue: resultHue=$resultHue",
+            )
+        }
+    }
+
+    @Test
     fun `blend at intensity 50 output hue converges to accent hue`() {
         // Contract: the blender does NOT produce an RGB midpoint between base
         // and accent — it lerps the base toward a synthesised HSB target
@@ -134,10 +160,19 @@ class ChromeTintBlenderTest {
         return if (raw > 0.5f) 1f - raw else raw
     }
 
+    private data class HueSeamScenario(
+        val baseHue: Float,
+        val accentHue: Float,
+    )
+
     companion object {
         // ε ≈ 0.01 on the unit hue circle ≈ 3.6° on a 360° wheel — same ε used
         // by ChromeTintBlenderHueUniformityTest (kept consistent across suites).
         private const val HUE_EPSILON = 0.01f
+        private const val HUE_SEAM_EPSILON = 0.03f
+        private const val RED_SEAM_HUE = 0.0f
+        private const val CYAN_DETOUR_HUE = 0.5f
+        private const val CYAN_DETOUR_MIN_DELTA = 0.35f
         private const val LOW_INTENSITY_GREEN_DELTA_MAX = 10
     }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/ChromeTintBlenderTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ChromeTintBlenderTest.kt
@@ -26,13 +26,13 @@ class ChromeTintBlenderTest {
     }
 
     @Test
-    fun `blend at intensity 100 output hue matches accent hue`() {
-        // Contract: at max intensity the blender returns the accent HUE on
+    fun `blend at max visible intensity output hue matches accent hue`() {
+        // Contract: at max visible intensity the blender returns the accent HUE on
         // the base's luminance (target = HSB(accent.H, accent.S, base.B)),
         // NOT the accent's RGB per-channel. The legacy per-channel identity
         // was superseded by the hue-uniformity invariant — see
         // ChromeTintBlenderHueUniformityTest for the 5-surface lock.
-        val result = ChromeTintBlender.blend(accentRed, darkBase, TintIntensity.of(100))
+        val result = ChromeTintBlender.blend(accentRed, darkBase, TintIntensity.of(TintIntensity.MAX))
         val resultHue = hueOf(result)
         val accentHue = hueOf(accentRed)
         assertTrue(
@@ -43,13 +43,29 @@ class ChromeTintBlenderTest {
     }
 
     @Test
-    fun `blend at intensity 50 output hue converges toward accent hue`() {
+    fun `blend at minimum visible intensity stays closer to stock than accent hue`() {
+        val stockStatusBar = Color(0x2E, 0x35, 0x44)
+        val result = ChromeTintBlender.blend(Color(0x5C, 0xCF, 0xE6), stockStatusBar, TintIntensity.of(10))
+        val resultHue = hueOf(result)
+        val stockHue = hueOf(stockStatusBar)
+        val accentHue = hueOf(Color(0x5C, 0xCF, 0xE6))
+
+        assertTrue(
+            hueDelta(resultHue, stockHue) < hueDelta(resultHue, accentHue),
+            "intensity=10 must stay visually closer to stock chrome than to the accent hue",
+        )
+        assertTrue(
+            result.green - stockStatusBar.green <= LOW_INTENSITY_GREEN_DELTA_MAX,
+            "intensity=10 must be a subtle accent; got green delta ${result.green - stockStatusBar.green}",
+        )
+    }
+
+    @Test
+    fun `blend at intensity 50 output hue converges to accent hue`() {
         // Contract: the blender does NOT produce an RGB midpoint between base
         // and accent — it lerps the base toward a synthesised HSB target
-        // (accent.H, accent.S, base.B), so the output hue converges from
-        // the base hue toward the accent hue. The neutral darkBase has S≈0
-        // (undefined hue), so any tint moves the output toward the accent hue
-        // within ε at 50%.
+        // (accent.H, accent.S, base.B), so max visible intensity reaches the
+        // accent hue while lower values stay closer to the stock chrome hue.
         val result = ChromeTintBlender.blend(accentRed, darkBase, TintIntensity.of(50))
         val resultHue = hueOf(result)
         val accentHue = hueOf(accentRed)
@@ -122,5 +138,6 @@ class ChromeTintBlenderTest {
         // ε ≈ 0.01 on the unit hue circle ≈ 3.6° on a 360° wheel — same ε used
         // by ChromeTintBlenderHueUniformityTest (kept consistent across suites).
         private const val HUE_EPSILON = 0.01f
+        private const val LOW_INTENSITY_GREEN_DELTA_MAX = 10
     }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/WcagForegroundTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/WcagForegroundTest.kt
@@ -1,5 +1,6 @@
 package dev.ayuislands.accent
 
+import com.intellij.ui.JBColor
 import dev.ayuislands.accent.WcagForeground.TextTarget
 import java.awt.Color
 import kotlin.math.abs
@@ -84,6 +85,28 @@ class WcagForegroundTest {
         val darkAyu = Color(0x1F, 0x24, 0x30)
         val picked = WcagForeground.pickForeground(darkAyu, TextTarget.PRIMARY_TEXT)
         assertEquals(Color.WHITE, picked, "white must be the first palette entry passing AA on dark Ayu")
+    }
+
+    @Test
+    fun `pickLightFamilyForeground keeps literal white under dark JBColor mode`() {
+        val wasBright = JBColor.isBright()
+        try {
+            JBColor.setDark(true)
+
+            val picked =
+                WcagForeground.pickLightFamilyForeground(
+                    Color(0x31, 0x48, 0x4C),
+                    TextTarget.PRIMARY_TEXT,
+                )
+
+            assertEquals(
+                Color.WHITE.rgb,
+                picked.rgb,
+                "Status-bar contrast must use literal white, not JBColor.WHITE's dark-LAF background.",
+            )
+        } finally {
+            JBColor.setDark(!wasBright)
+        }
     }
 
     // W-6

--- a/src/test/kotlin/dev/ayuislands/accent/elements/StatusBarElementTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/StatusBarElementTest.kt
@@ -58,7 +58,7 @@ class StatusBarElementTest {
         every { UIManager.put(any<String>(), any()) } returns null
 
         mockkObject(ChromeBaseColors)
-        every { ChromeBaseColors.get(any()) } returns stockBase
+        every { ChromeBaseColors[any()] } returns stockBase
 
         mockkObject(ChromeTintBlender)
         every { ChromeTintBlender.blend(any(), any<Color>(), any()) } returns blended
@@ -87,6 +87,7 @@ class StatusBarElementTest {
         verify { UIManager.put("StatusBar.background", blended) }
         verify { UIManager.put("StatusBar.borderColor", blended) }
         verify { UIManager.put("StatusBar.Widget.hoverBackground", null) }
+        verify { UIManager.put("StatusBar.Widget.pressedBackground", null) }
         // NavBar Compact (2026.1) state-specific bg keys read by
         // `NavBarItemComponent.highlightColor()` are translucent overlays, not
         // standalone surfaces. The compact panel receives the opaque tint directly;
@@ -106,7 +107,7 @@ class StatusBarElementTest {
         // applied plugin override cannot leak past a partial apply. Guards
         // against a future refactor that "optimizes" the null sweep behind an
         // `if (tinted.isNotEmpty())` check.
-        every { ChromeBaseColors.get(any()) } returns null
+        every { ChromeBaseColors[any()] } returns null
         state.chromeTintIntensity = 30
 
         StatusBarElement().apply(accent)
@@ -116,6 +117,7 @@ class StatusBarElementTest {
         verify { UIManager.put("StatusBar.Breadcrumbs.selectionInactiveBackground", null) }
         verify { UIManager.put("StatusBar.Breadcrumbs.floatingBackground", null) }
         verify { UIManager.put("StatusBar.Widget.hoverBackground", null) }
+        verify { UIManager.put("StatusBar.Widget.pressedBackground", null) }
         // No opaque tint should have been written since the bases were absent.
         verify(exactly = 0) { UIManager.put("StatusBar.background", blended) }
     }
@@ -128,15 +130,17 @@ class StatusBarElementTest {
         verify { UIManager.put("StatusBar.background", null) }
         verify { UIManager.put("StatusBar.borderColor", null) }
         verify { UIManager.put("StatusBar.Widget.hoverBackground", null) }
+        verify { UIManager.put("StatusBar.Widget.pressedBackground", null) }
         verify { UIManager.put("StatusBar.Breadcrumbs.hoverBackground", null) }
         verify { UIManager.put("StatusBar.Breadcrumbs.selectionBackground", null) }
         verify { UIManager.put("StatusBar.Breadcrumbs.selectionInactiveBackground", null) }
         verify { UIManager.put("StatusBar.Breadcrumbs.floatingBackground", null) }
-        // Foregrounds (2 Widget + 5 Breadcrumbs state) — every fg state the path
-        // widget can land in must be nulled so the LAF re-resolves stock when the
-        // user disables chrome tinting.
+        // Foregrounds (3 Widget + 5 Breadcrumbs state) — every fg state text
+        // can land in must be nulled so the LAF re-resolves stock when the user
+        // disables chrome tinting.
         verify { UIManager.put("StatusBar.Widget.foreground", null) }
         verify { UIManager.put("StatusBar.Widget.hoverForeground", null) }
+        verify { UIManager.put("StatusBar.Widget.pressedForeground", null) }
         verify { UIManager.put("StatusBar.Breadcrumbs.foreground", null) }
         verify { UIManager.put("StatusBar.Breadcrumbs.hoverForeground", null) }
         verify { UIManager.put("StatusBar.Breadcrumbs.floatingForeground", null) }
@@ -160,6 +164,22 @@ class StatusBarElementTest {
         }
         verify { UIManager.put("StatusBar.Widget.foreground", Color.GREEN) }
         verify { UIManager.put("StatusBar.Widget.hoverForeground", Color.GREEN) }
+        verify { UIManager.put("StatusBar.Widget.pressedForeground", Color.GREEN) }
+    }
+
+    @Test
+    fun `apply extends light-family pick to all 3 platform widget foreground states`() {
+        // `TextPanel.paintComponent()` (IntelliJ 2026.1) selects Widget
+        // FOREGROUND / HOVER_FOREGROUND / PRESSED_FOREGROUND from the current
+        // mouse effect. Every state must be written so clicking a status widget
+        // cannot fall through to stock black text on the tinted status bar.
+        state.chromeTintIntensity = 40
+
+        StatusBarElement().apply(accent)
+
+        verify(exactly = 1) { UIManager.put("StatusBar.Widget.foreground", Color.GREEN) }
+        verify(exactly = 1) { UIManager.put("StatusBar.Widget.hoverForeground", Color.GREEN) }
+        verify(exactly = 1) { UIManager.put("StatusBar.Widget.pressedForeground", Color.GREEN) }
     }
 
     @Test
@@ -187,9 +207,9 @@ class StatusBarElementTest {
         val overlayForeground = Color(0x1F, 0x24, 0x30)
         state.chromeTintIntensity = 40
 
-        every { ChromeBaseColors.get("StatusBar.background") } returns Color(0x24, 0x29, 0x36)
-        every { ChromeBaseColors.get("StatusBar.borderColor") } returns Color(0x24, 0x29, 0x36)
-        every { ChromeBaseColors.get("StatusBar.Widget.hoverBackground") } returns Color(0xFF, 0xFF, 0xFF, 0x18)
+        every { ChromeBaseColors["StatusBar.background"] } returns Color(0x24, 0x29, 0x36)
+        every { ChromeBaseColors["StatusBar.borderColor"] } returns Color(0x24, 0x29, 0x36)
+        every { ChromeBaseColors["StatusBar.Widget.hoverBackground"] } returns Color(0xFF, 0xFF, 0xFF, 0x18)
         every {
             ChromeTintBlender.blend(accent, Color(0x24, 0x29, 0x36), any())
         } returns rootTint
@@ -206,9 +226,13 @@ class StatusBarElementTest {
         StatusBarElement().apply(accent)
 
         verify { UIManager.put("StatusBar.Widget.hoverForeground", rootForeground) }
+        verify { UIManager.put("StatusBar.Widget.pressedForeground", rootForeground) }
         verify { UIManager.put("StatusBar.Breadcrumbs.hoverForeground", rootForeground) }
         verify(exactly = 0) {
             UIManager.put("StatusBar.Widget.hoverForeground", overlayForeground)
+        }
+        verify(exactly = 0) {
+            UIManager.put("StatusBar.Widget.pressedForeground", overlayForeground)
         }
         verify(exactly = 0) {
             UIManager.put("StatusBar.Breadcrumbs.hoverForeground", overlayForeground)

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerVcsRevokeTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerVcsRevokeTest.kt
@@ -204,7 +204,9 @@ class LicenseCheckerVcsRevokeTest {
         syntaxState.state.customOverrides["Java|KEYWORD"] = "85"
         syntaxState.state.customStyles["Java|KEYWORD"] = "BOLD"
         syntaxState.state.dimComments = true
+        syntaxState.state.softenDocumentation = true
         syntaxState.state.quietOperators = true
+        syntaxState.state.emphasizeDeclarations = true
 
         LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
 
@@ -213,7 +215,9 @@ class LicenseCheckerVcsRevokeTest {
         assertTrue(syntaxState.state.customOverrides.isEmpty(), "syntax custom overrides must be cleared")
         assertTrue(syntaxState.state.customStyles.isEmpty(), "syntax custom styles must be cleared")
         assertFalse(syntaxState.state.dimComments, "premium readability toggles must be cleared on downgrade")
+        assertFalse(syntaxState.state.softenDocumentation, "premium readability toggles must be cleared on downgrade")
         assertFalse(syntaxState.state.quietOperators, "premium readability toggles must be cleared on downgrade")
+        assertFalse(syntaxState.state.emphasizeDeclarations, "premium readability toggles must be cleared on downgrade")
         verify(exactly = 1) {
             syntaxService.apply(
                 SyntaxPreset.AMBIENT,

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerVcsRevokeTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerVcsRevokeTest.kt
@@ -15,6 +15,7 @@ import dev.ayuislands.settings.AyuIslandsState
 import dev.ayuislands.syntax.SyntaxIntensityService
 import dev.ayuislands.syntax.SyntaxIntensityState
 import dev.ayuislands.syntax.SyntaxPreset
+import dev.ayuislands.syntax.SyntaxReadabilityOptions
 import dev.ayuislands.vcs.VcsColorApplier
 import dev.ayuislands.vcs.VcsColorPreset
 import io.mockk.every
@@ -65,7 +66,7 @@ class LicenseCheckerVcsRevokeTest {
         every { AyuIslandsSettings.getInstance() } returns settings
 
         mockkObject(AccentApplicator)
-        every { AccentApplicator.apply(any()) } answers { Unit }
+        every { AccentApplicator.apply(any()) } just runs
         every { AccentApplicator.applyFromHexString(any()) } returns true
 
         mockkObject(GlowOverlayManager.Companion)
@@ -202,6 +203,8 @@ class LicenseCheckerVcsRevokeTest {
         syntaxState.state.subordinatePreset = SyntaxPreset.NEON.name
         syntaxState.state.customOverrides["Java|KEYWORD"] = "85"
         syntaxState.state.customStyles["Java|KEYWORD"] = "BOLD"
+        syntaxState.state.dimComments = true
+        syntaxState.state.quietOperators = true
 
         LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
 
@@ -209,8 +212,16 @@ class LicenseCheckerVcsRevokeTest {
         assertEquals(SyntaxPreset.AMBIENT.name, syntaxState.state.subordinatePreset)
         assertTrue(syntaxState.state.customOverrides.isEmpty(), "syntax custom overrides must be cleared")
         assertTrue(syntaxState.state.customStyles.isEmpty(), "syntax custom styles must be cleared")
+        assertFalse(syntaxState.state.dimComments, "premium readability toggles must be cleared on downgrade")
+        assertFalse(syntaxState.state.quietOperators, "premium readability toggles must be cleared on downgrade")
         verify(exactly = 1) {
-            syntaxService.apply(SyntaxPreset.AMBIENT, emptyMap())
+            syntaxService.apply(
+                SyntaxPreset.AMBIENT,
+                emptyMap(),
+                SyntaxPreset.AMBIENT,
+                emptyMap(),
+                SyntaxReadabilityOptions.DEFAULT,
+            )
         }
     }
 

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanelTest.kt
@@ -74,11 +74,6 @@ import kotlin.test.assertTrue
  * that have no cheap unit-level behavioral substitute. Each one catches a
  * concrete regression:
  *
- *  - `applyCustomPillTooltipIfFree` wire site: the SegmentedButton-internal
- *    Swing subtree is not API-stable; if the post-realise `invokeLater`
- *    queueing is dropped, free users lose the Pro affordance on the Custom
- *    pill. A behavioral test would have to build the DSL panel and walk the
- *    SegmentedButton's component tree on the EDT.
  *  - Two-column grouped layout (`CUSTOM_COLUMN_GROUPS` + `buildCategoryGroup`):
  *    a refactor back to the single unbroken table or to the deleted master /
  *    detail JBList would be a visible regression. Verifying the actual two
@@ -445,26 +440,59 @@ class AyuIslandsSyntaxPanelTest {
         }
     }
 
-    // ---------- Test 7 - documented compromise: tooltip pre-placement wire site ----------
+    @Test
+    fun `reset disables readability controls when license flips to free`() {
+        stateBase.selectedPreset = SyntaxPreset.AMBIENT.name
+        stateBase.dimComments = true
+        val panel = AyuIslandsSyntaxPanel()
+
+        try {
+            val component = buildSyntaxPanel(panel)
+            val dimComments = findDimCommentsCheckBox(component)
+            assertTrue(dimComments.isEnabled, "licensed users can edit readability controls")
+
+            every { LicenseChecker.isLicensedOrGrace() } returns false
+            io.mockk.clearMocks(intensityService, answers = false, recordedCalls = true)
+
+            panel.reset()
+
+            assertFalse(dimComments.isEnabled, "reset must disable readability after license loss")
+            assertFalse(dimComments.isSelected, "reset must hide persisted premium readability after license loss")
+
+            verify(exactly = 1) {
+                intensityService.apply(
+                    SyntaxPreset.AMBIENT,
+                    emptyMap(),
+                    any(),
+                    emptyMap(),
+                    SyntaxReadabilityOptions.DEFAULT,
+                )
+            }
+            io.mockk.clearMocks(intensityService, answers = false, recordedCalls = true)
+
+            dimComments.doClick()
+
+            verify(exactly = 0) {
+                intensityService.apply(any(), any(), any(), any(), any())
+            }
+            assertFalse(panel.isModified(), "disabled readability controls must not dirty the panel")
+        } finally {
+            panel.dispose()
+        }
+    }
 
     @Test
-    fun `panel source wires applyCustomPillTooltipIfFree post-realise (documented compromise)`() {
-        // Documented compromise: the SegmentedButton-internal Swing subtree is
-        // not API-stable across IntelliJ versions; if the post-realise
-        // invokeLater queueing is dropped, free users lose the Pro affordance
-        // on the Custom pill. Behavioral substitute would require building
-        // the DSL panel and walking the SegmentedButton component tree.
-        val source = readPanelSource()
-        assertTrue(
-            source.contains("applyCustomPillTooltipIfFree"),
-            "applyCustomPillTooltipIfFree helper must exist as the wire site for the runIde-" +
-                "finalised SegmentedButton Swing subtree lookup.",
-        )
-        assertTrue(
-            source.contains("SwingUtilities.invokeLater { applyCustomPillTooltipIfFree() }"),
-            "tooltip pre-placement must be queued post-realise via " +
-                "SwingUtilities.invokeLater { applyCustomPillTooltipIfFree() }.",
-        )
+    fun `unlicensed preset row disables Custom pill affordance`() {
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+        val panel = AyuIslandsSyntaxPanel()
+
+        buildPresetPanel(panel)
+        val customPill =
+            panel.customPresetPresentationForTest()
+                ?: error("Could not find Custom preset presentation")
+
+        assertFalse(customPill.enabled, "free users must see Custom as disabled")
+        assertEquals("Pro Feature", customPill.toolTipText)
     }
 
     // ---------- Test 8 - composite-key identity round-trip (Pitfall 1/2) ----------
@@ -1236,6 +1264,11 @@ class AyuIslandsSyntaxPanelTest {
     private fun buildSyntaxPanel(syntaxPanel: AyuIslandsSyntaxPanel): DialogPanel =
         panel {
             syntaxPanel.buildReadabilityBlockForTest(this)
+        }
+
+    private fun buildPresetPanel(syntaxPanel: AyuIslandsSyntaxPanel): DialogPanel =
+        panel {
+            syntaxPanel.buildPresetBlockForTest(this)
         }
 
     private fun findDimCommentsCheckBox(container: Container): JCheckBox =

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanelTest.kt
@@ -1,10 +1,15 @@
 package dev.ayuislands.settings
 
 import com.intellij.icons.AllIcons
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.editor.markup.TextAttributes
+import com.intellij.openapi.ui.DialogPanel
 import com.intellij.openapi.util.io.FileUtil
 import com.intellij.ui.InplaceButton
+import com.intellij.ui.dsl.builder.panel
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
 import dev.ayuislands.licensing.LicenseChecker
@@ -17,14 +22,18 @@ import dev.ayuislands.syntax.SyntaxPreset
 import dev.ayuislands.syntax.SyntaxReadabilityOptions
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkClass
 import io.mockk.mockkObject
+import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
 import io.mockk.verifyOrder
 import java.awt.Color
+import java.awt.Container
 import java.awt.Font
 import java.io.File
 import javax.swing.JButton
+import javax.swing.JCheckBox
 import javax.swing.JLabel
 import javax.swing.JSlider
 import javax.swing.Timer
@@ -96,6 +105,16 @@ import kotlin.test.assertTrue
  * actually builds the panel under a live IntelliJ application.
  */
 class AyuIslandsSyntaxPanelTest {
+    private companion object {
+        val readabilityCheckboxTexts =
+            linkedSetOf(
+                "Dim comments",
+                "Soften documentation",
+                "Quiet operators",
+                "Emphasize declarations",
+            )
+    }
+
     private lateinit var stateBase: SyntaxIntensityBaseState
     private lateinit var stateService: SyntaxIntensityState
     private lateinit var intensityService: SyntaxIntensityService
@@ -116,6 +135,21 @@ class AyuIslandsSyntaxPanelTest {
         // Default: licensed. Individual tests override to false where needed.
         every { LicenseChecker.isLicensedOrGrace() } returns true
         every { LicenseChecker.requestLicense(any()) } returns Unit
+
+        mockkStatic(ApplicationManager::class)
+        val appMock = mockk<Application>(relaxed = true)
+        val actionManagerMock = mockk<ActionManager>(relaxed = true)
+        mockkStatic(ActionManager::class)
+        every { ActionManager.getInstance() } returns actionManagerMock
+        every { ApplicationManager.getApplication() } returns appMock
+        every { appMock.invokeLater(any()) } answers { firstArg<Runnable>().run() }
+        every { appMock.getService(ActionManager::class.java) } returns actionManagerMock
+        every { actionManagerMock.getAction(any()) } returns null
+
+        @Suppress("UNCHECKED_CAST")
+        val experimentalUiClass = Class.forName("com.intellij.ui.ExperimentalUI") as Class<Any>
+        val experimentalUiMock = mockkClass(experimentalUiClass.kotlin, relaxed = true)
+        every { appMock.getService(experimentalUiClass) } returns experimentalUiMock
     }
 
     @AfterTest
@@ -334,6 +368,81 @@ class AyuIslandsSyntaxPanelTest {
         assertTrue(readPendingBoolean(panel, "pendingDimComments"))
         assertFalse(readPendingBoolean(panel, "pendingEmphasizeDeclarations"))
         assertFalse(panel.isModified())
+    }
+
+    @Test
+    fun `dim comments checkbox previews and reset restores stored readability`() {
+        stateBase.selectedPreset = SyntaxPreset.AMBIENT.name
+        val panel = AyuIslandsSyntaxPanel()
+
+        try {
+            val component = buildSyntaxPanel(panel)
+            val dimComments = findDimCommentsCheckBox(component)
+            io.mockk.clearMocks(intensityService, answers = false, recordedCalls = true)
+
+            dimComments.doClick()
+
+            verify(exactly = 1) {
+                intensityService.apply(
+                    SyntaxPreset.AMBIENT,
+                    emptyMap(),
+                    any(),
+                    emptyMap(),
+                    SyntaxReadabilityOptions(dimComments = true),
+                )
+            }
+            assertTrue(panel.isModified(), "toggling the real checkbox must dirty the syntax panel")
+
+            io.mockk.clearMocks(intensityService, answers = false, recordedCalls = true)
+            panel.reset()
+
+            verify(exactly = 1) {
+                intensityService.apply(
+                    SyntaxPreset.AMBIENT,
+                    emptyMap(),
+                    any(),
+                    emptyMap(),
+                    SyntaxReadabilityOptions.DEFAULT,
+                )
+            }
+            assertFalse(dimComments.isSelected, "reset must return the visible checkbox to stored state")
+            assertFalse(panel.isModified(), "reset must leave pending and stored readability in sync")
+        } finally {
+            panel.dispose()
+        }
+    }
+
+    @Test
+    fun `unlicensed build shows readability controls disabled without preview writes`() {
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+        stateBase.dimComments = true
+        val panel = AyuIslandsSyntaxPanel()
+
+        try {
+            val component = buildSyntaxPanel(panel)
+            val readabilityControls =
+                findCheckBoxes(component).filter { it.text in readabilityCheckboxTexts }
+
+            assertEquals(
+                readabilityCheckboxTexts,
+                readabilityControls.mapTo(linkedSetOf()) { it.text },
+                "free users must still see the premium readability controls",
+            )
+            readabilityControls.forEach { checkbox ->
+                assertFalse(checkbox.isEnabled, "${checkbox.text} must be disabled without a Pro license")
+                assertFalse(checkbox.isSelected, "${checkbox.text} must not expose persisted premium state")
+            }
+
+            io.mockk.clearMocks(intensityService, answers = false, recordedCalls = true)
+            findDimCommentsCheckBox(component).doClick()
+
+            verify(exactly = 0) {
+                intensityService.apply(any(), any(), any(), any(), any())
+            }
+            assertFalse(panel.isModified(), "disabled readability controls must not dirty the panel")
+        } finally {
+            panel.dispose()
+        }
     }
 
     // ---------- Test 7 - documented compromise: tooltip pre-placement wire site ----------
@@ -1123,6 +1232,32 @@ class AyuIslandsSyntaxPanelTest {
         method.invoke(panel)
         return panel
     }
+
+    private fun buildSyntaxPanel(syntaxPanel: AyuIslandsSyntaxPanel): DialogPanel =
+        panel {
+            syntaxPanel.buildReadabilityBlockForTest(this)
+        }
+
+    private fun findDimCommentsCheckBox(container: Container): JCheckBox =
+        findDimCommentsCheckBoxOrNull(container)
+            ?: error("Could not find checkbox with text: Dim comments")
+
+    private fun findDimCommentsCheckBoxOrNull(container: Container): JCheckBox? {
+        for (component in container.components) {
+            if (component is JCheckBox && component.text == "Dim comments") return component
+            if (component is Container) {
+                val nested = findDimCommentsCheckBoxOrNull(component)
+                if (nested != null) return nested
+            }
+        }
+        return null
+    }
+
+    private fun findCheckBoxes(container: Container): List<JCheckBox> =
+        container.components.flatMap { component ->
+            val nested = if (component is Container) findCheckBoxes(component) else emptyList()
+            if (component is JCheckBox) listOf(component) + nested else nested
+        }
 
     private fun invokeOnPresetChosen(
         panel: AyuIslandsSyntaxPanel,

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanelTest.kt
@@ -14,6 +14,7 @@ import dev.ayuislands.syntax.SyntaxIntensityBaseState
 import dev.ayuislands.syntax.SyntaxIntensityService
 import dev.ayuislands.syntax.SyntaxIntensityState
 import dev.ayuislands.syntax.SyntaxPreset
+import dev.ayuislands.syntax.SyntaxReadabilityOptions
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -274,6 +275,65 @@ class AyuIslandsSyntaxPanelTest {
         panel.reset()
 
         assertSame(SyntaxPreset.AMBIENT, readPendingPreset(panel))
+        assertFalse(panel.isModified())
+    }
+
+    @Test
+    fun `loadStateIntoPending loads readability toggles from state`() {
+        stateBase.dimComments = true
+        stateBase.softenDocumentation = true
+        stateBase.quietOperators = true
+        stateBase.emphasizeDeclarations = true
+
+        val panel = panelWithLoadedState()
+
+        assertTrue(readPendingBoolean(panel, "pendingDimComments"))
+        assertTrue(readPendingBoolean(panel, "pendingSoftenDocumentation"))
+        assertTrue(readPendingBoolean(panel, "pendingQuietOperators"))
+        assertTrue(readPendingBoolean(panel, "pendingEmphasizeDeclarations"))
+        assertFalse(panel.isModified(), "freshly loaded readability state must not dirty the panel")
+    }
+
+    @Test
+    fun `apply passes readability options before persisting them`() {
+        stateBase.selectedPreset = "AMBIENT"
+        stateBase.schemaVersion = 2
+        val panel = panelWithLoadedState()
+        writePendingBoolean(panel, "pendingDimComments", true)
+        writePendingBoolean(panel, "pendingQuietOperators", true)
+
+        panel.apply()
+
+        verifyOrder {
+            intensityService.apply(
+                SyntaxPreset.AMBIENT,
+                emptyMap(),
+                any(),
+                emptyMap(),
+                SyntaxReadabilityOptions(dimComments = true, quietOperators = true),
+            )
+            stateService.state
+        }
+        assertTrue(stateBase.dimComments)
+        assertTrue(stateBase.quietOperators)
+        assertFalse(stateBase.softenDocumentation)
+        assertFalse(stateBase.emphasizeDeclarations)
+        assertEquals(3, stateBase.schemaVersion)
+        assertFalse(panel.isModified(), "persisted readability toggles must become the stored buffer")
+    }
+
+    @Test
+    fun `reset reverts pending readability toggles to stored values`() {
+        stateBase.dimComments = true
+        val panel = panelWithLoadedState()
+        writePendingBoolean(panel, "pendingDimComments", false)
+        writePendingBoolean(panel, "pendingEmphasizeDeclarations", true)
+        assertTrue(panel.isModified())
+
+        panel.reset()
+
+        assertTrue(readPendingBoolean(panel, "pendingDimComments"))
+        assertFalse(readPendingBoolean(panel, "pendingEmphasizeDeclarations"))
         assertFalse(panel.isModified())
     }
 
@@ -1152,6 +1212,25 @@ class AyuIslandsSyntaxPanelTest {
         val field = AyuIslandsSyntaxPanel::class.java.getDeclaredField("pendingPreset")
         field.isAccessible = true
         field.set(panel, preset)
+    }
+
+    private fun readPendingBoolean(
+        panel: AyuIslandsSyntaxPanel,
+        fieldName: String,
+    ): Boolean {
+        val field = AyuIslandsSyntaxPanel::class.java.getDeclaredField(fieldName)
+        field.isAccessible = true
+        return field.getBoolean(panel)
+    }
+
+    private fun writePendingBoolean(
+        panel: AyuIslandsSyntaxPanel,
+        fieldName: String,
+        value: Boolean,
+    ) {
+        val field = AyuIslandsSyntaxPanel::class.java.getDeclaredField(fieldName)
+        field.isAccessible = true
+        field.setBoolean(panel, value)
     }
 
     private fun writeCurrentLanguage(

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanelTest.kt
@@ -84,13 +84,12 @@ import kotlin.test.assertTrue
  *    against 2025.1 throws `AbstractMethodError` on newer runtime IDEs and
  *    hangs the settings page on "Loading…". Unit tests against the embedded
  *    SDK cannot reproduce the runtime failure.
- *  - `InplaceButton`-only trailing slot zone: a bare `JToggleButton` or
- *    `ActionButton` re-introduces the `ActionToolbar.updateUI`
- *    `SlowOperations SEVERE` crash documented in the project's
- *    `feedback_no_threshold_or_ignore_changes` lesson. The fixed-slot
- *    `GridLayout(1, TRAILING_SLOT_COUNT, ...)` plus `TRAILING_SLOT_*`
- *    constants are DSL-build internals — building the panel under unit
- *    tests requires a full IntelliJ platform.
+ *  - `InplaceButton`-only trailing reset slot: `ActionButton` re-introduces
+ *    the `ActionToolbar.updateUI` `SlowOperations SEVERE` crash documented in
+ *    the project's `feedback_no_threshold_or_ignore_changes` lesson. The
+ *    fixed-slot `GridLayout(1, TRAILING_SLOT_COUNT, ...)` plus
+ *    `TRAILING_SLOT_*` constants are DSL-build internals — building the panel
+ *    under unit tests requires a full IntelliJ platform.
  *
  * Do not delete these source-regex assertions in future "remove theater"
  * cleanup passes without first wiring a working `integrationTest` task that
@@ -685,9 +684,9 @@ class AyuIslandsSyntaxPanelTest {
             "slider tracks must stay 140 to avoid horizontal bloat in the two-column matrix.",
         )
         assertEquals(
-            64,
+            20,
             readPrivateConst("TRAILING_ZONE_WIDTH"),
-            "fixed reset + Bold + Italic trailing zone must be 64.",
+            "fixed reset-only trailing zone must stay compact at 20.",
         )
     }
 
@@ -863,55 +862,10 @@ class AyuIslandsSyntaxPanelTest {
         assertFalse(stringLiteral.resetButton.isVisible, "untouched cell hides the category reset")
     }
 
-    // ---------- Part B Test 28 - toggle flips one bit and composes BOLD_ITALIC ----------
+    // ---------- Part B Test 29 - legacy styles still count as modifications ----------
 
     @Test
-    fun `onStyleToggle flips the bit B then I composes BOLD_ITALIC, toggling both off removes the key`() {
-        stateBase.selectedPreset = "CUSTOM"
-        val panel = panelWithLoadedState()
-        writeCurrentLanguage(panel, "Java")
-        seedWidgets(panel, PrimitiveCategory.KEYWORD)
-
-        try {
-            // First B -> BOLD.
-            invokeOnKeywordStyleToggle(panel, Font.BOLD)
-            assertEquals("BOLD", readPendingStyles(panel)["Java|KEYWORD"], "B toggle sets BOLD")
-
-            // Then I -> BOLD_ITALIC (bits compose, not replace).
-            invokeOnKeywordStyleToggle(panel, Font.ITALIC)
-            assertEquals(
-                "BOLD_ITALIC",
-                readPendingStyles(panel)["Java|KEYWORD"],
-                "I toggle composes onto BOLD to make BOLD_ITALIC",
-            )
-
-            // Toggle B off -> ITALIC remains.
-            invokeOnKeywordStyleToggle(panel, Font.BOLD)
-            assertEquals(
-                "ITALIC",
-                readPendingStyles(panel)["Java|KEYWORD"],
-                "dropping the bold bit leaves ITALIC",
-            )
-
-            // Toggle I off -> both bits off -> key REMOVED (inherit, no PLAIN written).
-            invokeOnKeywordStyleToggle(panel, Font.ITALIC)
-            assertFalse(
-                readPendingStyles(panel).containsKey("Java|KEYWORD"),
-                "both bits off must REMOVE the key (return to inherit) - v1 never persists PLAIN",
-            )
-            assertFalse(
-                readPendingStyles(panel).values.contains("PLAIN"),
-                "v1 must never write an explicit PLAIN style token",
-            )
-        } finally {
-            panel.dispose()
-        }
-    }
-
-    // ---------- Part B Test 29 - style toggle is a style-only modification ----------
-
-    @Test
-    fun `isModified is true after a style-only toggle (slider untouched)`() {
+    fun `isModified is true after a legacy style-only change (slider untouched)`() {
         stateBase.selectedPreset = "CUSTOM"
         val panel = panelWithLoadedState()
         writeCurrentLanguage(panel, "Java")
@@ -919,10 +873,10 @@ class AyuIslandsSyntaxPanelTest {
         assertFalse(panel.isModified(), "fresh CUSTOM panel with no changes is not modified")
 
         try {
-            invokeOnKeywordStyleToggle(panel, Font.BOLD)
+            seedPendingStyle(panel, "Java|KEYWORD", "BOLD")
             assertTrue(
                 panel.isModified(),
-                "a style-only toggle (no slider move) must mark the panel modified so Apply enables",
+                "a legacy style-only change (no slider move) must mark the panel modified so Apply enables",
             )
         } finally {
             panel.dispose()
@@ -1020,13 +974,12 @@ class AyuIslandsSyntaxPanelTest {
         }
     }
 
-    // ---------- Part B Test 33 - documented compromise: InplaceButton-only trailing controls ----------
+    // ---------- Part B Test 33 - documented compromise: InplaceButton-only trailing reset ----------
 
     @Test
-    fun `trailing controls use InplaceButton, never JToggleButton or ActionButton (documented compromise)`() {
-        // Documented compromise: a bare `JToggleButton` re-introduces the
-        // shouting toggle box across 32 instances, and `ActionButton` plus
-        // `updateComponentTreeUI` reproduce the `ActionToolbar.updateUI`
+    fun `trailing reset uses InplaceButton, never ActionButton (documented compromise)`() {
+        // Documented compromise: `ActionButton` plus `updateComponentTreeUI`
+        // reproduce the `ActionToolbar.updateUI`
         // `SlowOperations SEVERE` crash documented in the project's
         // testing-philosophy notes. The fixed-slot
         // `GridLayout(1, TRAILING_SLOT_COUNT, ...)` plus `TRAILING_SLOT_*`
@@ -1035,34 +988,25 @@ class AyuIslandsSyntaxPanelTest {
         val source = readPanelSource()
         assertTrue(
             source.contains("InplaceButton("),
-            "The trailing reset / Bold / Italic controls must be InplaceButton.",
+            "The trailing reset control must be InplaceButton.",
         )
         assertTrue(
-            source.contains("StyleGlyphIcon"),
-            "The grouped grid must use compact text-glyph B/I icons.",
-        )
-        assertTrue(
-            source.contains("JBUI.CurrentTheme.ActionButton.hoverBackground()") &&
-                source.contains("border = styleGlyphBorder()"),
-            "Inactive B/I icons must render as quiet chips, not bare text glyphs.",
-        )
-        assertTrue(
-            source.contains("JPanel(GridLayout(1, TRAILING_SLOT_COUNT, JBUI.scale(TRAILING_GAP), 0))"),
-            "The trailing reset / Bold / Italic zone must use fixed slots so B/I never shift when reset appears.",
+            source.contains("JPanel(GridLayout(1, TRAILING_SLOT_COUNT, 0, 0))"),
+            "The trailing reset zone must use a fixed slot so reset visibility never shifts the row.",
         )
         assertEquals(
-            3,
+            1,
             readPrivateConst("TRAILING_SLOT_COUNT"),
-            "the trailing zone must reserve three stable slots.",
+            "the trailing zone must reserve one stable reset slot.",
         )
         assertEquals(
             20,
             readPrivateConst("TRAILING_SLOT_SIDE"),
-            "the trailing zone slots must stay 20px so B/I never shift when reset appears.",
+            "the trailing reset slot must stay 20px so reset visibility never shifts the row.",
         )
         assertFalse(
             source.contains("JToggleButton"),
-            "Part B: no bare JToggleButton - its box shouts across 32 instances.",
+            "Part B: no bare JToggleButton - the reset is a lightweight InplaceButton.",
         )
         assertFalse(
             Regex("""[^a-zA-Z_]ActionButton\b""").containsMatchIn(source.substringBefore("JBUI.CurrentTheme")) &&
@@ -1288,20 +1232,6 @@ class AyuIslandsSyntaxPanelTest {
         putMethod.invoke(map, key, value)
     }
 
-    private fun invokeOnKeywordStyleToggle(
-        panel: AyuIslandsSyntaxPanel,
-        bit: Int,
-    ) {
-        val method =
-            AyuIslandsSyntaxPanel::class.java.getDeclaredMethod(
-                "onStyleToggle",
-                PrimitiveCategory::class.java,
-                Int::class.javaPrimitiveType,
-            )
-        method.isAccessible = true
-        method.invoke(panel, PrimitiveCategory.KEYWORD, bit)
-    }
-
     private fun invokeOnResetCurrentLanguage(panel: AyuIslandsSyntaxPanel) {
         val method = AyuIslandsSyntaxPanel::class.java.getDeclaredMethod("onResetCurrentLanguage")
         method.isAccessible = true
@@ -1346,9 +1276,9 @@ class AyuIslandsSyntaxPanelTest {
     }
 
     /**
-     * Materialize one category's slider / readout / reset-icon / Bold / Italic
-     * widgets and the master reset button so logic methods can be driven
-     * without a built [com.intellij.openapi.ui.DialogPanel].
+     * Materialize one category's slider / readout / reset-icon widgets and the
+     * master reset button so logic methods can be driven without a built
+     * [com.intellij.openapi.ui.DialogPanel].
      */
     private fun seedWidgets(
         panel: AyuIslandsSyntaxPanel,
@@ -1357,18 +1287,14 @@ class AyuIslandsSyntaxPanelTest {
         val slider = JSlider(0, 100, 50)
         val label = JLabel("0")
         val resetButton = InplaceButton("Reset", AllIcons.Actions.Rollback) {}
-        val boldToggle = InplaceButton("Bold", AllIcons.Actions.Rollback) {}
-        val italicToggle = InplaceButton("Italic", AllIcons.Actions.Rollback) {}
         val button = JButton()
         putIntoMapField(panel, "sliders", category, slider)
         putIntoMapField(panel, "sliderLabels", category, label)
         putIntoMapField(panel, "resetButtons", category, resetButton)
-        putIntoMapField(panel, "boldToggles", category, boldToggle)
-        putIntoMapField(panel, "italicToggles", category, italicToggle)
         val buttonField = AyuIslandsSyntaxPanel::class.java.getDeclaredField("masterResetButton")
         buttonField.isAccessible = true
         buttonField.set(panel, button)
-        return SeededWidgets(slider, label, resetButton, boldToggle, italicToggle, button)
+        return SeededWidgets(slider, label, resetButton, button)
     }
 
     private fun putIntoMapField(
@@ -1388,8 +1314,6 @@ class AyuIslandsSyntaxPanelTest {
         val slider: JSlider,
         val label: JLabel,
         val resetButton: InplaceButton,
-        val boldToggle: InplaceButton,
-        val italicToggle: InplaceButton,
         val button: JButton,
     )
 

--- a/src/test/kotlin/dev/ayuislands/syntax/SyntaxIntensityApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/syntax/SyntaxIntensityApplicatorTest.kt
@@ -839,66 +839,87 @@ class SyntaxIntensityApplicatorTest {
     fun `readability soften documentation quiets documentation keys`() {
         val docKey = TextAttributesKey.createTextAttributesKey("JAVA_DOC_COMMENT")
         val baselineFg = Color(0x9D, 0xA0, 0xA8)
+        val keywordFg = Color(0xFF, 0xAD, 0x66)
 
         val result =
             compute(
                 preset = SyntaxPreset.AMBIENT,
                 customOverrides = emptyMap(),
-                baseline = mapOf(docKey to attrsWithFg(baselineFg)),
+                baseline =
+                    mapOf(
+                        docKey to attrsWithFg(baselineFg),
+                        javaKeywordKey to attrsWithFg(keywordFg),
+                    ),
                 overlay = emptyMap(),
                 options = ComputeOptions(readabilityOptions = SyntaxReadabilityOptions(softenDocumentation = true)),
             )
 
         val output = assertNotNull(result[docKey]?.foregroundColor)
+        val keyword = assertNotNull(result[javaKeywordKey]?.foregroundColor)
         assertTrue(
             colorDistance(output, ComputeOptions().editorBg) < colorDistance(baselineFg, ComputeOptions().editorBg),
             "Soften documentation must move doc text toward the editor background",
         )
         assertNotEquals(baselineFg.rgb, output.rgb, "Soften documentation must visibly affect documentation keys")
+        assertEquals(keywordFg.rgb, keyword.rgb, "Soften documentation must not rewrite unrelated categories")
     }
 
     @Test
     fun `readability quiet operators quiets operator keys`() {
         val operatorKey = TextAttributesKey.createTextAttributesKey("JAVA_OPERATION_SIGN")
         val baselineFg = Color(0xB8, 0xC2, 0xCC)
+        val commentFg = Color(0x78, 0x7B, 0x80)
 
         val result =
             compute(
                 preset = SyntaxPreset.AMBIENT,
                 customOverrides = emptyMap(),
-                baseline = mapOf(operatorKey to attrsWithFg(baselineFg)),
+                baseline =
+                    mapOf(
+                        operatorKey to attrsWithFg(baselineFg),
+                        javaCommentKey to attrsWithFg(commentFg),
+                    ),
                 overlay = emptyMap(),
                 options = ComputeOptions(readabilityOptions = SyntaxReadabilityOptions(quietOperators = true)),
             )
 
         val output = assertNotNull(result[operatorKey]?.foregroundColor)
+        val comment = assertNotNull(result[javaCommentKey]?.foregroundColor)
         assertTrue(
             colorDistance(output, ComputeOptions().editorBg) < colorDistance(baselineFg, ComputeOptions().editorBg),
             "Quiet operators must move operator text toward the editor background",
         )
+        assertEquals(commentFg.rgb, comment.rgb, "Quiet operators must not rewrite unrelated categories")
     }
 
     @Test
     fun `readability emphasize declarations strengthens declaration keys`() {
         val functionKey = TextAttributesKey.createTextAttributesKey("JAVA_FUNCTION_DECLARATION")
         val baselineFg = Color(0xFF, 0xCC, 0x66)
+        val commentFg = Color(0x78, 0x7B, 0x80)
 
         val result =
             compute(
                 preset = SyntaxPreset.AMBIENT,
                 customOverrides = emptyMap(),
-                baseline = mapOf(functionKey to attrsWithFg(baselineFg)),
+                baseline =
+                    mapOf(
+                        functionKey to attrsWithFg(baselineFg),
+                        javaCommentKey to attrsWithFg(commentFg),
+                    ),
                 overlay = emptyMap(),
                 options = ComputeOptions(readabilityOptions = SyntaxReadabilityOptions(emphasizeDeclarations = true)),
             )
 
         val output = assertNotNull(result[functionKey]?.foregroundColor)
+        val comment = assertNotNull(result[javaCommentKey]?.foregroundColor)
         val inputDistance = abs(HslColor.fromColor(baselineFg).lightness - MID_LIGHTNESS)
         val outputDistance = abs(HslColor.fromColor(output).lightness - MID_LIGHTNESS)
         assertTrue(
             outputDistance < inputDistance,
             "Emphasize declarations must move declaration lightness toward peak chroma",
         )
+        assertEquals(commentFg.rgb, comment.rgb, "Emphasize declarations must not rewrite unrelated categories")
     }
 
     // --- Helpers ---------------------------------------------------------

--- a/src/test/kotlin/dev/ayuislands/syntax/SyntaxIntensityApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/syntax/SyntaxIntensityApplicatorTest.kt
@@ -894,7 +894,12 @@ class SyntaxIntensityApplicatorTest {
 
     @Test
     fun `readability emphasize declarations strengthens declaration keys`() {
-        val functionKey = TextAttributesKey.createTextAttributesKey("JAVA_FUNCTION_DECLARATION")
+        val declarationKeys =
+            listOf(
+                TextAttributesKey.createTextAttributesKey("JAVA_FUNCTION_DECLARATION"),
+                TextAttributesKey.createTextAttributesKey("JAVA_CLASS_DECLARATION"),
+                TextAttributesKey.createTextAttributesKey("JAVA_INTERFACE_DECLARATION"),
+            )
         val baselineFg = Color(0xFF, 0xCC, 0x66)
         val commentFg = Color(0x78, 0x7B, 0x80)
 
@@ -903,22 +908,22 @@ class SyntaxIntensityApplicatorTest {
                 preset = SyntaxPreset.AMBIENT,
                 customOverrides = emptyMap(),
                 baseline =
-                    mapOf(
-                        functionKey to attrsWithFg(baselineFg),
-                        javaCommentKey to attrsWithFg(commentFg),
-                    ),
+                    declarationKeys.associateWith { attrsWithFg(baselineFg) } +
+                        (javaCommentKey to attrsWithFg(commentFg)),
                 overlay = emptyMap(),
                 options = ComputeOptions(readabilityOptions = SyntaxReadabilityOptions(emphasizeDeclarations = true)),
             )
 
-        val output = assertNotNull(result[functionKey]?.foregroundColor)
-        val comment = assertNotNull(result[javaCommentKey]?.foregroundColor)
         val inputDistance = abs(HslColor.fromColor(baselineFg).lightness - MID_LIGHTNESS)
-        val outputDistance = abs(HslColor.fromColor(output).lightness - MID_LIGHTNESS)
-        assertTrue(
-            outputDistance < inputDistance,
-            "Emphasize declarations must move declaration lightness toward peak chroma",
-        )
+        for (key in declarationKeys) {
+            val output = assertNotNull(result[key]?.foregroundColor)
+            val outputDistance = abs(HslColor.fromColor(output).lightness - MID_LIGHTNESS)
+            assertTrue(
+                outputDistance < inputDistance,
+                "Emphasize declarations must move ${key.externalName} lightness toward peak chroma",
+            )
+        }
+        val comment = assertNotNull(result[javaCommentKey]?.foregroundColor)
         assertEquals(commentFg.rgb, comment.rgb, "Emphasize declarations must not rewrite unrelated categories")
     }
 

--- a/src/test/kotlin/dev/ayuislands/syntax/SyntaxIntensityApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/syntax/SyntaxIntensityApplicatorTest.kt
@@ -782,6 +782,125 @@ class SyntaxIntensityApplicatorTest {
         assertChannelDiff(expected, assertNotNull(result[csharpKeywordKey]?.foregroundColor))
     }
 
+    @Test
+    fun `readability dim comments only quiets comment keys on top of Ambient`() {
+        val baselineFg = Color(0x78, 0x7B, 0x80)
+        val keywordFg = Color(0xFF, 0xAD, 0x66)
+        val baseline =
+            mapOf(
+                javaCommentKey to attrsWithFg(baselineFg),
+                javaKeywordKey to attrsWithFg(keywordFg),
+            )
+
+        val result =
+            compute(
+                preset = SyntaxPreset.AMBIENT,
+                customOverrides = emptyMap(),
+                baseline = baseline,
+                overlay = emptyMap(),
+                options = ComputeOptions(readabilityOptions = SyntaxReadabilityOptions(dimComments = true)),
+            )
+
+        val comment = assertNotNull(result[javaCommentKey]?.foregroundColor)
+        val keyword = assertNotNull(result[javaKeywordKey]?.foregroundColor)
+        assertTrue(
+            HslColor.fromColor(comment).lightness < HslColor.fromColor(baselineFg).lightness,
+            "Dim comments must make comment text recede",
+        )
+        assertEquals(keywordFg.rgb, keyword.rgb, "Dim comments must not rewrite unrelated categories")
+    }
+
+    @Test
+    fun `readability dim comments moves toward the active editor background`() {
+        val lightEditorBg = Color(0xFC, 0xFC, 0xFC)
+        val commentFg = Color(0x78, 0x7B, 0x80)
+
+        val result =
+            compute(
+                preset = SyntaxPreset.AMBIENT,
+                customOverrides = emptyMap(),
+                baseline = mapOf(javaCommentKey to attrsWithFg(commentFg)),
+                overlay = emptyMap(),
+                options =
+                    ComputeOptions(
+                        editorBg = lightEditorBg,
+                        readabilityOptions = SyntaxReadabilityOptions(dimComments = true),
+                    ),
+            )
+
+        val output = assertNotNull(result[javaCommentKey]?.foregroundColor)
+        assertTrue(
+            colorDistance(output, lightEditorBg) < colorDistance(commentFg, lightEditorBg),
+            "Dim comments must recede toward the active background instead of always darkening",
+        )
+    }
+
+    @Test
+    fun `readability soften documentation quiets documentation keys`() {
+        val docKey = TextAttributesKey.createTextAttributesKey("JAVA_DOC_COMMENT")
+        val baselineFg = Color(0x9D, 0xA0, 0xA8)
+
+        val result =
+            compute(
+                preset = SyntaxPreset.AMBIENT,
+                customOverrides = emptyMap(),
+                baseline = mapOf(docKey to attrsWithFg(baselineFg)),
+                overlay = emptyMap(),
+                options = ComputeOptions(readabilityOptions = SyntaxReadabilityOptions(softenDocumentation = true)),
+            )
+
+        val output = assertNotNull(result[docKey]?.foregroundColor)
+        assertTrue(
+            colorDistance(output, ComputeOptions().editorBg) < colorDistance(baselineFg, ComputeOptions().editorBg),
+            "Soften documentation must move doc text toward the editor background",
+        )
+        assertNotEquals(baselineFg.rgb, output.rgb, "Soften documentation must visibly affect documentation keys")
+    }
+
+    @Test
+    fun `readability quiet operators quiets operator keys`() {
+        val operatorKey = TextAttributesKey.createTextAttributesKey("JAVA_OPERATION_SIGN")
+        val baselineFg = Color(0xB8, 0xC2, 0xCC)
+
+        val result =
+            compute(
+                preset = SyntaxPreset.AMBIENT,
+                customOverrides = emptyMap(),
+                baseline = mapOf(operatorKey to attrsWithFg(baselineFg)),
+                overlay = emptyMap(),
+                options = ComputeOptions(readabilityOptions = SyntaxReadabilityOptions(quietOperators = true)),
+            )
+
+        val output = assertNotNull(result[operatorKey]?.foregroundColor)
+        assertTrue(
+            colorDistance(output, ComputeOptions().editorBg) < colorDistance(baselineFg, ComputeOptions().editorBg),
+            "Quiet operators must move operator text toward the editor background",
+        )
+    }
+
+    @Test
+    fun `readability emphasize declarations strengthens declaration keys`() {
+        val functionKey = TextAttributesKey.createTextAttributesKey("JAVA_FUNCTION_DECLARATION")
+        val baselineFg = Color(0xFF, 0xCC, 0x66)
+
+        val result =
+            compute(
+                preset = SyntaxPreset.AMBIENT,
+                customOverrides = emptyMap(),
+                baseline = mapOf(functionKey to attrsWithFg(baselineFg)),
+                overlay = emptyMap(),
+                options = ComputeOptions(readabilityOptions = SyntaxReadabilityOptions(emphasizeDeclarations = true)),
+            )
+
+        val output = assertNotNull(result[functionKey]?.foregroundColor)
+        val inputDistance = abs(HslColor.fromColor(baselineFg).lightness - MID_LIGHTNESS)
+        val outputDistance = abs(HslColor.fromColor(output).lightness - MID_LIGHTNESS)
+        assertTrue(
+            outputDistance < inputDistance,
+            "Emphasize declarations must move declaration lightness toward peak chroma",
+        )
+    }
+
     // --- Helpers ---------------------------------------------------------
 
     private fun transformVia(
@@ -801,10 +920,19 @@ class SyntaxIntensityApplicatorTest {
 
     private fun Color.hex(): String = "%02X%02X%02X".format(red, green, blue)
 
+    private fun colorDistance(
+        a: Color,
+        b: Color,
+    ): Int =
+        abs(a.red - b.red) +
+            abs(a.green - b.green) +
+            abs(a.blue - b.blue)
+
     private data class ComputeOptions(
         val subordinatePreset: SyntaxPreset = SyntaxPreset.AMBIENT,
         val customStyles: Map<String, Map<String, Int>> = emptyMap(),
         val editorBg: Color = Color(0x1F, 0x24, 0x30),
+        val readabilityOptions: SyntaxReadabilityOptions = SyntaxReadabilityOptions.DEFAULT,
     )
 
     private fun compute(
@@ -824,6 +952,7 @@ class SyntaxIntensityApplicatorTest {
                 customOverrides = customOverrides,
                 subordinatePreset = options.subordinatePreset,
                 customStyles = options.customStyles,
+                readabilityOptions = options.readabilityOptions,
             ),
         )
 

--- a/src/test/kotlin/dev/ayuislands/syntax/SyntaxIntensityServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/syntax/SyntaxIntensityServiceTest.kt
@@ -370,6 +370,33 @@ class SyntaxIntensityServiceTest {
         }
     }
 
+    @Test
+    fun `reapplyForActiveLaf forwards readability options to compute`() {
+        val readabilityOptions =
+            SyntaxReadabilityOptions(
+                dimComments = true,
+                softenDocumentation = true,
+                quietOperators = true,
+                emphasizeDeclarations = true,
+            )
+        every { stateInstance.toPresetConfig() } returns
+            SyntaxPresetConfig(
+                selectedPreset = "AMBIENT",
+                customOverrides = emptyMap(),
+                readabilityOptions = readabilityOptions,
+            )
+
+        SyntaxIntensityService().reapplyForActiveLaf()
+
+        verify(atLeast = 1) {
+            SyntaxIntensityApplicator.compute(
+                match {
+                    it.preset == SyntaxPreset.AMBIENT && it.readabilityOptions == readabilityOptions
+                },
+            )
+        }
+    }
+
     // ---------- Test 13: CUSTOM gate log-once (Pattern A latch) ----------
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/syntax/SyntaxIntensityServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/syntax/SyntaxIntensityServiceTest.kt
@@ -397,6 +397,39 @@ class SyntaxIntensityServiceTest {
         }
     }
 
+    @Test
+    fun `reapplyForActiveLaf drops readability options when unlicensed`() {
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+        every { stateInstance.toPresetConfig() } returns
+            SyntaxPresetConfig(
+                selectedPreset = "AMBIENT",
+                customOverrides = emptyMap(),
+                readabilityOptions =
+                    SyntaxReadabilityOptions(
+                        dimComments = true,
+                        softenDocumentation = true,
+                        quietOperators = true,
+                        emphasizeDeclarations = true,
+                    ),
+            )
+
+        SyntaxIntensityService().reapplyForActiveLaf()
+
+        verify(exactly = 0) {
+            SyntaxIntensityApplicator.compute(
+                match { it.readabilityOptions != SyntaxReadabilityOptions.DEFAULT },
+            )
+        }
+        verify(atLeast = 1) {
+            SyntaxIntensityApplicator.compute(
+                match {
+                    it.preset == SyntaxPreset.AMBIENT &&
+                        it.readabilityOptions == SyntaxReadabilityOptions.DEFAULT
+                },
+            )
+        }
+    }
+
     // ---------- Test 13: CUSTOM gate log-once (Pattern A latch) ----------
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/syntax/SyntaxIntensityStateTest.kt
+++ b/src/test/kotlin/dev/ayuislands/syntax/SyntaxIntensityStateTest.kt
@@ -25,7 +25,7 @@ import kotlin.test.assertNotNull
  *
  * 10 invariants per the plan spec:
  *  1.  Default state: `selectedPreset == "AMBIENT"`, `customOverrides`
- *      empty, `schemaVersion == 1`.
+ *      empty, readability modifiers off, `schemaVersion == 3`.
  *  2.  `selectedPreset` round-trip via in-memory loadState.
  *  3.  `SyntaxPreset.fromName` integration - tampered preset name falls
  *      back to `AMBIENT`.
@@ -50,12 +50,16 @@ class SyntaxIntensityStateTest {
     // --- Test 1 - defaults --------------------------------------------------
 
     @Test
-    fun `default base state is AMBIENT preset with empty customOverrides and schemaVersion 2`() {
+    fun `default base state is AMBIENT preset with empty customOverrides readability off and schemaVersion 3`() {
         val state = SyntaxIntensityBaseState()
         assertEquals("AMBIENT", state.selectedPreset, "default selectedPreset must be AMBIENT per D-23")
         assertTrue(state.customOverrides.isEmpty(), "default customOverrides must be empty (free tier never writes)")
         assertTrue(state.customStyles.isEmpty(), "default customStyles must be empty (free tier never writes)")
-        assertEquals(2, state.schemaVersion, "default schemaVersion must be 2 since customStyles was added")
+        assertFalse(state.dimComments, "Dim comments must be opt-in")
+        assertFalse(state.softenDocumentation, "Soften documentation must be opt-in")
+        assertFalse(state.quietOperators, "Quiet operators must be opt-in")
+        assertFalse(state.emphasizeDeclarations, "Emphasize declarations must be opt-in")
+        assertEquals(3, state.schemaVersion, "default schemaVersion must be 3 since readability toggles were added")
     }
 
     // --- Test 2 - selectedPreset round-trip --------------------------------
@@ -124,7 +128,7 @@ class SyntaxIntensityStateTest {
     fun `schemaVersion survives loadState round-trip for default and bumped values`() {
         // No mutation - verify the default schemaVersion survives the round-trip.
         val reloadedDefault = roundTrip { _ -> }
-        assertEquals(2, reloadedDefault.state.schemaVersion)
+        assertEquals(3, reloadedDefault.state.schemaVersion)
 
         val reloadedBumped = roundTrip { state -> state.schemaVersion = 3 }
         assertEquals(3, reloadedBumped.state.schemaVersion, "schemaVersion 3 must round-trip for future migration")
@@ -315,6 +319,37 @@ class SyntaxIntensityStateTest {
         assertTrue(config.customStyles.isEmpty(), "absent customStyles must surface as an empty nested map")
         // Intensity overrides still decode - the bump is additive only.
         assertEquals(mapOf("Java" to mapOf("KEYWORD" to 75)), config.customOverrides)
+    }
+
+    // --- Test 18 - readability modifier persistence -----------------------
+
+    @Test
+    fun `readability toggles survive loadState round-trip`() {
+        val reloaded =
+            roundTrip { state ->
+                state.dimComments = true
+                state.softenDocumentation = true
+                state.quietOperators = true
+                state.emphasizeDeclarations = true
+            }
+
+        assertTrue(reloaded.state.dimComments)
+        assertTrue(reloaded.state.softenDocumentation)
+        assertTrue(reloaded.state.quietOperators)
+        assertTrue(reloaded.state.emphasizeDeclarations)
+    }
+
+    @Test
+    fun `toPresetConfig carries readability toggles without touching custom maps`() {
+        val component = SyntaxIntensityState()
+        component.state.dimComments = true
+        component.state.quietOperators = true
+
+        val config = component.toPresetConfig()
+
+        assertEquals(SyntaxReadabilityOptions(dimComments = true, quietOperators = true), config.readabilityOptions)
+        assertTrue(config.customOverrides.isEmpty())
+        assertTrue(config.customStyles.isEmpty())
     }
 
     // --- Test 10 - getInstance service lookup -----------------------------


### PR DESCRIPTION
## Why

Syntax readability needed first-class controls instead of hidden intensity side effects: comments should be dimmable without burying other code, documentation can be softened independently, operators can be quieted, and declarations can be emphasized.

This branch also fixes the chrome tint regression found during dogfooding: the status bar foreground must stay readable and low tint values must remain subtle.

## What changed

- Added syntax readability modifiers for dim comments, soften documentation, quiet operators, and emphasize declarations.
- Refined the Syntax settings panel layout for those controls.
- Applied readability modifiers through syntax intensity state, presets, and applicator behavior.
- Restored readable status bar text using literal WCAG foregrounds and guarded chrome base-color caching.
- Made low chrome tint intensity interpolate hue gradually instead of snapping to the accent.

## Verification

- ./gradlew test
- ./gradlew detekt ktlintCheck
- ./gradlew buildPlugin
- scripts/verify-docs.py
- scripts/guard-test-source-reads.py
- git diff --check
- Deployed to local IntelliJ IDEA 2026.1 and verified status bar readability + subtle 10% tint manually

## Summary by Sourcery

Add global syntax readability modifiers and refine chrome tint handling for better status bar contrast and subtle low-intensity tinting.

New Features:
- Introduce global syntax readability options (dim comments, soften documentation, quiet operators, emphasize declarations) and expose them as first-class controls in the Syntax settings panel.

Enhancements:
- Route readability options through syntax intensity presets, state, and applicator so they apply uniformly on top of any preset without affecting custom per-language overrides.
- Simplify the syntax tuning grid by removing per-cell bold/italic UI while still supporting legacy stored styles.
- Refine chrome tint blending to gradually interpolate hue at low intensities, keeping low tints close to stock chrome while converging to the accent hue at higher values.
- Strengthen status bar foreground contrast by using literal WCAG-compliant foreground colors and wiring all widget state foreground/background keys to the chosen contrast color.
- Harden chrome base-color caching to distinguish plugin tints from stock values so repeated applies do not compound tints after LAF changes.

Documentation:
- Update feature verification metadata for accent and chrome tint documentation to the latest verified revision.

Tests:
- Extend syntax panel, intensity applicator, intensity state, and service tests to cover readability options, schema versioning, and legacy style behavior.
- Expand chrome tint blender tests (including hue uniformity) to validate new hue interpolation behavior and low-intensity subtlety.
- Add tests for chrome base color caching to ensure plugin tints are not mistaken for stock colors across refreshes.
- Extend status bar element tests to cover all widget state foreground/background keys and light-family foreground selection under dark JBColor modes.