### PR TITLE
Show locked premium settings and polish previews

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -337,7 +337,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "218f8d9"
+          last_verified_sha: "5573f17"
           last_verified_date: "2026-05-30"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -240,8 +240,8 @@ categories:
           sources:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "8d5e1f6"
-          last_verified_date: "2026-05-24"
+          last_verified_sha: "049c230"
+          last_verified_date: "2026-05-30"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
   workspace:

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "5cb8e5d"
+          last_verified_sha: "853a4635"
           last_verified_date: "2026-05-28"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "5cb8e5d"
+          last_verified_sha: "853a4635"
           last_verified_date: "2026-05-28"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -209,7 +209,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "5cb8e5d"
+          last_verified_sha: "853a4635"
           last_verified_date: "2026-05-24"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -283,7 +283,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "2c8dbd7"
+          last_verified_sha: "853a4635"
           last_verified_date: "2026-05-12"
           content_sha256: "fc9ba63b9c9c53893a486a3c9055287bd6dc9c68f5439cae197efe5ae585d17c"
 
@@ -336,7 +336,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "5cb8e5d"
+          last_verified_sha: "853a4635"
           last_verified_date: "2026-05-19"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -209,7 +209,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "e8b119e"
+          last_verified_sha: "cac71cca"
           last_verified_date: "2026-05-30"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -284,7 +284,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "e8b119e"
+          last_verified_sha: "cac71cca"
           last_verified_date: "2026-05-30"
           content_sha256: "fc9ba63b9c9c53893a486a3c9055287bd6dc9c68f5439cae197efe5ae585d17c"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -239,8 +239,9 @@ categories:
           caption: "Font presets panel"
           sources:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
+            - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "049c230"
+          last_verified_sha: "e8b119e"
           last_verified_date: "2026-05-30"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -336,8 +337,8 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "853a4635"
-          last_verified_date: "2026-05-19"
+          last_verified_sha: "218f8d9"
+          last_verified_date: "2026-05-30"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 
   onboarding:

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,8 +89,8 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "853a4635"
-          last_verified_date: "2026-05-28"
+          last_verified_sha: "e8b119e"
+          last_verified_date: "2026-05-30"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
       - id: accent-scoped-language
@@ -110,8 +110,8 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "853a4635"
-          last_verified_date: "2026-05-28"
+          last_verified_sha: "e8b119e"
+          last_verified_date: "2026-05-30"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
       - id: accent-language-breakdown
@@ -209,8 +209,8 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "853a4635"
-          last_verified_date: "2026-05-24"
+          last_verified_sha: "e8b119e"
+          last_verified_date: "2026-05-30"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
   fonts:
@@ -283,8 +283,8 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "853a4635"
-          last_verified_date: "2026-05-12"
+          last_verified_sha: "e8b119e"
+          last_verified_date: "2026-05-30"
           content_sha256: "fc9ba63b9c9c53893a486a3c9055287bd6dc9c68f5439cae197efe5ae585d17c"
 
   tabs:

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -349,50 +349,58 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
         rotationCheckboxCell: Cell<JBCheckBox>,
         gate: PremiumFeatureGate,
     ) {
-        row {
-            label("Mode:")
-            val modeCombo =
-                comboBox(
-                    listOf("Preset cycle", "Random color"),
-                ).component
-            modeCombo.selectedIndex =
-                if (pendingRotationMode == AccentRotationMode.RANDOM.name) 1 else 0
-            modeCombo.applyPremiumLock(gate)
-            modeCombo.addActionListener {
-                if (!gate.isUnlocked) return@addActionListener
-                pendingRotationMode =
-                    if (modeCombo.selectedIndex == 1) {
-                        AccentRotationMode.RANDOM.name
-                    } else {
-                        AccentRotationMode.PRESET.name
-                    }
+        val controlsRow =
+            row {
+                label("Mode:")
+                val modeCombo =
+                    comboBox(
+                        listOf("Preset cycle", "Random color"),
+                    ).component
+                modeCombo.selectedIndex =
+                    if (pendingRotationMode == AccentRotationMode.RANDOM.name) 1 else 0
+                modeCombo.applyPremiumLock(gate)
+                modeCombo.addActionListener {
+                    if (!gate.isUnlocked) return@addActionListener
+                    pendingRotationMode =
+                        if (modeCombo.selectedIndex == 1) {
+                            AccentRotationMode.RANDOM.name
+                        } else {
+                            AccentRotationMode.PRESET.name
+                        }
+                }
             }
-        }.visibleIf(rotationCheckboxCell.selected)
+        if (gate.isUnlocked) {
+            controlsRow.visibleIf(rotationCheckboxCell.selected)
+        }
     }
 
     private fun Panel.buildRotationIntervalRow(
         rotationCheckboxCell: Cell<JBCheckBox>,
         gate: PremiumFeatureGate,
     ) {
-        row {
-            label("Interval:")
-            val intervalCombo =
-                comboBox(
-                    listOf("1 hour", "3 hours", "6 hours", "12 hours", "24 hours"),
-                ).component
-            intervalCombo.selectedIndex =
-                INTERVAL_VALUES
-                    .indexOf(pendingRotationInterval)
-                    .coerceAtLeast(0)
-            intervalCombo.applyPremiumLock(gate)
-            intervalCombo.addActionListener {
-                if (!gate.isUnlocked) return@addActionListener
-                pendingRotationInterval =
-                    INTERVAL_VALUES.getOrElse(intervalCombo.selectedIndex) {
-                        AyuIslandsState.DEFAULT_ROTATION_INTERVAL_HOURS
-                    }
+        val controlsRow =
+            row {
+                label("Interval:")
+                val intervalCombo =
+                    comboBox(
+                        listOf("1 hour", "3 hours", "6 hours", "12 hours", "24 hours"),
+                    ).component
+                intervalCombo.selectedIndex =
+                    INTERVAL_VALUES
+                        .indexOf(pendingRotationInterval)
+                        .coerceAtLeast(0)
+                intervalCombo.applyPremiumLock(gate)
+                intervalCombo.addActionListener {
+                    if (!gate.isUnlocked) return@addActionListener
+                    pendingRotationInterval =
+                        INTERVAL_VALUES.getOrElse(intervalCombo.selectedIndex) {
+                            AyuIslandsState.DEFAULT_ROTATION_INTERVAL_HOURS
+                        }
+                }
             }
-        }.visibleIf(rotationCheckboxCell.selected)
+        if (gate.isUnlocked) {
+            controlsRow.visibleIf(rotationCheckboxCell.selected)
+        }
     }
 
     private fun handleCustomTrigger() {

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -223,11 +223,13 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
                     }
                 } else {
                     val settings = AyuIslandsSettings.getInstance()
+                    val currentVariant = variant ?: return@addActionListener
                     val manualAccent =
-                        getManualAccent(
-                            variant ?: return@addActionListener,
-                            settings,
-                        )
+                        when (currentVariant) {
+                            AyuVariant.MIRAGE -> settings.state.mirageAccent ?: currentVariant.defaultAccent
+                            AyuVariant.DARK -> settings.state.darkAccent ?: currentVariant.defaultAccent
+                            AyuVariant.LIGHT -> settings.state.lightAccent ?: currentVariant.defaultAccent
+                        }
                     pendingAccent = manualAccent
                     applyInitialSelection(colorPanel, manualAccent)
                     onAccentChanged?.invoke(manualAccent)
@@ -296,6 +298,14 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
 
     private fun Panel.buildAccentRotationGroup() {
         val settings = AyuIslandsSettings.getInstance()
+        val gate =
+            PremiumFeatureGate(
+                featureName = "Accent rotation",
+                lockedDescription =
+                    "Accent rotation is a Pro feature. " +
+                        "Preview preset-cycle, random-color, and interval controls here.",
+                requestMessage = "Unlock accent rotation",
+            )
         val collapsible =
             collapsibleGroup("Accent Rotation") {
                 row {
@@ -303,9 +313,10 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
                         "Automatically change your accent color on a schedule.",
                     )
                 }
-                val rotationCheckboxCell = buildRotationEnableRow()
-                buildRotationModeRow(rotationCheckboxCell)
-                buildRotationIntervalRow(rotationCheckboxCell)
+                premiumFeatureNotice(gate)
+                val rotationCheckboxCell = buildRotationEnableRow(gate)
+                buildRotationModeRow(rotationCheckboxCell, gate)
+                buildRotationIntervalRow(rotationCheckboxCell, gate)
             }
         collapsible.expanded = settings.state.accentRotationGroupExpanded
         collapsible.addExpandedListener { expanded ->
@@ -313,15 +324,15 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
         }
     }
 
-    private fun Panel.buildRotationEnableRow(): Cell<JBCheckBox> {
+    private fun Panel.buildRotationEnableRow(gate: PremiumFeatureGate): Cell<JBCheckBox> {
         lateinit var cell: Cell<JBCheckBox>
         row {
             cell = checkBox("Enable accent rotation")
             val checkbox = cell.component
             checkbox.isSelected = pendingRotationEnabled
-            checkbox.isEnabled =
-                LicenseChecker.isLicensedOrGrace()
+            checkbox.applyPremiumLock(gate)
             checkbox.addActionListener {
+                if (!gate.isUnlocked) return@addActionListener
                 pendingRotationEnabled = checkbox.isSelected
                 if (pendingRotationEnabled && pendingFollowSystem) {
                     pendingFollowSystem = false
@@ -330,14 +341,14 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
                 }
             }
             rotationEnabledCheckbox = checkbox
-            if (!LicenseChecker.isLicensedOrGrace()) {
-                comment("Pro feature")
-            }
         }
         return cell
     }
 
-    private fun Panel.buildRotationModeRow(rotationCheckboxCell: Cell<JBCheckBox>) {
+    private fun Panel.buildRotationModeRow(
+        rotationCheckboxCell: Cell<JBCheckBox>,
+        gate: PremiumFeatureGate,
+    ) {
         row {
             label("Mode:")
             val modeCombo =
@@ -346,7 +357,9 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
                 ).component
             modeCombo.selectedIndex =
                 if (pendingRotationMode == AccentRotationMode.RANDOM.name) 1 else 0
+            modeCombo.applyPremiumLock(gate)
             modeCombo.addActionListener {
+                if (!gate.isUnlocked) return@addActionListener
                 pendingRotationMode =
                     if (modeCombo.selectedIndex == 1) {
                         AccentRotationMode.RANDOM.name
@@ -357,7 +370,10 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
         }.visibleIf(rotationCheckboxCell.selected)
     }
 
-    private fun Panel.buildRotationIntervalRow(rotationCheckboxCell: Cell<JBCheckBox>) {
+    private fun Panel.buildRotationIntervalRow(
+        rotationCheckboxCell: Cell<JBCheckBox>,
+        gate: PremiumFeatureGate,
+    ) {
         row {
             label("Interval:")
             val intervalCombo =
@@ -368,7 +384,9 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
                 INTERVAL_VALUES
                     .indexOf(pendingRotationInterval)
                     .coerceAtLeast(0)
+            intervalCombo.applyPremiumLock(gate)
             intervalCombo.addActionListener {
+                if (!gate.isUnlocked) return@addActionListener
                 pendingRotationInterval =
                     INTERVAL_VALUES.getOrElse(intervalCombo.selectedIndex) {
                         AyuIslandsState.DEFAULT_ROTATION_INTERVAL_HOURS
@@ -451,16 +469,6 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
         }
     }
 
-    private fun getManualAccent(
-        variant: AyuVariant,
-        settings: AyuIslandsSettings,
-    ): String =
-        when (variant) {
-            AyuVariant.MIRAGE -> settings.state.mirageAccent ?: variant.defaultAccent
-            AyuVariant.DARK -> settings.state.darkAccent ?: variant.defaultAccent
-            AyuVariant.LIGHT -> settings.state.lightAccent ?: variant.defaultAccent
-        }
-
     private fun updatePanelEnabled() {
         val following = pendingFollowSystem
         accentPanel?.let { panel ->
@@ -514,65 +522,7 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
         }
         storedAccent = effectiveAccent
 
-        val rotationChanged =
-            pendingRotationEnabled != storedRotationEnabled ||
-                pendingRotationMode != storedRotationMode ||
-                pendingRotationInterval != storedRotationInterval
-
-        if (rotationChanged) {
-            settings.state.accentRotationEnabled = pendingRotationEnabled
-            settings.state.accentRotationMode = pendingRotationMode
-            settings.state.accentRotationIntervalHours = pendingRotationInterval
-            storedRotationEnabled = pendingRotationEnabled
-            storedRotationMode = pendingRotationMode
-            storedRotationInterval = pendingRotationInterval
-
-            val service = AccentRotationService.getInstance()
-            if (pendingRotationEnabled) {
-                val mode = AccentRotationMode.fromName(pendingRotationMode)
-                when (mode) {
-                    AccentRotationMode.RANDOM -> {
-                        val rotationHex =
-                            ContrastAwareColorGenerator.generate(
-                                variant ?: return,
-                            )
-                        settings.setAccentForVariant(currentVariant, rotationHex)
-                        settings.state.accentRotationLastSwitchMs = System.currentTimeMillis()
-                        applyRotationRespectingOverrides(currentVariant)
-                        storedAccent = rotationHex
-                        pendingAccent = rotationHex
-                        accentPanel?.selectedPreset = null
-                        accentPanel?.customColor = rotationHex
-                        pendingCustomColor = rotationHex
-                        settings.state.lastShuffleColor = rotationHex
-                        accentPanel?.showThirteenthSwatchImmediate(rotationHex)
-                        onAccentChanged?.invoke(rotationHex)
-                        service.startRotation()
-                    }
-                    AccentRotationMode.PRESET -> {
-                        val currentIndex = settings.state.accentRotationPresetIndex
-                        val nextIndex = (currentIndex + 1) % AYU_ACCENT_PRESETS.size
-                        settings.state.accentRotationPresetIndex = nextIndex
-                        val presetHex = AYU_ACCENT_PRESETS[nextIndex].hex
-                        settings.setAccentForVariant(currentVariant, presetHex)
-                        settings.state.accentRotationLastSwitchMs = System.currentTimeMillis()
-                        applyRotationRespectingOverrides(currentVariant)
-                        storedAccent = presetHex
-                        pendingAccent = presetHex
-                        pendingCustomColor = null
-                        accentPanel?.selectedPreset = presetHex
-                        accentPanel?.customColor = null
-                        accentPanel?.showThirteenthSwatchImmediate(presetHex)
-                        settings.state.lastShuffleColor = null
-                        updateHeroGlow()
-                        onAccentChanged?.invoke(presetHex)
-                        service.startRotation()
-                    }
-                }
-            } else {
-                service.stopRotation()
-            }
-        }
+        applyRotationChangeIfAllowed(settings, currentVariant)
 
         if (overridesDirty) {
             overrides.apply()
@@ -581,6 +531,68 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
         // `isModified` guard here keeps the function under detekt's CyclomaticComplexMethod cap.
         quickSwitcher.apply()
         updateCurrentlyActiveLabel()
+    }
+
+    private fun applyRotationChangeIfAllowed(
+        settings: AyuIslandsSettings,
+        currentVariant: AyuVariant,
+    ) {
+        val rotationChanged =
+            pendingRotationEnabled != storedRotationEnabled ||
+                pendingRotationMode != storedRotationMode ||
+                pendingRotationInterval != storedRotationInterval
+        if (!rotationChanged) return
+        if (!LicenseChecker.isLicensedOrGrace() && pendingRotationEnabled) return
+
+        settings.state.accentRotationEnabled = pendingRotationEnabled
+        settings.state.accentRotationMode = pendingRotationMode
+        settings.state.accentRotationIntervalHours = pendingRotationInterval
+        storedRotationEnabled = pendingRotationEnabled
+        storedRotationMode = pendingRotationMode
+        storedRotationInterval = pendingRotationInterval
+
+        val service = AccentRotationService.getInstance()
+        if (!pendingRotationEnabled) {
+            service.stopRotation()
+            return
+        }
+
+        when (AccentRotationMode.fromName(pendingRotationMode)) {
+            AccentRotationMode.RANDOM -> {
+                val rotationHex = ContrastAwareColorGenerator.generate(currentVariant)
+                settings.setAccentForVariant(currentVariant, rotationHex)
+                settings.state.accentRotationLastSwitchMs = System.currentTimeMillis()
+                applyRotationRespectingOverrides(currentVariant)
+                storedAccent = rotationHex
+                pendingAccent = rotationHex
+                accentPanel?.selectedPreset = null
+                accentPanel?.customColor = rotationHex
+                pendingCustomColor = rotationHex
+                settings.state.lastShuffleColor = rotationHex
+                accentPanel?.showThirteenthSwatchImmediate(rotationHex)
+                onAccentChanged?.invoke(rotationHex)
+                service.startRotation()
+            }
+            AccentRotationMode.PRESET -> {
+                val currentIndex = settings.state.accentRotationPresetIndex
+                val nextIndex = (currentIndex + 1) % AYU_ACCENT_PRESETS.size
+                settings.state.accentRotationPresetIndex = nextIndex
+                val presetHex = AYU_ACCENT_PRESETS[nextIndex].hex
+                settings.setAccentForVariant(currentVariant, presetHex)
+                settings.state.accentRotationLastSwitchMs = System.currentTimeMillis()
+                applyRotationRespectingOverrides(currentVariant)
+                storedAccent = presetHex
+                pendingAccent = presetHex
+                pendingCustomColor = null
+                accentPanel?.selectedPreset = presetHex
+                accentPanel?.customColor = null
+                accentPanel?.showThirteenthSwatchImmediate(presetHex)
+                settings.state.lastShuffleColor = null
+                updateHeroGlow()
+                onAccentChanged?.invoke(presetHex)
+                service.startRotation()
+            }
+        }
     }
 
     override fun reset() {

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsChromePanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsChromePanel.kt
@@ -24,10 +24,9 @@ import javax.swing.JSlider
  *
  *  - Pending/stored pairs for each state field so [isModified] can diff without touching
  *    the live [AyuIslandsState] until [apply] is called.
- *  - Premium gate: unlicensed users see the collapsible header with a single
- *    "requires Pro license" comment instead of the full content. The underlying
- *    controls are not wired at all in the unlicensed path so there is no way to
- *    mutate chrome state without a license.
+ *  - Premium gate: unlicensed users see the full settings surface, but controls
+ *    are locked. The underlying apply path re-checks [LicenseChecker] so a
+ *    mid-session license revoke cannot persist premium state.
  *  - Probe gate: the Main Toolbar row is present but disabled (never hidden) with
  *    a user-visible comment when [ChromeDecorationsProbe.isCustomHeaderActive]
  *    reports native OS chrome. The row stays in the panel so users understand why
@@ -80,21 +79,29 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
     ) {
         this.variant = variant
         licensed = LicenseChecker.isLicensedOrGrace()
+        val gate =
+            PremiumFeatureGate(
+                featureName = "Chrome tinting",
+                lockedDescription =
+                    "Chrome tinting is a Pro feature. " +
+                        "Preview the status bar, toolbar, stripe, navigation bar, and border controls here.",
+                requestMessage = "Unlock chrome tinting",
+                isUnlocked = licensed,
+            )
         val state = AyuIslandsSettings.getInstance().state
         loadStored(state)
         val probeAllowsMainToolbar = ChromeDecorationsProbe.isCustomHeaderActive()
 
         val collapsible =
             panel.collapsibleGroup(GROUP_TITLE) {
-                if (!licensed) {
-                    row { comment("Chrome tinting requires a Pro license.") }
-                    return@collapsibleGroup
-                }
+                premiumFeatureNotice(gate)
 
                 row {
                     val cb = checkBox("Status bar")
                     cb.component.isSelected = pendingChromeStatusBar
+                    cb.component.applyPremiumLock(gate)
                     cb.component.addActionListener {
+                        if (!gate.isUnlocked) return@addActionListener
                         pendingChromeStatusBar = cb.component.isSelected
                     }
                     statusBarCheckbox = cb.component
@@ -102,8 +109,9 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
                 row {
                     val cb = checkBox("Main toolbar")
                     cb.component.isSelected = pendingChromeMainToolbar
-                    cb.component.isEnabled = probeAllowsMainToolbar
+                    cb.component.applyPremiumLock(gate, enabledWhenUnlocked = probeAllowsMainToolbar)
                     cb.component.addActionListener {
+                        if (!gate.isUnlocked || !probeAllowsMainToolbar) return@addActionListener
                         pendingChromeMainToolbar = cb.component.isSelected
                     }
                     mainToolbarCheckbox = cb.component
@@ -116,7 +124,9 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
                 row {
                     val cb = checkBox("Tool window stripe")
                     cb.component.isSelected = pendingChromeToolWindowStripe
+                    cb.component.applyPremiumLock(gate)
                     cb.component.addActionListener {
+                        if (!gate.isUnlocked) return@addActionListener
                         pendingChromeToolWindowStripe = cb.component.isSelected
                     }
                     toolWindowStripeCheckbox = cb.component
@@ -124,7 +134,9 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
                 row {
                     val cb = checkBox("Navigation bar")
                     cb.component.isSelected = pendingChromeNavBar
+                    cb.component.applyPremiumLock(gate)
                     cb.component.addActionListener {
+                        if (!gate.isUnlocked) return@addActionListener
                         pendingChromeNavBar = cb.component.isSelected
                     }
                     navBarCheckbox = cb.component
@@ -132,7 +144,9 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
                 row {
                     val cb = checkBox("Panel borders")
                     cb.component.isSelected = pendingChromePanelBorder
+                    cb.component.applyPremiumLock(gate)
                     cb.component.addActionListener {
+                        if (!gate.isUnlocked) return@addActionListener
                         pendingChromePanelBorder = cb.component.isSelected
                     }
                     panelBorderCheckbox = cb.component
@@ -142,8 +156,10 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
                     slider.paintTicks = true
                     slider.majorTickSpacing = INTENSITY_MAJOR_TICK
                     slider.minorTickSpacing = INTENSITY_MINOR_TICK
+                    slider.applyPremiumLock(gate)
                     val valueLabel = JLabel("${slider.value}")
                     slider.addChangeListener {
+                        if (!gate.isUnlocked) return@addChangeListener
                         pendingChromeTintIntensity = slider.value
                         valueLabel.text = "${slider.value}"
                     }
@@ -177,7 +193,7 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
         // License may have flipped mid-session (grace expired, entitlement revoked,
         // user signed out of JBA). When the panel was built licensed but the gate
         // has since closed, refuse to persist — otherwise chrome state writes keep
-        // happening behind a "requires Pro" UI the user can no longer interact with.
+        // happening behind locked premium UI.
         if (!LicenseChecker.isLicensedOrGrace()) {
             LOG.info(
                 "AyuIslandsChromePanel.apply: license no longer active; " +
@@ -351,6 +367,16 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
             navBarCheckbox,
             panelBorderCheckbox,
         ).size
+
+    @TestOnly
+    internal fun enabledSurfaceCheckboxCountForTest(): Int =
+        listOfNotNull(
+            statusBarCheckbox,
+            mainToolbarCheckbox,
+            toolWindowStripeCheckbox,
+            navBarCheckbox,
+            panelBorderCheckbox,
+        ).count { it.isEnabled }
 
     @TestOnly
     internal fun intensitySliderForTest(): JSlider? = intensitySlider

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsChromePanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsChromePanel.kt
@@ -95,62 +95,7 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
         val collapsible =
             panel.collapsibleGroup(GROUP_TITLE) {
                 premiumFeatureNotice(gate)
-
-                row {
-                    val cb = checkBox("Status bar")
-                    cb.component.isSelected = pendingChromeStatusBar
-                    cb.component.applyPremiumLock(gate)
-                    cb.component.addActionListener {
-                        if (!gate.isUnlocked) return@addActionListener
-                        pendingChromeStatusBar = cb.component.isSelected
-                    }
-                    statusBarCheckbox = cb.component
-                }
-                row {
-                    val cb = checkBox("Main toolbar")
-                    cb.component.isSelected = pendingChromeMainToolbar
-                    cb.component.applyPremiumLock(gate, enabledWhenUnlocked = probeAllowsMainToolbar)
-                    cb.component.addActionListener {
-                        if (!gate.isUnlocked || !probeAllowsMainToolbar) return@addActionListener
-                        pendingChromeMainToolbar = cb.component.isSelected
-                    }
-                    mainToolbarCheckbox = cb.component
-                    if (!probeAllowsMainToolbar) {
-                        val commentText = disabledMainToolbarComment()
-                        cb.comment(commentText)
-                        mainToolbarComment = commentText
-                    }
-                }
-                row {
-                    val cb = checkBox("Tool window stripe")
-                    cb.component.isSelected = pendingChromeToolWindowStripe
-                    cb.component.applyPremiumLock(gate)
-                    cb.component.addActionListener {
-                        if (!gate.isUnlocked) return@addActionListener
-                        pendingChromeToolWindowStripe = cb.component.isSelected
-                    }
-                    toolWindowStripeCheckbox = cb.component
-                }
-                row {
-                    val cb = checkBox("Navigation bar")
-                    cb.component.isSelected = pendingChromeNavBar
-                    cb.component.applyPremiumLock(gate)
-                    cb.component.addActionListener {
-                        if (!gate.isUnlocked) return@addActionListener
-                        pendingChromeNavBar = cb.component.isSelected
-                    }
-                    navBarCheckbox = cb.component
-                }
-                row {
-                    val cb = checkBox("Panel borders")
-                    cb.component.isSelected = pendingChromePanelBorder
-                    cb.component.applyPremiumLock(gate)
-                    cb.component.addActionListener {
-                        if (!gate.isUnlocked) return@addActionListener
-                        pendingChromePanelBorder = cb.component.isSelected
-                    }
-                    panelBorderCheckbox = cb.component
-                }
+                buildChromeSurfaceRows(gate, probeAllowsMainToolbar)
                 row("Intensity (%):") {
                     val slider = JSlider(MIN_INTENSITY, MAX_INTENSITY, pendingChromeTintIntensity)
                     slider.paintTicks = true
@@ -179,6 +124,76 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
         expandedListener = listener
         collapsible.addExpandedListener { expanded -> listener(expanded) }
     }
+
+    private fun Panel.buildChromeSurfaceRows(
+        gate: PremiumFeatureGate,
+        probeAllowsMainToolbar: Boolean,
+    ) {
+        val disabledToolbarComment =
+            if (probeAllowsMainToolbar) {
+                null
+            } else {
+                disabledMainToolbarComment()
+            }
+        mainToolbarComment = disabledToolbarComment
+
+        listOf(
+            ChromeSurfaceRow(
+                label = "Status bar",
+                selected = pendingChromeStatusBar,
+                onChanged = { pendingChromeStatusBar = it },
+                rememberComponent = { statusBarCheckbox = it },
+            ),
+            ChromeSurfaceRow(
+                label = "Main toolbar",
+                selected = pendingChromeMainToolbar,
+                onChanged = { pendingChromeMainToolbar = it },
+                rememberComponent = { mainToolbarCheckbox = it },
+                enabledWhenUnlocked = probeAllowsMainToolbar,
+                disabledComment = disabledToolbarComment,
+            ),
+            ChromeSurfaceRow(
+                label = "Tool window stripe",
+                selected = pendingChromeToolWindowStripe,
+                onChanged = { pendingChromeToolWindowStripe = it },
+                rememberComponent = { toolWindowStripeCheckbox = it },
+            ),
+            ChromeSurfaceRow(
+                label = "Navigation bar",
+                selected = pendingChromeNavBar,
+                onChanged = { pendingChromeNavBar = it },
+                rememberComponent = { navBarCheckbox = it },
+            ),
+            ChromeSurfaceRow(
+                label = "Panel borders",
+                selected = pendingChromePanelBorder,
+                onChanged = { pendingChromePanelBorder = it },
+                rememberComponent = { panelBorderCheckbox = it },
+            ),
+        ).forEach { surfaceRow ->
+            row {
+                val checkboxCell = checkBox(surfaceRow.label)
+                val checkbox = checkboxCell.component
+                checkbox.isSelected = surfaceRow.selected
+                checkbox.applyPremiumLock(gate, enabledWhenUnlocked = surfaceRow.enabledWhenUnlocked)
+                checkbox.addActionListener {
+                    if (!gate.isUnlocked || !surfaceRow.enabledWhenUnlocked) return@addActionListener
+                    surfaceRow.onChanged(checkbox.isSelected)
+                }
+                surfaceRow.rememberComponent(checkbox)
+                surfaceRow.disabledComment?.let { checkboxCell.comment(it) }
+            }
+        }
+    }
+
+    private class ChromeSurfaceRow(
+        val label: String,
+        val selected: Boolean,
+        val onChanged: (Boolean) -> Unit,
+        val rememberComponent: (JBCheckBox) -> Unit,
+        val enabledWhenUnlocked: Boolean = true,
+        val disabledComment: String? = null,
+    )
 
     override fun isModified(): Boolean =
         pendingChromeStatusBar != storedChromeStatusBar ||
@@ -315,8 +330,9 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
         // (corrupted XML, older schema, third-party migration) would otherwise slip
         // through the cap and reach the JSlider constructor, which throws when
         // value < min. The lower bound keeps the slider construction total.
-        storedChromeTintIntensity = state.chromeTintIntensity
-        pendingChromeTintIntensity = state.chromeTintIntensity.coerceIn(MIN_INTENSITY, MAX_INTENSITY)
+        val clampedIntensity = state.chromeTintIntensity.coerceIn(MIN_INTENSITY, MAX_INTENSITY)
+        storedChromeTintIntensity = if (licensed) state.chromeTintIntensity else clampedIntensity
+        pendingChromeTintIntensity = clampedIntensity
     }
 
     /**

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
@@ -152,9 +152,10 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
                 buildMasterToggleRow(this, licensed)
                 group("Style") {
                     buildPresetRow(this)
-                    buildStyleComboRow(this, licensed)
+                    buildStyleComboRow(this, gate)
                     buildSliderRow(
                         group = this,
+                        gate = gate,
                         config =
                             SliderConfig(
                                 label = "Intensity",
@@ -175,6 +176,7 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
                     )
                     buildSliderRow(
                         group = this,
+                        gate = gate,
                         config =
                             SliderConfig(
                                 label = "Width (px)",
@@ -192,9 +194,9 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
                             widthValueLabel = label
                         },
                     )
-                    buildAnimationRows(this, licensed)
+                    buildAnimationRows(this, gate)
                 }
-                buildTargetsGroup(this, licensed, customModeVisible)
+                buildTargetsGroup(this, gate, customModeVisible)
             }
 
         glowPanel.add(innerContent, BorderLayout.CENTER)
@@ -234,8 +236,9 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
 
     private fun buildStyleComboRow(
         group: Panel,
-        licensed: Boolean,
+        gate: PremiumFeatureGate,
     ) {
+        val licensed = gate.isUnlocked
         group
             .row {
                 label("Style")
@@ -254,11 +257,12 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
                 }
                 styleCombo = combo
                 cell(combo)
-            }.visibleIf(customModeVisible)
+            }.visibleIfUnlockedOrPreview(customModeVisible, gate)
     }
 
     private fun buildSliderRow(
         group: Panel,
+        gate: PremiumFeatureGate,
         config: SliderConfig,
         onValueChanged: (Int) -> Unit,
         onCreated: (JSlider, JLabel) -> Unit,
@@ -270,9 +274,10 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
                 slider.paintTicks = true
                 slider.majorTickSpacing = config.majorTick
                 if (config.minorTick > 0) slider.minorTickSpacing = config.minorTick
+                slider.applyPremiumLock(gate, pendingGlowEnabled)
                 val valueLabel = JLabel("${slider.value}")
                 slider.addChangeListener {
-                    if (!suppressListeners) {
+                    if (!suppressListeners && gate.isUnlocked) {
                         onValueChanged(slider.value)
                         switchToCustom()
                     }
@@ -281,13 +286,14 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
                 onCreated(slider, valueLabel)
                 cell(slider).resizableColumn().align(Align.FILL)
                 cell(valueLabel)
-            }.visibleIf(customModeVisible)
+            }.visibleIfUnlockedOrPreview(customModeVisible, gate)
     }
 
     private fun buildAnimationRows(
         group: Panel,
-        licensed: Boolean,
+        gate: PremiumFeatureGate,
     ) {
+        val licensed = gate.isUnlocked
         group
             .row {
                 label("Animation")
@@ -305,19 +311,20 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
                 }
                 animationCombo = combo
                 cell(combo)
-            }.visibleIf(customModeVisible)
+            }.visibleIfUnlockedOrPreview(customModeVisible, gate)
         group
             .row {
                 val descCell = comment(animationDescription(pendingAnimation))
                 animationDescriptionLabel = descCell.component
-            }.visibleIf(customModeVisible)
+            }.visibleIfUnlockedOrPreview(customModeVisible, gate)
     }
 
     private fun buildTargetsGroup(
         panel: Panel,
-        licensed: Boolean,
+        gate: PremiumFeatureGate,
         customVisible: AtomicBooleanProperty,
     ) {
+        val licensed = gate.isUnlocked
         panel
             .collapsibleGroup("Targets") {
                 row {
@@ -363,7 +370,7 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
                     { islandCheckbox("Debug", licensed) },
                     { },
                 )
-            }.visibleIf(customVisible)
+            }.visibleIfUnlockedOrPreview(customVisible, gate)
     }
 
     private fun Row.islandCheckbox(

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
@@ -216,7 +216,7 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
             segmented.selectedItem = pendingPreset
             @Suppress("UnstableApiUsage")
             segmented.whenItemSelected { preset ->
-                if (!suppressListeners) {
+                if (!suppressListeners && LicenseChecker.isLicensedOrGrace()) {
                     pendingPreset = preset
                     if (preset != GlowPreset.CUSTOM) {
                         applyPresetValues(preset)
@@ -516,7 +516,7 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
         widthSlider?.isEnabled = enabled
         styleCombo?.isEnabled = enabled
         animationCombo?.isEnabled = enabled
-        presetSegmentedButton?.enabled(enabled || !LicenseChecker.isLicensedOrGrace())
+        presetSegmentedButton?.enabled(enabled)
 
         for ((_, cb) in islandCheckboxes) {
             cb.isEnabled = enabled

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
@@ -94,9 +94,16 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
 
     fun buildGlowPanel(panel: Panel) {
         ensureStateLoaded()
-        val licensed = LicenseChecker.isLicensedOrGrace()
+        val gate =
+            PremiumFeatureGate(
+                featureName = "Glow",
+                lockedDescription =
+                    "Glow is a Pro feature. " +
+                        "Preview style, animation, width, intensity, and target controls here.",
+                requestMessage = "Unlock glow effects",
+            )
 
-        buildStyleGroup(panel, licensed)
+        buildStyleGroup(panel, gate)
 
         updateControlStates()
     }
@@ -130,8 +137,9 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
 
     private fun buildStyleGroup(
         panel: Panel,
-        licensed: Boolean,
+        gate: PremiumFeatureGate,
     ) {
+        val licensed = gate.isUnlocked
         val glowPanel = GlowGroupPanel()
         glowGroupPanel = glowPanel
 
@@ -140,6 +148,7 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
                 row {
                     comment("Neon glow effects around editor islands and UI elements.")
                 }
+                premiumFeatureNotice(gate)
                 buildMasterToggleRow(this, licensed)
                 group("Style") {
                     buildPresetRow(this)
@@ -542,6 +551,7 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
 
     override fun apply() {
         if (!isModified()) return
+        if (!LicenseChecker.isLicensedOrGrace()) return
         val state = AyuIslandsSettings.getInstance().state
 
         state.glowEnabled = pendingGlowEnabled

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsElementsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsElementsPanel.kt
@@ -160,7 +160,7 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
                 // Subsection 2: Tab underline
                 separator()
                 row { label("Tab underline").bold() }
-                buildActiveTabContent()
+                buildActiveTabContent(gate)
 
                 // Subsection 3: Bracket scope
                 separator()
@@ -189,7 +189,7 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
      * Called from inside the parent `Accent Elements` collapsibleGroup where this content
      * sits under the `Tab underline` subsection header.
      */
-    private fun Panel.buildActiveTabContent() {
+    private fun Panel.buildActiveTabContent(gate: PremiumFeatureGate) {
         val state = AyuIslandsSettings.getInstance().state
         val glowEnabled = state.glowEnabled
         val islandsUi = AyuVariant.isIslandsUi()
@@ -233,7 +233,7 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
                     }
                 }
                 thicknessSegmented = thickSegmented
-            }.visible(!tabModeIsOff && !islandsUi)
+            }.visibleWhenUnlockedOrPreview(!tabModeIsOff && !islandsUi, gate)
 
         // Sync with the glow width checkbox (hidden on Islands UI)
         syncRow =
@@ -255,15 +255,15 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
                     }
                 }
                 syncCheckbox = cb.component
-            }.visible(!tabModeIsOff && !islandsUi)
+            }.visibleWhenUnlockedOrPreview(!tabModeIsOff && !islandsUi, gate)
     }
 
     private fun updateThicknessRowVisibility() {
         val isOff = GlowTabMode.fromName(pendingTabMode) == GlowTabMode.OFF
-        val hidden = isOff || AyuVariant.isIslandsUi()
-        thicknessRow?.visible(!hidden)
-        syncRow?.visible(!hidden)
-        if (!hidden) {
+        val visible = if (licensed) !isOff && !AyuVariant.isIslandsUi() else !AyuVariant.isIslandsUi()
+        thicknessRow?.visible(visible)
+        syncRow?.visible(visible)
+        if (visible) {
             updateThicknessEnabledState()
         }
     }

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsElementsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsElementsPanel.kt
@@ -57,7 +57,15 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
     ) {
         this.variant = variant
         val state = AyuIslandsSettings.getInstance().state
-        licensed = LicenseChecker.isLicensedOrGrace()
+        val gate =
+            PremiumFeatureGate(
+                featureName = "Accent elements",
+                lockedDescription =
+                    "Accent elements are a Pro feature. " +
+                        "Preview per-element toggles, tab underline, and bracket scope controls here.",
+                requestMessage = "Unlock accent element customization",
+            )
+        licensed = gate.isUnlocked
 
         // Initialize toggle state from persisted settings. CHROME-group ids are owned
         // by the Chrome tinting panel (phase 40) and must NOT surface in this panel's
@@ -102,11 +110,9 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
         val settings = AyuIslandsSettings.getInstance()
         val collapsible =
             panel.collapsibleGroup("Accent Elements") {
+                premiumFeatureNotice(gate)
                 // Subsection 1: Per-element toggles
                 row { label("Per-element toggles").bold() }
-                if (!licensed) {
-                    row { comment("Per-element toggles require a Pro license.") }
-                }
                 row {
                     // Left: checkbox columns + enable/disable
                     panel {
@@ -166,6 +172,7 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
                     scopeCb.component.isSelected = pendingBracketScope
                     scopeCb.component.isEnabled = licensed
                     scopeCb.component.addActionListener {
+                        if (!licensed) return@addActionListener
                         pendingBracketScope = scopeCb.component.isSelected
                     }
                     bracketScopeCheckbox = scopeCb.component
@@ -203,6 +210,7 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
                 segmented.enabled(licensed)
                 @Suppress("UnstableApiUsage")
                 segmented.whenItemSelected { mode ->
+                    if (!licensed) return@whenItemSelected
                     pendingTabMode = mode.name
                     updateThicknessRowVisibility()
                 }
@@ -219,7 +227,11 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
                 thickSegmented.selectedItem = pendingTabUnderlineHeight
                 thickSegmented.enabled(licensed && !pendingTabUnderlineGlowSync)
                 @Suppress("UnstableApiUsage")
-                thickSegmented.whenItemSelected { value -> pendingTabUnderlineHeight = value }
+                thickSegmented.whenItemSelected { value ->
+                    if (licensed) {
+                        pendingTabUnderlineHeight = value
+                    }
+                }
                 thicknessSegmented = thickSegmented
             }.visible(!tabModeIsOff && !islandsUi)
 
@@ -233,6 +245,7 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
                     cb.component.toolTipText = "Enable glow to sync"
                 }
                 cb.component.addActionListener {
+                    if (!licensed) return@addActionListener
                     pendingTabUnderlineGlowSync = cb.component.isSelected
                     updateThicknessEnabledState()
                     if (pendingTabUnderlineGlowSync && glowEnabled) {
@@ -273,6 +286,7 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
             cb.component.isSelected = pendingToggles[id] ?: true
             cb.component.isEnabled = licensed && !isBlocking
             cb.component.addActionListener {
+                if (!licensed || isBlocking) return@addActionListener
                 pendingToggles[id] = cb.component.isSelected
                 syncPreviewToggles()
                 onToggleChanged?.invoke()
@@ -323,6 +337,7 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
 
     override fun apply() {
         if (!isModified()) return
+        if (!LicenseChecker.isLicensedOrGrace()) return
         val state = AyuIslandsSettings.getInstance().state
 
         for ((id, enabled) in pendingToggles) {

--- a/src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.observable.properties.AtomicBooleanProperty
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.ui.SimpleListCellRenderer
+import com.intellij.ui.dsl.builder.Align
 import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.dsl.builder.SegmentedButton
 import dev.ayuislands.accent.AccentApplicator
@@ -233,6 +234,8 @@ class FontPresetPanel : AyuIslandsSettingsPanel {
             previewComponent = preview
             refreshPreview(reloadPreset = true)
             cell(preview)
+                .resizableColumn()
+                .align(Align.FILL)
         }.visibleIf(presetEnabled)
     }
 

--- a/src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
@@ -8,6 +8,7 @@ import dev.ayuislands.font.FontWeight
 import java.awt.Color
 import java.awt.Dimension
 import java.awt.Font
+import java.awt.FontMetrics
 import java.awt.Graphics
 import java.awt.Graphics2D
 import java.awt.Rectangle
@@ -18,6 +19,7 @@ import java.awt.RenderingHints.VALUE_TEXT_ANTIALIAS_ON
 import java.awt.font.TextAttribute
 import javax.swing.JComponent
 import javax.swing.UIManager
+import kotlin.math.roundToInt
 
 /** Renders a live font preview for the selected FontPreset using Graphics2D. */
 class FontPreviewComponent : JComponent() {
@@ -70,9 +72,9 @@ class FontPreviewComponent : JComponent() {
         repaint()
     }
 
-    override fun getPreferredSize(): Dimension = Dimension(JBUI.scale(PANEL_WIDTH), JBUI.scale(PANEL_HEIGHT))
+    override fun getPreferredSize(): Dimension = Dimension(JBUI.scale(PANEL_WIDTH), preferredPreviewHeight())
 
-    override fun getMinimumSize(): Dimension = Dimension(JBUI.scale(MIN_PANEL_WIDTH), JBUI.scale(PANEL_HEIGHT))
+    override fun getMinimumSize(): Dimension = Dimension(JBUI.scale(MIN_PANEL_WIDTH), preferredPreviewHeight())
 
     override fun paintComponent(graphics: Graphics) {
         super.paintComponent(graphics)
@@ -176,7 +178,7 @@ class FontPreviewComponent : JComponent() {
 
         g2.font = JBUI.Fonts.smallFont()
         val smallMetrics = g2.fontMetrics
-        val lineHeight = JBUI.scale(CODE_ROW_HEIGHT)
+        val lineHeight = codeLineHeight(g2.getFontMetrics(codePreviewFont()))
         var rowY = y + JBUI.scale(CODE_TOP_PADDING)
         for (lineNumber in CODE_FIRST_LINE until CODE_FIRST_LINE + SAMPLE_LINES.size) {
             val baseline = rowY + (lineHeight - smallMetrics.height) / 2 + smallMetrics.ascent
@@ -222,21 +224,12 @@ class FontPreviewComponent : JComponent() {
         x: Int,
         y: Int,
     ) {
-        val attributes =
-            mutableMapOf<TextAttribute, Any>(
-                TextAttribute.FAMILY to resolvedFontFamily,
-                TextAttribute.SIZE to fontSize,
-                TextAttribute.WEIGHT to fontWeight.textAttributeValue,
-            )
-        if (enableLigatures) {
-            attributes[TextAttribute.LIGATURES] = TextAttribute.LIGATURES_ON
-        }
         val codeWidth = (width - x - JBUI.scale(PADDING)).coerceAtLeast(1)
         val previousClip = g2.clip
-        g2.clipRect(x, y, codeWidth, height - y - JBUI.scale(PADDING))
-        g2.font = Font(attributes)
+        g2.clipRect(x, y, codeWidth, (height - y - JBUI.scale(PADDING)).coerceAtLeast(1))
+        g2.font = codePreviewFont()
         val metrics = g2.fontMetrics
-        val lineHeight = (JBUI.scale(CODE_ROW_HEIGHT) * lineSpacing).toInt().coerceAtLeast(1)
+        val lineHeight = codeLineHeight(metrics)
         var rowY = y + JBUI.scale(CODE_TOP_PADDING)
         for ((index, line) in SAMPLE_LINES.withIndex()) {
             if (index in HIGHLIGHT_ROWS) {
@@ -250,6 +243,31 @@ class FontPreviewComponent : JComponent() {
         }
         g2.clip = previousClip
     }
+
+    private fun preferredPreviewHeight(): Int {
+        val lineHeight = codeLineHeight(getFontMetrics(codePreviewFont()))
+        val codeHeight = JBUI.scale(CODE_TOP_PADDING) * 2 + lineHeight * SAMPLE_LINES.size
+        return (JBUI.scale(PADDING) * 2 + codeHeight).coerceAtLeast(JBUI.scale(PANEL_HEIGHT))
+    }
+
+    private fun codePreviewFont(): Font {
+        val attributes =
+            mutableMapOf<TextAttribute, Any>(
+                TextAttribute.FAMILY to resolvedFontFamily,
+                TextAttribute.SIZE to fontSize,
+                TextAttribute.WEIGHT to fontWeight.textAttributeValue,
+            )
+        if (enableLigatures) {
+            attributes[TextAttribute.LIGATURES] = TextAttribute.LIGATURES_ON
+        }
+        return Font(attributes)
+    }
+
+    private fun codeLineHeight(metrics: FontMetrics): Int =
+        maxOf(
+            (metrics.height * lineSpacing).roundToInt(),
+            metrics.height,
+        )
 
     private fun surface(): Color = JBColor(FALLBACK_SURFACE_COLOR, FALLBACK_SURFACE_COLOR)
 

--- a/src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
@@ -5,10 +5,12 @@ import com.intellij.util.ui.JBUI
 import dev.ayuislands.font.FontDetector
 import dev.ayuislands.font.FontPreset
 import dev.ayuislands.font.FontWeight
+import java.awt.Color
 import java.awt.Dimension
 import java.awt.Font
 import java.awt.Graphics
 import java.awt.Graphics2D
+import java.awt.Rectangle
 import java.awt.RenderingHints.KEY_ANTIALIASING
 import java.awt.RenderingHints.KEY_TEXT_ANTIALIASING
 import java.awt.RenderingHints.VALUE_ANTIALIAS_ON
@@ -68,12 +70,9 @@ class FontPreviewComponent : JComponent() {
         repaint()
     }
 
-    override fun getPreferredSize(): Dimension {
-        val lineHeight = (fontSize * lineSpacing).toInt()
-        val codeHeight = lineHeight * SAMPLE_LINES.size
-        val totalHeight = PADDING_TOP + codeHeight + PADDING_BOTTOM
-        return Dimension(JBUI.scale(PANEL_WIDTH), JBUI.scale(totalHeight.coerceAtMost(MAX_HEIGHT)))
-    }
+    override fun getPreferredSize(): Dimension = Dimension(JBUI.scale(PANEL_WIDTH), JBUI.scale(PANEL_HEIGHT))
+
+    override fun getMinimumSize(): Dimension = Dimension(JBUI.scale(MIN_PANEL_WIDTH), JBUI.scale(PANEL_HEIGHT))
 
     override fun paintComponent(graphics: Graphics) {
         super.paintComponent(graphics)
@@ -82,23 +81,118 @@ class FontPreviewComponent : JComponent() {
             g2.setRenderingHint(KEY_ANTIALIASING, VALUE_ANTIALIAS_ON)
             g2.setRenderingHint(KEY_TEXT_ANTIALIASING, VALUE_TEXT_ANTIALIAS_ON)
 
-            val bg =
-                UIManager.getColor("Panel.background")?.darker()
-                    ?: JBColor.DARK_GRAY
-            g2.color = bg
-            g2.fillRoundRect(0, 0, width, height, ARC, ARC)
+            val arc = JBUI.scale(ARC)
+            g2.color = surface()
+            g2.fillRoundRect(0, 0, width, height, arc, arc)
+            g2.color = JBColor.border()
+            g2.drawRoundRect(0, 0, width - 1, height - 1, arc, arc)
 
-            if (!fontInstalled) {
-                drawFallbackMessage(g2)
-                return
+            val padding = JBUI.scale(PADDING)
+            val gap = JBUI.scale(COLUMN_GAP)
+            val showProjectPanel = width >= JBUI.scale(SPLIT_MIN_WIDTH)
+            val projectWidth =
+                if (showProjectPanel) {
+                    (width / PROJECT_WIDTH_DIVISOR)
+                        .coerceIn(JBUI.scale(PROJECT_MIN_WIDTH), JBUI.scale(PROJECT_MAX_WIDTH))
+                } else {
+                    0
+                }
+            if (showProjectPanel) {
+                drawProjectPanel(g2, padding, padding, projectWidth, height - padding * 2)
             }
-            drawCodePreview(g2)
+            val editorX = padding + projectWidth + if (showProjectPanel) gap else 0
+            val editorWidth = (width - editorX - padding).coerceAtLeast(1)
+            drawEditorPanel(g2, editorX, padding, editorWidth, height - padding * 2)
+            if (fontInstalled) {
+                drawCodePreview(g2, editorX + JBUI.scale(GUTTER_WIDTH), padding)
+            } else {
+                drawFallbackMessage(g2, editorX, padding, editorWidth, height - padding * 2)
+            }
         } finally {
             g2.dispose()
         }
     }
 
-    private fun drawFallbackMessage(g2: Graphics2D) {
+    private fun drawNestedSurface(
+        g2: Graphics2D,
+        bounds: Rectangle,
+        fill: Color,
+    ) {
+        val arc = JBUI.scale(INNER_ARC)
+        val shadowOffset = JBUI.scale(SHADOW_OFFSET)
+        g2.color = shadowColor()
+        g2.fillRoundRect(bounds.x + shadowOffset, bounds.y + shadowOffset, bounds.width, bounds.height, arc, arc)
+        g2.color = fill
+        g2.fillRoundRect(bounds.x, bounds.y, bounds.width, bounds.height, arc, arc)
+        g2.color = nestedBorder()
+        g2.drawRoundRect(bounds.x, bounds.y, bounds.width - 1, bounds.height - 1, arc, arc)
+        g2.color = nestedHighlight()
+        g2.drawLine(
+            bounds.x + JBUI.scale(HIGHLIGHT_INSET),
+            bounds.y + 1,
+            bounds.x + bounds.width - JBUI.scale(HIGHLIGHT_INSET),
+            bounds.y + 1,
+        )
+    }
+
+    private fun drawProjectPanel(
+        g2: Graphics2D,
+        x: Int,
+        y: Int,
+        width: Int,
+        height: Int,
+    ) {
+        drawNestedSurface(g2, Rectangle(x, y, width, height), panelSurface())
+
+        g2.font = JBUI.Fonts.smallFont()
+        val rowHeight = JBUI.scale(PROJECT_ROW_HEIGHT)
+        var rowY = y + JBUI.scale(PROJECT_TOP_PADDING)
+        for (row in PROJECT_ROWS) {
+            val baseline = rowY + (rowHeight - g2.fontMetrics.height) / 2 + g2.fontMetrics.ascent
+            g2.color = row.color
+            g2.fillRect(
+                x + JBUI.scale(FILE_DOT_X),
+                rowY + JBUI.scale(FILE_DOT_Y),
+                JBUI.scale(FILE_DOT),
+                JBUI.scale(FILE_DOT),
+            )
+            g2.drawString(row.text, x + JBUI.scale(FILE_TEXT_X), baseline)
+            rowY += rowHeight
+        }
+    }
+
+    private fun drawEditorPanel(
+        g2: Graphics2D,
+        x: Int,
+        y: Int,
+        width: Int,
+        height: Int,
+    ) {
+        drawNestedSurface(g2, Rectangle(x, y, width, height), editorSurface())
+
+        val gutterWidth = JBUI.scale(GUTTER_WIDTH)
+        g2.color = panelSurface()
+        g2.fillRect(x + 1, y + 1, gutterWidth - 1, height - 2)
+
+        g2.font = JBUI.Fonts.smallFont()
+        val smallMetrics = g2.fontMetrics
+        val lineHeight = JBUI.scale(CODE_ROW_HEIGHT)
+        var rowY = y + JBUI.scale(CODE_TOP_PADDING)
+        for (lineNumber in CODE_FIRST_LINE until CODE_FIRST_LINE + SAMPLE_LINES.size) {
+            val baseline = rowY + (lineHeight - smallMetrics.height) / 2 + smallMetrics.ascent
+            g2.color = mutedText()
+            g2.drawString("$lineNumber", x + JBUI.scale(LINE_NUMBER_X), baseline)
+            rowY += lineHeight
+        }
+    }
+
+    private fun drawFallbackMessage(
+        g2: Graphics2D,
+        x: Int,
+        y: Int,
+        width: Int,
+        height: Int,
+    ) {
         val disabledFg =
             UIManager.getColor("Label.disabledForeground")
                 ?: JBColor.GRAY
@@ -118,12 +212,16 @@ class FontPreviewComponent : JComponent() {
         val metrics = g2.fontMetrics
         g2.drawString(
             message,
-            (width - metrics.stringWidth(message)) / 2,
-            height / 2 + metrics.ascent / 2,
+            x + (width - metrics.stringWidth(message)) / 2,
+            y + height / 2 + metrics.ascent / 2,
         )
     }
 
-    private fun drawCodePreview(g2: Graphics2D) {
+    private fun drawCodePreview(
+        g2: Graphics2D,
+        x: Int,
+        y: Int,
+    ) {
         val attributes =
             mutableMapOf<TextAttribute, Any>(
                 TextAttribute.FAMILY to resolvedFontFamily,
@@ -133,31 +231,114 @@ class FontPreviewComponent : JComponent() {
         if (enableLigatures) {
             attributes[TextAttribute.LIGATURES] = TextAttribute.LIGATURES_ON
         }
+        val codeWidth = (width - x - JBUI.scale(PADDING)).coerceAtLeast(1)
+        val previousClip = g2.clip
+        g2.clipRect(x, y, codeWidth, height - y - JBUI.scale(PADDING))
         g2.font = Font(attributes)
-        g2.color = UIManager.getColor("Label.foreground") ?: JBColor.WHITE
         val metrics = g2.fontMetrics
-        val lineHeight = (metrics.height * lineSpacing).toInt()
-        var y = JBUI.scale(PADDING_TOP) + metrics.ascent
-        for (line in SAMPLE_LINES) {
-            g2.drawString(line, JBUI.scale(PADDING_LEFT), y)
-            y += lineHeight
+        val lineHeight = (JBUI.scale(CODE_ROW_HEIGHT) * lineSpacing).toInt().coerceAtLeast(1)
+        var rowY = y + JBUI.scale(CODE_TOP_PADDING)
+        for ((index, line) in SAMPLE_LINES.withIndex()) {
+            if (index in HIGHLIGHT_ROWS) {
+                g2.color = highlightColor(index)
+                g2.fillRect(x, rowY, codeWidth, lineHeight)
+            }
+            val baseline = rowY + (lineHeight - metrics.height) / 2 + metrics.ascent
+            g2.color = codeTextColor(index)
+            g2.drawString(line, x + JBUI.scale(CODE_LEFT_PADDING), baseline)
+            rowY += lineHeight
         }
+        g2.clip = previousClip
     }
 
+    private fun surface(): Color = JBColor(FALLBACK_SURFACE_COLOR, FALLBACK_SURFACE_COLOR)
+
+    private fun panelSurface(): Color = JBColor(FALLBACK_PANEL_COLOR, FALLBACK_PANEL_COLOR)
+
+    private fun editorSurface(): Color = JBColor(FALLBACK_EDITOR_COLOR, FALLBACK_EDITOR_COLOR)
+
+    private fun shadowColor(): Color = JBColor(SHADOW_COLOR, SHADOW_COLOR)
+
+    private fun nestedBorder(): Color = JBColor(NESTED_BORDER_COLOR, NESTED_BORDER_COLOR)
+
+    private fun nestedHighlight(): Color = JBColor(NESTED_HIGHLIGHT_COLOR, NESTED_HIGHLIGHT_COLOR)
+
+    private fun mutedText(): Color =
+        UIManager.getColor("Label.disabledForeground")
+            ?: JBColor.GRAY
+
+    private fun codeTextColor(index: Int): Color =
+        when (index) {
+            ADDED_LINE_INDEX -> JBColor(ADDED_TEXT_COLOR, ADDED_TEXT_COLOR)
+            RETURN_LINE_INDEX -> JBColor(RETURN_TEXT_COLOR, RETURN_TEXT_COLOR)
+            else -> UIManager.getColor("Label.foreground") ?: JBColor.WHITE
+        }
+
+    private fun highlightColor(index: Int): Color =
+        when (index) {
+            ADDED_LINE_INDEX -> JBColor(ADDED_HIGHLIGHT_COLOR, ADDED_HIGHLIGHT_COLOR)
+            RETURN_LINE_INDEX -> JBColor(RETURN_HIGHLIGHT_COLOR, RETURN_HIGHLIGHT_COLOR)
+            else -> panelSurface()
+        }
+
     private companion object {
-        const val PANEL_WIDTH = 440
-        const val MAX_HEIGHT = 200
-        const val PADDING_TOP = 12
-        const val PADDING_BOTTOM = 12
-        const val PADDING_LEFT = 16
-        const val ARC = 10
+        const val PANEL_WIDTH = 760
+        const val MIN_PANEL_WIDTH = 360
+        const val PANEL_HEIGHT = 136
+        const val SPLIT_MIN_WIDTH = 430
+        const val PROJECT_WIDTH_DIVISOR = 5
+        const val PROJECT_MIN_WIDTH = 120
+        const val PROJECT_MAX_WIDTH = 170
+        const val PADDING = 8
+        const val COLUMN_GAP = 8
+        const val ARC = 8
+        const val INNER_ARC = 6
+        const val PROJECT_ROW_HEIGHT = 22
+        const val PROJECT_TOP_PADDING = 12
+        const val FILE_DOT_X = 14
+        const val FILE_DOT_Y = 9
+        const val FILE_DOT = 6
+        const val FILE_TEXT_X = 28
+        const val GUTTER_WIDTH = 42
+        const val LINE_NUMBER_X = 12
+        const val CODE_FIRST_LINE = 12
+        const val CODE_ROW_HEIGHT = 22
+        const val CODE_TOP_PADDING = 8
+        const val CODE_LEFT_PADDING = 14
+        const val SHADOW_OFFSET = 2
+        const val HIGHLIGHT_INSET = 6
+        const val ADDED_LINE_INDEX = 1
+        const val RETURN_LINE_INDEX = 3
+        const val FALLBACK_SURFACE_COLOR = 0x1F2430
+        const val FALLBACK_PANEL_COLOR = 0x252B38
+        const val FALLBACK_EDITOR_COLOR = 0x171C28
+        const val SHADOW_COLOR = 0x10141C
+        const val NESTED_BORDER_COLOR = 0x31394A
+        const val NESTED_HIGHLIGHT_COLOR = 0x3A4354
+        const val ADDED_TEXT_COLOR = 0xC3E88D
+        const val RETURN_TEXT_COLOR = 0xFF757F
+        const val ADDED_HIGHLIGHT_COLOR = 0x253E27
+        const val RETURN_HIGHLIGHT_COLOR = 0x4A2637
+        val HIGHLIGHT_ROWS = setOf(ADDED_LINE_INDEX, RETURN_LINE_INDEX)
+        val PROJECT_ROWS =
+            listOf(
+                ProjectRow("PresetPreview.kt", JBColor(0x73D0FF, 0x73D0FF)),
+                ProjectRow("FontTokens.xml", JBColor(0xBAE67E, 0xBAE67E)),
+                ProjectRow("editor.icls", JBColor(0xFFAD66, 0xFFAD66)),
+                ProjectRow("build/", JBColor(0xFFCC66, 0xFFCC66)),
+            )
         val SAMPLE_LINES =
             listOf(
-                "fun processItems(items: List<Item>): Result {",
-                "  val filtered = items.filter { it.isValid }",
-                "    .map { item -> transform(item) }",
-                "  return Result(filtered.size, filtered)",
+                "fun renderPreset(font: EditorFont): Preview {",
+                "  val selected = font.family != fallback",
+                "  val glyphs = sample.map { char -> shape(char) }",
+                "  return Preview(glyphs, selected && font.ligatures)",
                 "}",
             )
+
+        data class ProjectRow(
+            val text: String,
+            val color: Color,
+        )
     }
 }

--- a/src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
@@ -33,6 +33,7 @@ class PluginsPanel : AyuIslandsSettingsPanel {
     private var alphaSlider: JSlider? = null
     private var alphaValueLabel: JLabel? = null
     private var presetSegmented: SegmentedButton<IndentPreset>? = null
+    private val irEnabled = AtomicBooleanProperty(false)
     private val customModeVisible = AtomicBooleanProperty(false)
     private var suppressListeners = false
 
@@ -54,7 +55,7 @@ class PluginsPanel : AyuIslandsSettingsPanel {
 
         loadStored(state)
         customModeVisible.set(isCustomIndentControlsVisible(licensed))
-        val irEnabled = AtomicBooleanProperty(pendingEnabled || !licensed)
+        irEnabled.set(pendingEnabled || !licensed)
 
         val cgpDetected = ConflictRegistry.isCodeGlanceProDetected()
         val irDetected = ConflictRegistry.isIndentRainbowDetected()
@@ -266,7 +267,9 @@ class PluginsPanel : AyuIslandsSettingsPanel {
         presetSegmented?.selectedItem = IndentPreset.fromName(storedPreset)
         alphaSlider?.value = storedCustomAlpha
         alphaValueLabel?.text = "$storedCustomAlpha"
-        customModeVisible.set(isCustomIndentControlsVisible(LicenseChecker.isLicensedOrGrace()))
+        val licensed = LicenseChecker.isLicensedOrGrace()
+        irEnabled.set(pendingEnabled || !licensed)
+        customModeVisible.set(isCustomIndentControlsVisible(licensed))
         suppressListeners = false
     }
 

--- a/src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
@@ -52,6 +52,31 @@ class PluginsPanel : AyuIslandsSettingsPanel {
             )
         val licensed = gate.isUnlocked
 
+        loadStored(state)
+        customModeVisible.set(isCustomIndentControlsVisible(licensed))
+        val irEnabled = AtomicBooleanProperty(pendingEnabled || !licensed)
+
+        val cgpDetected = ConflictRegistry.isCodeGlanceProDetected()
+        val irDetected = ConflictRegistry.isIndentRainbowDetected()
+
+        if (!cgpDetected && !irDetected) {
+            panel.buildNoSupportedPluginsMessage()
+            return
+        }
+
+        panel.row { comment("Sync Ayu accent colors with compatible plugins.") }
+        panel.premiumFeatureNotice(gate)
+
+        if (cgpDetected) {
+            panel.buildCodeGlanceProGroup(licensed)
+        }
+
+        if (irDetected) {
+            panel.buildIndentRainbowGroup(licensed, irEnabled)
+        }
+    }
+
+    private fun loadStored(state: AyuIslandsState) {
         storedCodeGlanceProIntegration = state.cgpIntegrationEnabled
         pendingCodeGlanceProIntegration = storedCodeGlanceProIntegration
         storedEnabled = state.irIntegrationEnabled
@@ -62,123 +87,138 @@ class PluginsPanel : AyuIslandsSettingsPanel {
         pendingPreset = storedPreset
         storedCustomAlpha = state.indentCustomAlpha
         pendingCustomAlpha = storedCustomAlpha
+    }
 
-        customModeVisible.set(
-            IndentPreset.fromName(pendingPreset) == IndentPreset.CUSTOM,
-        )
+    private fun isCustomIndentControlsVisible(licensed: Boolean): Boolean =
+        IndentPreset.fromName(pendingPreset) == IndentPreset.CUSTOM || !licensed
 
-        val irEnabled = AtomicBooleanProperty(pendingEnabled)
-
-        val cgpDetected = ConflictRegistry.isCodeGlanceProDetected()
-        val irDetected = ConflictRegistry.isIndentRainbowDetected()
-
-        if (!cgpDetected && !irDetected) {
-            panel.group("Plugins") {
-                row {
-                    comment(
-                        "No supported plugins detected." +
-                            " Install CodeGlance Pro or Indent Rainbow for accent color sync.",
-                    )
-                }
-            }
-            return
-        }
-
-        panel.row { comment("Sync Ayu accent colors with compatible plugins.") }
-        panel.premiumFeatureNotice(gate)
-
-        if (cgpDetected) {
-            panel.group("CodeGlance Pro") {
-                row {
-                    val cb =
-                        checkBox("Sync color with CodeGlance")
-                            .comment("Apply accent color to CodeGlance Pro viewport")
-                    cb.component.isSelected = pendingCodeGlanceProIntegration
-                    cb.component.isEnabled = licensed
-                    cb.component.addActionListener {
-                        if (!licensed) return@addActionListener
-                        pendingCodeGlanceProIntegration = cb.component.isSelected
-                    }
-                    cgpCheckbox = cb.component
-
-                    browserLink("Plugin page", "https://plugins.jetbrains.com/plugin/18824-codeglance-pro")
-                }
+    private fun Panel.buildNoSupportedPluginsMessage() {
+        group("Plugins") {
+            row {
+                comment(
+                    "No supported plugins detected." +
+                        " Install CodeGlance Pro or Indent Rainbow for accent color sync.",
+                )
             }
         }
+    }
 
-        if (irDetected) {
-            panel.group("Indent Rainbow") {
-                row {
-                    val cb =
-                        checkBox("Sync colors with Indent Rainbow")
-                            .comment("Apply Ayu color palette to Indent Rainbow indentation guides")
-                    cb.component.isSelected = pendingEnabled
-                    cb.component.isEnabled = licensed
-                    cb.component.addActionListener {
-                        if (!licensed) return@addActionListener
-                        pendingEnabled = cb.component.isSelected
-                        irEnabled.set(cb.component.isSelected)
-                    }
-                    enabledCheckbox = cb.component
-
-                    browserLink(
-                        "Plugin page",
-                        "https://plugins.jetbrains.com/plugin/13308-indent-rainbow",
-                    )
+    private fun Panel.buildCodeGlanceProGroup(licensed: Boolean) {
+        group("CodeGlance Pro") {
+            row {
+                val checkboxCell =
+                    checkBox("Sync color with CodeGlance")
+                        .comment("Apply accent color to CodeGlance Pro viewport")
+                checkboxCell.component.isSelected = pendingCodeGlanceProIntegration
+                checkboxCell.component.isEnabled = licensed
+                checkboxCell.component.addActionListener {
+                    if (!licensed) return@addActionListener
+                    pendingCodeGlanceProIntegration = checkboxCell.component.isSelected
                 }
+                cgpCheckbox = checkboxCell.component
 
-                row {
-                    label("Preset")
-                    val segmented =
-                        segmentedButton(IndentPreset.entries) { preset ->
-                            text = preset.displayName
-                        }
-                    segmented.maxButtonsCount(IndentPreset.entries.size)
-                    segmented.selectedItem = IndentPreset.fromName(pendingPreset)
-                    segmented.enabled(licensed)
-                    @Suppress("UnstableApiUsage")
-                    segmented.whenItemSelected { preset ->
-                        if (!suppressListeners && licensed) {
-                            pendingPreset = preset.name
-                            customModeVisible.set(preset == IndentPreset.CUSTOM)
-                        }
-                    }
-                    presetSegmented = segmented
-                }.visibleIf(irEnabled)
-
-                row {
-                    val cb =
-                        checkBox("Highlight indent errors")
-                            .comment("When off, lines with irregular indentation blend into the color gradient")
-                    cb.component.isSelected = pendingErrorHighlight
-                    cb.component.isEnabled = licensed
-                    cb.component.addActionListener {
-                        if (!licensed) return@addActionListener
-                        pendingErrorHighlight = cb.component.isSelected
-                    }
-                    errorHighlightCheckbox = cb.component
-                }.visibleIf(irEnabled)
-
-                row {
-                    label("Alpha")
-                    val slider = JSlider(MIN_ALPHA, MAX_ALPHA, pendingCustomAlpha)
-                    slider.paintTicks = true
-                    slider.majorTickSpacing = ALPHA_MAJOR_TICK
-                    slider.isEnabled = licensed
-                    val valueLabel = JLabel("${slider.value}")
-                    slider.addChangeListener {
-                        if (!suppressListeners && licensed) {
-                            pendingCustomAlpha = slider.value
-                            valueLabel.text = "${slider.value}"
-                        }
-                    }
-                    alphaSlider = slider
-                    alphaValueLabel = valueLabel
-                    cell(slider).resizableColumn().align(Align.FILL)
-                    cell(valueLabel)
-                }.visibleIf(customModeVisible)
+                browserLink("Plugin page", "https://plugins.jetbrains.com/plugin/18824-codeglance-pro")
             }
         }
+    }
+
+    private fun Panel.buildIndentRainbowGroup(
+        licensed: Boolean,
+        irEnabled: AtomicBooleanProperty,
+    ) {
+        group("Indent Rainbow") {
+            buildIndentRainbowEnableRow(licensed, irEnabled)
+            buildIndentRainbowPresetRow(licensed, irEnabled)
+            buildIndentRainbowErrorRow(licensed, irEnabled)
+            buildIndentRainbowAlphaRow(licensed)
+        }
+    }
+
+    private fun Panel.buildIndentRainbowEnableRow(
+        licensed: Boolean,
+        irEnabled: AtomicBooleanProperty,
+    ) {
+        row {
+            val checkboxCell =
+                checkBox("Sync colors with Indent Rainbow")
+                    .comment("Apply Ayu color palette to Indent Rainbow indentation guides")
+            checkboxCell.component.isSelected = pendingEnabled
+            checkboxCell.component.isEnabled = licensed
+            checkboxCell.component.addActionListener {
+                if (!licensed) return@addActionListener
+                pendingEnabled = checkboxCell.component.isSelected
+                irEnabled.set(checkboxCell.component.isSelected)
+            }
+            enabledCheckbox = checkboxCell.component
+
+            browserLink(
+                "Plugin page",
+                "https://plugins.jetbrains.com/plugin/13308-indent-rainbow",
+            )
+        }
+    }
+
+    private fun Panel.buildIndentRainbowPresetRow(
+        licensed: Boolean,
+        irEnabled: AtomicBooleanProperty,
+    ) {
+        row {
+            label("Preset")
+            val segmented =
+                segmentedButton(IndentPreset.entries) { preset ->
+                    text = preset.displayName
+                }
+            segmented.maxButtonsCount(IndentPreset.entries.size)
+            segmented.selectedItem = IndentPreset.fromName(pendingPreset)
+            segmented.enabled(licensed)
+            @Suppress("UnstableApiUsage")
+            segmented.whenItemSelected { preset ->
+                if (!suppressListeners && licensed) {
+                    pendingPreset = preset.name
+                    customModeVisible.set(preset == IndentPreset.CUSTOM)
+                }
+            }
+            presetSegmented = segmented
+        }.visibleIf(irEnabled)
+    }
+
+    private fun Panel.buildIndentRainbowErrorRow(
+        licensed: Boolean,
+        irEnabled: AtomicBooleanProperty,
+    ) {
+        row {
+            val checkboxCell =
+                checkBox("Highlight indent errors")
+                    .comment("When off, lines with irregular indentation blend into the color gradient")
+            checkboxCell.component.isSelected = pendingErrorHighlight
+            checkboxCell.component.isEnabled = licensed
+            checkboxCell.component.addActionListener {
+                if (!licensed) return@addActionListener
+                pendingErrorHighlight = checkboxCell.component.isSelected
+            }
+            errorHighlightCheckbox = checkboxCell.component
+        }.visibleIf(irEnabled)
+    }
+
+    private fun Panel.buildIndentRainbowAlphaRow(licensed: Boolean) {
+        row {
+            label("Alpha")
+            val slider = JSlider(MIN_ALPHA, MAX_ALPHA, pendingCustomAlpha)
+            slider.paintTicks = true
+            slider.majorTickSpacing = ALPHA_MAJOR_TICK
+            slider.isEnabled = licensed
+            val valueLabel = JLabel("${slider.value}")
+            slider.addChangeListener {
+                if (!suppressListeners && licensed) {
+                    pendingCustomAlpha = slider.value
+                    valueLabel.text = "${slider.value}"
+                }
+            }
+            alphaSlider = slider
+            alphaValueLabel = valueLabel
+            cell(slider).resizableColumn().align(Align.FILL)
+            cell(valueLabel)
+        }.visibleIf(customModeVisible)
     }
 
     override fun isModified(): Boolean =
@@ -226,9 +266,7 @@ class PluginsPanel : AyuIslandsSettingsPanel {
         presetSegmented?.selectedItem = IndentPreset.fromName(storedPreset)
         alphaSlider?.value = storedCustomAlpha
         alphaValueLabel?.text = "$storedCustomAlpha"
-        customModeVisible.set(
-            IndentPreset.fromName(pendingPreset) == IndentPreset.CUSTOM,
-        )
+        customModeVisible.set(isCustomIndentControlsVisible(LicenseChecker.isLicensedOrGrace()))
         suppressListeners = false
     }
 

--- a/src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
@@ -42,7 +42,15 @@ class PluginsPanel : AyuIslandsSettingsPanel {
     ) {
         this.variant = variant
         val state = AyuIslandsSettings.getInstance().state
-        val licensed = LicenseChecker.isLicensedOrGrace()
+        val gate =
+            PremiumFeatureGate(
+                featureName = "Plugin integrations",
+                lockedDescription =
+                    "Plugin integrations are a Pro feature. " +
+                        "Preview CodeGlance Pro and Indent Rainbow sync controls here.",
+                requestMessage = "Unlock plugin integrations",
+            )
+        val licensed = gate.isUnlocked
 
         storedCodeGlanceProIntegration = state.cgpIntegrationEnabled
         pendingCodeGlanceProIntegration = storedCodeGlanceProIntegration
@@ -77,6 +85,7 @@ class PluginsPanel : AyuIslandsSettingsPanel {
         }
 
         panel.row { comment("Sync Ayu accent colors with compatible plugins.") }
+        panel.premiumFeatureNotice(gate)
 
         if (cgpDetected) {
             panel.group("CodeGlance Pro") {
@@ -87,6 +96,7 @@ class PluginsPanel : AyuIslandsSettingsPanel {
                     cb.component.isSelected = pendingCodeGlanceProIntegration
                     cb.component.isEnabled = licensed
                     cb.component.addActionListener {
+                        if (!licensed) return@addActionListener
                         pendingCodeGlanceProIntegration = cb.component.isSelected
                     }
                     cgpCheckbox = cb.component
@@ -105,6 +115,7 @@ class PluginsPanel : AyuIslandsSettingsPanel {
                     cb.component.isSelected = pendingEnabled
                     cb.component.isEnabled = licensed
                     cb.component.addActionListener {
+                        if (!licensed) return@addActionListener
                         pendingEnabled = cb.component.isSelected
                         irEnabled.set(cb.component.isSelected)
                     }
@@ -124,9 +135,10 @@ class PluginsPanel : AyuIslandsSettingsPanel {
                         }
                     segmented.maxButtonsCount(IndentPreset.entries.size)
                     segmented.selectedItem = IndentPreset.fromName(pendingPreset)
+                    segmented.enabled(licensed)
                     @Suppress("UnstableApiUsage")
                     segmented.whenItemSelected { preset ->
-                        if (!suppressListeners) {
+                        if (!suppressListeners && licensed) {
                             pendingPreset = preset.name
                             customModeVisible.set(preset == IndentPreset.CUSTOM)
                         }
@@ -141,6 +153,7 @@ class PluginsPanel : AyuIslandsSettingsPanel {
                     cb.component.isSelected = pendingErrorHighlight
                     cb.component.isEnabled = licensed
                     cb.component.addActionListener {
+                        if (!licensed) return@addActionListener
                         pendingErrorHighlight = cb.component.isSelected
                     }
                     errorHighlightCheckbox = cb.component
@@ -154,7 +167,7 @@ class PluginsPanel : AyuIslandsSettingsPanel {
                     slider.isEnabled = licensed
                     val valueLabel = JLabel("${slider.value}")
                     slider.addChangeListener {
-                        if (!suppressListeners) {
+                        if (!suppressListeners && licensed) {
                             pendingCustomAlpha = slider.value
                             valueLabel.text = "${slider.value}"
                         }
@@ -177,6 +190,7 @@ class PluginsPanel : AyuIslandsSettingsPanel {
 
     override fun apply() {
         if (!isModified()) return
+        if (!LicenseChecker.isLicensedOrGrace()) return
         val state = AyuIslandsSettings.getInstance().state
 
         state.irIntegrationEnabled = pendingEnabled

--- a/src/main/kotlin/dev/ayuislands/settings/PremiumFeatureGate.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/PremiumFeatureGate.kt
@@ -1,0 +1,35 @@
+package dev.ayuislands.settings
+
+import com.intellij.ui.dsl.builder.Panel
+import dev.ayuislands.licensing.LicenseChecker
+import javax.swing.JComponent
+
+internal data class PremiumFeatureGate(
+    val featureName: String,
+    val lockedDescription: String,
+    val requestMessage: String,
+    val isUnlocked: Boolean = LicenseChecker.isLicensedOrGrace(),
+) {
+    val tooltip: String = "$featureName requires Ayu Islands Pro"
+
+    fun requestUnlock() {
+        LicenseChecker.requestLicense(requestMessage)
+    }
+}
+
+internal fun Panel.premiumFeatureNotice(gate: PremiumFeatureGate) {
+    if (gate.isUnlocked) return
+    row { comment(gate.lockedDescription) }
+    row {
+        link("Unlock Pro") { gate.requestUnlock() }
+    }
+}
+
+internal fun <T : JComponent> T.applyPremiumLock(
+    gate: PremiumFeatureGate,
+    enabledWhenUnlocked: Boolean = true,
+): T {
+    isEnabled = gate.isUnlocked && enabledWhenUnlocked
+    toolTipText = if (gate.isUnlocked) null else gate.tooltip
+    return this
+}

--- a/src/main/kotlin/dev/ayuislands/settings/PremiumFeatureGate.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/PremiumFeatureGate.kt
@@ -1,6 +1,10 @@
 package dev.ayuislands.settings
 
+import com.intellij.openapi.observable.properties.AtomicBooleanProperty
+import com.intellij.ui.dsl.builder.Cell
+import com.intellij.ui.dsl.builder.CollapsibleRow
 import com.intellij.ui.dsl.builder.Panel
+import com.intellij.ui.dsl.builder.Row
 import dev.ayuislands.licensing.LicenseChecker
 import javax.swing.JComponent
 
@@ -33,3 +37,33 @@ internal fun <T : JComponent> T.applyPremiumLock(
     toolTipText = if (gate.isUnlocked) null else gate.tooltip
     return this
 }
+
+internal fun Row.visibleIfUnlockedOrPreview(
+    condition: AtomicBooleanProperty,
+    gate: PremiumFeatureGate,
+): Row =
+    if (gate.isUnlocked) {
+        visibleIf(condition)
+    } else {
+        visible(true)
+    }
+
+internal fun <T : JComponent> Cell<T>.visibleIfUnlockedOrPreview(
+    condition: AtomicBooleanProperty,
+    gate: PremiumFeatureGate,
+): Cell<T> =
+    if (gate.isUnlocked) {
+        visibleIf(condition)
+    } else {
+        visible(true)
+    }
+
+internal fun CollapsibleRow.visibleIfUnlockedOrPreview(
+    condition: AtomicBooleanProperty,
+    gate: PremiumFeatureGate,
+): Row =
+    if (gate.isUnlocked) {
+        visibleIf(condition)
+    } else {
+        visible(true)
+    }

--- a/src/main/kotlin/dev/ayuislands/settings/PremiumFeatureGate.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/PremiumFeatureGate.kt
@@ -48,6 +48,11 @@ internal fun Row.visibleIfUnlockedOrPreview(
         visible(true)
     }
 
+internal fun Row.visibleWhenUnlockedOrPreview(
+    visibleWhenUnlocked: Boolean,
+    gate: PremiumFeatureGate,
+): Row = visible(visibleWhenUnlocked || !gate.isUnlocked)
+
 internal fun <T : JComponent> Cell<T>.visibleIfUnlockedOrPreview(
     condition: AtomicBooleanProperty,
     gate: PremiumFeatureGate,

--- a/src/main/kotlin/dev/ayuislands/settings/VcsColorPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/VcsColorPanel.kt
@@ -30,9 +30,9 @@ import javax.swing.JSlider
  * Mirrors the [AyuIslandsChromePanel] discipline:
  *  - Pending / stored pairs per field so [isModified] can diff without
  *    touching the live [AyuIslandsState] until [apply] is called.
- *  - Premium gate: unlicensed users see a placeholder comment + Pro upgrade
- *    link instead of the full content — no controls bound, no way to mutate
- *    VCS state without a license.
+ *  - Premium gate: unlicensed users see the full settings surface and preview,
+ *    but controls are locked. Runtime apply still re-checks the license so a
+ *    mid-session entitlement change cannot persist premium state.
  *  - On [apply] the panel wraps the applier call in
  *    [VcsColorContext.withSnapshot] so a throw leaves persisted state
  *    untouched and the user can retry.
@@ -102,31 +102,27 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
     ) {
         this.variant = variant
         licensed = LicenseChecker.isLicensedOrGrace()
+        val gate =
+            PremiumFeatureGate(
+                featureName = "VCS color customization",
+                lockedDescription =
+                    "VCS color customization is a Pro feature. " +
+                        "Preview the available diff, file-status, gutter, conflict, and blame controls here.",
+                requestMessage = "Unlock VCS color intensity customization",
+                isUnlocked = licensed,
+            )
         val state = AyuIslandsSettings.getInstance().state
         loadStored(state)
-        if (!licensed) {
-            panel.buildUnlicensedContent()
-            return
-        }
-        panel.buildLicensedContent(state)
+        masterEnabled.set(pendingEnabled || !gate.isUnlocked)
+        panel.buildContent(state, gate)
     }
 
-    private fun Panel.buildUnlicensedContent() {
-        row {
-            comment(
-                "VCS color customization is a Pro feature. " +
-                    "Free version uses the default colors shipped with v2.6.2.",
-            )
-        }
-        row {
-            link("Get Ayu Islands Pro — unlock VCS color customization") {
-                LicenseChecker.requestLicense("Unlock VCS color intensity customization")
-            }
-        }
-    }
-
-    private fun Panel.buildLicensedContent(state: AyuIslandsState) {
-        buildMasterToggleRow()
+    private fun Panel.buildContent(
+        state: AyuIslandsState,
+        gate: PremiumFeatureGate,
+    ) {
+        premiumFeatureNotice(gate)
+        buildMasterToggleRow(gate)
         row {
             val preview = VcsColorPreviewComponent(variant ?: AyuVariant.DARK, previewIntensities())
             vcsPreview = preview
@@ -134,16 +130,18 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
                 .resizableColumn()
                 .align(Align.FILL)
         }.visibleIf(masterEnabled)
-        buildSection(VcsSection.DIFF, state)
-        buildSection(VcsSection.MERGE, state)
-        buildSection(VcsSection.BLAME, state)
+        buildSection(VcsSection.DIFF, state, gate)
+        buildSection(VcsSection.MERGE, state, gate)
+        buildSection(VcsSection.BLAME, state, gate)
     }
 
-    private fun Panel.buildMasterToggleRow() {
+    private fun Panel.buildMasterToggleRow(gate: PremiumFeatureGate) {
         row {
             val cb = checkBox("Enable VCS color customization")
             cb.component.isSelected = pendingEnabled
+            cb.component.applyPremiumLock(gate)
             cb.component.addActionListener {
+                if (!gate.isUnlocked) return@addActionListener
                 pendingEnabled = cb.component.isSelected
                 masterEnabled.set(pendingEnabled)
             }
@@ -154,13 +152,14 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
     private fun Panel.buildSection(
         section: VcsSection,
         state: AyuIslandsState,
+        gate: PremiumFeatureGate,
     ) {
         val ctx = sectionContext(section)
         val collapsible =
             collapsibleGroup(section.title) {
-                buildSectionPresetRow(section, ctx)
+                buildSectionPresetRow(section, ctx, gate)
                 for ((category, label) in section.sliders) {
-                    buildSliderRow(category, label, ctx.customVisible)
+                    buildSliderRow(category, label, ctx.customVisible, gate)
                 }
             }
         collapsible.expanded =
@@ -203,12 +202,15 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
     private fun Panel.buildSectionPresetRow(
         section: VcsSection,
         ctx: SectionContext,
+        gate: PremiumFeatureGate,
     ) {
         row("Preset:") {
             val segmented = segmentedButton(VcsColorPreset.entries) { preset -> text = preset.displayName }
             segmented.maxButtonsCount(VcsColorPreset.entries.size)
             segmented.selectedItem = ctx.initialPreset
+            segmented.enabled(gate.isUnlocked)
             segmented.whenItemSelected { preset ->
+                if (!gate.isUnlocked) return@whenItemSelected
                 onSectionPresetChosen(section, preset)
                 ctx.customVisible.set(preset == VcsColorPreset.CUSTOM)
             }
@@ -220,6 +222,7 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
         category: VcsColorCategory,
         label: String,
         sectionCustomVisible: AtomicBooleanProperty,
+        gate: PremiumFeatureGate,
     ) {
         val initialValue =
             when (category) {
@@ -241,8 +244,13 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
                 slider.paintTicks = true
                 slider.majorTickSpacing = INTENSITY_MAJOR_TICK
                 slider.minorTickSpacing = INTENSITY_MINOR_TICK
+                slider.applyPremiumLock(gate)
                 val valueLabel = JLabel("$initialValue")
-                slider.addChangeListener { onSliderChanged(category, slider.value) }
+                slider.addChangeListener {
+                    if (gate.isUnlocked) {
+                        onSliderChanged(category, slider.value)
+                    }
+                }
                 cell(slider).resizableColumn().align(Align.FILL)
                 cell(valueLabel)
                 // Stash Swing refs for reset() refresh + test seams.

--- a/src/main/kotlin/dev/ayuislands/settings/VcsColorPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/VcsColorPanel.kt
@@ -463,7 +463,7 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
             diffPresetSegmented?.selectedItem = pendingDiffPreset
             mergePresetSegmented?.selectedItem = pendingMergePreset
             blamePresetSegmented?.selectedItem = pendingBlamePreset
-            masterEnabled.set(pendingEnabled)
+            masterEnabled.set(pendingEnabled || !licensed)
             diffCustomSelected.set(pendingDiffPreset == VcsColorPreset.CUSTOM)
             mergeCustomSelected.set(pendingMergePreset == VcsColorPreset.CUSTOM)
             blameCustomSelected.set(pendingBlamePreset == VcsColorPreset.CUSTOM)
@@ -502,7 +502,7 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
         pendingConflictMarkerIntensity = state.vcsConflictMarkerIntensity.coerceIn(MIN_INTENSITY, MAX_INTENSITY)
         storedBlameIntensity = state.vcsBlameIntensity
         pendingBlameIntensity = state.vcsBlameIntensity.coerceIn(MIN_INTENSITY, MAX_INTENSITY)
-        masterEnabled.set(pendingEnabled)
+        masterEnabled.set(pendingEnabled || !licensed)
         diffCustomSelected.set(pendingDiffPreset == VcsColorPreset.CUSTOM)
         mergeCustomSelected.set(pendingMergePreset == VcsColorPreset.CUSTOM)
         blameCustomSelected.set(pendingBlamePreset == VcsColorPreset.CUSTOM)

--- a/src/main/kotlin/dev/ayuislands/settings/VcsColorPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/VcsColorPanel.kt
@@ -278,7 +278,7 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
                     else -> Unit
                 }
             }
-        sliderRow.visibleIf(sectionCustomVisible)
+        sliderRow.visibleIfUnlockedOrPreview(sectionCustomVisible, gate)
     }
 
     private fun previewIntensities(): VcsPreviewIntensities =

--- a/src/main/kotlin/dev/ayuislands/settings/WorkspacePanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/WorkspacePanel.kt
@@ -157,7 +157,7 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
                     WidthModeGroupConfig(
                         projectWidth,
                         AutoFitCalculator.MIN_PROJECT_AUTOFIT_WIDTH,
-                        licensed,
+                        gate,
                         showMinSpinner = true,
                     ) {
                         updateGroupTitle(projectViewGroup, PROJECT_VIEW_TITLE, projectWidth.state)
@@ -175,7 +175,7 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
                     WidthModeGroupConfig(
                         commitWidth,
                         AutoFitCalculator.MIN_COMMIT_AUTOFIT_WIDTH,
-                        licensed,
+                        gate,
                         showMinSpinner = true,
                     ) {
                         updateGroupTitle(commitPanelGroup, COMMIT_PANEL_TITLE, commitWidth.state)
@@ -193,7 +193,7 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
                     WidthModeGroupConfig(
                         gitWidth,
                         AutoFitCalculator.MIN_GIT_AUTOFIT_WIDTH,
-                        licensed,
+                        gate,
                         showMinSpinner = true,
                     ) {
                         updateGroupTitle(gitPanelGroup, GIT_PANEL_TITLE, gitWidth.state)
@@ -231,10 +231,12 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
     private data class WidthModeGroupConfig(
         val uiState: WidthModeUiState,
         val minAutoFitWidth: Int,
-        val licensed: Boolean,
+        val gate: PremiumFeatureGate,
         val showMinSpinner: Boolean = false,
         val onModeChanged: () -> Unit = {},
-    )
+    ) {
+        val licensed: Boolean = gate.isUnlocked
+    }
 
     private fun createSpinner(
         value: Int,
@@ -344,14 +346,14 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
         panel.row {
             cell(comboBox)
             if (minSpinner != null) {
-                label("min").visibleIf(autoFitVisible)
-                cell(minSpinner).visibleIf(autoFitVisible)
+                label("min").visibleIfUnlockedOrPreview(autoFitVisible, config.gate)
+                cell(minSpinner).visibleIfUnlockedOrPreview(autoFitVisible, config.gate)
             }
-            label("max").visibleIf(autoFitVisible)
-            cell(autoFitSpinner).visibleIf(autoFitVisible)
-            label("px").visibleIf(autoFitVisible)
-            cell(fixedSpinner).visibleIf(fixedVisible)
-            label("px").visibleIf(fixedVisible)
+            label("max").visibleIfUnlockedOrPreview(autoFitVisible, config.gate)
+            cell(autoFitSpinner).visibleIfUnlockedOrPreview(autoFitVisible, config.gate)
+            label("px").visibleIfUnlockedOrPreview(autoFitVisible, config.gate)
+            cell(fixedSpinner).visibleIfUnlockedOrPreview(fixedVisible, config.gate)
+            label("px").visibleIfUnlockedOrPreview(fixedVisible, config.gate)
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/settings/WorkspacePanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/WorkspacePanel.kt
@@ -66,7 +66,15 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
         variant: AyuVariant,
     ) {
         val state = AyuIslandsSettings.getInstance().state
-        val licensed = LicenseChecker.isLicensedOrGrace()
+        val gate =
+            PremiumFeatureGate(
+                featureName = "Workspace customization",
+                lockedDescription =
+                    "Workspace customization is a Pro feature. " +
+                        "Preview tool window width and Project View display controls here.",
+                requestMessage = "Unlock workspace customization",
+            )
+        val licensed = gate.isUnlocked
 
         loadCheckboxPair(state.hideEditorVScrollbar) { s, p ->
             storedHideEditorVScrollbar = s
@@ -105,6 +113,7 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
         )
 
         panel.row { comment("Customize tool window width and Project View display options.") }
+        panel.premiumFeatureNotice(gate)
 
         editorGroup =
             panel.collapsibleGroup(EDITOR_TITLE) {
@@ -355,6 +364,7 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
 
     override fun apply() {
         if (!isModified()) return
+        if (!LicenseChecker.isLicensedOrGrace()) return
         val state = AyuIslandsSettings.getInstance().state
 
         val editorChanged =

--- a/src/main/kotlin/dev/ayuislands/settings/WorkspacePanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/WorkspacePanel.kt
@@ -239,11 +239,13 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
     private fun createSpinner(
         value: Int,
         min: Int,
+        enabled: Boolean,
         onChange: (Int) -> Unit,
     ): JSpinner =
         JSpinner(SpinnerNumberModel(value, min, MAX_AUTOFIT_WIDTH, AUTOFIT_WIDTH_STEP)).also { spinner ->
+            spinner.isEnabled = enabled
             spinner.addChangeListener {
-                if (!suppressListeners) onChange(spinner.value as Int)
+                if (!suppressListeners && spinner.isEnabled) onChange(spinner.value as Int)
             }
         }
 
@@ -295,7 +297,7 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
         fixedVisible.set(uiState.state.pendingMode == PanelWidthMode.FIXED)
 
         val autoFitSpinner =
-            createSpinner(uiState.state.pendingAutoFitMaxWidth, config.minAutoFitWidth) {
+            createSpinner(uiState.state.pendingAutoFitMaxWidth, config.minAutoFitWidth, config.licensed) {
                 uiState.state.pendingAutoFitMaxWidth = it
                 val currentMin = uiState.minSpinner
                 if (currentMin != null && it < uiState.state.pendingAutoFitMinWidth) {
@@ -308,7 +310,7 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
 
         val minSpinner =
             if (config.showMinSpinner) {
-                createSpinner(uiState.state.pendingAutoFitMinWidth, MIN_AUTOFIT_MIN_WIDTH) {
+                createSpinner(uiState.state.pendingAutoFitMinWidth, MIN_AUTOFIT_MIN_WIDTH, config.licensed) {
                     uiState.state.pendingAutoFitMinWidth = it
                     if (it > uiState.state.pendingAutoFitMaxWidth) {
                         uiState.state.pendingAutoFitMaxWidth = it
@@ -321,7 +323,7 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
             }
 
         val fixedSpinner =
-            createSpinner(uiState.state.pendingFixedWidth, AutoFitCalculator.MIN_FIXED_WIDTH) {
+            createSpinner(uiState.state.pendingFixedWidth, AutoFitCalculator.MIN_FIXED_WIDTH, config.licensed) {
                 uiState.state.pendingFixedWidth = it
                 config.onModeChanged()
             }
@@ -331,7 +333,7 @@ class WorkspacePanel : AyuIslandsSettingsPanel {
         uiState.modeComboBox = comboBox
 
         comboBox.addActionListener {
-            if (!suppressListeners) {
+            if (!suppressListeners && config.licensed) {
                 uiState.state.pendingMode = comboBox.selectedItem as PanelWidthMode
                 autoFitVisible.set(uiState.state.pendingMode == PanelWidthMode.AUTO_FIT)
                 fixedVisible.set(uiState.state.pendingMode == PanelWidthMode.FIXED)

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -878,10 +878,14 @@ class OverridesGroupBuilder {
                     updateHex = projectModel::updateHex,
                 )
             },
-            remove = { removeSelectedRow(projectTable, projectModel::remove) },
+            remove = {
+                if (licensed) {
+                    removeSelectedRow(projectTable, projectModel::remove)
+                }
+            },
             addEnabled = { licensed },
             editEnabled = { licensed && projectTable.selectedRow >= 0 },
-            removeEnabled = { projectTable.selectedRow >= 0 },
+            removeEnabled = { licensed && projectTable.selectedRow >= 0 },
             extraActions = extras,
         )
     }
@@ -898,10 +902,14 @@ class OverridesGroupBuilder {
                     updateHex = languageModel::updateHex,
                 )
             },
-            remove = { removeSelectedRow(languageTable, languageModel::remove) },
+            remove = {
+                if (licensed) {
+                    removeSelectedRow(languageTable, languageModel::remove)
+                }
+            },
             addEnabled = { licensed },
             editEnabled = { licensed && languageTable.selectedRow >= 0 },
-            removeEnabled = { languageTable.selectedRow >= 0 },
+            removeEnabled = { licensed && languageTable.selectedRow >= 0 },
             extraActions = emptyList(),
         )
 

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -26,6 +26,8 @@ import dev.ayuislands.accent.ProjectLanguageDetector
 import dev.ayuislands.accent.runCatchingPreservingCancellation
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.PremiumFeatureGate
+import dev.ayuislands.settings.premiumFeatureNotice
 import java.awt.BorderLayout
 import java.awt.CardLayout
 import java.awt.Color
@@ -206,6 +208,15 @@ class OverridesGroupBuilder {
         loadFromState()
 
         val licensed = LicenseChecker.isLicensedOrGrace()
+        val gate =
+            PremiumFeatureGate(
+                featureName = "Accent overrides",
+                lockedDescription =
+                    "Accent overrides are a Pro feature. " +
+                        "Preview project and language accent pins here.",
+                requestMessage = "Unlock accent overrides",
+                isUnlocked = licensed,
+            )
         // Capture the license snapshot up front so `renderProportionsInto`
         // reads one boolean + one nullable without bumping its cyclomatic
         // count. See `rescanLicensed` KDoc for why license and project
@@ -246,6 +257,7 @@ class OverridesGroupBuilder {
                             "Project overrides win over language overrides; both win over the global accent.",
                     )
                 }
+                premiumFeatureNotice(gate)
                 row {
                     cell(segmentedBar)
                 }
@@ -264,11 +276,6 @@ class OverridesGroupBuilder {
                     proportionsPanel = statusPanel
                     populateProportionsPanel(statusPanel)
                     cell(statusPanel)
-                }
-                if (!licensed) {
-                    row {
-                        comment("Pro feature")
-                    }
                 }
             }
         collapsible.expanded = settings.state.overridesGroupExpanded
@@ -329,6 +336,7 @@ class OverridesGroupBuilder {
     }
 
     fun apply() {
+        if (!LicenseChecker.isLicensedOrGrace()) return
         val state = AccentMappingsSettingsAccess.stateFor()
         state.projectAccents.clear()
         state.projectDisplayNames.clear()

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanelTest.kt
@@ -1,14 +1,28 @@
 package dev.ayuislands.settings
 
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.ex.ActionManagerEx
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.ui.DialogPanel
 import com.intellij.testFramework.LoggedErrorProcessor
+import com.intellij.ui.dsl.builder.panel
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.rotation.AccentRotationMode
+import dev.ayuislands.settings.mappings.AccentMappingsSettings
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkClass
 import io.mockk.mockkObject
+import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
+import java.awt.Component
+import java.awt.Container
+import javax.swing.JComboBox
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -37,11 +51,26 @@ import kotlin.test.Test
  * equivalent integration test.
  */
 class AyuIslandsAccentPanelTest {
+    private lateinit var state: AyuIslandsState
+    private lateinit var settings: AyuIslandsSettings
     private lateinit var swapService: ProjectAccentSwapService
 
     @BeforeTest
     fun setUp() {
+        state = AyuIslandsState()
+        settings = mockk(relaxed = true)
+        every { settings.state } returns state
+        every { settings.getAccentForVariant(any()) } answers {
+            firstArg<AyuVariant>().defaultAccent
+        }
+        mockkObject(AyuIslandsSettings.Companion)
+        every { AyuIslandsSettings.getInstance() } returns settings
+
+        mockkObject(LicenseChecker)
+        every { LicenseChecker.isLicensedOrGrace() } returns true
+
         mockkObject(AccentApplicator)
+        every { AccentApplicator.resolveFocusedProject() } returns null
         swapService = mockk(relaxed = true)
         mockkObject(ProjectAccentSwapService.Companion)
         every { ProjectAccentSwapService.getInstance() } returns swapService
@@ -280,5 +309,101 @@ class AyuIslandsAccentPanelTest {
             "Hook invocation order must be before → overrides → after so the visible " +
                 "render order (Accent → System → Overrides → Chrome Tinting → Rotation) is preserved",
         )
+    }
+
+    @Test
+    fun `unlicensed accent rotation keeps mode and interval controls visible`() {
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+        state.accentRotationEnabled = false
+        state.accentRotationMode = AccentRotationMode.PRESET.name
+        state.accentRotationIntervalHours = AyuIslandsState.DEFAULT_ROTATION_INTERVAL_HOURS
+        val accentPanel = AyuIslandsAccentPanel()
+
+        val dialogPanel = buildDialogPanel(accentPanel)
+        val comboBoxes = descendants(dialogPanel, JComboBox::class.java)
+        val modeCombo = comboBoxes.first { it.containsItem("Preset cycle") }
+        val intervalCombo = comboBoxes.first { it.containsItem("1 hour") }
+
+        kotlin.test.assertTrue(
+            modeCombo.isEffectivelyVisibleWithin(dialogPanel),
+            "Locked Accent Rotation preview must show the mode selector even when the toggle is off",
+        )
+        kotlin.test.assertFalse(
+            modeCombo.isEnabled,
+            "Locked Accent Rotation mode selector must be visible but not mutable",
+        )
+        kotlin.test.assertTrue(
+            intervalCombo.isEffectivelyVisibleWithin(dialogPanel),
+            "Locked Accent Rotation preview must show the interval selector even when the toggle is off",
+        )
+        kotlin.test.assertFalse(
+            intervalCombo.isEnabled,
+            "Locked Accent Rotation interval selector must be visible but not mutable",
+        )
+        kotlin.test.assertFalse(
+            accentPanel.isModified(),
+            "Rendering locked Accent Rotation controls must not dirty Settings",
+        )
+    }
+
+    private fun buildDialogPanel(accentPanel: AyuIslandsAccentPanel): DialogPanel {
+        wireUiDslServices()
+        return panel {
+            accentPanel.buildPanel(this, AyuVariant.MIRAGE)
+        }
+    }
+
+    private fun wireUiDslServices() {
+        mockkStatic(ApplicationManager::class)
+        val appMock = mockk<Application>(relaxed = true)
+        val actionManagerMock = mockk<ActionManagerEx>(relaxed = true)
+        val mappingsSettings = AccentMappingsSettings()
+        mockkStatic(ActionManager::class)
+        every { ActionManager.getInstance() } returns actionManagerMock
+        every { ApplicationManager.getApplication() } returns appMock
+        every { appMock.invokeLater(any()) } answers { firstArg<Runnable>().run() }
+        every { actionManagerMock.getAction(any()) } returns null
+
+        @Suppress("UNCHECKED_CAST")
+        val experimentalUiClass = Class.forName("com.intellij.ui.ExperimentalUI") as Class<Any>
+        val experimentalUiMock = mockkClass(experimentalUiClass.kotlin, relaxed = true)
+        every { appMock.getService(any<Class<*>>()) } answers {
+            when (val serviceClass = firstArg<Class<*>>()) {
+                ActionManager::class.java,
+                ActionManagerEx::class.java,
+                -> actionManagerMock
+                AccentMappingsSettings::class.java -> mappingsSettings
+                experimentalUiClass -> experimentalUiMock
+                else -> mockkClass(serviceClass.kotlin, relaxed = true)
+            }
+        }
+        every { appMock.getService(ActionManager::class.java) } returns actionManagerMock
+        every { appMock.getService(ActionManagerEx::class.java) } returns actionManagerMock
+        every { appMock.getServiceIfCreated(ActionManager::class.java) } returns actionManagerMock
+    }
+
+    private fun <T : Component> descendants(
+        container: Container,
+        type: Class<T>,
+    ): List<T> =
+        buildList {
+            fun visit(component: Component) {
+                if (type.isInstance(component)) add(type.cast(component))
+                if (component is Container) {
+                    component.components.forEach(::visit)
+                }
+            }
+            visit(container)
+        }
+
+    private fun JComboBox<*>.containsItem(item: String): Boolean = (0 until itemCount).any { getItemAt(it) == item }
+
+    private fun Component.isEffectivelyVisibleWithin(root: Component): Boolean {
+        var current: Component? = this
+        while (current != null && current !== root) {
+            if (!current.isVisible) return false
+            current = current.parent
+        }
+        return current === root && root.isVisible
     }
 }

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsChromePanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsChromePanelTest.kt
@@ -180,6 +180,25 @@ class AyuIslandsChromePanelTest {
     }
 
     @Test
+    fun `unlicensed legacy intensity clamps without dirtying locked chrome preview`() {
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+        state.chromeTintIntensity = 80
+        val chromePanel = AyuIslandsChromePanel()
+
+        buildPanel(chromePanel)
+
+        assertEquals(
+            50,
+            chromePanel.getPendingChromeTintIntensityForTest(),
+            "Free users must still see a slider-safe clamped chrome preview",
+        )
+        assertFalse(
+            chromePanel.isModified(),
+            "Locked chrome preview must not open dirty because free users cannot apply the clamp",
+        )
+    }
+
+    @Test
     fun `loadStored clamps negative legacy intensity up to MIN_INTENSITY so slider construction stays total`() {
         // Corrupted XML or a third-party migration may persist a negative intensity.
         // The prior coerceAtMost clamp only trimmed the upper bound, so a negative

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsChromePanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsChromePanelTest.kt
@@ -30,7 +30,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
-import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -44,9 +43,8 @@ import kotlin.test.assertTrue
  *    [AyuIslandsState]; [AccentApplicator.applyForFocusedProject] fires exactly once per
  *    modified apply and does NOT fire when there is no diff.
  *  - Reset: pending is restored to stored.
- *  - Premium gate: unlicensed users see no chrome tinting controls — the
- *    collapsible content collapses to a single "requires Pro" comment row so the gate is
- *    visible as a hint but none of the underlying bindings surface.
+ *  - Premium gate: unlicensed users see the chrome tinting controls, but every
+ *    mutating control is disabled and apply still re-checks the license.
  *  - Probe gate: the Main Toolbar row is enabled when
  *    [ChromeDecorationsProbe.isCustomHeaderActive] returns `true` and disabled (with a
  *    per-OS honest comment) when it returns `false` — present but disabled, never hidden.
@@ -536,7 +534,7 @@ class AyuIslandsChromePanelTest {
     // ── Test 9: premium gate ──────────────────────────────────────────────────
 
     @Test
-    fun `unlicensed build hides chrome tinting controls behind a 'requires Pro' comment`() {
+    fun `unlicensed build shows chrome tinting controls but locks mutation`() {
         every { LicenseChecker.isLicensedOrGrace() } returns false
         val chromePanel = AyuIslandsChromePanel()
 
@@ -544,16 +542,26 @@ class AyuIslandsChromePanelTest {
 
         assertFalse(
             chromePanel.collapsibleRenderedLicensedForTest(),
-            "Unlicensed build must not render the chrome tinting controls (premium gate)",
+            "Unlicensed build must record a locked premium gate",
+        )
+        assertEquals(
+            5,
+            chromePanel.surfaceCheckboxCountForTest(),
+            "Unlicensed build must render the 5 per-surface checkboxes as a preview",
         )
         assertEquals(
             0,
-            chromePanel.surfaceCheckboxCountForTest(),
-            "Unlicensed build must not wire any of the 5 per-surface checkboxes",
+            chromePanel.enabledSurfaceCheckboxCountForTest(),
+            "Unlicensed build must lock every per-surface checkbox",
         )
-        assertNull(
-            chromePanel.intensitySliderForTest(),
-            "Unlicensed build must not wire the intensity slider",
+        val slider =
+            assertNotNull(
+                chromePanel.intensitySliderForTest(),
+                "Unlicensed build must render the intensity slider as a preview",
+            )
+        assertFalse(
+            slider.isEnabled,
+            "Unlicensed build must lock the intensity slider",
         )
     }
 

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanelTest.kt
@@ -1,0 +1,89 @@
+package dev.ayuislands.settings
+
+import com.intellij.ide.ui.LafManager
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.ui.dsl.builder.SegmentedButton
+import dev.ayuislands.glow.GlowPreset
+import dev.ayuislands.licensing.LicenseChecker
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkClass
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+
+class AyuIslandsEffectsPanelTest {
+    private lateinit var state: AyuIslandsState
+    private lateinit var settings: AyuIslandsSettings
+
+    @BeforeTest
+    fun setUp() {
+        state =
+            AyuIslandsState().apply {
+                glowEnabled = true
+                glowPreset = GlowPreset.WHISPER.name
+            }
+        settings = mockk(relaxed = true)
+        every { settings.state } returns state
+        mockkObject(AyuIslandsSettings.Companion)
+        every { AyuIslandsSettings.getInstance() } returns settings
+
+        mockkObject(LicenseChecker)
+        every { LicenseChecker.isLicensedOrGrace() } returns true
+
+        mockkStatic(ApplicationManager::class)
+        val appMock = mockk<Application>(relaxed = true)
+        val actionManagerMock = mockk<ActionManager>(relaxed = true)
+        val lafManagerMock = mockk<LafManager>(relaxed = true)
+        every { ApplicationManager.getApplication() } returns appMock
+        every { appMock.invokeLater(any()) } answers { firstArg<Runnable>().run() }
+        every { appMock.getService(ActionManager::class.java) } returns actionManagerMock
+        every { appMock.getService(LafManager::class.java) } returns lafManagerMock
+        every { actionManagerMock.getAction(any()) } returns null
+
+        @Suppress("UNCHECKED_CAST")
+        val experimentalUiClass = Class.forName("com.intellij.ui.ExperimentalUI") as Class<Any>
+        val experimentalUiMock = mockkClass(experimentalUiClass.kotlin, relaxed = true)
+        every { appMock.getService(experimentalUiClass) } returns experimentalUiMock
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `unlicensed glow preset preview cannot mutate pending state`() {
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+        val effectsPanel = AyuIslandsEffectsPanel()
+        buildDialogPanel(effectsPanel)
+
+        assertFalse(effectsPanel.isModified(), "locked Glow preview must start clean")
+        presetSegmented(effectsPanel).selectedItem = GlowPreset.CYBERPUNK
+
+        assertFalse(
+            effectsPanel.isModified(),
+            "locked Glow preset preview must ignore selection changes instead of dirtying Settings",
+        )
+    }
+
+    private fun buildDialogPanel(panel: AyuIslandsEffectsPanel) =
+        com.intellij.ui.dsl.builder
+            .panel {
+                panel.buildGlowPanel(this@panel)
+            }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun presetSegmented(panel: AyuIslandsEffectsPanel): SegmentedButton<GlowPreset> {
+        val field = AyuIslandsEffectsPanel::class.java.getDeclaredField("presetSegmentedButton")
+        field.isAccessible = true
+        return field.get(panel) as? SegmentedButton<GlowPreset>
+            ?: error("Glow preset segmented button must be created")
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanelTest.kt
@@ -13,10 +13,17 @@ import io.mockk.mockkClass
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
+import java.awt.Component
+import java.awt.Container
+import javax.swing.JCheckBox
+import javax.swing.JComboBox
+import javax.swing.JLabel
+import javax.swing.JSlider
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class AyuIslandsEffectsPanelTest {
     private lateinit var state: AyuIslandsState
@@ -73,6 +80,59 @@ class AyuIslandsEffectsPanelTest {
         )
     }
 
+    @Test
+    fun `unlicensed glow keeps custom controls and targets visible but locked`() {
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+        state.glowEnabled = false
+        state.glowPreset = GlowPreset.WHISPER.name
+        val effectsPanel = AyuIslandsEffectsPanel()
+
+        val dialogPanel = buildDialogPanel(effectsPanel)
+        val styleCombo = field<JComboBox<*>>(effectsPanel, "styleCombo")
+        val animationCombo = field<JComboBox<*>>(effectsPanel, "animationCombo")
+        val intensitySlider = field<JSlider>(effectsPanel, "intensitySlider")
+        val widthSlider = field<JSlider>(effectsPanel, "widthSlider")
+        val targetCheckboxes = islandCheckboxes(effectsPanel).values.toList()
+        val targetsLabel = descendants(dialogPanel, JLabel::class.java).first { it.text == "Targets" }
+
+        assertTrue(
+            styleCombo.isEffectivelyVisibleWithin(dialogPanel),
+            "Locked Glow preview must show the style selector even when the preset is not Custom",
+        )
+        assertFalse(styleCombo.isEnabled, "Locked Glow style selector must not be mutable")
+        assertTrue(
+            intensitySlider.isEffectivelyVisibleWithin(dialogPanel),
+            "Locked Glow preview must show the intensity slider even when the preset is not Custom",
+        )
+        assertFalse(intensitySlider.isEnabled, "Locked Glow intensity slider must not be mutable")
+        assertTrue(
+            widthSlider.isEffectivelyVisibleWithin(dialogPanel),
+            "Locked Glow preview must show the width slider even when the preset is not Custom",
+        )
+        assertFalse(widthSlider.isEnabled, "Locked Glow width slider must not be mutable")
+        assertTrue(
+            animationCombo.isEffectivelyVisibleWithin(dialogPanel),
+            "Locked Glow preview must show animation controls even when the preset is not Custom",
+        )
+        assertFalse(animationCombo.isEnabled, "Locked Glow animation controls must not be mutable")
+        assertTrue(
+            targetsLabel.isEffectivelyVisibleWithin(dialogPanel),
+            "Locked Glow preview must show the Targets group even when the preset is not Custom",
+        )
+        assertTrue(targetCheckboxes.isNotEmpty(), "Locked Glow preview must render target checkboxes")
+        assertTrue(
+            targetCheckboxes.all { !it.isEnabled },
+            "Locked Glow target controls must not be mutable",
+        )
+
+        intensitySlider.value += 1
+
+        assertFalse(
+            effectsPanel.isModified(),
+            "Programmatic changes to locked Glow preview controls must not dirty Settings",
+        )
+    }
+
     private fun buildDialogPanel(panel: AyuIslandsEffectsPanel) =
         com.intellij.ui.dsl.builder
             .panel {
@@ -85,5 +145,46 @@ class AyuIslandsEffectsPanelTest {
         field.isAccessible = true
         return field.get(panel) as? SegmentedButton<GlowPreset>
             ?: error("Glow preset segmented button must be created")
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun islandCheckboxes(panel: AyuIslandsEffectsPanel): Map<String, JCheckBox> {
+        val field = AyuIslandsEffectsPanel::class.java.getDeclaredField("islandCheckboxes")
+        field.isAccessible = true
+        return field.get(panel) as? Map<String, JCheckBox>
+            ?: error("Glow target checkboxes must be created")
+    }
+
+    private fun <T : Component> field(
+        panel: AyuIslandsEffectsPanel,
+        fieldName: String,
+    ): T {
+        val field = AyuIslandsEffectsPanel::class.java.getDeclaredField(fieldName)
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        return field.get(panel) as? T ?: error("$fieldName must be created")
+    }
+
+    private fun <T : Component> descendants(
+        container: Container,
+        type: Class<T>,
+    ): List<T> =
+        buildList {
+            fun visit(component: Component) {
+                if (type.isInstance(component)) add(type.cast(component))
+                if (component is Container) {
+                    component.components.forEach(::visit)
+                }
+            }
+            visit(container)
+        }
+
+    private fun Component.isEffectivelyVisibleWithin(root: Component): Boolean {
+        var current: Component? = this
+        while (current != null && current !== root) {
+            if (!current.isVisible) return false
+            current = current.parent
+        }
+        return current === root && root.isVisible
     }
 }

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsElementsPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsElementsPanelTest.kt
@@ -1,0 +1,167 @@
+package dev.ayuislands.settings
+
+import com.intellij.ide.ui.LafManager
+import com.intellij.ide.ui.laf.UIThemeLookAndFeelInfo
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.ex.ActionManagerEx
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.ui.DialogPanel
+import com.intellij.ui.dsl.builder.panel
+import dev.ayuislands.accent.AccentElementId
+import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.accent.conflict.ConflictRegistry
+import dev.ayuislands.glow.GlowTabMode
+import dev.ayuislands.licensing.LicenseChecker
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkClass
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import java.awt.Component
+import javax.swing.JCheckBox
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AyuIslandsElementsPanelTest {
+    private lateinit var state: AyuIslandsState
+    private lateinit var settings: AyuIslandsSettings
+
+    @BeforeTest
+    fun setUp() {
+        state =
+            AyuIslandsState().apply {
+                accentElementsGroupExpanded = true
+                glowTabMode = GlowTabMode.MINIMAL.name
+                bracketScopeEnabled = true
+            }
+        settings = mockk(relaxed = true)
+        every { settings.state } returns state
+        every { settings.getAccentForVariant(AyuVariant.MIRAGE) } returns AyuVariant.MIRAGE.defaultAccent
+        mockkObject(AyuIslandsSettings.Companion)
+        every { AyuIslandsSettings.getInstance() } returns settings
+
+        mockkObject(LicenseChecker)
+        every { LicenseChecker.isLicensedOrGrace() } returns true
+
+        mockkObject(ConflictRegistry)
+        every { ConflictRegistry.detectConflicts() } returns emptyList()
+        every { ConflictRegistry.getConflictFor(any()) } returns null
+
+        wireUiDslServices()
+        wireAyuTheme()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `unlicensed accent elements keep controls visible but locked`() {
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+        val elementsPanel = AyuIslandsElementsPanel()
+
+        val dialogPanel = buildDialogPanel(elementsPanel)
+        val toggleCheckboxes = toggleCheckboxes(elementsPanel).values.toList()
+        val syncCheckbox = field<JCheckBox>(elementsPanel, "syncCheckbox")
+        val bracketCheckbox = field<JCheckBox>(elementsPanel, "bracketScopeCheckbox")
+
+        assertTrue(toggleCheckboxes.isNotEmpty(), "Locked Accent Elements preview must render toggles")
+        assertTrue(
+            toggleCheckboxes.all { it.isEffectivelyVisibleWithin(dialogPanel) && !it.isEnabled },
+            "Locked Accent Elements toggles must stay visible but not mutable",
+        )
+        assertTrue(
+            syncCheckbox.isEffectivelyVisibleWithin(dialogPanel),
+            "Locked Accent Elements preview must show tab underline sync controls",
+        )
+        assertFalse(syncCheckbox.isEnabled, "Locked tab underline sync must not be mutable")
+        assertTrue(
+            bracketCheckbox.isEffectivelyVisibleWithin(dialogPanel),
+            "Locked Accent Elements preview must show bracket scope controls",
+        )
+        assertFalse(bracketCheckbox.isEnabled, "Locked bracket scope control must not be mutable")
+
+        toggleCheckboxes.first().isSelected = !toggleCheckboxes.first().isSelected
+        syncCheckbox.isSelected = !syncCheckbox.isSelected
+        bracketCheckbox.isSelected = !bracketCheckbox.isSelected
+
+        assertFalse(
+            elementsPanel.isModified(),
+            "Programmatic changes to locked Accent Elements controls must not dirty Settings",
+        )
+    }
+
+    private fun buildDialogPanel(elementsPanel: AyuIslandsElementsPanel): DialogPanel =
+        panel {
+            elementsPanel.buildPanel(this, AyuVariant.MIRAGE)
+        }
+
+    private fun wireUiDslServices() {
+        mockkStatic(ApplicationManager::class)
+        val appMock = mockk<Application>(relaxed = true)
+        val actionManagerMock = mockk<ActionManagerEx>(relaxed = true)
+        mockkStatic(ActionManager::class)
+        every { ActionManager.getInstance() } returns actionManagerMock
+        every { ApplicationManager.getApplication() } returns appMock
+        every { appMock.invokeLater(any()) } answers { firstArg<Runnable>().run() }
+        every { actionManagerMock.getAction(any()) } returns null
+
+        @Suppress("UNCHECKED_CAST")
+        val experimentalUiClass = Class.forName("com.intellij.ui.ExperimentalUI") as Class<Any>
+        val experimentalUiMock = mockkClass(experimentalUiClass.kotlin, relaxed = true)
+        every { appMock.getService(any<Class<*>>()) } answers {
+            when (val serviceClass = firstArg<Class<*>>()) {
+                ActionManager::class.java,
+                ActionManagerEx::class.java,
+                -> actionManagerMock
+                experimentalUiClass -> experimentalUiMock
+                else -> mockkClass(serviceClass.kotlin, relaxed = true)
+            }
+        }
+        every { appMock.getService(ActionManager::class.java) } returns actionManagerMock
+        every { appMock.getService(ActionManagerEx::class.java) } returns actionManagerMock
+        every { appMock.getServiceIfCreated(ActionManager::class.java) } returns actionManagerMock
+    }
+
+    private fun wireAyuTheme() {
+        val lafManager = mockk<LafManager>(relaxed = true)
+        val themeLaf = mockk<UIThemeLookAndFeelInfo>(relaxed = true)
+        mockkStatic(LafManager::class)
+        every { LafManager.getInstance() } returns lafManager
+        every { themeLaf.name } returns "Ayu Mirage"
+        every { lafManager.currentUIThemeLookAndFeel } returns themeLaf
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun toggleCheckboxes(panel: AyuIslandsElementsPanel): Map<AccentElementId, JCheckBox> {
+        val field = AyuIslandsElementsPanel::class.java.getDeclaredField("checkboxes")
+        field.isAccessible = true
+        return field.get(panel) as? Map<AccentElementId, JCheckBox>
+            ?: error("Accent element checkboxes must be created")
+    }
+
+    private fun <T : Component> field(
+        panel: AyuIslandsElementsPanel,
+        fieldName: String,
+    ): T {
+        val field = AyuIslandsElementsPanel::class.java.getDeclaredField(fieldName)
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        return field.get(panel) as? T ?: error("$fieldName must be created")
+    }
+
+    private fun Component.isEffectivelyVisibleWithin(root: Component): Boolean {
+        var current: Component? = this
+        while (current != null && current !== root) {
+            if (!current.isVisible) return false
+            current = current.parent
+        }
+        return current === root && root.isVisible
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsElementsPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsElementsPanelTest.kt
@@ -1,12 +1,11 @@
 package dev.ayuislands.settings
 
-import com.intellij.ide.ui.LafManager
-import com.intellij.ide.ui.laf.UIThemeLookAndFeelInfo
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.ex.ActionManagerEx
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.ui.DialogPanel
+import com.intellij.ui.dsl.builder.SegmentedButton
 import com.intellij.ui.dsl.builder.panel
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.AyuVariant
@@ -20,7 +19,10 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import java.awt.Component
+import java.awt.Container
 import javax.swing.JCheckBox
+import javax.swing.JComponent
+import javax.swing.JLabel
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -30,13 +32,14 @@ import kotlin.test.assertTrue
 class AyuIslandsElementsPanelTest {
     private lateinit var state: AyuIslandsState
     private lateinit var settings: AyuIslandsSettings
+    private var isIslandsUi: Boolean = false
 
     @BeforeTest
     fun setUp() {
         state =
             AyuIslandsState().apply {
                 accentElementsGroupExpanded = true
-                glowTabMode = GlowTabMode.MINIMAL.name
+                glowTabMode = GlowTabMode.OFF.name
                 bracketScopeEnabled = true
             }
         settings = mockk(relaxed = true)
@@ -52,8 +55,10 @@ class AyuIslandsElementsPanelTest {
         every { ConflictRegistry.detectConflicts() } returns emptyList()
         every { ConflictRegistry.getConflictFor(any()) } returns null
 
+        mockkObject(AyuVariant.Companion)
+        every { AyuVariant.isIslandsUi() } answers { isIslandsUi }
+
         wireUiDslServices()
-        wireAyuTheme()
     }
 
     @AfterTest
@@ -70,6 +75,11 @@ class AyuIslandsElementsPanelTest {
         val toggleCheckboxes = toggleCheckboxes(elementsPanel).values.toList()
         val syncCheckbox = field<JCheckBox>(elementsPanel, "syncCheckbox")
         val bracketCheckbox = field<JCheckBox>(elementsPanel, "bracketScopeCheckbox")
+        val thicknessSegmented = modelField<SegmentedButton<Int>>(elementsPanel, "thicknessSegmented")
+        val thicknessLabel = descendants(dialogPanel, JLabel::class.java).first { it.text == "Underline thickness" }
+        val previewComponent =
+            descendants(dialogPanel, JComponent::class.java)
+                .first { it.javaClass.simpleName == "AccentPreviewComponent" }
 
         assertTrue(toggleCheckboxes.isNotEmpty(), "Locked Accent Elements preview must render toggles")
         assertTrue(
@@ -82,10 +92,19 @@ class AyuIslandsElementsPanelTest {
         )
         assertFalse(syncCheckbox.isEnabled, "Locked tab underline sync must not be mutable")
         assertTrue(
+            thicknessLabel.isEffectivelyVisibleWithin(dialogPanel),
+            "Locked Accent Elements preview must show underline thickness controls in classic UI",
+        )
+        thicknessSegmented.selectedItem = AyuIslandsState.DEFAULT_TAB_UNDERLINE_HEIGHT + 1
+        assertTrue(
             bracketCheckbox.isEffectivelyVisibleWithin(dialogPanel),
             "Locked Accent Elements preview must show bracket scope controls",
         )
         assertFalse(bracketCheckbox.isEnabled, "Locked bracket scope control must not be mutable")
+        assertTrue(
+            previewComponent.isEffectivelyVisibleWithin(dialogPanel),
+            "Locked Accent Elements preview must show the visual mock preview",
+        )
 
         toggleCheckboxes.first().isSelected = !toggleCheckboxes.first().isSelected
         syncCheckbox.isSelected = !syncCheckbox.isSelected
@@ -94,6 +113,27 @@ class AyuIslandsElementsPanelTest {
         assertFalse(
             elementsPanel.isModified(),
             "Programmatic changes to locked Accent Elements controls must not dirty Settings",
+        )
+    }
+
+    @Test
+    fun `unlicensed accent elements keep islands tab style selector visible but locked`() {
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+        isIslandsUi = true
+        val elementsPanel = AyuIslandsElementsPanel()
+
+        val dialogPanel = buildDialogPanel(elementsPanel)
+        val tabModeSegmented = modelField<SegmentedButton<GlowTabMode>>(elementsPanel, "tabModeSegmented")
+        val tabModeLabel = descendants(dialogPanel, JLabel::class.java).first { it.text == "Tab accent style" }
+
+        assertTrue(
+            tabModeLabel.isEffectivelyVisibleWithin(dialogPanel),
+            "Locked Accent Elements preview must show tab accent style controls in Islands UI",
+        )
+        tabModeSegmented.selectedItem = GlowTabMode.FULL
+        assertFalse(
+            elementsPanel.isModified(),
+            "Rendering locked Islands tab style controls must not dirty Settings",
         )
     }
 
@@ -129,15 +169,6 @@ class AyuIslandsElementsPanelTest {
         every { appMock.getServiceIfCreated(ActionManager::class.java) } returns actionManagerMock
     }
 
-    private fun wireAyuTheme() {
-        val lafManager = mockk<LafManager>(relaxed = true)
-        val themeLaf = mockk<UIThemeLookAndFeelInfo>(relaxed = true)
-        mockkStatic(LafManager::class)
-        every { LafManager.getInstance() } returns lafManager
-        every { themeLaf.name } returns "Ayu Mirage"
-        every { lafManager.currentUIThemeLookAndFeel } returns themeLaf
-    }
-
     @Suppress("UNCHECKED_CAST")
     private fun toggleCheckboxes(panel: AyuIslandsElementsPanel): Map<AccentElementId, JCheckBox> {
         val field = AyuIslandsElementsPanel::class.java.getDeclaredField("checkboxes")
@@ -155,6 +186,30 @@ class AyuIslandsElementsPanelTest {
         @Suppress("UNCHECKED_CAST")
         return field.get(panel) as? T ?: error("$fieldName must be created")
     }
+
+    private fun <T : Any> modelField(
+        panel: AyuIslandsElementsPanel,
+        fieldName: String,
+    ): T {
+        val field = AyuIslandsElementsPanel::class.java.getDeclaredField(fieldName)
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        return field.get(panel) as? T ?: error("$fieldName must be created")
+    }
+
+    private fun <T : Component> descendants(
+        container: Container,
+        type: Class<T>,
+    ): List<T> =
+        buildList {
+            fun visit(component: Component) {
+                if (type.isInstance(component)) add(type.cast(component))
+                if (component is Container) {
+                    component.components.forEach(::visit)
+                }
+            }
+            visit(container)
+        }
 
     private fun Component.isEffectivelyVisibleWithin(root: Component): Boolean {
         var current: Component? = this

--- a/src/test/kotlin/dev/ayuislands/settings/FontPreviewComponentTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/FontPreviewComponentTest.kt
@@ -1,0 +1,35 @@
+package dev.ayuislands.settings
+
+import dev.ayuislands.font.FontWeight
+import java.awt.image.BufferedImage
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class FontPreviewComponentTest {
+    @Test
+    fun `font preview preferred height expands for large custom typography`() {
+        val preview = FontPreviewComponent()
+        val defaultHeight = preview.preferredSize.height
+
+        preview.updateSettings(
+            newFontSize = 30f,
+            newLineSpacing = 2.0f,
+            newLigatures = true,
+            newWeight = FontWeight.SEMI_BOLD,
+        )
+        val expandedSize = preview.preferredSize
+
+        assertTrue(
+            expandedSize.height > defaultHeight,
+            "large font settings must ask layout for more height instead of clipping preview rows",
+        )
+        preview.setSize(expandedSize)
+        val image = BufferedImage(expandedSize.width, expandedSize.height, BufferedImage.TYPE_INT_ARGB)
+        val graphics = image.createGraphics()
+        try {
+            preview.paint(graphics)
+        } finally {
+            graphics.dispose()
+        }
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/settings/PluginsPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/PluginsPanelTest.kt
@@ -1,0 +1,143 @@
+package dev.ayuislands.settings
+
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.ex.ActionManagerEx
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.ui.DialogPanel
+import com.intellij.ui.dsl.builder.panel
+import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.accent.conflict.ConflictRegistry
+import dev.ayuislands.licensing.LicenseChecker
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkClass
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import java.awt.Component
+import java.awt.Container
+import javax.swing.JCheckBox
+import javax.swing.JSlider
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PluginsPanelTest {
+    private lateinit var state: AyuIslandsState
+    private lateinit var settings: AyuIslandsSettings
+
+    @BeforeTest
+    fun setUp() {
+        state = AyuIslandsState()
+        settings = mockk(relaxed = true)
+        every { settings.state } returns state
+        mockkObject(AyuIslandsSettings.Companion)
+        every { AyuIslandsSettings.getInstance() } returns settings
+
+        mockkObject(LicenseChecker)
+        every { LicenseChecker.isLicensedOrGrace() } returns true
+
+        mockkObject(ConflictRegistry)
+        every { ConflictRegistry.isCodeGlanceProDetected() } returns false
+        every { ConflictRegistry.isIndentRainbowDetected() } returns true
+
+        wireUiDslServices()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `unlicensed indent rainbow keeps nested preview controls visible but locked`() {
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+        state.irIntegrationEnabled = false
+        val pluginsPanel = PluginsPanel()
+
+        val dialogPanel = buildDialogPanel(pluginsPanel)
+        val errorCheckbox =
+            descendants(dialogPanel, JCheckBox::class.java)
+                .first { it.text == "Highlight indent errors" }
+        val alphaSlider = descendants(dialogPanel, JSlider::class.java).first()
+
+        assertTrue(
+            errorCheckbox.isEffectivelyVisibleWithin(dialogPanel),
+            "Locked Indent Rainbow preview must show the error-highlighting row even when sync is off",
+        )
+        assertFalse(
+            errorCheckbox.isEnabled,
+            "Locked Indent Rainbow error-highlighting checkbox must be visible but not mutable",
+        )
+        assertTrue(
+            alphaSlider.isEffectivelyVisibleWithin(dialogPanel),
+            "Locked Indent Rainbow preview must show the custom alpha row",
+        )
+        assertFalse(
+            alphaSlider.isEnabled,
+            "Locked Indent Rainbow alpha slider must be visible but not mutable",
+        )
+        assertFalse(
+            pluginsPanel.isModified(),
+            "Rendering locked plugin integration previews must not dirty Settings",
+        )
+    }
+
+    private fun buildDialogPanel(pluginsPanel: PluginsPanel): DialogPanel =
+        panel {
+            pluginsPanel.buildPanel(this, AyuVariant.MIRAGE)
+        }
+
+    private fun wireUiDslServices() {
+        mockkStatic(ApplicationManager::class)
+        val appMock = mockk<Application>(relaxed = true)
+        val actionManagerMock = mockk<ActionManagerEx>(relaxed = true)
+        mockkStatic(ActionManager::class)
+        every { ActionManager.getInstance() } returns actionManagerMock
+        every { ApplicationManager.getApplication() } returns appMock
+        every { appMock.invokeLater(any()) } answers { firstArg<Runnable>().run() }
+        every { actionManagerMock.getAction(any()) } returns null
+
+        @Suppress("UNCHECKED_CAST")
+        val experimentalUiClass = Class.forName("com.intellij.ui.ExperimentalUI") as Class<Any>
+        val experimentalUiMock = mockkClass(experimentalUiClass.kotlin, relaxed = true)
+        every { appMock.getService(any<Class<*>>()) } answers {
+            when (val serviceClass = firstArg<Class<*>>()) {
+                ActionManager::class.java,
+                ActionManagerEx::class.java,
+                -> actionManagerMock
+                experimentalUiClass -> experimentalUiMock
+                else -> mockkClass(serviceClass.kotlin, relaxed = true)
+            }
+        }
+        every { appMock.getService(ActionManager::class.java) } returns actionManagerMock
+        every { appMock.getService(ActionManagerEx::class.java) } returns actionManagerMock
+        every { appMock.getServiceIfCreated(ActionManager::class.java) } returns actionManagerMock
+    }
+
+    private fun <T : Component> descendants(
+        container: Container,
+        type: Class<T>,
+    ): List<T> =
+        buildList {
+            fun visit(component: Component) {
+                if (type.isInstance(component)) add(type.cast(component))
+                if (component is Container) {
+                    component.components.forEach(::visit)
+                }
+            }
+            visit(container)
+        }
+
+    private fun Component.isEffectivelyVisibleWithin(root: Component): Boolean {
+        var current: Component? = this
+        while (current != null && current !== root) {
+            if (!current.isVisible) return false
+            current = current.parent
+        }
+        return current === root && root.isVisible
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/settings/PluginsPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/PluginsPanelTest.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.ui.DialogPanel
 import com.intellij.ui.dsl.builder.panel
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.conflict.ConflictRegistry
+import dev.ayuislands.indent.IndentPreset
 import dev.ayuislands.licensing.LicenseChecker
 import io.mockk.every
 import io.mockk.mockk
@@ -84,6 +85,42 @@ class PluginsPanelTest {
             pluginsPanel.isModified(),
             "Rendering locked plugin integration previews must not dirty Settings",
         )
+    }
+
+    @Test
+    fun `reset restores indent rainbow nested row visibility for licensed users`() {
+        state.irIntegrationEnabled = true
+        state.indentPresetName = IndentPreset.CUSTOM.name
+        val pluginsPanel = PluginsPanel()
+
+        val dialogPanel = buildDialogPanel(pluginsPanel)
+        val enabledCheckbox =
+            descendants(dialogPanel, JCheckBox::class.java)
+                .first { it.text == "Sync colors with Indent Rainbow" }
+        val errorCheckbox =
+            descendants(dialogPanel, JCheckBox::class.java)
+                .first { it.text == "Highlight indent errors" }
+        val alphaSlider = descendants(dialogPanel, JSlider::class.java).first()
+
+        enabledCheckbox.doClick()
+
+        assertFalse(
+            errorCheckbox.isEffectivelyVisibleWithin(dialogPanel),
+            "Disabling Indent Rainbow sync should hide dependent rows for licensed users",
+        )
+
+        pluginsPanel.reset()
+
+        assertTrue(enabledCheckbox.isSelected, "Reset must restore the stored Indent Rainbow enabled state")
+        assertTrue(
+            errorCheckbox.isEffectivelyVisibleWithin(dialogPanel),
+            "Reset must restore dependent Indent Rainbow rows when stored sync is enabled",
+        )
+        assertTrue(
+            alphaSlider.isEffectivelyVisibleWithin(dialogPanel),
+            "Reset must restore custom alpha row visibility when stored preset is Custom",
+        )
+        assertFalse(pluginsPanel.isModified(), "Reset must leave Plugins settings clean")
     }
 
     private fun buildDialogPanel(pluginsPanel: PluginsPanel): DialogPanel =

--- a/src/test/kotlin/dev/ayuislands/settings/VcsColorPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/VcsColorPanelTest.kt
@@ -474,10 +474,33 @@ class VcsColorPanelTest {
         every { LicenseChecker.isLicensedOrGrace() } returns false
         val panel = newBuiltPanel()
         assertNotNull(vcsPreview(panel), "Unlicensed VCS gate must keep the preview visible")
-        assertFalse(slider(panel, "diffSlider").isEnabled, "Unlicensed VCS gate must lock sliders")
+        assertFalse(diffSlider(panel).isEnabled, "Unlicensed VCS gate must lock sliders")
         panel.setPendingEnabledForTest(true)
         panel.apply()
         verify(exactly = 0) { VcsColorApplier.applyAll() }
+    }
+
+    @Test
+    fun `unlicensed reset keeps VCS preview visible when customization is disabled`() {
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+        state.vcsColorEnabled = false
+        val panel = newBuiltPanel()
+
+        assertTrue(
+            vcsPreview(panel).isVisible,
+            "Free users must see the locked VCS preview even when customization is disabled",
+        )
+
+        panel.reset()
+
+        assertTrue(
+            vcsPreview(panel).isVisible,
+            "Reset must keep the locked VCS preview visible instead of hiding premium content",
+        )
+        assertFalse(
+            panel.isModified(),
+            "Resetting a locked preview must not dirty the settings dialog",
+        )
     }
 
     private fun newBuiltPanel(): VcsColorPanel {
@@ -509,13 +532,10 @@ class VcsColorPanelTest {
             ?: error("$fieldName must be created")
     }
 
-    private fun slider(
-        panel: VcsColorPanel,
-        fieldName: String,
-    ): JSlider {
-        val field = VcsColorPanel::class.java.getDeclaredField(fieldName)
+    private fun diffSlider(panel: VcsColorPanel): JSlider {
+        val field = VcsColorPanel::class.java.getDeclaredField("diffSlider")
         field.isAccessible = true
-        return field.get(panel) as? JSlider ?: error("$fieldName must be created")
+        return field.get(panel) as? JSlider ?: error("diffSlider must be created")
     }
 
     private fun layoutTree(container: Container) {

--- a/src/test/kotlin/dev/ayuislands/settings/VcsColorPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/VcsColorPanelTest.kt
@@ -20,6 +20,7 @@ import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.verify
+import java.awt.Component
 import java.awt.Container
 import javax.swing.JSlider
 import javax.swing.SwingUtilities
@@ -503,6 +504,34 @@ class VcsColorPanelTest {
         )
     }
 
+    @Test
+    fun `unlicensed VCS keeps custom sliders visible from default presets`() {
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+        state.vcsColorEnabled = false
+        state.vcsDiffPreset = VcsColorPreset.AMBIENT.name
+        state.vcsMergePreset = VcsColorPreset.AMBIENT.name
+        state.vcsBlamePreset = VcsColorPreset.AMBIENT.name
+        state.vcsDiffSectionExpanded = true
+        state.vcsMergeSectionExpanded = true
+        state.vcsBlameSectionExpanded = true
+        val panel = VcsColorPanel()
+
+        val dialogPanel = buildDialogPanel(panel)
+        val sliders = descendants(dialogPanel, JSlider::class.java)
+
+        assertTrue(sliders.isNotEmpty(), "Locked VCS preview must render custom intensity sliders")
+        assertTrue(
+            sliders.all { it.isEffectivelyVisibleWithin(dialogPanel) && !it.isEnabled },
+            "Locked VCS preview must show custom sliders even when stored presets are not Custom",
+        )
+        sliders.first().value += 1
+
+        assertFalse(
+            panel.isModified(),
+            "Programmatic changes to locked VCS preview sliders must not dirty Settings",
+        )
+    }
+
     private fun newBuiltPanel(): VcsColorPanel {
         val panel = VcsColorPanel()
         buildDialogPanel(panel)
@@ -536,6 +565,29 @@ class VcsColorPanelTest {
         val field = VcsColorPanel::class.java.getDeclaredField("diffSlider")
         field.isAccessible = true
         return field.get(panel) as? JSlider ?: error("diffSlider must be created")
+    }
+
+    private fun <T : Component> descendants(
+        container: Container,
+        type: Class<T>,
+    ): List<T> =
+        buildList {
+            fun visit(component: Component) {
+                if (type.isInstance(component)) add(type.cast(component))
+                if (component is Container) {
+                    component.components.forEach(::visit)
+                }
+            }
+            visit(container)
+        }
+
+    private fun Component.isEffectivelyVisibleWithin(root: Component): Boolean {
+        var current: Component? = this
+        while (current != null && current !== root) {
+            if (!current.isVisible) return false
+            current = current.parent
+        }
+        return current === root && root.isVisible
     }
 
     private fun layoutTree(container: Container) {

--- a/src/test/kotlin/dev/ayuislands/settings/VcsColorPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/VcsColorPanelTest.kt
@@ -29,6 +29,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 /**
@@ -46,8 +47,8 @@ import kotlin.test.assertTrue
  *    buildPanel and apply skips persistence.
  *  - Apply error path: if [VcsColorApplier.applyAll] throws, persisted state
  *    stays at the pre-apply baseline.
- *  - Premium gate: an unlicensed user records `licensed = false` and renders
- *    only the placeholder.
+ *  - Premium gate: an unlicensed user sees the preview and controls, but every
+ *    mutating control is disabled and apply still re-checks the license.
  */
 class VcsColorPanelTest {
     private lateinit var state: AyuIslandsState
@@ -468,12 +469,12 @@ class VcsColorPanelTest {
 
     @Test
     fun `unlicensed buildPanel does not trigger the applier on subsequent apply`() {
-        // Unlicensed path renders only the placeholder + Pro upgrade link — no
-        // licensed controls bound, no pending diffs even after a setPending* call
-        // before apply. Verifying via the applier-not-called assertion proves the
-        // premium gate held without exposing a dedicated `licensedForTest()` seam.
+        // Unlicensed path renders the premium preview, but the apply-time license
+        // guard still prevents persistence if state is manipulated through a test seam.
         every { LicenseChecker.isLicensedOrGrace() } returns false
         val panel = newBuiltPanel()
+        assertNotNull(vcsPreview(panel), "Unlicensed VCS gate must keep the preview visible")
+        assertFalse(slider(panel, "diffSlider").isEnabled, "Unlicensed VCS gate must lock sliders")
         panel.setPendingEnabledForTest(true)
         panel.apply()
         verify(exactly = 0) { VcsColorApplier.applyAll() }
@@ -506,6 +507,15 @@ class VcsColorPanelTest {
         field.isAccessible = true
         return field.get(panel) as? SegmentedButton<VcsColorPreset>
             ?: error("$fieldName must be created")
+    }
+
+    private fun slider(
+        panel: VcsColorPanel,
+        fieldName: String,
+    ): JSlider {
+        val field = VcsColorPanel::class.java.getDeclaredField(fieldName)
+        field.isAccessible = true
+        return field.get(panel) as? JSlider ?: error("$fieldName must be created")
     }
 
     private fun layoutTree(container: Container) {

--- a/src/test/kotlin/dev/ayuislands/settings/WorkspacePanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/WorkspacePanelTest.kt
@@ -1,0 +1,97 @@
+package dev.ayuislands.settings
+
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
+import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.licensing.LicenseChecker
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkClass
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import java.awt.Component
+import java.awt.Container
+import javax.swing.JSpinner
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class WorkspacePanelTest {
+    private lateinit var state: AyuIslandsState
+    private lateinit var settings: AyuIslandsSettings
+
+    @BeforeTest
+    fun setUp() {
+        state =
+            AyuIslandsState().apply {
+                projectPanelWidthMode = PanelWidthMode.AUTO_FIT.name
+                commitPanelWidthMode = PanelWidthMode.FIXED.name
+                gitPanelWidthMode = PanelWidthMode.AUTO_FIT.name
+            }
+        settings = mockk(relaxed = true)
+        every { settings.state } returns state
+        mockkObject(AyuIslandsSettings.Companion)
+        every { AyuIslandsSettings.getInstance() } returns settings
+
+        mockkObject(LicenseChecker)
+        every { LicenseChecker.isLicensedOrGrace() } returns true
+
+        mockkStatic(ApplicationManager::class)
+        val appMock = mockk<Application>(relaxed = true)
+        val actionManagerMock = mockk<ActionManager>(relaxed = true)
+        every { ApplicationManager.getApplication() } returns appMock
+        every { appMock.invokeLater(any()) } answers { firstArg<Runnable>().run() }
+        every { appMock.getService(ActionManager::class.java) } returns actionManagerMock
+        every { actionManagerMock.getAction(any()) } returns null
+
+        @Suppress("UNCHECKED_CAST")
+        val experimentalUiClass = Class.forName("com.intellij.ui.ExperimentalUI") as Class<Any>
+        val experimentalUiMock = mockkClass(experimentalUiClass.kotlin, relaxed = true)
+        every { appMock.getService(experimentalUiClass) } returns experimentalUiMock
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `unlicensed width controls stay visible but cannot dirty settings`() {
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+        val workspacePanel = WorkspacePanel()
+        val dialogPanel =
+            com.intellij.ui.dsl.builder
+                .panel {
+                    workspacePanel.buildPanel(this@panel, AyuVariant.MIRAGE)
+                }
+        val spinners = components(dialogPanel, JSpinner::class.java)
+
+        assertTrue(spinners.isNotEmpty(), "locked Workspace preview must still render width spinners")
+        assertTrue(spinners.all { !it.isEnabled }, "locked Workspace preview must disable width spinners")
+        spinners.first().value = (spinners.first().value as Int) + 10
+
+        assertFalse(
+            workspacePanel.isModified(),
+            "locked Workspace preview spinner changes must not dirty Settings",
+        )
+    }
+
+    private fun <T : Component> components(
+        container: Container,
+        componentClass: Class<T>,
+    ): List<T> =
+        container.components.flatMap { child ->
+            val current = if (componentClass.isInstance(child)) listOf(componentClass.cast(child)) else emptyList()
+            val descendants =
+                if (child is Container) {
+                    components(child, componentClass)
+                } else {
+                    emptyList()
+                }
+            current + descendants
+        }
+}

--- a/src/test/kotlin/dev/ayuislands/settings/WorkspacePanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/WorkspacePanelTest.kt
@@ -80,6 +80,37 @@ class WorkspacePanelTest {
         )
     }
 
+    @Test
+    fun `unlicensed default workspace keeps every width mode preview visible`() {
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+        state.projectPanelWidthMode = PanelWidthMode.DEFAULT.name
+        state.commitPanelWidthMode = PanelWidthMode.DEFAULT.name
+        state.gitPanelWidthMode = PanelWidthMode.DEFAULT.name
+        state.workspaceProjectViewExpanded = true
+        state.workspaceCommitPanelExpanded = true
+        state.workspaceGitPanelExpanded = true
+        val workspacePanel = WorkspacePanel()
+
+        val dialogPanel =
+            com.intellij.ui.dsl.builder
+                .panel {
+                    workspacePanel.buildPanel(this@panel, AyuVariant.MIRAGE)
+                }
+        val spinners = components(dialogPanel, JSpinner::class.java)
+
+        assertTrue(spinners.isNotEmpty(), "locked Workspace preview must render width controls")
+        assertTrue(
+            spinners.all { it.isEffectivelyVisibleWithin(dialogPanel) && !it.isEnabled },
+            "Locked Workspace preview must show every width mode control even when stored mode is Default",
+        )
+        spinners.first().value = (spinners.first().value as Int) + 10
+
+        assertFalse(
+            workspacePanel.isModified(),
+            "Locked Workspace default-mode preview controls must not dirty Settings",
+        )
+    }
+
     private fun <T : Component> components(
         container: Container,
         componentClass: Class<T>,
@@ -94,4 +125,13 @@ class WorkspacePanelTest {
                 }
             current + descendants
         }
+
+    private fun Component.isEffectivelyVisibleWithin(root: Component): Boolean {
+        var current: Component? = this
+        while (current != null && current !== root) {
+            if (!current.isVisible) return false
+            current = current.parent
+        }
+        return current === root && root.isVisible
+    }
 }

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderApplyTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderApplyTest.kt
@@ -5,6 +5,7 @@ import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.ProjectLanguageDetector
+import dev.ayuislands.licensing.LicenseChecker
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -50,6 +51,8 @@ class OverridesGroupBuilderApplyTest {
         mockkObject(AccentResolver)
         mockkObject(AccentApplicator)
         mockkObject(ProjectAccentSwapService.Companion)
+        mockkObject(LicenseChecker)
+        every { LicenseChecker.isLicensedOrGrace() } returns true
     }
 
     @AfterTest
@@ -141,6 +144,30 @@ class OverridesGroupBuilderApplyTest {
         assertFalse(builder.isModified(), "stored snapshot must advance on happy path too")
         io.mockk.verify(exactly = 1) { AccentApplicator.applyFromHexString("#AABBCC") }
         io.mockk.verify(exactly = 1) { swapService.notifyExternalApply("#AABBCC") }
+    }
+
+    @Test
+    fun `apply() is a no-op when license is unavailable`() {
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+        val builder =
+            OverridesGroupBuilder().apply {
+                seedPendingForTest(
+                    projects =
+                        listOf(
+                            ProjectMapping(
+                                canonicalPath = "/tmp/apply-locked",
+                                displayName = "locked",
+                                hex = "#AABBCC",
+                            ),
+                        ),
+                )
+            }
+
+        builder.apply()
+
+        assertTrue(mappingsState.projectAccents.isEmpty(), "locked overrides must not persist")
+        assertTrue(builder.isModified(), "locked apply must not advance the stored snapshot")
+        io.mockk.verify(exactly = 0) { AccentApplicator.applyFromHexString(any()) }
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderApplyTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderApplyTest.kt
@@ -10,6 +10,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
+import javax.swing.JTable
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -171,6 +172,31 @@ class OverridesGroupBuilderApplyTest {
     }
 
     @Test
+    fun `unlicensed override remove actions cannot delete visible preview rows`() {
+        val projectMapping = ProjectMapping("/tmp/locked-preview", "locked-preview", "#AABBCC")
+        val languageMapping = LanguageMapping("kotlin", "Kotlin", "#BBCCDD")
+        val builder =
+            OverridesGroupBuilder().apply {
+                seedPendingForTest(
+                    projects = listOf(projectMapping),
+                    languages = listOf(languageMapping),
+                )
+            }
+        table(builder, "projectTable").selectionModel.setSelectionInterval(0, 0)
+        table(builder, "languageTable").selectionModel.setSelectionInterval(0, 0)
+
+        val projectActions = actions(builder, "projectActions", licensed = false)
+        val languageActions = actions(builder, "languageActions", licensed = false)
+
+        assertFalse(projectActions.removeEnabled(), "locked project preview rows must not enable Remove")
+        assertFalse(languageActions.removeEnabled(), "locked language preview rows must not enable Remove")
+        projectActions.remove()
+        languageActions.remove()
+        assertEquals(listOf(projectMapping), projectRows(builder), "locked project preview rows must remain visible")
+        assertEquals(listOf(languageMapping), languageRows(builder), "locked language preview rows must remain visible")
+    }
+
+    @Test
     fun `apply() falls back to AccentApplicator resolveFocusedProject when parentProject is not bound`() {
         // Guards the second-tier project source inside apply(): when setParentProjectForTest
         // has not been called (e.g. Settings Apply reached here before the panel finished
@@ -211,5 +237,65 @@ class OverridesGroupBuilderApplyTest {
         io.mockk.verify(exactly = 1) { AccentApplicator.resolveFocusedProject() }
         io.mockk.verify(exactly = 1) { AccentResolver.resolve(focusedProject, AyuVariant.MIRAGE) }
         io.mockk.verify(exactly = 1) { AccentApplicator.applyFromHexString("#5CCFE6") }
+    }
+
+    private fun table(
+        builder: OverridesGroupBuilder,
+        fieldName: String,
+    ): JTable {
+        val field = OverridesGroupBuilder::class.java.getDeclaredField(fieldName)
+        field.isAccessible = true
+        return field.get(builder) as JTable
+    }
+
+    private fun actions(
+        builder: OverridesGroupBuilder,
+        methodName: String,
+        licensed: Boolean,
+    ): TableActionHandle {
+        val method = OverridesGroupBuilder::class.java.getDeclaredMethod(methodName, Boolean::class.javaPrimitiveType)
+        method.isAccessible = true
+        return TableActionHandle(method.invoke(builder, licensed))
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun projectRows(builder: OverridesGroupBuilder): List<ProjectMapping> {
+        val model = model(builder, "projectModel")
+        return model.javaClass.getDeclaredMethod("snapshot").invoke(model) as List<ProjectMapping>
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun languageRows(builder: OverridesGroupBuilder): List<LanguageMapping> {
+        val model = model(builder, "languageModel")
+        return model.javaClass.getDeclaredMethod("snapshot").invoke(model) as List<LanguageMapping>
+    }
+
+    private fun model(
+        builder: OverridesGroupBuilder,
+        fieldName: String,
+    ): Any {
+        val field = OverridesGroupBuilder::class.java.getDeclaredField(fieldName)
+        field.isAccessible = true
+        return field.get(builder)
+    }
+
+    private class TableActionHandle(
+        delegate: Any,
+    ) {
+        private val removeAction = delegate.action("getRemove")
+        private val removeEnabledAction = delegate.action("getRemoveEnabled")
+
+        fun remove() {
+            removeAction()
+        }
+
+        fun removeEnabled(): Boolean = removeEnabledAction() as Boolean
+
+        @Suppress("UNCHECKED_CAST")
+        private fun Any.action(name: String): () -> Any? {
+            val method = javaClass.getDeclaredMethod(name)
+            method.isAccessible = true
+            return method.invoke(this) as () -> Any?
+        }
     }
 }


### PR DESCRIPTION
-- Summary --------------------------------
Free users could not evaluate premium settings because several paid panels hid their content entirely. This PR makes paid settings visible but locked when the license is inactive, then brings the Font preset preview up to the same visual quality as the VCS preview.

-- Changes --------------------------------
- Feat: Add `PremiumFeatureGate.kt` as the shared visible-but-locked gate for premium settings.
- Feat: Apply the gate to VCS, chrome tinting, glow/effects, elements, workspace cleanup, plugins, accent rotation, and override controls without locking free accent selection.
- Feat: Keep VCS configuration preview visible for unlicensed users while preventing apply-time activation.
- Feat: Replace the flat Font preset sample with a responsive IDE-style project/editor preview and nested depth treatment.
- Test: Cover locked premium visibility and apply guards for VCS, chrome, and override controls.
- Docs: Re-stamp `docs/features.yml` metadata required by the repository docs guard.

-- Validation --------------------------------
- `./gradlew test --tests dev.ayuislands.settings.VcsColorPanelTest --tests dev.ayuislands.settings.AyuIslandsChromePanelTest`
- `./gradlew test --tests dev.ayuislands.settings.mappings.OverridesGroupBuilderApplyTest`
- `./gradlew test --tests dev.ayuislands.settings.FontPresetPanelCustomRegressionTest`
- `./gradlew test --tests dev.ayuislands.settings.*`
- `./gradlew detekt ktlintCheck`
- `./gradlew test`
- `./gradlew buildPlugin --no-build-cache --rerun-tasks`
- Local deploy to IntelliJIdea2026.1 with installed JAR bytecode verification for `PremiumFeatureGate` and `FontPreviewComponent`.

-- Notes --------------------------------
- Free accent color selection remains ungated.
- Paid controls stay visible for discovery, but user-triggered apply paths still check the license gate.