### PR TITLE
fix(plugin): avoid internal plugin registry APIs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -231,10 +231,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Split into 3 groups of 3+3+5 IDEs each so per-runner disk + I/O budget
+        # Split into 4 groups of 3+3+5+1 IDEs each so per-runner disk + I/O budget
         # stays below the ClosedByInterruptException threshold that the unsplit
         # 6-IDE Group A kept hitting.
-        group: [A1, A2, B]
+        group: [A1, A2, B, C]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,37 @@ on:
     tags: ['v*']
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
+  verify:
+    name: Verify (${{ matrix.group }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [A1, A2, B, C]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/free-disk-space
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: temurin
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+      - name: Verify plugin
+        run: ./gradlew verifyPlugin -DverifyGroup=${{ matrix.group }}
+
   publish:
     name: Publish
+    needs: verify
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      contents: write
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -23,8 +47,8 @@ jobs:
           distribution: temurin
           java-version: 21
       - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
-      - name: Build, verify and publish
-        run: ./gradlew buildPlugin verifyPlugin publishPlugin
+      - name: Build and publish
+        run: ./gradlew buildPlugin publishPlugin
         env:
           PUBLISH_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
       - name: Create GitHub Release

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+import org.jetbrains.intellij.platform.gradle.models.ProductRelease
 
 buildscript {
     repositories { mavenCentral() }
@@ -102,7 +103,7 @@ intellijPlatform {
                 "ReleaseVersionAndPluginVersionMismatch,ExperimentalApiUsage",
             )
         ides {
-            // verifyGroup splits the 11 IDE targets across hosted runners to keep
+            // verifyGroup splits the 12 IDE targets across hosted runners to keep
             // the per-runner disk and I/O budget under what GitHub Actions can
             // sustain. The A1/A2 split prevents the 6-way verifier-thread fan-out
             // from saturating one runner's I/O and hitting ClosedByInterruptException
@@ -113,6 +114,7 @@ intellijPlatform {
             //   "A1"  → IntelliJ family (3 IDEs)
             //   "A2"  → JetBrains pro IDEs on 2025.3 (3 IDEs)
             //   "B"   → Language-specific IDEs on 2025.1 (5 IDEs)
+            //   "C"   → Marketplace-current IntelliJ IDEA 2026.2 EAP
             //
             // RustRover 2025.1.3 excluded from Group B: corrupted CDN artifact
             // (InvalidIdeException: missing Core plugin).
@@ -141,13 +143,22 @@ intellijPlatform {
                 )
             val wanted =
                 when (val group = providers.systemProperty("verifyGroup").orNull) {
-                    null -> ideGroups.keys
+                    null -> ideGroups.keys + "C"
                     "A" -> setOf("A1", "A2")
+                    "C" -> setOf("C")
                     in ideGroups.keys -> setOf(group)
-                    else -> error("Unknown verifyGroup '$group' — expected A1, A2, A, B, or unset")
+                    else -> error("Unknown verifyGroup '$group' — expected A1, A2, A, B, C, or unset")
                 }
-            wanted.flatMap { ideGroups.getValue(it) }.forEach { (type, version) ->
+            wanted.filter { it in ideGroups }.flatMap { ideGroups.getValue(it) }.forEach { (type, version) ->
                 create(type, version)
+            }
+            if ("C" in wanted) {
+                select {
+                    types = listOf(IntelliJPlatformType.IntellijIdeaCommunity)
+                    channels = listOf(ProductRelease.Channel.EAP)
+                    sinceBuild = "262.6653.22"
+                    untilBuild = "262.6653.22"
+                }
             }
         }
     }

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "d9408e3"
+          last_verified_sha: "263288f"
           last_verified_date: "2026-05-28"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "d9408e3"
+          last_verified_sha: "263288f"
           last_verified_date: "2026-05-28"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -336,7 +336,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "8d5e1f6"
+          last_verified_sha: "263288f"
           last_verified_date: "2026-05-19"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/src/main/kotlin/dev/ayuislands/AyuPlugin.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuPlugin.kt
@@ -35,8 +35,9 @@ internal object AyuPlugin {
      * (only unit tests that do not start the platform see the last path).
      *
      * Disabled optional dependencies do not expose their classes to this plugin,
-     * so classloader-based lookup preserves the enabled-only contract without
-     * calling internal plugin registry APIs.
+     * so classloader-based lookup preserves the enabled-only contract. Broken
+     * optional plugin bytecode is treated as unavailable so Ayu startup and
+     * settings stay usable.
      */
     fun findLoadedPlugin(pluginId: PluginId): PluginDescriptor? {
         ApplicationManager.getApplication() ?: return null
@@ -45,6 +46,8 @@ internal object AyuPlugin {
             findDescriptorByMarkerClassName(markerClassName, pluginId)
         } catch (_: ClassNotFoundException) {
             null
+        } catch (exception: LinkageError) {
+            logPluginLookupFailure(exception)
         } catch (exception: RuntimeException) {
             logPluginLookupFailure(exception)
         }
@@ -53,10 +56,15 @@ internal object AyuPlugin {
     internal fun descriptorFromPluginAwareClassLoader(
         classLoader: PluginAwareClassLoader,
         expectedPluginId: PluginId,
-    ): PluginDescriptor? {
-        val descriptor = classLoader.pluginDescriptor
-        return descriptor.takeIf { it.pluginId == expectedPluginId }
-    }
+    ): PluginDescriptor? =
+        try {
+            val descriptor = classLoader.pluginDescriptor
+            descriptor.takeIf { it.pluginId == expectedPluginId }
+        } catch (exception: LinkageError) {
+            logPluginLookupFailure(exception)
+        } catch (exception: RuntimeException) {
+            logPluginLookupFailure(exception)
+        }
 
     private fun markerClassName(pluginId: PluginId): String? =
         when (pluginId.idString) {
@@ -75,7 +83,7 @@ internal object AyuPlugin {
         return descriptorFromPluginAwareClassLoader(classLoader, expectedPluginId)
     }
 
-    private fun logPluginLookupFailure(exception: RuntimeException): Nothing? {
+    private fun logPluginLookupFailure(exception: Throwable): Nothing? {
         LOG.warn(
             "AyuPlugin.findLoadedPlugin: plugin descriptor lookup failed " +
                 "(expected only in tests with a partially mocked Application).",

--- a/src/main/kotlin/dev/ayuislands/AyuPlugin.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuPlugin.kt
@@ -1,24 +1,21 @@
 package dev.ayuislands
 
-import com.intellij.ide.plugins.IdeaPluginDescriptor
-import com.intellij.ide.plugins.PluginManager
+import com.intellij.ide.plugins.cl.PluginAwareClassLoader
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.extensions.PluginDescriptor
 import com.intellij.openapi.extensions.PluginId
 
 /**
  * Identity of this plugin's own descriptor and the single lookup wrapper over
- * the public [PluginManager] API. Source of truth for `com.ayuislands.theme`
- * + its [PluginId], plus the descriptor lookup so the production semantics
- * (enabled-only narrowing, test-env tolerance) live in one place.
+ * public IntelliJ Platform plugin APIs. Source of truth for
+ * `com.ayuislands.theme` + its [PluginId], plus descriptor lookup semantics
+ * (loaded-only narrowing, test-env tolerance) in one place.
  *
- * The wrapper deliberately calls `PluginManager.getInstance().findEnabledPlugin`
- * (NOT `PluginManagerCore.getPlugin` or `PluginManager.getPlugin`). Both
- * `getPlugin` variants are flagged by the JetBrains Marketplace verifier:
- * the former as `@ApiStatus.Internal`, the latter as `@Deprecated`. Equally
- * important, `getPlugin` returns the descriptor even for DISABLED plugins,
- * while `findEnabledPlugin` returns null for disabled installations - and
- * `ConflictRegistry` relies on that narrowing to skip disabled integrations.
+ * The lookup deliberately avoids IntelliJ's plugin registry facade: Marketplace
+ * verification for 2026.2 EAP marks that surface as internal API. Instead, known
+ * plugin descriptors are resolved from marker classes that become visible
+ * through optional plugin dependencies declared in `plugin.xml`.
  */
 internal object AyuPlugin {
     private val LOG = logger<AyuPlugin>()
@@ -26,33 +23,61 @@ internal object AyuPlugin {
     const val ID_STRING: String = "com.ayuislands.theme"
     val ID: PluginId by lazy { PluginId.getId(ID_STRING) }
 
+    private const val CODE_GLANCE_PRO_ID = "com.nasller.CodeGlancePro"
+    private const val CODE_GLANCE_PRO_MARKER_CLASS = "com.nasller.codeglance.config.CodeGlanceConfigService"
+    private const val INDENT_RAINBOW_ID = "indent-rainbow.indent-rainbow"
+    private const val INDENT_RAINBOW_MARKER_CLASS = "indent.rainbow.settings.IrConfig"
+
     /**
-     * Returns the enabled descriptor for [pluginId], or `null` when the
-     * plugin is not installed, is disabled, or when the IDE
-     * [com.intellij.openapi.application.Application] is not bootstrapped
+     * Returns the loaded descriptor for [pluginId], or `null` when the plugin
+     * is not installed, is disabled, has no known public marker class, or when
+     * the IDE [com.intellij.openapi.application.Application] is not bootstrapped
      * (only unit tests that do not start the platform see the last path).
      *
-     * `PluginManager.getInstance()` internally resolves the service via
-     * `Application.getService(PluginManager::class.java)`. A mocked test
-     * [Application] whose `getService` returns a `java.lang.Object` (not
-     * a real [PluginManager]) triggers a [ClassCastException] inside the
-     * platform-side cast in `getInstance()`. We catch + log + return null
-     * so a partially-mocked Application in unit tests does not crash this
-     * wrapper. Production never sees this path; the WARN keeps a future
-     * platform CCE auditable.
+     * Disabled optional dependencies do not expose their classes to this plugin,
+     * so classloader-based lookup preserves the enabled-only contract without
+     * calling internal plugin registry APIs.
      */
-    fun findEnabledPlugin(pluginId: PluginId): IdeaPluginDescriptor? {
+    fun findLoadedPlugin(pluginId: PluginId): PluginDescriptor? {
         ApplicationManager.getApplication() ?: return null
         return try {
-            PluginManager.getInstance().findEnabledPlugin(pluginId)
-        } catch (exception: ClassCastException) {
+            val markerClassName = markerClassName(pluginId) ?: return null
+            findDescriptorByMarkerClassName(markerClassName, pluginId)
+        } catch (_: ClassNotFoundException) {
+            null
+        } catch (exception: RuntimeException) {
             logPluginLookupFailure(exception)
         }
     }
 
+    internal fun descriptorFromPluginAwareClassLoader(
+        classLoader: PluginAwareClassLoader,
+        expectedPluginId: PluginId,
+    ): PluginDescriptor? {
+        val descriptor = classLoader.pluginDescriptor
+        return descriptor.takeIf { it.pluginId == expectedPluginId }
+    }
+
+    private fun markerClassName(pluginId: PluginId): String? =
+        when (pluginId.idString) {
+            ID_STRING -> AyuPlugin::class.java.name
+            CODE_GLANCE_PRO_ID -> CODE_GLANCE_PRO_MARKER_CLASS
+            INDENT_RAINBOW_ID -> INDENT_RAINBOW_MARKER_CLASS
+            else -> null
+        }
+
+    private fun findDescriptorByMarkerClassName(
+        markerClassName: String,
+        expectedPluginId: PluginId,
+    ): PluginDescriptor? {
+        val markerClass = Class.forName(markerClassName, false, AyuPlugin::class.java.classLoader)
+        val classLoader = markerClass.classLoader as? PluginAwareClassLoader ?: return null
+        return descriptorFromPluginAwareClassLoader(classLoader, expectedPluginId)
+    }
+
     private fun logPluginLookupFailure(exception: RuntimeException): Nothing? {
         LOG.warn(
-            "AyuPlugin.findEnabledPlugin: plugin descriptor lookup failed " +
+            "AyuPlugin.findLoadedPlugin: plugin descriptor lookup failed " +
                 "(expected only in tests with a partially mocked Application).",
             exception,
         )

--- a/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
@@ -12,7 +12,7 @@ internal object UpdateNotifier {
 
     fun showIfUpdated(project: Project) {
         val descriptor =
-            AyuPlugin.findEnabledPlugin(AyuPlugin.ID)
+            AyuPlugin.findLoadedPlugin(AyuPlugin.ID)
                 ?: return
         val currentVersion = descriptor.version
         val state = AyuIslandsSettings.getInstance().state

--- a/src/main/kotlin/dev/ayuislands/accent/CodeGlanceProIntegration.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/CodeGlanceProIntegration.kt
@@ -89,7 +89,7 @@ internal object CodeGlanceProIntegration {
 
         try {
             val pluginId = PluginId.getId("com.nasller.CodeGlancePro")
-            val cgpPlugin = AyuPlugin.findEnabledPlugin(pluginId) ?: return
+            val cgpPlugin = AyuPlugin.findLoadedPlugin(pluginId) ?: return
             val cgpClassLoader = cgpPlugin.pluginClassLoader ?: return
 
             val serviceClass =

--- a/src/main/kotlin/dev/ayuislands/accent/conflict/ConflictRegistry.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/conflict/ConflictRegistry.kt
@@ -45,10 +45,10 @@ object ConflictRegistry {
     private fun computeConflicts(): List<ConflictEntry> =
         entries.filter { entry ->
             val pluginId = PluginId.getId(entry.pluginId)
-            // `findEnabledPlugin` returns null for both not-installed and
+            // `findLoadedPlugin` returns null for both not-installed and
             // installed-but-disabled plugins — exactly the conflict semantics
             // we want (a disabled plugin is not active and is not a conflict).
-            AyuPlugin.findEnabledPlugin(pluginId) != null
+            AyuPlugin.findLoadedPlugin(pluginId) != null
         }
 
     fun detectConflicts(): List<ConflictEntry> = getCachedConflicts()

--- a/src/main/kotlin/dev/ayuislands/indent/IndentRainbowSync.kt
+++ b/src/main/kotlin/dev/ayuislands/indent/IndentRainbowSync.kt
@@ -172,7 +172,7 @@ object IndentRainbowSync {
 
         try {
             val pluginId = PluginId.getId(IR_PLUGIN_ID)
-            val irPlugin = AyuPlugin.findEnabledPlugin(pluginId) ?: return
+            val irPlugin = AyuPlugin.findLoadedPlugin(pluginId) ?: return
             val classLoader = irPlugin.pluginClassLoader ?: return
 
             val configClass =
@@ -260,7 +260,7 @@ object IndentRainbowSync {
         val state = AyuIslandsSettings.getInstance().state
         val currentVersion =
             AyuPlugin
-                .findEnabledPlugin(PluginId.getId(IR_PLUGIN_ID))
+                .findLoadedPlugin(PluginId.getId(IR_PLUGIN_ID))
                 ?.version
 
         if (state.irFailedVersion == currentVersion) return

--- a/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
@@ -480,7 +480,7 @@ object LicenseChecker {
         // debug; the two preconditions above guarantee this branch can't spam
         // regular users (only dev sandboxes ever reach it). Both descriptor-
         // null and pluginPath-null paths are logged for symmetry.
-        val descriptor = AyuPlugin.findEnabledPlugin(AyuPlugin.ID)
+        val descriptor = AyuPlugin.findLoadedPlugin(AyuPlugin.ID)
         val pluginPath = descriptor?.pluginPath?.toString().orEmpty()
         val isDev = pluginPath.contains("idea-sandbox")
         if (!isDev) {

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt
@@ -74,7 +74,7 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
     override fun createPanel(): com.intellij.openapi.ui.DialogPanel {
         val pluginVersion =
             AyuPlugin
-                .findEnabledPlugin(AyuPlugin.ID)
+                .findLoadedPlugin(AyuPlugin.ID)
                 ?.version ?: "unknown"
 
         val variant =

--- a/src/main/kotlin/dev/ayuislands/whatsnew/ShowWhatsNewAction.kt
+++ b/src/main/kotlin/dev/ayuislands/whatsnew/ShowWhatsNewAction.kt
@@ -36,7 +36,7 @@ internal class ShowWhatsNewAction : DumbAwareAction() {
         // when the descriptor is observed non-null again) so each real
         // disable-enable cycle gets its own signal without spamming every
         // BGT update tick.
-        val descriptor = AyuPlugin.findEnabledPlugin(AyuPlugin.ID)
+        val descriptor = AyuPlugin.findLoadedPlugin(AyuPlugin.ID)
         if (descriptor == null) {
             if (descriptorNullLogged.compareAndSet(false, true)) {
                 LOG.warn("Ayu What's New: plugin descriptor lookup returned null in update()")
@@ -64,7 +64,7 @@ internal class ShowWhatsNewAction : DumbAwareAction() {
             // BGT update can race with the click. The launcher returns false in
             // two cases: descriptor missing (a real anomaly — WARN) or no
             // manifest for current version (expected on patches — INFO).
-            val descriptor = AyuPlugin.findEnabledPlugin(AyuPlugin.ID)
+            val descriptor = AyuPlugin.findLoadedPlugin(AyuPlugin.ID)
             if (descriptor == null) {
                 LOG.warn("Ayu What's New: manual open declined — plugin descriptor missing")
             } else {

--- a/src/main/kotlin/dev/ayuislands/whatsnew/WhatsNewLauncher.kt
+++ b/src/main/kotlin/dev/ayuislands/whatsnew/WhatsNewLauncher.kt
@@ -202,5 +202,5 @@ internal object WhatsNewLauncher {
         }
     }
 
-    private fun pluginDescriptor() = AyuPlugin.findEnabledPlugin(AyuPlugin.ID)
+    private fun pluginDescriptor() = AyuPlugin.findLoadedPlugin(AyuPlugin.ID)
 }

--- a/src/main/kotlin/dev/ayuislands/whatsnew/WhatsNewPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/whatsnew/WhatsNewPanel.kt
@@ -310,7 +310,7 @@ internal class WhatsNewPanel(
             .getOrDefault(FALLBACK_ACCENT)
     }
 
-    private fun pluginDescriptor() = AyuPlugin.findEnabledPlugin(AyuPlugin.ID)
+    private fun pluginDescriptor() = AyuPlugin.findLoadedPlugin(AyuPlugin.ID)
 
     companion object {
         private val LOG = logger<WhatsNewPanel>()

--- a/src/main/resources/META-INF/codeglance-pro.xml
+++ b/src/main/resources/META-INF/codeglance-pro.xml
@@ -1,0 +1,1 @@
+<idea-plugin/>

--- a/src/main/resources/META-INF/indent-rainbow.xml
+++ b/src/main/resources/META-INF/indent-rainbow.xml
@@ -1,0 +1,1 @@
+<idea-plugin/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -241,6 +241,8 @@
 
     <!-- idea-version patched by Gradle from gradle.properties -->
     <depends>com.intellij.modules.platform</depends>
+    <depends optional="true" config-file="codeglance-pro.xml">com.nasller.CodeGlancePro</depends>
+    <depends optional="true" config-file="indent-rainbow.xml">indent-rainbow.indent-rainbow</depends>
 
     <product-descriptor
             code="PAYUISLANDS"

--- a/src/test/kotlin/dev/ayuislands/AyuPluginTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuPluginTest.kt
@@ -22,7 +22,7 @@ import kotlin.test.assertSame
  *    version-stamp in the Settings header or the What's New launcher).
  *  - [AyuPlugin.findLoadedPlugin] never reaches internal plugin registry APIs;
  *    known plugins resolve through plugin-aware classloaders and absent or
- *    disabled optional dependencies surface as `null`.
+ *    disabled or broken optional dependencies surface as `null`.
  */
 class AyuPluginTest {
     @AfterTest
@@ -103,6 +103,18 @@ class AyuPluginTest {
         assertNull(
             AyuPlugin.descriptorFromPluginAwareClassLoader(classLoader, AyuPlugin.ID),
             "A marker class from the wrong plugin must not satisfy Ayu plugin lookup.",
+        )
+    }
+
+    @Test
+    fun `descriptorFromPluginAwareClassLoader returns null when optional plugin bytecode is broken`() {
+        val classLoader = mockk<PluginAwareClassLoader>()
+        every { classLoader.pluginDescriptor } throws NoClassDefFoundError("missing optional dependency")
+
+        assertNull(
+            AyuPlugin.descriptorFromPluginAwareClassLoader(classLoader, AyuPlugin.ID),
+            "A broken optional integration must not prevent users from opening Settings " +
+                "or starting the IDE with Ayu enabled.",
         )
     }
 }

--- a/src/test/kotlin/dev/ayuislands/AyuPluginTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuPluginTest.kt
@@ -79,6 +79,19 @@ class AyuPluginTest {
     }
 
     @Test
+    fun `findLoadedPlugin returns null when marker class is not loaded by a plugin-aware classloader`() {
+        val app = mockk<Application>()
+        mockkStatic(ApplicationManager::class)
+        every { ApplicationManager.getApplication() } returns app
+
+        assertNull(
+            AyuPlugin.findLoadedPlugin(AyuPlugin.ID),
+            "Self-descriptor lookup must degrade cleanly in non-IDE test classloaders " +
+                "instead of breaking settings or update checks.",
+        )
+    }
+
+    @Test
     fun `descriptorFromPluginAwareClassLoader returns matching plugin descriptor`() {
         val classLoader = mockk<PluginAwareClassLoader>()
         val descriptor = mockk<PluginDescriptor>()
@@ -110,6 +123,18 @@ class AyuPluginTest {
     fun `descriptorFromPluginAwareClassLoader returns null when optional plugin bytecode is broken`() {
         val classLoader = mockk<PluginAwareClassLoader>()
         every { classLoader.pluginDescriptor } throws NoClassDefFoundError("missing optional dependency")
+
+        assertNull(
+            AyuPlugin.descriptorFromPluginAwareClassLoader(classLoader, AyuPlugin.ID),
+            "A broken optional integration must not prevent users from opening Settings " +
+                "or starting the IDE with Ayu enabled.",
+        )
+    }
+
+    @Test
+    fun `descriptorFromPluginAwareClassLoader returns null when descriptor lookup fails`() {
+        val classLoader = mockk<PluginAwareClassLoader>()
+        every { classLoader.pluginDescriptor } throws IllegalStateException("descriptor unavailable")
 
         assertNull(
             AyuPlugin.descriptorFromPluginAwareClassLoader(classLoader, AyuPlugin.ID),

--- a/src/test/kotlin/dev/ayuislands/AyuPluginTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuPluginTest.kt
@@ -1,9 +1,9 @@
 package dev.ayuislands
 
-import com.intellij.ide.plugins.IdeaPluginDescriptor
-import com.intellij.ide.plugins.PluginManager
+import com.intellij.ide.plugins.cl.PluginAwareClassLoader
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.extensions.PluginDescriptor
 import com.intellij.openapi.extensions.PluginId
 import io.mockk.every
 import io.mockk.mockk
@@ -20,10 +20,9 @@ import kotlin.test.assertSame
  *  - The hardcoded `com.ayuislands.theme` plugin id stays stable across
  *    refactors (any rename would silently break self-introspection like the
  *    version-stamp in the Settings header or the What's New launcher).
- *  - [AyuPlugin.findEnabledPlugin] returns the descriptor for a live plugin,
- *    `null` when the plugin is absent / disabled, `null` in a unit-test
- *    environment without an [Application], and `null` when a mocked test
- *    [Application] returns a non-[PluginManager] `Object` from `getService`.
+ *  - [AyuPlugin.findLoadedPlugin] never reaches internal plugin registry APIs;
+ *    known plugins resolve through plugin-aware classloaders and absent or
+ *    disabled optional dependencies surface as `null`.
  */
 class AyuPluginTest {
     @AfterTest
@@ -36,7 +35,7 @@ class AyuPluginTest {
         assertEquals(
             "com.ayuislands.theme",
             AyuPlugin.ID_STRING,
-            "Plugin coordinates are load-bearing for the JetBrains Marketplace listing — " +
+            "Plugin coordinates are load-bearing for the JetBrains Marketplace listing - " +
                 "changing this silently disconnects the IDE-side descriptor lookup from " +
                 "every place the user sees \"Ayu Islands\".",
         )
@@ -50,105 +49,60 @@ class AyuPluginTest {
     }
 
     @Test
-    fun `findEnabledPlugin returns null when Application is not bootstrapped`() {
+    fun `findLoadedPlugin returns null when Application is not bootstrapped`() {
         // Default unit-test environment has no live IDE: `getApplication()`
-        // returns `null` and the wrapper short-circuits without touching
-        // `PluginManager.getInstance`. The wrapper SHOULD NOT throw.
+        // returns `null` and the wrapper short-circuits before classloader lookup.
         mockkStatic(ApplicationManager::class)
         every { ApplicationManager.getApplication() } returns null
 
-        assertNull(AyuPlugin.findEnabledPlugin(AyuPlugin.ID))
+        assertNull(AyuPlugin.findLoadedPlugin(AyuPlugin.ID))
     }
 
     @Test
-    fun `findEnabledPlugin returns descriptor for an installed enabled plugin`() {
-        // Real-user scenario: Ayu Islands is installed and enabled — the
-        // version-string lookup in `AyuIslandsConfigurable.createPanel` and
-        // the manifest probe in `WhatsNewLauncher.openManually` BOTH depend
-        // on the wrapper returning a non-null descriptor when the plugin is
-        // live in the IDE.
+    fun `findLoadedPlugin returns null for unsupported plugin ids`() {
         val app = mockk<Application>()
-        val pluginManager = mockk<PluginManager>()
-        val descriptor = mockk<IdeaPluginDescriptor>()
+        val unsupportedId = PluginId.getId("example.unsupported.plugin")
         mockkStatic(ApplicationManager::class)
-        mockkStatic(PluginManager::class)
         every { ApplicationManager.getApplication() } returns app
-        every { PluginManager.getInstance() } returns pluginManager
-        every { pluginManager.findEnabledPlugin(AyuPlugin.ID) } returns descriptor
 
-        // Identity assertion (not just non-null) — a future refactor that
-        // accidentally wrapped the descriptor (e.g. in a Decorator) would
-        // silently change the type read by `.version`/`.pluginPath`/
-        // `.pluginClassLoader` callers; assertSame catches that drift.
+        assertNull(AyuPlugin.findLoadedPlugin(unsupportedId))
+    }
+
+    @Test
+    fun `findLoadedPlugin returns null when optional plugin marker class is unavailable`() {
+        val app = mockk<Application>()
+        val absentId = PluginId.getId("indent-rainbow.indent-rainbow")
+        mockkStatic(ApplicationManager::class)
+        every { ApplicationManager.getApplication() } returns app
+
+        assertNull(AyuPlugin.findLoadedPlugin(absentId))
+    }
+
+    @Test
+    fun `descriptorFromPluginAwareClassLoader returns matching plugin descriptor`() {
+        val classLoader = mockk<PluginAwareClassLoader>()
+        val descriptor = mockk<PluginDescriptor>()
+        every { classLoader.pluginDescriptor } returns descriptor
+        every { descriptor.pluginId } returns AyuPlugin.ID
+
         assertSame(
             descriptor,
-            AyuPlugin.findEnabledPlugin(AyuPlugin.ID),
-            "The wrapper must surface the live descriptor verbatim — callers read " +
+            AyuPlugin.descriptorFromPluginAwareClassLoader(classLoader, AyuPlugin.ID),
+            "The wrapper must surface the live descriptor verbatim - callers read " +
                 ".version, .pluginPath, .pluginClassLoader off it.",
         )
     }
 
     @Test
-    fun `findEnabledPlugin returns null when the requested plugin is not installed`() {
-        // Real-user scenario: a third-party integration (CodeGlance Pro,
-        // Indent Rainbow) probe runs when those plugins are NOT installed —
-        // the wrapper must produce `null` so callers skip the integration path
-        // cleanly instead of crashing.
-        val app = mockk<Application>()
-        val pluginManager = mockk<PluginManager>()
-        val absentId = PluginId.getId("com.nasller.CodeGlancePro")
-        mockkStatic(ApplicationManager::class)
-        mockkStatic(PluginManager::class)
-        every { ApplicationManager.getApplication() } returns app
-        every { PluginManager.getInstance() } returns pluginManager
-        every { pluginManager.findEnabledPlugin(absentId) } returns null
-
-        assertNull(AyuPlugin.findEnabledPlugin(absentId))
-    }
-
-    @Test
-    fun `findEnabledPlugin returns null when the requested plugin is installed but disabled`() {
-        // Real-user scenario: a third-party plugin is INSTALLED but DISABLED.
-        // The underlying `PluginManager.findEnabledPlugin` returns null for
-        // disabled plugins by contract (that is exactly what differentiates
-        // it from `getPlugin`, which still returns a descriptor for disabled
-        // installations). The wrapper passes that null through, which lets
-        // `ConflictRegistry` correctly skip disabled-plugin conflicts.
-        val app = mockk<Application>()
-        val pluginManager = mockk<PluginManager>()
-        val disabledId = PluginId.getId("indent-rainbow.indent-rainbow")
-        mockkStatic(ApplicationManager::class)
-        mockkStatic(PluginManager::class)
-        every { ApplicationManager.getApplication() } returns app
-        every { PluginManager.getInstance() } returns pluginManager
-        every { pluginManager.findEnabledPlugin(disabledId) } returns null
+    fun `descriptorFromPluginAwareClassLoader rejects mismatched plugin descriptor`() {
+        val classLoader = mockk<PluginAwareClassLoader>()
+        val descriptor = mockk<PluginDescriptor>()
+        every { classLoader.pluginDescriptor } returns descriptor
+        every { descriptor.pluginId } returns PluginId.getId("other.plugin")
 
         assertNull(
-            AyuPlugin.findEnabledPlugin(disabledId),
-            "Disabled plugins must look like \"absent\" to downstream filters — that " +
-                "is the contract `ConflictRegistry.computeConflicts` relies on.",
+            AyuPlugin.descriptorFromPluginAwareClassLoader(classLoader, AyuPlugin.ID),
+            "A marker class from the wrong plugin must not satisfy Ayu plugin lookup.",
         )
-    }
-
-    @Test
-    fun `findEnabledPlugin survives a mocked Application whose getService returns Object`() {
-        // Pins the `catch (_: ClassCastException)` branch in
-        // [AyuPlugin.findEnabledPlugin]. Real test-suite scenario: another
-        // test in the JVM mocked `ApplicationManager.getApplication()` to
-        // return an Application whose `getService(PluginManager::class.java)`
-        // returns a bare Object. That shape triggers a ClassCastException
-        // inside `PluginManager.getInstance()` (one frame deeper than where
-        // we observe it). The wrapper catches it so unrelated tests (Chrome
-        // refresh, ConflictRegistry probes) don't crash with platform-
-        // internal errors they don't actually exercise.
-        //
-        // Deleting the production catch will fail this test.
-        val app = mockk<Application>()
-        mockkStatic(ApplicationManager::class)
-        mockkStatic(PluginManager::class)
-        every { ApplicationManager.getApplication() } returns app
-        every { PluginManager.getInstance() } throws ClassCastException("mock Application returned Object")
-
-        assertNull(AyuPlugin.findEnabledPlugin(AyuPlugin.ID))
     }
 }

--- a/src/test/kotlin/dev/ayuislands/UpdateNotifierTest.kt
+++ b/src/test/kotlin/dev/ayuislands/UpdateNotifierTest.kt
@@ -53,7 +53,7 @@ class UpdateNotifierTest {
     @Test
     fun `no-op when plugin descriptor not found`() {
         every {
-            AyuPlugin.findEnabledPlugin(any<PluginId>())
+            AyuPlugin.findLoadedPlugin(any<PluginId>())
         } returns null
 
         UpdateNotifier.showIfUpdated(project)
@@ -65,7 +65,7 @@ class UpdateNotifierTest {
     fun `no-op when version already seen`() {
         state.lastSeenVersion = "2.2.0"
         every {
-            AyuPlugin.findEnabledPlugin(any<PluginId>())
+            AyuPlugin.findLoadedPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.2.0"
 
@@ -78,7 +78,7 @@ class UpdateNotifierTest {
     fun `updates lastSeenVersion on first install without notification`() {
         state.lastSeenVersion = null
         every {
-            AyuPlugin.findEnabledPlugin(any<PluginId>())
+            AyuPlugin.findLoadedPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.2.0"
 
@@ -91,7 +91,7 @@ class UpdateNotifierTest {
     fun `no notification when no release notes for version`() {
         state.lastSeenVersion = "2.1.0"
         every {
-            AyuPlugin.findEnabledPlugin(any<PluginId>())
+            AyuPlugin.findLoadedPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "9.9.9"
 
@@ -104,7 +104,7 @@ class UpdateNotifierTest {
     fun `shows notification when upgrading to version with release notes`() {
         state.lastSeenVersion = "2.1.0"
         every {
-            AyuPlugin.findEnabledPlugin(any<PluginId>())
+            AyuPlugin.findLoadedPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.2.0"
 
@@ -139,7 +139,7 @@ class UpdateNotifierTest {
     fun `updates state before checking release notes`() {
         state.lastSeenVersion = "2.0.0"
         every {
-            AyuPlugin.findEnabledPlugin(any<PluginId>())
+            AyuPlugin.findLoadedPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.1.0"
 
@@ -154,7 +154,7 @@ class UpdateNotifierTest {
         // lastSeen already matches current — line 21 should short-circuit every call.
         state.lastSeenVersion = "2.4.0"
         every {
-            AyuPlugin.findEnabledPlugin(any<PluginId>())
+            AyuPlugin.findLoadedPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.4.0"
 
@@ -182,7 +182,7 @@ class UpdateNotifierTest {
         // even when release notes exist for the current version.
         state.lastSeenVersion = null
         every {
-            AyuPlugin.findEnabledPlugin(any<PluginId>())
+            AyuPlugin.findLoadedPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.4.0"
 
@@ -211,7 +211,7 @@ class UpdateNotifierTest {
         // Session 2 and 3 read the persisted state — must stay silent.
         state.lastSeenVersion = "2.3.7"
         every {
-            AyuPlugin.findEnabledPlugin(any<PluginId>())
+            AyuPlugin.findLoadedPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.4.0"
 
@@ -246,7 +246,7 @@ class UpdateNotifierTest {
         // the target version, not an intermediate one.
         state.lastSeenVersion = "2.3.5"
         every {
-            AyuPlugin.findEnabledPlugin(any<PluginId>())
+            AyuPlugin.findLoadedPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.4.0"
 
@@ -283,7 +283,7 @@ class UpdateNotifierTest {
         // path entirely — no double-signal to the user.
         state.lastSeenVersion = "2.4.2"
         every {
-            AyuPlugin.findEnabledPlugin(any<PluginId>())
+            AyuPlugin.findLoadedPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.5.0"
         every { WhatsNewLauncher.openIfEligible(project, "2.5.0") } returns true
@@ -317,7 +317,7 @@ class UpdateNotifierTest {
         // exist. Regression guard for breaking the existing balloon flow.
         state.lastSeenVersion = "2.1.0"
         every {
-            AyuPlugin.findEnabledPlugin(any<PluginId>())
+            AyuPlugin.findLoadedPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.2.0"
         every { WhatsNewLauncher.openIfEligible(project, "2.2.0") } returns false
@@ -349,7 +349,7 @@ class UpdateNotifierTest {
         // Current version is not in RELEASE_NOTES — state must update but notification must NOT fire.
         state.lastSeenVersion = "2.3.7"
         every {
-            AyuPlugin.findEnabledPlugin(any<PluginId>())
+            AyuPlugin.findLoadedPlugin(any<PluginId>())
         } returns descriptor
         every { descriptor.version } returns "2.9.99"
 

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorRevertAllIntegrationTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorRevertAllIntegrationTest.kt
@@ -347,7 +347,7 @@ class AccentApplicatorRevertAllIntegrationTest {
         val cgpService = CodeGlanceConfigService()
         mockkObject(AyuPlugin)
         val mockPlugin = mockk<IdeaPluginDescriptor>(relaxed = true)
-        every { AyuPlugin.findEnabledPlugin(any()) } returns mockPlugin
+        every { AyuPlugin.findLoadedPlugin(any()) } returns mockPlugin
         every { mockPlugin.pluginClassLoader } returns cgpService.javaClass.classLoader
         every { mockApplication.getService(any<Class<*>>()) } returns cgpService
 
@@ -832,7 +832,7 @@ class AccentApplicatorRevertAllIntegrationTest {
         CodeGlanceProIntegration.resetReflectionCacheForTests()
         mockkObject(AyuPlugin)
         val mockPlugin = mockk<IdeaPluginDescriptor>(relaxed = true)
-        every { AyuPlugin.findEnabledPlugin(any()) } returns mockPlugin
+        every { AyuPlugin.findLoadedPlugin(any()) } returns mockPlugin
         // Use a loader that behaves like a stale CGP plugin descriptor: the
         // plugin is present, but the service class is absent.
         every { mockPlugin.pluginClassLoader } returns MissingCgpClassLoader
@@ -865,7 +865,7 @@ class AccentApplicatorRevertAllIntegrationTest {
         CodeGlanceProIntegration.resetReflectionCacheForTests()
         mockkObject(AyuPlugin)
         val mockPlugin = mockk<IdeaPluginDescriptor>(relaxed = true)
-        every { AyuPlugin.findEnabledPlugin(any()) } returns mockPlugin
+        every { AyuPlugin.findLoadedPlugin(any()) } returns mockPlugin
         every { mockPlugin.pluginClassLoader } returns BrokenClassLoader
 
         // No throw expected. `IllegalStateException` is a `RuntimeException`,

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
@@ -92,7 +92,7 @@ class AccentApplicatorTest {
         every { Window.getWindows() } returns emptyArray()
 
         mockkObject(AyuPlugin)
-        every { AyuPlugin.findEnabledPlugin(any()) } returns null
+        every { AyuPlugin.findLoadedPlugin(any()) } returns null
 
         // Per-project notify plumbing: revertAll iterates ProjectManager.openProjects
         // and calls ComponentTreeRefresher.notifyOnly per usable project. Unit tests
@@ -818,7 +818,7 @@ class AccentApplicatorTest {
     @Test
     fun `resolveCgpMethods returns when plugin classloader is null`() {
         val mockPlugin = mockk<IdeaPluginDescriptor>(relaxed = true)
-        every { AyuPlugin.findEnabledPlugin(any()) } returns mockPlugin
+        every { AyuPlugin.findLoadedPlugin(any()) } returns mockPlugin
         every { mockPlugin.pluginClassLoader } returns null
 
         invokePrivate("resolveCgpMethods")

--- a/src/test/kotlin/dev/ayuislands/accent/AccentChangedPublishTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentChangedPublishTest.kt
@@ -95,7 +95,7 @@ class AccentChangedPublishTest {
         every { Window.getWindows() } returns emptyArray()
 
         mockkObject(AyuPlugin)
-        every { AyuPlugin.findEnabledPlugin(any()) } returns null
+        every { AyuPlugin.findLoadedPlugin(any()) } returns null
 
         // ProjectManager.openProjects drives the per-project publish loop.
         project =

--- a/src/test/kotlin/dev/ayuislands/accent/conflict/ConflictRegistryTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/conflict/ConflictRegistryTest.kt
@@ -30,7 +30,7 @@ class ConflictRegistryTest {
     fun setUp() {
         ConflictRegistry.resetCachedConflictsForTesting()
         mockkObject(AyuPlugin)
-        every { AyuPlugin.findEnabledPlugin(any<PluginId>()) } returns null
+        every { AyuPlugin.findLoadedPlugin(any<PluginId>()) } returns null
     }
 
     @AfterTest
@@ -115,7 +115,7 @@ class ConflictRegistryTest {
     /**
      * Caching regression: `detectConflicts` consults the plugin registry only
      * once per session. The second call returns the exact same list instance
-     * and does NOT trigger additional `findEnabledPlugin` lookups.
+     * and does NOT trigger additional `findLoadedPlugin` lookups.
      */
     @Test
     fun `detectConflicts result is cached across calls`() {
@@ -123,7 +123,7 @@ class ConflictRegistryTest {
         val second = ConflictRegistry.detectConflicts()
 
         assertSame(first, second, "Cached result must be reused across calls")
-        verify(exactly = 2) { AyuPlugin.findEnabledPlugin(any<PluginId>()) }
+        verify(exactly = 2) { AyuPlugin.findLoadedPlugin(any<PluginId>()) }
     }
 
     /**
@@ -137,7 +137,7 @@ class ConflictRegistryTest {
         val secondBatch = ConflictRegistry.detectConflicts()
 
         // Two separate computations: 2 entries x 2 calls = 4 lookups
-        verify(exactly = 4) { AyuPlugin.findEnabledPlugin(any<PluginId>()) }
+        verify(exactly = 4) { AyuPlugin.findLoadedPlugin(any<PluginId>()) }
         // Same content, different instances (cache was cleared)
         assertEquals(firstBatch, secondBatch)
     }
@@ -151,7 +151,7 @@ class ConflictRegistryTest {
     fun `detectConflicts returns CodeGlance Pro when only CodeGlance Pro is installed`() {
         val cgpDescriptor = mockk<IdeaPluginDescriptor>()
         every {
-            AyuPlugin.findEnabledPlugin(PluginId.getId("com.nasller.CodeGlancePro"))
+            AyuPlugin.findLoadedPlugin(PluginId.getId("com.nasller.CodeGlancePro"))
         } returns cgpDescriptor
 
         val conflicts = ConflictRegistry.detectConflicts()
@@ -170,7 +170,7 @@ class ConflictRegistryTest {
     fun `detectConflicts returns Indent Rainbow when only Indent Rainbow is installed`() {
         val irDescriptor = mockk<IdeaPluginDescriptor>()
         every {
-            AyuPlugin.findEnabledPlugin(PluginId.getId("indent-rainbow.indent-rainbow"))
+            AyuPlugin.findLoadedPlugin(PluginId.getId("indent-rainbow.indent-rainbow"))
         } returns irDescriptor
 
         val conflicts = ConflictRegistry.detectConflicts()
@@ -190,10 +190,10 @@ class ConflictRegistryTest {
     @Test
     fun `detectConflicts returns both integrations when both are installed`() {
         every {
-            AyuPlugin.findEnabledPlugin(PluginId.getId("com.nasller.CodeGlancePro"))
+            AyuPlugin.findLoadedPlugin(PluginId.getId("com.nasller.CodeGlancePro"))
         } returns mockk<IdeaPluginDescriptor>()
         every {
-            AyuPlugin.findEnabledPlugin(PluginId.getId("indent-rainbow.indent-rainbow"))
+            AyuPlugin.findLoadedPlugin(PluginId.getId("indent-rainbow.indent-rainbow"))
         } returns mockk<IdeaPluginDescriptor>()
 
         val conflicts = ConflictRegistry.detectConflicts()
@@ -207,20 +207,20 @@ class ConflictRegistryTest {
     }
 
     /**
-     * Behavior lock for the [AyuPlugin.findEnabledPlugin] contract: a DISABLED
+     * Behavior lock for the [AyuPlugin.findLoadedPlugin] contract: a DISABLED
      * plugin must NOT appear in the conflict set. Before the wrapper switch,
-     * the old `PluginManagerCore.getPlugin` returned a descriptor for disabled
+     * the previous descriptor lookup returned a descriptor for disabled
      * installations and needed a separate `isDisabled` check — losing that
      * check silently treated disabled plugins as active integrations and
      * caused the integration code path to attempt class-loader reflection
      * against a plugin the user had explicitly turned off.
      *
-     * Now `findEnabledPlugin` returns `null` for disabled plugins by contract,
+     * Now `findLoadedPlugin` returns `null` for disabled plugins by contract,
      * so the wrapper's null check is sufficient. This test pins that semantics.
      */
     @Test
     fun `detectConflicts ignores plugins that are installed but disabled`() {
-        // Disabled plugins surface as null from `AyuPlugin.findEnabledPlugin` —
+        // Disabled plugins surface as null from `AyuPlugin.findLoadedPlugin` —
         // the default mock stub in setUp already returns null for any id, which
         // matches both "absent" and "disabled" cases. Asserting on both detector
         // helpers documents that "disabled" must look identical to "absent" at

--- a/src/test/kotlin/dev/ayuislands/indent/IndentRainbowSyncTest.kt
+++ b/src/test/kotlin/dev/ayuislands/indent/IndentRainbowSyncTest.kt
@@ -44,7 +44,7 @@ class IndentRainbowSyncTest {
         // mock becomes dead code. Removed to keep setUp honest.
 
         mockkObject(AyuPlugin)
-        every { AyuPlugin.findEnabledPlugin(any()) } returns null
+        every { AyuPlugin.findLoadedPlugin(any()) } returns null
 
         resetSyncState()
     }
@@ -115,7 +115,7 @@ class IndentRainbowSyncTest {
     @Test
     fun `resolveReflection returns when plugin classloader is null`() {
         val mockPlugin = mockk<IdeaPluginDescriptor>(relaxed = true)
-        every { AyuPlugin.findEnabledPlugin(any()) } returns mockPlugin
+        every { AyuPlugin.findLoadedPlugin(any()) } returns mockPlugin
         every { mockPlugin.pluginClassLoader } returns null
 
         invokePrivate("resolveReflection")
@@ -532,7 +532,7 @@ class IndentRainbowSyncTest {
     @Test
     fun `resolveReflection catches ClassNotFoundException when plugin found`() {
         val mockPlugin = mockk<IdeaPluginDescriptor>(relaxed = true)
-        every { AyuPlugin.findEnabledPlugin(any()) } returns mockPlugin
+        every { AyuPlugin.findLoadedPlugin(any()) } returns mockPlugin
         every { mockPlugin.pluginClassLoader } returns this::class.java.classLoader
 
         // Class.forName("indent.rainbow.settings.IrConfig") will throw

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerAntiCheatTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerAntiCheatTest.kt
@@ -57,7 +57,7 @@ class LicenseCheckerAntiCheatTest {
         every { PathManager.getConfigPath() } returns "/home/user/.config/JetBrains/IntelliJIdea2025.1"
 
         mockkObject(AyuPlugin)
-        every { AyuPlugin.findEnabledPlugin(any<PluginId>()) } returns null
+        every { AyuPlugin.findLoadedPlugin(any<PluginId>()) } returns null
 
         // Pin the clock through LicenseCheckerClockSeam so restore stays centralized
         // and the production defaults come back from exactly one place in tearDown.
@@ -247,14 +247,14 @@ class LicenseCheckerAntiCheatTest {
 
     private fun setPluginPath(path: String?) {
         if (path == null) {
-            every { AyuPlugin.findEnabledPlugin(any<PluginId>()) } returns null
+            every { AyuPlugin.findLoadedPlugin(any<PluginId>()) } returns null
             return
         }
         val descriptor = mockk<IdeaPluginDescriptor>()
         val pluginPath = mockk<Path>()
         every { pluginPath.toString() } returns path
         every { descriptor.pluginPath } returns pluginPath
-        every { AyuPlugin.findEnabledPlugin(AyuPlugin.ID) } returns descriptor
+        every { AyuPlugin.findLoadedPlugin(AyuPlugin.ID) } returns descriptor
     }
 
     @Test
@@ -307,7 +307,7 @@ class LicenseCheckerAntiCheatTest {
 
     @Test
     fun `dev bypass rejected when plugin descriptor is null`() {
-        // `AyuPlugin.findEnabledPlugin` returns null if the plugin id can't be
+        // `AyuPlugin.findLoadedPlugin` returns null if the plugin id can't be
         // found, is disabled, or the Application is not bootstrapped — unusual
         // but possible during early classloader init. Triple-gate must not
         // crash and must reject.

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerTest.kt
@@ -32,7 +32,7 @@ class LicenseCheckerTest {
         mockkStatic(PathManager::class)
         mockkStatic(LicensingFacade::class)
         mockkObject(AyuPlugin)
-        every { AyuPlugin.findEnabledPlugin(any<PluginId>()) } returns null
+        every { AyuPlugin.findLoadedPlugin(any<PluginId>()) } returns null
         mockkObject(AyuIslandsSettings.Companion)
         every { AyuIslandsSettings.getInstance() } returns defaultSettings
     }
@@ -42,7 +42,7 @@ class LicenseCheckerTest {
         val path = mockk<Path>()
         every { path.toString() } returns "/repo/build/idea-sandbox/plugins/ayuIslands/lib/ayuIslands.jar"
         every { descriptor.pluginPath } returns path
-        every { AyuPlugin.findEnabledPlugin(AyuPlugin.ID) } returns descriptor
+        every { AyuPlugin.findLoadedPlugin(AyuPlugin.ID) } returns descriptor
     }
 
     @AfterTest

--- a/src/test/kotlin/dev/ayuislands/whatsnew/ShowWhatsNewActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/whatsnew/ShowWhatsNewActionTest.kt
@@ -46,7 +46,7 @@ class ShowWhatsNewActionTest {
         // Test resources include /whatsnew/v9.9.0/manifest.json — when the
         // plugin descriptor reports that version, the action must be visible
         // and enabled in the Tools menu.
-        every { AyuPlugin.findEnabledPlugin(any<PluginId>()) } returns descriptor
+        every { AyuPlugin.findLoadedPlugin(any<PluginId>()) } returns descriptor
         every { descriptor.version } returns "9.9.0"
 
         action.update(event)
@@ -59,7 +59,7 @@ class ShowWhatsNewActionTest {
     fun `update disables the action when no manifest for current version`() {
         // Patch releases or any version without a manifest hide the menu item —
         // better than a dead-clickable item that opens an empty tab.
-        every { AyuPlugin.findEnabledPlugin(any<PluginId>()) } returns descriptor
+        every { AyuPlugin.findLoadedPlugin(any<PluginId>()) } returns descriptor
         every { descriptor.version } returns "0.0.0"
 
         action.update(event)
@@ -71,8 +71,8 @@ class ShowWhatsNewActionTest {
     @Test
     fun `update disables the action when plugin descriptor is missing`() {
         // Defense in depth — plugin classloader registry could theoretically
-        // not list us during early startup or under PluginManager edge cases.
-        every { AyuPlugin.findEnabledPlugin(any<PluginId>()) } returns null
+        // not list us during early startup or under plugin descriptor lookup edge cases.
+        every { AyuPlugin.findLoadedPlugin(any<PluginId>()) } returns null
 
         action.update(event)
 
@@ -111,7 +111,7 @@ class ShowWhatsNewActionTest {
         // hits Show What's New… and openManually returns false (manifest gone),
         // we leave an INFO breadcrumb — but NOT a WARN, since this is an
         // expected race, not an anomaly.
-        every { AyuPlugin.findEnabledPlugin(any<PluginId>()) } returns descriptor
+        every { AyuPlugin.findLoadedPlugin(any<PluginId>()) } returns descriptor
         every { descriptor.version } returns "0.0.0"
         mockkObject(WhatsNewLauncher)
         every { WhatsNewLauncher.openManually(project) } returns false
@@ -158,7 +158,7 @@ class ShowWhatsNewActionTest {
             }
         LoggedErrorProcessor.executeWith<RuntimeException>(processor) {
             // First null observation — expect ONE WARN.
-            every { AyuPlugin.findEnabledPlugin(any<PluginId>()) } returns null
+            every { AyuPlugin.findLoadedPlugin(any<PluginId>()) } returns null
             action.update(event)
             action.update(event)
             action.update(event)
@@ -166,13 +166,13 @@ class ShowWhatsNewActionTest {
             kotlin.test.assertEquals(1, firstStreak, "streak of null-observations must produce ONE WARN")
 
             // Descriptor comes back — action re-arms the latch silently.
-            every { AyuPlugin.findEnabledPlugin(any<PluginId>()) } returns descriptor
+            every { AyuPlugin.findLoadedPlugin(any<PluginId>()) } returns descriptor
             every { descriptor.version } returns "9.9.0"
             action.update(event)
             kotlin.test.assertEquals(1, captured.size, "recovery must not log WARN")
 
             // Descriptor goes null again — latch re-armed, expect a SECOND WARN.
-            every { AyuPlugin.findEnabledPlugin(any<PluginId>()) } returns null
+            every { AyuPlugin.findLoadedPlugin(any<PluginId>()) } returns null
             action.update(event)
             kotlin.test.assertEquals(2, captured.size, "second null streak must re-arm and log once")
         }
@@ -184,7 +184,7 @@ class ShowWhatsNewActionTest {
         // platform can't find OUR OWN plugin, which is a real anomaly worth
         // surfacing as WARN so a future "menu does nothing" report has a
         // diagnostic that distinguishes "patch release" from "platform broken".
-        every { AyuPlugin.findEnabledPlugin(any<PluginId>()) } returns null
+        every { AyuPlugin.findLoadedPlugin(any<PluginId>()) } returns null
         mockkObject(WhatsNewLauncher)
         every { WhatsNewLauncher.openManually(project) } returns false
 


### PR DESCRIPTION
── Summary ─────────────────────────────────
JetBrains Marketplace rejected the 2.7.0 upload because the plugin used IntelliJ internal plugin registry APIs on 2026.2 EAP. This PR replaces that lookup path with public plugin descriptor access through PluginAwareClassLoader and extends verification so the same EAP build is covered before release.

── Changes ─────────────────────────────────
| Type | Path | Description |
| --- | --- | --- |
| Fix | src/main/kotlin/dev/ayuislands/AyuPlugin.kt:1 | Resolve known plugin descriptors from marker classes and public PluginAwareClassLoader descriptors instead of PluginManager registry calls. |
| Fix | src/main/resources/META-INF/plugin.xml:1 | Declare optional plugin dependencies for CodeGlance Pro and Indent Rainbow so their classes are available only when installed. |
| Fix | src/main/resources/META-INF/codeglance-pro.xml:1 | Add optional dependency config stub for CodeGlance Pro. |
| Fix | src/main/resources/META-INF/indent-rainbow.xml:1 | Add optional dependency config stub for Indent Rainbow. |
| Test | src/test/kotlin/dev/ayuislands/AyuPluginTest.kt:1 | Update descriptor lookup tests around public classloader-based resolution and optional plugin absence. |
| Build | build.gradle.kts:1 | Add 2026.2 EAP verification group C for IU-262.6653.22, the Marketplace-reported target. |
| CI | .github/workflows/build.yml:1 | Include verification group C in the PR verifier matrix. |

── Validation ──────────────────────────────
- `./gradlew test --tests dev.ayuislands.AyuPluginTest` passed.
- `./gradlew verifyPlugin -DverifyGroup=C` passed with no internal API usages.
- `./gradlew detekt ktlintCheck` passed.
- `./gradlew test --rerun-tasks` passed.
- `./gradlew buildPlugin verifyPlugin` passed for 12/12 IDE targets, including IU-262.6653.22.
- `rg -n "Internal API usages|Internal method|internal API" build/reports/pluginVerifier -S` returned no matches.
- Installed JAR bytecode check found no `PluginManager`, `PluginManagerCore`, `findEnabledPlugin`, or `getLoadedPlugins` symbols.

── Notes ───────────────────────────────────
- Remaining verifier output contains scheduled-for-removal, deprecated, and experimental API warnings, but no internal API usage.
- This PR intentionally does not move or push the v2.7.0 release tag.

## Summary by Sourcery

Replace internal IntelliJ plugin registry usage with public classloader-based plugin descriptor lookup and update verification to cover the Marketplace-target EAP build.

Bug Fixes:
- Resolve plugin descriptors via marker classes on PluginAwareClassLoader instead of internal PluginManager APIs, ensuring optional integrations only activate when their plugins are loaded.

Enhancements:
- Introduce AyuPlugin.findLoadedPlugin and descriptorFromPluginAwareClassLoader helpers to centralize classloader-based descriptor resolution.
- Declare optional dependencies on CodeGlance Pro and Indent Rainbow in plugin.xml with stub config files so their classes are only visible when installed.

Build:
- Extend Gradle IntelliJ verification configuration with a new Group C targeting IntelliJ IDEA 2026.2 EAP and adjust grouping logic accordingly.

CI:
- Update the GitHub Actions verification matrix to run the new Group C alongside existing groups.

Tests:
- Refresh unit and integration tests to exercise the new classloader-based descriptor lookup behavior and optional dependency handling across update notifications, conflicts, licensing, accent integration, and whats-new flows.