### PR TITLE
fix(glow): refresh overlays on accent changes

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -209,7 +209,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "a76d876"
+          last_verified_sha: "b7506aa"
           last_verified_date: "2026-05-24"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "2e2ad33"
+          last_verified_sha: "361549e"
           last_verified_date: "2026-05-28"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "2e2ad33"
+          last_verified_sha: "361549e"
           last_verified_date: "2026-05-28"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -209,7 +209,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "2e2ad33"
+          last_verified_sha: "361549e"
           last_verified_date: "2026-05-24"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -336,7 +336,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "2e2ad33"
+          last_verified_sha: "361549e"
           last_verified_date: "2026-05-19"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "a76d876"
+          last_verified_sha: "4868a56"
           last_verified_date: "2026-05-28"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "a76d876"
+          last_verified_sha: "4868a56"
           last_verified_date: "2026-05-28"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "361549e"
+          last_verified_sha: "a76d876"
           last_verified_date: "2026-05-28"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "361549e"
+          last_verified_sha: "a76d876"
           last_verified_date: "2026-05-28"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -209,7 +209,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "361549e"
+          last_verified_sha: "a76d876"
           last_verified_date: "2026-05-24"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "263288f"
+          last_verified_sha: "2e2ad33"
           last_verified_date: "2026-05-28"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "263288f"
+          last_verified_sha: "2e2ad33"
           last_verified_date: "2026-05-28"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -209,7 +209,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "8d5e1f6"
+          last_verified_sha: "2e2ad33"
           last_verified_date: "2026-05-24"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -336,7 +336,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "263288f"
+          last_verified_sha: "2e2ad33"
           last_verified_date: "2026-05-19"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
@@ -6,7 +6,6 @@ import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
-import dev.ayuislands.settings.mappings.AccentMappingsSettings
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
@@ -35,9 +34,9 @@ import javax.swing.SwingUtilities
  * On EDT, first-call detection on a large monorepo is a ~300–500 ms freeze. To avoid
  * that, an EDT invocation with an empty cache kicks off a deduplicated background scan
  * via [ProjectLanguageScanAsync] and returns null immediately; the caller falls through
- * to the global accent. When the BG scan completes, if the detected id has an active
- * language-accent override, the detector re-applies the accent on EDT so the UI picks
- * up the winner without waiting for the next focus swap.
+ * to the global accent. When the BG scan completes with a cacheable verdict, the
+ * detector re-applies the resolver result on EDT so the UI picks up either the new
+ * winner or the fallback without waiting for the next focus swap.
  *
  * Cache correctness: a detection whose scan threw is NOT cached — the next call
  * retries. A scan that ran cleanly but produced no winner (after both the proportional
@@ -302,8 +301,12 @@ object ProjectLanguageDetector {
                     cache[key] != null -> ScanOutcome.Polyglot
                     else -> ScanOutcome.Unavailable
                 }
-            if (detected != null) {
-                tryRefreshAccentForDetected(project, detected)
+            when (outcome) {
+                is ScanOutcome.Detected,
+                ScanOutcome.Polyglot,
+                -> tryRefreshAccentAfterCacheableScan(project)
+
+                ScanOutcome.Unavailable -> Unit
             }
             publishScanCompleted(project, outcome)
         }
@@ -343,54 +346,34 @@ object ProjectLanguageDetector {
     }
 
     /**
-     * After a background scan settles on an id, re-apply the accent if the user
-     * has an override configured for it — otherwise the UI would stay on the
-     * global accent until the next focus swap / IDE restart, even though
-     * detection just proved the override should apply.
+     * After a background scan reaches a cacheable verdict, re-apply the current
+     * resolver result. Both positive hits and definitive polyglot/no-match
+     * outcomes can change the visible accent: a hit may enable a language
+     * override, while a fallback verdict may remove one.
      */
-    private fun tryRefreshAccentForDetected(
-        project: Project,
-        detectedId: String,
-    ) {
-        SwingUtilities.invokeLater { refreshAccentOnEdt(project, detectedId) }
+    private fun tryRefreshAccentAfterCacheableScan(project: Project) {
+        SwingUtilities.invokeLater { refreshAccentOnEdt(project) }
     }
 
     /**
-     * EDT body extracted from [tryRefreshAccentForDetected] so the membership
-     * check + apply chain can be red/green tested synchronously without having
-     * to pump a Swing event loop. The caller is expected to already be on the
-     * EDT (production: wrapped in `SwingUtilities.invokeLater`; tests: called
-     * directly on the test thread). Returns early on disposal or on a
-     * language-override miss, logs and swallows any downstream apply or
-     * settings-read failure.
+     * EDT body extracted from [tryRefreshAccentAfterCacheableScan] so the
+     * resolver + apply chain can be red/green tested synchronously without
+     * having to pump a Swing event loop. The caller is expected to already be
+     * on the EDT (production: wrapped in `SwingUtilities.invokeLater`; tests:
+     * called directly on the test thread). Returns early on disposal, logs and
+     * swallows any downstream apply failure.
      *
-     * `internal` (no `@TestOnly`) because [tryRefreshAccentForDetected] — the
-     * production caller — reaches this helper through the `SwingUtilities.invokeLater`
-     * boundary; marking it test-only would misrepresent the call graph and
-     * any `@TestOnly` inspection would either miss real misuse or flag this
-     * legitimate production path.
+     * `internal` (no `@TestOnly`) because [tryRefreshAccentAfterCacheableScan]
+     * — the production caller — reaches this helper through the
+     * `SwingUtilities.invokeLater` boundary; marking it test-only would
+     * misrepresent the call graph and any `@TestOnly` inspection would either
+     * miss real misuse or flag this legitimate production path.
      */
-    internal fun refreshAccentOnEdt(
-        project: Project,
-        detectedId: String,
-    ) {
+    internal fun refreshAccentOnEdt(project: Project) {
         if (project.isDisposed) return
-        // Widen the runCatching to cover the settings read AND the apply
-        // chain. `AccentMappingsSettings.getInstance()` can fail during a
-        // plugin-unload race or a corrupt persistent-state XML read on the
-        // EDT — without the wrap, that throw would bubble out of the
-        // invokeLater callback as an uncaught EDT exception, exactly the
-        // failure mode the inner block already contains for the apply chain.
         runCatchingPreservingCancellation {
-            // Re-read the mappings ON the EDT so membership reflects the
-            // same state the apply chain is about to resolve against — the
-            // Settings UI mutates `languageAccents` on EDT, and an off-EDT
-            // membership check could observe a stale map between scan
-            // completion and this callback's scheduling.
-            val mappings = AccentMappingsSettings.getInstance().state
-            if (detectedId !in mappings.languageAccents) return@runCatchingPreservingCancellation
-            // Best-effort refresh: the cache already has the detected id,
-            // so `dominant()` behavior is unaffected by failures here.
+            // Best-effort refresh: the cache already has the cacheable scan
+            // verdict, so `dominant()` behavior is unaffected by failures here.
             // Containing exceptions keeps a regression in any of the
             // downstream apply paths (variant detection, UIManager writes,
             // focus-swap notification) from surfacing as an uncaught EDT

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
@@ -378,6 +378,10 @@ object ProjectLanguageDetector {
             // downstream apply paths (variant detection, UIManager writes,
             // focus-swap notification) from surfacing as an uncaught EDT
             // exception and risking the UI.
+            if (AccentApplicator.resolveFocusedProject() !== project) {
+                LOG.debug("Post-scan accent refresh skipped because focused project changed")
+                return@runCatchingPreservingCancellation
+            }
             val variant = AyuVariant.detect() ?: return@runCatchingPreservingCancellation
             val hex = AccentResolver.resolve(project, variant)
             val applied = AccentApplicator.applyFromHexString(hex)

--- a/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
@@ -12,6 +12,9 @@ import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener
+import dev.ayuislands.accent.AccentChangeListener
+import dev.ayuislands.accent.AccentChangedTopic
+import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.licensing.LicenseChecker
@@ -166,6 +169,29 @@ class GlowOverlayManager(
                 override fun selectionChanged(event: FileEditorManagerEvent) {
                     SwingUtilities.invokeLater {
                         attachEditorOverlayIfNeeded()
+                    }
+                }
+            },
+        )
+
+        connection.subscribe(
+            AccentChangedTopic.TOPIC,
+            @Suppress("ObjectLiteralToLambda")
+            object : AccentChangeListener {
+                override fun accentChanged(
+                    project: Project,
+                    hex: AccentHex,
+                    source: AccentResolver.Source,
+                ) {
+                    if (disposed) return
+                    if (project !== this@GlowOverlayManager.project) return
+
+                    if (SwingUtilities.isEventDispatchThread()) {
+                        updateGlow()
+                    } else {
+                        SwingUtilities.invokeLater {
+                            if (!disposed) updateGlow()
+                        }
                     }
                 }
             },

--- a/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
@@ -247,7 +247,7 @@ class GlowOverlayManager(
                 log.debug("AyuVariant.detect() returned null in initializeFocusRingGlow, skipping focus-ring glow")
                 return
             }
-        val accentHex = AccentResolver.resolve(project, variant)
+        val accentHex = resolveCurrentGlowAccentHex(project, state, variant)
         val style = GlowStyle.fromName(state.glowStyle ?: GlowStyle.SOFT.name)
         val accent = safeDecodeColor(accentHex)
         val intensity = state.getIntensityForStyle(style)
@@ -295,7 +295,7 @@ class GlowOverlayManager(
                 log.debug("AyuVariant.detect() returned null in attachOverlay($id), skipping overlay attach")
                 return
             }
-        val accentHex = AccentResolver.resolve(project, variant)
+        val accentHex = resolveCurrentGlowAccentHex(project, state, variant)
         val style = GlowStyle.fromName(state.glowStyle ?: GlowStyle.SOFT.name)
 
         val glassPane =
@@ -460,7 +460,7 @@ class GlowOverlayManager(
                             )
                             return
                         }
-                    AccentResolver.resolve(project, variant)
+                    resolveCurrentGlowAccentHex(project, state, variant)
                 }
         val accent = safeDecodeColor(accentHex)
         val style = GlowStyle.fromName(state.glowStyle ?: GlowStyle.SOFT.name)
@@ -542,3 +542,14 @@ class GlowOverlayManager(
         }
     }
 }
+
+private fun resolveCurrentGlowAccentHex(
+    project: Project,
+    state: AyuIslandsState,
+    variant: AyuVariant,
+): String =
+    state
+        .effectiveLastAppliedAccentHex()
+        ?.takeIf { state.lastApplyOk }
+        ?.value
+        ?: AccentResolver.resolve(project, variant)

--- a/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
@@ -187,10 +187,10 @@ class GlowOverlayManager(
                     if (project !== this@GlowOverlayManager.project) return
 
                     if (SwingUtilities.isEventDispatchThread()) {
-                        updateGlow()
+                        updateGlow(hex)
                     } else {
                         SwingUtilities.invokeLater {
-                            if (!disposed) updateGlow()
+                            if (!disposed) updateGlow(hex)
                         }
                     }
                 }
@@ -431,7 +431,7 @@ class GlowOverlayManager(
         glassPane.animationAlpha = 1.0f
     }
 
-    fun updateGlow() {
+    fun updateGlow(appliedAccent: AccentHex? = null) {
         if (disposed) return
         if (!AyuVariant.isAyuActive()) {
             removeAllOverlays()
@@ -449,12 +449,19 @@ class GlowOverlayManager(
         // disposed overlays when the LAF is non-Ayu, so reaching here with a
         // null detect() is the rare race window between guard and detect();
         // surface a DEBUG breadcrumb instead of falling through silently.
-        val variant =
-            AyuVariant.detect() ?: run {
-                log.debug("AyuVariant.detect() returned null in updateGlow after isAyuActive guard, skipping refresh")
-                return
-            }
-        val accentHex = AccentResolver.resolve(project, variant)
+        val accentHex =
+            appliedAccent?.value
+                ?: run {
+                    val variant =
+                        AyuVariant.detect() ?: run {
+                            log.debug(
+                                "AyuVariant.detect() returned null in updateGlow after " +
+                                    "isAyuActive guard, skipping refresh",
+                            )
+                            return
+                        }
+                    AccentResolver.resolve(project, variant)
+                }
         val accent = safeDecodeColor(accentHex)
         val style = GlowStyle.fromName(state.glowStyle ?: GlowStyle.SOFT.name)
 

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -52,10 +52,10 @@ class AyuIslandsState : BaseState() {
      * flicker users see when multiple project windows restore simultaneously with
      * distinct per-project overrides.
      *
-     * Written by every `apply()`, read once in
-     * [dev.ayuislands.AyuIslandsAppListener.appFrameCreated] and then effectively
-     * ignored at runtime (the live resolver chain inside `AyuIslandsStartupActivity`
-     * overrides it per project once contexts are available).
+     * Written by every `apply()`, read by
+     * [dev.ayuislands.AyuIslandsAppListener.appFrameCreated] for first-frame
+     * anti-flicker and by [dev.ayuislands.glow.GlowOverlayManager] so late-created
+     * glow overlays match the app-global chrome accent that was actually painted.
      *
      * Stored as hex string (e.g. `"#5CCFE6"`) for IDE-state simplicity — no color
      * serialization round-trip. `null` on first launch (pre-plugin-install history).

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
@@ -936,12 +936,18 @@ class ProjectLanguageDetectorTest {
         wireMessageBus(project, listener)
         runInvokeLaterInline()
         runSchedulerInline()
+        mockkObject(AyuVariant.Companion)
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        mockkObject(AccentResolver)
+        every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returns "#FFCC66"
         mockkObject(AccentApplicator)
+        every { AccentApplicator.resolveFocusedProject() } returns project
         every { AccentApplicator.apply(any()) } answers { Unit }
 
         ProjectLanguageDetector.rescan(project)
 
         verify(exactly = 1) { listener.scanCompleted(ScanOutcome.Unavailable) }
+        verify(exactly = 0) { AccentApplicator.resolveFocusedProject() }
         verify(exactly = 0) { AccentApplicator.apply(any()) }
     }
 

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
@@ -690,6 +690,7 @@ class ProjectLanguageDetectorTest {
         } returns swapService
 
         val project = stubProject("/tmp/refresh-fallback-${System.nanoTime()}")
+        every { AccentApplicator.resolveFocusedProject() } returns project
         ProjectLanguageDetector.refreshAccentOnEdt(project)
 
         verify(exactly = 1) { AccentApplicator.applyFromHexString("#FFCC66") }
@@ -716,6 +717,7 @@ class ProjectLanguageDetectorTest {
         } returns swapService
 
         val project = stubProject("/tmp/refresh-hit-${System.nanoTime()}")
+        every { AccentApplicator.resolveFocusedProject() } returns project
         ProjectLanguageDetector.refreshAccentOnEdt(project)
 
         verify(exactly = 1) { AccentApplicator.applyFromHexString("#FFCC66") }
@@ -737,6 +739,7 @@ class ProjectLanguageDetectorTest {
         every { AccentApplicator.apply(any()) } throws RuntimeException("LafManager boom")
 
         val project = stubProject("/tmp/refresh-throw-${System.nanoTime()}")
+        every { AccentApplicator.resolveFocusedProject() } returns project
         // Must not throw — load-bearing assertion is simply that the call
         // completes. A regression dropping the runCatching would propagate
         // the RuntimeException and fail this test.
@@ -757,6 +760,7 @@ class ProjectLanguageDetectorTest {
         every { AccentApplicator.apply(any()) } answers { Unit }
 
         val project = stubProject("/tmp/refresh-settings-boom-${System.nanoTime()}")
+        every { AccentApplicator.resolveFocusedProject() } returns project
 
         // Must not throw — the runCatching contains the resolver.
         ProjectLanguageDetector.refreshAccentOnEdt(project)
@@ -778,7 +782,24 @@ class ProjectLanguageDetectorTest {
         every { AccentApplicator.apply(any()) } answers { Unit }
 
         val project = stubProject("/tmp/refresh-null-variant-${System.nanoTime()}")
+        every { AccentApplicator.resolveFocusedProject() } returns project
         ProjectLanguageDetector.refreshAccentOnEdt(project)
+
+        verify(exactly = 0) { AccentApplicator.apply(any()) }
+    }
+
+    @Test
+    fun `refreshAccentOnEdt skips apply chain when focused project changed after scan`() {
+        // The apply path writes app-global UIManager state. A background scan
+        // from an old project must not repaint over the project that gained
+        // focus while the scan was running.
+        val scannedProject = stubProject("/tmp/refresh-old-focus-${System.nanoTime()}")
+        val focusedProject = stubProject("/tmp/refresh-new-focus-${System.nanoTime()}")
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.resolveFocusedProject() } returns focusedProject
+        every { AccentApplicator.apply(any()) } answers { Unit }
+
+        ProjectLanguageDetector.refreshAccentOnEdt(scannedProject)
 
         verify(exactly = 0) { AccentApplicator.apply(any()) }
     }
@@ -968,6 +989,7 @@ class ProjectLanguageDetectorTest {
         mockkObject(AccentResolver)
         every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returns "#FFCC66"
         mockkObject(AccentApplicator)
+        every { AccentApplicator.resolveFocusedProject() } returns project
         every { AccentApplicator.apply(any()) } answers { Unit }
         val swapService = mockk<dev.ayuislands.settings.mappings.ProjectAccentSwapService>(relaxed = true)
         mockkObject(dev.ayuislands.settings.mappings.ProjectAccentSwapService.Companion)

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
@@ -6,8 +6,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.projectRoots.SdkTypeId
 import com.intellij.openapi.roots.ProjectRootManager
-import dev.ayuislands.settings.mappings.AccentMappingsSettings
-import dev.ayuislands.settings.mappings.AccentMappingsState
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -670,44 +668,40 @@ class ProjectLanguageDetectorTest {
         )
     }
 
-    // ── refreshAccentOnEdt (extracted from tryRefreshAccentForDetected) ───────
+    // ── refreshAccentOnEdt (extracted from cacheable scan refresh) ────────────
 
     @Test
-    fun `refreshAccentOnEdt skips apply chain when detected id has no language override`() {
-        // Round 2 moved the membership check inside the EDT body so the
-        // apply chain reads the same snapshot the resolver will resolve
-        // against. Locking the "no override → no apply" branch here so a
-        // regression flipping the `!in` guard is caught.
-        val mappingsState = AccentMappingsState()
-        val settings = mockk<AccentMappingsSettings>()
-        every { settings.state } returns mappingsState
-        mockkObject(AccentMappingsSettings.Companion)
-        every { AccentMappingsSettings.getInstance() } returns settings
-
+    fun `refreshAccentOnEdt reapplies resolver fallback when language override no longer matches`() {
+        // A cacheable scan can remove the active language override as well as
+        // add one. The resolver owns that fallback decision; this helper must
+        // apply whatever it resolves so chrome/glow do not stay on the old
+        // language accent until the next focus swap.
+        mockkObject(AyuVariant.Companion)
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        mockkObject(AccentResolver)
+        every { AccentResolver.resolve(any(), any()) } returns "#FFCC66"
         mockkObject(AccentApplicator)
         every { AccentApplicator.apply(any()) } answers { Unit }
+        val swapService = mockk<dev.ayuislands.settings.mappings.ProjectAccentSwapService>(relaxed = true)
+        mockkObject(dev.ayuislands.settings.mappings.ProjectAccentSwapService.Companion)
+        every {
+            dev.ayuislands.settings.mappings.ProjectAccentSwapService
+                .getInstance()
+        } returns swapService
 
-        val project = stubProject("/tmp/refresh-miss-${System.nanoTime()}")
-        ProjectLanguageDetector.refreshAccentOnEdt(project, "kotlin")
+        val project = stubProject("/tmp/refresh-fallback-${System.nanoTime()}")
+        ProjectLanguageDetector.refreshAccentOnEdt(project)
 
-        verify(exactly = 0) { AccentApplicator.apply(any()) }
+        verify(exactly = 1) { AccentApplicator.applyFromHexString("#FFCC66") }
+        verify(exactly = 1) { swapService.notifyExternalApply("#FFCC66") }
     }
 
     @Test
     fun `refreshAccentOnEdt runs the full apply chain when override is present`() {
-        // Happy-path lock: given a language override for the detected id on a
-        // live project, the helper must call the full resolver → applicator →
-        // swap-cache chain. A regression flipping the `!in` guard or dropping
-        // any of the three downstream calls would leave users stuck on the
-        // global accent until the next focus swap — exactly the bug the
-        // extraction was meant to lock down.
-        val mappingsState =
-            AccentMappingsState().apply { languageAccents["kotlin"] = "#FFCC66" }
-        val settings = mockk<AccentMappingsSettings>()
-        every { settings.state } returns mappingsState
-        mockkObject(AccentMappingsSettings.Companion)
-        every { AccentMappingsSettings.getInstance() } returns settings
-
+        // Happy-path lock: given a resolved language override on a live
+        // project, the helper must call the full resolver → applicator →
+        // swap-cache chain. Dropping any of the three downstream calls would
+        // leave users stuck on the previous accent until the next focus swap.
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
         mockkObject(AccentResolver)
@@ -722,7 +716,7 @@ class ProjectLanguageDetectorTest {
         } returns swapService
 
         val project = stubProject("/tmp/refresh-hit-${System.nanoTime()}")
-        ProjectLanguageDetector.refreshAccentOnEdt(project, "kotlin")
+        ProjectLanguageDetector.refreshAccentOnEdt(project)
 
         verify(exactly = 1) { AccentApplicator.applyFromHexString("#FFCC66") }
         verify(exactly = 1) { swapService.notifyExternalApply("#FFCC66") }
@@ -735,13 +729,6 @@ class ProjectLanguageDetectorTest {
         // shutdown; if that propagates out of the invokeLater callback it
         // becomes an uncaught EDT exception. This test asserts the helper
         // returns normally (WARN-logged internally) instead of rethrowing.
-        val mappingsState =
-            AccentMappingsState().apply { languageAccents["kotlin"] = "#FFCC66" }
-        val settings = mockk<AccentMappingsSettings>()
-        every { settings.state } returns mappingsState
-        mockkObject(AccentMappingsSettings.Companion)
-        every { AccentMappingsSettings.getInstance() } returns settings
-
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
         mockkObject(AccentResolver)
@@ -753,30 +740,28 @@ class ProjectLanguageDetectorTest {
         // Must not throw — load-bearing assertion is simply that the call
         // completes. A regression dropping the runCatching would propagate
         // the RuntimeException and fail this test.
-        ProjectLanguageDetector.refreshAccentOnEdt(project, "kotlin")
+        ProjectLanguageDetector.refreshAccentOnEdt(project)
     }
 
     @Test
-    fun `refreshAccentOnEdt swallows a throwing settings read without rethrowing`() {
-        // Lock on the round-5 widening of runCatching: the settings read at
-        // AccentMappingsSettings.getInstance() can fail during a plugin-unload
-        // race or a corrupt persistent-state XML read. Must be contained inside
-        // the wrapper so it never bubbles out as an uncaught EDT exception.
-        // Narrowing the runCatching back to "apply chain only" would regress
-        // round-5 and this test would fail.
-        mockkObject(AccentMappingsSettings.Companion)
-        every { AccentMappingsSettings.getInstance() } throws RuntimeException("plugin unload race")
+    fun `refreshAccentOnEdt swallows a throwing resolver without rethrowing`() {
+        // The resolver now owns both hit and fallback decisions. A corrupt
+        // override, plugin-unload race, or resolver regression must not escape
+        // the invokeLater callback as an uncaught EDT exception.
+        mockkObject(AyuVariant.Companion)
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        mockkObject(AccentResolver)
+        every { AccentResolver.resolve(any(), any()) } throws RuntimeException("resolver boom")
 
         mockkObject(AccentApplicator)
         every { AccentApplicator.apply(any()) } answers { Unit }
 
         val project = stubProject("/tmp/refresh-settings-boom-${System.nanoTime()}")
 
-        // Must not throw — the widened runCatching contains the settings read.
-        ProjectLanguageDetector.refreshAccentOnEdt(project, "kotlin")
+        // Must not throw — the runCatching contains the resolver.
+        ProjectLanguageDetector.refreshAccentOnEdt(project)
 
-        // And because the membership check never executed, the apply chain
-        // must not have been reached.
+        // And because the resolver failed, the apply chain must not be reached.
         verify(exactly = 0) { AccentApplicator.apply(any()) }
     }
 
@@ -786,13 +771,6 @@ class ProjectLanguageDetectorTest {
         // the applicator from touching UIManager when there's no Ayu theme to
         // drive. Locking the guard so a future author doesn't delete it as
         // "dead code" — it's the fallback path for users on a non-Ayu theme.
-        val mappingsState =
-            AccentMappingsState().apply { languageAccents["kotlin"] = "#FFCC66" }
-        val settings = mockk<AccentMappingsSettings>()
-        every { settings.state } returns mappingsState
-        mockkObject(AccentMappingsSettings.Companion)
-        every { AccentMappingsSettings.getInstance() } returns settings
-
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns null
 
@@ -800,7 +778,7 @@ class ProjectLanguageDetectorTest {
         every { AccentApplicator.apply(any()) } answers { Unit }
 
         val project = stubProject("/tmp/refresh-null-variant-${System.nanoTime()}")
-        ProjectLanguageDetector.refreshAccentOnEdt(project, "kotlin")
+        ProjectLanguageDetector.refreshAccentOnEdt(project)
 
         verify(exactly = 0) { AccentApplicator.apply(any()) }
     }
@@ -811,20 +789,13 @@ class ProjectLanguageDetectorTest {
         // and EDT dispatch can close the project. The early return here
         // keeps the applicator from writing UIManager entries for a dead
         // project's swap-cache.
-        val mappingsState =
-            AccentMappingsState().apply { languageAccents["kotlin"] = "#FFCC66" }
-        val settings = mockk<AccentMappingsSettings>()
-        every { settings.state } returns mappingsState
-        mockkObject(AccentMappingsSettings.Companion)
-        every { AccentMappingsSettings.getInstance() } returns settings
-
         mockkObject(AccentApplicator)
         every { AccentApplicator.apply(any()) } answers { Unit }
 
         val project = stubProject("/tmp/refresh-disposed-${System.nanoTime()}")
         every { project.isDisposed } returns true
 
-        ProjectLanguageDetector.refreshAccentOnEdt(project, "kotlin")
+        ProjectLanguageDetector.refreshAccentOnEdt(project)
 
         verify(exactly = 0) { AccentApplicator.apply(any()) }
     }
@@ -944,10 +915,13 @@ class ProjectLanguageDetectorTest {
         wireMessageBus(project, listener)
         runInvokeLaterInline()
         runSchedulerInline()
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.apply(any()) } answers { Unit }
 
         ProjectLanguageDetector.rescan(project)
 
         verify(exactly = 1) { listener.scanCompleted(ScanOutcome.Unavailable) }
+        verify(exactly = 0) { AccentApplicator.apply(any()) }
     }
 
     @Test
@@ -970,6 +944,43 @@ class ProjectLanguageDetectorTest {
         ProjectLanguageDetector.rescan(project)
 
         verify(exactly = 1) { listener.scanCompleted(ScanOutcome.Polyglot) }
+    }
+
+    @Test
+    fun `rescan refreshes fallback accent on polyglot no-winner verdict`() {
+        // Polyglot is a definitive cacheable verdict, not a transient failure.
+        // If the previous cache selected a language override, the UI must
+        // re-apply the resolver fallback immediately instead of waiting for
+        // focus swap to recover chrome and glow.
+        val project = stubProject("/tmp/rescan-polyglot-refresh-${System.nanoTime()}")
+        every { ProjectLanguageScanner.scan(project) } returns mapOf("kotlin" to 500L, "java" to 500L)
+        wireProjectRootManager(project, sdkName = null)
+        wireModuleManager(project, moduleNames = emptyList())
+
+        stubDumbServiceSmart(project)
+        val listener = mockk<ProjectLanguageDetectionListener>(relaxed = true)
+        wireMessageBus(project, listener)
+        runInvokeLaterInline()
+        runSchedulerInline()
+
+        mockkObject(AyuVariant.Companion)
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        mockkObject(AccentResolver)
+        every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returns "#FFCC66"
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.apply(any()) } answers { Unit }
+        val swapService = mockk<dev.ayuislands.settings.mappings.ProjectAccentSwapService>(relaxed = true)
+        mockkObject(dev.ayuislands.settings.mappings.ProjectAccentSwapService.Companion)
+        every {
+            dev.ayuislands.settings.mappings.ProjectAccentSwapService
+                .getInstance()
+        } returns swapService
+
+        ProjectLanguageDetector.rescan(project)
+
+        verify(exactly = 1) { listener.scanCompleted(ScanOutcome.Polyglot) }
+        verify(exactly = 1) { AccentApplicator.applyFromHexString("#FFCC66") }
+        verify(exactly = 1) { swapService.notifyExternalApply("#FFCC66") }
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/glow/GlowOverlayManagerLifecycleTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/GlowOverlayManagerLifecycleTest.kt
@@ -25,10 +25,12 @@ import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.verify
 import java.awt.Color
+import java.awt.Point
 import javax.swing.SwingUtilities
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -61,6 +63,8 @@ class GlowOverlayManagerLifecycleTest {
         every { AyuIslandsSettings.getInstance() } returns mockSettings
         every { mockSettings.state } returns state
         state.glowEnabled = true
+        state.lastAppliedAccentHex = null
+        state.lastApplyOk = false
 
         mockkObject(LicenseChecker)
         every { LicenseChecker.isLicensedOrGrace() } returns true
@@ -145,6 +149,69 @@ class GlowOverlayManagerLifecycleTest {
             overlaysAfter.isEmpty() && !overlaysAfter.containsKey(sentinelKey),
             "updateGlow with isAyuActive=true MUST NOT dispose pre-existing overlays",
         )
+    }
+
+    @Test
+    fun `updateGlow paints clean last applied accent instead of project resolver`() {
+        // Glow follows the app-global chrome color that was actually painted.
+        // A background project may resolve to a different override, but its
+        // status bar was already repainted with the last clean apply payload.
+        every { AyuVariant.isAyuActive() } returns true
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        state.lastAppliedAccentHex = "#5CCFE6"
+        state.lastApplyOk = true
+
+        val project = stubProject("background-project")
+        val manager = GlowOverlayManager(project)
+        val glassPane = mockk<GlowGlassPane>(relaxed = true)
+        seedOverlaysMapWithMocks(
+            manager,
+            glassPane,
+            host = mockk(relaxed = true),
+            layeredPane = mockk(relaxed = true),
+        )
+
+        every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returns "#FFCC66"
+
+        manager.updateGlow()
+
+        verify(exactly = 1) { glassPane.glowColor = Color.decode("#5CCFE6") }
+        verify(exactly = 0) { glassPane.glowColor = Color.decode("#FFCC66") }
+        verify(exactly = 0) { AccentResolver.resolve(project, AyuVariant.MIRAGE) }
+    }
+
+    @Test
+    fun `attachOverlay seeds clean last applied accent instead of project resolver`() {
+        // Late-created overlays must match the already-painted status bar even
+        // if this project's resolver would choose a different override. This is
+        // the startup/late-attach path that does not receive a fresh topic
+        // payload after the overlay exists.
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        every { SwingUtilities.invokeLater(any()) } answers { firstArg<Runnable>().run() }
+        state.lastAppliedAccentHex = "#5CCFE6"
+        state.lastApplyOk = true
+
+        val project = stubProject("late-overlay-project")
+        val manager = GlowOverlayManager(project)
+        val host = mockk<javax.swing.JComponent>(relaxed = true)
+        val rootPane = mockk<javax.swing.JRootPane>(relaxed = true)
+        val layeredPane = mockk<javax.swing.JLayeredPane>(relaxed = true)
+        every { host.width } returns 120
+        every { host.height } returns 80
+        every { host.isShowing } returns true
+        every { rootPane.layeredPane } returns layeredPane
+        every { SwingUtilities.getRootPane(host) } returns rootPane
+        every { SwingUtilities.convertPoint(host, 0, 0, layeredPane) } returns Point(0, 0)
+        every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returns "#FFCC66"
+
+        invokeAttachOverlay(manager, "LateOverlay", host)
+
+        assertEquals(
+            Color.decode("#5CCFE6"),
+            readOverlayGlassPane(manager, "LateOverlay").glowColor,
+            "new overlays must seed from the clean app-global applied accent, not the project resolver",
+        )
+        verify(exactly = 0) { AccentResolver.resolve(project, AyuVariant.MIRAGE) }
     }
 
     @Test
@@ -380,6 +447,32 @@ class GlowOverlayManagerLifecycleTest {
         val field = GlowOverlayManager::class.java.getDeclaredField("overlays")
         field.isAccessible = true
         return field.get(manager) as Map<*, *>
+    }
+
+    private fun readOverlayGlassPane(
+        manager: GlowOverlayManager,
+        key: String,
+    ): GlowGlassPane {
+        val entry = readOverlaysMap(manager)[key] ?: error("Overlay '$key' was not attached")
+        val field = entry.javaClass.getDeclaredField("glassPane")
+        field.isAccessible = true
+        return field.get(entry) as GlowGlassPane
+    }
+
+    private fun invokeAttachOverlay(
+        manager: GlowOverlayManager,
+        id: String,
+        host: javax.swing.JComponent,
+    ) {
+        val method =
+            GlowOverlayManager::class.java.getDeclaredMethod(
+                "attachOverlay",
+                String::class.java,
+                javax.swing.JComponent::class.java,
+                Boolean::class.javaPrimitiveType,
+            )
+        method.isAccessible = true
+        method.invoke(manager, id, host, false)
     }
 
     /**

--- a/src/test/kotlin/dev/ayuislands/glow/GlowOverlayManagerLifecycleTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/GlowOverlayManagerLifecycleTest.kt
@@ -148,7 +148,7 @@ class GlowOverlayManagerLifecycleTest {
     }
 
     @Test
-    fun `AccentChangedTopic event recolors existing glow overlays for matching project`() {
+    fun `AccentChangedTopic event uses applied accent payload for matching project`() {
         every { AyuVariant.isAyuActive() } returns true
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
         every { SwingUtilities.invokeLater(any()) } just Runs
@@ -172,7 +172,7 @@ class GlowOverlayManagerLifecycleTest {
             layeredPane = mockk(relaxed = true),
         )
 
-        every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returns "#5CCFE6"
+        every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returns "#FFCC66"
 
         manager.initialize()
 
@@ -188,6 +188,7 @@ class GlowOverlayManagerLifecycleTest {
         )
 
         verify(exactly = 1) { glassPane.glowColor = Color.decode("#5CCFE6") }
+        verify(exactly = 0) { glassPane.glowColor = Color.decode("#FFCC66") }
     }
 
     @Test
@@ -257,7 +258,7 @@ class GlowOverlayManagerLifecycleTest {
             layeredPane = mockk(relaxed = true),
         )
 
-        every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returns "#5CCFE6"
+        every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returns "#FFCC66"
 
         manager.initialize()
 
@@ -283,6 +284,7 @@ class GlowOverlayManagerLifecycleTest {
         scheduled.forEach { it.run() }
 
         verify(exactly = 1) { glassPane.glowColor = Color.decode("#5CCFE6") }
+        verify(exactly = 0) { glassPane.glowColor = Color.decode("#FFCC66") }
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/glow/GlowOverlayManagerLifecycleTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/GlowOverlayManagerLifecycleTest.kt
@@ -1,20 +1,30 @@
 package dev.ayuislands.glow
 
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
+import com.intellij.util.messages.MessageBus
+import com.intellij.util.messages.MessageBusConnection
+import dev.ayuislands.accent.AccentChangeListener
+import dev.ayuislands.accent.AccentChangedTopic
+import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
+import io.mockk.Runs
 import io.mockk.clearAllMocks
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
+import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.verify
+import java.awt.Color
 import javax.swing.SwingUtilities
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -135,6 +145,144 @@ class GlowOverlayManagerLifecycleTest {
             overlaysAfter.isEmpty() && !overlaysAfter.containsKey(sentinelKey),
             "updateGlow with isAyuActive=true MUST NOT dispose pre-existing overlays",
         )
+    }
+
+    @Test
+    fun `AccentChangedTopic event recolors existing glow overlays for matching project`() {
+        every { AyuVariant.isAyuActive() } returns true
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        every { SwingUtilities.invokeLater(any()) } just Runs
+
+        val project = stubProject("focused-project")
+        val messageBus = mockk<MessageBus>()
+        val connection = mockk<MessageBusConnection>(relaxed = true)
+        val accentListenerSlot = slot<AccentChangeListener>()
+        every { project.messageBus } returns messageBus
+        every { messageBus.connect(any<Disposable>()) } returns connection
+        every {
+            connection.subscribe(eq(AccentChangedTopic.TOPIC), capture(accentListenerSlot))
+        } just Runs
+
+        val manager = GlowOverlayManager(project)
+        val glassPane = mockk<GlowGlassPane>(relaxed = true)
+        seedOverlaysMapWithMocks(
+            manager,
+            glassPane,
+            host = mockk(relaxed = true),
+            layeredPane = mockk(relaxed = true),
+        )
+
+        every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returns "#5CCFE6"
+
+        manager.initialize()
+
+        assertTrue(
+            accentListenerSlot.isCaptured,
+            "GlowOverlayManager must subscribe to AccentChangedTopic so chrome-only accent refreshes recolor glow",
+        )
+
+        accentListenerSlot.captured.accentChanged(
+            project,
+            AccentHex.unsafeOf("#5CCFE6"),
+            AccentResolver.Source.GLOBAL,
+        )
+
+        verify(exactly = 1) { glassPane.glowColor = Color.decode("#5CCFE6") }
+    }
+
+    @Test
+    fun `AccentChangedTopic event ignores a different project`() {
+        every { AyuVariant.isAyuActive() } returns true
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        every { SwingUtilities.invokeLater(any()) } just Runs
+
+        val project = stubProject("focused-project")
+        val otherProject = stubProject("other-project")
+        val messageBus = mockk<MessageBus>()
+        val connection = mockk<MessageBusConnection>(relaxed = true)
+        val accentListenerSlot = slot<AccentChangeListener>()
+        every { project.messageBus } returns messageBus
+        every { messageBus.connect(any<Disposable>()) } returns connection
+        every {
+            connection.subscribe(eq(AccentChangedTopic.TOPIC), capture(accentListenerSlot))
+        } just Runs
+
+        val manager = GlowOverlayManager(project)
+        val glassPane = mockk<GlowGlassPane>(relaxed = true)
+        seedOverlaysMapWithMocks(
+            manager,
+            glassPane,
+            host = mockk(relaxed = true),
+            layeredPane = mockk(relaxed = true),
+        )
+
+        manager.initialize()
+
+        assertTrue(
+            accentListenerSlot.isCaptured,
+            "GlowOverlayManager must subscribe before it can filter project-scoped accent events",
+        )
+
+        accentListenerSlot.captured.accentChanged(
+            otherProject,
+            AccentHex.unsafeOf("#D95757"),
+            AccentResolver.Source.PROJECT_OVERRIDE,
+        )
+
+        verify(exactly = 0) { glassPane.glowColor = any<Color>() }
+    }
+
+    @Test
+    fun `AccentChangedTopic event reschedules glow update when fired off EDT`() {
+        every { AyuVariant.isAyuActive() } returns true
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        every { SwingUtilities.invokeLater(any()) } just Runs
+
+        val project = stubProject("focused-project")
+        val messageBus = mockk<MessageBus>()
+        val connection = mockk<MessageBusConnection>(relaxed = true)
+        val accentListenerSlot = slot<AccentChangeListener>()
+        every { project.messageBus } returns messageBus
+        every { messageBus.connect(any<Disposable>()) } returns connection
+        every {
+            connection.subscribe(eq(AccentChangedTopic.TOPIC), capture(accentListenerSlot))
+        } just Runs
+
+        val manager = GlowOverlayManager(project)
+        val glassPane = mockk<GlowGlassPane>(relaxed = true)
+        seedOverlaysMapWithMocks(
+            manager,
+            glassPane,
+            host = mockk(relaxed = true),
+            layeredPane = mockk(relaxed = true),
+        )
+
+        every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returns "#5CCFE6"
+
+        manager.initialize()
+
+        assertTrue(
+            accentListenerSlot.isCaptured,
+            "GlowOverlayManager must subscribe before it can reschedule off-EDT accent events",
+        )
+
+        val scheduled = mutableListOf<Runnable>()
+        every { SwingUtilities.isEventDispatchThread() } returns false
+        every { SwingUtilities.invokeLater(any()) } answers {
+            scheduled.add(firstArg<Runnable>())
+        }
+
+        accentListenerSlot.captured.accentChanged(
+            project,
+            AccentHex.unsafeOf("#5CCFE6"),
+            AccentResolver.Source.GLOBAL,
+        )
+
+        verify(exactly = 0) { glassPane.glowColor = any<Color>() }
+
+        scheduled.forEach { it.run() }
+
+        verify(exactly = 1) { glassPane.glowColor = Color.decode("#5CCFE6") }
     }
 
     @Test


### PR DESCRIPTION
── Summary ─────────────────────────────────

Fixes intermittent glow/status-bar accent drift by tying glow refreshes and newly attached glow overlays to the same applied-accent state that repaints chrome, by refreshing the accent after cacheable language rescans that move a project back to fallback/global color, and by ignoring stale scan refreshes once focus has already moved to another project.

The important distinction is now explicit:

- direct accent applies use the `AccentChangedTopic` payload because that is the color actually painted into chrome/status-bar surfaces;
- existing glow overlays and late-created overlays use the last clean app-global applied accent before falling back to the per-project resolver;
- language scan `Detected` and `Polyglot` outcomes both re-apply the resolver result, while transient `Unavailable` outcomes do not;
- post-scan refreshes only apply when the scanned project is still the focused project, so a slow scan from an old project cannot repaint the active IDE chrome.

── Changes ─────────────────────────────────

| Type | Path | Description |
| --- | --- | --- |
| Fix | `src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt` | Subscribe glow overlays to `AccentChangedTopic`, filter to the manager's project, repaint from the applied event payload on the EDT, and seed late-created overlays from the last clean applied chrome accent. |
| Fix | `src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt` | Re-apply the current resolver result after cacheable language scans, including `Polyglot` fallback outcomes, and skip stale post-scan applies when focus has moved to another project. |
| Docs | `src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt` | Keep the last-applied accent state contract accurate now that glow reads the same clean cache at runtime. |
| Test | `src/test/kotlin/dev/ayuislands/glow/GlowOverlayManagerLifecycleTest.kt` | Cover matching-project payload repaint, different-project ignore, off-EDT rescheduling, clean applied-accent refresh, and late overlay seeding. |
| Test | `src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt` | Cover fallback re-apply, polyglot refresh, no re-apply for transient unavailable scans, and no stale apply after focus moves. |
| Docs | `docs/features.yml` | Restamp guarded screenshot metadata; screenshot hashes are unchanged. |

── Validation ──────────────────────────────

```bash
./gradlew test --tests dev.ayuislands.glow.GlowOverlayManagerLifecycleTest
./gradlew test --tests dev.ayuislands.accent.ProjectLanguageDetectorTest
./gradlew detekt ktlintCheck
./gradlew test koverVerify
scripts/verify-docs.py
git diff --check
```

All commands passed locally.

── Notes ───────────────────────────────────

- No theme JSON changes.
- Manual dogfooding via local IDE deployment is still useful because the original symptom was intermittent and visual.
