### PR TITLE
docs(release): mention user-facing fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,17 @@
 ### Free
 - **Expanded semantic highlighting** — hundreds more editor keys now carry Ayu-aware color across 26+ language families, including YAML/HCL, Scala docs, Kotlin gaps, Dart accessors, Groovy, and Go exported identifiers.
 - **Syntax presets** — *Settings -> Ayu Islands -> Syntax* adds four one-click syntax moods: **Whisper**, **Ambient**, **Neon**, and **Cyberpunk**.
-- **Readability polish** — matching tag highlights are calmer, status bar text stays readable on tinted chrome, and low chrome-tint intensity remains subtle instead of snapping straight to saturated accent color.
 
 ### Paid
 - **Custom syntax tuning** — Pro users can tune each language separately with sliders for declarations, identifiers, keywords/docs, literals, and operators while untouched cells inherit the selected base preset.
 - **Readability controls** — **Dim comments**, **Soften documentation**, **Quiet operators**, and **Emphasize declarations** layer on top of the active preset so dense code gets quieter without manual per-key Color Scheme editing.
+
+### Fixed
+- Matching tag highlights are calmer on dark backgrounds and no longer fall back to unreadable light-background styling.
+- Status bar text stays readable on tinted chrome, and low chrome-tint intensity remains subtle instead of snapping straight to saturated accent color.
+- YAML/HCL semantic keys and HCL block names keep Ayu styling after JetBrains key migration.
+- The Syntax Custom page opens reliably on newer IDEs and keeps its compact, aligned slider layout.
+- Syntax presets keep their expected intensity ordering on vivid palettes; custom cells also inherit the selected preset without losing scheme inheritance or stale colors after theme changes.
 
 ## [2.6.4] - 2026-05-18
 

--- a/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
@@ -59,7 +59,7 @@ internal object UpdateNotifier {
                 releaseNotes(
                     "Expanded semantic highlighting across 26+ language families",
                     "Syntax presets: Whisper, Ambient, Neon, and Cyberpunk",
-                    "Matching tags and chrome tinting read calmer at low intensity",
+                    "Matching tags, YAML/HCL, Syntax Custom, and chrome tinting fixes",
                     "Custom per-language syntax tuning and readability controls for Pro",
                 ),
             "2.6.4" to

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -117,9 +117,10 @@
     <ul>
       <li>[Free] <b>Expanded semantic highlighting</b> — Ayu Islands now covers hundreds more editor keys across 26+ language families, with focused passes for YAML/HCL, Scala docs, Kotlin gaps, Dart accessors, Groovy, and Go exported identifiers.</li>
       <li>[Free] <b>Syntax presets</b> — the new Settings → Ayu Islands → Syntax tab gives everyone four one-click syntax moods: <b>Whisper</b>, <b>Ambient</b>, <b>Neon</b>, and <b>Cyberpunk</b>.</li>
-      <li>[Free] <b>Readability polish</b> — matching tags are calmer on dark backgrounds, status bar text stays readable on tinted chrome, and low chrome-tint values now remain subtle instead of jumping straight to saturated accent color.</li>
       <li>[Paid] <b>Custom syntax tuning</b> — Pro users can tune each language separately with sliders for declarations, identifiers, keywords/docs, literals, and operators while untouched cells inherit the selected base preset.</li>
       <li>[Paid] <b>Readability controls</b> — Dim comments, Soften documentation, Quiet operators, and Emphasize declarations layer on top of the active preset so dense code gets quieter without manual per-key Color Scheme editing.</li>
+      <li><b>Fixed:</b> matching tag highlights are calmer, status bar text stays readable on tinted chrome, and low chrome-tint values stay subtle instead of jumping straight to saturated accent color.</li>
+      <li><b>Fixed:</b> YAML/HCL semantic keys, HCL block names, Syntax Custom layout/opening, preset intensity ordering, and custom reapply now behave consistently across newer IDEs and theme changes.</li>
     </ul>
     <h3>2.6.4</h3>
     <ul>


### PR DESCRIPTION
── Summary ─────────────────────────────────
The 2.7.0 release notes were selling the new syntax controls but under-described the visible fixes shipped with them. This follow-up separates those bug fixes so Marketplace, CHANGELOG, and the update notification call out user-facing behavior clearly.

── Changes ─────────────────────────────────
| Type | Files | Description |
| --- | --- | --- |
| Docs | CHANGELOG.md:5 | Add a Fixed section for matching tags, status bar/chrome tinting, YAML/HCL styling, Syntax Custom layout, and preset inheritance fixes. |
| Docs | src/main/resources/META-INF/plugin.xml:117 | Mirror the user-facing fixes in Marketplace change notes. |
| Docs | src/main/kotlin/dev/ayuislands/UpdateNotifier.kt:59 | Condense the in-IDE update note so users see both features and fixes. |

── Validation ───────────────────────────────
- `./gradlew test --tests dev.ayuislands.UpdateNotifierTest ktlintCheck detekt` passed
- `./gradlew clean buildPlugin` passed
- `./gradlew verifyPlugin` passed, 11/11 IDE compatible
- `git diff --check` passed

## Summary by Sourcery

Clarify and surface the user-facing fixes included in the 2.7.0 release across changelog, Marketplace notes, and in-IDE update messaging.

Enhancements:
- Condense the in-IDE update notification copy so it calls out both new syntax features and the major user-visible fixes.

Documentation:
- Add a dedicated Fixed section to the 2.7.0 changelog describing tag highlighting, chrome tinting, YAML/HCL styling, Syntax Custom layout, and preset inheritance fixes.
- Update Marketplace change notes to explicitly list the key user-facing fixes shipped alongside the new syntax features.