### PR TITLE
fix(release): use public plugin descriptor lookup

### DIFF
--- a/src/main/kotlin/dev/ayuislands/AyuPlugin.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuPlugin.kt
@@ -1,22 +1,24 @@
 package dev.ayuislands
 
 import com.intellij.ide.plugins.IdeaPluginDescriptor
-import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.extensions.PluginId
 
 /**
  * Identity of this plugin's own descriptor and the single lookup wrapper over
- * the platform plugin descriptor APIs. Source of truth for `com.ayuislands.theme`
+ * the public [PluginManager] API. Source of truth for `com.ayuislands.theme`
  * + its [PluginId], plus the descriptor lookup so the production semantics
  * (enabled-only narrowing, test-env tolerance) live in one place.
  *
- * The wrapper deliberately avoids `PluginManager.findEnabledPlugin`: newer
- * Marketplace verification treats that method as internal API. The replacement
- * keeps the same enabled-only contract by checking [PluginManagerCore.isDisabled]
- * before reading [PluginManagerCore.getPlugin]. `ConflictRegistry` relies on the
- * null-for-disabled narrowing to skip disabled integrations.
+ * The wrapper deliberately calls `PluginManager.getInstance().findEnabledPlugin`
+ * (NOT `PluginManagerCore.getPlugin` or `PluginManager.getPlugin`). Both
+ * `getPlugin` variants are flagged by the JetBrains Marketplace verifier:
+ * the former as `@ApiStatus.Internal`, the latter as `@Deprecated`. Equally
+ * important, `getPlugin` returns the descriptor even for DISABLED plugins,
+ * while `findEnabledPlugin` returns null for disabled installations - and
+ * `ConflictRegistry` relies on that narrowing to skip disabled integrations.
  */
 internal object AyuPlugin {
     private val LOG = logger<AyuPlugin>()
@@ -30,18 +32,19 @@ internal object AyuPlugin {
      * [com.intellij.openapi.application.Application] is not bootstrapped
      * (only unit tests that do not start the platform see the last path).
      *
-     * Some unit tests mock a partially-bootstrapped [Application] while the
-     * platform plugin set remains absent or synthetic. Catching runtime lookup
-     * failures keeps those tests isolated; production should never hit this
-     * branch, and the WARN keeps any future platform regression visible.
+     * `PluginManager.getInstance()` internally resolves the service via
+     * `Application.getService(PluginManager::class.java)`. A mocked test
+     * [Application] whose `getService` returns a `java.lang.Object` (not
+     * a real [PluginManager]) triggers a [ClassCastException] inside the
+     * platform-side cast in `getInstance()`. We catch + log + return null
+     * so a partially-mocked Application in unit tests does not crash this
+     * wrapper. Production never sees this path; the WARN keeps a future
+     * platform CCE auditable.
      */
     fun findEnabledPlugin(pluginId: PluginId): IdeaPluginDescriptor? {
         ApplicationManager.getApplication() ?: return null
         return try {
-            if (PluginManagerCore.isDisabled(pluginId)) return null
-            PluginManagerCore.getPlugin(pluginId)
-        } catch (exception: IllegalStateException) {
-            logPluginLookupFailure(exception)
+            PluginManager.getInstance().findEnabledPlugin(pluginId)
         } catch (exception: ClassCastException) {
             logPluginLookupFailure(exception)
         }

--- a/src/test/kotlin/dev/ayuislands/AyuPluginTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuPluginTest.kt
@@ -1,7 +1,7 @@
 package dev.ayuislands
 
 import com.intellij.ide.plugins.IdeaPluginDescriptor
-import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.extensions.PluginId
@@ -23,7 +23,7 @@ import kotlin.test.assertSame
  *  - [AyuPlugin.findEnabledPlugin] returns the descriptor for a live plugin,
  *    `null` when the plugin is absent / disabled, `null` in a unit-test
  *    environment without an [Application], and `null` when a mocked test
- *    [Application] leaves platform plugin lookup unavailable.
+ *    [Application] returns a non-[PluginManager] `Object` from `getService`.
  */
 class AyuPluginTest {
     @AfterTest
@@ -53,7 +53,7 @@ class AyuPluginTest {
     fun `findEnabledPlugin returns null when Application is not bootstrapped`() {
         // Default unit-test environment has no live IDE: `getApplication()`
         // returns `null` and the wrapper short-circuits without touching
-        // platform plugin lookup. The wrapper SHOULD NOT throw.
+        // `PluginManager.getInstance`. The wrapper SHOULD NOT throw.
         mockkStatic(ApplicationManager::class)
         every { ApplicationManager.getApplication() } returns null
 
@@ -68,12 +68,13 @@ class AyuPluginTest {
         // on the wrapper returning a non-null descriptor when the plugin is
         // live in the IDE.
         val app = mockk<Application>()
+        val pluginManager = mockk<PluginManager>()
         val descriptor = mockk<IdeaPluginDescriptor>()
         mockkStatic(ApplicationManager::class)
-        mockkStatic(PluginManagerCore::class)
+        mockkStatic(PluginManager::class)
         every { ApplicationManager.getApplication() } returns app
-        every { PluginManagerCore.isDisabled(AyuPlugin.ID) } returns false
-        every { PluginManagerCore.getPlugin(AyuPlugin.ID) } returns descriptor
+        every { PluginManager.getInstance() } returns pluginManager
+        every { pluginManager.findEnabledPlugin(AyuPlugin.ID) } returns descriptor
 
         // Identity assertion (not just non-null) — a future refactor that
         // accidentally wrapped the descriptor (e.g. in a Decorator) would
@@ -94,12 +95,13 @@ class AyuPluginTest {
         // the wrapper must produce `null` so callers skip the integration path
         // cleanly instead of crashing.
         val app = mockk<Application>()
+        val pluginManager = mockk<PluginManager>()
         val absentId = PluginId.getId("com.nasller.CodeGlancePro")
         mockkStatic(ApplicationManager::class)
-        mockkStatic(PluginManagerCore::class)
+        mockkStatic(PluginManager::class)
         every { ApplicationManager.getApplication() } returns app
-        every { PluginManagerCore.isDisabled(absentId) } returns false
-        every { PluginManagerCore.getPlugin(absentId) } returns null
+        every { PluginManager.getInstance() } returns pluginManager
+        every { pluginManager.findEnabledPlugin(absentId) } returns null
 
         assertNull(AyuPlugin.findEnabledPlugin(absentId))
     }
@@ -107,15 +109,19 @@ class AyuPluginTest {
     @Test
     fun `findEnabledPlugin returns null when the requested plugin is installed but disabled`() {
         // Real-user scenario: a third-party plugin is INSTALLED but DISABLED.
-        // `PluginManagerCore.getPlugin` can still return a descriptor for
-        // disabled installations, so the wrapper must check disabled state first.
-        // `ConflictRegistry` depends on this null-for-disabled contract.
+        // The underlying `PluginManager.findEnabledPlugin` returns null for
+        // disabled plugins by contract (that is exactly what differentiates
+        // it from `getPlugin`, which still returns a descriptor for disabled
+        // installations). The wrapper passes that null through, which lets
+        // `ConflictRegistry` correctly skip disabled-plugin conflicts.
         val app = mockk<Application>()
+        val pluginManager = mockk<PluginManager>()
         val disabledId = PluginId.getId("indent-rainbow.indent-rainbow")
         mockkStatic(ApplicationManager::class)
-        mockkStatic(PluginManagerCore::class)
+        mockkStatic(PluginManager::class)
         every { ApplicationManager.getApplication() } returns app
-        every { PluginManagerCore.isDisabled(disabledId) } returns true
+        every { PluginManager.getInstance() } returns pluginManager
+        every { pluginManager.findEnabledPlugin(disabledId) } returns null
 
         assertNull(
             AyuPlugin.findEnabledPlugin(disabledId),
@@ -125,20 +131,23 @@ class AyuPluginTest {
     }
 
     @Test
-    fun `findEnabledPlugin survives unavailable platform plugin lookup`() {
-        // Pins the runtime lookup guard in [AyuPlugin.findEnabledPlugin]. Real
-        // test-suite scenario: another test in the JVM mocked
-        // `ApplicationManager.getApplication()` while the platform plugin set is
-        // synthetic or unavailable. The wrapper catches the lookup failure so
-        // unrelated tests don't crash with platform bootstrap errors they don't
-        // actually exercise.
+    fun `findEnabledPlugin survives a mocked Application whose getService returns Object`() {
+        // Pins the `catch (_: ClassCastException)` branch in
+        // [AyuPlugin.findEnabledPlugin]. Real test-suite scenario: another
+        // test in the JVM mocked `ApplicationManager.getApplication()` to
+        // return an Application whose `getService(PluginManager::class.java)`
+        // returns a bare Object. That shape triggers a ClassCastException
+        // inside `PluginManager.getInstance()` (one frame deeper than where
+        // we observe it). The wrapper catches it so unrelated tests (Chrome
+        // refresh, ConflictRegistry probes) don't crash with platform-
+        // internal errors they don't actually exercise.
         //
         // Deleting the production catch will fail this test.
         val app = mockk<Application>()
         mockkStatic(ApplicationManager::class)
-        mockkStatic(PluginManagerCore::class)
+        mockkStatic(PluginManager::class)
         every { ApplicationManager.getApplication() } returns app
-        every { PluginManagerCore.isDisabled(AyuPlugin.ID) } throws IllegalStateException("plugin set unavailable")
+        every { PluginManager.getInstance() } throws ClassCastException("mock Application returned Object")
 
         assertNull(AyuPlugin.findEnabledPlugin(AyuPlugin.ID))
     }


### PR DESCRIPTION
── Summary ─────────────────────────────────
Marketplace rejected the 2.7.0 update because the packaged plugin referenced an internal IntelliJ Platform plugin manager API. This PR restores the public PluginManager facade so the 2.7.0 artifact can pass review without changing release metadata.

── Changes ─────────────────────────────────
| Type | Path | Description |
| --- | --- | --- |
| Fix | src/main/kotlin/dev/ayuislands/AyuPlugin.kt:3 | Replace PluginManagerCore descriptor lookup with public PluginManager.getInstance().findEnabledPlugin while preserving disabled-plugin null behavior. |
| Test | src/test/kotlin/dev/ayuislands/AyuPluginTest.kt:3 | Update wrapper tests to mock the public facade and keep absent, disabled, and partially mocked Application coverage. |

── Validation ─────────────────────────────────
- ./gradlew test --tests dev.ayuislands.AyuPluginTest
- ./gradlew detekt ktlintCheck
- ./gradlew buildPlugin
- ./gradlew verifyPlugin
- javap -classpath build/libs/ayu-jetbrains-2.7.0.jar -c -p dev.ayuislands.AyuPlugin | rg "PluginManagerCore|getPlugin|PluginManager|getInstance|findEnabledPlugin"

── Notes ─────────────────────────────────
- GitHub Release asset v2.7.0 has already been replaced with the fixed ZIP digest sha256:1d05e44716949a9d5c2706ae565af0810a927ca7610ef17b317b646a465688e2.
- The tag v2.7.0 was not moved.

## Summary by Sourcery

Restore the plugin descriptor lookup to use the public PluginManager API and adjust tests to match the new lookup behavior.

Bug Fixes:
- Avoid use of internal/deprecated plugin manager APIs to satisfy JetBrains Marketplace verification while preserving null-for-disabled behavior.

Tests:
- Update AyuPlugin tests to mock PluginManager.getInstance().findEnabledPlugin and cover ClassCastException handling from mocked Applications.