### PR TITLE
chore(release): refresh 2.7.1 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [2.7.1] - 2026-06-01
 
 ### Added
-- **.ignore file colors** — `.ignore` files now use dedicated Ayu colors across Dark, Mirage, and Light editor schemes, including Syntax preset transformations and a Plugins-tab opt-out.
+- **.ignore plugin colors** — when the optional `.ignore` plugin is installed, its files use dedicated Ayu colors across Dark, Mirage, and Light editor schemes, including Syntax preset transformations and a Plugins-tab opt-out.
 
 ### Changed
 - **Visible locked premium previews** — free users can now inspect premium Settings controls in their real layout, with the controls greyed out until a license or trial unlocks them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,20 @@
 # Changelog
 
-## [2.7.1] - 2026-05-31
+## [2.7.1] - 2026-06-01
 
 ### Changed
 - **Visible locked premium previews** — free users can now inspect premium Settings controls in their real layout, with the controls greyed out until a license or trial unlocks them.
 - **Unified VCS preview** — the VCS tab now shows one compact code-style preview that reflects diff, merge/conflict, blame, and file-status presets together.
 - **Font preset preview polish** — the Font tab now uses the same editor-style preview treatment as VCS, with clearer depth and file context.
+- **Release verifier gate** — release builds now fail before Marketplace upload if JetBrains Plugin Verifier reports internal IntelliJ Platform API usage.
 
 ### Fixed
 - Premium Settings controls stay visible-but-locked across VCS, Glow, Workspace, Chrome tinting, Accent Elements, plugin integrations, and accent overrides instead of disappearing behind a Pro notice.
 - Locked premium controls no longer mark Settings as modified when clicked by unlicensed users.
 - Reset/Revert restores nested plugin-integration rows correctly, including Indent Rainbow custom controls.
 - Settings tabs and preview panels shrink more consistently in narrow Settings windows.
+- Accent Settings preview stays synchronized with the selected color instead of restoring stale shuffle state during panel creation.
+- Visible managed tool windows re-measure after layout and theme refreshes, so auto-fit sizing stays consistent.
 
 ## [2.7.0] - 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [2.7.1] - 2026-06-01
 
+### Added
+- **.ignore file colors** — `.ignore` files now use dedicated Ayu colors across Dark, Mirage, and Light editor schemes, including Syntax preset transformations.
+
 ### Changed
 - **Visible locked premium previews** — free users can now inspect premium Settings controls in their real layout, with the controls greyed out until a license or trial unlocks them.
 - **Unified VCS preview** — the VCS tab now shows one compact code-style preview that reflects diff, merge/conflict, blame, and file-status presets together.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [2.7.1] - 2026-06-01
 
 ### Added
-- **.ignore file colors** — `.ignore` files now use dedicated Ayu colors across Dark, Mirage, and Light editor schemes, including Syntax preset transformations.
+- **.ignore file colors** — `.ignore` files now use dedicated Ayu colors across Dark, Mirage, and Light editor schemes, including Syntax preset transformations and a Plugins-tab opt-out.
 
 ### Changed
 - **Visible locked premium previews** — free users can now inspect premium Settings controls in their real layout, with the controls greyed out until a license or trial unlocks them.

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -90,7 +90,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "ec28e522"
+          last_verified_sha: "c8d64418"
           last_verified_date: "2026-05-31"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -112,7 +112,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "ec28e522"
+          last_verified_sha: "c8d64418"
           last_verified_date: "2026-05-31"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -211,7 +211,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "2638bb64"
+          last_verified_sha: "c8d64418"
           last_verified_date: "2026-05-30"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -243,7 +243,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "2638bb64"
+          last_verified_sha: "c8d64418"
           last_verified_date: "2026-05-30"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -286,7 +286,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "2638bb64"
+          last_verified_sha: "c8d64418"
           last_verified_date: "2026-05-30"
           content_sha256: "fc9ba63b9c9c53893a486a3c9055287bd6dc9c68f5439cae197efe5ae585d17c"
 
@@ -339,7 +339,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "2638bb64"
+          last_verified_sha: "c8d64418"
           last_verified_date: "2026-05-30"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
@@ -61,7 +61,7 @@ internal object UpdateNotifier {
                     "VCS and Font presets now use polished editor-style previews",
                     "Accent Settings preview now stays synced with the selected color",
                     "Tool windows keep auto-fit sizing after layout and theme refreshes",
-                    ".ignore files now use dedicated Ayu colors across all schemes",
+                    ".ignore files now use dedicated Ayu colors with a Plugins-tab opt-out",
                 ),
             "2.7.0" to
                 releaseNotes(

--- a/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
@@ -58,9 +58,10 @@ internal object UpdateNotifier {
             "2.7.1" to
                 releaseNotes(
                     "Locked premium Settings controls are now visible as greyed-out previews",
-                    "VCS presets now update one compact code-style preview",
-                    "Font presets now use the same polished editor-style preview",
-                    "Settings tabs and previews shrink more consistently in narrow windows",
+                    "VCS and Font presets now use polished editor-style previews",
+                    "Accent Settings preview now stays synced with the selected color",
+                    "Tool windows keep auto-fit sizing after layout and theme refreshes",
+                    "Release verification now blocks internal IntelliJ API usage before upload",
                 ),
             "2.7.0" to
                 releaseNotes(

--- a/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
@@ -61,7 +61,7 @@ internal object UpdateNotifier {
                     "VCS and Font presets now use polished editor-style previews",
                     "Accent Settings preview now stays synced with the selected color",
                     "Tool windows keep auto-fit sizing after layout and theme refreshes",
-                    ".ignore files now use dedicated Ayu colors with a Plugins-tab opt-out",
+                    "Optional .ignore plugin files now use dedicated Ayu colors with a Plugins-tab opt-out",
                 ),
             "2.7.0" to
                 releaseNotes(

--- a/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
@@ -61,7 +61,7 @@ internal object UpdateNotifier {
                     "VCS and Font presets now use polished editor-style previews",
                     "Accent Settings preview now stays synced with the selected color",
                     "Tool windows keep auto-fit sizing after layout and theme refreshes",
-                    "Release verification now blocks internal IntelliJ API usage before upload",
+                    ".ignore files now use dedicated Ayu colors across all schemes",
                 ),
             "2.7.0" to
                 releaseNotes(

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -154,6 +154,10 @@ class AyuIslandsState : BaseState() {
     // IR version that failed reflection (suppresses repeated notifications)
     var irFailedVersion by string(null)
 
+    // `.ignore` plugin syntax colors are free and default ON. Users can opt out
+    // from the Plugins tab to keep the optional plugin's stock TextAttributes.
+    var ignorePluginSyntaxColorsEnabled by property(true)
+
     // Project View tweaks
     var hideProjectRootPath by property(false)
     var hideProjectViewHScrollbar by property(false)

--- a/src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
@@ -9,6 +9,7 @@ import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.conflict.ConflictRegistry
 import dev.ayuislands.indent.IndentPreset
 import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.syntax.SyntaxIntensityService
 import javax.swing.JCheckBox
 import javax.swing.JLabel
 import javax.swing.JSlider
@@ -25,11 +26,14 @@ class PluginsPanel : AyuIslandsSettingsPanel {
     private var storedCodeGlanceProIntegration: Boolean = false
     private var pendingErrorHighlight: Boolean = true
     private var storedErrorHighlight: Boolean = true
+    private var pendingIgnorePluginSyntaxColors: Boolean = true
+    private var storedIgnorePluginSyntaxColors: Boolean = true
 
     private var variant: AyuVariant? = null
     private var enabledCheckbox: JCheckBox? = null
     private var cgpCheckbox: JCheckBox? = null
     private var errorHighlightCheckbox: JCheckBox? = null
+    private var ignorePluginCheckbox: JCheckBox? = null
     private var alphaSlider: JSlider? = null
     private var alphaValueLabel: JLabel? = null
     private var presetSegmented: SegmentedButton<IndentPreset>? = null
@@ -60,13 +64,12 @@ class PluginsPanel : AyuIslandsSettingsPanel {
         val cgpDetected = ConflictRegistry.isCodeGlanceProDetected()
         val irDetected = ConflictRegistry.isIndentRainbowDetected()
 
-        if (!cgpDetected && !irDetected) {
-            panel.buildNoSupportedPluginsMessage()
-            return
-        }
+        panel.row { comment("Tune how Ayu colors integrate with compatible plugins.") }
+        panel.buildIgnorePluginGroup()
 
-        panel.row { comment("Sync Ayu accent colors with compatible plugins.") }
-        panel.premiumFeatureNotice(gate)
+        if (cgpDetected || irDetected) {
+            panel.premiumFeatureNotice(gate)
+        }
 
         if (cgpDetected) {
             panel.buildCodeGlanceProGroup(licensed)
@@ -74,6 +77,10 @@ class PluginsPanel : AyuIslandsSettingsPanel {
 
         if (irDetected) {
             panel.buildIndentRainbowGroup(licensed, irEnabled)
+        }
+
+        if (!cgpDetected && !irDetected) {
+            panel.buildNoSupportedPluginsMessage()
         }
     }
 
@@ -84,6 +91,8 @@ class PluginsPanel : AyuIslandsSettingsPanel {
         pendingEnabled = storedEnabled
         storedErrorHighlight = state.irErrorHighlightEnabled
         pendingErrorHighlight = storedErrorHighlight
+        storedIgnorePluginSyntaxColors = state.ignorePluginSyntaxColorsEnabled
+        pendingIgnorePluginSyntaxColors = storedIgnorePluginSyntaxColors
         storedPreset = state.indentPresetName ?: IndentPreset.AMBIENT.name
         pendingPreset = storedPreset
         storedCustomAlpha = state.indentCustomAlpha
@@ -97,9 +106,23 @@ class PluginsPanel : AyuIslandsSettingsPanel {
         group("Plugins") {
             row {
                 comment(
-                    "No supported plugins detected." +
-                        " Install CodeGlance Pro or Indent Rainbow for accent color sync.",
+                    "Install CodeGlance Pro or Indent Rainbow for premium accent color sync.",
                 )
+            }
+        }
+    }
+
+    private fun Panel.buildIgnorePluginGroup() {
+        group(".ignore") {
+            row {
+                val checkboxCell =
+                    checkBox("Use Ayu colors for .ignore files")
+                        .comment("When off, keep the .ignore plugin's default syntax colors")
+                checkboxCell.component.isSelected = pendingIgnorePluginSyntaxColors
+                checkboxCell.component.addActionListener {
+                    pendingIgnorePluginSyntaxColors = checkboxCell.component.isSelected
+                }
+                ignorePluginCheckbox = checkboxCell.component
             }
         }
     }
@@ -227,12 +250,27 @@ class PluginsPanel : AyuIslandsSettingsPanel {
             pendingPreset != storedPreset ||
             pendingCustomAlpha != storedCustomAlpha ||
             pendingCodeGlanceProIntegration != storedCodeGlanceProIntegration ||
-            pendingErrorHighlight != storedErrorHighlight
+            pendingErrorHighlight != storedErrorHighlight ||
+            pendingIgnorePluginSyntaxColors != storedIgnorePluginSyntaxColors
 
     override fun apply() {
         if (!isModified()) return
-        if (!LicenseChecker.isLicensedOrGrace()) return
         val state = AyuIslandsSettings.getInstance().state
+        val ignorePluginChanged = pendingIgnorePluginSyntaxColors != storedIgnorePluginSyntaxColors
+        if (ignorePluginChanged) {
+            state.ignorePluginSyntaxColorsEnabled = pendingIgnorePluginSyntaxColors
+            storedIgnorePluginSyntaxColors = pendingIgnorePluginSyntaxColors
+            SyntaxIntensityService.getInstance().reapplyForActiveLaf()
+        }
+
+        val premiumChanged =
+            pendingEnabled != storedEnabled ||
+                pendingPreset != storedPreset ||
+                pendingCustomAlpha != storedCustomAlpha ||
+                pendingCodeGlanceProIntegration != storedCodeGlanceProIntegration ||
+                pendingErrorHighlight != storedErrorHighlight
+        if (!premiumChanged) return
+        if (!LicenseChecker.isLicensedOrGrace()) return
 
         state.irIntegrationEnabled = pendingEnabled
         state.indentPresetName = pendingPreset
@@ -259,11 +297,13 @@ class PluginsPanel : AyuIslandsSettingsPanel {
         pendingCustomAlpha = storedCustomAlpha
         pendingCodeGlanceProIntegration = storedCodeGlanceProIntegration
         pendingErrorHighlight = storedErrorHighlight
+        pendingIgnorePluginSyntaxColors = storedIgnorePluginSyntaxColors
 
         suppressListeners = true
         enabledCheckbox?.isSelected = storedEnabled
         cgpCheckbox?.isSelected = storedCodeGlanceProIntegration
         errorHighlightCheckbox?.isSelected = storedErrorHighlight
+        ignorePluginCheckbox?.isSelected = storedIgnorePluginSyntaxColors
         presetSegmented?.selectedItem = IndentPreset.fromName(storedPreset)
         alphaSlider?.value = storedCustomAlpha
         alphaValueLabel?.text = "$storedCustomAlpha"

--- a/src/main/kotlin/dev/ayuislands/syntax/SyntaxCategoryRegistry.kt
+++ b/src/main/kotlin/dev/ayuislands/syntax/SyntaxCategoryRegistry.kt
@@ -25,7 +25,7 @@ import java.util.concurrent.ConcurrentHashMap
  * construction: immutable rule list + `ConcurrentHashMap`-backed latch.
  * No exception-handling primitives appear in this file because the classifier
  * does no I/O; the only operations are regex matching and set membership,
- * neither of which fails recoverably (Pattern B compliance).
+ * neither of which can fail in a recoverable way (Pattern B compliance).
  */
 object SyntaxCategoryRegistry {
     private const val SUFFIX_LATCH_MAX_CHARS = 24
@@ -57,194 +57,193 @@ object SyntaxCategoryRegistry {
      *    `_ATTRIBUTES` to many keys.
      */
     private val suffixRules: List<Pair<Regex, PrimitiveCategory>> =
-        listOf(
+        buildList {
             // --- Documentation: must beat COMMENT and KEYWORD ----------------
-            Regex(
-                "DOC_COMMENT($|_)|DOC_TAG|DOCUMENTATION$|KDOC_LINK|KDOC_TAG_NAME|" +
-                    "DOC_IDENTIFIER|DOC_METHOD_IDENTIFIER|DOC_PROPERTY_IDENTIFIER|" +
-                    "DOC_VAR|LUA_DOC_VALUE|ScalaDoc|MARKDOWN_LIST_MARKER|" +
-                    "MARKDOWN_HRULE|MARKDOWN_CODE_FENCE_LANGUAGE|MARKDOWN_STRIKE_THROUGH",
-            ) to PrimitiveCategory.DOCUMENTATION,
+            addRules(
+                PrimitiveCategory.DOCUMENTATION,
+                "DOC_COMMENT($|_)|DOC_TAG|DOCUMENTATION$|KDOC_LINK|KDOC_TAG_NAME",
+                "DOC_IDENTIFIER|DOC_METHOD_IDENTIFIER|DOC_PROPERTY_IDENTIFIER|DOC_VAR|LUA_DOC_VALUE",
+                "ScalaDoc|MARKDOWN_LIST_MARKER|MARKDOWN_HRULE|MARKDOWN_CODE_FENCE_LANGUAGE",
+                "MARKDOWN_STRIKE_THROUGH|IGNORE\\.COMMENT",
+            )
             // --- Comments ---------------------------------------------------
-            Regex(
-                "LINE_COMMENT$|BLOCK_COMMENT$|COMMENT$|COMMENT_REFERENCE$|" +
-                    "_COMMENT_|MARKDOWN_BLOCK_QUOTE_MARKER|MARKDOWN_FRONT_MATTER",
-            ) to PrimitiveCategory.COMMENT,
+            addRules(
+                PrimitiveCategory.COMMENT,
+                "LINE_COMMENT$|BLOCK_COMMENT$|COMMENT$|COMMENT_REFERENCE$|_COMMENT_",
+                "MARKDOWN_BLOCK_QUOTE_MARKER|MARKDOWN_FRONT_MATTER|IGNORE\\.UNUSED_ENTRY",
+            )
             // --- Fields (must beat KEYWORD / LOCAL_VAR) ---------------------
-            Regex(
-                "STATIC_FIELD|STATIC_FINAL_FIELD|STATIC_GETTER|STATIC_SETTER|" +
-                    "STATIC_METHOD|STATIC_MEMBER|^Static field$|" +
-                    "org\\.rust\\.STATIC|org\\.rust\\.MUT_STATIC|PHP_CONSTANT",
-            ) to PrimitiveCategory.STATIC_FIELD,
-            Regex(
-                "INSTANCE_FIELD|INSTANCE_FINAL_FIELD|INSTANCE_GETTER|INSTANCE_SETTER|" +
-                    "INSTANCE_METHOD|INSTANCE_MEMBER|INSTANCE_PROPERTY|" +
-                    "TOP_LEVEL_GETTER|TOP_LEVEL_SETTER|TOP_LEVEL_VARIABLE|TOP_LEVEL_FUNCTION|" +
-                    "PROPERTY_REFERENCE|HASH_KEY|TAG_KEY|TAG_VALUE|MAP_KEY|" +
-                    "INSTANCE_PROPERTY_CUSTOM|INSTANCE_PROPERTY|PACKAGE_PROPERTY|" +
-                    "INSTANCE_FIELD_ATTRIBUTES|SYNTHETIC_EXTENSION_PROPERTY|" +
-                    "^Instance field$|^Map key$|LUA_FIELD|SWIFT_PROPERTY|" +
-                    "Instance property reference|GO_TAG_TEXT|MAGIC_MEMBER_ACCESS|" +
-                    "EDITORCONFIG_PROPERTY_KEY|DOTENV_KEY|HCL\\.BLOCK_ONLY_NAME_KEY",
-            ) to PrimitiveCategory.INSTANCE_FIELD,
+            addRules(
+                PrimitiveCategory.STATIC_FIELD,
+                "STATIC_FIELD|STATIC_FINAL_FIELD|STATIC_GETTER|STATIC_SETTER|STATIC_METHOD",
+                "STATIC_MEMBER|^Static field$|org\\.rust\\.STATIC|org\\.rust\\.MUT_STATIC|PHP_CONSTANT",
+            )
+            addRules(
+                PrimitiveCategory.INSTANCE_FIELD,
+                "INSTANCE_FIELD|INSTANCE_FINAL_FIELD|INSTANCE_GETTER|INSTANCE_SETTER|INSTANCE_METHOD",
+                "INSTANCE_MEMBER|INSTANCE_PROPERTY|TOP_LEVEL_GETTER|TOP_LEVEL_SETTER",
+                "TOP_LEVEL_VARIABLE|TOP_LEVEL_FUNCTION|PROPERTY_REFERENCE|HASH_KEY|TAG_KEY",
+                "TAG_VALUE|MAP_KEY|INSTANCE_PROPERTY_CUSTOM|PACKAGE_PROPERTY",
+                "INSTANCE_FIELD_ATTRIBUTES|SYNTHETIC_EXTENSION_PROPERTY|^Instance field$",
+                "^Map key$|LUA_FIELD|SWIFT_PROPERTY|Instance property reference|GO_TAG_TEXT",
+                "MAGIC_MEMBER_ACCESS|EDITORCONFIG_PROPERTY_KEY|DOTENV_KEY|HCL\\.BLOCK_ONLY_NAME_KEY",
+            )
             // --- Functions / methods (must beat KEYWORD / OPERATOR) ---------
-            Regex(
-                "FUNCTION_DECLARATION$|METHOD_DECLARATION$|FUNCTION_DEFINITION$|" +
-                    "FUNCTION_DECL$|METHOD_DECL$|FUNCTION_CALL|METHOD_CALL|" +
-                    "FUNCTION_DEF_NAME|GLOBAL_FUNCTION|LOCAL_FUNCTION|" +
-                    "LOCAL_METHOD|NESTED_FUNCTION|NESTED_FUNC_DEFINITION|" +
-                    "SUSPEND_FUNCTION_CALL|EXTENSION_FUNCTION_CALL|" +
-                    "BUILTIN_FUNCTION_CALL|EXPORTED_FUNCTION|FUNCTION_ARROW|" +
-                    "CONSTRUCTOR_CALL|CONSTRUCTOR_DECLARATION|CONSTRUCTOR_TEAR_OFF|" +
-                    "METHOD_CALL_ATTRIBUTES|METHOD_DECLARATION_ATTRIBUTES|" +
-                    "STATIC_METHOD_ATTRIBUTES|STATIC_METHOD_IMPORTED_ATTRIBUTES|" +
-                    "CONSTRUCTOR_CALL_ATTRIBUTES|CONSTRUCTOR_DECLARATION_ATTRIBUTES|" +
-                    "ABSTRACT_METHOD_ATTRIBUTES|INHERITED_METHOD_ATTRIBUTES|" +
-                    "PRIVATE_CALL|PROTECTED_CALL|PUBLIC_CALL|" +
-                    "STATIC_FUNCTION|REQUIRE_CALL|IMPORT_CALL|REQUIRE_ARG_CALL|" +
-                    "VARIABLE_AS_FUNCTION|PARAMDEF_CALL|FUNCTION$|METHOD$|" +
-                    "KOTLIN_CONSTRUCTOR|TEAR_OFF|Method call|Method declaration|" +
-                    "Groovy method declaration|Groovy constructor declaration|" +
-                    "Groovy constructor call|LOCAL_FUNC|STD_API|" +
-                    "POWER_SHELL_COMMAND_NAME|POWER_SHELL_METHOD_CALL_NAME|" +
-                    "RBS_TMETHOD_NAME|RBS_RUBY_SPECIFIC_CALLS",
-            ) to PrimitiveCategory.FUNCTION_DECL,
+            addRules(
+                PrimitiveCategory.FUNCTION_DECL,
+                "FUNCTION_DECLARATION$|METHOD_DECLARATION$|FUNCTION_DEFINITION$",
+                "FUNCTION_DECL$|METHOD_DECL$|FUNCTION_CALL|METHOD_CALL|FUNCTION_DEF_NAME",
+                "GLOBAL_FUNCTION|LOCAL_FUNCTION|LOCAL_METHOD|NESTED_FUNCTION|NESTED_FUNC_DEFINITION",
+                "SUSPEND_FUNCTION_CALL|EXTENSION_FUNCTION_CALL|BUILTIN_FUNCTION_CALL",
+                "EXPORTED_FUNCTION|FUNCTION_ARROW|CONSTRUCTOR_CALL|CONSTRUCTOR_DECLARATION",
+                "CONSTRUCTOR_TEAR_OFF|METHOD_CALL_ATTRIBUTES|METHOD_DECLARATION_ATTRIBUTES",
+                "STATIC_METHOD_ATTRIBUTES|STATIC_METHOD_IMPORTED_ATTRIBUTES",
+                "CONSTRUCTOR_CALL_ATTRIBUTES|CONSTRUCTOR_DECLARATION_ATTRIBUTES",
+                "ABSTRACT_METHOD_ATTRIBUTES|INHERITED_METHOD_ATTRIBUTES|PRIVATE_CALL",
+                "PROTECTED_CALL|PUBLIC_CALL|STATIC_FUNCTION|REQUIRE_CALL|IMPORT_CALL",
+                "REQUIRE_ARG_CALL|VARIABLE_AS_FUNCTION|PARAMDEF_CALL|FUNCTION$|METHOD$",
+                "KOTLIN_CONSTRUCTOR|TEAR_OFF|Method call|Method declaration",
+                "Groovy method declaration|Groovy constructor declaration|Groovy constructor call",
+                "LOCAL_FUNC|STD_API|POWER_SHELL_COMMAND_NAME|POWER_SHELL_METHOD_CALL_NAME",
+                "RBS_TMETHOD_NAME|RBS_RUBY_SPECIFIC_CALLS",
+            )
             // --- Interface / trait -----------------------------------------
-            Regex(
-                "INTERFACE_NAME$|INTERFACE_DECLARATION$|TRAIT_NAME$|" +
-                    "INTERFACE_REFERENCE|INTERFACE_NAME_ATTRIBUTES|" +
-                    "PROTOCOL_REFERENCE|KOTLIN_TRAIT|EXPORTED_INTERFACE|" +
-                    "INTERFACE$|^Trait name$|^Interface name$|" +
-                    "Scala Trait|RBS_TINTERFACEIDENT",
-            ) to PrimitiveCategory.INTERFACE_DECL,
+            addRules(
+                PrimitiveCategory.INTERFACE_DECL,
+                "INTERFACE_NAME$|INTERFACE_DECLARATION$|TRAIT_NAME$|INTERFACE_REFERENCE",
+                "INTERFACE_NAME_ATTRIBUTES|PROTOCOL_REFERENCE|KOTLIN_TRAIT|EXPORTED_INTERFACE",
+                "INTERFACE$|^Trait name$|^Interface name$|Scala Trait|RBS_TINTERFACEIDENT",
+            )
             // --- Class / enum / struct (declarations + references) ----------
-            Regex(
-                "CLASS_DECLARATION$|CLASS_NAME$|CLASS_REFERENCE|CLASS_METHOD_CALL|" +
-                    "CLASS_NAME_ATTRIBUTES|ANONYMOUS_CLASS_NAME|ABSTRACT_CLASS_NAME|" +
-                    "ENUM_NAME|ENUM_REFERENCE|ENUM_VALUE|ENUM_ENTRY|ENUM_SINGLETON|" +
-                    "ENUM_CLASS_CASE|RECORD_NAME|RECORD_COMPONENT|STRUCT_REFERENCE|" +
-                    "STRUCT_LOCAL_MEMBER_CALL|STRUCT_EXPORTED_MEMBER_CALL|" +
-                    "PACKAGE_EXPORTED_STRUCT|PACKAGE_LOCAL_STRUCT|" +
-                    "PACKAGE_EXPORTED_INTERFACE|PACKAGE_LOCAL_INTERFACE|" +
-                    "LOCAL_INTERFACE_REFERENCE|EXPORTED_STRUCT_REFERENCE|" +
-                    "ACTOR_REFERENCE|MIXIN|DATA_OBJECT|GIVEN|" +
-                    "ABSTRACT_CLASS|MODULE_NAME|OBJECT$|CLASS$|ENUM$|" +
-                    "^Class$|^Enum name$|^Anonymous class name$|^Abstract class name$|" +
-                    "Scala Class|Scala Object|Scala Given|Scala Abstract class|" +
-                    "Scala Enum|GO_TYPE_SPECIFICATION|MAKEFILE_TARGET|" +
-                    "MAKEFILE_SPECIAL_TARGET|MAKEFILE_PREREQUISITE|NGINX_TYPES|" +
-                    "DART_EXTENSION$|DART_MIXIN|GRAPHQL_IDENTIFIER|QL_ENTITY|" +
-                    "IntelliJComposableCallTextAttributes",
-            ) to PrimitiveCategory.CLASS_DECL,
+            addRules(
+                PrimitiveCategory.CLASS_DECL,
+                "CLASS_DECLARATION$|CLASS_NAME$|CLASS_REFERENCE|CLASS_METHOD_CALL",
+                "CLASS_NAME_ATTRIBUTES|ANONYMOUS_CLASS_NAME|ABSTRACT_CLASS_NAME|ENUM_NAME",
+                "ENUM_REFERENCE|ENUM_VALUE|ENUM_ENTRY|ENUM_SINGLETON|ENUM_CLASS_CASE",
+                "RECORD_NAME|RECORD_COMPONENT|STRUCT_REFERENCE|STRUCT_LOCAL_MEMBER_CALL",
+                "STRUCT_EXPORTED_MEMBER_CALL|PACKAGE_EXPORTED_STRUCT|PACKAGE_LOCAL_STRUCT",
+                "PACKAGE_EXPORTED_INTERFACE|PACKAGE_LOCAL_INTERFACE|LOCAL_INTERFACE_REFERENCE",
+                "EXPORTED_STRUCT_REFERENCE|ACTOR_REFERENCE|MIXIN|DATA_OBJECT|GIVEN",
+                "ABSTRACT_CLASS|MODULE_NAME|OBJECT$|CLASS$|ENUM$|^Class$",
+                "^Enum name$|^Anonymous class name$|^Abstract class name$|Scala Class",
+                "Scala Object|Scala Given|Scala Abstract class|Scala Enum|GO_TYPE_SPECIFICATION",
+                "MAKEFILE_TARGET|MAKEFILE_SPECIAL_TARGET|MAKEFILE_PREREQUISITE|NGINX_TYPES",
+                "DART_EXTENSION$|DART_MIXIN|GRAPHQL_IDENTIFIER|QL_ENTITY",
+                "IntelliJComposableCallTextAttributes",
+            )
             // --- Generics --------------------------------------------------
-            Regex(
-                "TYPE_PARAMETER$|GENERICS$|GENERIC$|TYPE_ARGUMENT$|" +
-                    "TYPE_NAME_DYNAMIC",
-            ) to PrimitiveCategory.GENERICS,
+            addRules(
+                PrimitiveCategory.GENERICS,
+                "TYPE_PARAMETER$|GENERICS$|GENERIC$|TYPE_ARGUMENT$|TYPE_NAME_DYNAMIC",
+            )
             // --- Keywords / modifiers --------------------------------------
-            Regex(
-                "KEYWORD($|S|_)|MODIFIER$|RESERVED_WORD$|KEYWORD_OPERATIONS$|" +
-                    "DIRECTIVE$|HEADER$|TAG_NAME$|XML_NS_PREFIX|XML_TAG_DATA|" +
-                    "DIRECTIVE_PREFIX|DIRECTIVE_COMMAND|DIRECTIVE_KEY|DIRECTIVE_VALUE|" +
-                    "MACRO_RULES|MACRO_IDENTIFIER|MACRO_BINDING|MACRO_META_VAR|" +
-                    "MACRO_GROUP|MACRO_DOLLAR|MACRO_COLON|MACRO_EXCL|" +
-                    "REQUIRE_CALL|WORDS|TAG_NAME$|MARKDOWN_HEADER|" +
-                    "NGINX_IF|NGINX_GEO|NGINX_MAP|DROOLS_OPERATIONS|" +
-                    "Scalatest keyword|Scala directive|Scala XML tag$|" +
-                    "Scala XML tag name|GENERATED_ITEM|QUTE_BOOLEAN|" +
-                    "JSONPATH\\.BOOLEAN|JSONPATH\\.OPERATIONS|JSONPATH\\.CONTEXT|" +
-                    "IGNORE\\.NEGATION|IGNORE\\.SYNTAX|IGNORE\\.SLASH|" +
-                    "IGNORE\\.SECTION|MAKEFILE_FUNCTION$|GITLAB_CI_EXPRESSION_REGEXP|" +
-                    "CDATA_SECTION|XML_TAG_DATA|PHP_TAG|PHP_MARKUP_ID|" +
-                    "MISSORTED_IMPORTS_ATTRIBUTES",
-            ) to PrimitiveCategory.KEYWORD,
+            addRules(
+                PrimitiveCategory.KEYWORD,
+                "KEYWORD($|S|_)|MODIFIER$|RESERVED_WORD$|KEYWORD_OPERATIONS$",
+                "DIRECTIVE$|HEADER$|TAG_NAME$|XML_NS_PREFIX|XML_TAG_DATA",
+                "DIRECTIVE_PREFIX|DIRECTIVE_COMMAND|DIRECTIVE_KEY|DIRECTIVE_VALUE",
+                "MACRO_RULES|MACRO_IDENTIFIER|MACRO_BINDING|MACRO_META_VAR",
+                "MACRO_GROUP|MACRO_DOLLAR|MACRO_COLON|MACRO_EXCL",
+                "REQUIRE_CALL|WORDS|MARKDOWN_HEADER|NGINX_IF|NGINX_GEO",
+                "NGINX_MAP|DROOLS_OPERATIONS|Scalatest keyword|Scala directive",
+                "Scala XML tag$|Scala XML tag name|GENERATED_ITEM|QUTE_BOOLEAN",
+                "JSONPATH\\.BOOLEAN|JSONPATH\\.OPERATIONS|JSONPATH\\.CONTEXT",
+                "IGNORE\\.NEGATION|IGNORE\\.SYNTAX|IGNORE\\.SLASH",
+                "IGNORE\\.SECTION|IGNORE\\.HEADER|MAKEFILE_FUNCTION$",
+                "GITLAB_CI_EXPRESSION_REGEXP|CDATA_SECTION|PHP_TAG|PHP_MARKUP_ID",
+                "MISSORTED_IMPORTS_ATTRIBUTES",
+            )
             // --- Parameter --------------------------------------------------
-            Regex(
-                "PARAMETER$|FUNCTION_PARAMETER$|ARG$|NAMED_ARGUMENT$|" +
-                    "PARAMETER_DECLARATION|PARAMETER_REFERENCE|" +
-                    "DYNAMIC_PARAMETER_DECLARATION|DYNAMIC_PARAMETER_REFERENCE|" +
-                    "PARAMETER_ATTRIBUTES|REASSIGNED_PARAMETER_ATTRIBUTES|" +
-                    "LAMBDA_PARAMETER_ATTRIBUTES|ARGUMENT_LABEL|ANONYMOUS_PARAMETER|" +
-                    "TUPLE_LABEL|TUPLE_TYPE_LABEL|FUNCTION_PARAM|MAKEFILE_FUNCTION_PARAM|" +
-                    "Closure parameter|Groovy parameter|Groovy reassigned parameter|" +
-                    "Scala Parameter|Scala Named Argument|Scala Anonymous Parameter",
-            ) to PrimitiveCategory.PARAMETER,
+            addRules(
+                PrimitiveCategory.PARAMETER,
+                "PARAMETER$|FUNCTION_PARAMETER$|ARG$|NAMED_ARGUMENT$|PARAMETER_DECLARATION",
+                "PARAMETER_REFERENCE|DYNAMIC_PARAMETER_DECLARATION|DYNAMIC_PARAMETER_REFERENCE",
+                "PARAMETER_ATTRIBUTES|REASSIGNED_PARAMETER_ATTRIBUTES|LAMBDA_PARAMETER_ATTRIBUTES",
+                "ARGUMENT_LABEL|ANONYMOUS_PARAMETER|TUPLE_LABEL|TUPLE_TYPE_LABEL",
+                "FUNCTION_PARAM|MAKEFILE_FUNCTION_PARAM|Closure parameter|Groovy parameter",
+                "Groovy reassigned parameter|Scala Parameter|Scala Named Argument",
+                "Scala Anonymous Parameter",
+            )
             // --- Local variables -------------------------------------------
-            Regex(
-                "LOCAL_VARIABLE$|LOCAL_VAR$|LOCAL_VARIABLE_ATTRIBUTES|" +
-                    "REASSIGNED_LOCAL_VARIABLE_ATTRIBUTES|LOCAL_VAR_|LOCAL_VARIABLE_|" +
-                    "VAR_USE|VAR_DEF|VAR_USE_COMPOSED|VAR_DEF_NAME|" +
-                    "DYNAMIC_LOCAL_VARIABLE_DECLARATION|DYNAMIC_LOCAL_VARIABLE_REFERENCE|" +
-                    "REASSIGNMENT_IN_SHORT_VAR|SCOPE_VARIABLE|LOCAL_VARIABLE_CALL|" +
-                    "GLOBAL_VARIABLE|VARIABLE$|VARIABLE_CALL|VAR$|CVAR$|UP_VALUE|SELF$|" +
-                    "Scala Local value|Scala Local variable|Scala Local lazy|" +
-                    "Scala Template val|Scala Template var|Scala Template lazy|" +
-                    "Scala Pattern value|Scala For statement value|Groovy var|" +
-                    "Groovy reassigned var|IDENTIFIER$|TUIDENT$|TLIDENT$|TGLOBALIDENT$|" +
-                    "TSYMBOL$|TNAMESPACE$|RBS_T|BATCH\\.EXPRESSION|" +
-                    "DQL_PLACEHOLDER|DQL_EXPR|CRONEXP\\.IDENTIFIER|" +
-                    "EDITORCONFIG_IDENTIFIER|EDITORCONFIG_PATTERN|" +
-                    "EDITORCONFIG_SPECIAL_SYMBOL|EDITORCONFIG_VARIABLE|" +
-                    "NGINX_VARIABLE|NGINX_LUA_BLOCK_DIRECTIVE|" +
-                    "HTTP_REQUEST_PROTOCOL|HTTP_REQUEST_PORT|" +
-                    "HTTP_REQUEST_PARAMETER_NAME|HTTP_REQUEST_PARAMETER_VALUE|" +
-                    "HTTP_REQUEST_FILE_VARIABLE_NAME|COOKIE_TOKEN|" +
-                    "POWER_SHELL_VARIABLE|POWER_SHELL_PROPERTY_REF_NAME|" +
-                    "SWIFT_GLOBAL_VARIABLE|SWIFT_NESTED_FUNCTION_CALL|" +
-                    "QUTE_IDENTIFIER|QUTE_TAG_NAME|TIL\\.IDENTIFIER|" +
-                    "TIL\\.PROPERTY_REFERENCE|TIL\\.RESOURCE_INSTANCE_REFERENCE|" +
-                    "PROTO_IDENTIFIER|PROTOTEXT_IDENTIFIER|PROTO_ENUM_VALUE|" +
-                    "PROTOTEXT_ENUM_VALUE|JSONPATH\\.IDENTIFIER|JSONPATH\\.FUNCTION|" +
-                    "GITLAB_CI_EXPRESSION_IDENTIFIER|RUBY_PARAMDEF_CALL|" +
-                    "GO_TAG_KEY|CSS\\.UNIT|CSS\\.UNICODE",
-            ) to PrimitiveCategory.LOCAL_VAR,
+            addRules(
+                PrimitiveCategory.LOCAL_VAR,
+                "LOCAL_VARIABLE$|LOCAL_VAR$|LOCAL_VARIABLE_ATTRIBUTES|REASSIGNED_LOCAL_VARIABLE_ATTRIBUTES",
+                "LOCAL_VAR_|LOCAL_VARIABLE_|VAR_USE|VAR_DEF|VAR_USE_COMPOSED|VAR_DEF_NAME",
+                "DYNAMIC_LOCAL_VARIABLE_DECLARATION|DYNAMIC_LOCAL_VARIABLE_REFERENCE",
+                "REASSIGNMENT_IN_SHORT_VAR|SCOPE_VARIABLE|LOCAL_VARIABLE_CALL",
+                "GLOBAL_VARIABLE|VARIABLE$|VARIABLE_CALL|VAR$|CVAR$|UP_VALUE|SELF$",
+                "Scala Local value|Scala Local variable|Scala Local lazy|Scala Template val",
+                "Scala Template var|Scala Template lazy|Scala Pattern value|Scala For statement value",
+                "Groovy var|Groovy reassigned var|IDENTIFIER$|TUIDENT$|TLIDENT$",
+                "TGLOBALIDENT$|TSYMBOL$|TNAMESPACE$|RBS_T|BATCH\\.EXPRESSION",
+                "DQL_PLACEHOLDER|DQL_EXPR|CRONEXP\\.IDENTIFIER|EDITORCONFIG_IDENTIFIER",
+                "EDITORCONFIG_PATTERN|EDITORCONFIG_SPECIAL_SYMBOL|EDITORCONFIG_VARIABLE",
+                "NGINX_VARIABLE|NGINX_LUA_BLOCK_DIRECTIVE|HTTP_REQUEST_PROTOCOL",
+                "HTTP_REQUEST_PORT|HTTP_REQUEST_PARAMETER_NAME|HTTP_REQUEST_PARAMETER_VALUE",
+                "HTTP_REQUEST_FILE_VARIABLE_NAME|COOKIE_TOKEN|POWER_SHELL_VARIABLE",
+                "POWER_SHELL_PROPERTY_REF_NAME|SWIFT_GLOBAL_VARIABLE|SWIFT_NESTED_FUNCTION_CALL",
+                "QUTE_IDENTIFIER|QUTE_TAG_NAME|TIL\\.IDENTIFIER|TIL\\.PROPERTY_REFERENCE",
+                "TIL\\.RESOURCE_INSTANCE_REFERENCE|PROTO_IDENTIFIER|PROTOTEXT_IDENTIFIER",
+                "PROTO_ENUM_VALUE|PROTOTEXT_ENUM_VALUE|JSONPATH\\.IDENTIFIER|JSONPATH\\.FUNCTION",
+                "GITLAB_CI_EXPRESSION_IDENTIFIER|RUBY_PARAMDEF_CALL|GO_TAG_KEY",
+                "CSS\\.UNIT|CSS\\.UNICODE",
+            )
             // --- String literals -------------------------------------------
-            Regex(
-                "STRING$|TEMPLATE_STRING$|RAW_STRING$|CHAR$|CHARACTER$|STRING_LITERAL$|" +
-                    "STRING_ESCAPE|HEREDOC_ID|HEREDOC_CONTENT|HEREDOC|" +
-                    "BACKQUOTE|GString|FSTRING_FRAGMENT|REGEX$|REGEXP$|" +
-                    "ESCAPE$|VALID_ESCAPE|INVALID_ESCAPE|MARKDOWN_CODE_SPAN|" +
-                    "INTERPOLATION|String Injection|VALUE$|CONTENT$",
-            ) to PrimitiveCategory.STRING_LITERAL,
+            addRules(
+                PrimitiveCategory.STRING_LITERAL,
+                "STRING$|TEMPLATE_STRING$|RAW_STRING$|CHAR$|CHARACTER$|STRING_LITERAL$",
+                "STRING_ESCAPE|HEREDOC_ID|HEREDOC_CONTENT|HEREDOC|BACKQUOTE",
+                "GString|FSTRING_FRAGMENT|REGEX$|REGEXP$|ESCAPE$",
+                "VALID_ESCAPE|INVALID_ESCAPE|MARKDOWN_CODE_SPAN|INTERPOLATION",
+                "String Injection|VALUE$|CONTENT$",
+            )
             // --- Number literals -------------------------------------------
-            Regex(
+            addRules(
+                PrimitiveCategory.NUMBER_LITERAL,
                 "NUMBER$|INTEGER$|FLOAT$|HEX$|NUMBER_LITERAL$",
-            ) to PrimitiveCategory.NUMBER_LITERAL,
+            )
             // --- Annotations / decorators / metadata ------------------------
-            Regex(
-                "ANNOTATION$|DECORATOR$|ATTRIBUTE$|ANNOTATION_NAME|" +
-                    "ATTRIBUTE_NAME|ATTRIBUTE_ARGUMENT|ANNOTATION_ATTRIBUTE_NAME|" +
-                    "ANNOTATION_ATTRIBUTE_NAME_ATTRIBUTES|BUILD_TAG|" +
-                    "Scala Annotation|^Annotation$|^Anotation attribute name$|" +
-                    "PROPERTY_BINDING_ATTR_NAME|EVENT_BINDING_ATTR_NAME|" +
-                    "BANANA_BINDING_ATTR_NAME|TEMPLATE_VARIABLE_ATTR_NAME|" +
-                    "TEMPLATE_BINDINGS_ATTR_NAME|YAML_ANCHOR|Scala XML attribute",
-            ) to PrimitiveCategory.ANNOTATION,
+            addRules(
+                PrimitiveCategory.ANNOTATION,
+                "ANNOTATION$|DECORATOR$|ATTRIBUTE$|ANNOTATION_NAME|ATTRIBUTE_NAME",
+                "ATTRIBUTE_ARGUMENT|ANNOTATION_ATTRIBUTE_NAME|ANNOTATION_ATTRIBUTE_NAME_ATTRIBUTES",
+                "BUILD_TAG|Scala Annotation|^Annotation$|^Anotation attribute name$",
+                "PROPERTY_BINDING_ATTR_NAME|EVENT_BINDING_ATTR_NAME|BANANA_BINDING_ATTR_NAME",
+                "TEMPLATE_VARIABLE_ATTR_NAME|TEMPLATE_BINDINGS_ATTR_NAME|YAML_ANCHOR",
+                "Scala XML attribute",
+            )
             // --- Operators / punctuation -----------------------------------
-            Regex(
-                "OPERATION_SIGN$|OPERATOR$|OPERATORS$|PUNCTUATION$|BRACES$|BRACKETS$|" +
-                    "PARENTHS$|FAT_ARROW|PIPE$|BANG$|AMP$|SPREAD$|SIGN$|" +
-                    "BINARY_OPERATORS|REDIRECTION|SEPARATOR|CONCATENATION|" +
-                    "TAG_BRACE|SCRIPT_DELIMITERS|TEMPLATE_BINDINGS|" +
-                    "^Lambda braces$|^Closure braces$|^Label$|JS\\.LABEL|" +
-                    "BATCH\\.LABEL|BATCH\\.LABEL_REFERENCE|GOTO_LABEL|" +
-                    "POWER_SHELL_LABEL_NAME|YAML_SCALAR_LIST|CSS\\.AMPERSAND|" +
-                    "PROGUARD_WILDCARD",
-            ) to PrimitiveCategory.OPERATOR,
+            addRules(
+                PrimitiveCategory.OPERATOR,
+                "OPERATION_SIGN$|OPERATOR$|OPERATORS$|PUNCTUATION$|BRACES$",
+                "BRACKETS$|PARENTHS$|FAT_ARROW|PIPE$|BANG$|AMP$|SPREAD$",
+                "SIGN$|BINARY_OPERATORS|REDIRECTION|SEPARATOR|CONCATENATION",
+                "TAG_BRACE|SCRIPT_DELIMITERS|TEMPLATE_BINDINGS|^Lambda braces$",
+                "^Closure braces$|^Label$|JS\\.LABEL|BATCH\\.LABEL",
+                "BATCH\\.LABEL_REFERENCE|GOTO_LABEL|POWER_SHELL_LABEL_NAME",
+                "YAML_SCALAR_LIST|CSS\\.AMPERSAND|PROGUARD_WILDCARD|IGNORE\\.BRACKET",
+            )
             // --- Type references / aliases ---------------------------------
-            Regex(
-                "TYPE_REFERENCE$|TYPE_NAME$|TYPE_ALIAS$|TYPE$|TYPEALIAS_REFERENCE|" +
-                    "PRIMITIVE_TYPE_HINT|PREDEFINED_SCOPE|PREDEFINED|" +
-                    "Scala Type|Scala Predefined types|Scala Mutable Collection|" +
-                    "Scala Immutable Collection|StandardF Java Collection|Type parameter|" +
-                    "TYPE_GUARD|DOCKER_ATTRIBUTES|DOCKER_CONSTANT|QL_DATETIME|" +
-                    "PUBLIC_REFERENCE|PROTECTED_REFERENCE|PACKAGE_PRIVATE_REFERENCE|" +
-                    "PRIVATE_REFERENCE|KOTLIN_WRAPPED_INTO_REF|" +
-                    "KOTLIN_ANDROID_EXTENSIONS_PROPERTY_CALL|VELOCITY_REFERENCE|" +
-                    "FTL_REFERENCE|PHP_ALIAS_REFERENCE|RUBY_CONSTANT_DECLARATION|" +
-                    "RUBY_CONSTANT_DEF_ID|Implicit conversion",
-            ) to PrimitiveCategory.TYPE_REF,
-        )
+            addRules(
+                PrimitiveCategory.TYPE_REF,
+                "TYPE_REFERENCE$|TYPE_NAME$|TYPE_ALIAS$|TYPE$|TYPEALIAS_REFERENCE",
+                "PRIMITIVE_TYPE_HINT|PREDEFINED_SCOPE|PREDEFINED|Scala Type",
+                "Scala Predefined types|Scala Mutable Collection|Scala Immutable Collection",
+                "StandardF Java Collection|Type parameter|TYPE_GUARD|DOCKER_ATTRIBUTES",
+                "DOCKER_CONSTANT|QL_DATETIME|PUBLIC_REFERENCE|PROTECTED_REFERENCE",
+                "PACKAGE_PRIVATE_REFERENCE|PRIVATE_REFERENCE|KOTLIN_WRAPPED_INTO_REF",
+                "KOTLIN_ANDROID_EXTENSIONS_PROPERTY_CALL|VELOCITY_REFERENCE|FTL_REFERENCE",
+                "PHP_ALIAS_REFERENCE|RUBY_CONSTANT_DECLARATION|RUBY_CONSTANT_DEF_ID",
+                "Implicit conversion",
+            )
+        }
+
+    private fun MutableList<Pair<Regex, PrimitiveCategory>>.addRules(
+        category: PrimitiveCategory,
+        vararg patterns: String,
+    ) {
+        patterns.forEach { pattern -> add(Regex(pattern) to category) }
+    }
 
     /**
      * Classify a `TextAttributesKey` external name into a [PrimitiveCategory].

--- a/src/main/kotlin/dev/ayuislands/syntax/SyntaxCategoryRegistry.kt
+++ b/src/main/kotlin/dev/ayuislands/syntax/SyntaxCategoryRegistry.kt
@@ -64,13 +64,14 @@ object SyntaxCategoryRegistry {
                 "DOC_COMMENT($|_)|DOC_TAG|DOCUMENTATION$|KDOC_LINK|KDOC_TAG_NAME",
                 "DOC_IDENTIFIER|DOC_METHOD_IDENTIFIER|DOC_PROPERTY_IDENTIFIER|DOC_VAR|LUA_DOC_VALUE",
                 "ScalaDoc|MARKDOWN_LIST_MARKER|MARKDOWN_HRULE|MARKDOWN_CODE_FENCE_LANGUAGE",
-                "MARKDOWN_STRIKE_THROUGH|IGNORE\\.COMMENT",
+                "MARKDOWN_STRIKE_THROUGH",
             )
             // --- Comments ---------------------------------------------------
             addRules(
                 PrimitiveCategory.COMMENT,
                 "LINE_COMMENT$|BLOCK_COMMENT$|COMMENT$|COMMENT_REFERENCE$|_COMMENT_",
-                "MARKDOWN_BLOCK_QUOTE_MARKER|MARKDOWN_FRONT_MATTER|IGNORE\\.UNUSED_ENTRY",
+                "MARKDOWN_BLOCK_QUOTE_MARKER|MARKDOWN_FRONT_MATTER",
+                "IGNORE\\.COMMENT|IGNORE\\.UNUSED_ENTRY",
             )
             // --- Fields (must beat KEYWORD / LOCAL_VAR) ---------------------
             addRules(

--- a/src/main/kotlin/dev/ayuislands/syntax/SyntaxIntensityService.kt
+++ b/src/main/kotlin/dev/ayuislands/syntax/SyntaxIntensityService.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.editor.colors.EditorColorsScheme
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.editor.markup.TextAttributes
 import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.settings.AyuIslandsSettings
 import java.awt.Color
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
@@ -90,6 +91,8 @@ class SyntaxIntensityService {
                 subordinatePreset = subordinatePreset,
                 customStyles = customStyles,
                 readabilityOptions = effectiveReadabilityOptions,
+                ignorePluginSyntaxColorsEnabled =
+                    AyuIslandsSettings.getInstance().state.ignorePluginSyntaxColorsEnabled,
             )
         val manager = EditorColorsManager.getInstance()
         val touched = mutableSetOf<EditorColorsScheme>()
@@ -107,7 +110,7 @@ class SyntaxIntensityService {
                     variantTag = overlayVariant,
                     context = context,
                 )
-            writeSchemeAttributes(scheme, computed, schemeName)
+            writeSchemeAttributes(scheme, applyIgnorePluginPreference(computed, context), schemeName)
             touched.add(scheme)
         }
         writeActiveSchemeIfNotTouched(context, touched)
@@ -128,6 +131,7 @@ class SyntaxIntensityService {
         val subordinatePreset: SyntaxPreset,
         val customStyles: Map<String, Map<String, Int>>,
         val readabilityOptions: SyntaxReadabilityOptions,
+        val ignorePluginSyntaxColorsEnabled: Boolean,
     )
 
     /**
@@ -239,7 +243,7 @@ class SyntaxIntensityService {
                 variantTag = variant,
                 context = context,
             )
-        writeSchemeAttributes(active, computed, active.name)
+        writeSchemeAttributes(active, applyIgnorePluginPreference(computed, context), active.name)
     }
 
     private fun computeSchemeAttributes(
@@ -261,6 +265,20 @@ class SyntaxIntensityService {
                 readabilityOptions = context.readabilityOptions,
             ),
         )
+    }
+
+    private fun applyIgnorePluginPreference(
+        computed: Map<TextAttributesKey, TextAttributes>,
+        context: ApplyContext,
+    ): Map<TextAttributesKey, TextAttributes> {
+        if (context.ignorePluginSyntaxColorsEnabled) return computed
+
+        val result = LinkedHashMap(computed)
+        for (keyName in IGNORE_PLUGIN_KEY_NAMES) {
+            val key = TextAttributesKey.find(keyName)
+            result[key] = key.defaultAttributes?.clone() ?: TextAttributes()
+        }
+        return result
     }
 
     /**
@@ -323,6 +341,19 @@ class SyntaxIntensityService {
         // when defaultBackground == Color.WHITE. The Light variant's
         // Color.WHITE IS correct and must flow through unchanged.
         private val DARK_OVERLAY_VARIANTS = setOf("Mirage", "Dark")
+
+        private val IGNORE_PLUGIN_KEY_NAMES =
+            listOf(
+                "IGNORE.COMMENT",
+                "IGNORE.SECTION",
+                "IGNORE.HEADER",
+                "IGNORE.NEGATION",
+                "IGNORE.BRACKET",
+                "IGNORE.SLASH",
+                "IGNORE.SYNTAX",
+                "IGNORE.VALUE",
+                "IGNORE.UNUSED_ENTRY",
+            )
 
         fun getInstance(): SyntaxIntensityService {
             val app = ApplicationManager.getApplication()

--- a/src/main/kotlin/dev/ayuislands/syntax/SyntaxIntensityService.kt
+++ b/src/main/kotlin/dev/ayuislands/syntax/SyntaxIntensityService.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.editor.markup.TextAttributes
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import java.awt.Color
+import java.awt.Font
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -110,7 +111,11 @@ class SyntaxIntensityService {
                     variantTag = overlayVariant,
                     context = context,
                 )
-            writeSchemeAttributes(scheme, applyIgnorePluginPreference(computed, context), schemeName)
+            writeSchemeAttributes(
+                scheme,
+                applyIgnorePluginPreference(computed, context, overlayVariant),
+                schemeName,
+            )
             touched.add(scheme)
         }
         writeActiveSchemeIfNotTouched(context, touched)
@@ -243,7 +248,11 @@ class SyntaxIntensityService {
                 variantTag = variant,
                 context = context,
             )
-        writeSchemeAttributes(active, applyIgnorePluginPreference(computed, context), active.name)
+        writeSchemeAttributes(
+            active,
+            applyIgnorePluginPreference(computed, context, variant),
+            active.name,
+        )
     }
 
     private fun computeSchemeAttributes(
@@ -270,16 +279,25 @@ class SyntaxIntensityService {
     private fun applyIgnorePluginPreference(
         computed: Map<TextAttributesKey, TextAttributes>,
         context: ApplyContext,
+        variantTag: String,
     ): Map<TextAttributesKey, TextAttributes> {
         if (context.ignorePluginSyntaxColorsEnabled) return computed
 
         val result = LinkedHashMap(computed)
         for (keyName in IGNORE_PLUGIN_KEY_NAMES) {
             val key = TextAttributesKey.find(keyName)
-            result[key] = key.defaultAttributes?.clone() ?: TextAttributes()
+            result[key] = ignorePluginStockAttributes(variantTag, keyName)
         }
         return result
     }
+
+    private fun ignorePluginStockAttributes(
+        variantTag: String,
+        keyName: String,
+    ): TextAttributes =
+        (if (variantTag == "Light") IGNORE_PLUGIN_DEFAULT_STOCK else IGNORE_PLUGIN_DARCULA_STOCK)
+            .getValue(keyName)
+            .toTextAttributes()
 
     /**
      * Map a named or `_@user_`-derived Ayu active scheme name to its overlay
@@ -354,6 +372,65 @@ class SyntaxIntensityService {
                 "IGNORE.VALUE",
                 "IGNORE.UNUSED_ENTRY",
             )
+
+        private val IGNORE_PLUGIN_DARCULA_STOCK =
+            mapOf(
+                "IGNORE.COMMENT" to IgnorePluginStockStyle(foregroundRgb = 0x808080),
+                "IGNORE.SECTION" to IgnorePluginStockStyle(foregroundRgb = 0x8C8C8C, backgroundRgb = 0x3A3A3A),
+                "IGNORE.HEADER" to
+                    IgnorePluginStockStyle(
+                        foregroundRgb = 0x8C8C8C,
+                        backgroundRgb = 0x3A3A3A,
+                        fontType = Font.BOLD,
+                    ),
+                "IGNORE.NEGATION" to IgnorePluginStockStyle(foregroundRgb = 0xCC7832, fontType = Font.BOLD),
+                "IGNORE.BRACKET" to IgnorePluginStockStyle(foregroundRgb = 0xCC7832, fontType = Font.BOLD),
+                "IGNORE.SLASH" to IgnorePluginStockStyle(foregroundRgb = 0x808080),
+                "IGNORE.SYNTAX" to
+                    IgnorePluginStockStyle(
+                        foregroundRgb = 0xACACAC,
+                        backgroundRgb = 0x4A4A4A,
+                        fontType = Font.BOLD,
+                    ),
+                "IGNORE.VALUE" to IgnorePluginStockStyle(foregroundRgb = 0x629755),
+                "IGNORE.UNUSED_ENTRY" to IgnorePluginStockStyle(foregroundRgb = 0x808080, fontType = Font.ITALIC),
+            )
+
+        private val IGNORE_PLUGIN_DEFAULT_STOCK =
+            mapOf(
+                "IGNORE.COMMENT" to IgnorePluginStockStyle(foregroundRgb = 0x808080),
+                "IGNORE.SECTION" to IgnorePluginStockStyle(foregroundRgb = 0x808080, backgroundRgb = 0xECFAEB),
+                "IGNORE.HEADER" to
+                    IgnorePluginStockStyle(
+                        foregroundRgb = 0x808080,
+                        backgroundRgb = 0xECFAEB,
+                        fontType = Font.BOLD,
+                    ),
+                "IGNORE.NEGATION" to IgnorePluginStockStyle(foregroundRgb = 0xCC7832, fontType = Font.BOLD),
+                "IGNORE.BRACKET" to IgnorePluginStockStyle(foregroundRgb = 0xCC7832, fontType = Font.BOLD),
+                "IGNORE.SLASH" to IgnorePluginStockStyle(foregroundRgb = 0x808080),
+                "IGNORE.SYNTAX" to
+                    IgnorePluginStockStyle(
+                        foregroundRgb = 0xACACAC,
+                        backgroundRgb = 0x4A4A4A,
+                        fontType = Font.BOLD,
+                    ),
+                "IGNORE.VALUE" to IgnorePluginStockStyle(foregroundRgb = 0x5C9F30),
+                "IGNORE.UNUSED_ENTRY" to IgnorePluginStockStyle(foregroundRgb = 0x808080, fontType = Font.ITALIC),
+            )
+
+        private data class IgnorePluginStockStyle(
+            val foregroundRgb: Int,
+            val backgroundRgb: Int? = null,
+            val fontType: Int = Font.PLAIN,
+        ) {
+            fun toTextAttributes(): TextAttributes =
+                TextAttributes().also { attributes ->
+                    attributes.foregroundColor = Color(foregroundRgb)
+                    attributes.backgroundColor = backgroundRgb?.let(::Color)
+                    attributes.fontType = fontType
+                }
+        }
 
         fun getInstance(): SyntaxIntensityService {
             val app = ApplicationManager.getApplication()

--- a/src/main/kotlin/dev/ayuislands/syntax/SyntaxIntensityService.kt
+++ b/src/main/kotlin/dev/ayuislands/syntax/SyntaxIntensityService.kt
@@ -360,63 +360,73 @@ class SyntaxIntensityService {
         // Color.WHITE IS correct and must flow through unchanged.
         private val DARK_OVERLAY_VARIANTS = setOf("Mirage", "Dark")
 
+        private const val IGNORE_COMMENT_KEY = "IGNORE.COMMENT"
+        private const val IGNORE_SECTION_KEY = "IGNORE.SECTION"
+        private const val IGNORE_HEADER_KEY = "IGNORE.HEADER"
+        private const val IGNORE_NEGATION_KEY = "IGNORE.NEGATION"
+        private const val IGNORE_BRACKET_KEY = "IGNORE.BRACKET"
+        private const val IGNORE_SLASH_KEY = "IGNORE.SLASH"
+        private const val IGNORE_SYNTAX_KEY = "IGNORE.SYNTAX"
+        private const val IGNORE_VALUE_KEY = "IGNORE.VALUE"
+        private const val IGNORE_UNUSED_ENTRY_KEY = "IGNORE.UNUSED_ENTRY"
+
         private val IGNORE_PLUGIN_KEY_NAMES =
             listOf(
-                "IGNORE.COMMENT",
-                "IGNORE.SECTION",
-                "IGNORE.HEADER",
-                "IGNORE.NEGATION",
-                "IGNORE.BRACKET",
-                "IGNORE.SLASH",
-                "IGNORE.SYNTAX",
-                "IGNORE.VALUE",
-                "IGNORE.UNUSED_ENTRY",
+                IGNORE_COMMENT_KEY,
+                IGNORE_SECTION_KEY,
+                IGNORE_HEADER_KEY,
+                IGNORE_NEGATION_KEY,
+                IGNORE_BRACKET_KEY,
+                IGNORE_SLASH_KEY,
+                IGNORE_SYNTAX_KEY,
+                IGNORE_VALUE_KEY,
+                IGNORE_UNUSED_ENTRY_KEY,
             )
 
         private val IGNORE_PLUGIN_DARCULA_STOCK =
             mapOf(
-                "IGNORE.COMMENT" to IgnorePluginStockStyle(foregroundRgb = 0x808080),
-                "IGNORE.SECTION" to IgnorePluginStockStyle(foregroundRgb = 0x8C8C8C, backgroundRgb = 0x3A3A3A),
-                "IGNORE.HEADER" to
+                IGNORE_COMMENT_KEY to IgnorePluginStockStyle(foregroundRgb = 0x808080),
+                IGNORE_SECTION_KEY to IgnorePluginStockStyle(foregroundRgb = 0x8C8C8C, backgroundRgb = 0x3A3A3A),
+                IGNORE_HEADER_KEY to
                     IgnorePluginStockStyle(
                         foregroundRgb = 0x8C8C8C,
                         backgroundRgb = 0x3A3A3A,
                         fontType = Font.BOLD,
                     ),
-                "IGNORE.NEGATION" to IgnorePluginStockStyle(foregroundRgb = 0xCC7832, fontType = Font.BOLD),
-                "IGNORE.BRACKET" to IgnorePluginStockStyle(foregroundRgb = 0xCC7832, fontType = Font.BOLD),
-                "IGNORE.SLASH" to IgnorePluginStockStyle(foregroundRgb = 0x808080),
-                "IGNORE.SYNTAX" to
+                IGNORE_NEGATION_KEY to IgnorePluginStockStyle(foregroundRgb = 0xCC7832, fontType = Font.BOLD),
+                IGNORE_BRACKET_KEY to IgnorePluginStockStyle(foregroundRgb = 0xCC7832, fontType = Font.BOLD),
+                IGNORE_SLASH_KEY to IgnorePluginStockStyle(foregroundRgb = 0x808080),
+                IGNORE_SYNTAX_KEY to
                     IgnorePluginStockStyle(
                         foregroundRgb = 0xACACAC,
                         backgroundRgb = 0x4A4A4A,
                         fontType = Font.BOLD,
                     ),
-                "IGNORE.VALUE" to IgnorePluginStockStyle(foregroundRgb = 0x629755),
-                "IGNORE.UNUSED_ENTRY" to IgnorePluginStockStyle(foregroundRgb = 0x808080, fontType = Font.ITALIC),
+                IGNORE_VALUE_KEY to IgnorePluginStockStyle(foregroundRgb = 0x629755),
+                IGNORE_UNUSED_ENTRY_KEY to IgnorePluginStockStyle(foregroundRgb = 0x808080, fontType = Font.ITALIC),
             )
 
         private val IGNORE_PLUGIN_DEFAULT_STOCK =
             mapOf(
-                "IGNORE.COMMENT" to IgnorePluginStockStyle(foregroundRgb = 0x808080),
-                "IGNORE.SECTION" to IgnorePluginStockStyle(foregroundRgb = 0x808080, backgroundRgb = 0xECFAEB),
-                "IGNORE.HEADER" to
+                IGNORE_COMMENT_KEY to IgnorePluginStockStyle(foregroundRgb = 0x808080),
+                IGNORE_SECTION_KEY to IgnorePluginStockStyle(foregroundRgb = 0x808080, backgroundRgb = 0xECFAEB),
+                IGNORE_HEADER_KEY to
                     IgnorePluginStockStyle(
                         foregroundRgb = 0x808080,
                         backgroundRgb = 0xECFAEB,
                         fontType = Font.BOLD,
                     ),
-                "IGNORE.NEGATION" to IgnorePluginStockStyle(foregroundRgb = 0xCC7832, fontType = Font.BOLD),
-                "IGNORE.BRACKET" to IgnorePluginStockStyle(foregroundRgb = 0xCC7832, fontType = Font.BOLD),
-                "IGNORE.SLASH" to IgnorePluginStockStyle(foregroundRgb = 0x808080),
-                "IGNORE.SYNTAX" to
+                IGNORE_NEGATION_KEY to IgnorePluginStockStyle(foregroundRgb = 0xCC7832, fontType = Font.BOLD),
+                IGNORE_BRACKET_KEY to IgnorePluginStockStyle(foregroundRgb = 0xCC7832, fontType = Font.BOLD),
+                IGNORE_SLASH_KEY to IgnorePluginStockStyle(foregroundRgb = 0x808080),
+                IGNORE_SYNTAX_KEY to
                     IgnorePluginStockStyle(
                         foregroundRgb = 0xACACAC,
                         backgroundRgb = 0x4A4A4A,
                         fontType = Font.BOLD,
                     ),
-                "IGNORE.VALUE" to IgnorePluginStockStyle(foregroundRgb = 0x5C9F30),
-                "IGNORE.UNUSED_ENTRY" to IgnorePluginStockStyle(foregroundRgb = 0x808080, fontType = Font.ITALIC),
+                IGNORE_VALUE_KEY to IgnorePluginStockStyle(foregroundRgb = 0x5C9F30),
+                IGNORE_UNUSED_ENTRY_KEY to IgnorePluginStockStyle(foregroundRgb = 0x808080, fontType = Font.ITALIC),
             )
 
         private data class IgnorePluginStockStyle(

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -115,6 +115,7 @@
     <change-notes><![CDATA[
     <h3>2.7.1</h3>
     <ul>
+      <li><b>Added:</b> <code>.ignore</code> files now use dedicated Ayu colors across Dark, Mirage, and Light editor schemes, including Syntax preset transformations.</li>
       <li><b>Changed:</b> free users can inspect premium Settings controls in their real layout, with controls greyed out until a license or trial unlocks them.</li>
       <li><b>Changed:</b> the VCS tab now shows one compact code-style preview that reflects diff, merge/conflict, blame, and file-status presets together.</li>
       <li><b>Changed:</b> the Font tab now uses the same editor-style preview treatment as VCS, with clearer depth and file context.</li>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -115,7 +115,7 @@
     <change-notes><![CDATA[
     <h3>2.7.1</h3>
     <ul>
-      <li><b>Added:</b> <code>.ignore</code> files now use dedicated Ayu colors across Dark, Mirage, and Light editor schemes, including Syntax preset transformations.</li>
+      <li><b>Added:</b> <code>.ignore</code> files now use dedicated Ayu colors across Dark, Mirage, and Light editor schemes, including Syntax preset transformations and a Plugins-tab opt-out.</li>
       <li><b>Changed:</b> free users can inspect premium Settings controls in their real layout, with controls greyed out until a license or trial unlocks them.</li>
       <li><b>Changed:</b> the VCS tab now shows one compact code-style preview that reflects diff, merge/conflict, blame, and file-status presets together.</li>
       <li><b>Changed:</b> the Font tab now uses the same editor-style preview treatment as VCS, with clearer depth and file context.</li>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -121,6 +121,9 @@
       <li><b>Fixed:</b> premium Settings controls stay visible-but-locked across VCS, Glow, Workspace, Chrome tinting, Accent Elements, plugin integrations, and accent overrides instead of disappearing behind a Pro notice.</li>
       <li><b>Fixed:</b> locked premium controls no longer mark Settings as modified when clicked by unlicensed users, and Reset/Revert restores nested plugin-integration rows correctly.</li>
       <li><b>Fixed:</b> Settings tabs and preview panels shrink more consistently in narrow Settings windows.</li>
+      <li><b>Fixed:</b> Accent Settings preview stays synchronized with the selected color instead of restoring stale shuffle state.</li>
+      <li><b>Fixed:</b> visible managed tool windows re-measure after layout and theme refreshes, so auto-fit sizing stays consistent.</li>
+      <li><b>Compatibility:</b> release builds now block IntelliJ Plugin Verifier internal API findings before Marketplace upload.</li>
     </ul>
     <h3>2.7.0</h3>
     <ul>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -115,7 +115,7 @@
     <change-notes><![CDATA[
     <h3>2.7.1</h3>
     <ul>
-      <li><b>Added:</b> <code>.ignore</code> files now use dedicated Ayu colors across Dark, Mirage, and Light editor schemes, including Syntax preset transformations and a Plugins-tab opt-out.</li>
+      <li><b>Added:</b> when the optional <code>.ignore</code> plugin is installed, its files use dedicated Ayu colors across Dark, Mirage, and Light editor schemes, including Syntax preset transformations and a Plugins-tab opt-out.</li>
       <li><b>Changed:</b> free users can inspect premium Settings controls in their real layout, with controls greyed out until a license or trial unlocks them.</li>
       <li><b>Changed:</b> the VCS tab now shows one compact code-style preview that reflects diff, merge/conflict, blame, and file-status presets together.</li>
       <li><b>Changed:</b> the Font tab now uses the same editor-style preview treatment as VCS, with clearer depth and file context.</li>

--- a/src/main/resources/themes/AyuIslandsDark.xml
+++ b/src/main/resources/themes/AyuIslandsDark.xml
@@ -1302,6 +1302,59 @@
             </value>
         </option>
 
+        <!-- Ignore plugin -->
+        <option name="IGNORE.COMMENT">
+            <value>
+                <option name="FOREGROUND" value="AAD94C" />
+                <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="IGNORE.SECTION">
+            <value>
+                <option name="FOREGROUND" value="FFB454" />
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="IGNORE.HEADER">
+            <value>
+                <option name="FOREGROUND" value="D2A6FF" />
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="IGNORE.NEGATION">
+            <value>
+                <option name="FOREGROUND" value="F07178" />
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="IGNORE.BRACKET">
+            <value>
+                <option name="FOREGROUND" value="F29668" />
+            </value>
+        </option>
+        <option name="IGNORE.SLASH">
+            <value>
+                <option name="FOREGROUND" value="ACB6BF" />
+            </value>
+        </option>
+        <option name="IGNORE.SYNTAX">
+            <value>
+                <option name="FOREGROUND" value="FF8F40" />
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="IGNORE.VALUE">
+            <value>
+                <option name="FOREGROUND" value="95E6CB" />
+            </value>
+        </option>
+        <option name="IGNORE.UNUSED_ENTRY">
+            <value>
+                <option name="FOREGROUND" value="ACB6BF" />
+                <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+
         <!-- Identifier under caret -->
         <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
             <value>

--- a/src/main/resources/themes/AyuIslandsLight.xml
+++ b/src/main/resources/themes/AyuIslandsLight.xml
@@ -1302,6 +1302,59 @@
             </value>
         </option>
 
+        <!-- Ignore plugin -->
+        <option name="IGNORE.COMMENT">
+            <value>
+                <option name="FOREGROUND" value="86B300" />
+                <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="IGNORE.SECTION">
+            <value>
+                <option name="FOREGROUND" value="EBA400" />
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="IGNORE.HEADER">
+            <value>
+                <option name="FOREGROUND" value="A37ACC" />
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="IGNORE.NEGATION">
+            <value>
+                <option name="FOREGROUND" value="F07171" />
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="IGNORE.BRACKET">
+            <value>
+                <option name="FOREGROUND" value="F2A191" />
+            </value>
+        </option>
+        <option name="IGNORE.SLASH">
+            <value>
+                <option name="FOREGROUND" value="ADAEB1" />
+            </value>
+        </option>
+        <option name="IGNORE.SYNTAX">
+            <value>
+                <option name="FOREGROUND" value="FA8532" />
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="IGNORE.VALUE">
+            <value>
+                <option name="FOREGROUND" value="4CBF99" />
+            </value>
+        </option>
+        <option name="IGNORE.UNUSED_ENTRY">
+            <value>
+                <option name="FOREGROUND" value="ADAEB1" />
+                <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+
         <!-- Identifier under caret -->
         <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
             <value>

--- a/src/main/resources/themes/AyuIslandsMirage.xml
+++ b/src/main/resources/themes/AyuIslandsMirage.xml
@@ -1302,6 +1302,59 @@
             </value>
         </option>
 
+        <!-- Ignore plugin -->
+        <option name="IGNORE.COMMENT">
+            <value>
+                <option name="FOREGROUND" value="D5FF80" />
+                <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+        <option name="IGNORE.SECTION">
+            <value>
+                <option name="FOREGROUND" value="FFD173" />
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="IGNORE.HEADER">
+            <value>
+                <option name="FOREGROUND" value="DFBFFF" />
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="IGNORE.NEGATION">
+            <value>
+                <option name="FOREGROUND" value="F28779" />
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="IGNORE.BRACKET">
+            <value>
+                <option name="FOREGROUND" value="F29E74" />
+            </value>
+        </option>
+        <option name="IGNORE.SLASH">
+            <value>
+                <option name="FOREGROUND" value="B8CFE6" />
+            </value>
+        </option>
+        <option name="IGNORE.SYNTAX">
+            <value>
+                <option name="FOREGROUND" value="FFAD66" />
+                <option name="FONT_TYPE" value="1" />
+            </value>
+        </option>
+        <option name="IGNORE.VALUE">
+            <value>
+                <option name="FOREGROUND" value="95E6CB" />
+            </value>
+        </option>
+        <option name="IGNORE.UNUSED_ENTRY">
+            <value>
+                <option name="FOREGROUND" value="B8CFE6" />
+                <option name="FONT_TYPE" value="2" />
+            </value>
+        </option>
+
         <!-- Identifier under caret -->
         <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
             <value>

--- a/src/main/resources/themes/extended/AyuIslandsDark.extended.xml
+++ b/src/main/resources/themes/extended/AyuIslandsDark.extended.xml
@@ -2266,15 +2266,21 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="IGNORE.HEADER">
+    <option name="IGNORE.COMMENT">
       <value>
-        <option name="FOREGROUND" value="FFA759" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="AAD94C" />
+        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="IGNORE.SECTION">
       <value>
-        <option name="FOREGROUND" value="E69F25" />
+        <option name="FOREGROUND" value="FFB454" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="IGNORE.HEADER">
+      <value>
+        <option name="FOREGROUND" value="D2A6FF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -2284,22 +2290,34 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
+    <option name="IGNORE.BRACKET">
+      <value>
+        <option name="FOREGROUND" value="F29668" />
+        <option name="FONT_TYPE" value="0" />
+      </value>
+    </option>
     <option name="IGNORE.SYNTAX">
       <value>
-        <option name="FOREGROUND" value="FFA759" />
+        <option name="FOREGROUND" value="FF8F40" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
     <option name="IGNORE.SLASH">
       <value>
-        <option name="FOREGROUND" value="FFA759" />
+        <option name="FOREGROUND" value="ACB6BF" />
         <option name="FONT_TYPE" value="0" />
       </value>
     </option>
     <option name="IGNORE.VALUE">
       <value>
-        <option name="FOREGROUND" value="BFBDB6" />
+        <option name="FOREGROUND" value="95E6CB" />
         <option name="FONT_TYPE" value="0" />
+      </value>
+    </option>
+    <option name="IGNORE.UNUSED_ENTRY">
+      <value>
+        <option name="FOREGROUND" value="ACB6BF" />
+        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="RBS_KEYWORDS">

--- a/src/main/resources/themes/extended/AyuIslandsLight.extended.xml
+++ b/src/main/resources/themes/extended/AyuIslandsLight.extended.xml
@@ -2266,15 +2266,21 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="IGNORE.HEADER">
+    <option name="IGNORE.COMMENT">
       <value>
-        <option name="FOREGROUND" value="FA8532" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="86B300" />
+        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="IGNORE.SECTION">
       <value>
-        <option name="FOREGROUND" value="D89400" />
+        <option name="FOREGROUND" value="EBA400" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="IGNORE.HEADER">
+      <value>
+        <option name="FOREGROUND" value="A37ACC" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -2282,6 +2288,12 @@
       <value>
         <option name="FOREGROUND" value="F07171" />
         <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="IGNORE.BRACKET">
+      <value>
+        <option name="FOREGROUND" value="F2A191" />
+        <option name="FONT_TYPE" value="0" />
       </value>
     </option>
     <option name="IGNORE.SYNTAX">
@@ -2292,14 +2304,20 @@
     </option>
     <option name="IGNORE.SLASH">
       <value>
-        <option name="FOREGROUND" value="FA8532" />
+        <option name="FOREGROUND" value="ADAEB1" />
         <option name="FONT_TYPE" value="0" />
       </value>
     </option>
     <option name="IGNORE.VALUE">
       <value>
-        <option name="FOREGROUND" value="5C6166" />
+        <option name="FOREGROUND" value="4CBF99" />
         <option name="FONT_TYPE" value="0" />
+      </value>
+    </option>
+    <option name="IGNORE.UNUSED_ENTRY">
+      <value>
+        <option name="FOREGROUND" value="ADAEB1" />
+        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="RBS_KEYWORDS">

--- a/src/main/resources/themes/extended/AyuIslandsMirage.extended.xml
+++ b/src/main/resources/themes/extended/AyuIslandsMirage.extended.xml
@@ -2266,15 +2266,21 @@
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
-    <option name="IGNORE.HEADER">
+    <option name="IGNORE.COMMENT">
       <value>
-        <option name="FOREGROUND" value="FFAD66" />
-        <option name="FONT_TYPE" value="1" />
+        <option name="FOREGROUND" value="D5FF80" />
+        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="IGNORE.SECTION">
       <value>
-        <option name="FOREGROUND" value="FFCC66" />
+        <option name="FOREGROUND" value="FFD173" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="IGNORE.HEADER">
+      <value>
+        <option name="FOREGROUND" value="DFBFFF" />
         <option name="FONT_TYPE" value="1" />
       </value>
     </option>
@@ -2282,6 +2288,12 @@
       <value>
         <option name="FOREGROUND" value="F28779" />
         <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="IGNORE.BRACKET">
+      <value>
+        <option name="FOREGROUND" value="F29E74" />
+        <option name="FONT_TYPE" value="0" />
       </value>
     </option>
     <option name="IGNORE.SYNTAX">
@@ -2292,14 +2304,20 @@
     </option>
     <option name="IGNORE.SLASH">
       <value>
-        <option name="FOREGROUND" value="FFAD66" />
+        <option name="FOREGROUND" value="B8CFE6" />
         <option name="FONT_TYPE" value="0" />
       </value>
     </option>
     <option name="IGNORE.VALUE">
       <value>
-        <option name="FOREGROUND" value="CCCAC2" />
+        <option name="FOREGROUND" value="95E6CB" />
         <option name="FONT_TYPE" value="0" />
+      </value>
+    </option>
+    <option name="IGNORE.UNUSED_ENTRY">
+      <value>
+        <option name="FOREGROUND" value="B8CFE6" />
+        <option name="FONT_TYPE" value="2" />
       </value>
     </option>
     <option name="RBS_KEYWORDS">

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStatePersistenceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStatePersistenceTest.kt
@@ -216,6 +216,16 @@ class AyuIslandsStatePersistenceTest {
         assertEquals(2, reloaded.state.explicitlyUninstalledFonts.size)
     }
 
+    @Test
+    fun `ignore plugin syntax color opt-out survives save reload cycle`() {
+        val reloaded =
+            roundTrip { state ->
+                state.ignorePluginSyntaxColorsEnabled = false
+            }
+
+        assertFalse(reloaded.state.ignorePluginSyntaxColorsEnabled)
+    }
+
     // ---------- Chrome tinting (phase 40) XML round-trip for all 8 new fields ----------
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateTest.kt
@@ -529,6 +529,16 @@ class AyuIslandsStateTest {
     }
 
     @Test
+    fun `ignore plugin syntax colors default on and can be disabled`() {
+        val state = freshState()
+        assertTrue(state.ignorePluginSyntaxColorsEnabled, ".ignore colors should ship enabled by default")
+
+        state.ignorePluginSyntaxColorsEnabled = false
+
+        assertFalse(state.ignorePluginSyntaxColorsEnabled)
+    }
+
+    @Test
     fun `PanelWidthMode fromString parses valid names`() {
         assertEquals(PanelWidthMode.DEFAULT, PanelWidthMode.fromString("DEFAULT"))
         assertEquals(PanelWidthMode.AUTO_FIT, PanelWidthMode.fromString("AUTO_FIT"))

--- a/src/test/kotlin/dev/ayuislands/settings/PluginsPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/PluginsPanelTest.kt
@@ -165,6 +165,28 @@ class PluginsPanelTest {
         verify(exactly = 1) { syntaxIntensityService.reapplyForActiveLaf() }
     }
 
+    @Test
+    fun `unlicensed users can re-enable ignore plugin syntax colors`() {
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+        every { ConflictRegistry.isIndentRainbowDetected() } returns false
+        state.ignorePluginSyntaxColorsEnabled = false
+        val pluginsPanel = PluginsPanel()
+
+        val dialogPanel = buildDialogPanel(pluginsPanel)
+        val ignoreCheckbox =
+            descendants(dialogPanel, JCheckBox::class.java)
+                .first { it.text == "Use Ayu colors for .ignore files" }
+
+        assertFalse(ignoreCheckbox.isSelected, "Stored .ignore opt-out must render unchecked")
+
+        ignoreCheckbox.doClick()
+        pluginsPanel.apply()
+
+        assertTrue(state.ignorePluginSyntaxColorsEnabled, "Free users must be able to re-enable .ignore colors")
+        assertFalse(pluginsPanel.isModified(), "Persisting the .ignore opt-in should clean the panel state")
+        verify(exactly = 1) { syntaxIntensityService.reapplyForActiveLaf() }
+    }
+
     private fun buildDialogPanel(pluginsPanel: PluginsPanel): DialogPanel =
         panel {
             pluginsPanel.buildPanel(this, AyuVariant.MIRAGE)

--- a/src/test/kotlin/dev/ayuislands/settings/PluginsPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/PluginsPanelTest.kt
@@ -10,12 +10,14 @@ import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.conflict.ConflictRegistry
 import dev.ayuislands.indent.IndentPreset
 import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.syntax.SyntaxIntensityService
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkClass
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
+import io.mockk.verify
 import java.awt.Component
 import java.awt.Container
 import javax.swing.JCheckBox
@@ -29,12 +31,14 @@ import kotlin.test.assertTrue
 class PluginsPanelTest {
     private lateinit var state: AyuIslandsState
     private lateinit var settings: AyuIslandsSettings
+    private lateinit var syntaxIntensityService: SyntaxIntensityService
 
     @BeforeTest
     fun setUp() {
         state = AyuIslandsState()
         settings = mockk(relaxed = true)
         every { settings.state } returns state
+        syntaxIntensityService = mockk(relaxed = true)
         mockkObject(AyuIslandsSettings.Companion)
         every { AyuIslandsSettings.getInstance() } returns settings
 
@@ -123,6 +127,44 @@ class PluginsPanelTest {
         assertFalse(pluginsPanel.isModified(), "Reset must leave Plugins settings clean")
     }
 
+    @Test
+    fun `ignore plugin toggle stays visible without premium plugin detections`() {
+        every { ConflictRegistry.isIndentRainbowDetected() } returns false
+        val pluginsPanel = PluginsPanel()
+
+        val dialogPanel = buildDialogPanel(pluginsPanel)
+        val ignoreCheckbox =
+            descendants(dialogPanel, JCheckBox::class.java)
+                .first { it.text == "Use Ayu colors for .ignore files" }
+
+        assertTrue(
+            ignoreCheckbox.isEffectivelyVisibleWithin(dialogPanel),
+            ".ignore syntax-color opt-out must stay visible even when premium plugin sync targets are absent",
+        )
+        assertTrue(ignoreCheckbox.isSelected, ".ignore syntax colors default on for the release feature")
+        assertFalse(pluginsPanel.isModified(), "Rendering the default-on .ignore toggle must not dirty Settings")
+    }
+
+    @Test
+    fun `unlicensed users can disable ignore plugin syntax colors`() {
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+        every { ConflictRegistry.isIndentRainbowDetected() } returns false
+        state.ignorePluginSyntaxColorsEnabled = true
+        val pluginsPanel = PluginsPanel()
+
+        val dialogPanel = buildDialogPanel(pluginsPanel)
+        val ignoreCheckbox =
+            descendants(dialogPanel, JCheckBox::class.java)
+                .first { it.text == "Use Ayu colors for .ignore files" }
+
+        ignoreCheckbox.doClick()
+        pluginsPanel.apply()
+
+        assertFalse(state.ignorePluginSyntaxColorsEnabled, "Free users must be able to opt out of .ignore colors")
+        assertFalse(pluginsPanel.isModified(), "Persisting the .ignore opt-out should clean the panel state")
+        verify(exactly = 1) { syntaxIntensityService.reapplyForActiveLaf() }
+    }
+
     private fun buildDialogPanel(pluginsPanel: PluginsPanel): DialogPanel =
         panel {
             pluginsPanel.buildPanel(this, AyuVariant.MIRAGE)
@@ -146,6 +188,7 @@ class PluginsPanelTest {
                 ActionManager::class.java,
                 ActionManagerEx::class.java,
                 -> actionManagerMock
+                SyntaxIntensityService::class.java -> syntaxIntensityService
                 experimentalUiClass -> experimentalUiMock
                 else -> mockkClass(serviceClass.kotlin, relaxed = true)
             }

--- a/src/test/kotlin/dev/ayuislands/syntax/SyntaxCategoryRegistryTest.kt
+++ b/src/test/kotlin/dev/ayuislands/syntax/SyntaxCategoryRegistryTest.kt
@@ -145,6 +145,35 @@ class SyntaxCategoryRegistryTest {
         )
     }
 
+    @Test
+    fun `all ignore plugin keys classify for Syntax presets`() {
+        val expectedCategories =
+            mapOf(
+                "IGNORE.COMMENT" to PrimitiveCategory.DOCUMENTATION,
+                "IGNORE.SECTION" to PrimitiveCategory.KEYWORD,
+                "IGNORE.HEADER" to PrimitiveCategory.KEYWORD,
+                "IGNORE.NEGATION" to PrimitiveCategory.KEYWORD,
+                "IGNORE.BRACKET" to PrimitiveCategory.OPERATOR,
+                "IGNORE.SLASH" to PrimitiveCategory.KEYWORD,
+                "IGNORE.SYNTAX" to PrimitiveCategory.KEYWORD,
+                "IGNORE.VALUE" to PrimitiveCategory.STRING_LITERAL,
+                "IGNORE.UNUSED_ENTRY" to PrimitiveCategory.COMMENT,
+            )
+
+        for ((key, expected) in expectedCategories) {
+            assertEquals(
+                expected,
+                SyntaxCategoryRegistry.classify(key),
+                "$key must classify so Syntax presets can transform .ignore plugin colors.",
+            )
+            assertEquals(
+                "Ignore",
+                SyntaxLanguageRegistry.classify(key).tag,
+                "$key must stay grouped under the Ignore language tag.",
+            )
+        }
+    }
+
     // ---------------------------------------------------------------------
     // Unknown suffix + Pattern A latch
     // ---------------------------------------------------------------------

--- a/src/test/kotlin/dev/ayuislands/syntax/SyntaxCategoryRegistryTest.kt
+++ b/src/test/kotlin/dev/ayuislands/syntax/SyntaxCategoryRegistryTest.kt
@@ -149,7 +149,7 @@ class SyntaxCategoryRegistryTest {
     fun `all ignore plugin keys classify for Syntax presets`() {
         val expectedCategories =
             mapOf(
-                "IGNORE.COMMENT" to PrimitiveCategory.DOCUMENTATION,
+                "IGNORE.COMMENT" to PrimitiveCategory.COMMENT,
                 "IGNORE.SECTION" to PrimitiveCategory.KEYWORD,
                 "IGNORE.HEADER" to PrimitiveCategory.KEYWORD,
                 "IGNORE.NEGATION" to PrimitiveCategory.KEYWORD,

--- a/src/test/kotlin/dev/ayuislands/syntax/SyntaxIntensityApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/syntax/SyntaxIntensityApplicatorTest.kt
@@ -836,6 +836,50 @@ class SyntaxIntensityApplicatorTest {
     }
 
     @Test
+    fun `readability dim comments treats ignore comments as comments`() {
+        val ignoreCommentKey = TextAttributesKey.createTextAttributesKey("IGNORE.COMMENT")
+        val commentFg = Color(0x80, 0x80, 0x80)
+        val editorBg = Color(0x1F, 0x24, 0x30)
+
+        val dimResult =
+            compute(
+                preset = SyntaxPreset.AMBIENT,
+                customOverrides = emptyMap(),
+                baseline = mapOf(ignoreCommentKey to attrsWithFg(commentFg)),
+                overlay = emptyMap(),
+                options =
+                    ComputeOptions(
+                        editorBg = editorBg,
+                        readabilityOptions = SyntaxReadabilityOptions(dimComments = true),
+                    ),
+            )
+        val documentationResult =
+            compute(
+                preset = SyntaxPreset.AMBIENT,
+                customOverrides = emptyMap(),
+                baseline = mapOf(ignoreCommentKey to attrsWithFg(commentFg)),
+                overlay = emptyMap(),
+                options =
+                    ComputeOptions(
+                        editorBg = editorBg,
+                        readabilityOptions = SyntaxReadabilityOptions(softenDocumentation = true),
+                    ),
+            )
+
+        val dimmed = assertNotNull(dimResult[ignoreCommentKey]?.foregroundColor)
+        val documentationOnly = assertNotNull(documentationResult[ignoreCommentKey]?.foregroundColor)
+        assertTrue(
+            colorDistance(dimmed, editorBg) < colorDistance(commentFg, editorBg),
+            "Dim comments must move .ignore comments toward the active background",
+        )
+        assertEquals(
+            commentFg.rgb,
+            documentationOnly.rgb,
+            "Soften documentation must not rewrite .ignore comments",
+        )
+    }
+
+    @Test
     fun `readability soften documentation quiets documentation keys`() {
         val docKey = TextAttributesKey.createTextAttributesKey("JAVA_DOC_COMMENT")
         val baselineFg = Color(0x9D, 0xA0, 0xA8)

--- a/src/test/kotlin/dev/ayuislands/syntax/SyntaxIntensityServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/syntax/SyntaxIntensityServiceTest.kt
@@ -250,6 +250,21 @@ class SyntaxIntensityServiceTest {
     }
 
     @Test
+    fun `disabled ignore plugin colors restore stock attributes on user-derived active Ayu scheme`() {
+        ayuState.ignorePluginSyntaxColorsEnabled = false
+        val userDerivedScheme: EditorColorsScheme =
+            mockk(relaxed = true) {
+                every { name } returns "_@user_Ayu Islands Mirage"
+                every { defaultBackground } returns Color(0x1F, 0x24, 0x30)
+            }
+        every { mockManager.globalScheme } returns userDerivedScheme
+
+        SyntaxIntensityService().apply(SyntaxPreset.WHISPER, emptyMap())
+
+        verifyIgnorePluginStockWrites(userDerivedScheme, ignorePluginDarculaStock)
+    }
+
+    @Test
     fun `enabled ignore plugin colors do not add default restore writes`() {
         ayuState.ignorePluginSyntaxColorsEnabled = true
 

--- a/src/test/kotlin/dev/ayuislands/syntax/SyntaxIntensityServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/syntax/SyntaxIntensityServiceTest.kt
@@ -10,6 +10,8 @@ import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.ui.JBColor
 import com.intellij.util.messages.MessageBus
 import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -43,6 +45,8 @@ class SyntaxIntensityServiceTest {
     private lateinit var mockApp: Application
     private lateinit var loader: SyntaxOverlayLoader
     private lateinit var stateInstance: SyntaxIntensityState
+    private lateinit var ayuSettings: AyuIslandsSettings
+    private lateinit var ayuState: AyuIslandsState
     private val keyCache = mutableMapOf<String, TextAttributesKey>()
 
     @BeforeTest
@@ -65,6 +69,9 @@ class SyntaxIntensityServiceTest {
         mockMessageBus = mockk(relaxed = true)
         mockPublisher = mockk(relaxed = true)
         mockApp = mockk(relaxed = true)
+        ayuState = AyuIslandsState()
+        ayuSettings = mockk(relaxed = true)
+        every { ayuSettings.state } returns ayuState
 
         mockkStatic(EditorColorsManager::class)
         every { EditorColorsManager.getInstance() } returns mockManager
@@ -124,6 +131,7 @@ class SyntaxIntensityServiceTest {
         } returns payload
 
         every { mockApp.getService(SyntaxIntensityService::class.java) } returns SyntaxIntensityService()
+        every { mockApp.getService(AyuIslandsSettings::class.java) } returns ayuSettings
     }
 
     @AfterTest
@@ -227,6 +235,46 @@ class SyntaxIntensityServiceTest {
         service.apply(SyntaxPreset.WHISPER, emptyMap())
 
         verify(exactly = 0) { solarizedScheme.setAttributes(any(), any<TextAttributes>()) }
+    }
+
+    @Test
+    fun `disabled ignore plugin colors restore default attributes on Ayu schemes`() {
+        ayuState.ignorePluginSyntaxColorsEnabled = false
+
+        SyntaxIntensityService().apply(SyntaxPreset.WHISPER, emptyMap())
+
+        verify(exactly = 1) {
+            mockMirage.setAttributes(
+                keyCache.getValue("IGNORE.COMMENT"),
+                any<TextAttributes>(),
+            )
+        }
+        verify(exactly = 1) {
+            mockDark.setAttributes(
+                keyCache.getValue("IGNORE.VALUE"),
+                any<TextAttributes>(),
+            )
+        }
+        verify(exactly = 1) {
+            mockLight.setAttributes(
+                keyCache.getValue("IGNORE.UNUSED_ENTRY"),
+                any<TextAttributes>(),
+            )
+        }
+    }
+
+    @Test
+    fun `enabled ignore plugin colors do not add default restore writes`() {
+        ayuState.ignorePluginSyntaxColorsEnabled = true
+
+        SyntaxIntensityService().apply(SyntaxPreset.WHISPER, emptyMap())
+
+        verify(exactly = 0) {
+            mockMirage.setAttributes(
+                TextAttributesKey.find("IGNORE.COMMENT"),
+                any<TextAttributes>(),
+            )
+        }
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/syntax/SyntaxIntensityServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/syntax/SyntaxIntensityServiceTest.kt
@@ -21,6 +21,7 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
 import java.awt.Color
+import java.awt.Font
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -243,24 +244,9 @@ class SyntaxIntensityServiceTest {
 
         SyntaxIntensityService().apply(SyntaxPreset.WHISPER, emptyMap())
 
-        verify(exactly = 1) {
-            mockMirage.setAttributes(
-                keyCache.getValue("IGNORE.COMMENT"),
-                any<TextAttributes>(),
-            )
-        }
-        verify(exactly = 1) {
-            mockDark.setAttributes(
-                keyCache.getValue("IGNORE.VALUE"),
-                any<TextAttributes>(),
-            )
-        }
-        verify(exactly = 1) {
-            mockLight.setAttributes(
-                keyCache.getValue("IGNORE.UNUSED_ENTRY"),
-                any<TextAttributes>(),
-            )
-        }
+        verifyIgnorePluginStockWrites(mockMirage, ignorePluginDarculaStock)
+        verifyIgnorePluginStockWrites(mockDark, ignorePluginDarculaStock)
+        verifyIgnorePluginStockWrites(mockLight, ignorePluginDefaultStock)
     }
 
     @Test
@@ -493,4 +479,75 @@ class SyntaxIntensityServiceTest {
             )
         }
     }
+
+    private fun verifyIgnorePluginStockWrites(
+        scheme: EditorColorsScheme,
+        expectedStyles: Map<String, ExpectedIgnorePluginStyle>,
+    ) {
+        for ((keyName, expectedStyle) in expectedStyles) {
+            verify(exactly = 1) {
+                scheme.setAttributes(
+                    keyCache.getValue(keyName),
+                    match { attributes -> attributes.matches(expectedStyle) },
+                )
+            }
+        }
+    }
+
+    private fun TextAttributes.matches(expectedStyle: ExpectedIgnorePluginStyle): Boolean =
+        foregroundColor?.rgb == Color(expectedStyle.foregroundRgb).rgb &&
+            backgroundColor?.rgb == expectedStyle.backgroundRgb?.let(::Color)?.rgb &&
+            fontType == expectedStyle.fontType
+
+    private data class ExpectedIgnorePluginStyle(
+        val foregroundRgb: Int,
+        val backgroundRgb: Int? = null,
+        val fontType: Int = Font.PLAIN,
+    )
+
+    private val ignorePluginDarculaStock =
+        mapOf(
+            "IGNORE.COMMENT" to ExpectedIgnorePluginStyle(foregroundRgb = 0x808080),
+            "IGNORE.SECTION" to ExpectedIgnorePluginStyle(foregroundRgb = 0x8C8C8C, backgroundRgb = 0x3A3A3A),
+            "IGNORE.HEADER" to
+                ExpectedIgnorePluginStyle(
+                    foregroundRgb = 0x8C8C8C,
+                    backgroundRgb = 0x3A3A3A,
+                    fontType = Font.BOLD,
+                ),
+            "IGNORE.NEGATION" to ExpectedIgnorePluginStyle(foregroundRgb = 0xCC7832, fontType = Font.BOLD),
+            "IGNORE.BRACKET" to ExpectedIgnorePluginStyle(foregroundRgb = 0xCC7832, fontType = Font.BOLD),
+            "IGNORE.SLASH" to ExpectedIgnorePluginStyle(foregroundRgb = 0x808080),
+            "IGNORE.SYNTAX" to
+                ExpectedIgnorePluginStyle(
+                    foregroundRgb = 0xACACAC,
+                    backgroundRgb = 0x4A4A4A,
+                    fontType = Font.BOLD,
+                ),
+            "IGNORE.VALUE" to ExpectedIgnorePluginStyle(foregroundRgb = 0x629755),
+            "IGNORE.UNUSED_ENTRY" to ExpectedIgnorePluginStyle(foregroundRgb = 0x808080, fontType = Font.ITALIC),
+        )
+
+    private val ignorePluginDefaultStock =
+        mapOf(
+            "IGNORE.COMMENT" to ExpectedIgnorePluginStyle(foregroundRgb = 0x808080),
+            "IGNORE.SECTION" to ExpectedIgnorePluginStyle(foregroundRgb = 0x808080, backgroundRgb = 0xECFAEB),
+            "IGNORE.HEADER" to
+                ExpectedIgnorePluginStyle(
+                    foregroundRgb = 0x808080,
+                    backgroundRgb = 0xECFAEB,
+                    fontType = Font.BOLD,
+                ),
+            "IGNORE.NEGATION" to ExpectedIgnorePluginStyle(foregroundRgb = 0xCC7832, fontType = Font.BOLD),
+            "IGNORE.BRACKET" to ExpectedIgnorePluginStyle(foregroundRgb = 0xCC7832, fontType = Font.BOLD),
+            "IGNORE.SLASH" to ExpectedIgnorePluginStyle(foregroundRgb = 0x808080),
+            "IGNORE.SYNTAX" to
+                ExpectedIgnorePluginStyle(
+                    foregroundRgb = 0xACACAC,
+                    backgroundRgb = 0x4A4A4A,
+                    fontType = Font.BOLD,
+                ),
+            "IGNORE.VALUE" to ExpectedIgnorePluginStyle(foregroundRgb = 0x5C9F30),
+            "IGNORE.UNUSED_ENTRY" to ExpectedIgnorePluginStyle(foregroundRgb = 0x808080, fontType = Font.ITALIC),
+        )
 }

--- a/src/test/kotlin/dev/ayuislands/theme/IgnorePluginSchemeKeysTest.kt
+++ b/src/test/kotlin/dev/ayuislands/theme/IgnorePluginSchemeKeysTest.kt
@@ -1,0 +1,215 @@
+package dev.ayuislands.theme
+
+import org.w3c.dom.Document
+import org.w3c.dom.Element
+import javax.xml.XMLConstants
+import javax.xml.parsers.DocumentBuilderFactory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+/**
+ * Regression lock for JetBrains `.ignore` plugin color keys. Ayu Islands does
+ * not depend on the optional plugin; editor schemes define the static
+ * TextAttributesKey names so the plugin can consume them when installed.
+ */
+class IgnorePluginSchemeKeysTest {
+    private val requiredIgnoreKeys =
+        setOf(
+            "IGNORE.COMMENT",
+            "IGNORE.SECTION",
+            "IGNORE.HEADER",
+            "IGNORE.NEGATION",
+            "IGNORE.BRACKET",
+            "IGNORE.SLASH",
+            "IGNORE.SYNTAX",
+            "IGNORE.VALUE",
+            "IGNORE.UNUSED_ENTRY",
+        )
+
+    private val baseSchemes =
+        listOf(
+            "/themes/AyuIslandsDark.xml",
+            "/themes/AyuIslandsMirage.xml",
+            "/themes/AyuIslandsLight.xml",
+        )
+
+    private val extendedOverlays =
+        listOf(
+            "/themes/extended/AyuIslandsDark.extended.xml",
+            "/themes/extended/AyuIslandsMirage.extended.xml",
+            "/themes/extended/AyuIslandsLight.extended.xml",
+        )
+
+    private val expectedDarkIgnoreColors =
+        mapOf(
+            "IGNORE.COMMENT" to "AAD94C",
+            "IGNORE.SECTION" to "FFB454",
+            "IGNORE.HEADER" to "D2A6FF",
+            "IGNORE.NEGATION" to "F07178",
+            "IGNORE.BRACKET" to "F29668",
+            "IGNORE.SLASH" to "ACB6BF",
+            "IGNORE.SYNTAX" to "FF8F40",
+            "IGNORE.VALUE" to "95E6CB",
+            "IGNORE.UNUSED_ENTRY" to "ACB6BF",
+        )
+
+    private val expectedMirageIgnoreColors =
+        mapOf(
+            "IGNORE.COMMENT" to "D5FF80",
+            "IGNORE.SECTION" to "FFD173",
+            "IGNORE.HEADER" to "DFBFFF",
+            "IGNORE.NEGATION" to "F28779",
+            "IGNORE.BRACKET" to "F29E74",
+            "IGNORE.SLASH" to "B8CFE6",
+            "IGNORE.SYNTAX" to "FFAD66",
+            "IGNORE.VALUE" to "95E6CB",
+            "IGNORE.UNUSED_ENTRY" to "B8CFE6",
+        )
+
+    private val expectedLightIgnoreColors =
+        mapOf(
+            "IGNORE.COMMENT" to "86B300",
+            "IGNORE.SECTION" to "EBA400",
+            "IGNORE.HEADER" to "A37ACC",
+            "IGNORE.NEGATION" to "F07171",
+            "IGNORE.BRACKET" to "F2A191",
+            "IGNORE.SLASH" to "ADAEB1",
+            "IGNORE.SYNTAX" to "FA8532",
+            "IGNORE.VALUE" to "4CBF99",
+            "IGNORE.UNUSED_ENTRY" to "ADAEB1",
+        )
+
+    private val expectedIgnoreForegrounds =
+        mapOf(
+            "/themes/AyuIslandsDark.xml" to expectedDarkIgnoreColors,
+            "/themes/AyuIslandsMirage.xml" to expectedMirageIgnoreColors,
+            "/themes/AyuIslandsLight.xml" to expectedLightIgnoreColors,
+            "/themes/extended/AyuIslandsDark.extended.xml" to expectedDarkIgnoreColors,
+            "/themes/extended/AyuIslandsMirage.extended.xml" to expectedMirageIgnoreColors,
+            "/themes/extended/AyuIslandsLight.extended.xml" to expectedLightIgnoreColors,
+        )
+
+    @Test
+    fun `base editor schemes define complete ignore plugin key set`() {
+        for (resource in baseSchemes) {
+            assertIgnoreKeys(resource)
+        }
+    }
+
+    @Test
+    fun `extended overlays define complete ignore plugin key set`() {
+        for (resource in extendedOverlays) {
+            assertIgnoreKeys(resource)
+        }
+    }
+
+    @Test
+    fun `ignore plugin remains optional`() {
+        val pluginXml = readPluginXml()
+
+        assertFalse(
+            pluginXml.contains("mobi.hsz.idea.gitignore"),
+            "Ayu Islands should expose static IGNORE.* color keys without depending on the optional .ignore plugin.",
+        )
+    }
+
+    @Test
+    fun `ignore keys use the full variant palette`() {
+        for ((resource, expectedColors) in expectedIgnoreForegrounds) {
+            for ((key, expectedColor) in expectedColors) {
+                assertEquals(
+                    expectedColor,
+                    foregroundOption(resource, key),
+                    "$resource must render $key with its assigned variant color.",
+                )
+            }
+        }
+    }
+
+    private fun assertIgnoreKeys(resource: String) {
+        val actual = optionNames(resource).filterTo(mutableSetOf()) { it.startsWith("IGNORE.") }
+
+        assertEquals(
+            requiredIgnoreKeys,
+            actual,
+            "$resource must define exactly the upstream .ignore plugin color key set.",
+        )
+    }
+
+    private fun optionNames(resource: String): Set<String> {
+        val document = readDocument(resource)
+        val nodes = document.documentElement.getElementsByTagName("option")
+        return buildSet {
+            for (index in 0 until nodes.length) {
+                val element = nodes.item(index) as? Element ?: continue
+                val name = element.getAttribute("name")
+                if (name.isNotBlank()) add(name)
+            }
+        }
+    }
+
+    private fun foregroundOption(
+        resource: String,
+        key: String,
+    ): String {
+        val document = readDocument(resource)
+        val nodes = document.documentElement.getElementsByTagName("option")
+
+        for (index in 0 until nodes.length) {
+            val element = nodes.item(index) as? Element ?: continue
+            if (element.getAttribute("name") != key) continue
+
+            return childOption(element, "FOREGROUND")
+                ?: error("$resource missing FOREGROUND for $key")
+        }
+
+        error("$resource missing $key")
+    }
+
+    private fun childOption(
+        parent: Element,
+        name: String,
+    ): String? {
+        val childOptions = parent.getElementsByTagName("option")
+        for (index in 0 until childOptions.length) {
+            val child = childOptions.item(index) as? Element ?: continue
+            if (child.getAttribute("name") == name) return child.getAttribute("value")
+        }
+
+        return null
+    }
+
+    private fun readDocument(resource: String): Document =
+        readResourceStream(resource).use { stream ->
+            documentBuilderFactory().newDocumentBuilder().parse(stream)
+        }
+
+    private fun readPluginXml(): String {
+        val stream = readResourceStream("/META-INF/plugin.xml")
+        return stream.bufferedReader().use { it.readText() }
+    }
+
+    private fun readResourceStream(path: String) =
+        javaClass.getResourceAsStream(path)
+            ?: error("Resource not found on classpath: $path")
+
+    private fun documentBuilderFactory(): DocumentBuilderFactory =
+        DocumentBuilderFactory.newInstance().apply {
+            isNamespaceAware = false
+            isValidating = false
+            setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true)
+            setFeature(
+                "http" + "://apache.org/xml/features/disallow-doctype-decl",
+                true,
+            )
+            setFeature(
+                "http" + "://xml.org/sax/features/external-general-entities",
+                false,
+            )
+            setFeature(
+                "http" + "://xml.org/sax/features/external-parameter-entities",
+                false,
+            )
+        }
+}


### PR DESCRIPTION
Release 2.7.1 was removed from Marketplace and needs to be re-published with notes that match the fixed artifact. This keeps the plugin version locked at 2.7.1, refreshes the user-facing release text, and folds in the optional .ignore plugin syntax-color work plus the Plugins-tab opt-out requested for users who prefer stock .ignore colors.

-- Summary ------------------------------------------------

Refresh the 2.7.1 re-release notes and ship optional .ignore plugin syntax colors with a default-on, free opt-out in Settings > Plugins.

-- Changes ------------------------------------------------

| Type | Files | Description |
| --- | --- | --- |
| Chore | CHANGELOG.md:3, src/main/resources/META-INF/plugin.xml:116, src/main/kotlin/dev/ayuislands/UpdateNotifier.kt:58 | Refresh 2.7.1 changelog, Marketplace notes, and update notification for the re-release. |
| Feat | src/main/resources/themes/AyuIslandsDark.xml:1302, src/main/resources/themes/AyuIslandsMirage.xml:1302, src/main/resources/themes/AyuIslandsLight.xml:1302 | Add static IGNORE.* editor scheme keys so the optional .ignore plugin renders with Ayu colors when installed. |
| Feat | src/main/resources/themes/extended/AyuIslandsDark.extended.xml:2266 | Align extended scheme .ignore keys with the variant palette and complete the missing key set. |
| Feat | src/main/kotlin/dev/ayuislands/syntax/SyntaxCategoryRegistry.kt:57 | Classify .ignore keys for Syntax preset transformations, including treating IGNORE.COMMENT as comments for readability controls. |
| Feat | src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt:116, src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt:157, src/main/kotlin/dev/ayuislands/syntax/SyntaxIntensityService.kt:274 | Add a free Plugins-tab toggle that restores IGNORE.* keys to upstream .ignore plugin stock colors when disabled. |
| Test | src/test/kotlin/dev/ayuislands/theme/IgnorePluginSchemeKeysTest.kt:94, src/test/kotlin/dev/ayuislands/settings/PluginsPanelTest.kt:131, src/test/kotlin/dev/ayuislands/syntax/SyntaxIntensityServiceTest.kt:241, src/test/kotlin/dev/ayuislands/syntax/SyntaxIntensityApplicatorTest.kt:205 | Lock scheme keys, optional dependency behavior, free opt-out visibility, persistence, upstream restore behavior, active derived scheme opt-out, and comment-category transformations. |

-- Review Fixes -------------------------------------------

- Routed IGNORE.COMMENT through COMMENT instead of DOCUMENTATION so comment dimming affects .ignore comments and documentation softening does not.
- Restored upstream .ignore stock attributes on opt-out for Dark, Mirage, Light, and user-derived active Ayu schemes, including foregrounds, backgrounds, and font styles.
- Clarified release text so the feature is described as applying when the optional .ignore plugin is installed.
- Restamped release metadata after the changelog and Marketplace notes changed.

-- Validation ---------------------------------------------

- scripts/verify-docs.py: passed.
- ./gradlew test --tests dev.ayuislands.syntax.SyntaxCategoryRegistryTest --tests dev.ayuislands.syntax.SyntaxIntensityApplicatorTest --tests dev.ayuislands.syntax.SyntaxIntensityServiceTest --tests dev.ayuislands.theme.IgnorePluginSchemeKeysTest --tests dev.ayuislands.settings.PluginsPanelTest --tests dev.ayuislands.settings.AyuIslandsStateTest --tests dev.ayuislands.settings.AyuIslandsStatePersistenceTest: BUILD SUCCESSFUL.
- ./gradlew test --tests dev.ayuislands.syntax.SyntaxCategoryRegistryTest --tests dev.ayuislands.syntax.SyntaxIntensityApplicatorTest --tests dev.ayuislands.syntax.SyntaxIntensityServiceTest --tests dev.ayuislands.settings.PluginsPanelTest: BUILD SUCCESSFUL after review fixes.
- ./gradlew test --tests dev.ayuislands.syntax.SyntaxIntensityServiceTest: BUILD SUCCESSFUL after the active derived scheme regression test.
- ./gradlew detekt ktlintCheck: BUILD SUCCESSFUL.
- ./gradlew koverVerify: BUILD SUCCESSFUL after review fixes.
- git diff --check: passed.
- ./gradlew clean buildPlugin: BUILD SUCCESSFUL before the .ignore follow-up.
- ./gradlew verifyPlugin: BUILD SUCCESSFUL before the .ignore follow-up; all verified IDE targets compatible.
- python3 scripts/verify-plugin-verifier.py: internal=0, deprecated=0, experimental=6 before the .ignore follow-up.