### PR TITLE
fix(toolwindow): prevent right panel width collapse

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -283,7 +283,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "1657812"
+          last_verified_sha: "2c8dbd7"
           last_verified_date: "2026-05-12"
           content_sha256: "fc9ba63b9c9c53893a486a3c9055287bd6dc9c68f5439cae197efe5ae585d17c"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -283,7 +283,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "5cb8e5d"
+          last_verified_sha: "1657812"
           last_verified_date: "2026-05-12"
           content_sha256: "fc9ba63b9c9c53893a486a3c9055287bd6dc9c68f5439cae197efe5ae585d17c"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "4868a56"
+          last_verified_sha: "5cb8e5d"
           last_verified_date: "2026-05-28"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "4868a56"
+          last_verified_sha: "5cb8e5d"
           last_verified_date: "2026-05-28"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -209,7 +209,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "b7506aa"
+          last_verified_sha: "5cb8e5d"
           last_verified_date: "2026-05-24"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -283,7 +283,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "8d5e1f6"
+          last_verified_sha: "5cb8e5d"
           last_verified_date: "2026-05-12"
           content_sha256: "fc9ba63b9c9c53893a486a3c9055287bd6dc9c68f5439cae197efe5ae585d17c"
 
@@ -336,7 +336,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "361549e"
+          last_verified_sha: "5cb8e5d"
           last_verified_date: "2026-05-19"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/src/main/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManager.kt
+++ b/src/main/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManager.kt
@@ -34,19 +34,31 @@ class CommitPanelAutoFitManager(
             object : ToolWindowManagerListener {
                 override fun stateChanged(
                     toolWindowManager: ToolWindowManager,
+                    changeType: ToolWindowManagerListener.ToolWindowManagerEventType,
+                ) {
+                    if (!changeType.shouldTriggerAutoFitFor(toolWindowManager, TOOL_WINDOW_ID)) return
+                    applyIfWidthManaged()
+                }
+
+                override fun stateChanged(
+                    toolWindowManager: ToolWindowManager,
                     toolWindow: ToolWindow,
                     changeType: ToolWindowManagerListener.ToolWindowManagerEventType,
                 ) {
                     if (!changeType.shouldTriggerAutoFitFor(toolWindow, TOOL_WINDOW_ID)) return
-                    val mode =
-                        PanelWidthMode.fromString(
-                            AyuIslandsSettings.getInstance().state.commitPanelWidthMode,
-                        )
-                    if (mode == PanelWidthMode.DEFAULT) return
-                    apply()
+                    applyIfWidthManaged()
                 }
             },
         )
+    }
+
+    private fun applyIfWidthManaged() {
+        val mode =
+            PanelWidthMode.fromString(
+                AyuIslandsSettings.getInstance().state.commitPanelWidthMode,
+            )
+        if (mode == PanelWidthMode.DEFAULT) return
+        apply()
     }
 
     fun apply() {

--- a/src/main/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManager.kt
+++ b/src/main/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManager.kt
@@ -3,6 +3,7 @@ package dev.ayuislands.commitpanel
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener
 import dev.ayuislands.licensing.LicenseChecker
@@ -10,7 +11,7 @@ import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.PanelWidthMode
 import dev.ayuislands.toolwindow.AutoFitCalculator
 import dev.ayuislands.toolwindow.ToolWindowAutoFitter
-import dev.ayuislands.toolwindow.shouldTriggerAutoFit
+import dev.ayuislands.toolwindow.shouldTriggerAutoFitFor
 
 /** Per-project service that auto-fits the Commit tool window width to its tree content. */
 @Service(Service.Level.PROJECT)
@@ -20,7 +21,7 @@ class CommitPanelAutoFitManager(
     private val autoFitter =
         ToolWindowAutoFitter(
             project = project,
-            toolWindowId = "Commit",
+            toolWindowId = TOOL_WINDOW_ID,
             minWidth = AutoFitCalculator.MIN_COMMIT_AUTOFIT_WIDTH,
         ).apply {
             maxWidthProvider = { AyuIslandsSettings.getInstance().state.autoFitCommitMaxWidth }
@@ -33,11 +34,10 @@ class CommitPanelAutoFitManager(
             object : ToolWindowManagerListener {
                 override fun stateChanged(
                     toolWindowManager: ToolWindowManager,
+                    toolWindow: ToolWindow,
                     changeType: ToolWindowManagerListener.ToolWindowManagerEventType,
                 ) {
-                    if (!changeType.shouldTriggerAutoFit()) return
-                    val tw = toolWindowManager.getToolWindow("Commit") ?: return
-                    if (!tw.isVisible) return
+                    if (!changeType.shouldTriggerAutoFitFor(toolWindow, TOOL_WINDOW_ID)) return
                     val mode =
                         PanelWidthMode.fromString(
                             AyuIslandsSettings.getInstance().state.commitPanelWidthMode,
@@ -64,6 +64,8 @@ class CommitPanelAutoFitManager(
     }
 
     companion object {
+        private const val TOOL_WINDOW_ID = "Commit"
+
         fun getInstance(project: Project): CommitPanelAutoFitManager =
             project.getService(
                 CommitPanelAutoFitManager::class.java,

--- a/src/main/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManager.kt
+++ b/src/main/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManager.kt
@@ -4,13 +4,14 @@ import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Splitter
+import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.PanelWidthMode
 import dev.ayuislands.toolwindow.AutoFitCalculator
-import dev.ayuislands.toolwindow.shouldTriggerAutoFit
+import dev.ayuislands.toolwindow.shouldTriggerAutoFitFor
 import javax.swing.JTable
 import javax.swing.JTree
 import javax.swing.Timer
@@ -35,11 +36,10 @@ class GitPanelAutoFitManager(
             object : ToolWindowManagerListener {
                 override fun stateChanged(
                     toolWindowManager: ToolWindowManager,
+                    toolWindow: ToolWindow,
                     changeType: ToolWindowManagerListener.ToolWindowManagerEventType,
                 ) {
-                    if (!changeType.shouldTriggerAutoFit()) return
-                    val tw = toolWindowManager.getToolWindow("Version Control") ?: return
-                    if (!tw.isVisible) return
+                    if (!changeType.shouldTriggerAutoFitFor(toolWindow, TOOL_WINDOW_ID)) return
                     val mode =
                         PanelWidthMode.fromString(
                             AyuIslandsSettings.getInstance().state.gitPanelWidthMode,

--- a/src/main/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManager.kt
+++ b/src/main/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManager.kt
@@ -36,19 +36,31 @@ class GitPanelAutoFitManager(
             object : ToolWindowManagerListener {
                 override fun stateChanged(
                     toolWindowManager: ToolWindowManager,
+                    changeType: ToolWindowManagerListener.ToolWindowManagerEventType,
+                ) {
+                    if (!changeType.shouldTriggerAutoFitFor(toolWindowManager, TOOL_WINDOW_ID)) return
+                    scheduleFitIfWidthManaged()
+                }
+
+                override fun stateChanged(
+                    toolWindowManager: ToolWindowManager,
                     toolWindow: ToolWindow,
                     changeType: ToolWindowManagerListener.ToolWindowManagerEventType,
                 ) {
                     if (!changeType.shouldTriggerAutoFitFor(toolWindow, TOOL_WINDOW_ID)) return
-                    val mode =
-                        PanelWidthMode.fromString(
-                            AyuIslandsSettings.getInstance().state.gitPanelWidthMode,
-                        )
-                    if (mode == PanelWidthMode.DEFAULT) return
-                    debounceTimer.restart()
+                    scheduleFitIfWidthManaged()
                 }
             },
         )
+    }
+
+    private fun scheduleFitIfWidthManaged() {
+        val mode =
+            PanelWidthMode.fromString(
+                AyuIslandsSettings.getInstance().state.gitPanelWidthMode,
+            )
+        if (mode == PanelWidthMode.DEFAULT) return
+        debounceTimer.restart()
     }
 
     fun apply() {

--- a/src/main/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManager.kt
+++ b/src/main/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManager.kt
@@ -12,6 +12,7 @@ import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.PanelWidthMode
 import dev.ayuislands.toolwindow.AutoFitCalculator
 import dev.ayuislands.toolwindow.shouldTriggerAutoFitFor
+import org.jetbrains.annotations.TestOnly
 import javax.swing.JTable
 import javax.swing.JTree
 import javax.swing.Timer
@@ -61,6 +62,15 @@ class GitPanelAutoFitManager(
             )
         if (mode == PanelWidthMode.DEFAULT) return
         debounceTimer.restart()
+    }
+
+    @TestOnly
+    internal fun flushDebounceForTesting() {
+        val hadPending = debounceTimer.isRunning
+        debounceTimer.stop()
+        if (hadPending) {
+            fitSplitters()
+        }
     }
 
     fun apply() {

--- a/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
+++ b/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.registry.Registry
+import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener
 import com.intellij.ui.SimpleColoredComponent
@@ -15,7 +16,7 @@ import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.PanelWidthMode
 import dev.ayuislands.toolwindow.AutoFitCalculator
 import dev.ayuislands.toolwindow.ToolWindowAutoFitter
-import dev.ayuislands.toolwindow.shouldTriggerAutoFit
+import dev.ayuislands.toolwindow.shouldTriggerAutoFitFor
 import dev.ayuislands.ui.ComponentTreeRefreshedListener
 import dev.ayuislands.ui.ComponentTreeRefreshedTopic
 import java.awt.Component
@@ -40,7 +41,7 @@ class ProjectViewScrollbarManager(
     private val autoFitter =
         ToolWindowAutoFitter(
             project = project,
-            toolWindowId = "Project",
+            toolWindowId = TOOL_WINDOW_ID,
             minWidth = AutoFitCalculator.MIN_PROJECT_AUTOFIT_WIDTH,
         ).apply {
             maxWidthProvider = { AyuIslandsSettings.getInstance().state.autoFitMaxWidth }
@@ -53,11 +54,10 @@ class ProjectViewScrollbarManager(
             object : ToolWindowManagerListener {
                 override fun stateChanged(
                     toolWindowManager: ToolWindowManager,
+                    toolWindow: ToolWindow,
                     changeType: ToolWindowManagerListener.ToolWindowManagerEventType,
                 ) {
-                    if (!changeType.shouldTriggerAutoFit()) return
-                    val tw = toolWindowManager.getToolWindow("Project") ?: return
-                    if (!tw.isVisible) return
+                    if (!changeType.shouldTriggerAutoFitFor(toolWindow, TOOL_WINDOW_ID)) return
                     val state =
                         AyuIslandsSettings.getInstance().state
                     val widthMode = PanelWidthMode.fromString(state.projectPanelWidthMode)
@@ -237,7 +237,7 @@ class ProjectViewScrollbarManager(
         val toolWindow =
             ToolWindowManager
                 .getInstance(project)
-                .getToolWindow("Project")
+                .getToolWindow(TOOL_WINDOW_ID)
                 ?: return null
         return toolWindow
             .contentManager
@@ -274,6 +274,7 @@ class ProjectViewScrollbarManager(
 
     companion object {
         private val LOG = logger<ProjectViewScrollbarManager>()
+        private const val TOOL_WINDOW_ID = "Project"
         private const val SHOW_URL_KEY = "project.tree.structure.show.url"
 
         fun getInstance(project: Project): ProjectViewScrollbarManager =

--- a/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
+++ b/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
@@ -54,20 +54,19 @@ class ProjectViewScrollbarManager(
             object : ToolWindowManagerListener {
                 override fun stateChanged(
                     toolWindowManager: ToolWindowManager,
+                    changeType: ToolWindowManagerListener.ToolWindowManagerEventType,
+                ) {
+                    if (!changeType.shouldTriggerAutoFitFor(toolWindowManager, TOOL_WINDOW_ID)) return
+                    applyIfAnyProjectFeatureManaged()
+                }
+
+                override fun stateChanged(
+                    toolWindowManager: ToolWindowManager,
                     toolWindow: ToolWindow,
                     changeType: ToolWindowManagerListener.ToolWindowManagerEventType,
                 ) {
                     if (!changeType.shouldTriggerAutoFitFor(toolWindow, TOOL_WINDOW_ID)) return
-                    val state =
-                        AyuIslandsSettings.getInstance().state
-                    val widthMode = PanelWidthMode.fromString(state.projectPanelWidthMode)
-                    val allFeaturesDisabled =
-                        !state.hideProjectRootPath &&
-                            !state.hideProjectViewHScrollbar
-                    if (allFeaturesDisabled && widthMode == PanelWidthMode.DEFAULT) {
-                        return
-                    }
-                    apply()
+                    applyIfAnyProjectFeatureManaged()
                 }
             },
         )
@@ -86,6 +85,16 @@ class ProjectViewScrollbarManager(
                 ComponentTreeRefreshedTopic.TOPIC,
                 ComponentTreeRefreshedListener { apply() },
             )
+    }
+
+    private fun applyIfAnyProjectFeatureManaged() {
+        val state = AyuIslandsSettings.getInstance().state
+        val widthMode = PanelWidthMode.fromString(state.projectPanelWidthMode)
+        val allFeaturesDisabled =
+            !state.hideProjectRootPath &&
+                !state.hideProjectViewHScrollbar
+        if (allFeaturesDisabled && widthMode == PanelWidthMode.DEFAULT) return
+        apply()
     }
 
     fun apply() {

--- a/src/main/kotlin/dev/ayuislands/toolwindow/AutoFitTriggers.kt
+++ b/src/main/kotlin/dev/ayuislands/toolwindow/AutoFitTriggers.kt
@@ -1,6 +1,7 @@
 package dev.ayuislands.toolwindow
 
 import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener
 
 /**
@@ -30,3 +31,11 @@ internal fun ToolWindowManagerListener.ToolWindowManagerEventType.shouldTriggerA
     shouldTriggerAutoFit() &&
         toolWindow.id == expectedToolWindowId &&
         toolWindow.isVisible
+
+internal fun ToolWindowManagerListener.ToolWindowManagerEventType.shouldTriggerAutoFitFor(
+    toolWindowManager: ToolWindowManager,
+    expectedToolWindowId: String,
+): Boolean {
+    val toolWindow = toolWindowManager.getToolWindow(expectedToolWindowId) ?: return false
+    return shouldTriggerAutoFit() && toolWindow.isVisible
+}

--- a/src/main/kotlin/dev/ayuislands/toolwindow/AutoFitTriggers.kt
+++ b/src/main/kotlin/dev/ayuislands/toolwindow/AutoFitTriggers.kt
@@ -1,5 +1,6 @@
 package dev.ayuislands.toolwindow
 
+import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener
 
 /**
@@ -21,3 +22,11 @@ import com.intellij.openapi.wm.ex.ToolWindowManagerListener
 internal fun ToolWindowManagerListener.ToolWindowManagerEventType.shouldTriggerAutoFit(): Boolean =
     this != ToolWindowManagerListener.ToolWindowManagerEventType.MovedOrResized &&
         this != ToolWindowManagerListener.ToolWindowManagerEventType.ShowToolWindow
+
+internal fun ToolWindowManagerListener.ToolWindowManagerEventType.shouldTriggerAutoFitFor(
+    toolWindow: ToolWindow,
+    expectedToolWindowId: String,
+): Boolean =
+    shouldTriggerAutoFit() &&
+        toolWindow.id == expectedToolWindowId &&
+        toolWindow.isVisible

--- a/src/test/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManagerTest.kt
@@ -2,10 +2,12 @@ package dev.ayuislands.commitpanel
 
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ToolWindowType
 import com.intellij.openapi.wm.ex.ToolWindowEx
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener
+import com.intellij.openapi.wm.ex.ToolWindowManagerListener.ToolWindowManagerEventType
 import com.intellij.ui.content.Content
 import com.intellij.ui.content.ContentManager
 import com.intellij.util.messages.MessageBus
@@ -19,6 +21,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
+import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.verify
 import java.awt.FlowLayout
@@ -181,6 +184,74 @@ class CommitPanelAutoFitManagerTest {
     }
 
     @Test
+    fun `stateChanged ignores events from another visible tool window`() {
+        SwingUtilities.invokeAndWait {
+            every {
+                LicenseChecker.isLicensedOrGrace()
+            } returns true
+            realState.commitPanelWidthMode =
+                PanelWidthMode.FIXED.name
+
+            val listenerSlot = slot<ToolWindowManagerListener>()
+            every {
+                connection.subscribe(
+                    ToolWindowManagerListener.TOPIC,
+                    capture(listenerSlot),
+                )
+            } returns Unit
+
+            CommitPanelAutoFitManager(project)
+
+            val foreignToolWindow = visibleToolWindow("AWS")
+            listenerSlot.captured.stateChanged(
+                toolWindowManager,
+                foreignToolWindow,
+                ToolWindowManagerEventType.ActivateToolWindow,
+            )
+
+            verify(exactly = 0) {
+                toolWindowManager.getToolWindow("Commit")
+            }
+        }
+    }
+
+    @Test
+    fun `stateChanged applies fixed width for own visible tool window activation`() {
+        SwingUtilities.invokeAndWait {
+            every {
+                LicenseChecker.isLicensedOrGrace()
+            } returns true
+            realState.commitPanelWidthMode =
+                PanelWidthMode.FIXED.name
+            realState.commitPanelFixedWidth = 350
+
+            val panel = JPanel(FlowLayout())
+            panel.setSize(200, 400)
+            setupCommitToolWindow(panel)
+            every { toolWindowEx.id } returns "Commit"
+            every { toolWindowEx.isVisible } returns true
+
+            val listenerSlot = slot<ToolWindowManagerListener>()
+            every {
+                connection.subscribe(
+                    ToolWindowManagerListener.TOPIC,
+                    capture(listenerSlot),
+                )
+            } returns Unit
+
+            CommitPanelAutoFitManager(project)
+
+            listenerSlot.captured.stateChanged(
+                toolWindowManager,
+                toolWindowEx,
+                ToolWindowManagerEventType.ActivateToolWindow,
+            )
+
+            verify { toolWindowEx.stretchWidth(any()) }
+        }
+    }
+
+    @Test
     fun `apply with AUTO_FIT installs expansion listener and stretches on expand`() {
         SwingUtilities.invokeAndWait {
             every {
@@ -288,6 +359,12 @@ class CommitPanelAutoFitManagerTest {
             toolWindowEx.type
         } returns ToolWindowType.DOCKED
     }
+
+    private fun visibleToolWindow(id: String): ToolWindow =
+        mockk {
+            every { this@mockk.id } returns id
+            every { isVisible } returns true
+        }
 
     private fun mockCalculatorForDefaultMeasuredWidth() {
         mockkObject(AutoFitCalculator)

--- a/src/test/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManagerTest.kt
@@ -252,6 +252,41 @@ class CommitPanelAutoFitManagerTest {
     }
 
     @Test
+    fun `stateChanged applies fixed width for global layout changes`() {
+        SwingUtilities.invokeAndWait {
+            every {
+                LicenseChecker.isLicensedOrGrace()
+            } returns true
+            realState.commitPanelWidthMode =
+                PanelWidthMode.FIXED.name
+            realState.commitPanelFixedWidth = 350
+
+            val panel = JPanel(FlowLayout())
+            panel.setSize(200, 400)
+            setupCommitToolWindow(panel)
+            every { toolWindowEx.id } returns "Commit"
+            every { toolWindowEx.isVisible } returns true
+
+            val listenerSlot = slot<ToolWindowManagerListener>()
+            every {
+                connection.subscribe(
+                    ToolWindowManagerListener.TOPIC,
+                    capture(listenerSlot),
+                )
+            } returns Unit
+
+            CommitPanelAutoFitManager(project)
+
+            listenerSlot.captured.stateChanged(
+                toolWindowManager,
+                ToolWindowManagerEventType.SetLayout,
+            )
+
+            verify { toolWindowEx.stretchWidth(any()) }
+        }
+    }
+
+    @Test
     fun `apply with AUTO_FIT installs expansion listener and stretches on expand`() {
         SwingUtilities.invokeAndWait {
             every {

--- a/src/test/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManagerTest.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.ui.Splitter
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener
+import com.intellij.openapi.wm.ex.ToolWindowManagerListener.ToolWindowManagerEventType
 import com.intellij.ui.content.Content
 import com.intellij.ui.content.ContentManager
 import com.intellij.util.messages.MessageBus
@@ -19,6 +20,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
+import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.verify
 import java.awt.FlowLayout
@@ -304,6 +306,36 @@ class GitPanelAutoFitManagerTest {
     }
 
     @Test
+    fun `stateChanged ignores events from another visible tool window`() {
+        every {
+            LicenseChecker.isLicensedOrGrace()
+        } returns true
+        realState.gitPanelWidthMode =
+            PanelWidthMode.AUTO_FIT.name
+
+        val listenerSlot = slot<ToolWindowManagerListener>()
+        every {
+            connection.subscribe(
+                ToolWindowManagerListener.TOPIC,
+                capture(listenerSlot),
+            )
+        } returns Unit
+
+        GitPanelAutoFitManager(project)
+
+        val foreignToolWindow = visibleToolWindow("AWS")
+        listenerSlot.captured.stateChanged(
+            toolWindowManager,
+            foreignToolWindow,
+            ToolWindowManagerEventType.ActivateToolWindow,
+        )
+
+        verify(exactly = 0) {
+            toolWindowManager.getToolWindow("Version Control")
+        }
+    }
+
+    @Test
     fun `listener is removed when mode switches from AUTO_FIT to DEFAULT`() {
         SwingUtilities.invokeAndWait {
             every {
@@ -371,4 +403,10 @@ class GitPanelAutoFitManagerTest {
             }
         }
     }
+
+    private fun visibleToolWindow(id: String): ToolWindow =
+        mockk {
+            every { this@mockk.id } returns id
+            every { isVisible } returns true
+        }
 }

--- a/src/test/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManagerTest.kt
@@ -336,6 +336,38 @@ class GitPanelAutoFitManagerTest {
     }
 
     @Test
+    fun `stateChanged handles global layout changes for visible Version Control`() {
+        every {
+            LicenseChecker.isLicensedOrGrace()
+        } returns true
+        realState.gitPanelWidthMode =
+            PanelWidthMode.AUTO_FIT.name
+
+        val listenerSlot = slot<ToolWindowManagerListener>()
+        every {
+            connection.subscribe(
+                ToolWindowManagerListener.TOPIC,
+                capture(listenerSlot),
+            )
+        } returns Unit
+        every {
+            toolWindowManager.getToolWindow("Version Control")
+        } returns visibleToolWindow("Version Control")
+
+        val manager = GitPanelAutoFitManager(project)
+        try {
+            listenerSlot.captured.stateChanged(
+                toolWindowManager,
+                ToolWindowManagerEventType.SetLayout,
+            )
+
+            verify { toolWindowManager.getToolWindow("Version Control") }
+        } finally {
+            manager.dispose()
+        }
+    }
+
+    @Test
     fun `listener is removed when mode switches from AUTO_FIT to DEFAULT`() {
         SwingUtilities.invokeAndWait {
             every {

--- a/src/test/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManagerTest.kt
@@ -337,33 +337,80 @@ class GitPanelAutoFitManagerTest {
 
     @Test
     fun `stateChanged handles global layout changes for visible Version Control`() {
-        every {
-            LicenseChecker.isLicensedOrGrace()
-        } returns true
-        realState.gitPanelWidthMode =
-            PanelWidthMode.AUTO_FIT.name
+        SwingUtilities.invokeAndWait {
+            every {
+                LicenseChecker.isLicensedOrGrace()
+            } returns true
+            realState.gitPanelWidthMode =
+                PanelWidthMode.AUTO_FIT.name
+            realState.gitPanelAutoFitMaxWidth = 500
+            realState.gitPanelAutoFitMinWidth = 200
 
-        val listenerSlot = slot<ToolWindowManagerListener>()
-        every {
-            connection.subscribe(
-                ToolWindowManagerListener.TOPIC,
-                capture(listenerSlot),
-            )
-        } returns Unit
-        every {
-            toolWindowManager.getToolWindow("Version Control")
-        } returns visibleToolWindow("Version Control")
+            mockkObject(AutoFitCalculator)
+            every {
+                AutoFitCalculator.measureTreeMaxRowWidth(any())
+            } returns 250
 
-        val manager = GitPanelAutoFitManager(project)
-        try {
-            listenerSlot.captured.stateChanged(
-                toolWindowManager,
-                ToolWindowManagerEventType.SetLayout,
-            )
+            val tree = JTree()
+            val table = JTable()
+            val innerFirst = JPanel(FlowLayout())
+            innerFirst.add(table)
+            val innerSecond = JPanel(FlowLayout())
+            innerSecond.add(tree)
 
-            verify { toolWindowManager.getToolWindow("Version Control") }
-        } finally {
-            manager.dispose()
+            val splitter = Splitter()
+            splitter.setSize(1000, 400)
+            splitter.proportion = 0.9f
+            splitter.firstComponent = innerFirst
+            splitter.secondComponent = innerSecond
+
+            val logContent =
+                mockk<Content>(relaxed = true) {
+                    every { tabName } returns "Log"
+                    every { component } returns splitter
+                }
+            val contentManager =
+                mockk<ContentManager>(relaxed = true) {
+                    every {
+                        contents
+                    } returns arrayOf(logContent)
+                }
+            val toolWindow =
+                mockk<ToolWindow>(relaxed = true) {
+                    every { id } returns "Version Control"
+                    every { isVisible } returns true
+                    every {
+                        this@mockk.contentManager
+                    } returns contentManager
+                }
+            every {
+                toolWindowManager.getToolWindow("Version Control")
+            } returns toolWindow
+
+            val listenerSlot = slot<ToolWindowManagerListener>()
+            every {
+                connection.subscribe(
+                    ToolWindowManagerListener.TOPIC,
+                    capture(listenerSlot),
+                )
+            } returns Unit
+
+            val manager = GitPanelAutoFitManager(project)
+            try {
+                listenerSlot.captured.stateChanged(
+                    toolWindowManager,
+                    ToolWindowManagerEventType.SetLayout,
+                )
+                manager.flushDebounceForTesting()
+
+                val proportion = splitter.proportion
+                assertTrue(
+                    proportion in 0.7f..0.76f,
+                    "Expected global layout refresh to fit splitter, got $proportion",
+                )
+            } finally {
+                manager.dispose()
+            }
         }
     }
 

--- a/src/test/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManagerTest.kt
@@ -16,10 +16,13 @@ import com.intellij.util.messages.MessageBusConnection
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
+import dev.ayuislands.settings.PanelWidthMode
+import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
+import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.verify
 import java.awt.FlowLayout
@@ -284,6 +287,41 @@ class ProjectViewScrollbarManagerTest {
     }
 
     @Test
+    fun `stateChanged ignores events from another visible tool window`() {
+        realState.projectPanelWidthMode = PanelWidthMode.DEFAULT.name
+        realState.hideProjectViewHScrollbar = true
+
+        val listenerSlot = slot<ToolWindowManagerListener>()
+        every {
+            connection.subscribe(
+                ToolWindowManagerListener.TOPIC,
+                capture(listenerSlot),
+            )
+        } returns Unit
+
+        val manager = ProjectViewScrollbarManager(project)
+        try {
+            SwingUtilities.invokeAndWait {}
+            clearMocks(toolWindowManager, answers = false)
+
+            val foreignToolWindow = visibleToolWindow("AWS")
+            listenerSlot.captured.stateChanged(
+                toolWindowManager,
+                foreignToolWindow,
+                ToolWindowManagerListener.ToolWindowManagerEventType.ActivateToolWindow,
+            )
+
+            verify(exactly = 0) {
+                toolWindowManager.getToolWindow("Project")
+            }
+        } finally {
+            SwingUtilities.invokeAndWait {
+                manager.dispose()
+            }
+        }
+    }
+
+    @Test
     fun `apply is idempotent when called multiple times with same state`() {
         realState.hideProjectViewHScrollbar = true
         realState.hideProjectRootPath = false
@@ -344,4 +382,10 @@ class ProjectViewScrollbarManagerTest {
             toolWindowManager.getToolWindow("Project")
         } returns toolWindow
     }
+
+    private fun visibleToolWindow(id: String): ToolWindow =
+        mockk {
+            every { this@mockk.id } returns id
+            every { isVisible } returns true
+        }
 }

--- a/src/test/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManagerTest.kt
@@ -322,6 +322,47 @@ class ProjectViewScrollbarManagerTest {
     }
 
     @Test
+    fun `stateChanged reapplies project tweaks for global layout changes`() {
+        realState.projectPanelWidthMode = PanelWidthMode.DEFAULT.name
+        realState.hideProjectViewHScrollbar = true
+
+        val tree = JTree()
+        val scrollPane = JScrollPane(tree)
+        val wrapper = JPanel(FlowLayout())
+        wrapper.add(scrollPane)
+        setupToolWindowContent(wrapper)
+
+        val listenerSlot = slot<ToolWindowManagerListener>()
+        every {
+            connection.subscribe(
+                ToolWindowManagerListener.TOPIC,
+                capture(listenerSlot),
+            )
+        } returns Unit
+
+        val manager = ProjectViewScrollbarManager(project)
+        try {
+            SwingUtilities.invokeAndWait {}
+            scrollPane.horizontalScrollBarPolicy =
+                ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED
+
+            listenerSlot.captured.stateChanged(
+                toolWindowManager,
+                ToolWindowManagerListener.ToolWindowManagerEventType.SetLayout,
+            )
+
+            assertEquals(
+                ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER,
+                scrollPane.horizontalScrollBarPolicy,
+            )
+        } finally {
+            SwingUtilities.invokeAndWait {
+                manager.dispose()
+            }
+        }
+    }
+
+    @Test
     fun `apply is idempotent when called multiple times with same state`() {
         realState.hideProjectViewHScrollbar = true
         realState.hideProjectRootPath = false
@@ -374,6 +415,7 @@ class ProjectViewScrollbarManagerTest {
             }
         val toolWindow =
             mockk<ToolWindow>(relaxed = true) {
+                every { isVisible } returns true
                 every {
                     this@mockk.contentManager
                 } returns contentManager

--- a/src/test/kotlin/dev/ayuislands/toolwindow/AutoFitTriggersTest.kt
+++ b/src/test/kotlin/dev/ayuislands/toolwindow/AutoFitTriggersTest.kt
@@ -1,6 +1,7 @@
 package dev.ayuislands.toolwindow
 
 import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener.ToolWindowManagerEventType
 import io.mockk.every
 import io.mockk.mockk
@@ -73,6 +74,30 @@ class AutoFitTriggersTest {
         assertFalse(
             ToolWindowManagerEventType.ShowToolWindow
                 .shouldTriggerAutoFitFor(toolWindow, expectedToolWindowId = "Commit"),
+        )
+    }
+
+    @Test
+    fun `global layout event triggers scoped auto-fit for visible managed tool window`() {
+        val toolWindowManager = mockk<ToolWindowManager>()
+        val toolWindow = toolWindow(id = "Commit", isVisible = true)
+        every { toolWindowManager.getToolWindow("Commit") } returns toolWindow
+
+        assertTrue(
+            ToolWindowManagerEventType.SetLayout
+                .shouldTriggerAutoFitFor(toolWindowManager, expectedToolWindowId = "Commit"),
+        )
+    }
+
+    @Test
+    fun `global layout event ignores hidden managed tool window`() {
+        val toolWindowManager = mockk<ToolWindowManager>()
+        val toolWindow = toolWindow(id = "Commit", isVisible = false)
+        every { toolWindowManager.getToolWindow("Commit") } returns toolWindow
+
+        assertFalse(
+            ToolWindowManagerEventType.SetLayout
+                .shouldTriggerAutoFitFor(toolWindowManager, expectedToolWindowId = "Commit"),
         )
     }
 

--- a/src/test/kotlin/dev/ayuislands/toolwindow/AutoFitTriggersTest.kt
+++ b/src/test/kotlin/dev/ayuislands/toolwindow/AutoFitTriggersTest.kt
@@ -1,6 +1,9 @@
 package dev.ayuislands.toolwindow
 
+import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener.ToolWindowManagerEventType
+import io.mockk.every
+import io.mockk.mockk
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -32,4 +35,53 @@ class AutoFitTriggersTest {
     fun `ActivateToolWindow triggers auto-fit`() {
         assertTrue(ToolWindowManagerEventType.ActivateToolWindow.shouldTriggerAutoFit())
     }
+
+    @Test
+    fun `foreign visible tool window does not trigger scoped auto-fit`() {
+        val toolWindow = toolWindow(id = "AWS", isVisible = true)
+
+        assertFalse(
+            ToolWindowManagerEventType.ActivateToolWindow
+                .shouldTriggerAutoFitFor(toolWindow, expectedToolWindowId = "Commit"),
+        )
+    }
+
+    @Test
+    fun `own hidden tool window does not trigger scoped auto-fit`() {
+        val toolWindow = toolWindow(id = "Commit", isVisible = false)
+
+        assertFalse(
+            ToolWindowManagerEventType.ActivateToolWindow
+                .shouldTriggerAutoFitFor(toolWindow, expectedToolWindowId = "Commit"),
+        )
+    }
+
+    @Test
+    fun `own visible tool window triggers scoped auto-fit for accepted events`() {
+        val toolWindow = toolWindow(id = "Commit", isVisible = true)
+
+        assertTrue(
+            ToolWindowManagerEventType.ActivateToolWindow
+                .shouldTriggerAutoFitFor(toolWindow, expectedToolWindowId = "Commit"),
+        )
+    }
+
+    @Test
+    fun `own visible tool window keeps rejected event filter`() {
+        val toolWindow = toolWindow(id = "Commit", isVisible = true)
+
+        assertFalse(
+            ToolWindowManagerEventType.ShowToolWindow
+                .shouldTriggerAutoFitFor(toolWindow, expectedToolWindowId = "Commit"),
+        )
+    }
+
+    private fun toolWindow(
+        id: String,
+        isVisible: Boolean,
+    ): ToolWindow =
+        mockk {
+            every { this@mockk.id } returns id
+            every { this@mockk.isVisible } returns isVisible
+        }
 }


### PR DESCRIPTION
── Summary ─────────────────────────────────

Switching between right-side tool windows could trigger auto-fit logic from the wrong panel, letting Commit/Git/Project sizing code re-apply widths after a foreign tool window event. This scopes per-window auto-fit triggers to the source `ToolWindow`, while preserving source-less layout refreshes such as `SetLayout` so IDE layout restore/apply can still reassert configured panel widths.

── Changes ─────────────────────────────────

- Fix: [AutoFitTriggers.kt](/barad1tos/ayu-jetbrains/blob/fix/right-toolwindow-width-collapse/src/main/kotlin/dev/ayuislands/toolwindow/AutoFitTriggers.kt#L26) — Share source-window and global-manager visibility gates.
- Fix: [CommitPanelAutoFitManager.kt](/barad1tos/ayu-jetbrains/blob/fix/right-toolwindow-width-collapse/src/main/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManager.kt#L35), [GitPanelAutoFitManager.kt](/barad1tos/ayu-jetbrains/blob/fix/right-toolwindow-width-collapse/src/main/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManager.kt#L37), [ProjectViewScrollbarManager.kt](/barad1tos/ayu-jetbrains/blob/fix/right-toolwindow-width-collapse/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt#L55) — Ignore foreign source tool-window events, but still handle source-less global layout events for the managed visible panel.
- Test: [AutoFitTriggersTest.kt](/barad1tos/ayu-jetbrains/blob/fix/right-toolwindow-width-collapse/src/test/kotlin/dev/ayuislands/toolwindow/AutoFitTriggersTest.kt#L39) — Cover foreign, hidden, own visible, rejected show, and global `SetLayout` trigger gates.
- Test: [CommitPanelAutoFitManagerTest.kt](/barad1tos/ayu-jetbrains/blob/fix/right-toolwindow-width-collapse/src/test/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManagerTest.kt#L187), [GitPanelAutoFitManagerTest.kt](/barad1tos/ayu-jetbrains/blob/fix/right-toolwindow-width-collapse/src/test/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManagerTest.kt#L309), [ProjectViewScrollbarManagerTest.kt](/barad1tos/ayu-jetbrains/blob/fix/right-toolwindow-width-collapse/src/test/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManagerTest.kt#L290) — Lock foreign-event ignore behavior and global layout refresh behavior for the affected managers.
- Test: [GitPanelAutoFitManager.kt](/barad1tos/ayu-jetbrains/blob/fix/right-toolwindow-width-collapse/src/main/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManager.kt#L67), [GitPanelAutoFitManagerTest.kt](/barad1tos/ayu-jetbrains/blob/fix/right-toolwindow-width-collapse/src/test/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManagerTest.kt#L339) — Add a deterministic test-only debounce flush so the Git global layout test proves splitter refresh, not just manager lookup.
- Docs: [features.yml](/barad1tos/ayu-jetbrains/blob/fix/right-toolwindow-width-collapse/docs/features.yml#L286) — Restamp unchanged workspace screenshot metadata after the source fix.

── Validation ─────────────────────────────────

Expected: all commands exit 0.

```bash
./gradlew test --tests dev.ayuislands.toolwindow.AutoFitTriggersTest --tests dev.ayuislands.commitpanel.CommitPanelAutoFitManagerTest --tests dev.ayuislands.gitpanel.GitPanelAutoFitManagerTest --tests dev.ayuislands.projectview.ProjectViewScrollbarManagerTest
./gradlew detekt ktlintCheck
./gradlew test
./gradlew koverVerify
./gradlew build
./gradlew buildPlugin --no-build-cache --rerun-tasks
scripts/verify-docs.py
```

Manual check: deployed to IntelliJIdea2026.1, restarted IntelliJ IDEA, and verified that switching right-side panels no longer collapses the open side panel.

── Review Notes ──────────────────────────────

Wave 1 accepted one IMPORTANT finding: moving only to the source-aware listener suppressed source-less layout events. The follow-up fix restores the 2-arg global event path for managed visible panels while keeping the 3-arg source filter for per-window events.

Wave 2 accepted one test hardening finding: the Git global layout test only proved lookup. The follow-up test now flushes the pending debounce and asserts splitter proportions change.

SUGGESTION-only findings remain non-blocking: extra positive listener tests for Git/Project can be considered later.
