### PR TITLE
Guard verifier API usage and sync accent preview

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -247,6 +247,8 @@ jobs:
       - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
       - name: Verify plugin (group ${{ matrix.group }})
         run: ./gradlew verifyPlugin -DverifyGroup=${{ matrix.group }}
+      - name: Fail on internal API verifier findings
+        run: python3 scripts/verify-plugin-verifier.py
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: matrix.group == 'A1'
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,6 +100,8 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: scripts/uv.lock
+      - name: Test Plugin Verifier API gate
+        run: python3 scripts/test-verify-plugin-verifier.py
       - name: Verify docs sync (features.yml ↔ README + plugin.xml + CHANGELOG)
         run: scripts/verify-docs.py
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
       - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
       - name: Verify plugin
         run: ./gradlew verifyPlugin -DverifyGroup=${{ matrix.group }}
+      - name: Fail on internal API verifier findings
+        run: python3 scripts/verify-plugin-verifier.py
 
   publish:
     name: Publish

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -89,7 +89,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "e8b119e"
+          last_verified_sha: "2638bb64"
           last_verified_date: "2026-05-30"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -110,7 +110,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "e8b119e"
+          last_verified_sha: "2638bb64"
           last_verified_date: "2026-05-30"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -209,7 +209,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "cac71cca"
+          last_verified_sha: "2638bb64"
           last_verified_date: "2026-05-30"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -241,7 +241,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "e8b119e"
+          last_verified_sha: "2638bb64"
           last_verified_date: "2026-05-30"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -284,7 +284,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "cac71cca"
+          last_verified_sha: "2638bb64"
           last_verified_date: "2026-05-30"
           content_sha256: "fc9ba63b9c9c53893a486a3c9055287bd6dc9c68f5439cae197efe5ae585d17c"
 
@@ -337,7 +337,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "5573f17"
+          last_verified_sha: "2638bb64"
           last_verified_date: "2026-05-30"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -86,11 +86,12 @@ categories:
           path: src/main/resources/whatsnew/v2.5.0/slide-project-overrides.png
           caption: "Per-project accent overrides table"
           sources:
+            - src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "2638bb64"
-          last_verified_date: "2026-05-30"
+          last_verified_sha: "ec28e522"
+          last_verified_date: "2026-05-31"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
       - id: accent-scoped-language
@@ -107,11 +108,12 @@ categories:
           path: src/main/resources/whatsnew/v2.5.0/slide-language-overrides.png
           caption: "Per-language accent overrides table"
           sources:
+            - src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "2638bb64"
-          last_verified_date: "2026-05-30"
+          last_verified_sha: "ec28e522"
+          last_verified_date: "2026-05-31"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
       - id: accent-language-breakdown

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -71,6 +71,24 @@ python3 scripts/verify-bytecode.py path/to/plugin.jar  # explicit path
 
 Deps: stdlib only (`subprocess` shells out to `javap`). Plain `python3`.
 
+### `verify-plugin-verifier.py` — IntelliJ API release gate
+
+After `./gradlew verifyPlugin`, enforces the project API policy:
+
+1. Internal IntelliJ Platform API is release-blocking. Any
+   `internal-api-usages.txt` finding fails the gate before merge or Marketplace
+   upload.
+2. Deprecated, scheduled-for-removal, and experimental API usage is advisory
+   but must stay visible. The script prints de-duplicated
+   `deprecated-usages.txt` and `experimental-api-usages.txt` findings so we
+   minimize them whenever stable public replacements exist.
+
+```bash
+python3 scripts/verify-plugin-verifier.py
+```
+
+Deps: stdlib only. Plain `python3`.
+
 ### `verify-proguard-keeps.py` — ProGuard keep-rule coverage
 
 Every class referenced in `plugin.xml` must have a `-keep class X { *; }`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -85,6 +85,7 @@ After `./gradlew verifyPlugin`, enforces the project API policy:
 
 ```bash
 python3 scripts/verify-plugin-verifier.py
+python3 scripts/test-verify-plugin-verifier.py
 ```
 
 Deps: stdlib only. Plain `python3`.

--- a/scripts/test-verify-plugin-verifier.py
+++ b/scripts/test-verify-plugin-verifier.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""CLI-boundary tests for verify-plugin-verifier.py."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "verify-plugin-verifier.py"
+
+
+class VerifyPluginVerifierTest(unittest.TestCase):
+    def test_missing_reports_directory_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            reports_dir = Path(temporary_directory) / "missing"
+
+            result = run_gate(reports_dir)
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("reports directory not found", result.stderr)
+
+    def test_reports_without_verdict_files_fail(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            reports_dir = Path(temporary_directory)
+
+            result = run_gate(reports_dir)
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("No verification-verdict.txt files found", result.stderr)
+
+    def test_internal_api_usage_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            target = make_target(Path(temporary_directory))
+            (target / "internal-api-usages.txt").write_text(
+                "Internal API method com.intellij.Secret.call() invocation\n",
+                encoding="utf-8",
+            )
+
+            result = run_gate(Path(temporary_directory))
+
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("reported internal API usage", result.stderr)
+        self.assertIn("com.intellij.Secret.call()", result.stderr)
+
+    def test_deprecated_and_experimental_usage_is_advisory(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            target = make_target(Path(temporary_directory))
+            (target / "deprecated-usages.txt").write_text(
+                "Deprecated API method com.intellij.Old.call() invocation\n",
+                encoding="utf-8",
+            )
+            (target / "experimental-api-usages.txt").write_text(
+                "Experimental API method com.intellij.New.call() invocation\n",
+                encoding="utf-8",
+            )
+
+            result = run_gate(Path(temporary_directory))
+
+        self.assertEqual(0, result.returncode)
+        self.assertIn("deprecated=1", result.stdout)
+        self.assertIn("experimental=1", result.stdout)
+        self.assertIn("Deprecated API method", result.stderr)
+        self.assertIn("Experimental API method", result.stderr)
+
+
+def make_target(reports_dir: Path) -> Path:
+    target = reports_dir / "IC-251" / "plugins" / "com.ayuislands.theme" / "2.7.1"
+    target.mkdir(parents=True)
+    (target / "verification-verdict.txt").write_text("Compatible\n", encoding="utf-8")
+    return target
+
+
+def run_gate(reports_dir: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--reports-dir", str(reports_dir)],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify-plugin-verifier.py
+++ b/scripts/verify-plugin-verifier.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Gate IntelliJ Plugin Verifier API findings.
+
+Run after `./gradlew verifyPlugin`. The Gradle task can still exit 0 when
+Plugin Verifier marks a target as "Compatible" but records warnings in
+`build/reports/pluginVerifier`.
+
+Policy:
+- internal API findings are a hard CI/release failure;
+- deprecated, scheduled-for-removal, and experimental API findings are surfaced
+  as advisory debt so each merge or release can minimize them when a stable
+  public replacement exists.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_REPORTS_DIR = REPO_ROOT / "build" / "reports" / "pluginVerifier"
+
+
+def relative(path: Path) -> str:
+    """Return a repo-relative path when possible."""
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def nonblank_lines(path: Path) -> list[str]:
+    """Return stripped, non-empty lines from a verifier finding file."""
+    return [
+        line.strip()
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines()
+        if line.strip()
+    ]
+
+
+def verifier_targets_exist(reports_dir: Path) -> bool:
+    """Return True if the directory looks like output from `verifyPlugin`."""
+    return any(reports_dir.rglob("verification-verdict.txt"))
+
+
+def collect_usages(reports_dir: Path, file_name: str) -> dict[str, list[Path]]:
+    """Group verifier finding lines by their exact verifier message."""
+    findings: dict[str, list[Path]] = defaultdict(list)
+    for path in sorted(reports_dir.rglob(file_name)):
+        for line in nonblank_lines(path):
+            findings[line].append(path)
+    return findings
+
+
+def print_findings(
+    findings: dict[str, list[Path]],
+    *,
+    heading: str,
+    guidance: str,
+) -> None:
+    """Print a concise, de-duplicated verifier report."""
+    print(heading, file=sys.stderr)
+    print(guidance, file=sys.stderr)
+    print(file=sys.stderr)
+
+    for index, (message, paths) in enumerate(sorted(findings.items()), start=1):
+        first_path = paths[0]
+        print(f"{index}. {message}", file=sys.stderr)
+        print(
+            f"   seen in {len(paths)} verifier target(s); first: {relative(first_path)}",
+            file=sys.stderr,
+        )
+
+
+def print_internal_failure(findings: dict[str, list[Path]]) -> None:
+    """Print the hard-failure report for internal API findings."""
+    print_findings(
+        findings,
+        heading="ERROR: IntelliJ Plugin Verifier reported internal API usage.",
+        guidance=(
+            "Replace @ApiStatus.Internal / @IntellijInternalApi usages before "
+            "merge or release."
+        ),
+    )
+
+
+def print_advisory(
+    *,
+    deprecated: dict[str, list[Path]],
+    experimental: dict[str, list[Path]],
+) -> None:
+    """Print non-fatal deprecated and experimental API debt."""
+    if deprecated:
+        print_findings(
+            deprecated,
+            heading=(
+                "WARNING: IntelliJ Plugin Verifier reported deprecated or "
+                "scheduled-for-removal API usage."
+            ),
+            guidance=(
+                "Minimize before merge or release when a stable public replacement "
+                "is available."
+            ),
+        )
+        print(file=sys.stderr)
+
+    if experimental:
+        print_findings(
+            experimental,
+            heading="WARNING: IntelliJ Plugin Verifier reported experimental API usage.",
+            guidance=(
+                "Keep experimental API usage narrowly isolated and justified; "
+                "prefer stable public API when one exists."
+            ),
+        )
+        print(file=sys.stderr)
+
+
+def main() -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--reports-dir",
+        type=Path,
+        default=DEFAULT_REPORTS_DIR,
+        help="Plugin Verifier reports directory.",
+    )
+    args = parser.parse_args()
+
+    reports_dir = args.reports_dir.resolve()
+    if not reports_dir.is_dir():
+        print(
+            f"ERROR: Plugin Verifier reports directory not found: {reports_dir}",
+            file=sys.stderr,
+        )
+        print("Run ./gradlew verifyPlugin before this gate.", file=sys.stderr)
+        return 1
+
+    if not verifier_targets_exist(reports_dir):
+        print(
+            f"ERROR: No verification-verdict.txt files found under {relative(reports_dir)}.",
+            file=sys.stderr,
+        )
+        print("Run ./gradlew verifyPlugin before this gate.", file=sys.stderr)
+        return 1
+
+    if findings := collect_usages(reports_dir, "internal-api-usages.txt"):
+        print_internal_failure(findings)
+        return 1
+
+    deprecated = collect_usages(reports_dir, "deprecated-usages.txt")
+    experimental = collect_usages(reports_dir, "experimental-api-usages.txt")
+    print_advisory(deprecated=deprecated, experimental=experimental)
+
+    print(
+        "Plugin Verifier API gate passed: "
+        f"internal=0, deprecated={len(deprecated)}, experimental={len(experimental)}; "
+        f"reports={relative(reports_dir)}",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/main/kotlin/dev/ayuislands/AppearanceSyncService.kt
+++ b/src/main/kotlin/dev/ayuislands/AppearanceSyncService.kt
@@ -1,6 +1,5 @@
 package dev.ayuislands
 
-import com.intellij.ide.ui.LafManager
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.logger
@@ -8,7 +7,6 @@ import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.SystemAppearanceProvider
 import dev.ayuislands.accent.SystemAppearanceProvider.Appearance
 import dev.ayuislands.settings.AyuIslandsSettings
-import javax.swing.SwingUtilities
 
 @Service
 class AppearanceSyncService {
@@ -53,26 +51,22 @@ class AppearanceSyncService {
         LOG.info("Recorded manual appearance choice: $themeName")
     }
 
-    @Suppress("UnstableApiUsage") // installedThemes, UIThemeLookAndFeelInfo — no stable alternative
     private fun switchToTheme(targetThemeName: String) {
-        val lafManager = LafManager.getInstance()
         val currentThemeName = AyuVariant.currentThemeName()
         if (currentThemeName == targetThemeName) return
 
-        val target =
-            lafManager.installedThemes
-                .firstOrNull { it.name == targetThemeName }
-        if (target == null) {
+        if (!AyuLaf.switchToThemeByName(
+                targetThemeName,
+                shouldLockEditorScheme = true,
+                shouldApplyLater = true,
+            )
+        ) {
             LOG.warn("Target theme not found: $targetThemeName")
             return
         }
 
         LOG.info("Switching theme: $currentThemeName -> $targetThemeName")
         programmaticSwitch = true
-        SwingUtilities.invokeLater {
-            lafManager.setCurrentLookAndFeel(target, true)
-            lafManager.updateUI()
-        }
     }
 
     companion object {

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsLafListener.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsLafListener.kt
@@ -15,7 +15,6 @@ import dev.ayuislands.ui.ComponentTreeRefresher
 
 /** Re-applies accent, font, glow, and scrollbar settings on theme change. */
 class AyuIslandsLafListener : LafManagerListener {
-    @Suppress("UnstableApiUsage")
     override fun lookAndFeelChanged(source: LafManager) {
         val variant = AyuVariant.detect()
         if (variant == null) {
@@ -52,7 +51,7 @@ class AyuIslandsLafListener : LafManagerListener {
         // Track manual sub-variant choices for appearance sync
         val syncService = AppearanceSyncService.getInstance()
         if (settings.state.followSystemAppearance && !syncService.programmaticSwitch) {
-            val themeName = source.currentUIThemeLookAndFeel.name
+            val themeName = AyuLaf.currentThemeName(source)
             syncService.recordManualChoice(themeName)
         }
         syncService.clearProgrammaticSwitch()

--- a/src/main/kotlin/dev/ayuislands/AyuLaf.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuLaf.kt
@@ -1,0 +1,32 @@
+package dev.ayuislands
+
+import com.intellij.ide.ui.LafManager
+import javax.swing.SwingUtilities
+
+object AyuLaf {
+    @Suppress("UnstableApiUsage")
+    fun currentThemeName(lafManager: LafManager = LafManager.getInstance()): String {
+        val currentTheme = lafManager.currentUIThemeLookAndFeel
+        return currentTheme?.name.orEmpty()
+    }
+
+    @Suppress("UnstableApiUsage") // No stable public API resolves installed theme display names.
+    fun switchToThemeByName(
+        themeName: String,
+        shouldLockEditorScheme: Boolean,
+        shouldApplyLater: Boolean,
+    ): Boolean {
+        val lafManager = LafManager.getInstance()
+        val target = lafManager.installedThemes.firstOrNull { it.name == themeName } ?: return false
+        val apply = {
+            lafManager.setCurrentLookAndFeel(target, shouldLockEditorScheme)
+            lafManager.updateUI()
+        }
+        if (shouldApplyLater) {
+            SwingUtilities.invokeLater(apply)
+        } else {
+            apply()
+        }
+        return true
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -5,7 +5,6 @@ import com.intellij.notification.NotificationType
 import com.intellij.notification.Notifications
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
-import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.editor.colors.ColorKey
 import com.intellij.openapi.editor.colors.EditorColorsManager
@@ -668,11 +667,11 @@ object AccentApplicator {
         }
 
         // Notify editors to repaint with an updated scheme
-        // Wrapped in ReadAction because Jupyter's NotebookEditorColorsListener
+        // Wrapped in a read action because Jupyter's NotebookEditorColorsListener
         // accesses PSI from globalSchemeChange, which requires read access.
-        ReadAction.run<RuntimeException> {
-            ApplicationManager
-                .getApplication()
+        val application = ApplicationManager.getApplication()
+        application.runReadAction {
+            application
                 .messageBus
                 .syncPublisher(EditorColorsManager.TOPIC)
                 .globalSchemeChange(null)
@@ -713,9 +712,9 @@ object AccentApplicator {
             scheme.setAttributes(attrKey, defaultAttrs ?: EMPTY_TEXT_ATTRIBUTES)
         }
 
-        ReadAction.run<RuntimeException> {
-            ApplicationManager
-                .getApplication()
+        val application = ApplicationManager.getApplication()
+        application.runReadAction {
+            application
                 .messageBus
                 .syncPublisher(EditorColorsManager.TOPIC)
                 .globalSchemeChange(null)

--- a/src/main/kotlin/dev/ayuislands/accent/AyuVariant.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AyuVariant.kt
@@ -1,6 +1,6 @@
 package dev.ayuislands.accent
 
-import com.intellij.ide.ui.LafManager
+import dev.ayuislands.AyuLaf
 
 enum class AyuVariant(
     val defaultAccent: String,
@@ -18,13 +18,7 @@ enum class AyuVariant(
 
         fun fromThemeName(name: String): AyuVariant? = entries.firstOrNull { name in it.themeNames }
 
-        @Suppress("UnstableApiUsage")
-        fun currentThemeName(): String =
-            LafManager
-                .getInstance()
-                .currentUIThemeLookAndFeel
-                ?.name
-                .orEmpty()
+        fun currentThemeName(): String = AyuLaf.currentThemeName()
 
         fun detect(): AyuVariant? = fromThemeName(currentThemeName())
 

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageScanner.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageScanner.kt
@@ -1,6 +1,6 @@
 package dev.ayuislands.accent
 
-import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
@@ -8,7 +8,7 @@ import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.vfs.VirtualFile
 
 /**
- * Walks a project's content roots under a [ReadAction] and tallies per-language
+ * Walks a project's content roots under a read action and tallies per-language
  * bytes, cap-limited per file so generated monsters can't skew proportions and
  * cap-limited by total file count so the scan doesn't block the EDT on
  * linux-kernel-sized repos.
@@ -19,7 +19,7 @@ import com.intellij.openapi.vfs.VirtualFile
  *
  * Returned map semantics:
  *  - `null`  → scan is not authoritative right now (project disposed, dumb mode,
- *              or ReadAction threw). Caller must NOT cache this; the next call
+ *              or the read action threw). Caller must NOT cache this; the next call
  *              retries — critical so a "scan during indexing" doesn't freeze a
  *              pre-indexing fallback into the cache forever.
  *  - empty map → scan ran cleanly and found zero recognized source files. Caller
@@ -53,7 +53,7 @@ internal object ProjectLanguageScanner {
 
         val scanResult =
             runCatchingPreservingCancellation {
-                ReadAction.compute<Map<String, Long>, RuntimeException> {
+                ApplicationManager.getApplication().runReadAction<Map<String, Long>> {
                     scanUnderReadAction(project)
                 }
             }

--- a/src/main/kotlin/dev/ayuislands/accent/elements/BracketFadeManager.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/BracketFadeManager.kt
@@ -2,7 +2,7 @@ package dev.ayuislands.accent.elements
 
 import com.intellij.codeInsight.highlighting.BraceMatchingUtil
 import com.intellij.openapi.Disposable
-import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.EditorFactory
@@ -85,19 +85,19 @@ object BracketFadeManager {
 
         val project = editor.project ?: return
 
-        // PSI access requires ReadAction (EDT alone is not enough since 2025.1 threading model)
+        // PSI access requires a read action (EDT alone is not enough since 2025.1 threading model)
         val bracketRange =
             try {
-                ReadAction.compute<IntArray?, RuntimeException> {
+                ApplicationManager.getApplication().runReadAction<IntArray?> {
                     val psiFile =
                         PsiDocumentManager.getInstance(project).getPsiFile(editor.document)
-                            ?: return@compute null
+                            ?: return@runReadAction null
                     val context =
                         BraceMatchingUtil.computeHighlightingAndNavigationContext(editor, psiFile)
-                            ?: return@compute null
+                            ?: return@runReadAction null
                     val currentOffset = context.currentBraceOffset()
                     val matchOffset = context.navigationOffset()
-                    if (currentOffset == matchOffset) return@compute null
+                    if (currentOffset == matchOffset) return@runReadAction null
                     intArrayOf(
                         minOf(currentOffset, matchOffset),
                         maxOf(currentOffset, matchOffset),

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/VariantSwitcherRow.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/VariantSwitcherRow.kt
@@ -1,8 +1,8 @@
 package dev.ayuislands.accent.toolbar
 
-import com.intellij.ide.ui.LafManager
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.util.ui.JBUI
+import dev.ayuislands.AyuLaf
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentDefaults
 import dev.ayuislands.accent.AccentResolver
@@ -36,13 +36,7 @@ internal class VariantSwitcherRow(
     private var islandsUi: Boolean
 
     init {
-        @Suppress("UnstableApiUsage")
-        islandsUi =
-            LafManager
-                .getInstance()
-                .currentUIThemeLookAndFeel
-                ?.name
-                ?.contains(ISLANDS_UI_SUFFIX) == true
+        islandsUi = AyuLaf.currentThemeName().contains(ISLANDS_UI_SUFFIX)
 
         val segmented =
             SegmentedControl(initialVariant) { selected ->
@@ -77,7 +71,6 @@ internal class VariantSwitcherRow(
         }
     }
 
-    @Suppress("UnstableApiUsage") // getInstalledThemes + setCurrentLookAndFeel(UIThemeLookAndFeelInfo, Boolean)
     private fun applyVariantAndChrome(
         variant: AyuVariant,
         islandsUi: Boolean,
@@ -94,21 +87,21 @@ internal class VariantSwitcherRow(
         // attempt succeeds.
         try {
             val themeName = VariantThemeNameResolver.resolveThemeName(variant, islandsUi)
-            val lafManager = LafManager.getInstance()
             // `findLaf(String)` on IDEA 2026.1 expects the platform theme *id* (e.g.
             // `com.ayuislands.theme.mirage`), not the user-visible *name* ("Ayu Mirage").
             // Match by name across the installed-themes sequence so this stays decoupled
             // from plugin.xml `themeProvider` ids — if those ids ever change, this still
             // resolves as long as the display names in `themes/*.theme.json` match.
-            val laf =
-                lafManager.installedThemes.firstOrNull { it.name == themeName } ?: run {
-                    LOG.warn("Theme not found for variant=$variant islandsUi=$islandsUi name='$themeName'")
-                    return
-                }
             // Second arg is `lockEditorScheme = false` so the same-named editor
             // scheme follows the theme switch instead of locking on the old.
-            lafManager.setCurrentLookAndFeel(laf, false)
-            lafManager.updateUI()
+            if (!AyuLaf.switchToThemeByName(
+                    themeName,
+                    shouldLockEditorScheme = false,
+                    shouldApplyLater = false,
+                )
+            ) {
+                LOG.warn("Theme not found for variant=$variant islandsUi=$islandsUi name='$themeName'")
+            }
         } catch (exception: RuntimeException) {
             LOG.warn(
                 "Variant/Islands apply failed (variant=$variant islandsUi=$islandsUi)",

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/popup/IconPillButton.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/popup/IconPillButton.kt
@@ -1,13 +1,7 @@
 package dev.ayuislands.accent.toolbar.popup
 
-import com.intellij.openapi.actionSystem.ActionUiKind
+import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.AnAction
-import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.actionSystem.DataContext
-import com.intellij.openapi.actionSystem.PlatformCoreDataKeys
-import com.intellij.openapi.actionSystem.Presentation
-import com.intellij.openapi.actionSystem.ex.ActionUtil
-import com.intellij.openapi.actionSystem.impl.SimpleDataContext
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.util.ui.JBUI
 import java.awt.Color
@@ -34,14 +28,11 @@ import javax.swing.JComponent
  * Tooltip text comes from the action's `templatePresentation.description` (or
  * `text` as fallback).
  *
- * Click handler uses the non-deprecated 6-arg event-factory form on
- * [AnActionEvent] and dispatches through [ActionUtil.invokeAction] rather
- * than calling the action's perform method directly: IntelliJ 2025.1+
- * marks `AnAction.actionPerformed` as `@ApiStatus.OverrideOnly`, so
- * direct invocation by callers bypasses platform plumbing
- * (beforeActionPerformed listeners, action-promoter chain, error
- * reporting). [ActionUtil.invokeAction] is the project-canonical
- * helper — see `LicenseChecker.kt` for prior art.
+ * Click handler dispatches through [ActionManager.tryToExecute] rather than
+ * calling the action's perform method directly: IntelliJ 2025.1+ marks
+ * `AnAction.actionPerformed` as `@ApiStatus.OverrideOnly`, so direct invocation
+ * by callers bypasses platform plumbing (beforeActionPerformed listeners,
+ * action-promoter chain, error reporting).
  * The dispatch is wrapped in
  * `try { ... } catch (exception: RuntimeException) { LOG.warn(...) }` per
  * Pattern B — a throwing action must NOT kill the EDT or crash the popup.
@@ -50,8 +41,7 @@ import javax.swing.JComponent
  * `Graphics.create()` block dismisses in `finally`.
  *
  * @param action the [AnAction] this pill delegates to on click.
- * @param anchor the popup's invoker [JComponent] — used as `CONTEXT_COMPONENT`
- *   in the synthetic [AnActionEvent].
+ * @param anchor the popup's invoker [JComponent].
  * @param icon the 16x16 [Icon] rendered inside the pill.
  */
 internal class IconPillButton(
@@ -151,24 +141,7 @@ internal class IconPillButton(
 
     private fun invokeAction() {
         try {
-            val dataContext: DataContext =
-                SimpleDataContext
-                    .builder()
-                    .add(PlatformCoreDataKeys.CONTEXT_COMPONENT, anchor)
-                    .build()
-            val event =
-                AnActionEvent.createEvent(
-                    action,
-                    dataContext,
-                    Presentation(),
-                    POPUP_PLACE,
-                    ActionUiKind.POPUP,
-                    null,
-                )
-            // Project-canonical dispatch — mirrors [LicenseChecker.invokeAction].
-            // Direct `action.actionPerformed(event)` would bypass `@ApiStatus.OverrideOnly`
-            // contract on 2025.1+ and miss the beforeActionPerformed plumbing.
-            ActionUtil.invokeAction(action, event, null)
+            ActionManager.getInstance().tryToExecute(action, null, anchor, POPUP_PLACE, true)
         } catch (exception: RuntimeException) {
             LOG.warn("IconPillButton action ${action.javaClass.simpleName} failed", exception)
         }

--- a/src/main/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManager.kt
+++ b/src/main/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManager.kt
@@ -3,7 +3,6 @@ package dev.ayuislands.commitpanel
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener
 import dev.ayuislands.licensing.LicenseChecker
@@ -37,15 +36,6 @@ class CommitPanelAutoFitManager(
                     changeType: ToolWindowManagerListener.ToolWindowManagerEventType,
                 ) {
                     if (!changeType.shouldTriggerAutoFitFor(toolWindowManager, TOOL_WINDOW_ID)) return
-                    applyIfWidthManaged()
-                }
-
-                override fun stateChanged(
-                    toolWindowManager: ToolWindowManager,
-                    toolWindow: ToolWindow,
-                    changeType: ToolWindowManagerListener.ToolWindowManagerEventType,
-                ) {
-                    if (!changeType.shouldTriggerAutoFitFor(toolWindow, TOOL_WINDOW_ID)) return
                     applyIfWidthManaged()
                 }
             },

--- a/src/main/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManager.kt
+++ b/src/main/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManager.kt
@@ -4,7 +4,6 @@ import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Splitter
-import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener
 import dev.ayuislands.licensing.LicenseChecker
@@ -40,15 +39,6 @@ class GitPanelAutoFitManager(
                     changeType: ToolWindowManagerListener.ToolWindowManagerEventType,
                 ) {
                     if (!changeType.shouldTriggerAutoFitFor(toolWindowManager, TOOL_WINDOW_ID)) return
-                    scheduleFitIfWidthManaged()
-                }
-
-                override fun stateChanged(
-                    toolWindowManager: ToolWindowManager,
-                    toolWindow: ToolWindow,
-                    changeType: ToolWindowManagerListener.ToolWindowManagerEventType,
-                ) {
-                    if (!changeType.shouldTriggerAutoFitFor(toolWindow, TOOL_WINDOW_ID)) return
                     scheduleFitIfWidthManaged()
                 }
             },

--- a/src/main/kotlin/dev/ayuislands/onboarding/FreeOnboardingPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/onboarding/FreeOnboardingPanel.kt
@@ -2,7 +2,6 @@ package dev.ayuislands.onboarding
 
 import com.intellij.icons.AllIcons
 import com.intellij.ide.BrowserUtil
-import com.intellij.ide.ui.LafManager
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.fileEditor.FileEditorManager
@@ -13,6 +12,7 @@ import com.intellij.ui.ColorUtil
 import com.intellij.ui.JBColor
 import com.intellij.ui.components.JBLabel
 import com.intellij.util.ui.JBUI
+import dev.ayuislands.AyuLaf
 import dev.ayuislands.accent.AYU_ACCENT_PRESETS
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentColor
@@ -351,17 +351,15 @@ internal class FreeOnboardingPanel(
         updateTrialHeadline(label.font.size2D)
     }
 
-    @Suppress("UnstableApiUsage")
     private fun applyVariantLaf(variant: AyuVariant) {
-        val lafManager = LafManager.getInstance()
         val targetName =
             variant.themeNames.firstOrNull { it.contains("Islands UI") }
                 ?: variant.themeNames.first()
-        val target = lafManager.installedThemes.firstOrNull { it.name == targetName } ?: return
-        SwingUtilities.invokeLater {
-            lafManager.setCurrentLookAndFeel(target, true)
-            lafManager.updateUI()
-        }
+        AyuLaf.switchToThemeByName(
+            targetName,
+            shouldLockEditorScheme = true,
+            shouldApplyLater = true,
+        )
     }
 
     /** Color shown as the variant card's accent dot. Selected swatch takes priority. */

--- a/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
+++ b/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
@@ -6,7 +6,6 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.registry.Registry
-import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener
 import com.intellij.ui.SimpleColoredComponent
@@ -57,15 +56,6 @@ class ProjectViewScrollbarManager(
                     changeType: ToolWindowManagerListener.ToolWindowManagerEventType,
                 ) {
                     if (!changeType.shouldTriggerAutoFitFor(toolWindowManager, TOOL_WINDOW_ID)) return
-                    applyIfAnyProjectFeatureManaged()
-                }
-
-                override fun stateChanged(
-                    toolWindowManager: ToolWindowManager,
-                    toolWindow: ToolWindow,
-                    changeType: ToolWindowManagerListener.ToolWindowManagerEventType,
-                ) {
-                    if (!changeType.shouldTriggerAutoFitFor(toolWindow, TOOL_WINDOW_ID)) return
                     applyIfAnyProjectFeatureManaged()
                 }
             },

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -165,14 +165,6 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
                 },
             )
         accentPanel = colorPanel
-
-        val lastShuffle = AyuIslandsSettings.getInstance().state.lastShuffleColor
-        if (lastShuffle != null) {
-            colorPanel.showThirteenthSwatchImmediate(lastShuffle)
-        } else if (storedAccent.isNotEmpty()) {
-            colorPanel.showThirteenthSwatchImmediate(storedAccent)
-        }
-
         return colorPanel
     }
 
@@ -411,6 +403,7 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
             pendingAccent = existingCustom
             panel.selectedPreset = null
             panel.customColor = existingCustom
+            panel.showThirteenthSwatchImmediate(existingCustom)
             onAccentChanged?.invoke(existingCustom)
             return
         }
@@ -464,17 +457,21 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
             colorPanel.selectedPreset = null
             colorPanel.customColor = null
             pendingCustomColor = null
+            colorPanel.hideThirteenthSwatch()
             return
         }
 
         val matchesPreset = AYU_ACCENT_PRESETS.any { it.hex.equals(accent, ignoreCase = true) }
         if (matchesPreset) {
             colorPanel.selectedPreset = accent
+            colorPanel.customColor = null
+            pendingCustomColor = null
         } else {
             colorPanel.selectedPreset = null
             colorPanel.customColor = accent
             pendingCustomColor = accent
         }
+        colorPanel.showThirteenthSwatchImmediate(accent)
     }
 
     private fun updatePanelEnabled() {
@@ -489,6 +486,7 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
         pendingCustomColor = null
         accentPanel?.selectedPreset = null
         accentPanel?.customColor = null
+        accentPanel?.hideThirteenthSwatch()
         onAccentChanged?.invoke("")
     }
 

--- a/src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
@@ -25,6 +25,7 @@ import dev.ayuislands.font.FontWeight
 import java.awt.datatransfer.StringSelection
 import javax.swing.JCheckBox
 import javax.swing.JLabel
+import javax.swing.JList
 import javax.swing.JSpinner
 import javax.swing.SpinnerNumberModel
 
@@ -452,7 +453,18 @@ class FontPresetPanel : AyuIslandsSettingsPanel {
 
             label("Weight:")
             val wCombo = ComboBox(FontWeight.entries.toTypedArray())
-            wCombo.renderer = SimpleListCellRenderer.create("") { it.displayName }
+            wCombo.renderer =
+                object : SimpleListCellRenderer<FontWeight>() {
+                    override fun customize(
+                        list: JList<out FontWeight>,
+                        value: FontWeight?,
+                        index: Int,
+                        selected: Boolean,
+                        hasFocus: Boolean,
+                    ) {
+                        text = value?.displayName.orEmpty()
+                    }
+                }
             wCombo.selectedItem = currentSettings.weight
             wCombo.addActionListener {
                 if (!suppressListeners) {

--- a/src/main/kotlin/dev/ayuislands/syntax/SyntaxIntensityService.kt
+++ b/src/main/kotlin/dev/ayuislands/syntax/SyntaxIntensityService.kt
@@ -1,7 +1,6 @@
 package dev.ayuislands.syntax
 
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.editor.colors.EditorColorsManager
@@ -25,7 +24,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  *  - R-7 single publish: exactly one
  *    `MessageBus.syncPublisher(EditorColorsManager.TOPIC)` invocation
  *    publishing a single global-scheme-change event per apply call,
- *    wrapped in `ReadAction.run`.
+ *    wrapped in a read action.
  *  - Pattern A latches: a missing named scheme logs WARN once per (scheme,
  *    session); an unknown overlay variant tag arriving via
  *    [resolveActiveAyuOverlayVariant] (a future Ayu variant outside the whitelist)
@@ -299,9 +298,9 @@ class SyntaxIntensityService {
     }
 
     private fun publishSchemeChange() {
-        ReadAction.run<RuntimeException> {
-            ApplicationManager
-                .getApplication()
+        val application = ApplicationManager.getApplication()
+        application.runReadAction {
+            application
                 .messageBus
                 .syncPublisher(EditorColorsManager.TOPIC)
                 .globalSchemeChange(null)

--- a/src/main/kotlin/dev/ayuislands/toolwindow/AutoFitTriggers.kt
+++ b/src/main/kotlin/dev/ayuislands/toolwindow/AutoFitTriggers.kt
@@ -1,6 +1,5 @@
 package dev.ayuislands.toolwindow
 
-import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener
 
@@ -25,17 +24,12 @@ internal fun ToolWindowManagerListener.ToolWindowManagerEventType.shouldTriggerA
         this != ToolWindowManagerListener.ToolWindowManagerEventType.ShowToolWindow
 
 internal fun ToolWindowManagerListener.ToolWindowManagerEventType.shouldTriggerAutoFitFor(
-    toolWindow: ToolWindow,
-    expectedToolWindowId: String,
-): Boolean =
-    shouldTriggerAutoFit() &&
-        toolWindow.id == expectedToolWindowId &&
-        toolWindow.isVisible
-
-internal fun ToolWindowManagerListener.ToolWindowManagerEventType.shouldTriggerAutoFitFor(
     toolWindowManager: ToolWindowManager,
     expectedToolWindowId: String,
 ): Boolean {
+    if (!shouldTriggerAutoFit()) return false
+    if (toolWindowManager.activeToolWindowId != expectedToolWindowId) return false
+
     val toolWindow = toolWindowManager.getToolWindow(expectedToolWindowId) ?: return false
-    return shouldTriggerAutoFit() && toolWindow.isVisible
+    return toolWindow.isVisible
 }

--- a/src/main/kotlin/dev/ayuislands/toolwindow/AutoFitTriggers.kt
+++ b/src/main/kotlin/dev/ayuislands/toolwindow/AutoFitTriggers.kt
@@ -28,7 +28,12 @@ internal fun ToolWindowManagerListener.ToolWindowManagerEventType.shouldTriggerA
     expectedToolWindowId: String,
 ): Boolean {
     if (!shouldTriggerAutoFit()) return false
-    if (toolWindowManager.activeToolWindowId != expectedToolWindowId) return false
+    if (
+        this == ToolWindowManagerListener.ToolWindowManagerEventType.ActivateToolWindow &&
+        toolWindowManager.activeToolWindowId != expectedToolWindowId
+    ) {
+        return false
+    }
 
     val toolWindow = toolWindowManager.getToolWindow(expectedToolWindowId) ?: return false
     return toolWindow.isVisible

--- a/src/test/kotlin/dev/ayuislands/accent/elements/BracketFadeManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/BracketFadeManagerTest.kt
@@ -399,6 +399,24 @@ class BracketFadeManagerTest {
     }
 
     @Test
+    fun `handleCaretMove computes bracket range inside read action`() {
+        setPrivateField("currentColor", Color.CYAN)
+        val mockContext = mockk<BraceHighlightingAndNavigationContext>(relaxed = true)
+        every {
+            BraceMatchingUtil.computeHighlightingAndNavigationContext(any(), any())
+        } returns mockContext
+        every { mockContext.currentBraceOffset() } returns 10
+        every { mockContext.navigationOffset() } returns 50
+        every { mockDocument.getLineNumber(any()) } returns 0
+
+        invokePrivate("handleCaretMove", mockEditor)
+
+        verify(exactly = 1) {
+            mockApplication.runReadAction<Any?>(any())
+        }
+    }
+
+    @Test
     fun `handleCaretMove coerces endOffset plus one to textLength`() {
         setPrivateField("currentColor", Color.RED)
         val mockContext = mockk<BraceHighlightingAndNavigationContext>(relaxed = true)

--- a/src/test/kotlin/dev/ayuislands/accent/elements/BracketFadeManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/BracketFadeManagerTest.kt
@@ -4,7 +4,6 @@ import com.intellij.codeInsight.highlighting.BraceMatchingUtil
 import com.intellij.codeInsight.highlighting.BraceMatchingUtil.BraceHighlightingAndNavigationContext
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.EditorFactory
@@ -13,6 +12,7 @@ import com.intellij.openapi.editor.markup.HighlighterTargetArea
 import com.intellij.openapi.editor.markup.MarkupModel
 import com.intellij.openapi.editor.markup.RangeHighlighter
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Computable
 import com.intellij.openapi.util.Disposer
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiFile
@@ -83,11 +83,10 @@ class BracketFadeManagerTest {
         every { PsiDocumentManager.getInstance(any()) } returns mockPsiDocumentManager
         every { mockPsiDocumentManager.getPsiFile(any()) } returns mockPsiFile
 
-        mockkStatic(ReadAction::class)
         every {
-            ReadAction.compute<Any?, RuntimeException>(any())
+            mockApplication.runReadAction<Any?>(any())
         } answers {
-            firstArg<com.intellij.openapi.util.ThrowableComputable<Any?, RuntimeException>>().compute()
+            firstArg<Computable<Any?>>().compute()
         }
 
         mockkStatic(BraceMatchingUtil::class)

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/popup/IconPillButtonTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/popup/IconPillButtonTest.kt
@@ -3,17 +3,12 @@ package dev.ayuislands.accent.toolbar.popup
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.AnAction
-import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.actionSystem.Presentation
-import com.intellij.openapi.actionSystem.ex.ActionUtil
-import com.intellij.openapi.actionSystem.impl.SimpleDataContext
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.util.ActionCallback
 import com.intellij.util.ui.JBUI
-import io.mockk.Runs
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
@@ -32,12 +27,15 @@ import kotlin.test.assertTrue
  * per Pattern B so the button stays enabled.
  */
 class IconPillButtonTest {
+    private lateinit var actionManager: ActionManager
+
     @BeforeTest
     fun setUp() {
         mockkStatic(ApplicationManager::class)
         val mockApp = mockk<Application>(relaxed = true)
+        actionManager = mockk(relaxed = true)
         every { ApplicationManager.getApplication() } returns mockApp
-        every { mockApp.getService(ActionManager::class.java) } returns mockk<ActionManager>(relaxed = true)
+        every { mockApp.getService(ActionManager::class.java) } returns actionManager
     }
 
     @AfterTest
@@ -66,65 +64,34 @@ class IconPillButtonTest {
     }
 
     @Test
-    fun `click dispatches the action through ActionUtil invokeAction with the 6-arg event`() {
+    fun `click dispatches the action through ActionManager tryToExecute`() {
         // Behavior test: direct `action.actionPerformed(event)` is a call to
         // an `@ApiStatus.OverrideOnly` member on 2025.1+, so the dispatch
-        // routes through [ActionUtil.invokeAction] (same helper LicenseChecker
-        // uses).
-        //
-        // Headless harness can't run SimpleDataContext.builder().build() — it
-        // reaches for IdeUiService which is null outside a real Application.
-        // Stub the data-context builder to short-circuit that path, then
-        // verify the helper is the actual dispatcher (and direct
-        // actionPerformed is NOT called).
-        mockkStatic(ActionUtil::class)
-        mockkStatic(SimpleDataContext::class)
-        val stubBuilder = mockk<SimpleDataContext.Builder>(relaxed = true)
-        every { SimpleDataContext.builder() } returns stubBuilder
-        every { stubBuilder.add(any<com.intellij.openapi.actionSystem.DataKey<Any>>(), any()) } returns stubBuilder
-        val stubContext = mockk<DataContext>(relaxed = true)
-        every { stubBuilder.build() } returns stubContext
+        // routes through the platform action dispatcher.
 
         val action = mockk<AnAction>(relaxed = true)
         val presentation = Presentation("Pin").apply { description = "Pin this accent" }
         every { action.templatePresentation } returns presentation
-        val captured = mutableListOf<AnActionEvent>()
         every {
-            ActionUtil.invokeAction(eq(action), capture(captured), null)
-        } just Runs
+            actionManager.tryToExecute(eq(action), null, any(), eq("AyuQuickSwitcher.Popup"), true)
+        } returns ActionCallback.DONE
 
         val button = IconPillButton(action, JLabel(), AllIcons.Actions.PinTab)
         button.doClick()
 
-        verify(exactly = 1) { ActionUtil.invokeAction(action, any(), null) }
-        // The positive verify above already proves the dispatch went through the
-        // ActionUtil helper; a redundant negative on the action's perform method
-        // tripped the platform's `@ApiStatus.OverrideOnly` inspection without
-        // adding coverage.
-        assertEquals(1, captured.size, "Helper must receive exactly one event")
-        val event = captured.single()
-        assertEquals(
-            "AyuQuickSwitcher.Popup",
-            event.place,
-            "Event place must be the popup constant so action-update gating reads correctly",
-        )
+        verify(exactly = 1) {
+            actionManager.tryToExecute(action, null, any(), "AyuQuickSwitcher.Popup", true)
+        }
     }
 
     @Test
     fun `click swallows RuntimeException from the action without crashing the button`() {
         // Pattern B behavior lock. A throwing action must NOT escape the
         // button or leave it disabled.
-        mockkStatic(ActionUtil::class)
-        mockkStatic(SimpleDataContext::class)
-        val stubBuilder = mockk<SimpleDataContext.Builder>(relaxed = true)
-        every { SimpleDataContext.builder() } returns stubBuilder
-        every { stubBuilder.add(any<com.intellij.openapi.actionSystem.DataKey<Any>>(), any()) } returns stubBuilder
-        every { stubBuilder.build() } returns mockk(relaxed = true)
-
         val action = mockk<AnAction>(relaxed = true)
         every { action.templatePresentation } returns Presentation("Pin")
         every {
-            ActionUtil.invokeAction(eq(action), any(), null)
+            actionManager.tryToExecute(eq(action), null, any(), eq("AyuQuickSwitcher.Popup"), true)
         } throws RuntimeException("boom action")
 
         val button = IconPillButton(action, JLabel(), AllIcons.Actions.PinTab)

--- a/src/test/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManagerTest.kt
@@ -2,7 +2,6 @@ package dev.ayuislands.commitpanel
 
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ToolWindowType
 import com.intellij.openapi.wm.ex.ToolWindowEx
@@ -191,6 +190,7 @@ class CommitPanelAutoFitManagerTest {
             } returns true
             realState.commitPanelWidthMode =
                 PanelWidthMode.FIXED.name
+            every { toolWindowManager.activeToolWindowId } returns "AWS"
 
             val listenerSlot = slot<ToolWindowManagerListener>()
             every {
@@ -202,10 +202,8 @@ class CommitPanelAutoFitManagerTest {
 
             CommitPanelAutoFitManager(project)
 
-            val foreignToolWindow = visibleToolWindow("AWS")
             listenerSlot.captured.stateChanged(
                 toolWindowManager,
-                foreignToolWindow,
                 ToolWindowManagerEventType.ActivateToolWindow,
             )
 
@@ -228,6 +226,7 @@ class CommitPanelAutoFitManagerTest {
             val panel = JPanel(FlowLayout())
             panel.setSize(200, 400)
             setupCommitToolWindow(panel)
+            every { toolWindowManager.activeToolWindowId } returns "Commit"
             every { toolWindowEx.id } returns "Commit"
             every { toolWindowEx.isVisible } returns true
 
@@ -243,7 +242,6 @@ class CommitPanelAutoFitManagerTest {
 
             listenerSlot.captured.stateChanged(
                 toolWindowManager,
-                toolWindowEx,
                 ToolWindowManagerEventType.ActivateToolWindow,
             )
 
@@ -264,6 +262,7 @@ class CommitPanelAutoFitManagerTest {
             val panel = JPanel(FlowLayout())
             panel.setSize(200, 400)
             setupCommitToolWindow(panel)
+            every { toolWindowManager.activeToolWindowId } returns "Commit"
             every { toolWindowEx.id } returns "Commit"
             every { toolWindowEx.isVisible } returns true
 
@@ -394,12 +393,6 @@ class CommitPanelAutoFitManagerTest {
             toolWindowEx.type
         } returns ToolWindowType.DOCKED
     }
-
-    private fun visibleToolWindow(id: String): ToolWindow =
-        mockk {
-            every { this@mockk.id } returns id
-            every { isVisible } returns true
-        }
 
     private fun mockCalculatorForDefaultMeasuredWidth() {
         mockkObject(AutoFitCalculator)

--- a/src/test/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/gitpanel/GitPanelAutoFitManagerTest.kt
@@ -312,6 +312,7 @@ class GitPanelAutoFitManagerTest {
         } returns true
         realState.gitPanelWidthMode =
             PanelWidthMode.AUTO_FIT.name
+        every { toolWindowManager.activeToolWindowId } returns "AWS"
 
         val listenerSlot = slot<ToolWindowManagerListener>()
         every {
@@ -323,10 +324,8 @@ class GitPanelAutoFitManagerTest {
 
         GitPanelAutoFitManager(project)
 
-        val foreignToolWindow = visibleToolWindow("AWS")
         listenerSlot.captured.stateChanged(
             toolWindowManager,
-            foreignToolWindow,
             ToolWindowManagerEventType.ActivateToolWindow,
         )
 
@@ -383,6 +382,7 @@ class GitPanelAutoFitManagerTest {
                         this@mockk.contentManager
                     } returns contentManager
                 }
+            every { toolWindowManager.activeToolWindowId } returns "Version Control"
             every {
                 toolWindowManager.getToolWindow("Version Control")
             } returns toolWindow
@@ -482,10 +482,4 @@ class GitPanelAutoFitManagerTest {
             }
         }
     }
-
-    private fun visibleToolWindow(id: String): ToolWindow =
-        mockk {
-            every { this@mockk.id } returns id
-            every { isVisible } returns true
-        }
 }

--- a/src/test/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManagerTest.kt
@@ -290,6 +290,7 @@ class ProjectViewScrollbarManagerTest {
     fun `stateChanged ignores events from another visible tool window`() {
         realState.projectPanelWidthMode = PanelWidthMode.DEFAULT.name
         realState.hideProjectViewHScrollbar = true
+        every { toolWindowManager.activeToolWindowId } returns "AWS"
 
         val listenerSlot = slot<ToolWindowManagerListener>()
         every {
@@ -303,11 +304,10 @@ class ProjectViewScrollbarManagerTest {
         try {
             SwingUtilities.invokeAndWait {}
             clearMocks(toolWindowManager, answers = false)
+            every { toolWindowManager.activeToolWindowId } returns "AWS"
 
-            val foreignToolWindow = visibleToolWindow("AWS")
             listenerSlot.captured.stateChanged(
                 toolWindowManager,
-                foreignToolWindow,
                 ToolWindowManagerListener.ToolWindowManagerEventType.ActivateToolWindow,
             )
 
@@ -331,6 +331,7 @@ class ProjectViewScrollbarManagerTest {
         val wrapper = JPanel(FlowLayout())
         wrapper.add(scrollPane)
         setupToolWindowContent(wrapper)
+        every { toolWindowManager.activeToolWindowId } returns "Project"
 
         val listenerSlot = slot<ToolWindowManagerListener>()
         every {
@@ -424,10 +425,4 @@ class ProjectViewScrollbarManagerTest {
             toolWindowManager.getToolWindow("Project")
         } returns toolWindow
     }
-
-    private fun visibleToolWindow(id: String): ToolWindow =
-        mockk {
-            every { this@mockk.id } returns id
-            every { isVisible } returns true
-        }
 }

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanelTest.kt
@@ -346,6 +346,29 @@ class AyuIslandsAccentPanelTest {
         )
     }
 
+    @Test
+    fun `initial accent preview follows selected preset instead of stale shuffle color`() {
+        val selectedPreset = "#F28779"
+        state.mirageAccent = selectedPreset
+        state.lastShuffleColor = "#5CCFE6"
+        every { settings.getAccentForVariant(AyuVariant.MIRAGE) } returns selectedPreset
+
+        val accentPanel = AyuIslandsAccentPanel()
+        val dialogPanel = buildDialogPanel(accentPanel)
+        val colorPanel = descendants(dialogPanel, AccentColorPanel::class.java).single()
+
+        kotlin.test.assertEquals(
+            selectedPreset,
+            colorPanel.selectedPreset,
+            "Accent selector must initialize from the stored preset",
+        )
+        kotlin.test.assertEquals(
+            selectedPreset,
+            thirteenthSwatchColorHex(colorPanel),
+            "Large accent preview must not reuse a stale lastShuffleColor from an older pending shuffle",
+        )
+    }
+
     private fun buildDialogPanel(accentPanel: AyuIslandsAccentPanel): DialogPanel {
         wireUiDslServices()
         return panel {
@@ -395,6 +418,16 @@ class AyuIslandsAccentPanelTest {
             }
             visit(container)
         }
+
+    private fun thirteenthSwatchColorHex(panel: AccentColorPanel): String? {
+        val swatch =
+            descendants(panel, Component::class.java)
+                .firstOrNull { it.javaClass.simpleName == "ThirteenthSwatch" }
+                ?: error("AccentColorPanel must contain a ThirteenthSwatch preview component")
+        val field = swatch.javaClass.getDeclaredField("colorHex")
+        field.isAccessible = true
+        return field.get(swatch) as String?
+    }
 
     private fun JComboBox<*>.containsItem(item: String): Boolean = (0 until itemCount).any { getItemAt(it) == item }
 

--- a/src/test/kotlin/dev/ayuislands/syntax/SyntaxIntensityServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/syntax/SyntaxIntensityServiceTest.kt
@@ -2,14 +2,12 @@ package dev.ayuislands.syntax
 
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.editor.colors.EditorColorsListener
 import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.colors.EditorColorsScheme
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.ui.JBColor
-import com.intellij.util.ThrowableRunnable
 import com.intellij.util.messages.MessageBus
 import dev.ayuislands.licensing.LicenseChecker
 import io.mockk.Runs
@@ -30,7 +28,7 @@ import kotlin.test.assertFailsWith
  * Orchestration tests for [SyntaxIntensityService]. Reuses the prior
  * service-orchestrator MockK harness - mocks the three named Ayu schemes
  * via `EditorColorsManager.getScheme(...)` plus the active `globalScheme`,
- * verifies a single `ReadAction`-wrapped `globalSchemeChange` publish per
+ * verifies a single read-action-wrapped `globalSchemeChange` publish per
  * `apply()` invocation (R-7), and pins the R-1 fallback + service-layer
  * `CUSTOM` premium gate behaviour through `mockkObject` calls into
  * `RgbBlend` / `LicenseChecker` / `SyntaxIntensityApplicator`.
@@ -83,9 +81,8 @@ class SyntaxIntensityServiceTest {
         every { mockApp.messageBus } returns mockMessageBus
         every { mockMessageBus.syncPublisher(EditorColorsManager.TOPIC) } returns mockPublisher
 
-        mockkStatic(ReadAction::class)
-        every { ReadAction.run<RuntimeException>(any()) } answers {
-            firstArg<ThrowableRunnable<RuntimeException>>().run()
+        every { mockApp.runReadAction(any<Runnable>()) } answers {
+            firstArg<Runnable>().run()
         }
 
         loader = mockk(relaxed = true)
@@ -176,13 +173,13 @@ class SyntaxIntensityServiceTest {
         verify(exactly = 1) { mockPublisher.globalSchemeChange(null) }
     }
 
-    // ---------- Test 4: R-7 ReadAction wrap ----------
+    // ---------- Test 4: R-7 read-action wrap ----------
 
     @Test
-    fun `globalSchemeChange publish is wrapped in ReadAction (R-7)`() {
-        every { ReadAction.run<RuntimeException>(any()) } just Runs
+    fun `globalSchemeChange publish is wrapped in read action (R-7)`() {
+        every { mockApp.runReadAction(any<Runnable>()) } just Runs
         SyntaxIntensityService().apply(SyntaxPreset.WHISPER, emptyMap())
-        verify(exactly = 1) { ReadAction.run<RuntimeException>(any()) }
+        verify(exactly = 1) { mockApp.runReadAction(any<Runnable>()) }
     }
 
     // ---------- Test 5: R-1 fallback engages for dark variant + WHITE bg ----------

--- a/src/test/kotlin/dev/ayuislands/toolwindow/AutoFitTriggersTest.kt
+++ b/src/test/kotlin/dev/ayuislands/toolwindow/AutoFitTriggersTest.kt
@@ -28,7 +28,7 @@ class AutoFitTriggersTest {
     }
 
     @Test
-    fun `HideToolWindow falls through for downstream tw isVisible filter`() {
+    fun `HideToolWindow falls through for downstream visibility filter`() {
         assertTrue(ToolWindowManagerEventType.HideToolWindow.shouldTriggerAutoFit())
     }
 
@@ -38,50 +38,67 @@ class AutoFitTriggersTest {
     }
 
     @Test
-    fun `foreign visible tool window does not trigger scoped auto-fit`() {
-        val toolWindow = toolWindow(id = "AWS", isVisible = true)
+    fun `foreign active tool window does not trigger scoped auto-fit`() {
+        val toolWindowManager = mockk<ToolWindowManager>()
+        every { toolWindowManager.activeToolWindowId } returns "AWS"
 
         assertFalse(
             ToolWindowManagerEventType.ActivateToolWindow
-                .shouldTriggerAutoFitFor(toolWindow, expectedToolWindowId = "Commit"),
+                .shouldTriggerAutoFitFor(toolWindowManager, expectedToolWindowId = "Commit"),
         )
     }
 
     @Test
-    fun `own hidden tool window does not trigger scoped auto-fit`() {
-        val toolWindow = toolWindow(id = "Commit", isVisible = false)
+    fun `missing active tool window does not trigger scoped auto-fit`() {
+        val toolWindowManager = mockk<ToolWindowManager>()
+        every { toolWindowManager.activeToolWindowId } returns null
 
         assertFalse(
             ToolWindowManagerEventType.ActivateToolWindow
-                .shouldTriggerAutoFitFor(toolWindow, expectedToolWindowId = "Commit"),
+                .shouldTriggerAutoFitFor(toolWindowManager, expectedToolWindowId = "Commit"),
         )
     }
 
     @Test
-    fun `own visible tool window triggers scoped auto-fit for accepted events`() {
-        val toolWindow = toolWindow(id = "Commit", isVisible = true)
+    fun `active hidden tool window does not trigger scoped auto-fit`() {
+        val toolWindowManager = mockk<ToolWindowManager>()
+        every { toolWindowManager.activeToolWindowId } returns "Commit"
+        every { toolWindowManager.getToolWindow("Commit") } returns toolWindow(isVisible = false)
+
+        assertFalse(
+            ToolWindowManagerEventType.ActivateToolWindow
+                .shouldTriggerAutoFitFor(toolWindowManager, expectedToolWindowId = "Commit"),
+        )
+    }
+
+    @Test
+    fun `active visible tool window triggers scoped auto-fit for accepted events`() {
+        val toolWindowManager = mockk<ToolWindowManager>()
+        every { toolWindowManager.activeToolWindowId } returns "Commit"
+        every { toolWindowManager.getToolWindow("Commit") } returns toolWindow(isVisible = true)
 
         assertTrue(
             ToolWindowManagerEventType.ActivateToolWindow
-                .shouldTriggerAutoFitFor(toolWindow, expectedToolWindowId = "Commit"),
+                .shouldTriggerAutoFitFor(toolWindowManager, expectedToolWindowId = "Commit"),
         )
     }
 
     @Test
-    fun `own visible tool window keeps rejected event filter`() {
-        val toolWindow = toolWindow(id = "Commit", isVisible = true)
+    fun `active visible tool window keeps rejected event filter`() {
+        val toolWindowManager = mockk<ToolWindowManager>()
+        every { toolWindowManager.activeToolWindowId } returns "Commit"
 
         assertFalse(
             ToolWindowManagerEventType.ShowToolWindow
-                .shouldTriggerAutoFitFor(toolWindow, expectedToolWindowId = "Commit"),
+                .shouldTriggerAutoFitFor(toolWindowManager, expectedToolWindowId = "Commit"),
         )
     }
 
     @Test
-    fun `global layout event triggers scoped auto-fit for visible managed tool window`() {
+    fun `global layout event triggers scoped auto-fit for active visible managed tool window`() {
         val toolWindowManager = mockk<ToolWindowManager>()
-        val toolWindow = toolWindow(id = "Commit", isVisible = true)
-        every { toolWindowManager.getToolWindow("Commit") } returns toolWindow
+        every { toolWindowManager.activeToolWindowId } returns "Commit"
+        every { toolWindowManager.getToolWindow("Commit") } returns toolWindow(isVisible = true)
 
         assertTrue(
             ToolWindowManagerEventType.SetLayout
@@ -92,8 +109,8 @@ class AutoFitTriggersTest {
     @Test
     fun `global layout event ignores hidden managed tool window`() {
         val toolWindowManager = mockk<ToolWindowManager>()
-        val toolWindow = toolWindow(id = "Commit", isVisible = false)
-        every { toolWindowManager.getToolWindow("Commit") } returns toolWindow
+        every { toolWindowManager.activeToolWindowId } returns "Commit"
+        every { toolWindowManager.getToolWindow("Commit") } returns toolWindow(isVisible = false)
 
         assertFalse(
             ToolWindowManagerEventType.SetLayout
@@ -101,12 +118,8 @@ class AutoFitTriggersTest {
         )
     }
 
-    private fun toolWindow(
-        id: String,
-        isVisible: Boolean,
-    ): ToolWindow =
+    private fun toolWindow(isVisible: Boolean): ToolWindow =
         mockk {
-            every { this@mockk.id } returns id
             every { this@mockk.isVisible } returns isVisible
         }
 }

--- a/src/test/kotlin/dev/ayuislands/toolwindow/AutoFitTriggersTest.kt
+++ b/src/test/kotlin/dev/ayuislands/toolwindow/AutoFitTriggersTest.kt
@@ -107,6 +107,18 @@ class AutoFitTriggersTest {
     }
 
     @Test
+    fun `global layout event triggers scoped auto-fit for visible managed tool window even when inactive`() {
+        val toolWindowManager = mockk<ToolWindowManager>()
+        every { toolWindowManager.activeToolWindowId } returns "AWS"
+        every { toolWindowManager.getToolWindow("Commit") } returns toolWindow(isVisible = true)
+
+        assertTrue(
+            ToolWindowManagerEventType.SetLayout
+                .shouldTriggerAutoFitFor(toolWindowManager, expectedToolWindowId = "Commit"),
+        )
+    }
+
+    @Test
     fun `global layout event ignores hidden managed tool window`() {
         val toolWindowManager = mockk<ToolWindowManager>()
         every { toolWindowManager.activeToolWindowId } returns "Commit"


### PR DESCRIPTION
-- Summary ----------------

Marketplace verification can report internal API usage while the Gradle task still exits successfully. This PR adds a hard CI/release gate for internal API findings, keeps deprecated and experimental API debt visible, and fixes the Accent settings preview so stale shuffle state cannot display a different swatch than the selected preset.

-- Changes ----------------

- Chore: [verify-plugin-verifier.py](scripts/verify-plugin-verifier.py) - Add a stdlib Plugin Verifier report gate for internal/deprecated/experimental API findings.
- CI: [build.yml](.github/workflows/build.yml) and [release.yml](.github/workflows/release.yml) - Run the verifier gate after `verifyPlugin`.
- Fix: [AyuIslandsAccentPanel.kt](src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt#L122) - Keep the large accent preview tied to the current selected accent instead of stale shuffle state.
- Test: [AyuIslandsAccentPanelTest.kt](src/test/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanelTest.kt#L349) - Cover stored Coral with stale Cyan shuffle state.
- Docs: [scripts/README.md](scripts/README.md) and [features.yml](docs/features.yml) - Document the gate and re-stamp feature metadata required by repo hooks.

-- Validation ----------------

```bash
./gradlew test --rerun-tasks -Dorg.gradle.jvmargs=-Xmx4g -Dkotlin.daemon.jvm.options=-Xmx2g --tests 'dev.ayuislands.settings.AyuIslandsAccentPanelTest'\n./gradlew detekt ktlintCheck\n./gradlew buildPlugin --no-build-cache --rerun-tasks\n```\n\nManual: deployed to IntelliJIdea2026.1 via `/deploy-to-ide`; Accent tab preview verified in the real IDE.\n\n-- Notes ----------------\n\nInternal API findings are release-blocking. Deprecated, scheduled-for-removal, and experimental API findings remain advisory so they stay visible without blocking when no stable replacement exists yet.\n