### PR TITLE
Support Ayu accents on external themes

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -90,7 +90,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "d2c6682d"
+          last_verified_sha: "3cbd3d0"
           last_verified_date: "2026-05-31"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -112,7 +112,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "d2c6682d"
+          last_verified_sha: "3cbd3d0"
           last_verified_date: "2026-05-31"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -211,7 +211,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "d2c6682d"
+          last_verified_sha: "3cbd3d0"
           last_verified_date: "2026-05-30"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -243,7 +243,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "cdf1e135"
+          last_verified_sha: "3cbd3d0"
           last_verified_date: "2026-05-30"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -339,7 +339,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "d2c6682d"
+          last_verified_sha: "3cbd3d0"
           last_verified_date: "2026-05-30"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -211,7 +211,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "cdf1e135"
+          last_verified_sha: "7e84a95d"
           last_verified_date: "2026-05-30"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -339,7 +339,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "83fc0c22"
+          last_verified_sha: "652c86be"
           last_verified_date: "2026-05-30"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -90,7 +90,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "435a007c"
+          last_verified_sha: "83fc0c22"
           last_verified_date: "2026-05-31"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -112,7 +112,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "435a007c"
+          last_verified_sha: "83fc0c22"
           last_verified_date: "2026-05-31"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -339,7 +339,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "cdf1e135"
+          last_verified_sha: "83fc0c22"
           last_verified_date: "2026-05-30"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -90,7 +90,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "c8d64418"
+          last_verified_sha: "cdf1e135"
           last_verified_date: "2026-05-31"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -112,7 +112,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "c8d64418"
+          last_verified_sha: "cdf1e135"
           last_verified_date: "2026-05-31"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -211,7 +211,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "c8d64418"
+          last_verified_sha: "cdf1e135"
           last_verified_date: "2026-05-30"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -243,7 +243,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "c8d64418"
+          last_verified_sha: "cdf1e135"
           last_verified_date: "2026-05-30"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -286,7 +286,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "c8d64418"
+          last_verified_sha: "cdf1e135"
           last_verified_date: "2026-05-30"
           content_sha256: "fc9ba63b9c9c53893a486a3c9055287bd6dc9c68f5439cae197efe5ae585d17c"
 
@@ -339,7 +339,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "c8d64418"
+          last_verified_sha: "cdf1e135"
           last_verified_date: "2026-05-30"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -90,7 +90,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "1bbea0ee"
+          last_verified_sha: "d2c6682d"
           last_verified_date: "2026-05-31"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -112,7 +112,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "1bbea0ee"
+          last_verified_sha: "d2c6682d"
           last_verified_date: "2026-05-31"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -211,7 +211,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "e2608433"
+          last_verified_sha: "d2c6682d"
           last_verified_date: "2026-05-30"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -339,7 +339,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "652c86be"
+          last_verified_sha: "d2c6682d"
           last_verified_date: "2026-05-30"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -211,7 +211,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "7e84a95d"
+          last_verified_sha: "e2608433"
           last_verified_date: "2026-05-30"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -90,7 +90,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "83fc0c22"
+          last_verified_sha: "1bbea0ee"
           last_verified_date: "2026-05-31"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -112,7 +112,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "83fc0c22"
+          last_verified_sha: "1bbea0ee"
           last_verified_date: "2026-05-31"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -90,7 +90,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "cdf1e135"
+          last_verified_sha: "435a007c"
           last_verified_date: "2026-05-31"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -112,7 +112,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "cdf1e135"
+          last_verified_sha: "435a007c"
           last_verified_date: "2026-05-31"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -90,7 +90,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "3cbd3d0"
+          last_verified_sha: "44ba0033"
           last_verified_date: "2026-05-31"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -112,7 +112,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "3cbd3d0"
+          last_verified_sha: "44ba0033"
           last_verified_date: "2026-05-31"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsLafListener.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsLafListener.kt
@@ -5,6 +5,7 @@ import com.intellij.ide.ui.LafManagerListener
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.ProjectManager
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.font.FontPresetApplicator
 import dev.ayuislands.glow.GlowOverlayManager
@@ -16,15 +17,26 @@ import dev.ayuislands.ui.ComponentTreeRefresher
 /** Re-applies accent, font, glow, and scrollbar settings on theme change. */
 class AyuIslandsLafListener : LafManagerListener {
     override fun lookAndFeelChanged(source: LafManager) {
-        val variant = AyuVariant.detect()
-        if (variant == null) {
-            // Switched away from the Ayu theme -- clean up accent, font, and glow overrides
+        val context = AccentContext.detect()
+        if (context == null) {
+            // Switched away from an active Ayu Islands context -- clean up managed overrides.
             AccentApplicator.revertAll()
             FontPresetApplicator.revert()
             GlowOverlayManager.syncGlowForAllProjects()
             return
         }
 
+        when (context) {
+            is AccentContext.Ayu -> applyAyuThemeChange(source, context)
+            AccentContext.External -> applyExternalThemeChange()
+        }
+    }
+
+    private fun applyAyuThemeChange(
+        source: LafManager,
+        context: AccentContext.Ayu,
+    ) {
+        val variant = context.ayuVariant
         val settings = AyuIslandsSettings.getInstance()
 
         // Bind matching editor color scheme BEFORE `AccentApplicator` mutates
@@ -42,7 +54,7 @@ class AyuIslandsLafListener : LafManagerListener {
             AyuEditorSchemeBinder.bindForVariant(variant)
         }
 
-        val accentHex = AccentApplicator.applyForFocusedProject(variant)
+        val accentHex = AccentApplicator.applyForFocusedProject(context)
         LOG.info("Ayu Islands accent re-applied on theme change: $accentHex")
 
         // Re-apply font preset if enabled
@@ -56,18 +68,7 @@ class AyuIslandsLafListener : LafManagerListener {
         }
         syncService.clearProgrammaticSwitch()
 
-        // Platform already walked the component tree during the LAF change, resetting component-level
-        // overrides (scrollbar preferredSize, horizontal policy, rendering wrappers). Publish the
-        // refresh event per open project so subscribed managers reapply. No tree walk needed here.
-        //
-        // Load-bearing platform-behavior assumption — verified against IntelliJ Platform 2025.1
-        // (`LafManagerImpl.updateLafNoSave` walks frames before firing `lookAndFeelChanged`).
-        // If a future platform bump changes the order, scrollbar hides will regress after theme
-        // switches and we'll need to switch this back to `ComponentTreeRefresher.walkAndNotify`.
-        for (openProject in ProjectManager.getInstance().openProjects) {
-            if (openProject.isDefault || openProject.isDisposed) continue
-            ComponentTreeRefresher.notifyOnly(openProject)
-        }
+        notifyOpenProjects()
 
         // Update glow overlays with new accent color
         GlowOverlayManager.syncGlowForAllProjects()
@@ -79,6 +80,31 @@ class AyuIslandsLafListener : LafManagerListener {
         // `SyntaxIntensityService.reapplyForActiveLaf` itself stays lifecycle-agnostic.
         if (AyuVariant.isAyuActive()) {
             SyntaxIntensityService.getInstance().reapplyForActiveLaf()
+        }
+    }
+
+    private fun applyExternalThemeChange() {
+        val accentHex = AccentApplicator.applyForFocusedProject(AccentContext.External)
+        LOG.info("Ayu Islands external accent applied on theme change: $accentHex")
+
+        // External themes only receive integration surfaces that can resolve against
+        // a generic accent; editor scheme binding, font preset, and syntax intensity
+        // remain Ayu-theme lifecycle features.
+        GlowOverlayManager.syncGlowForAllProjects()
+    }
+
+    private fun notifyOpenProjects() {
+        // Platform already walked the component tree during the LAF change, resetting component-level
+        // overrides (scrollbar preferredSize, horizontal policy, rendering wrappers). Publish the
+        // refresh event per open project so subscribed managers reapply. No tree walk needed here.
+        //
+        // Load-bearing platform-behavior assumption — verified against IntelliJ Platform 2025.1
+        // (`LafManagerImpl.updateLafNoSave` walks frames before firing `lookAndFeelChanged`).
+        // If a future platform bump changes the order, scrollbar hides will regress after theme
+        // switches and we'll need to switch this back to `ComponentTreeRefresher.walkAndNotify`.
+        for (openProject in ProjectManager.getInstance().openProjects) {
+            if (openProject.isDefault || openProject.isDisposed) continue
+            ComponentTreeRefresher.notifyOnly(openProject)
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsLafListener.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsLafListener.kt
@@ -84,6 +84,9 @@ class AyuIslandsLafListener : LafManagerListener {
     }
 
     private fun applyExternalThemeChange() {
+        AccentApplicator.revertAll()
+        FontPresetApplicator.revert()
+
         val accentHex = AccentApplicator.applyForFocusedProject(AccentContext.External)
         LOG.info("Ayu Islands external accent applied on theme change: $accentHex")
 

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
 import com.intellij.openapi.wm.WindowManager
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.ProjectLanguageDetector
@@ -36,8 +37,9 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
         val themeName = AyuVariant.currentThemeName()
         LOG.info("Ayu Islands loaded — active theme: $themeName, project: ${project.name}")
 
-        val variant = AyuVariant.fromThemeName(themeName) ?: return initializeExternalGlowIfEnabled(project)
         val settings = AyuIslandsSettings.getInstance()
+        val variant =
+            AyuVariant.fromThemeName(themeName) ?: return initializeExternalThemeIfEnabled(project, settings)
 
         // Belt-and-suspenders: accent is pre-applied in appFrameCreated() (no gold flash),
         // but project-dependent features (BracketFadeManager, editor TextAttributesKey overrides)
@@ -207,8 +209,21 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
         runStep("apply-persisted-vcs-colors") { applyPersistedVcsColors(settings) }
     }
 
-    private fun initializeExternalGlowIfEnabled(project: Project) {
-        if (!AyuIslandsSettings.getInstance().state.isExternalGlowAllowed()) return
+    private suspend fun initializeExternalThemeIfEnabled(
+        project: Project,
+        settings: AyuIslandsSettings,
+    ) {
+        if (settings.state.externalThemeEnhancementsEnabled) {
+            runStartupAccentOnEdt(project, AccentContext.External)
+        }
+        initializeExternalGlowIfEnabled(project, settings)
+    }
+
+    private fun initializeExternalGlowIfEnabled(
+        project: Project,
+        settings: AyuIslandsSettings,
+    ) {
+        if (!settings.state.isExternalGlowAllowed()) return
 
         ApplicationManager.getApplication().invokeLater(
             { GlowOverlayManager.getInstance(project).initialize() },
@@ -257,6 +272,13 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
         project: Project,
         variant: AyuVariant,
     ) {
+        runStartupAccentOnEdt(project, AccentContext.Ayu(variant))
+    }
+
+    private suspend fun runStartupAccentOnEdt(
+        project: Project,
+        context: AccentContext,
+    ) {
         // Narrow the projectName capture catch to RuntimeException so
         // CancellationException propagates instead of being swallowed into
         // the "<disposed>" fallback. `project.name` access is non-suspend;
@@ -279,7 +301,7 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
             val applyOutcome =
                 runCatchingPreservingCancellation {
                     val focusedProject = AccentApplicator.resolveFocusedProject() ?: project
-                    val resolved = AccentResolver.resolve(focusedProject, variant)
+                    val resolved = AccentResolver.resolve(focusedProject, context)
                     val applied = AccentApplicator.applyFromHexString(resolved)
                     if (applied) resolved else null
                 }

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -36,7 +36,7 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
         val themeName = AyuVariant.currentThemeName()
         LOG.info("Ayu Islands loaded — active theme: $themeName, project: ${project.name}")
 
-        val variant = AyuVariant.fromThemeName(themeName) ?: return
+        val variant = AyuVariant.fromThemeName(themeName) ?: return initializeExternalGlowIfEnabled(project)
         val settings = AyuIslandsSettings.getInstance()
 
         // Belt-and-suspenders: accent is pre-applied in appFrameCreated() (no gold flash),
@@ -205,6 +205,15 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
         }
 
         runStep("apply-persisted-vcs-colors") { applyPersistedVcsColors(settings) }
+    }
+
+    private fun initializeExternalGlowIfEnabled(project: Project) {
+        if (!AyuIslandsSettings.getInstance().state.externalThemeEnhancementsEnabled) return
+
+        ApplicationManager.getApplication().invokeLater(
+            { GlowOverlayManager.getInstance(project).initialize() },
+            project.disposed,
+        )
     }
 
     /**

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -208,7 +208,7 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
     }
 
     private fun initializeExternalGlowIfEnabled(project: Project) {
-        if (!AyuIslandsSettings.getInstance().state.externalThemeEnhancementsEnabled) return
+        if (!AyuIslandsSettings.getInstance().state.isExternalGlowAllowed()) return
 
         ApplicationManager.getApplication().invokeLater(
             { GlowOverlayManager.getInstance(project).initialize() },

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -201,7 +201,8 @@ object AccentApplicator {
         val trimmedHex = accentHex.value
         val accent = accentHex.toColor()
         val state = AyuIslandsSettings.getInstance().state
-        val variant = AyuVariant.detect()
+        val context = AccentContext.detect()
+        val variant = context?.variant
 
         // Persist BEFORE the EP iteration so the cache survives a mid-EP
         // throw. Clear the clean-apply flag here and only set it true after the
@@ -216,7 +217,9 @@ object AccentApplicator {
             Runnable {
                 applyAlwaysOnUiKeys(state, accent)
 
-                applyElements(state, accent, variant)
+                if (variant != null) {
+                    applyElements(state, accent, variant)
+                }
                 // Pattern G + L — ordering lock. Apply path mirrors the
                 // revert path: IR before CGP before notifyOnly. The revert
                 // ordering is locked by AccentApplicatorRevertAllSymmetryTest;
@@ -225,12 +228,14 @@ object AccentApplicator {
                 // CGP's cache holding what IR's cache pushed first; revert
                 // unwinds the other way). Keep both sequences identical so
                 // future debugging only has to reason about one ordering.
-                if (variant != null) {
-                    IndentRainbowSync.apply(variant, trimmedHex)
+                if (context != null) {
+                    IndentRainbowSync.apply(context, trimmedHex)
                 }
                 CodeGlanceProIntegration.syncCodeGlanceProViewport(trimmedHex)
                 applyAlwaysOnEditorKeys(accent)
-                applyTabUnderline(state, variant)
+                if (variant != null) {
+                    applyTabUnderline(state, variant)
+                }
 
                 // Mirror of the refresh hook in revertAll. Re-publish
                 // ComponentTreeRefreshedTopic after EP apply so subscribers
@@ -326,9 +331,9 @@ object AccentApplicator {
      * a bare volatile write with no dispatch. Callers MUST already be on the EDT.
      */
     @RequiresEdt
-    fun applyForFocusedProject(variant: AyuVariant): String {
+    fun applyForFocusedProject(context: AccentContext): String {
         val focusedProject = resolveFocusedProject()
-        val hex = AccentResolver.resolve(focusedProject, variant)
+        val hex = AccentResolver.resolve(focusedProject, context)
         // apply returns a validation flag. If the resolver hands back a hex
         // that fails shape validation (corrupted per-project override, manual
         // XML edit, future resolver bug), skip the swap-cache publish so the
@@ -346,6 +351,9 @@ object AccentApplicator {
         }
         return hex
     }
+
+    @RequiresEdt
+    fun applyForFocusedProject(variant: AyuVariant): String = applyForFocusedProject(AccentContext.Ayu(variant))
 
     /**
      * Resolves the *actually* focused project — the one whose window is currently on top
@@ -636,17 +644,6 @@ object AccentApplicator {
         }
     }
 
-    fun resolveUnderlineHeight(state: AyuIslandsState): Int {
-        val tabMode = GlowTabMode.fromName(state.glowTabMode ?: "MINIMAL")
-        if (tabMode == GlowTabMode.OFF) return state.tabUnderlineHeight
-
-        if (state.tabUnderlineGlowSync && state.glowEnabled) {
-            val style = GlowStyle.fromName(state.glowStyle ?: GlowStyle.SOFT.name)
-            return state.getWidthForStyle(style)
-        }
-        return state.tabUnderlineHeight
-    }
-
     private fun applyAlwaysOnEditorKeys(accent: Color) {
         val scheme = EditorColorsManager.getInstance().globalScheme
 
@@ -828,6 +825,17 @@ object AccentApplicator {
         apply(accent)
         return true
     }
+}
+
+internal fun resolveUnderlineHeight(state: AyuIslandsState): Int {
+    val tabMode = GlowTabMode.fromName(state.glowTabMode ?: "MINIMAL")
+    if (tabMode == GlowTabMode.OFF) return state.tabUnderlineHeight
+
+    if (state.tabUnderlineGlowSync && state.glowEnabled) {
+        val style = GlowStyle.fromName(state.glowStyle ?: GlowStyle.SOFT.name)
+        return state.getWidthForStyle(style)
+    }
+    return state.tabUnderlineHeight
 }
 
 /**

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -231,7 +231,7 @@ object AccentApplicator {
                 if (context != null) {
                     IndentRainbowSync.apply(context, trimmedHex)
                 }
-                CodeGlanceProIntegration.syncCodeGlanceProViewport(trimmedHex)
+                CodeGlanceProIntegration.syncCodeGlanceProViewport(trimmedHex, context)
                 applyAlwaysOnEditorKeys(accent)
                 if (variant != null) {
                     applyTabUnderline(state, variant)

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -774,8 +774,11 @@ object AccentApplicator {
      * swap service achieves the cache write without the apply path's
      * redundant work.
      */
-    internal fun syncCodeGlanceProViewportForSwap(hex: String) {
-        CodeGlanceProIntegration.syncCodeGlanceProViewport(hex)
+    internal fun syncCodeGlanceProViewportForSwap(
+        hex: String,
+        context: AccentContext? = null,
+    ) {
+        CodeGlanceProIntegration.syncCodeGlanceProViewport(hex, context)
     }
 
     /**

--- a/src/main/kotlin/dev/ayuislands/accent/AccentContext.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentContext.kt
@@ -1,0 +1,31 @@
+package dev.ayuislands.accent
+
+import dev.ayuislands.settings.AyuIslandsSettings
+
+sealed interface AccentContext {
+    val variant: AyuVariant?
+
+    data class Ayu(
+        val ayuVariant: AyuVariant,
+    ) : AccentContext {
+        override val variant: AyuVariant
+            get() = ayuVariant
+    }
+
+    data object External : AccentContext {
+        override val variant: AyuVariant? = null
+    }
+
+    companion object {
+        fun detect(): AccentContext? {
+            val ayuVariant = AyuVariant.detect()
+            if (ayuVariant != null) return Ayu(ayuVariant)
+
+            val state = AyuIslandsSettings.getInstance().state
+            return if (state.externalThemeEnhancementsEnabled) External else null
+        }
+
+        /** Returns true for both native Ayu themes and opted-in external theme compatibility. */
+        fun isAccentActive(): Boolean = detect() != null
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/accent/AccentContext.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentContext.kt
@@ -39,3 +39,10 @@ sealed interface AccentContext {
         fun isQuickSwitcherActive(): Boolean = detectQuickSwitcher() != null
     }
 }
+
+internal fun AccentContext.persistExternalManualAccentIfNeeded(hex: String) {
+    if (this != AccentContext.External) return
+    val state = AyuIslandsSettings.getInstance().state
+    state.externalThemeAccent = hex
+    state.externalThemeAccentSource = ExternalAccentSource.MANUAL.name
+}

--- a/src/main/kotlin/dev/ayuislands/accent/AccentContext.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentContext.kt
@@ -27,5 +27,15 @@ sealed interface AccentContext {
 
         /** Returns true for both native Ayu themes and opted-in external theme compatibility. */
         fun isAccentActive(): Boolean = detect() != null
+
+        fun detectQuickSwitcher(): AccentContext? {
+            val context = detect() ?: return null
+            if (context is Ayu) return context
+
+            val state = AyuIslandsSettings.getInstance().state
+            return if (state.isExternalQuickSwitcherAllowed()) External else null
+        }
+
+        fun isQuickSwitcherActive(): Boolean = detectQuickSwitcher() != null
     }
 }

--- a/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
@@ -4,14 +4,20 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
 import dev.ayuislands.settings.mappings.AccentMappingsSettings
 import org.jetbrains.annotations.TestOnly
+import java.awt.Color
 import java.io.File
 import java.util.Collections
+import java.util.Locale
 import java.util.WeakHashMap
+import javax.swing.UIManager
 
 /**
- * Resolves the effective accent hex for a project + variant pair in priority order:
+ * Resolves the effective accent hex for a project + accent context in priority order.
+ *
+ * Native [AyuVariant] contexts keep the historical project + variant chain:
  *
  *  1. **Project override** — `AccentMappingsState.projectAccents` keyed by the project's
  *     canonical base path.
@@ -28,7 +34,7 @@ import java.util.WeakHashMap
  * so projects without any language overrides take a pure map-lookup path.
  */
 object AccentResolver {
-    enum class Source { PROJECT_OVERRIDE, LANGUAGE_OVERRIDE, GLOBAL }
+    enum class Source { PROJECT_OVERRIDE, LANGUAGE_OVERRIDE, MATERIAL_THEME, IDE_ACCENT, EXTERNAL_ACCENT, GLOBAL }
 
     private val LOG = logger<AccentResolver>()
 
@@ -41,6 +47,10 @@ object AccentResolver {
     private val basePathWarnGate = OneShotProjectGate()
     private val canonicalWarnGate = OneShotProjectGate()
 
+    private val uiColorProviderOverride = ThreadLocal<(String) -> Color?>()
+
+    private fun uiColor(key: String): Color? = uiColorProviderOverride.get()?.invoke(key) ?: UIManager.getColor(key)
+
     /**
      * Resolves the effective accent hex. Delegates to the shared override-traversal helper,
      * falling back to the global per-variant accent when no override applies.
@@ -48,10 +58,12 @@ object AccentResolver {
     fun resolve(
         project: Project?,
         variant: AyuVariant,
-    ): String {
-        val globalAccent = AyuIslandsSettings.getInstance().getAccentForVariant(variant)
-        return findOverride(project)?.second ?: globalAccent
-    }
+    ): String = resolveAyu(project, variant).hex
+
+    fun resolve(
+        project: Project?,
+        context: AccentContext,
+    ): String = resolveContext(project, context).hex
 
     /**
      * Returns which layer of the resolution chain produced the accent for [project].
@@ -61,7 +73,12 @@ object AccentResolver {
      * so the UI label does not claim a project/language override is "active" when the
      * resolver is actually returning the global accent.
      */
-    fun source(project: Project?): Source = findOverride(project)?.first ?: Source.GLOBAL
+    fun source(project: Project?): Source = findOverride(project, validateHex = false)?.source ?: Source.GLOBAL
+
+    fun source(
+        project: Project?,
+        context: AccentContext,
+    ): Source = resolveContext(project, context).source
 
     /**
      * Human-readable label for [source], suitable for tooltips and Settings
@@ -73,15 +90,58 @@ object AccentResolver {
      * Pure pattern-match over the closed [Source] enum; no IO, no reflection.
      * Pattern L regression lock lives in `AccentResolverSourceLabelTest` —
      * adding a new [Source] value without extending this helper fails the
-     * `Source.values().size == 3` assertion so silent "Global" fallback drift
+     * `Source.entries.size == 6` assertion so silent "Global" fallback drift
      * cannot land.
      */
     fun sourceLabel(source: Source): String =
         when (source) {
             Source.PROJECT_OVERRIDE -> "Project override"
             Source.LANGUAGE_OVERRIDE -> "Language override"
+            Source.MATERIAL_THEME -> "Material Theme"
+            Source.IDE_ACCENT -> "IDE accent"
+            Source.EXTERNAL_ACCENT -> "External accent"
             Source.GLOBAL -> "Global"
         }
+
+    private fun resolveContext(
+        project: Project?,
+        context: AccentContext,
+    ): ResolvedAccent =
+        when (context) {
+            is AccentContext.Ayu -> resolveAyu(project, context.ayuVariant)
+            AccentContext.External -> resolveExternal(project)
+        }
+
+    private fun resolveAyu(
+        project: Project?,
+        variant: AyuVariant,
+    ): ResolvedAccent {
+        val globalAccent = AyuIslandsSettings.getInstance().getAccentForVariant(variant)
+        return findOverride(project, validateHex = false) ?: ResolvedAccent(Source.GLOBAL, globalAccent)
+    }
+
+    private fun resolveExternal(project: Project?): ResolvedAccent {
+        val state = AyuIslandsSettings.getInstance().state
+        if (ExternalAccentSource.fromName(state.externalThemeAccentSource) == ExternalAccentSource.MANUAL) {
+            return storedExternalAccent(state)
+        }
+
+        findOverride(project, validateHex = true)?.let { return it }
+        uiColorAccent(MATERIAL_ACCENT_KEY, Source.MATERIAL_THEME)?.let { return it }
+        uiColorAccent(COMPONENT_ACCENT_KEY, Source.IDE_ACCENT)?.let { return it }
+        uiColorAccent(ACTIONS_BLUE_KEY, Source.IDE_ACCENT)?.let { return it }
+        return storedExternalAccent(state)
+    }
+
+    private fun uiColorAccent(
+        key: String,
+        source: Source,
+    ): ResolvedAccent? = uiColor(key)?.let { ResolvedAccent(source, it.toHex()) }
+
+    private fun storedExternalAccent(state: AyuIslandsState): ResolvedAccent {
+        val hex = AccentHex.of(state.externalThemeAccent)?.value ?: AyuVariant.MIRAGE.defaultAccent
+        return ResolvedAccent(Source.EXTERNAL_ACCENT, hex)
+    }
 
     /**
      * Single traversal of the override priority chain shared by [resolve] and [source].
@@ -91,21 +151,35 @@ object AccentResolver {
      * Centralizing the traversal means adding a new override tier (e.g. folder override)
      * touches only this function, and [resolve]/[source] cannot drift out of sync.
      */
-    private fun findOverride(project: Project?): Pair<Source, String>? {
+    private fun findOverride(
+        project: Project?,
+        validateHex: Boolean,
+    ): ResolvedAccent? {
         if (!LicenseChecker.isLicensedOrGrace()) return null
         if (project == null || project.isDefault || project.isDisposed) return null
 
         val mappings = AccentMappingsSettings.getInstance().state
         projectKey(project)
             ?.let { mappings.projectAccents[it] }
-            ?.let { return Source.PROJECT_OVERRIDE to it }
+            ?.let { rawHex -> overrideAccent(Source.PROJECT_OVERRIDE, rawHex, validateHex)?.let { return it } }
 
         if (mappings.languageAccents.isNotEmpty()) {
             ProjectLanguageDetector.dominant(project)?.let { languageId ->
-                mappings.languageAccents[languageId]?.let { return Source.LANGUAGE_OVERRIDE to it }
+                mappings.languageAccents[languageId]?.let { rawHex ->
+                    overrideAccent(Source.LANGUAGE_OVERRIDE, rawHex, validateHex)?.let { return it }
+                }
             }
         }
         return null
+    }
+
+    private fun overrideAccent(
+        source: Source,
+        rawHex: String,
+        validateHex: Boolean,
+    ): ResolvedAccent? {
+        val hex = if (validateHex) AccentHex.of(rawHex)?.value else rawHex
+        return hex?.let { ResolvedAccent(source, it) }
     }
 
     /**
@@ -174,6 +248,36 @@ object AccentResolver {
         canonicalWarnGate.clear()
     }
 
+    @TestOnly
+    internal fun resetUiColorProviderForTest() {
+        uiColorProviderOverride.remove()
+    }
+
+    @TestOnly
+    internal fun <T> withUiColorProviderForTest(
+        provider: (String) -> Color?,
+        block: () -> T,
+    ): T {
+        val previous = uiColorProviderOverride.get()
+        uiColorProviderOverride.set(provider)
+        return try {
+            block()
+        } finally {
+            if (previous == null) {
+                uiColorProviderOverride.remove()
+            } else {
+                uiColorProviderOverride.set(previous)
+            }
+        }
+    }
+
+    private fun Color.toHex(): String = "#%02X%02X%02X".format(Locale.ROOT, red, green, blue)
+
+    private data class ResolvedAccent(
+        val source: Source,
+        val hex: String,
+    )
+
     /**
      * One-shot per-project warn gate. [tryAcquire] returns `true` the first time a given
      * project is seen and `false` on every subsequent call — so hot-path callers can emit
@@ -199,4 +303,8 @@ object AccentResolver {
             seen.clear()
         }
     }
+
+    private const val MATERIAL_ACCENT_KEY = "material.accent"
+    private const val COMPONENT_ACCENT_KEY = "Component.accentColor"
+    private const val ACTIONS_BLUE_KEY = "Actions.Blue"
 }

--- a/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
@@ -178,8 +178,10 @@ object AccentResolver {
         rawHex: String,
         validateHex: Boolean,
     ): ResolvedAccent? {
-        val hex = if (validateHex) AccentHex.of(rawHex)?.value else rawHex
-        return hex?.let { ResolvedAccent(source, it) }
+        if (!validateHex) {
+            return ResolvedAccent(source, rawHex)
+        }
+        return AccentHex.of(rawHex)?.let { ResolvedAccent(source, it.value) }
     }
 
     /**

--- a/src/main/kotlin/dev/ayuislands/accent/CodeGlanceProIntegration.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/CodeGlanceProIntegration.kt
@@ -133,7 +133,17 @@ internal object CodeGlanceProIntegration {
      * swap, same-hex fast path).
      */
     fun syncCodeGlanceProViewport(accentHex: String) {
-        if (!AyuIslandsSettings.getInstance().state.cgpIntegrationEnabled) {
+        syncCodeGlanceProViewport(accentHex, null)
+    }
+
+    fun syncCodeGlanceProViewport(
+        accentHex: String,
+        context: AccentContext?,
+    ) {
+        val state = AyuIslandsSettings.getInstance().state
+        if (!state.cgpIntegrationEnabled ||
+            (context == AccentContext.External && !state.isExternalCodeGlanceProAllowed())
+        ) {
             // Pattern G + J — toggle-off symmetry. Mirror of
             // [IndentRainbowSync.apply], which reverts when its integration is
             // disabled. Without this, flipping the CGP toggle off after an

--- a/src/main/kotlin/dev/ayuislands/accent/ExternalAccentSource.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ExternalAccentSource.kt
@@ -1,0 +1,13 @@
+package dev.ayuislands.accent
+
+enum class ExternalAccentSource(
+    val displayName: String,
+) {
+    AUTOMATIC("Automatic"),
+    MANUAL("Manual"),
+    ;
+
+    companion object {
+        fun fromName(name: String?): ExternalAccentSource = entries.firstOrNull { it.name == name } ?: AUTOMATIC
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentGrid.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentGrid.kt
@@ -10,11 +10,13 @@ import com.intellij.ui.components.ActionLink
 import com.intellij.util.ui.JBUI
 import dev.ayuislands.accent.AYU_ACCENT_PRESETS
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
-import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.accent.ExternalAccentSource
 import dev.ayuislands.accent.toolbar.popup.Density
 import dev.ayuislands.accent.toolbar.popup.PopupSwatch
+import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 import java.awt.BorderLayout
 import java.awt.Color
@@ -101,10 +103,10 @@ internal class QuickSwitcherAccentGrid {
     }
 
     private fun resolveCurrentAccent(): String {
-        val variant = AyuVariant.detect() ?: return AYU_ACCENT_PRESETS.first().hex
+        val context = AccentContext.detect() ?: return AYU_ACCENT_PRESETS.first().hex
         val project = AccentApplicator.resolveFocusedProject()
         return try {
-            AccentResolver.resolve(project, variant)
+            AccentResolver.resolve(project, context)
         } catch (exception: RuntimeException) {
             LOG.warn("Accent resolve failed for grid construction", exception)
             AYU_ACCENT_PRESETS.first().hex
@@ -116,6 +118,7 @@ internal class QuickSwitcherAccentGrid {
         try {
             val applied = AccentApplicator.applyFromHexString(raw)
             if (applied) {
+                persistExternalAccentIfNeeded(raw)
                 ProjectAccentSwapService.getInstance().notifyExternalApply(raw)
                 swatches.forEach { swatch -> swatch.setSelected(swatch.hex.value.equals(raw, ignoreCase = true)) }
             } else {
@@ -124,6 +127,13 @@ internal class QuickSwitcherAccentGrid {
         } catch (exception: RuntimeException) {
             LOG.warn("Accent preset apply failed hex=$raw", exception)
         }
+    }
+
+    private fun persistExternalAccentIfNeeded(hex: String) {
+        if (AccentContext.detect() != AccentContext.External) return
+        val state = AyuIslandsSettings.getInstance().state
+        state.externalThemeAccent = hex
+        state.externalThemeAccentSource = ExternalAccentSource.MANUAL.name
     }
 
     private fun openCustomColorPicker() {

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentGrid.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentGrid.kt
@@ -13,10 +13,9 @@ import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
-import dev.ayuislands.accent.ExternalAccentSource
+import dev.ayuislands.accent.persistExternalManualAccentIfNeeded
 import dev.ayuislands.accent.toolbar.popup.Density
 import dev.ayuislands.accent.toolbar.popup.PopupSwatch
-import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 import java.awt.BorderLayout
 import java.awt.Color
@@ -118,7 +117,7 @@ internal class QuickSwitcherAccentGrid {
         try {
             val applied = AccentApplicator.applyFromHexString(raw)
             if (applied) {
-                persistExternalAccentIfNeeded(raw)
+                AccentContext.detectQuickSwitcher()?.persistExternalManualAccentIfNeeded(raw)
                 ProjectAccentSwapService.getInstance().notifyExternalApply(raw)
                 swatches.forEach { swatch -> swatch.setSelected(swatch.hex.value.equals(raw, ignoreCase = true)) }
             } else {
@@ -127,13 +126,6 @@ internal class QuickSwitcherAccentGrid {
         } catch (exception: RuntimeException) {
             LOG.warn("Accent preset apply failed hex=$raw", exception)
         }
-    }
-
-    private fun persistExternalAccentIfNeeded(hex: String) {
-        if (AccentContext.detectQuickSwitcher() != AccentContext.External) return
-        val state = AyuIslandsSettings.getInstance().state
-        state.externalThemeAccent = hex
-        state.externalThemeAccentSource = ExternalAccentSource.MANUAL.name
     }
 
     private fun openCustomColorPicker() {

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentGrid.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentGrid.kt
@@ -103,7 +103,7 @@ internal class QuickSwitcherAccentGrid {
     }
 
     private fun resolveCurrentAccent(): String {
-        val context = AccentContext.detect() ?: return AYU_ACCENT_PRESETS.first().hex
+        val context = AccentContext.detectQuickSwitcher() ?: return AYU_ACCENT_PRESETS.first().hex
         val project = AccentApplicator.resolveFocusedProject()
         return try {
             AccentResolver.resolve(project, context)
@@ -130,7 +130,7 @@ internal class QuickSwitcherAccentGrid {
     }
 
     private fun persistExternalAccentIfNeeded(hex: String) {
-        if (AccentContext.detect() != AccentContext.External) return
+        if (AccentContext.detectQuickSwitcher() != AccentContext.External) return
         val state = AyuIslandsSettings.getInstance().state
         state.externalThemeAccent = hex
         state.externalThemeAccentSource = ExternalAccentSource.MANUAL.name

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipComponent.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipComponent.kt
@@ -10,9 +10,9 @@ import com.intellij.util.ui.JBUI
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentChangeListener
 import dev.ayuislands.accent.AccentChangedTopic
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
-import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.toolbar.actions.QuickSwitcherActionGroup
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.mappings.AccentMappingsSettings
@@ -87,7 +87,7 @@ internal class QuickSwitcherChipComponent : JLabel() {
         addMouseListener(
             object : MouseAdapter() {
                 override fun mousePressed(event: MouseEvent) {
-                    if (!AyuVariant.isAyuActive()) return
+                    if (!AccentContext.isAccentActive()) return
                     when {
                         SwingUtilities.isRightMouseButton(event) -> showContextMenu(event.x, event.y)
                         SwingUtilities.isLeftMouseButton(event) -> handleLeftClick(event.x, event.y)
@@ -125,7 +125,9 @@ internal class QuickSwitcherChipComponent : JLabel() {
      * (`applied == false`) and the thrown-exception branch the same way.
      */
     private fun togglePin() {
-        val variant = AyuVariant.detect() ?: return
+        val context = AccentContext.detect()
+        if (context !is AccentContext.Ayu) return
+        val variant = context.ayuVariant
         val project = AccentApplicator.resolveFocusedProject() ?: return
         val key =
             AccentResolver.projectKey(project) ?: run {
@@ -268,16 +270,16 @@ internal class QuickSwitcherChipComponent : JLabel() {
      * so the chip stays paintable with its previous icon.
      */
     fun refreshFromFocusedProject() {
-        val variant = AyuVariant.detect() ?: return
+        val context = AccentContext.detect() ?: return
         val project = AccentApplicator.resolveFocusedProject()
         val hex =
             try {
-                AccentResolver.resolve(project, variant)
+                AccentResolver.resolve(project, context)
             } catch (exception: RuntimeException) {
                 LOG.warn("QuickSwitcher chip resolve failed", exception)
                 return
             }
-        val source = AccentResolver.source(project)
+        val source = AccentResolver.source(project, context)
         val pinned = source == AccentResolver.Source.PROJECT_OVERRIDE
         // [AccentResolver.resolve] returns a validated `#RRGGBB` (resolver
         // produces either a stored override or `AyuIslandsSettings.getAccentForVariant`,

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipComponent.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipComponent.kt
@@ -104,7 +104,10 @@ internal class QuickSwitcherChipComponent : JLabel() {
     ) {
         val size = JBUI.scale(CHIP_BOX_PX)
         val onInner = LayeredAccentIcon.isInsideInnerIslandHitBox(x, y, size)
-        if (onInner && LicenseChecker.isLicensedOrGrace()) {
+        if (onInner &&
+            LicenseChecker.isLicensedOrGrace() &&
+            AccentContext.detectQuickSwitcher() is AccentContext.Ayu
+        ) {
             togglePin()
             return
         }

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipComponent.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipComponent.kt
@@ -87,7 +87,7 @@ internal class QuickSwitcherChipComponent : JLabel() {
         addMouseListener(
             object : MouseAdapter() {
                 override fun mousePressed(event: MouseEvent) {
-                    if (!AccentContext.isAccentActive()) return
+                    if (!AccentContext.isQuickSwitcherActive()) return
                     when {
                         SwingUtilities.isRightMouseButton(event) -> showContextMenu(event.x, event.y)
                         SwingUtilities.isLeftMouseButton(event) -> handleLeftClick(event.x, event.y)
@@ -125,7 +125,7 @@ internal class QuickSwitcherChipComponent : JLabel() {
      * (`applied == false`) and the thrown-exception branch the same way.
      */
     private fun togglePin() {
-        val context = AccentContext.detect()
+        val context = AccentContext.detectQuickSwitcher()
         if (context !is AccentContext.Ayu) return
         val variant = context.ayuVariant
         val project = AccentApplicator.resolveFocusedProject() ?: return
@@ -270,7 +270,7 @@ internal class QuickSwitcherChipComponent : JLabel() {
      * so the chip stays paintable with its previous icon.
      */
     fun refreshFromFocusedProject() {
-        val context = AccentContext.detect() ?: return
+        val context = AccentContext.detectQuickSwitcher() ?: return
         val project = AccentApplicator.resolveFocusedProject()
         val hex =
             try {

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherPopup.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherPopup.kt
@@ -60,7 +60,7 @@ internal object QuickSwitcherPopup {
 
         val accentGrid = QuickSwitcherAccentGrid()
         val togglesSection = QuickSwitcherRelatedTogglesSection()
-        val actionsRow = QuickSwitcherQuickActionsRow(anchor)
+        val actionsRow = QuickSwitcherQuickActionsRow(anchor, context)
 
         val variantCard =
             when (context) {

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherPopup.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherPopup.kt
@@ -56,7 +56,7 @@ internal object QuickSwitcherPopup {
         anchor: JComponent,
         chip: QuickSwitcherChipComponent? = null,
     ) {
-        val context = AccentContext.detect() ?: return
+        val context = AccentContext.detectQuickSwitcher() ?: return
 
         val accentGrid = QuickSwitcherAccentGrid()
         val togglesSection = QuickSwitcherRelatedTogglesSection()

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherPopup.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherPopup.kt
@@ -12,9 +12,9 @@ import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.layout.ComponentPredicate
 import com.intellij.util.ui.JBUI
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentDefaults
 import dev.ayuislands.accent.AccentResolver
-import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.toolbar.popup.AccentStripe
 import dev.ayuislands.accent.toolbar.popup.BlockSeparator
 import dev.ayuislands.accent.toolbar.popup.Density
@@ -43,7 +43,7 @@ import javax.swing.SwingUtilities
  * listener auto-disposes with the popup (Pattern E — never attached to the
  * chip's own lifetime).
  *
- * Belt-and-braces: if `AyuVariant.detect()` returns `null` (LAF flipped between
+ * Belt-and-braces: if [AccentContext.detect] returns `null` (LAF flipped between
  * the chip's BGT update tick and the click landing), early-return without
  * building the popup so the user does not see a half-built panel against a
  * non-Ayu theme.
@@ -56,19 +56,23 @@ internal object QuickSwitcherPopup {
         anchor: JComponent,
         chip: QuickSwitcherChipComponent? = null,
     ) {
-        val variant = AyuVariant.detect() ?: return // belt-and-braces: non-Ayu LAF
+        val context = AccentContext.detect() ?: return
 
-        val variantRow = VariantSwitcherRow(variant)
         val accentGrid = QuickSwitcherAccentGrid()
         val togglesSection = QuickSwitcherRelatedTogglesSection()
         val actionsRow = QuickSwitcherQuickActionsRow(anchor)
 
-        val variantCard = SectionCard("Variant").apply { setContent(variantRow.component) }
+        val variantCard =
+            when (context) {
+                is AccentContext.Ayu ->
+                    SectionCard("Variant").apply { setContent(VariantSwitcherRow(context.ayuVariant).component) }
+                AccentContext.External -> null
+            }
         val accentCard = SectionCard("Accent").apply { setContent(accentGrid.component) }
         val togglesCard = SectionCard("Toggles").apply { setContent(togglesSection.component) }
         val actionsCard = SectionCard("Actions").apply { setContent(actionsRow.component) }
 
-        val stripe = AccentStripe { resolveCurrentAccentHex(variant) }
+        val stripe = AccentStripe { resolveCurrentAccentHex(context) }
 
         val licenseGate = licenseGate()
         val content =
@@ -76,9 +80,11 @@ internal object QuickSwitcherPopup {
                 row { cell(stripe).align(AlignX.FILL) }
                     .topGap(TopGap.NONE)
                     .bottomGap(BottomGap.NONE)
-                row { cell(variantCard).align(AlignX.FILL) }
-                    .topGap(TopGap.NONE)
-                    .bottomGap(BottomGap.NONE)
+                if (variantCard != null) {
+                    row { cell(variantCard).align(AlignX.FILL) }
+                        .topGap(TopGap.NONE)
+                        .bottomGap(BottomGap.NONE)
+                }
                 row { cell(accentCard).align(AlignX.FILL) }
                     .topGap(TopGap.NONE)
                     .bottomGap(BottomGap.NONE)
@@ -127,9 +133,9 @@ internal object QuickSwitcherPopup {
         popup.showUnderneathOf(anchor)
     }
 
-    private fun resolveCurrentAccentHex(variant: AyuVariant): String =
+    private fun resolveCurrentAccentHex(context: AccentContext): String =
         try {
-            AccentResolver.resolve(AccentApplicator.resolveFocusedProject(), variant)
+            AccentResolver.resolve(AccentApplicator.resolveFocusedProject(), context)
         } catch (exception: RuntimeException) {
             LOG.warn("AccentStripe resolve failed", exception)
             DEFAULT_ACCENT_FALLBACK

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherQuickActionsRow.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherQuickActionsRow.kt
@@ -2,6 +2,7 @@ package dev.ayuislands.accent.toolbar
 
 import com.intellij.icons.AllIcons
 import com.intellij.util.ui.JBUI
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.toolbar.actions.CopyHexAction
 import dev.ayuislands.accent.toolbar.actions.DarkerAccentAction
 import dev.ayuislands.accent.toolbar.actions.LighterAccentAction
@@ -27,11 +28,14 @@ import javax.swing.JPanel
  */
 internal class QuickSwitcherQuickActionsRow(
     private val anchor: JComponent,
+    private val context: AccentContext,
 ) {
     val component: JPanel =
         JPanel(FlowLayout(FlowLayout.LEFT, JBUI.scale(Density.ACTION_GAP), 0)).apply {
             isOpaque = false
-            add(IconPillButton(PinAccentAction(), anchor, AllIcons.Actions.PinTab))
+            if (context is AccentContext.Ayu) {
+                add(IconPillButton(PinAccentAction(), anchor, AllIcons.Actions.PinTab))
+            }
             add(IconPillButton(RandomAccentAction(), anchor, AllIcons.Actions.Refresh))
             add(IconPillButton(LighterAccentAction(), anchor, AllIcons.General.ChevronUp))
             add(IconPillButton(DarkerAccentAction(), anchor, AllIcons.General.ChevronDown))

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherRelatedTogglesSection.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherRelatedTogglesSection.kt
@@ -6,9 +6,9 @@ import com.intellij.ui.dsl.builder.bindSelected
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.util.ui.JBUI
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentDefaults
 import dev.ayuislands.accent.AccentResolver
-import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.toolbar.popup.Density
 import dev.ayuislands.accent.toolbar.popup.ToggleSwitch
 import dev.ayuislands.accent.toolbar.popup.ToggleTile
@@ -66,9 +66,13 @@ internal class QuickSwitcherRelatedTogglesSection {
     init {
         val state = AyuIslandsSettings.getInstance().state
         val accentSupplier: () -> String = {
-            val variant = AyuVariant.detect() ?: AyuVariant.DARK
+            val context = AccentContext.detect()
             try {
-                AccentResolver.resolve(AccentApplicator.resolveFocusedProject(), variant)
+                if (context == null) {
+                    AccentDefaults.MIRAGE_HEX
+                } else {
+                    AccentResolver.resolve(AccentApplicator.resolveFocusedProject(), context)
+                }
             } catch (exception: RuntimeException) {
                 LOG.warn("Toggles section accent resolve failed", exception)
                 AccentDefaults.MIRAGE_HEX

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherRelatedTogglesSection.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherRelatedTogglesSection.kt
@@ -66,7 +66,7 @@ internal class QuickSwitcherRelatedTogglesSection {
     init {
         val state = AyuIslandsSettings.getInstance().state
         val accentSupplier: () -> String = {
-            val context = AccentContext.detect()
+            val context = AccentContext.detectQuickSwitcher()
             try {
                 if (context == null) {
                     AccentDefaults.MIRAGE_HEX

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherWidgetAction.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherWidgetAction.kt
@@ -16,7 +16,7 @@ import javax.swing.JComponent
  * `.visibleIf { LicenseChecker.isLicensedOrGrace() }`.
  *
  * Visibility is gated by a two-conjunct predicate on every BGT [update] tick:
- *   1. Accent context must be active — [AccentContext.isAccentActive].
+ *   1. Quick-switcher context must be active — [AccentContext.isQuickSwitcherActive].
  *   2. Settings toggle ON — `AyuIslandsState.quickSwitcherWidgetEnabled`
  *      (default ON).
  *

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherWidgetAction.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherWidgetAction.kt
@@ -33,7 +33,7 @@ class QuickSwitcherWidgetAction :
     override fun update(event: AnActionEvent) {
         val state = AyuIslandsSettings.getInstance().state
         event.presentation.isEnabledAndVisible =
-            AccentContext.isAccentActive() &&
+            AccentContext.isQuickSwitcherActive() &&
             state.quickSwitcherWidgetEnabled
     }
 

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherWidgetAction.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherWidgetAction.kt
@@ -5,7 +5,7 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.Presentation
 import com.intellij.openapi.actionSystem.ex.CustomComponentAction
-import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.settings.AyuIslandsSettings
 import javax.swing.JComponent
 
@@ -16,7 +16,7 @@ import javax.swing.JComponent
  * `.visibleIf { LicenseChecker.isLicensedOrGrace() }`.
  *
  * Visibility is gated by a two-conjunct predicate on every BGT [update] tick:
- *   1. LAF must be Ayu — [AyuVariant.isAyuActive] (chip would lie otherwise).
+ *   1. Accent context must be active — [AccentContext.isAccentActive].
  *   2. Settings toggle ON — `AyuIslandsState.quickSwitcherWidgetEnabled`
  *      (default ON).
  *
@@ -33,7 +33,7 @@ class QuickSwitcherWidgetAction :
     override fun update(event: AnActionEvent) {
         val state = AyuIslandsSettings.getInstance().state
         event.presentation.isEnabledAndVisible =
-            AyuVariant.isAyuActive() &&
+            AccentContext.isAccentActive() &&
             state.quickSwitcherWidgetEnabled
     }
 

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/CopyHexAction.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/CopyHexAction.kt
@@ -22,12 +22,12 @@ class CopyHexAction : DumbAwareAction("Copy Hex", "Copy the current accent hex t
 
     override fun update(event: AnActionEvent) {
         event.presentation.isEnabledAndVisible =
-            AccentContext.isAccentActive() &&
+            AccentContext.isQuickSwitcherActive() &&
             LicenseChecker.isLicensedOrGrace()
     }
 
     override fun actionPerformed(event: AnActionEvent) {
-        val context = AccentContext.detect() ?: return
+        val context = AccentContext.detectQuickSwitcher() ?: return
         val project = AccentApplicator.resolveFocusedProject()
         val hex =
             try {

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/CopyHexAction.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/CopyHexAction.kt
@@ -6,8 +6,8 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.ide.CopyPasteManager
 import com.intellij.openapi.project.DumbAwareAction
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentResolver
-import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.licensing.LicenseChecker
 import java.awt.datatransfer.StringSelection
 
@@ -22,18 +22,18 @@ class CopyHexAction : DumbAwareAction("Copy Hex", "Copy the current accent hex t
 
     override fun update(event: AnActionEvent) {
         event.presentation.isEnabledAndVisible =
-            AyuVariant.isAyuActive() &&
+            AccentContext.isAccentActive() &&
             LicenseChecker.isLicensedOrGrace()
     }
 
     override fun actionPerformed(event: AnActionEvent) {
-        val variant = AyuVariant.detect() ?: return
+        val context = AccentContext.detect() ?: return
         val project = AccentApplicator.resolveFocusedProject()
         val hex =
             try {
                 // Read at invocation time — no cached state. Avoids leaking
                 // a prior window's resolved hex on burst clipboard reads.
-                AccentResolver.resolve(project, variant)
+                AccentResolver.resolve(project, context)
             } catch (exception: RuntimeException) {
                 LOG.warn("CopyHex: resolve failed", exception)
                 return

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/DarkerAccentAction.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/DarkerAccentAction.kt
@@ -26,12 +26,12 @@ class DarkerAccentAction : DumbAwareAction("Darker", "Darken the current accent 
 
     override fun update(event: AnActionEvent) {
         event.presentation.isEnabledAndVisible =
-            AccentContext.isAccentActive() &&
+            AccentContext.isQuickSwitcherActive() &&
             LicenseChecker.isLicensedOrGrace()
     }
 
     override fun actionPerformed(event: AnActionEvent) {
-        val context = AccentContext.detect() ?: return
+        val context = AccentContext.detectQuickSwitcher() ?: return
         val project = AccentApplicator.resolveFocusedProject()
         val currentHex =
             try {

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/DarkerAccentAction.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/DarkerAccentAction.kt
@@ -5,11 +5,13 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.DumbAwareAction
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
-import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.accent.ExternalAccentSource
 import dev.ayuislands.accent.color.AccentHsl
 import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 
 /**
@@ -24,16 +26,16 @@ class DarkerAccentAction : DumbAwareAction("Darker", "Darken the current accent 
 
     override fun update(event: AnActionEvent) {
         event.presentation.isEnabledAndVisible =
-            AyuVariant.isAyuActive() &&
+            AccentContext.isAccentActive() &&
             LicenseChecker.isLicensedOrGrace()
     }
 
     override fun actionPerformed(event: AnActionEvent) {
-        val variant = AyuVariant.detect() ?: return
+        val context = AccentContext.detect() ?: return
         val project = AccentApplicator.resolveFocusedProject()
         val currentHex =
             try {
-                AccentResolver.resolve(project, variant)
+                AccentResolver.resolve(project, context)
             } catch (exception: RuntimeException) {
                 LOG.warn("Darker: resolve failed", exception)
                 return
@@ -44,6 +46,7 @@ class DarkerAccentAction : DumbAwareAction("Darker", "Darken the current accent 
         try {
             val applied = AccentApplicator.applyFromHexString(newHex)
             if (applied) {
+                persistExternalAccentIfNeeded(context, newHex)
                 ProjectAccentSwapService.getInstance().notifyExternalApply(newHex)
             } else {
                 LOG.warn("Darker: applyFromHexString rejected hex=$newHex")
@@ -51,6 +54,16 @@ class DarkerAccentAction : DumbAwareAction("Darker", "Darken the current accent 
         } catch (exception: RuntimeException) {
             LOG.warn("Darker: apply failed hex=$newHex", exception)
         }
+    }
+
+    private fun persistExternalAccentIfNeeded(
+        context: AccentContext,
+        hex: String,
+    ) {
+        if (context != AccentContext.External) return
+        val state = AyuIslandsSettings.getInstance().state
+        state.externalThemeAccent = hex
+        state.externalThemeAccentSource = ExternalAccentSource.MANUAL.name
     }
 
     private companion object {

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/DarkerAccentAction.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/DarkerAccentAction.kt
@@ -8,10 +8,9 @@ import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
-import dev.ayuislands.accent.ExternalAccentSource
 import dev.ayuislands.accent.color.AccentHsl
+import dev.ayuislands.accent.persistExternalManualAccentIfNeeded
 import dev.ayuislands.licensing.LicenseChecker
-import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 
 /**
@@ -46,7 +45,7 @@ class DarkerAccentAction : DumbAwareAction("Darker", "Darken the current accent 
         try {
             val applied = AccentApplicator.applyFromHexString(newHex)
             if (applied) {
-                persistExternalAccentIfNeeded(context, newHex)
+                context.persistExternalManualAccentIfNeeded(newHex)
                 ProjectAccentSwapService.getInstance().notifyExternalApply(newHex)
             } else {
                 LOG.warn("Darker: applyFromHexString rejected hex=$newHex")
@@ -54,16 +53,6 @@ class DarkerAccentAction : DumbAwareAction("Darker", "Darken the current accent 
         } catch (exception: RuntimeException) {
             LOG.warn("Darker: apply failed hex=$newHex", exception)
         }
-    }
-
-    private fun persistExternalAccentIfNeeded(
-        context: AccentContext,
-        hex: String,
-    ) {
-        if (context != AccentContext.External) return
-        val state = AyuIslandsSettings.getInstance().state
-        state.externalThemeAccent = hex
-        state.externalThemeAccentSource = ExternalAccentSource.MANUAL.name
     }
 
     private companion object {

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/LighterAccentAction.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/LighterAccentAction.kt
@@ -26,12 +26,12 @@ class LighterAccentAction : DumbAwareAction("Lighter", "Lighten the current acce
 
     override fun update(event: AnActionEvent) {
         event.presentation.isEnabledAndVisible =
-            AccentContext.isAccentActive() &&
+            AccentContext.isQuickSwitcherActive() &&
             LicenseChecker.isLicensedOrGrace()
     }
 
     override fun actionPerformed(event: AnActionEvent) {
-        val context = AccentContext.detect() ?: return
+        val context = AccentContext.detectQuickSwitcher() ?: return
         val project = AccentApplicator.resolveFocusedProject()
         val currentHex =
             try {

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/LighterAccentAction.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/LighterAccentAction.kt
@@ -5,11 +5,13 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.DumbAwareAction
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
-import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.accent.ExternalAccentSource
 import dev.ayuislands.accent.color.AccentHsl
 import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 
 /**
@@ -24,16 +26,16 @@ class LighterAccentAction : DumbAwareAction("Lighter", "Lighten the current acce
 
     override fun update(event: AnActionEvent) {
         event.presentation.isEnabledAndVisible =
-            AyuVariant.isAyuActive() &&
+            AccentContext.isAccentActive() &&
             LicenseChecker.isLicensedOrGrace()
     }
 
     override fun actionPerformed(event: AnActionEvent) {
-        val variant = AyuVariant.detect() ?: return
+        val context = AccentContext.detect() ?: return
         val project = AccentApplicator.resolveFocusedProject()
         val currentHex =
             try {
-                AccentResolver.resolve(project, variant)
+                AccentResolver.resolve(project, context)
             } catch (exception: RuntimeException) {
                 LOG.warn("Lighter: resolve failed", exception)
                 return
@@ -44,6 +46,7 @@ class LighterAccentAction : DumbAwareAction("Lighter", "Lighten the current acce
         try {
             val applied = AccentApplicator.applyFromHexString(newHex)
             if (applied) {
+                persistExternalAccentIfNeeded(context, newHex)
                 ProjectAccentSwapService.getInstance().notifyExternalApply(newHex)
             } else {
                 LOG.warn("Lighter: applyFromHexString rejected hex=$newHex")
@@ -51,6 +54,16 @@ class LighterAccentAction : DumbAwareAction("Lighter", "Lighten the current acce
         } catch (exception: RuntimeException) {
             LOG.warn("Lighter: apply failed hex=$newHex", exception)
         }
+    }
+
+    private fun persistExternalAccentIfNeeded(
+        context: AccentContext,
+        hex: String,
+    ) {
+        if (context != AccentContext.External) return
+        val state = AyuIslandsSettings.getInstance().state
+        state.externalThemeAccent = hex
+        state.externalThemeAccentSource = ExternalAccentSource.MANUAL.name
     }
 
     private companion object {

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/LighterAccentAction.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/LighterAccentAction.kt
@@ -8,10 +8,9 @@ import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
-import dev.ayuislands.accent.ExternalAccentSource
 import dev.ayuislands.accent.color.AccentHsl
+import dev.ayuislands.accent.persistExternalManualAccentIfNeeded
 import dev.ayuislands.licensing.LicenseChecker
-import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 
 /**
@@ -46,7 +45,7 @@ class LighterAccentAction : DumbAwareAction("Lighter", "Lighten the current acce
         try {
             val applied = AccentApplicator.applyFromHexString(newHex)
             if (applied) {
-                persistExternalAccentIfNeeded(context, newHex)
+                context.persistExternalManualAccentIfNeeded(newHex)
                 ProjectAccentSwapService.getInstance().notifyExternalApply(newHex)
             } else {
                 LOG.warn("Lighter: applyFromHexString rejected hex=$newHex")
@@ -54,16 +53,6 @@ class LighterAccentAction : DumbAwareAction("Lighter", "Lighten the current acce
         } catch (exception: RuntimeException) {
             LOG.warn("Lighter: apply failed hex=$newHex", exception)
         }
-    }
-
-    private fun persistExternalAccentIfNeeded(
-        context: AccentContext,
-        hex: String,
-    ) {
-        if (context != AccentContext.External) return
-        val state = AyuIslandsSettings.getInstance().state
-        state.externalThemeAccent = hex
-        state.externalThemeAccentSource = ExternalAccentSource.MANUAL.name
     }
 
     private companion object {

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/PinAccentAction.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/PinAccentAction.kt
@@ -5,8 +5,8 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.DumbAwareAction
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentResolver
-import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.mappings.AccentMappingsSettings
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
@@ -20,7 +20,7 @@ import dev.ayuislands.settings.mappings.ProjectAccentSwapService
  * follow-up marker below keeps the integration point discoverable.
  *
  * Premium gate via Pattern J two-level predicate
- * (`AyuVariant.isAyuActive() && LicenseChecker.isLicensedOrGrace()`) on every
+ * (`AccentContext.detect() is AccentContext.Ayu && LicenseChecker.isLicensedOrGrace()`) on every
  * `update` tick — both the right-click context menu and the popup quick-action
  * row must go through this gate.
  */
@@ -29,12 +29,14 @@ class PinAccentAction : DumbAwareAction("Pin Accent", "Pin the current accent to
 
     override fun update(event: AnActionEvent) {
         event.presentation.isEnabledAndVisible =
-            AyuVariant.isAyuActive() &&
+            AccentContext.detect() is AccentContext.Ayu &&
             LicenseChecker.isLicensedOrGrace()
     }
 
     override fun actionPerformed(event: AnActionEvent) {
-        val variant = AyuVariant.detect() ?: return
+        val context = AccentContext.detect()
+        if (context !is AccentContext.Ayu) return
+        val variant = context.ayuVariant
         val project = AccentApplicator.resolveFocusedProject() ?: return
         val hex =
             try {

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/RandomAccentAction.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/RandomAccentAction.kt
@@ -7,10 +7,9 @@ import com.intellij.openapi.project.DumbAwareAction
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AyuVariant
-import dev.ayuislands.accent.ExternalAccentSource
+import dev.ayuislands.accent.persistExternalManualAccentIfNeeded
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.rotation.ContrastAwareColorGenerator
-import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 
 /**
@@ -46,7 +45,7 @@ class RandomAccentAction : DumbAwareAction("Random Accent", "Pick a random reada
         try {
             val applied = AccentApplicator.applyFromHexString(hex)
             if (applied) {
-                persistExternalAccentIfNeeded(context, hex)
+                context.persistExternalManualAccentIfNeeded(hex)
                 ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
             } else {
                 LOG.warn("Random: applyFromHexString rejected hex=$hex")
@@ -54,16 +53,6 @@ class RandomAccentAction : DumbAwareAction("Random Accent", "Pick a random reada
         } catch (exception: RuntimeException) {
             LOG.warn("Random: apply failed hex=$hex", exception)
         }
-    }
-
-    private fun persistExternalAccentIfNeeded(
-        context: AccentContext,
-        hex: String,
-    ) {
-        if (context != AccentContext.External) return
-        val state = AyuIslandsSettings.getInstance().state
-        state.externalThemeAccent = hex
-        state.externalThemeAccentSource = ExternalAccentSource.MANUAL.name
     }
 
     private companion object {

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/RandomAccentAction.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/RandomAccentAction.kt
@@ -5,9 +5,12 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.DumbAwareAction
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.accent.ExternalAccentSource
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.rotation.ContrastAwareColorGenerator
+import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 
 /**
@@ -24,15 +27,18 @@ class RandomAccentAction : DumbAwareAction("Random Accent", "Pick a random reada
 
     override fun update(event: AnActionEvent) {
         event.presentation.isEnabledAndVisible =
-            AyuVariant.isAyuActive() &&
+            AccentContext.isAccentActive() &&
             LicenseChecker.isLicensedOrGrace()
     }
 
     override fun actionPerformed(event: AnActionEvent) {
-        val variant = AyuVariant.detect() ?: return
+        val context = AccentContext.detect() ?: return
         val hex =
             try {
-                ContrastAwareColorGenerator.generate(variant)
+                when (context) {
+                    is AccentContext.Ayu -> ContrastAwareColorGenerator.generate(context.ayuVariant)
+                    AccentContext.External -> ContrastAwareColorGenerator.generate(AyuVariant.MIRAGE)
+                }
             } catch (exception: RuntimeException) {
                 LOG.warn("Random: generate failed", exception)
                 return
@@ -40,6 +46,7 @@ class RandomAccentAction : DumbAwareAction("Random Accent", "Pick a random reada
         try {
             val applied = AccentApplicator.applyFromHexString(hex)
             if (applied) {
+                persistExternalAccentIfNeeded(context, hex)
                 ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
             } else {
                 LOG.warn("Random: applyFromHexString rejected hex=$hex")
@@ -47,6 +54,16 @@ class RandomAccentAction : DumbAwareAction("Random Accent", "Pick a random reada
         } catch (exception: RuntimeException) {
             LOG.warn("Random: apply failed hex=$hex", exception)
         }
+    }
+
+    private fun persistExternalAccentIfNeeded(
+        context: AccentContext,
+        hex: String,
+    ) {
+        if (context != AccentContext.External) return
+        val state = AyuIslandsSettings.getInstance().state
+        state.externalThemeAccent = hex
+        state.externalThemeAccentSource = ExternalAccentSource.MANUAL.name
     }
 
     private companion object {

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/RandomAccentAction.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/RandomAccentAction.kt
@@ -27,12 +27,12 @@ class RandomAccentAction : DumbAwareAction("Random Accent", "Pick a random reada
 
     override fun update(event: AnActionEvent) {
         event.presentation.isEnabledAndVisible =
-            AccentContext.isAccentActive() &&
+            AccentContext.isQuickSwitcherActive() &&
             LicenseChecker.isLicensedOrGrace()
     }
 
     override fun actionPerformed(event: AnActionEvent) {
-        val context = AccentContext.detect() ?: return
+        val context = AccentContext.detectQuickSwitcher() ?: return
         val hex =
             try {
                 when (context) {

--- a/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
@@ -14,9 +14,9 @@ import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener
 import dev.ayuislands.accent.AccentChangeListener
 import dev.ayuislands.accent.AccentChangedTopic
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
-import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
@@ -99,8 +99,8 @@ class GlowOverlayManager(
             return
         }
 
-        if (!AyuVariant.isAyuActive()) {
-            log.info("No Ayu variant detected, skipping glow initialization")
+        if (AccentContext.detect() == null) {
+            log.info("No accent context detected, skipping glow initialization")
             return
         }
 
@@ -238,16 +238,16 @@ class GlowOverlayManager(
         val state = AyuIslandsSettings.getInstance().state
         if (!state.glowFocusRing) return
 
-        // Pattern A — log-once gate. AyuVariant.detect() returns null only when
-        // a non-Ayu LAF is active; without the diagnostic, a user reporting
+        // Pattern A — log-once gate. AccentContext.detect() returns null only when
+        // no Ayu Islands accent context is active; without the diagnostic, a user reporting
         // "focus ring glow stopped working after theme tweak" hands us logs
         // with no breadcrumb of which guard fired.
-        val variant =
-            AyuVariant.detect() ?: run {
-                log.debug("AyuVariant.detect() returned null in initializeFocusRingGlow, skipping focus-ring glow")
+        val context =
+            AccentContext.detect() ?: run {
+                log.debug("AccentContext.detect() returned null in initializeFocusRingGlow, skipping focus-ring glow")
                 return
             }
-        val accentHex = resolveCurrentGlowAccentHex(project, state, variant)
+        val accentHex = resolveCurrentGlowAccentHex(project, state, context)
         val style = GlowStyle.fromName(state.glowStyle ?: GlowStyle.SOFT.name)
         val accent = safeDecodeColor(accentHex)
         val intensity = state.getIntensityForStyle(style)
@@ -286,16 +286,15 @@ class GlowOverlayManager(
         val layeredPane = rootPane.layeredPane
 
         val state = AyuIslandsSettings.getInstance().state
-        // Pattern A — log-once gate. attachOverlay fires from message-bus
-        // callbacks (tool-window state change, editor selection); a silent
-        // skip on a non-Ayu LAF leaves the overlay un-attached without any
-        // trace in idea.log.
-        val variant =
-            AyuVariant.detect() ?: run {
-                log.debug("AyuVariant.detect() returned null in attachOverlay($id), skipping overlay attach")
+        // Pattern A — log-once gate. attachOverlay fires from message-bus callbacks
+        // (tool-window state change, editor selection); a silent skip when no accent
+        // context is active leaves the overlay un-attached without any trace in idea.log.
+        val context =
+            AccentContext.detect() ?: run {
+                log.debug("AccentContext.detect() returned null in attachOverlay($id), skipping overlay attach")
                 return
             }
-        val accentHex = resolveCurrentGlowAccentHex(project, state, variant)
+        val accentHex = resolveCurrentGlowAccentHex(project, state, context)
         val style = GlowStyle.fromName(state.glowStyle ?: GlowStyle.SOFT.name)
 
         val glassPane =
@@ -433,7 +432,8 @@ class GlowOverlayManager(
 
     fun updateGlow(appliedAccent: AccentHex? = null) {
         if (disposed) return
-        if (!AyuVariant.isAyuActive()) {
+        val context = AccentContext.detect()
+        if (context == null) {
             removeAllOverlays()
             return
         }
@@ -445,23 +445,9 @@ class GlowOverlayManager(
             return
         }
 
-        // Pattern A — log-once gate. The isAyuActive() guard above already
-        // disposed overlays when the LAF is non-Ayu, so reaching here with a
-        // null detect() is the rare race window between guard and detect();
-        // surface a DEBUG breadcrumb instead of falling through silently.
         val accentHex =
             appliedAccent?.value
-                ?: run {
-                    val variant =
-                        AyuVariant.detect() ?: run {
-                            log.debug(
-                                "AyuVariant.detect() returned null in updateGlow after " +
-                                    "isAyuActive guard, skipping refresh",
-                            )
-                            return
-                        }
-                    resolveCurrentGlowAccentHex(project, state, variant)
-                }
+                ?: resolveCurrentGlowAccentHex(project, state, context)
         val accent = safeDecodeColor(accentHex)
         val style = GlowStyle.fromName(state.glowStyle ?: GlowStyle.SOFT.name)
 
@@ -546,10 +532,10 @@ class GlowOverlayManager(
 private fun resolveCurrentGlowAccentHex(
     project: Project,
     state: AyuIslandsState,
-    variant: AyuVariant,
+    context: AccentContext,
 ): String =
     state
         .effectiveLastAppliedAccentHex()
         ?.takeIf { state.lastApplyOk }
         ?.value
-        ?: AccentResolver.resolve(project, variant)
+        ?: AccentResolver.resolve(project, context)

--- a/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
@@ -252,6 +252,7 @@ class GlowOverlayManager(
                 log.debug("AccentContext.detect() returned null in initializeFocusRingGlow, skipping focus-ring glow")
                 return
             }
+        if (isExternalGlowBlocked(context, state, "initializeFocusRingGlow")) return
         val accentHex = resolveCurrentGlowAccentHex(project, state, context)
         val style = GlowStyle.fromName(state.glowStyle ?: GlowStyle.SOFT.name)
         val accent = safeDecodeColor(accentHex)
@@ -299,6 +300,7 @@ class GlowOverlayManager(
                 log.debug("AccentContext.detect() returned null in attachOverlay($id), skipping overlay attach")
                 return
             }
+        if (isExternalGlowBlocked(context, state, "attachOverlay($id)")) return
         val accentHex = resolveCurrentGlowAccentHex(project, state, context)
         val style = GlowStyle.fromName(state.glowStyle ?: GlowStyle.SOFT.name)
 
@@ -536,6 +538,16 @@ class GlowOverlayManager(
             focusRingManager.dispose()
         }
     }
+}
+
+private fun isExternalGlowBlocked(
+    context: AccentContext,
+    state: AyuIslandsState,
+    callSite: String,
+): Boolean {
+    if (context != AccentContext.External || state.isExternalGlowAllowed()) return false
+    logger<GlowOverlayManager>().debug("External glow disabled, skipping $callSite")
+    return true
 }
 
 private fun resolveCurrentGlowAccentHex(

--- a/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
@@ -99,8 +99,13 @@ class GlowOverlayManager(
             return
         }
 
-        if (AccentContext.detect() == null) {
+        val context = AccentContext.detect()
+        if (context == null) {
             log.info("No accent context detected, skipping glow initialization")
+            return
+        }
+        if (context == AccentContext.External && !settings.state.isExternalGlowAllowed()) {
+            log.info("External glow disabled, skipping overlay initialization")
             return
         }
 
@@ -441,6 +446,10 @@ class GlowOverlayManager(
         val settings = AyuIslandsSettings.getInstance()
         val state = settings.state
         if (!state.glowEnabled) {
+            removeAllOverlays()
+            return
+        }
+        if (context == AccentContext.External && !state.isExternalGlowAllowed()) {
             removeAllOverlays()
             return
         }

--- a/src/main/kotlin/dev/ayuislands/indent/IndentPalette.kt
+++ b/src/main/kotlin/dev/ayuislands/indent/IndentPalette.kt
@@ -40,9 +40,11 @@ data class IndentPalette(
     }
 
     companion object {
+        private const val EXTERNAL_ERROR_COLOR = "F27983"
+
         private val ERROR_COLORS =
             mapOf(
-                AyuVariant.MIRAGE to "F27983",
+                AyuVariant.MIRAGE to EXTERNAL_ERROR_COLOR,
                 AyuVariant.DARK to "F26D78",
                 AyuVariant.LIGHT to "FF7383",
             )
@@ -54,6 +56,11 @@ data class IndentPalette(
             val accent = accentHex.removePrefix("#")
             val error = ERROR_COLORS[variant] ?: ERROR_COLORS.getValue(AyuVariant.MIRAGE)
             return IndentPalette(errorColor = error, accentColor = accent)
+        }
+
+        fun forExternalAccent(accentHex: String): IndentPalette {
+            val accent = accentHex.removePrefix("#")
+            return IndentPalette(errorColor = EXTERNAL_ERROR_COLOR, accentColor = accent)
         }
     }
 }

--- a/src/main/kotlin/dev/ayuislands/indent/IndentRainbowSync.kt
+++ b/src/main/kotlin/dev/ayuislands/indent/IndentRainbowSync.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.extensions.PluginId
 import dev.ayuislands.AyuPlugin
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.settings.AyuIslandsSettings
 import java.lang.reflect.Field
@@ -62,6 +63,30 @@ object IndentRainbowSync {
         variant: AyuVariant,
         accentHex: String,
     ) {
+        applyPalette(
+            palette = IndentPalette.forAccent(accentHex, variant),
+            logContext = "for ${variant.name}",
+        )
+    }
+
+    fun apply(
+        context: AccentContext,
+        accentHex: String,
+    ) {
+        when (context) {
+            is AccentContext.Ayu -> apply(context.ayuVariant, accentHex)
+            AccentContext.External ->
+                applyPalette(
+                    palette = IndentPalette.forExternalAccent(accentHex),
+                    logContext = "for external theme",
+                )
+        }
+    }
+
+    private fun applyPalette(
+        palette: IndentPalette,
+        logContext: String,
+    ) {
         val state = AyuIslandsSettings.getInstance().state
         if (!state.irIntegrationEnabled) {
             revert()
@@ -74,7 +99,6 @@ object IndentRainbowSync {
         val enumValue = customEnumValue ?: return
 
         try {
-            val palette = IndentPalette.forAccent(accentHex, variant)
             val preset =
                 IndentPreset.fromName(
                     state.indentPresetName ?: IndentPreset.AMBIENT.name,
@@ -94,7 +118,7 @@ object IndentRainbowSync {
 
             resolved.flushCache()
 
-            log.info("Indent Rainbow colors synced for ${variant.name}")
+            log.info("Indent Rainbow colors synced $logContext")
         } catch (exception: InvocationTargetException) {
             val cause = exception.cause
             logWarning(SYNC_FAILED, cause ?: exception)

--- a/src/main/kotlin/dev/ayuislands/indent/IndentRainbowSync.kt
+++ b/src/main/kotlin/dev/ayuislands/indent/IndentRainbowSync.kt
@@ -76,10 +76,14 @@ object IndentRainbowSync {
         when (context) {
             is AccentContext.Ayu -> apply(context.ayuVariant, accentHex)
             AccentContext.External ->
-                applyPalette(
-                    palette = IndentPalette.forExternalAccent(accentHex),
-                    logContext = "for external theme",
-                )
+                if (AyuIslandsSettings.getInstance().state.isExternalIndentRainbowAllowed()) {
+                    applyPalette(
+                        palette = IndentPalette.forExternalAccent(accentHex),
+                        logContext = "for external theme",
+                    )
+                } else {
+                    revert()
+                }
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -285,6 +285,10 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
                         ?: "?"
                 "language override: $dominant"
             }
+            AccentResolver.Source.MATERIAL_THEME,
+            AccentResolver.Source.IDE_ACCENT,
+            AccentResolver.Source.EXTERNAL_ACCENT,
+            -> AccentResolver.sourceLabel(source)
             AccentResolver.Source.GLOBAL -> "global"
         }
 

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.ui.Messages
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.components.JBTabbedPane
 import com.intellij.ui.dsl.builder.Align
+import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.util.ui.JBUI
 import dev.ayuislands.AyuPlugin
@@ -34,6 +35,11 @@ import javax.swing.SwingConstants
 import javax.swing.Timer
 
 /** Settings page at Appearance > Ayu Islands with Accent / Glow tabs. */
+private fun resolvePluginVersion(): String =
+    AyuPlugin
+        .findLoadedPlugin(AyuPlugin.ID)
+        ?.version ?: "unknown"
+
 class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
     private val log = logger<AyuIslandsConfigurable>()
 
@@ -57,6 +63,7 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
     private val effectsPanel = AyuIslandsEffectsPanel()
     private val vcsColorPanel = VcsColorPanel()
     private val syntaxPanel = AyuIslandsSyntaxPanel()
+    private var builtPanels: List<AyuIslandsSettingsPanel> = emptyList()
 
     private val panels: List<AyuIslandsSettingsPanel> =
         listOf(
@@ -73,39 +80,41 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
         )
 
     override fun createPanel(): com.intellij.openapi.ui.DialogPanel {
-        val pluginVersion =
-            AyuPlugin
-                .findLoadedPlugin(AyuPlugin.ID)
-                ?.version ?: "unknown"
+        val pluginVersion = resolvePluginVersion()
+        val variant = AyuVariant.detect()
+        val effectiveVariant = variant ?: AyuVariant.MIRAGE
+        val activePanels = mutableListOf<AyuIslandsSettingsPanel>()
 
-        val variant =
-            AyuVariant.detect() ?: return panel {
-                row {
-                    scaleIcon()?.let { icon(it) }
-                    label("v$pluginVersion")
-                        .applyToComponent { font = JBUI.Fonts.smallFont() }
-                }
-                row {
-                    comment("Activate an Ayu Islands theme to configure accent colors")
-                }
+        if (variant != null) {
+            configureAyuPanelComposition(variant)
+        }
+
+        val contentTabs = buildContentTabs(variant, effectiveVariant, activePanels)
+        builtPanels = activePanels
+
+        val settings = AyuIslandsSettings.getInstance()
+        val state = settings.state
+        val tabs =
+            createSettingsTabs(
+                contentTabs = contentTabs,
+                accentColor = resolveTabAccentColor(settings, variant),
+                selectedIndex = state.settingsSelectedTab,
+            ) { selectedIndex ->
+                AyuIslandsSettings.getInstance().state.settingsSelectedTab = selectedIndex
             }
 
-        // Wire accent color changes to the element preview
+        return buildRootPanel(pluginVersion, variant, tabs)
+    }
+
+    private fun configureAyuPanelComposition(variant: AyuVariant) {
+        // Wire accent color changes to the element preview.
         accentPanel.onAccentChanged = { hex -> elementsPanel.updatePreviewAccent(hex) }
 
-        // Visual order: Accent Color → System → Overrides → Chrome Tinting → Rotation → Elements.
-        // AccentPanel renders Accent Color → (beforeOverrides) → Overrides →
-        // (afterOverrides) → Rotation. The beforeOverrides hook hosts
+        // Visual order: Accent Color -> System -> Overrides -> Chrome Tinting -> Rotation -> Elements.
+        // AccentPanel renders Accent Color -> (beforeOverrides) -> Overrides ->
+        // (afterOverrides) -> Rotation. The beforeOverrides hook hosts
         // AppearancePanel's "System" collapsibleGroup; the afterOverrides hook hosts
         // the Chrome Tinting collapsible.
-        //
-        // Chrome Tinting renders AFTER Overrides and BEFORE Rotation because it
-        // consumes the *resolved* accent produced by override rules — mirroring the
-        // data-flow dependency gives users a top-to-bottom reading order: choose
-        // accent → system integrations → scope overrides → chrome surface toggles →
-        // rotation schedule → per-element toggles. The two parallel injection hooks
-        // keep AccentPanel composition-friendly without turning the order into a
-        // free-form list.
         accentPanel.beforeOverridesInjection = { injectionPanel ->
             appearancePanel.buildPanel(injectionPanel, variant)
         }
@@ -115,95 +124,124 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
         appearancePanel.systemAccentRowInstaller = { rowHostPanel ->
             accentPanel.installSystemAccentCheckbox(rowHostPanel)
         }
+    }
 
-        // Build tab content panels eagerly via DSL
-        val accentTab =
-            panel {
+    private fun buildContentTabs(
+        variant: AyuVariant?,
+        effectiveVariant: AyuVariant,
+        activePanels: MutableList<AyuIslandsSettingsPanel>,
+    ): List<Pair<String, JComponent>> {
+        fontPresetPanel.initState()
+        return listOf(
+            "Accent" to buildAccentTab(variant, activePanels),
+            "Font" to buildFontTab(activePanels),
+            "Glow" to buildGlowTab(activePanels),
+            // Syntax slots between Glow and VCS so rendering-related tabs cluster
+            // before source-control and workspace tabs.
+            "Syntax" to buildAyuOnlyTab(variant, "syntax intensity", syntaxPanel, activePanels),
+            "VCS" to buildAyuOnlyTab(variant, "VCS colors", vcsColorPanel, activePanels),
+            "Workspace" to buildAlwaysAvailableTab(workspacePanel, effectiveVariant, activePanels),
+            "Plugins" to buildAlwaysAvailableTab(pluginsPanel, effectiveVariant, activePanels),
+        )
+    }
+
+    private fun buildAccentTab(
+        variant: AyuVariant?,
+        activePanels: MutableList<AyuIslandsSettingsPanel>,
+    ): JComponent =
+        panel {
+            if (variant == null) {
+                buildAyuThemeRequiredMessage("accent colors")
+            } else {
                 accentPanel.buildPanel(this@panel, variant)
                 elementsPanel.buildPanel(this@panel, variant)
+                activePanels += accentPanel
+                activePanels += elementsPanel
+                buildResetAllSettingsRow()
+            }
+        }
 
-                // "Reset all settings..." link at the bottom of the Accent tab
-                row {
-                    link("Reset all Ayu settings\u2026") {
-                        val result =
-                            Messages.showYesNoDialog(
-                                "Reset all Ayu Islands settings to defaults?\n\n" +
-                                    "This will reset accent color, element toggles, and all glow settings.",
-                                "Reset All Settings",
-                                Messages.getWarningIcon(),
-                            )
-                        if (result == Messages.YES) {
-                            resetAllSettings()
-                        }
-                    }
+    private fun buildFontTab(activePanels: MutableList<AyuIslandsSettingsPanel>): JComponent =
+        panel {
+            fontPresetPanel.buildFontTab(this@panel)
+            activePanels += fontPresetPanel
+        }
+
+    private fun buildGlowTab(activePanels: MutableList<AyuIslandsSettingsPanel>): JComponent =
+        panel {
+            effectsPanel.buildGlowPanel(this@panel)
+            activePanels += effectsPanel
+        }
+
+    private fun buildAyuOnlyTab(
+        variant: AyuVariant?,
+        sectionName: String,
+        settingsPanel: AyuIslandsSettingsPanel,
+        activePanels: MutableList<AyuIslandsSettingsPanel>,
+    ): JComponent =
+        panel {
+            if (variant == null) {
+                buildAyuThemeRequiredMessage(sectionName)
+            } else {
+                settingsPanel.buildPanel(this@panel, variant)
+                activePanels += settingsPanel
+            }
+        }
+
+    private fun buildAlwaysAvailableTab(
+        settingsPanel: AyuIslandsSettingsPanel,
+        variant: AyuVariant,
+        activePanels: MutableList<AyuIslandsSettingsPanel>,
+    ): JComponent =
+        panel {
+            settingsPanel.buildPanel(this@panel, variant)
+            activePanels += settingsPanel
+        }
+
+    private fun Panel.buildResetAllSettingsRow() {
+        row {
+            link("Reset all Ayu settings\u2026") {
+                val result =
+                    Messages.showYesNoDialog(
+                        "Reset all Ayu Islands settings to defaults?\n\n" +
+                            "This will reset accent color, element toggles, and all glow settings.",
+                        "Reset All Settings",
+                        Messages.getWarningIcon(),
+                    )
+                if (result == Messages.YES) {
+                    resetAllSettings()
                 }
             }
+        }
+    }
 
-        fontPresetPanel.initState()
+    private fun resolveTabAccentColor(
+        settings: AyuIslandsSettings,
+        variant: AyuVariant?,
+    ): Color =
+        if (variant == null) {
+            JBUI.CurrentTheme.Link.Foreground.ENABLED
+        } else {
+            decodeAccentColor(settings, variant)
+        }
 
-        val fontTab =
-            panel {
-                fontPresetPanel.buildFontTab(this@panel)
-            }
+    private fun decodeAccentColor(
+        settings: AyuIslandsSettings,
+        variant: AyuVariant,
+    ): Color =
+        try {
+            Color.decode(settings.getAccentForVariant(variant))
+        } catch (exception: NumberFormatException) {
+            log.warn("Invalid accent color for ${variant.name}, using theme default", exception)
+            JBUI.CurrentTheme.Link.Foreground.ENABLED
+        }
 
-        val glowTab =
-            panel {
-                effectsPanel.buildGlowPanel(this@panel)
-            }
-
-        val syntaxTab =
-            panel {
-                syntaxPanel.buildPanel(this@panel, variant)
-            }
-
-        val vcsTab =
-            panel {
-                vcsColorPanel.buildPanel(this@panel, variant)
-            }
-
-        val workspaceTab =
-            panel {
-                workspacePanel.buildPanel(this@panel, variant)
-            }
-
-        val pluginsTab =
-            panel {
-                pluginsPanel.buildPanel(this@panel, variant)
-            }
-
-        // Single-level tab container
-        val settings = AyuIslandsSettings.getInstance()
-        val state = settings.state
-        val accentColor =
-            try {
-                Color.decode(settings.getAccentForVariant(variant))
-            } catch (exception: NumberFormatException) {
-                log.warn("Invalid accent color for ${variant.name}, using theme default", exception)
-                JBUI.CurrentTheme.Link.Foreground.ENABLED
-            }
-
-        val tabs =
-            createSettingsTabs(
-                contentTabs =
-                    listOf(
-                        "Accent" to accentTab,
-                        "Font" to fontTab,
-                        "Glow" to glowTab,
-                        // Syntax slots between Glow and VCS so rendering-related
-                        // tabs cluster before source-control and workspace tabs.
-                        "Syntax" to syntaxTab,
-                        "VCS" to vcsTab,
-                        "Workspace" to workspaceTab,
-                        "Plugins" to pluginsTab,
-                    ),
-                accentColor = accentColor,
-                selectedIndex = state.settingsSelectedTab,
-            ) { selectedIndex ->
-                AyuIslandsSettings.getInstance().state.settingsSelectedTab = selectedIndex
-            }
-
-        return panel {
-            // Header
+    private fun buildRootPanel(
+        pluginVersion: String,
+        variant: AyuVariant?,
+        tabs: JBTabbedPane,
+    ): com.intellij.openapi.ui.DialogPanel =
+        panel {
             row {
                 scaleIcon()?.let { icon(it) }
                 label("v$pluginVersion")
@@ -211,7 +249,8 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
             }
             row {
                 val status = if (LicenseChecker.isLicensedOrGrace()) "Licensed" else ""
-                comment("${variant.name} variant $status".trim())
+                val themeStatus = variant?.let { "${it.name} variant" } ?: "External theme"
+                comment("$themeStatus $status".trim())
             }
 
             if (!LicenseChecker.isLicensedOrGrace()) {
@@ -224,12 +263,16 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
                 }
             }
 
-            // Tab container
             row {
                 cell(tabs)
                     .resizableColumn()
                     .align(Align.FILL)
             }
+        }
+
+    private fun Panel.buildAyuThemeRequiredMessage(sectionName: String) {
+        row {
+            comment("Activate an Ayu Islands theme to configure $sectionName.")
         }
     }
 
@@ -441,12 +484,12 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
         super.disposeUIResources()
     }
 
-    override fun isModified(): Boolean = super.isModified() || panels.any { it.isModified() }
+    override fun isModified(): Boolean = builtPanels.any { it.isModified() }
 
     override fun apply() {
         super.apply()
 
-        for (section in panels) {
+        for (section in builtPanels) {
             section.apply()
         }
 
@@ -479,7 +522,7 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
 
     override fun reset() {
         super.reset()
-        for (section in panels) {
+        for (section in builtPanels) {
             section.reset()
         }
     }

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -3,6 +3,8 @@ package dev.ayuislands.settings
 import com.intellij.openapi.components.BaseState
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.AccentHex
+import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.accent.ExternalAccentSource
 import dev.ayuislands.accent.TintIntensity
 import dev.ayuislands.glow.GlowAnimation
 import dev.ayuislands.glow.GlowPreset
@@ -30,6 +32,9 @@ class AyuIslandsState : BaseState() {
     var mirageAccent by string("#FFCC66")
     var darkAccent by string("#E6B450")
     var lightAccent by string("#F29718")
+    var externalThemeEnhancementsEnabled by property(false)
+    var externalThemeAccentSource by string(ExternalAccentSource.AUTOMATIC.name)
+    var externalThemeAccent by string(AyuVariant.MIRAGE.defaultAccent)
     var followSystemAccent by property(false)
     var followSystemAppearance by property(false)
     var lastDarkAppearanceTheme by string("Ayu Mirage (Islands UI)")

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -33,6 +33,10 @@ class AyuIslandsState : BaseState() {
     var darkAccent by string("#E6B450")
     var lightAccent by string("#F29718")
     var externalThemeEnhancementsEnabled by property(false)
+    var externalThemeQuickSwitcherEnabled by property(true)
+    var externalThemeGlowEnabled by property(false)
+    var externalThemeCodeGlanceProEnabled by property(true)
+    var externalThemeIndentRainbowEnabled by property(true)
     var externalThemeAccentSource by string(ExternalAccentSource.AUTOMATIC.name)
     var externalThemeAccent by string(AyuVariant.MIRAGE.defaultAccent)
     var followSystemAccent by property(false)
@@ -569,6 +573,16 @@ class AyuIslandsState : BaseState() {
             commitPanelWidthMode = PanelWidthMode.AUTO_FIT.name
         }
     }
+
+    fun isExternalQuickSwitcherAllowed(): Boolean = externalAllowed(externalThemeQuickSwitcherEnabled)
+
+    fun isExternalGlowAllowed(): Boolean = externalAllowed(externalThemeGlowEnabled)
+
+    fun isExternalCodeGlanceProAllowed(): Boolean = externalAllowed(externalThemeCodeGlanceProEnabled)
+
+    fun isExternalIndentRainbowAllowed(): Boolean = externalAllowed(externalThemeIndentRainbowEnabled)
+
+    private fun externalAllowed(enabled: Boolean): Boolean = externalThemeEnhancementsEnabled && enabled
 
     companion object {
         private const val PATH_SEP = "\n"

--- a/src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
@@ -610,7 +610,12 @@ class FontPresetPanel : AyuIslandsSettingsPanel {
         if (pendingPreset != storedPreset) return true
         if (pendingConsole != storedConsole) return true
         for ((name, settings) in customizations) {
-            if (settings.encode() != storedCustomizations[name]) return true
+            val storedSettings =
+                FontSettings.decode(
+                    storedCustomizations[name],
+                    FontPreset.fromName(name),
+                )
+            if (settings.encode() != storedSettings.encode()) return true
         }
         return false
     }

--- a/src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
@@ -1,16 +1,21 @@
 package dev.ayuislands.settings
 
 import com.intellij.openapi.observable.properties.AtomicBooleanProperty
+import com.intellij.ui.SimpleListCellRenderer
 import com.intellij.ui.dsl.builder.Align
 import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.dsl.builder.SegmentedButton
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentDefaults
 import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.accent.ExternalAccentSource
 import dev.ayuislands.accent.conflict.ConflictRegistry
 import dev.ayuislands.indent.IndentPreset
 import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.settings.mappings.AccentSwatchPickerRow
 import dev.ayuislands.syntax.SyntaxIntensityService
 import javax.swing.JCheckBox
+import javax.swing.JComboBox
 import javax.swing.JLabel
 import javax.swing.JSlider
 
@@ -28,12 +33,21 @@ class PluginsPanel : AyuIslandsSettingsPanel {
     private var storedErrorHighlight: Boolean = true
     private var pendingIgnorePluginSyntaxColors: Boolean = true
     private var storedIgnorePluginSyntaxColors: Boolean = true
+    private var pendingExternalThemeEnhancements: Boolean = false
+    private var storedExternalThemeEnhancements: Boolean = false
+    private var pendingExternalAccentSource: String = ExternalAccentSource.AUTOMATIC.name
+    private var storedExternalAccentSource: String = ExternalAccentSource.AUTOMATIC.name
+    private var pendingExternalAccent: String = AccentDefaults.MIRAGE_HEX
+    private var storedExternalAccent: String = AccentDefaults.MIRAGE_HEX
 
     private var variant: AyuVariant? = null
     private var enabledCheckbox: JCheckBox? = null
     private var cgpCheckbox: JCheckBox? = null
     private var errorHighlightCheckbox: JCheckBox? = null
     private var ignorePluginCheckbox: JCheckBox? = null
+    private var externalThemeCheckbox: JCheckBox? = null
+    private var externalAccentSourceCombo: JComboBox<ExternalAccentSource>? = null
+    private var externalAccentPicker: AccentSwatchPickerRow? = null
     private var alphaSlider: JSlider? = null
     private var alphaValueLabel: JLabel? = null
     private var presetSegmented: SegmentedButton<IndentPreset>? = null
@@ -65,6 +79,7 @@ class PluginsPanel : AyuIslandsSettingsPanel {
         val irDetected = ConflictRegistry.isIndentRainbowDetected()
 
         panel.row { comment("Tune how Ayu colors integrate with compatible plugins.") }
+        panel.buildExternalThemesGroup()
         panel.buildIgnorePluginGroup()
 
         if (cgpDetected || irDetected) {
@@ -93,6 +108,12 @@ class PluginsPanel : AyuIslandsSettingsPanel {
         pendingErrorHighlight = storedErrorHighlight
         storedIgnorePluginSyntaxColors = state.ignorePluginSyntaxColorsEnabled
         pendingIgnorePluginSyntaxColors = storedIgnorePluginSyntaxColors
+        storedExternalThemeEnhancements = state.externalThemeEnhancementsEnabled
+        pendingExternalThemeEnhancements = storedExternalThemeEnhancements
+        storedExternalAccentSource = state.externalThemeAccentSource ?: ExternalAccentSource.AUTOMATIC.name
+        pendingExternalAccentSource = storedExternalAccentSource
+        storedExternalAccent = state.externalThemeAccent ?: AccentDefaults.MIRAGE_HEX
+        pendingExternalAccent = storedExternalAccent
         storedPreset = state.indentPresetName ?: IndentPreset.AMBIENT.name
         pendingPreset = storedPreset
         storedCustomAlpha = state.indentCustomAlpha
@@ -123,6 +144,55 @@ class PluginsPanel : AyuIslandsSettingsPanel {
                     pendingIgnorePluginSyntaxColors = checkboxCell.component.isSelected
                 }
                 ignorePluginCheckbox = checkboxCell.component
+            }
+        }
+    }
+
+    private fun Panel.buildExternalThemesGroup() {
+        group("External themes") {
+            row {
+                val checkboxCell =
+                    checkBox("Enable Ayu enhancements on other themes")
+                        .comment(
+                            "Apply Glow, plugin sync, and quick-switcher accent actions " +
+                                "when the active IDE theme is not Ayu",
+                        )
+                checkboxCell.component.isSelected = pendingExternalThemeEnhancements
+                checkboxCell.component.addActionListener {
+                    pendingExternalThemeEnhancements = checkboxCell.component.isSelected
+                }
+                externalThemeCheckbox = checkboxCell.component
+            }
+            row("Accent source") {
+                val combo =
+                    comboBox(ExternalAccentSource.entries.toList())
+                        .component
+                combo.selectedItem = ExternalAccentSource.fromName(pendingExternalAccentSource)
+                combo.renderer = SimpleListCellRenderer.create("") { it.displayName }
+                combo.addActionListener {
+                    if (suppressListeners) return@addActionListener
+                    pendingExternalAccentSource =
+                        (combo.selectedItem as? ExternalAccentSource ?: ExternalAccentSource.AUTOMATIC).name
+                }
+                externalAccentSourceCombo = combo
+            }
+            row {
+                comment(
+                    "Automatic uses project/language pins, Material Theme accent, IDE accent, " +
+                        "then External accent fallback.",
+                )
+            }
+            row("External accent") {
+                val picker =
+                    AccentSwatchPickerRow { selected ->
+                        pendingExternalAccent = selected
+                        pendingExternalAccentSource = ExternalAccentSource.MANUAL.name
+                        externalAccentSourceCombo?.selectedItem = ExternalAccentSource.MANUAL
+                    }
+                picker.selectedHex = pendingExternalAccent
+                externalAccentPicker = picker
+                cell(picker)
+                    .comment("Used in Manual mode and as the final Automatic fallback")
             }
         }
     }
@@ -251,11 +321,27 @@ class PluginsPanel : AyuIslandsSettingsPanel {
             pendingCustomAlpha != storedCustomAlpha ||
             pendingCodeGlanceProIntegration != storedCodeGlanceProIntegration ||
             pendingErrorHighlight != storedErrorHighlight ||
-            pendingIgnorePluginSyntaxColors != storedIgnorePluginSyntaxColors
+            pendingIgnorePluginSyntaxColors != storedIgnorePluginSyntaxColors ||
+            pendingExternalThemeEnhancements != storedExternalThemeEnhancements ||
+            pendingExternalAccentSource != storedExternalAccentSource ||
+            pendingExternalAccent != storedExternalAccent
 
     override fun apply() {
         if (!isModified()) return
         val state = AyuIslandsSettings.getInstance().state
+        val externalChanged =
+            pendingExternalThemeEnhancements != storedExternalThemeEnhancements ||
+                pendingExternalAccentSource != storedExternalAccentSource ||
+                pendingExternalAccent != storedExternalAccent
+        if (externalChanged) {
+            state.externalThemeEnhancementsEnabled = pendingExternalThemeEnhancements
+            state.externalThemeAccentSource = pendingExternalAccentSource
+            state.externalThemeAccent = pendingExternalAccent
+            storedExternalThemeEnhancements = pendingExternalThemeEnhancements
+            storedExternalAccentSource = pendingExternalAccentSource
+            storedExternalAccent = pendingExternalAccent
+        }
+
         val ignorePluginChanged = pendingIgnorePluginSyntaxColors != storedIgnorePluginSyntaxColors
         if (ignorePluginChanged) {
             state.ignorePluginSyntaxColorsEnabled = pendingIgnorePluginSyntaxColors
@@ -298,12 +384,18 @@ class PluginsPanel : AyuIslandsSettingsPanel {
         pendingCodeGlanceProIntegration = storedCodeGlanceProIntegration
         pendingErrorHighlight = storedErrorHighlight
         pendingIgnorePluginSyntaxColors = storedIgnorePluginSyntaxColors
+        pendingExternalThemeEnhancements = storedExternalThemeEnhancements
+        pendingExternalAccentSource = storedExternalAccentSource
+        pendingExternalAccent = storedExternalAccent
 
         suppressListeners = true
         enabledCheckbox?.isSelected = storedEnabled
         cgpCheckbox?.isSelected = storedCodeGlanceProIntegration
         errorHighlightCheckbox?.isSelected = storedErrorHighlight
         ignorePluginCheckbox?.isSelected = storedIgnorePluginSyntaxColors
+        externalThemeCheckbox?.isSelected = storedExternalThemeEnhancements
+        externalAccentSourceCombo?.selectedItem = ExternalAccentSource.fromName(storedExternalAccentSource)
+        externalAccentPicker?.selectedHex = storedExternalAccent
         presetSegmented?.selectedItem = IndentPreset.fromName(storedPreset)
         alphaSlider?.value = storedCustomAlpha
         alphaValueLabel?.text = "$storedCustomAlpha"

--- a/src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
@@ -1,10 +1,16 @@
+@file:Suppress("DialogTitleCapitalization")
+
 package dev.ayuislands.settings
 
 import com.intellij.openapi.observable.properties.AtomicBooleanProperty
 import com.intellij.ui.SimpleListCellRenderer
 import com.intellij.ui.dsl.builder.Align
+import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.Panel
+import com.intellij.ui.dsl.builder.RightGap
+import com.intellij.ui.dsl.builder.Row
 import com.intellij.ui.dsl.builder.SegmentedButton
+import com.intellij.ui.dsl.builder.panel
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentDefaults
 import dev.ayuislands.accent.AyuVariant
@@ -35,6 +41,8 @@ class PluginsPanel : AyuIslandsSettingsPanel {
     private var storedIgnorePluginSyntaxColors: Boolean = true
     private var pendingExternalThemeEnhancements: Boolean = false
     private var storedExternalThemeEnhancements: Boolean = false
+    private var pendingExternalInheritance = ExternalInheritanceSettings()
+    private var storedExternalInheritance = ExternalInheritanceSettings()
     private var pendingExternalAccentSource: String = ExternalAccentSource.AUTOMATIC.name
     private var storedExternalAccentSource: String = ExternalAccentSource.AUTOMATIC.name
     private var pendingExternalAccent: String = AccentDefaults.MIRAGE_HEX
@@ -46,6 +54,10 @@ class PluginsPanel : AyuIslandsSettingsPanel {
     private var errorHighlightCheckbox: JCheckBox? = null
     private var ignorePluginCheckbox: JCheckBox? = null
     private var externalThemeCheckbox: JCheckBox? = null
+    private var externalQuickSwitcherCheckbox: JCheckBox? = null
+    private var externalGlowCheckbox: JCheckBox? = null
+    private var externalCodeGlanceProCheckbox: JCheckBox? = null
+    private var externalIndentRainbowCheckbox: JCheckBox? = null
     private var externalAccentSourceCombo: JComboBox<ExternalAccentSource>? = null
     private var externalAccentPicker: AccentSwatchPickerRow? = null
     private var alphaSlider: JSlider? = null
@@ -79,24 +91,14 @@ class PluginsPanel : AyuIslandsSettingsPanel {
         val irDetected = ConflictRegistry.isIndentRainbowDetected()
 
         panel.row { comment("Tune how Ayu colors integrate with compatible plugins.") }
-        panel.buildExternalThemesGroup()
-        panel.buildIgnorePluginGroup()
-
-        if (cgpDetected || irDetected) {
-            panel.premiumFeatureNotice(gate)
-        }
-
-        if (cgpDetected) {
-            panel.buildCodeGlanceProGroup(licensed)
-        }
-
-        if (irDetected) {
-            panel.buildIndentRainbowGroup(licensed, irEnabled)
-        }
-
-        if (!cgpDetected && !irDetected) {
-            panel.buildNoSupportedPluginsMessage()
-        }
+        panel.buildExternalThemeSupportGroup()
+        panel.buildPluginIntegrationsGroup(
+            gate = gate,
+            licensed = licensed,
+            isCodeGlanceProDetected = cgpDetected,
+            isIndentRainbowDetected = irDetected,
+            irEnabled = irEnabled,
+        )
     }
 
     private fun loadStored(state: AyuIslandsState) {
@@ -110,6 +112,8 @@ class PluginsPanel : AyuIslandsSettingsPanel {
         pendingIgnorePluginSyntaxColors = storedIgnorePluginSyntaxColors
         storedExternalThemeEnhancements = state.externalThemeEnhancementsEnabled
         pendingExternalThemeEnhancements = storedExternalThemeEnhancements
+        storedExternalInheritance = ExternalInheritanceSettings.fromState(state)
+        pendingExternalInheritance = storedExternalInheritance
         storedExternalAccentSource = state.externalThemeAccentSource ?: ExternalAccentSource.AUTOMATIC.name
         pendingExternalAccentSource = storedExternalAccentSource
         storedExternalAccent = state.externalThemeAccent ?: AccentDefaults.MIRAGE_HEX
@@ -124,38 +128,60 @@ class PluginsPanel : AyuIslandsSettingsPanel {
         IndentPreset.fromName(pendingPreset) == IndentPreset.CUSTOM || !licensed
 
     private fun Panel.buildNoSupportedPluginsMessage() {
-        group("Plugins") {
-            row {
-                comment(
-                    "Install CodeGlance Pro or Indent Rainbow for premium accent color sync.",
-                )
+        row {
+            comment(
+                "Install CodeGlance Pro or Indent Rainbow for premium accent color sync.",
+            )
+        }
+    }
+
+    private fun Panel.buildPluginIntegrationsGroup(
+        gate: PremiumFeatureGate,
+        licensed: Boolean,
+        isCodeGlanceProDetected: Boolean,
+        isIndentRainbowDetected: Boolean,
+        irEnabled: AtomicBooleanProperty,
+    ) {
+        group("Plugin Integrations") {
+            if (isCodeGlanceProDetected || isIndentRainbowDetected) {
+                premiumFeatureNotice(gate)
+            }
+            buildIgnorePluginRow()
+
+            if (isCodeGlanceProDetected) {
+                buildCodeGlanceProRow(licensed)
+            }
+
+            if (isIndentRainbowDetected) {
+                buildIndentRainbowRows(licensed, irEnabled)
+            }
+
+            if (!isCodeGlanceProDetected && !isIndentRainbowDetected) {
+                buildNoSupportedPluginsMessage()
             }
         }
     }
 
-    private fun Panel.buildIgnorePluginGroup() {
-        group(".ignore") {
-            row {
-                val checkboxCell =
-                    checkBox("Use Ayu colors for .ignore files")
-                        .comment("When off, keep the .ignore plugin's default syntax colors")
-                checkboxCell.component.isSelected = pendingIgnorePluginSyntaxColors
-                checkboxCell.component.addActionListener {
-                    pendingIgnorePluginSyntaxColors = checkboxCell.component.isSelected
-                }
-                ignorePluginCheckbox = checkboxCell.component
+    private fun Panel.buildIgnorePluginRow() {
+        row {
+            val checkboxCell =
+                checkBox(".ignore syntax colors")
+                    .comment("Use Ayu colors for .ignore files")
+            checkboxCell.component.isSelected = pendingIgnorePluginSyntaxColors
+            checkboxCell.component.addActionListener {
+                pendingIgnorePluginSyntaxColors = checkboxCell.component.isSelected
             }
+            ignorePluginCheckbox = checkboxCell.component
         }
     }
 
-    private fun Panel.buildExternalThemesGroup() {
-        group("External themes") {
+    private fun Panel.buildExternalThemeSupportGroup() {
+        group("External Theme Support") {
             row {
                 val checkboxCell =
                     checkBox("Enable Ayu enhancements on other themes")
                         .comment(
-                            "Apply Glow, plugin sync, and quick-switcher accent actions " +
-                                "when the active IDE theme is not Ayu",
+                            "Use selected Ayu features when the active IDE theme is not Ayu.",
                         )
                 checkboxCell.component.isSelected = pendingExternalThemeEnhancements
                 checkboxCell.component.addActionListener {
@@ -163,79 +189,129 @@ class PluginsPanel : AyuIslandsSettingsPanel {
                 }
                 externalThemeCheckbox = checkboxCell.component
             }
-            row("Accent source") {
-                val combo =
-                    comboBox(ExternalAccentSource.entries.toList())
-                        .component
-                combo.selectedItem = ExternalAccentSource.fromName(pendingExternalAccentSource)
-                combo.renderer = SimpleListCellRenderer.create("") { it.displayName }
-                combo.addActionListener {
-                    if (suppressListeners) return@addActionListener
-                    pendingExternalAccentSource =
-                        (combo.selectedItem as? ExternalAccentSource ?: ExternalAccentSource.AUTOMATIC).name
-                }
-                externalAccentSourceCombo = combo
-            }
+
             row {
-                comment(
-                    "Automatic uses project/language pins, Material Theme accent, IDE accent, " +
-                        "then External accent fallback.",
-                )
-            }
-            row("External accent") {
-                val picker =
-                    AccentSwatchPickerRow { selected ->
-                        pendingExternalAccent = selected
-                        pendingExternalAccentSource = ExternalAccentSource.MANUAL.name
-                        externalAccentSourceCombo?.selectedItem = ExternalAccentSource.MANUAL
+                label("Allowed features").gap(RightGap.COLUMNS)
+                panel {
+                    row {
+                        panel {
+                            row {
+                                buildExternalInheritanceToggleCell(
+                                    label = "Quick switcher",
+                                    isSelected = ExternalInheritanceSettings::isQuickSwitcherEnabled,
+                                    updateSelection = { copy(isQuickSwitcherEnabled = it) },
+                                    storeCheckbox = { externalQuickSwitcherCheckbox = it },
+                                )
+                            }
+                            row {
+                                buildExternalInheritanceToggleCell(
+                                    label = "CodeGlance Pro",
+                                    isSelected = ExternalInheritanceSettings::isCodeGlanceProEnabled,
+                                    updateSelection = { copy(isCodeGlanceProEnabled = it) },
+                                    storeCheckbox = { externalCodeGlanceProCheckbox = it },
+                                )
+                            }
+                        }.gap(RightGap.COLUMNS)
+                        panel {
+                            row {
+                                buildExternalInheritanceToggleCell(
+                                    label = "Glow",
+                                    isSelected = ExternalInheritanceSettings::isGlowEnabled,
+                                    updateSelection = { copy(isGlowEnabled = it) },
+                                    storeCheckbox = { externalGlowCheckbox = it },
+                                )
+                            }
+                            row {
+                                buildExternalInheritanceToggleCell(
+                                    label = "Indent Rainbow",
+                                    isSelected = ExternalInheritanceSettings::isIndentRainbowEnabled,
+                                    updateSelection = { copy(isIndentRainbowEnabled = it) },
+                                    storeCheckbox = { externalIndentRainbowCheckbox = it },
+                                )
+                            }
+                        }
                     }
-                picker.selectedHex = pendingExternalAccent
-                externalAccentPicker = picker
-                cell(picker)
-                    .comment("Used in Manual mode and as the final Automatic fallback")
+                }.align(AlignX.FILL)
             }
-        }
-    }
 
-    private fun Panel.buildCodeGlanceProGroup(licensed: Boolean) {
-        group("CodeGlance Pro") {
-            row {
-                val checkboxCell =
-                    checkBox("Sync color with CodeGlance")
-                        .comment("Apply accent color to CodeGlance Pro viewport")
-                checkboxCell.component.isSelected = pendingCodeGlanceProIntegration
-                checkboxCell.component.isEnabled = licensed
-                checkboxCell.component.addActionListener {
-                    if (!licensed) return@addActionListener
-                    pendingCodeGlanceProIntegration = checkboxCell.component.isSelected
+            val accentInheritance =
+                collapsibleGroup("Accent Inheritance") {
+                    row("Accent source") {
+                        val combo =
+                            comboBox(ExternalAccentSource.entries.toList())
+                                .component
+                        combo.selectedItem = ExternalAccentSource.fromName(pendingExternalAccentSource)
+                        combo.renderer = SimpleListCellRenderer.create("") { it.displayName }
+                        combo.addActionListener {
+                            if (suppressListeners) return@addActionListener
+                            pendingExternalAccentSource =
+                                (combo.selectedItem as? ExternalAccentSource ?: ExternalAccentSource.AUTOMATIC).name
+                        }
+                        externalAccentSourceCombo = combo
+                    }
+                    row {
+                        comment(
+                            "Automatic uses project/language pins, Material Theme accent, IDE accent, " +
+                                "then External accent fallback.",
+                        )
+                    }
+                    row("External accent") {
+                        val picker =
+                            AccentSwatchPickerRow { selected ->
+                                pendingExternalAccent = selected
+                                pendingExternalAccentSource = ExternalAccentSource.MANUAL.name
+                                externalAccentSourceCombo?.selectedItem = ExternalAccentSource.MANUAL
+                            }
+                        picker.selectedHex = pendingExternalAccent
+                        externalAccentPicker = picker
+                        cell(picker)
+                            .comment("Used in Manual mode and as the final Automatic fallback")
+                    }
                 }
-                cgpCheckbox = checkboxCell.component
-
-                browserLink("Plugin page", "https://plugins.jetbrains.com/plugin/18824-codeglance-pro")
-            }
+            accentInheritance.expanded = false
         }
     }
 
-    private fun Panel.buildIndentRainbowGroup(
-        licensed: Boolean,
-        irEnabled: AtomicBooleanProperty,
+    private fun Row.buildExternalInheritanceToggleCell(
+        label: String,
+        isSelected: (ExternalInheritanceSettings) -> Boolean,
+        updateSelection: ExternalInheritanceSettings.(Boolean) -> ExternalInheritanceSettings,
+        storeCheckbox: (JCheckBox) -> Unit,
     ) {
-        group("Indent Rainbow") {
-            buildIndentRainbowEnableRow(licensed, irEnabled)
-            buildIndentRainbowPresetRow(licensed, irEnabled)
-            buildIndentRainbowErrorRow(licensed, irEnabled)
-            buildIndentRainbowAlphaRow(licensed)
+        val checkboxCell = checkBox(label)
+        checkboxCell.component.isSelected = isSelected(pendingExternalInheritance)
+        checkboxCell.component.addActionListener {
+            pendingExternalInheritance =
+                pendingExternalInheritance.updateSelection(checkboxCell.component.isSelected)
+        }
+        storeCheckbox(checkboxCell.component)
+    }
+
+    private fun Panel.buildCodeGlanceProRow(licensed: Boolean) {
+        row {
+            val checkboxCell =
+                checkBox("CodeGlance Pro viewport")
+                    .comment("Apply accent color to the CodeGlance Pro viewport")
+            checkboxCell.component.isSelected = pendingCodeGlanceProIntegration
+            checkboxCell.component.isEnabled = licensed
+            checkboxCell.component.addActionListener {
+                if (!licensed) return@addActionListener
+                pendingCodeGlanceProIntegration = checkboxCell.component.isSelected
+            }
+            cgpCheckbox = checkboxCell.component
+
+            browserLink("Plugin page", "https://plugins.jetbrains.com/plugin/18824-codeglance-pro")
         }
     }
 
-    private fun Panel.buildIndentRainbowEnableRow(
+    private fun Panel.buildIndentRainbowRows(
         licensed: Boolean,
         irEnabled: AtomicBooleanProperty,
     ) {
         row {
             val checkboxCell =
-                checkBox("Sync colors with Indent Rainbow")
-                    .comment("Apply Ayu color palette to Indent Rainbow indentation guides")
+                checkBox("Indent Rainbow guides")
+                    .comment("Sync the Ayu palette with Indent Rainbow indentation guides")
             checkboxCell.component.isSelected = pendingEnabled
             checkboxCell.component.isEnabled = licensed
             checkboxCell.component.addActionListener {
@@ -250,6 +326,10 @@ class PluginsPanel : AyuIslandsSettingsPanel {
                 "https://plugins.jetbrains.com/plugin/13308-indent-rainbow",
             )
         }
+
+        buildIndentRainbowPresetRow(licensed, irEnabled)
+        buildIndentRainbowErrorRow(licensed, irEnabled)
+        buildIndentRainbowAlphaRow(licensed)
     }
 
     private fun Panel.buildIndentRainbowPresetRow(
@@ -322,22 +402,36 @@ class PluginsPanel : AyuIslandsSettingsPanel {
             pendingCodeGlanceProIntegration != storedCodeGlanceProIntegration ||
             pendingErrorHighlight != storedErrorHighlight ||
             pendingIgnorePluginSyntaxColors != storedIgnorePluginSyntaxColors ||
-            pendingExternalThemeEnhancements != storedExternalThemeEnhancements ||
-            pendingExternalAccentSource != storedExternalAccentSource ||
-            pendingExternalAccent != storedExternalAccent
+            hasExternalChanges()
+
+    private fun hasExternalChanges(): Boolean =
+        listOf(
+            pendingExternalThemeEnhancements != storedExternalThemeEnhancements,
+            pendingExternalInheritance != storedExternalInheritance,
+            pendingExternalAccentSource != storedExternalAccentSource,
+            pendingExternalAccent != storedExternalAccent,
+        ).any { it }
+
+    private fun hasPremiumChanges(): Boolean =
+        listOf(
+            pendingEnabled != storedEnabled,
+            pendingPreset != storedPreset,
+            pendingCustomAlpha != storedCustomAlpha,
+            pendingCodeGlanceProIntegration != storedCodeGlanceProIntegration,
+            pendingErrorHighlight != storedErrorHighlight,
+        ).any { it }
 
     override fun apply() {
         if (!isModified()) return
         val state = AyuIslandsSettings.getInstance().state
-        val externalChanged =
-            pendingExternalThemeEnhancements != storedExternalThemeEnhancements ||
-                pendingExternalAccentSource != storedExternalAccentSource ||
-                pendingExternalAccent != storedExternalAccent
+        val externalChanged = hasExternalChanges()
         if (externalChanged) {
             state.externalThemeEnhancementsEnabled = pendingExternalThemeEnhancements
+            pendingExternalInheritance.applyTo(state)
             state.externalThemeAccentSource = pendingExternalAccentSource
             state.externalThemeAccent = pendingExternalAccent
             storedExternalThemeEnhancements = pendingExternalThemeEnhancements
+            storedExternalInheritance = pendingExternalInheritance
             storedExternalAccentSource = pendingExternalAccentSource
             storedExternalAccent = pendingExternalAccent
         }
@@ -349,12 +443,7 @@ class PluginsPanel : AyuIslandsSettingsPanel {
             SyntaxIntensityService.getInstance().reapplyForActiveLaf()
         }
 
-        val premiumChanged =
-            pendingEnabled != storedEnabled ||
-                pendingPreset != storedPreset ||
-                pendingCustomAlpha != storedCustomAlpha ||
-                pendingCodeGlanceProIntegration != storedCodeGlanceProIntegration ||
-                pendingErrorHighlight != storedErrorHighlight
+        val premiumChanged = hasPremiumChanges()
         if (!premiumChanged) return
         if (!LicenseChecker.isLicensedOrGrace()) return
 
@@ -385,6 +474,7 @@ class PluginsPanel : AyuIslandsSettingsPanel {
         pendingErrorHighlight = storedErrorHighlight
         pendingIgnorePluginSyntaxColors = storedIgnorePluginSyntaxColors
         pendingExternalThemeEnhancements = storedExternalThemeEnhancements
+        pendingExternalInheritance = storedExternalInheritance
         pendingExternalAccentSource = storedExternalAccentSource
         pendingExternalAccent = storedExternalAccent
 
@@ -394,6 +484,10 @@ class PluginsPanel : AyuIslandsSettingsPanel {
         errorHighlightCheckbox?.isSelected = storedErrorHighlight
         ignorePluginCheckbox?.isSelected = storedIgnorePluginSyntaxColors
         externalThemeCheckbox?.isSelected = storedExternalThemeEnhancements
+        externalQuickSwitcherCheckbox?.isSelected = storedExternalInheritance.isQuickSwitcherEnabled
+        externalGlowCheckbox?.isSelected = storedExternalInheritance.isGlowEnabled
+        externalCodeGlanceProCheckbox?.isSelected = storedExternalInheritance.isCodeGlanceProEnabled
+        externalIndentRainbowCheckbox?.isSelected = storedExternalInheritance.isIndentRainbowEnabled
         externalAccentSourceCombo?.selectedItem = ExternalAccentSource.fromName(storedExternalAccentSource)
         externalAccentPicker?.selectedHex = storedExternalAccent
         presetSegmented?.selectedItem = IndentPreset.fromName(storedPreset)
@@ -403,6 +497,30 @@ class PluginsPanel : AyuIslandsSettingsPanel {
         irEnabled.set(pendingEnabled || !licensed)
         customModeVisible.set(isCustomIndentControlsVisible(licensed))
         suppressListeners = false
+    }
+
+    private data class ExternalInheritanceSettings(
+        val isQuickSwitcherEnabled: Boolean = true,
+        val isGlowEnabled: Boolean = false,
+        val isCodeGlanceProEnabled: Boolean = true,
+        val isIndentRainbowEnabled: Boolean = true,
+    ) {
+        fun applyTo(state: AyuIslandsState) {
+            state.externalThemeQuickSwitcherEnabled = isQuickSwitcherEnabled
+            state.externalThemeGlowEnabled = isGlowEnabled
+            state.externalThemeCodeGlanceProEnabled = isCodeGlanceProEnabled
+            state.externalThemeIndentRainbowEnabled = isIndentRainbowEnabled
+        }
+
+        companion object {
+            fun fromState(state: AyuIslandsState): ExternalInheritanceSettings =
+                ExternalInheritanceSettings(
+                    isQuickSwitcherEnabled = state.externalThemeQuickSwitcherEnabled,
+                    isGlowEnabled = state.externalThemeGlowEnabled,
+                    isCodeGlanceProEnabled = state.externalThemeCodeGlanceProEnabled,
+                    isIndentRainbowEnabled = state.externalThemeIndentRainbowEnabled,
+                )
+        }
     }
 
     companion object {

--- a/src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
@@ -10,12 +10,13 @@ import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.dsl.builder.RightGap
 import com.intellij.ui.dsl.builder.Row
 import com.intellij.ui.dsl.builder.SegmentedButton
-import com.intellij.ui.dsl.builder.panel
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentDefaults
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.ExternalAccentSource
 import dev.ayuislands.accent.conflict.ConflictRegistry
+import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.indent.IndentPreset
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.mappings.AccentSwatchPickerRow
@@ -27,28 +28,9 @@ import javax.swing.JSlider
 
 /** Plugin's tab: third-party plugin integrations (CodeGlance Pro, Indent Rainbow). */
 class PluginsPanel : AyuIslandsSettingsPanel {
-    private var pendingEnabled: Boolean = false
-    private var storedEnabled: Boolean = false
-    private var pendingPreset: String = IndentPreset.AMBIENT.name
-    private var storedPreset: String = IndentPreset.AMBIENT.name
-    private var pendingCustomAlpha: Int = IndentPreset.DEFAULT_ALPHA
-    private var storedCustomAlpha: Int = IndentPreset.DEFAULT_ALPHA
-    private var pendingCodeGlanceProIntegration: Boolean = false
-    private var storedCodeGlanceProIntegration: Boolean = false
-    private var pendingErrorHighlight: Boolean = true
-    private var storedErrorHighlight: Boolean = true
-    private var pendingIgnorePluginSyntaxColors: Boolean = true
-    private var storedIgnorePluginSyntaxColors: Boolean = true
-    private var pendingExternalThemeEnhancements: Boolean = false
-    private var storedExternalThemeEnhancements: Boolean = false
-    private var pendingExternalInheritance = ExternalInheritanceSettings()
-    private var storedExternalInheritance = ExternalInheritanceSettings()
-    private var pendingExternalAccentSource: String = ExternalAccentSource.AUTOMATIC.name
-    private var storedExternalAccentSource: String = ExternalAccentSource.AUTOMATIC.name
-    private var pendingExternalAccent: String = AccentDefaults.MIRAGE_HEX
-    private var storedExternalAccent: String = AccentDefaults.MIRAGE_HEX
+    private var pendingSettings = PluginSettingsSnapshot()
+    private var storedSettings = PluginSettingsSnapshot()
 
-    private var variant: AyuVariant? = null
     private var enabledCheckbox: JCheckBox? = null
     private var cgpCheckbox: JCheckBox? = null
     private var errorHighlightCheckbox: JCheckBox? = null
@@ -71,7 +53,6 @@ class PluginsPanel : AyuIslandsSettingsPanel {
         panel: Panel,
         variant: AyuVariant,
     ) {
-        this.variant = variant
         val state = AyuIslandsSettings.getInstance().state
         val gate =
             PremiumFeatureGate(
@@ -85,7 +66,7 @@ class PluginsPanel : AyuIslandsSettingsPanel {
 
         loadStored(state)
         customModeVisible.set(isCustomIndentControlsVisible(licensed))
-        irEnabled.set(pendingEnabled || !licensed)
+        irEnabled.set(pendingSettings.isIndentRainbowEnabled || !licensed)
 
         val cgpDetected = ConflictRegistry.isCodeGlanceProDetected()
         val irDetected = ConflictRegistry.isIndentRainbowDetected()
@@ -102,30 +83,12 @@ class PluginsPanel : AyuIslandsSettingsPanel {
     }
 
     private fun loadStored(state: AyuIslandsState) {
-        storedCodeGlanceProIntegration = state.cgpIntegrationEnabled
-        pendingCodeGlanceProIntegration = storedCodeGlanceProIntegration
-        storedEnabled = state.irIntegrationEnabled
-        pendingEnabled = storedEnabled
-        storedErrorHighlight = state.irErrorHighlightEnabled
-        pendingErrorHighlight = storedErrorHighlight
-        storedIgnorePluginSyntaxColors = state.ignorePluginSyntaxColorsEnabled
-        pendingIgnorePluginSyntaxColors = storedIgnorePluginSyntaxColors
-        storedExternalThemeEnhancements = state.externalThemeEnhancementsEnabled
-        pendingExternalThemeEnhancements = storedExternalThemeEnhancements
-        storedExternalInheritance = ExternalInheritanceSettings.fromState(state)
-        pendingExternalInheritance = storedExternalInheritance
-        storedExternalAccentSource = state.externalThemeAccentSource ?: ExternalAccentSource.AUTOMATIC.name
-        pendingExternalAccentSource = storedExternalAccentSource
-        storedExternalAccent = state.externalThemeAccent ?: AccentDefaults.MIRAGE_HEX
-        pendingExternalAccent = storedExternalAccent
-        storedPreset = state.indentPresetName ?: IndentPreset.AMBIENT.name
-        pendingPreset = storedPreset
-        storedCustomAlpha = state.indentCustomAlpha
-        pendingCustomAlpha = storedCustomAlpha
+        storedSettings = PluginSettingsSnapshot.fromState(state)
+        pendingSettings = storedSettings
     }
 
     private fun isCustomIndentControlsVisible(licensed: Boolean): Boolean =
-        IndentPreset.fromName(pendingPreset) == IndentPreset.CUSTOM || !licensed
+        IndentPreset.fromName(pendingSettings.indentPresetName) == IndentPreset.CUSTOM || !licensed
 
     private fun Panel.buildNoSupportedPluginsMessage() {
         row {
@@ -167,9 +130,10 @@ class PluginsPanel : AyuIslandsSettingsPanel {
             val checkboxCell =
                 checkBox(".ignore syntax colors")
                     .comment("Use Ayu colors for .ignore files")
-            checkboxCell.component.isSelected = pendingIgnorePluginSyntaxColors
+            checkboxCell.component.isSelected = pendingSettings.isIgnorePluginSyntaxColorsEnabled
             checkboxCell.component.addActionListener {
-                pendingIgnorePluginSyntaxColors = checkboxCell.component.isSelected
+                pendingSettings =
+                    pendingSettings.copy(isIgnorePluginSyntaxColorsEnabled = checkboxCell.component.isSelected)
             }
             ignorePluginCheckbox = checkboxCell.component
         }
@@ -183,9 +147,10 @@ class PluginsPanel : AyuIslandsSettingsPanel {
                         .comment(
                             "Use selected Ayu features when the active IDE theme is not Ayu.",
                         )
-                checkboxCell.component.isSelected = pendingExternalThemeEnhancements
+                checkboxCell.component.isSelected = pendingSettings.isExternalThemeEnhancementsEnabled
                 checkboxCell.component.addActionListener {
-                    pendingExternalThemeEnhancements = checkboxCell.component.isSelected
+                    pendingSettings =
+                        pendingSettings.copy(isExternalThemeEnhancementsEnabled = checkboxCell.component.isSelected)
                 }
                 externalThemeCheckbox = checkboxCell.component
             }
@@ -240,12 +205,18 @@ class PluginsPanel : AyuIslandsSettingsPanel {
                         val combo =
                             comboBox(ExternalAccentSource.entries.toList())
                                 .component
-                        combo.selectedItem = ExternalAccentSource.fromName(pendingExternalAccentSource)
+                        combo.selectedItem = ExternalAccentSource.fromName(pendingSettings.externalAccentSource)
                         combo.renderer = SimpleListCellRenderer.create("") { it.displayName }
                         combo.addActionListener {
                             if (suppressListeners) return@addActionListener
-                            pendingExternalAccentSource =
-                                (combo.selectedItem as? ExternalAccentSource ?: ExternalAccentSource.AUTOMATIC).name
+                            pendingSettings =
+                                pendingSettings.copy(
+                                    externalAccentSource =
+                                        (
+                                            combo.selectedItem as? ExternalAccentSource
+                                                ?: ExternalAccentSource.AUTOMATIC
+                                        ).name,
+                                )
                         }
                         externalAccentSourceCombo = combo
                     }
@@ -258,11 +229,14 @@ class PluginsPanel : AyuIslandsSettingsPanel {
                     row("External accent") {
                         val picker =
                             AccentSwatchPickerRow { selected ->
-                                pendingExternalAccent = selected
-                                pendingExternalAccentSource = ExternalAccentSource.MANUAL.name
+                                pendingSettings =
+                                    pendingSettings.copy(
+                                        externalAccent = selected,
+                                        externalAccentSource = ExternalAccentSource.MANUAL.name,
+                                    )
                                 externalAccentSourceCombo?.selectedItem = ExternalAccentSource.MANUAL
                             }
-                        picker.selectedHex = pendingExternalAccent
+                        picker.selectedHex = pendingSettings.externalAccent
                         externalAccentPicker = picker
                         cell(picker)
                             .comment("Used in Manual mode and as the final Automatic fallback")
@@ -279,26 +253,47 @@ class PluginsPanel : AyuIslandsSettingsPanel {
         storeCheckbox: (JCheckBox) -> Unit,
     ) {
         val checkboxCell = checkBox(label)
-        checkboxCell.component.isSelected = isSelected(pendingExternalInheritance)
+        checkboxCell.component.isSelected = isSelected(pendingSettings.externalInheritance)
         checkboxCell.component.addActionListener {
-            pendingExternalInheritance =
-                pendingExternalInheritance.updateSelection(checkboxCell.component.isSelected)
+            pendingSettings =
+                pendingSettings.copy(
+                    externalInheritance =
+                        pendingSettings.externalInheritance.updateSelection(checkboxCell.component.isSelected),
+                )
         }
         storeCheckbox(checkboxCell.component)
     }
 
+    private fun Row.buildLicensedCheckbox(
+        labelText: String,
+        description: String,
+        licensed: Boolean,
+        isSelected: Boolean,
+        onSelectionChanged: (Boolean) -> Unit,
+    ): JCheckBox {
+        val checkboxCell =
+            checkBox(labelText)
+                .comment(description)
+        checkboxCell.component.isSelected = isSelected
+        checkboxCell.component.isEnabled = licensed
+        checkboxCell.component.addActionListener {
+            if (!licensed) return@addActionListener
+            onSelectionChanged(checkboxCell.component.isSelected)
+        }
+        return checkboxCell.component
+    }
+
     private fun Panel.buildCodeGlanceProRow(licensed: Boolean) {
         row {
-            val checkboxCell =
-                checkBox("CodeGlance Pro viewport")
-                    .comment("Apply accent color to the CodeGlance Pro viewport")
-            checkboxCell.component.isSelected = pendingCodeGlanceProIntegration
-            checkboxCell.component.isEnabled = licensed
-            checkboxCell.component.addActionListener {
-                if (!licensed) return@addActionListener
-                pendingCodeGlanceProIntegration = checkboxCell.component.isSelected
-            }
-            cgpCheckbox = checkboxCell.component
+            cgpCheckbox =
+                buildLicensedCheckbox(
+                    labelText = "CodeGlance Pro viewport",
+                    description = "Apply accent color to the CodeGlance Pro viewport",
+                    licensed = licensed,
+                    isSelected = pendingSettings.isCodeGlanceProEnabled,
+                ) { isSelected ->
+                    pendingSettings = pendingSettings.copy(isCodeGlanceProEnabled = isSelected)
+                }
 
             browserLink("Plugin page", "https://plugins.jetbrains.com/plugin/18824-codeglance-pro")
         }
@@ -309,17 +304,16 @@ class PluginsPanel : AyuIslandsSettingsPanel {
         irEnabled: AtomicBooleanProperty,
     ) {
         row {
-            val checkboxCell =
-                checkBox("Indent Rainbow guides")
-                    .comment("Sync the Ayu palette with Indent Rainbow indentation guides")
-            checkboxCell.component.isSelected = pendingEnabled
-            checkboxCell.component.isEnabled = licensed
-            checkboxCell.component.addActionListener {
-                if (!licensed) return@addActionListener
-                pendingEnabled = checkboxCell.component.isSelected
-                irEnabled.set(checkboxCell.component.isSelected)
-            }
-            enabledCheckbox = checkboxCell.component
+            enabledCheckbox =
+                buildLicensedCheckbox(
+                    labelText = "Indent Rainbow guides",
+                    description = "Sync the Ayu palette with Indent Rainbow indentation guides",
+                    licensed = licensed,
+                    isSelected = pendingSettings.isIndentRainbowEnabled,
+                ) { isSelected ->
+                    pendingSettings = pendingSettings.copy(isIndentRainbowEnabled = isSelected)
+                    irEnabled.set(isSelected)
+                }
 
             browserLink(
                 "Plugin page",
@@ -343,12 +337,12 @@ class PluginsPanel : AyuIslandsSettingsPanel {
                     text = preset.displayName
                 }
             segmented.maxButtonsCount(IndentPreset.entries.size)
-            segmented.selectedItem = IndentPreset.fromName(pendingPreset)
+            segmented.selectedItem = IndentPreset.fromName(pendingSettings.indentPresetName)
             segmented.enabled(licensed)
             @Suppress("UnstableApiUsage")
             segmented.whenItemSelected { preset ->
                 if (!suppressListeners && licensed) {
-                    pendingPreset = preset.name
+                    pendingSettings = pendingSettings.copy(indentPresetName = preset.name)
                     customModeVisible.set(preset == IndentPreset.CUSTOM)
                 }
             }
@@ -361,30 +355,29 @@ class PluginsPanel : AyuIslandsSettingsPanel {
         irEnabled: AtomicBooleanProperty,
     ) {
         row {
-            val checkboxCell =
-                checkBox("Highlight indent errors")
-                    .comment("When off, lines with irregular indentation blend into the color gradient")
-            checkboxCell.component.isSelected = pendingErrorHighlight
-            checkboxCell.component.isEnabled = licensed
-            checkboxCell.component.addActionListener {
-                if (!licensed) return@addActionListener
-                pendingErrorHighlight = checkboxCell.component.isSelected
-            }
-            errorHighlightCheckbox = checkboxCell.component
+            errorHighlightCheckbox =
+                buildLicensedCheckbox(
+                    labelText = "Highlight indent errors",
+                    description = "When off, lines with irregular indentation blend into the color gradient",
+                    licensed = licensed,
+                    isSelected = pendingSettings.isErrorHighlightEnabled,
+                ) { isSelected ->
+                    pendingSettings = pendingSettings.copy(isErrorHighlightEnabled = isSelected)
+                }
         }.visibleIf(irEnabled)
     }
 
     private fun Panel.buildIndentRainbowAlphaRow(licensed: Boolean) {
         row {
             label("Alpha")
-            val slider = JSlider(MIN_ALPHA, MAX_ALPHA, pendingCustomAlpha)
+            val slider = JSlider(MIN_ALPHA, MAX_ALPHA, pendingSettings.indentCustomAlpha)
             slider.paintTicks = true
             slider.majorTickSpacing = ALPHA_MAJOR_TICK
             slider.isEnabled = licensed
             val valueLabel = JLabel("${slider.value}")
             slider.addChangeListener {
                 if (!suppressListeners && licensed) {
-                    pendingCustomAlpha = slider.value
+                    pendingSettings = pendingSettings.copy(indentCustomAlpha = slider.value)
                     valueLabel.text = "${slider.value}"
                 }
             }
@@ -395,108 +388,159 @@ class PluginsPanel : AyuIslandsSettingsPanel {
         }.visibleIf(customModeVisible)
     }
 
-    override fun isModified(): Boolean =
-        pendingEnabled != storedEnabled ||
-            pendingPreset != storedPreset ||
-            pendingCustomAlpha != storedCustomAlpha ||
-            pendingCodeGlanceProIntegration != storedCodeGlanceProIntegration ||
-            pendingErrorHighlight != storedErrorHighlight ||
-            pendingIgnorePluginSyntaxColors != storedIgnorePluginSyntaxColors ||
-            hasExternalChanges()
+    override fun isModified(): Boolean = pendingSettings != storedSettings
 
-    private fun hasExternalChanges(): Boolean =
-        listOf(
-            pendingExternalThemeEnhancements != storedExternalThemeEnhancements,
-            pendingExternalInheritance != storedExternalInheritance,
-            pendingExternalAccentSource != storedExternalAccentSource,
-            pendingExternalAccent != storedExternalAccent,
-        ).any { it }
+    private fun hasExternalChanges(): Boolean = pendingSettings.hasExternalChangesFrom(storedSettings)
 
-    private fun hasPremiumChanges(): Boolean =
-        listOf(
-            pendingEnabled != storedEnabled,
-            pendingPreset != storedPreset,
-            pendingCustomAlpha != storedCustomAlpha,
-            pendingCodeGlanceProIntegration != storedCodeGlanceProIntegration,
-            pendingErrorHighlight != storedErrorHighlight,
-        ).any { it }
+    private fun hasPremiumChanges(): Boolean = pendingSettings.hasPremiumChangesFrom(storedSettings)
 
     override fun apply() {
         if (!isModified()) return
         val state = AyuIslandsSettings.getInstance().state
         val externalChanged = hasExternalChanges()
         if (externalChanged) {
-            state.externalThemeEnhancementsEnabled = pendingExternalThemeEnhancements
-            pendingExternalInheritance.applyTo(state)
-            state.externalThemeAccentSource = pendingExternalAccentSource
-            state.externalThemeAccent = pendingExternalAccent
-            storedExternalThemeEnhancements = pendingExternalThemeEnhancements
-            storedExternalInheritance = pendingExternalInheritance
-            storedExternalAccentSource = pendingExternalAccentSource
-            storedExternalAccent = pendingExternalAccent
+            pendingSettings.applyExternalTo(state)
+            storedSettings =
+                storedSettings.copy(
+                    isExternalThemeEnhancementsEnabled = pendingSettings.isExternalThemeEnhancementsEnabled,
+                    externalInheritance = pendingSettings.externalInheritance,
+                    externalAccentSource = pendingSettings.externalAccentSource,
+                    externalAccent = pendingSettings.externalAccent,
+                )
         }
 
-        val ignorePluginChanged = pendingIgnorePluginSyntaxColors != storedIgnorePluginSyntaxColors
+        val ignorePluginChanged =
+            pendingSettings.isIgnorePluginSyntaxColorsEnabled != storedSettings.isIgnorePluginSyntaxColorsEnabled
         if (ignorePluginChanged) {
-            state.ignorePluginSyntaxColorsEnabled = pendingIgnorePluginSyntaxColors
-            storedIgnorePluginSyntaxColors = pendingIgnorePluginSyntaxColors
+            state.ignorePluginSyntaxColorsEnabled = pendingSettings.isIgnorePluginSyntaxColorsEnabled
+            storedSettings =
+                storedSettings.copy(
+                    isIgnorePluginSyntaxColorsEnabled = pendingSettings.isIgnorePluginSyntaxColorsEnabled,
+                )
             SyntaxIntensityService.getInstance().reapplyForActiveLaf()
         }
 
         val premiumChanged = hasPremiumChanges()
-        if (!premiumChanged) return
-        if (!LicenseChecker.isLicensedOrGrace()) return
+        val premiumApplied =
+            if (premiumChanged && LicenseChecker.isLicensedOrGrace()) {
+                pendingSettings.applyPremiumTo(state)
+                storedSettings =
+                    storedSettings.copy(
+                        isIndentRainbowEnabled = pendingSettings.isIndentRainbowEnabled,
+                        indentPresetName = pendingSettings.indentPresetName,
+                        indentCustomAlpha = pendingSettings.indentCustomAlpha,
+                        isCodeGlanceProEnabled = pendingSettings.isCodeGlanceProEnabled,
+                        isErrorHighlightEnabled = pendingSettings.isErrorHighlightEnabled,
+                    )
+                true
+            } else {
+                false
+            }
 
-        state.irIntegrationEnabled = pendingEnabled
-        state.indentPresetName = pendingPreset
-        state.indentCustomAlpha = pendingCustomAlpha
-        state.cgpIntegrationEnabled = pendingCodeGlanceProIntegration
-        state.irErrorHighlightEnabled = pendingErrorHighlight
+        if (externalChanged || premiumApplied) {
+            applyVisibleAccentSurfaces(externalChanged)
+        }
+    }
 
-        storedEnabled = pendingEnabled
-        storedPreset = pendingPreset
-        storedCustomAlpha = pendingCustomAlpha
-        storedCodeGlanceProIntegration = pendingCodeGlanceProIntegration
-        storedErrorHighlight = pendingErrorHighlight
-
-        // Route through AccentApplicator.applyForFocusedProject so per-project/per-language
-        // overrides are preserved during the settings apply cycle (PluginsPanel runs after
-        // AccentPanel in Configurable.apply).
-        val currentVariant = variant ?: return
-        AccentApplicator.applyForFocusedProject(currentVariant)
+    private fun applyVisibleAccentSurfaces(externalChanged: Boolean) {
+        val context = AccentContext.detect()
+        when {
+            context != null -> {
+                AccentApplicator.applyForFocusedProject(context)
+                if (context == AccentContext.External) {
+                    GlowOverlayManager.syncGlowForAllProjects()
+                }
+            }
+            externalChanged -> {
+                AccentApplicator.revertAll()
+                GlowOverlayManager.syncGlowForAllProjects()
+            }
+        }
     }
 
     override fun reset() {
-        pendingEnabled = storedEnabled
-        pendingPreset = storedPreset
-        pendingCustomAlpha = storedCustomAlpha
-        pendingCodeGlanceProIntegration = storedCodeGlanceProIntegration
-        pendingErrorHighlight = storedErrorHighlight
-        pendingIgnorePluginSyntaxColors = storedIgnorePluginSyntaxColors
-        pendingExternalThemeEnhancements = storedExternalThemeEnhancements
-        pendingExternalInheritance = storedExternalInheritance
-        pendingExternalAccentSource = storedExternalAccentSource
-        pendingExternalAccent = storedExternalAccent
+        pendingSettings = storedSettings
 
         suppressListeners = true
-        enabledCheckbox?.isSelected = storedEnabled
-        cgpCheckbox?.isSelected = storedCodeGlanceProIntegration
-        errorHighlightCheckbox?.isSelected = storedErrorHighlight
-        ignorePluginCheckbox?.isSelected = storedIgnorePluginSyntaxColors
-        externalThemeCheckbox?.isSelected = storedExternalThemeEnhancements
-        externalQuickSwitcherCheckbox?.isSelected = storedExternalInheritance.isQuickSwitcherEnabled
-        externalGlowCheckbox?.isSelected = storedExternalInheritance.isGlowEnabled
-        externalCodeGlanceProCheckbox?.isSelected = storedExternalInheritance.isCodeGlanceProEnabled
-        externalIndentRainbowCheckbox?.isSelected = storedExternalInheritance.isIndentRainbowEnabled
-        externalAccentSourceCombo?.selectedItem = ExternalAccentSource.fromName(storedExternalAccentSource)
-        externalAccentPicker?.selectedHex = storedExternalAccent
-        presetSegmented?.selectedItem = IndentPreset.fromName(storedPreset)
-        alphaSlider?.value = storedCustomAlpha
-        alphaValueLabel?.text = "$storedCustomAlpha"
+        enabledCheckbox?.isSelected = storedSettings.isIndentRainbowEnabled
+        cgpCheckbox?.isSelected = storedSettings.isCodeGlanceProEnabled
+        errorHighlightCheckbox?.isSelected = storedSettings.isErrorHighlightEnabled
+        ignorePluginCheckbox?.isSelected = storedSettings.isIgnorePluginSyntaxColorsEnabled
+        externalThemeCheckbox?.isSelected = storedSettings.isExternalThemeEnhancementsEnabled
+        externalQuickSwitcherCheckbox?.isSelected = storedSettings.externalInheritance.isQuickSwitcherEnabled
+        externalGlowCheckbox?.isSelected = storedSettings.externalInheritance.isGlowEnabled
+        externalCodeGlanceProCheckbox?.isSelected = storedSettings.externalInheritance.isCodeGlanceProEnabled
+        externalIndentRainbowCheckbox?.isSelected = storedSettings.externalInheritance.isIndentRainbowEnabled
+        externalAccentSourceCombo?.selectedItem = ExternalAccentSource.fromName(storedSettings.externalAccentSource)
+        externalAccentPicker?.selectedHex = storedSettings.externalAccent
+        presetSegmented?.selectedItem = IndentPreset.fromName(storedSettings.indentPresetName)
+        alphaSlider?.value = storedSettings.indentCustomAlpha
+        alphaValueLabel?.text = "${storedSettings.indentCustomAlpha}"
         val licensed = LicenseChecker.isLicensedOrGrace()
-        irEnabled.set(pendingEnabled || !licensed)
+        irEnabled.set(pendingSettings.isIndentRainbowEnabled || !licensed)
         customModeVisible.set(isCustomIndentControlsVisible(licensed))
         suppressListeners = false
+    }
+
+    private data class PluginSettingsSnapshot(
+        val isIndentRainbowEnabled: Boolean = false,
+        val indentPresetName: String = IndentPreset.AMBIENT.name,
+        val indentCustomAlpha: Int = IndentPreset.DEFAULT_ALPHA,
+        val isCodeGlanceProEnabled: Boolean = false,
+        val isErrorHighlightEnabled: Boolean = true,
+        val isIgnorePluginSyntaxColorsEnabled: Boolean = true,
+        val isExternalThemeEnhancementsEnabled: Boolean = false,
+        val externalInheritance: ExternalInheritanceSettings = ExternalInheritanceSettings(),
+        val externalAccentSource: String = ExternalAccentSource.AUTOMATIC.name,
+        val externalAccent: String = AccentDefaults.MIRAGE_HEX,
+    ) {
+        fun hasExternalChangesFrom(stored: PluginSettingsSnapshot): Boolean =
+            listOf(
+                isExternalThemeEnhancementsEnabled != stored.isExternalThemeEnhancementsEnabled,
+                externalInheritance != stored.externalInheritance,
+                externalAccentSource != stored.externalAccentSource,
+                externalAccent != stored.externalAccent,
+            ).any { it }
+
+        fun hasPremiumChangesFrom(stored: PluginSettingsSnapshot): Boolean =
+            listOf(
+                isIndentRainbowEnabled != stored.isIndentRainbowEnabled,
+                indentPresetName != stored.indentPresetName,
+                indentCustomAlpha != stored.indentCustomAlpha,
+                isCodeGlanceProEnabled != stored.isCodeGlanceProEnabled,
+                isErrorHighlightEnabled != stored.isErrorHighlightEnabled,
+            ).any { it }
+
+        fun applyExternalTo(state: AyuIslandsState) {
+            state.externalThemeEnhancementsEnabled = isExternalThemeEnhancementsEnabled
+            externalInheritance.applyTo(state)
+            state.externalThemeAccentSource = externalAccentSource
+            state.externalThemeAccent = externalAccent
+        }
+
+        fun applyPremiumTo(state: AyuIslandsState) {
+            state.irIntegrationEnabled = isIndentRainbowEnabled
+            state.indentPresetName = indentPresetName
+            state.indentCustomAlpha = indentCustomAlpha
+            state.cgpIntegrationEnabled = isCodeGlanceProEnabled
+            state.irErrorHighlightEnabled = isErrorHighlightEnabled
+        }
+
+        companion object {
+            fun fromState(state: AyuIslandsState): PluginSettingsSnapshot =
+                PluginSettingsSnapshot(
+                    isIndentRainbowEnabled = state.irIntegrationEnabled,
+                    indentPresetName = state.indentPresetName ?: IndentPreset.AMBIENT.name,
+                    indentCustomAlpha = state.indentCustomAlpha,
+                    isCodeGlanceProEnabled = state.cgpIntegrationEnabled,
+                    isErrorHighlightEnabled = state.irErrorHighlightEnabled,
+                    isIgnorePluginSyntaxColorsEnabled = state.ignorePluginSyntaxColorsEnabled,
+                    isExternalThemeEnhancementsEnabled = state.externalThemeEnhancementsEnabled,
+                    externalInheritance = ExternalInheritanceSettings.fromState(state),
+                    externalAccentSource = state.externalThemeAccentSource ?: ExternalAccentSource.AUTOMATIC.name,
+                    externalAccent = state.externalThemeAccent ?: AccentDefaults.MIRAGE_HEX,
+                )
+        }
     }
 
     private data class ExternalInheritanceSettings(

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapService.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapService.kt
@@ -8,11 +8,12 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.WindowManager
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentChangedTopic
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
-import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.indent.IndentRainbowSync
 import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
 import dev.ayuislands.ui.ComponentTreeRefresher
 import org.jetbrains.annotations.TestOnly
 import java.awt.AWTEvent
@@ -61,6 +62,11 @@ class ProjectAccentSwapService : Disposable {
     @Volatile
     private var windowManagerUnavailableLogged: Boolean = false
 
+    private data class EffectiveAccent(
+        val context: AccentContext,
+        val hex: String,
+    )
+
     fun install() {
         if (listener != null) return
         val awtListener =
@@ -102,71 +108,14 @@ class ProjectAccentSwapService : Disposable {
         val project = findProjectForWindow(window) ?: return
         if (project.isDisposed || project.isDefault) return
 
-        // Re-resolve on every activation. Alt-tab away to a non-IDE app and back reports the
-        // same project, but any external apply (rotation tick, Settings panel Apply, LAF
-        // change — anything that reaches `notifyExternalApply`) may have pushed a different
-        // color into the JVM-wide UIManager/globalScheme since the last activation. The
-        // resolver call is cheap (canonicalPath + HashMap lookup); the hex gate below still
-        // skips the expensive apply when the resolver output matches.
-        val variant = AyuVariant.detect() ?: return
-        val effectiveHex = AccentResolver.resolve(project, variant)
+        val effectiveAccent = resolveEffectiveAccent(project) ?: return
 
-        val hexChanged = effectiveHex != lastAppliedHex
+        val hexChanged = effectiveAccent.hex != lastAppliedHex
         if (hexChanged) {
-            // Different hex from last apply: re-run the full apply path. UIManager
-            // writes, EP elements, editor keys, AND integrations are all refreshed
-            // through AccentApplicator.applyFromHexString -> apply.
-            val applied = AccentApplicator.applyFromHexString(effectiveHex)
-            if (!applied) {
-                LOG.warn("Skipping swap publish: applyFromHexString rejected '$effectiveHex'")
-                return
-            }
-            lastAppliedHex = effectiveHex
+            if (!applyChangedHex(effectiveAccent.hex)) return
         } else {
-            // Same hex but a different project just gained focus (or alt-tab back to the
-            // same project). The app-scoped CGP `CodeGlanceConfigService` and IR `IrConfig`
-            // caches still hold whoever wrote last; force-refresh them so the newly-focused
-            // minimap + indent panels paint the correct per-project accent.
-            //
-            // walkAndNotify alone CANNOT close this gap because CGP and IR do not subscribe
-            // to ComponentTreeRefreshedTopic — they read from the app-scoped cache directly.
-            // The two calls below push the per-project hex into those caches without
-            // re-running the apply path's UIManager work (already correct for the unchanged
-            // hex).
-            //
-            // Pattern J — gate IR refresh on the integration toggle. IndentRainbowSync.apply
-            // itself reverts when irIntegrationEnabled is false, so calling it on every
-            // alt-tab from a user who disabled IR would silently re-stamp IR's IrConfig
-            // with a DEFAULT palette write per focus swap. Skip the call entirely so a
-            // disabled integration is truly disabled, not "disabled with a side-effect on
-            // every focus swap". CGP gates internally and short-circuits the same way.
-            AccentApplicator.syncCodeGlanceProViewportForSwap(effectiveHex)
-            if (AyuIslandsSettings.getInstance().state.irIntegrationEnabled) {
-                IndentRainbowSync.apply(variant, effectiveHex)
-            }
-
-            // Same-hex focus swap does NOT re-enter AccentApplicator.apply (whose
-            // publish would fire), so we publish AccentChangedTopic here. Without
-            // this, focus swap between two projects sharing a hex leaves chip /
-            // stripe stuck on the prior project's resolution source label (e.g.
-            // "Global" vs "Project override"). Pattern B isolates a throwing
-            // subscriber.
-            try {
-                val source = AccentResolver.source(project)
-                // Pattern K — `effectiveHex` comes from `AccentResolver.resolve`
-                // whose contract guarantees a validated `#RRGGBB` string;
-                // wrap via `unsafeOf` to surface the contract in the type.
-                ApplicationManager
-                    .getApplication()
-                    .messageBus
-                    .syncPublisher(AccentChangedTopic.TOPIC)
-                    .accentChanged(project, AccentHex.unsafeOf(effectiveHex), source)
-            } catch (exception: RuntimeException) {
-                LOG.warn(
-                    "AccentChangedTopic publish failed in same-hex swap for ${project.name}",
-                    exception,
-                )
-            }
+            refreshSameHexIntegrations(effectiveAccent)
+            publishSameHexAccentChanged(project, effectiveAccent.hex)
         }
 
         // Always refresh the component tree on focus swap — preserves the
@@ -178,8 +127,101 @@ class ProjectAccentSwapService : Disposable {
         // customizations got reset by the walk (scrollbar hiders etc.) reapply themselves.
         ComponentTreeRefresher.walkAndNotify(project, window)
         LOG.info(
-            "Project accent refreshed for ${project.name} (hex=$effectiveHex, changed=$hexChanged)",
+            "Project accent refreshed for ${project.name} (hex=${effectiveAccent.hex}, changed=$hexChanged)",
         )
+    }
+
+    private fun resolveEffectiveAccent(project: Project): EffectiveAccent? {
+        // Re-resolve on every activation. Alt-tab away to a non-IDE app and back reports the
+        // same project, but any external apply (rotation tick, Settings panel Apply, LAF
+        // change — anything that reaches `notifyExternalApply`) may have pushed a different
+        // color into the JVM-wide UIManager/globalScheme since the last activation. The
+        // resolver call is cheap (canonicalPath + HashMap lookup); the hex gate still
+        // skips the expensive apply when the resolver output matches.
+        val context = AccentContext.detect() ?: return null
+        val hex =
+            when (context) {
+                is AccentContext.Ayu -> AccentResolver.resolve(project, context.ayuVariant)
+                AccentContext.External -> AccentResolver.resolve(project, context)
+            }
+        return EffectiveAccent(context, hex)
+    }
+
+    private fun applyChangedHex(hex: String): Boolean {
+        // Different hex from last apply: re-run the full apply path. UIManager
+        // writes, EP elements, editor keys, AND integrations are all refreshed
+        // through AccentApplicator.applyFromHexString -> apply.
+        val applied = AccentApplicator.applyFromHexString(hex)
+        if (!applied) {
+            LOG.warn("Skipping swap publish: applyFromHexString rejected '$hex'")
+            return false
+        }
+        lastAppliedHex = hex
+        return true
+    }
+
+    private fun refreshSameHexIntegrations(effectiveAccent: EffectiveAccent) {
+        // Same hex but a different project just gained focus (or alt-tab back to the
+        // same project). The app-scoped CGP `CodeGlanceConfigService` and IR `IrConfig`
+        // caches still hold whoever wrote last; force-refresh them so the newly-focused
+        // minimap + indent panels paint the correct per-project accent.
+        //
+        // walkAndNotify alone CANNOT close this gap because CGP and IR do not subscribe
+        // to ComponentTreeRefreshedTopic — they read from the app-scoped cache directly.
+        val state = AyuIslandsSettings.getInstance().state
+        when (val context = effectiveAccent.context) {
+            is AccentContext.Ayu -> refreshAyuIntegrations(context, effectiveAccent.hex, state)
+            AccentContext.External -> refreshExternalIntegrations(effectiveAccent.hex, state)
+        }
+    }
+
+    private fun refreshAyuIntegrations(
+        context: AccentContext.Ayu,
+        hex: String,
+        state: AyuIslandsState,
+    ) {
+        AccentApplicator.syncCodeGlanceProViewportForSwap(hex)
+        if (state.irIntegrationEnabled) {
+            IndentRainbowSync.apply(context.ayuVariant, hex)
+        }
+    }
+
+    private fun refreshExternalIntegrations(
+        hex: String,
+        state: AyuIslandsState,
+    ) {
+        AccentApplicator.syncCodeGlanceProViewportForSwap(hex, AccentContext.External)
+        if (state.irIntegrationEnabled && state.isExternalIndentRainbowAllowed()) {
+            IndentRainbowSync.apply(AccentContext.External, hex)
+        }
+    }
+
+    private fun publishSameHexAccentChanged(
+        project: Project,
+        hex: String,
+    ) {
+        // Same-hex focus swap does NOT re-enter AccentApplicator.apply (whose
+        // publish would fire), so we publish AccentChangedTopic here. Without
+        // this, focus swap between two projects sharing a hex leaves chip /
+        // stripe stuck on the prior project's resolution source label (e.g.
+        // "Global" vs "Project override"). Pattern B isolates a throwing
+        // subscriber.
+        try {
+            val source = AccentResolver.source(project)
+            // Pattern K — `hex` comes from `AccentResolver.resolve`
+            // whose contract guarantees a validated `#RRGGBB` string;
+            // wrap via `unsafeOf` to surface the contract in the type.
+            ApplicationManager
+                .getApplication()
+                .messageBus
+                .syncPublisher(AccentChangedTopic.TOPIC)
+                .accentChanged(project, AccentHex.unsafeOf(hex), source)
+        } catch (exception: RuntimeException) {
+            LOG.warn(
+                "AccentChangedTopic publish failed in same-hex swap for ${project.name}",
+                exception,
+            )
+        }
     }
 
     /**

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsAppListenerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsAppListenerTest.kt
@@ -153,7 +153,7 @@ class AyuIslandsAppListenerTest {
         verify(exactly = 1) { AccentApplicator.applyFromHexString("#5CCFE6") }
         // Resolver must NOT be consulted when cached hex is available — that's the whole
         // point of the anti-flicker cache.
-        verify(exactly = 0) { AccentResolver.resolve(any(), any()) }
+        verify(exactly = 0) { AccentResolver.resolve(any(), any<AyuVariant>()) }
     }
 
     @Test
@@ -257,7 +257,7 @@ class AyuIslandsAppListenerTest {
         listener.appFrameCreated(mutableListOf())
 
         verify(exactly = 1) { AccentApplicator.applyFromHexString("#5CCFE6") }
-        verify(exactly = 0) { AccentResolver.resolve(any(), any()) }
+        verify(exactly = 0) { AccentResolver.resolve(any(), any<AyuVariant>()) }
         assertEquals("#5CCFE6", state.lastAppliedAccentHex, "valid cached hex must remain persisted")
     }
 

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsLafListenerSyntaxReapplyTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsLafListenerSyntaxReapplyTest.kt
@@ -4,6 +4,7 @@ import com.intellij.ide.ui.LafManager
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.util.io.FileUtil
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.font.FontPresetApplicator
 import dev.ayuislands.glow.GlowOverlayManager
@@ -37,13 +38,14 @@ import kotlin.test.assertTrue
  */
 @Suppress("UnstableApiUsage")
 class AyuIslandsLafListenerSyntaxReapplyTest {
-    private val state = AyuIslandsState()
+    private lateinit var state: AyuIslandsState
     private val mockSettings = mockk<AyuIslandsSettings>(relaxed = true)
     private val mockProjectManager = mockk<ProjectManager>(relaxed = true)
     private val mockSyntaxService = mockk<SyntaxIntensityService>(relaxed = true)
 
     @BeforeTest
     fun setUp() {
+        state = AyuIslandsState()
         every { mockSettings.state } returns state
         mockkObject(AyuIslandsSettings.Companion)
         every { AyuIslandsSettings.getInstance() } returns mockSettings
@@ -60,7 +62,8 @@ class AyuIslandsLafListenerSyntaxReapplyTest {
         mockkObject(AppearanceSyncService.Companion)
         mockkObject(SyntaxIntensityService.Companion)
 
-        every { AccentApplicator.applyForFocusedProject(any<dev.ayuislands.accent.AyuVariant>()) } returns "#FFCC66"
+        every { AccentApplicator.applyForFocusedProject(any<AccentContext>()) } returns "#FFCC66"
+        every { AccentApplicator.applyForFocusedProject(any<AyuVariant>()) } returns "#FFCC66"
         every { AccentApplicator.revertAll() } returns Unit
         every { FontPresetApplicator.applyFromState() } returns Unit
         every { FontPresetApplicator.revert() } returns Unit
@@ -99,6 +102,7 @@ class AyuIslandsLafListenerSyntaxReapplyTest {
         // `detect` returns null which triggers the listener's early-return
         // BEFORE the syntax reapply block; `isAyuActive` returns false to
         // double-lock the gate at the call site for future audits.
+        state.externalThemeEnhancementsEnabled = false
         every { AyuVariant.detect() } returns null
         every { AyuVariant.isAyuActive() } returns false
         val mockLafManager = mockk<LafManager>(relaxed = true)

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsLafListenerSyntaxReapplyTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsLafListenerSyntaxReapplyTest.kt
@@ -60,7 +60,7 @@ class AyuIslandsLafListenerSyntaxReapplyTest {
         mockkObject(AppearanceSyncService.Companion)
         mockkObject(SyntaxIntensityService.Companion)
 
-        every { AccentApplicator.applyForFocusedProject(any()) } returns "#FFCC66"
+        every { AccentApplicator.applyForFocusedProject(any<dev.ayuislands.accent.AyuVariant>()) } returns "#FFCC66"
         every { AccentApplicator.revertAll() } returns Unit
         every { FontPresetApplicator.applyFromState() } returns Unit
         every { FontPresetApplicator.revert() } returns Unit

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsLafListenerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsLafListenerTest.kt
@@ -149,7 +149,7 @@ class AyuIslandsLafListenerTest {
     }
 
     @Test
-    fun `lookAndFeelChanged on non-Ayu LAF with external mode applies external context`() {
+    fun `lookAndFeelChanged on non-Ayu LAF with external mode cleans Ayu state then applies external context`() {
         state.syncEditorScheme = true
         state.externalThemeEnhancementsEnabled = true
         every { AyuVariant.detect() } returns null
@@ -161,8 +161,11 @@ class AyuIslandsLafListenerTest {
         AyuIslandsLafListener().lookAndFeelChanged(mockLafManager)
 
         verify(exactly = 0) { AyuEditorSchemeBinder.bindForVariant(any()) }
-        verify(exactly = 0) { AccentApplicator.revertAll() }
-        verify(exactly = 0) { FontPresetApplicator.revert() }
+        verifyOrder {
+            AccentApplicator.revertAll()
+            FontPresetApplicator.revert()
+            AccentApplicator.applyForFocusedProject(AccentContext.External)
+        }
         verify(exactly = 1) { AccentApplicator.applyForFocusedProject(AccentContext.External) }
         verify(exactly = 1) { GlowOverlayManager.syncGlowForAllProjects() }
         verify(exactly = 0) { mockSyntaxService.reapplyForActiveLaf() }

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsLafListenerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsLafListenerTest.kt
@@ -62,7 +62,7 @@ class AyuIslandsLafListenerTest {
         // resolves without reaching into `ApplicationManager.getApplication().getService(...)`.
         mockkObject(SyntaxIntensityService.Companion)
 
-        every { AccentApplicator.applyForFocusedProject(any()) } returns "#FFCC66"
+        every { AccentApplicator.applyForFocusedProject(any<dev.ayuislands.accent.AyuVariant>()) } returns "#FFCC66"
         every { AccentApplicator.revertAll() } returns Unit
         every { FontPresetApplicator.applyFromState() } returns Unit
         every { FontPresetApplicator.revert() } returns Unit

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsLafListenerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsLafListenerTest.kt
@@ -3,6 +3,7 @@ package dev.ayuislands
 import com.intellij.ide.ui.LafManager
 import com.intellij.openapi.project.ProjectManager
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.font.FontPresetApplicator
 import dev.ayuislands.glow.GlowOverlayManager
@@ -36,13 +37,14 @@ import kotlin.test.Test
  */
 @Suppress("UnstableApiUsage")
 class AyuIslandsLafListenerTest {
-    private val state = AyuIslandsState()
+    private lateinit var state: AyuIslandsState
     private val mockSettings = mockk<AyuIslandsSettings>(relaxed = true)
     private val mockProjectManager = mockk<ProjectManager>(relaxed = true)
     private val mockSyntaxService = mockk<SyntaxIntensityService>(relaxed = true)
 
     @BeforeTest
     fun setUp() {
+        state = AyuIslandsState()
         every { mockSettings.state } returns state
         mockkObject(AyuIslandsSettings.Companion)
         every { AyuIslandsSettings.getInstance() } returns mockSettings
@@ -62,7 +64,8 @@ class AyuIslandsLafListenerTest {
         // resolves without reaching into `ApplicationManager.getApplication().getService(...)`.
         mockkObject(SyntaxIntensityService.Companion)
 
-        every { AccentApplicator.applyForFocusedProject(any<dev.ayuislands.accent.AyuVariant>()) } returns "#FFCC66"
+        every { AccentApplicator.applyForFocusedProject(any<AccentContext>()) } returns "#FFCC66"
+        every { AccentApplicator.applyForFocusedProject(any<AyuVariant>()) } returns "#FFCC66"
         every { AccentApplicator.revertAll() } returns Unit
         every { FontPresetApplicator.applyFromState() } returns Unit
         every { FontPresetApplicator.revert() } returns Unit
@@ -103,7 +106,7 @@ class AyuIslandsLafListenerTest {
 
         verify(exactly = 0) { AyuEditorSchemeBinder.bindForVariant(any()) }
         // Pattern G regression lock: AccentApplicator still runs even when binder is gated off.
-        verify(exactly = 1) { AccentApplicator.applyForFocusedProject(AyuVariant.DARK) }
+        verify(exactly = 1) { AccentApplicator.applyForFocusedProject(AccentContext.Ayu(AyuVariant.DARK)) }
     }
 
     @Test
@@ -123,7 +126,7 @@ class AyuIslandsLafListenerTest {
 
         verifyOrder {
             AyuEditorSchemeBinder.bindForVariant(AyuVariant.LIGHT)
-            AccentApplicator.applyForFocusedProject(AyuVariant.LIGHT)
+            AccentApplicator.applyForFocusedProject(AccentContext.Ayu(AyuVariant.LIGHT))
         }
     }
 
@@ -133,6 +136,7 @@ class AyuIslandsLafListenerTest {
         // call the binder. The binder has no revert path (Ayu→non-Ayu would
         // require persisting the user's prior scheme — separate feature).
         state.syncEditorScheme = true
+        state.externalThemeEnhancementsEnabled = false
         every { AyuVariant.detect() } returns null
         val mockLafManager = mockk<LafManager>(relaxed = true)
 
@@ -142,5 +146,25 @@ class AyuIslandsLafListenerTest {
         verify(exactly = 1) { AccentApplicator.revertAll() }
         verify(exactly = 1) { FontPresetApplicator.revert() }
         verify(exactly = 1) { GlowOverlayManager.syncGlowForAllProjects() }
+    }
+
+    @Test
+    fun `lookAndFeelChanged on non-Ayu LAF with external mode applies external context`() {
+        state.syncEditorScheme = true
+        state.externalThemeEnhancementsEnabled = true
+        every { AyuVariant.detect() } returns null
+        every { AyuVariant.isAyuActive() } returns false
+        every { AccentApplicator.applyForFocusedProject(AccentContext.External) } returns "#AABBCC"
+        val mockLafManager = mockk<LafManager>(relaxed = true)
+        every { mockLafManager.currentUIThemeLookAndFeel.name } returns "Darcula"
+
+        AyuIslandsLafListener().lookAndFeelChanged(mockLafManager)
+
+        verify(exactly = 0) { AyuEditorSchemeBinder.bindForVariant(any()) }
+        verify(exactly = 0) { AccentApplicator.revertAll() }
+        verify(exactly = 0) { FontPresetApplicator.revert() }
+        verify(exactly = 1) { AccentApplicator.applyForFocusedProject(AccentContext.External) }
+        verify(exactly = 1) { GlowOverlayManager.syncGlowForAllProjects() }
+        verify(exactly = 0) { mockSyntaxService.reapplyForActiveLaf() }
     }
 }

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
@@ -209,8 +209,8 @@ class AyuIslandsStartupActivityTest {
     fun `execute initializes glow for external themes before non-Ayu early return`() {
         // Regression guard: external themes skip the Ayu-only startup pipeline,
         // but glow overlays still need per-project initialization when the user
-        // opted into external theme enhancements. Keep this before the early
-        // return so startup does not wait for a later LAF event to create it.
+        // opted into external Glow inheritance. Keep this before the early return
+        // so startup does not wait for a later LAF event to create it.
         val source = readStartupActivitySource()
         val earlyReturn =
             Regex(
@@ -221,7 +221,7 @@ class AyuIslandsStartupActivityTest {
         val externalGlowInitializer =
             Regex(
                 """private\s+fun\s+initializeExternalGlowIfEnabled\(project:\s*Project\)\s*\{.*?""" +
-                    """state\.externalThemeEnhancementsEnabled.*?""" +
+                    """state\.isExternalGlowAllowed\(\).*?""" +
                     """ApplicationManager\.getApplication\(\)\.invokeLater\s*\(\s*""" +
                     """\{\s*GlowOverlayManager\.getInstance\(project\)\.initialize\(\)\s*},\s*""" +
                     """project\.disposed,\s*\).*?}""",

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
@@ -206,22 +206,30 @@ class AyuIslandsStartupActivityTest {
     }
 
     @Test
-    fun `execute initializes glow for external themes before non-Ayu early return`() {
+    fun `execute applies external accents and initializes glow before non-Ayu early return`() {
         // Regression guard: external themes skip the Ayu-only startup pipeline,
-        // but glow overlays still need per-project initialization when the user
-        // opted into external Glow inheritance. Keep this before the early return
-        // so startup does not wait for a later LAF event to create it.
+        // but external accent integrations and Glow still need per-project
+        // initialization when the user opted in. Keep both before the early
+        // return so startup does not wait for a later Settings or LAF event.
         val source = readStartupActivitySource()
         val earlyReturn =
             Regex(
                 """AyuVariant\.fromThemeName\(themeName\)\s*\?:\s*return\s+""" +
-                    """initializeExternalGlowIfEnabled\(project\)""",
+                    """initializeExternalThemeIfEnabled\(project,\s*settings\)""",
+                RegexOption.DOT_MATCHES_ALL,
+            )
+        val externalStartup =
+            Regex(
+                """private\s+suspend\s+fun\s+initializeExternalThemeIfEnabled""" +
+                    """.*?state\.externalThemeEnhancementsEnabled""" +
+                    """.*?runStartupAccentOnEdt\(project,\s*AccentContext\.External\)""" +
+                    """.*?initializeExternalGlowIfEnabled\(project,\s*settings\)""",
                 RegexOption.DOT_MATCHES_ALL,
             )
         val externalGlowInitializer =
             Regex(
-                """private\s+fun\s+initializeExternalGlowIfEnabled\(project:\s*Project\)\s*\{.*?""" +
-                    """state\.isExternalGlowAllowed\(\).*?""" +
+                """private\s+fun\s+initializeExternalGlowIfEnabled""" +
+                    """.*?state\.isExternalGlowAllowed\(\).*?""" +
                     """ApplicationManager\.getApplication\(\)\.invokeLater\s*\(\s*""" +
                     """\{\s*GlowOverlayManager\.getInstance\(project\)\.initialize\(\)\s*},\s*""" +
                     """project\.disposed,\s*\).*?}""",
@@ -229,7 +237,11 @@ class AyuIslandsStartupActivityTest {
             )
         assertTrue(
             earlyReturn.containsMatchIn(source),
-            "Non-Ayu startup must route through initializeExternalGlowIfEnabled before returning",
+            "Non-Ayu startup must route through initializeExternalThemeIfEnabled before returning",
+        )
+        assertTrue(
+            externalStartup.containsMatchIn(source),
+            "External theme startup must apply AccentContext.External before returning",
         )
         assertTrue(
             externalGlowInitializer.containsMatchIn(source),

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
@@ -206,6 +206,38 @@ class AyuIslandsStartupActivityTest {
     }
 
     @Test
+    fun `execute initializes glow for external themes before non-Ayu early return`() {
+        // Regression guard: external themes skip the Ayu-only startup pipeline,
+        // but glow overlays still need per-project initialization when the user
+        // opted into external theme enhancements. Keep this before the early
+        // return so startup does not wait for a later LAF event to create it.
+        val source = readStartupActivitySource()
+        val earlyReturn =
+            Regex(
+                """AyuVariant\.fromThemeName\(themeName\)\s*\?:\s*return\s+""" +
+                    """initializeExternalGlowIfEnabled\(project\)""",
+                RegexOption.DOT_MATCHES_ALL,
+            )
+        val externalGlowInitializer =
+            Regex(
+                """private\s+fun\s+initializeExternalGlowIfEnabled\(project:\s*Project\)\s*\{.*?""" +
+                    """state\.externalThemeEnhancementsEnabled.*?""" +
+                    """ApplicationManager\.getApplication\(\)\.invokeLater\s*\(\s*""" +
+                    """\{\s*GlowOverlayManager\.getInstance\(project\)\.initialize\(\)\s*},\s*""" +
+                    """project\.disposed,\s*\).*?}""",
+                RegexOption.DOT_MATCHES_ALL,
+            )
+        assertTrue(
+            earlyReturn.containsMatchIn(source),
+            "Non-Ayu startup must route through initializeExternalGlowIfEnabled before returning",
+        )
+        assertTrue(
+            externalGlowInitializer.containsMatchIn(source),
+            "External theme startup must initialize GlowOverlayManager before the non-Ayu early return",
+        )
+    }
+
+    @Test
     fun `startup projectName is captured before the EDT hop`() {
         // Regression lock. `projectName` MUST be captured OUTSIDE
         // `withContext(Dispatchers.EDT)` so a mid-hop disposal cannot NPE

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt
@@ -168,7 +168,7 @@ class AccentApplicatorFocusedProjectTest {
 
         assertEquals("#FOCUSED", applied)
         verify(exactly = 1) { AccentResolver.resolve(focusedProject, AyuVariant.MIRAGE) }
-        verify(exactly = 0) { AccentResolver.resolve(otherProject, any()) }
+        verify(exactly = 0) { AccentResolver.resolve(otherProject, any<AyuVariant>()) }
     }
 
     @Test
@@ -284,7 +284,7 @@ class AccentApplicatorFocusedProjectTest {
 
         assertEquals("#OS", applied)
         verify(exactly = 1) { AccentResolver.resolve(osActiveProject, AyuVariant.MIRAGE) }
-        verify(exactly = 0) { AccentResolver.resolve(lastFocusedProject, any()) }
+        verify(exactly = 0) { AccentResolver.resolve(lastFocusedProject, any<AyuVariant>()) }
     }
 
     @Test
@@ -350,7 +350,7 @@ class AccentApplicatorFocusedProjectTest {
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
 
         assertEquals("#FALLBACK", applied)
-        verify(exactly = 0) { AccentResolver.resolve(disposedProject, any()) }
+        verify(exactly = 0) { AccentResolver.resolve(disposedProject, any<AyuVariant>()) }
     }
 
     @Test
@@ -495,7 +495,7 @@ class AccentApplicatorFocusedProjectTest {
 
         assertEquals("#FIRST", applied)
         verify(exactly = 1) { AccentResolver.resolve(firstProject, AyuVariant.MIRAGE) }
-        verify(exactly = 0) { AccentResolver.resolve(secondProject, any()) }
+        verify(exactly = 0) { AccentResolver.resolve(secondProject, any<AyuVariant>()) }
     }
 
     @Test
@@ -526,7 +526,7 @@ class AccentApplicatorFocusedProjectTest {
 
         assertEquals("#HEALTHY", applied)
         verify(exactly = 1) { AccentResolver.resolve(healthyProject, AyuVariant.MIRAGE) }
-        verify(exactly = 0) { AccentResolver.resolve(detachedProject, any()) }
+        verify(exactly = 0) { AccentResolver.resolve(detachedProject, any<AyuVariant>()) }
     }
 
     @Test
@@ -568,7 +568,7 @@ class AccentApplicatorFocusedProjectTest {
 
         assertEquals("#FOCUS", applied)
         verify(exactly = 1) { AccentResolver.resolve(focusedProject, AyuVariant.MIRAGE) }
-        verify(exactly = 0) { AccentResolver.resolve(projectManagerProject, any()) }
+        verify(exactly = 0) { AccentResolver.resolve(projectManagerProject, any<AyuVariant>()) }
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt
@@ -52,6 +52,7 @@ class AccentApplicatorFocusedProjectTest {
         mockkStatic(ProjectManager::class)
         mockkObject(AccentResolver)
         mockkObject(AccentApplicator, recordPrivateCalls = false)
+        every { AccentApplicator.applyFromHexString(any()) } returns true
         every { AccentApplicator.apply(any()) } answers { Unit }
 
         mockkObject(ProjectAccentSwapService.Companion)
@@ -94,13 +95,29 @@ class AccentApplicatorFocusedProjectTest {
         val manager = mockk<ProjectManager>()
         every { manager.openProjects } returns arrayOf(focused)
         every { ProjectManager.getInstance() } returns manager
-        every { AccentResolver.resolve(focused, AyuVariant.MIRAGE) } returns "#ABCDEF"
+        every { AccentResolver.resolve(focused, ayu(AyuVariant.MIRAGE)) } returns "#ABCDEF"
 
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
 
         assertEquals("#ABCDEF", applied)
         verify(exactly = 1) { AccentApplicator.applyFromHexString("#ABCDEF") }
         verify(exactly = 1) { swapService.notifyExternalApply("#ABCDEF") }
+    }
+
+    @Test
+    fun `applyForFocusedProject resolves and applies external context`() {
+        val focused = stubProject(isDefault = false, isDisposed = false)
+        val manager = mockk<ProjectManager>()
+        every { manager.openProjects } returns arrayOf(focused)
+        every { ProjectManager.getInstance() } returns manager
+        every { AccentResolver.resolve(focused, AccentContext.External) } returns "#AABBCC"
+
+        val applied = AccentApplicator.applyForFocusedProject(AccentContext.External)
+
+        assertEquals("#AABBCC", applied)
+        verify(exactly = 1) { AccentResolver.resolve(focused, AccentContext.External) }
+        verify(exactly = 1) { AccentApplicator.applyFromHexString("#AABBCC") }
+        verify(exactly = 1) { swapService.notifyExternalApply("#AABBCC") }
     }
 
     @Test
@@ -111,12 +128,12 @@ class AccentApplicatorFocusedProjectTest {
         val manager = mockk<ProjectManager>()
         every { manager.openProjects } returns arrayOf(defaultProject, disposedProject, realFocus)
         every { ProjectManager.getInstance() } returns manager
-        every { AccentResolver.resolve(realFocus, AyuVariant.DARK) } returns "#123456"
+        every { AccentResolver.resolve(realFocus, ayu(AyuVariant.DARK)) } returns "#123456"
 
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.DARK)
 
         assertEquals("#123456", applied)
-        verify(exactly = 1) { AccentResolver.resolve(realFocus, AyuVariant.DARK) }
+        verify(exactly = 1) { AccentResolver.resolve(realFocus, ayu(AyuVariant.DARK)) }
     }
 
     @Test
@@ -126,7 +143,7 @@ class AccentApplicatorFocusedProjectTest {
         val manager = mockk<ProjectManager>()
         every { manager.openProjects } returns emptyArray()
         every { ProjectManager.getInstance() } returns manager
-        every { AccentResolver.resolve(null, AyuVariant.LIGHT) } returns "#F29718"
+        every { AccentResolver.resolve(null, ayu(AyuVariant.LIGHT)) } returns "#F29718"
 
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.LIGHT)
 
@@ -162,13 +179,13 @@ class AccentApplicatorFocusedProjectTest {
         every { manager.openProjects } returns arrayOf(otherProject, focusedProject)
         every { ProjectManager.getInstance() } returns manager
 
-        every { AccentResolver.resolve(focusedProject, AyuVariant.MIRAGE) } returns "#FOCUSED"
+        every { AccentResolver.resolve(focusedProject, ayu(AyuVariant.MIRAGE)) } returns "#FOCUSED"
 
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
 
         assertEquals("#FOCUSED", applied)
-        verify(exactly = 1) { AccentResolver.resolve(focusedProject, AyuVariant.MIRAGE) }
-        verify(exactly = 0) { AccentResolver.resolve(otherProject, any<AyuVariant>()) }
+        verify(exactly = 1) { AccentResolver.resolve(focusedProject, ayu(AyuVariant.MIRAGE)) }
+        verify(exactly = 0) { AccentResolver.resolve(otherProject, any<AccentContext>()) }
     }
 
     @Test
@@ -192,12 +209,12 @@ class AccentApplicatorFocusedProjectTest {
         every { manager.openProjects } returns arrayOf(healthyProject)
         every { ProjectManager.getInstance() } returns manager
 
-        every { AccentResolver.resolve(healthyProject, AyuVariant.MIRAGE) } returns "#FALLBACK"
+        every { AccentResolver.resolve(healthyProject, ayu(AyuVariant.MIRAGE)) } returns "#FALLBACK"
 
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
 
         assertEquals("#FALLBACK", applied)
-        verify(exactly = 1) { AccentResolver.resolve(healthyProject, AyuVariant.MIRAGE) }
+        verify(exactly = 1) { AccentResolver.resolve(healthyProject, ayu(AyuVariant.MIRAGE)) }
     }
 
     @Test
@@ -223,12 +240,12 @@ class AccentApplicatorFocusedProjectTest {
         every { manager.openProjects } returns arrayOf(healthyProject)
         every { ProjectManager.getInstance() } returns manager
 
-        every { AccentResolver.resolve(healthyProject, AyuVariant.MIRAGE) } returns "#FALLBACK"
+        every { AccentResolver.resolve(healthyProject, ayu(AyuVariant.MIRAGE)) } returns "#FALLBACK"
 
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
 
         assertEquals("#FALLBACK", applied)
-        verify(exactly = 1) { AccentResolver.resolve(healthyProject, AyuVariant.MIRAGE) }
+        verify(exactly = 1) { AccentResolver.resolve(healthyProject, ayu(AyuVariant.MIRAGE)) }
     }
 
     @Test
@@ -239,12 +256,12 @@ class AccentApplicatorFocusedProjectTest {
         val manager = mockk<ProjectManager>()
         every { manager.openProjects } returns arrayOf(focused)
         every { ProjectManager.getInstance() } returns manager
-        every { AccentResolver.resolve(focused, AyuVariant.MIRAGE) } returns "#FFCC66"
+        every { AccentResolver.resolve(focused, ayu(AyuVariant.MIRAGE)) } returns "#FFCC66"
 
         AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
 
         io.mockk.verifyOrder {
-            AccentResolver.resolve(focused, AyuVariant.MIRAGE)
+            AccentResolver.resolve(focused, ayu(AyuVariant.MIRAGE))
             AccentApplicator.applyFromHexString("#FFCC66")
             swapService.notifyExternalApply("#FFCC66")
         }
@@ -278,13 +295,13 @@ class AccentApplicatorFocusedProjectTest {
         mockkStatic(IdeFocusManager::class)
         every { IdeFocusManager.getGlobalInstance() } returns focusManager
 
-        every { AccentResolver.resolve(osActiveProject, AyuVariant.MIRAGE) } returns "#OS"
+        every { AccentResolver.resolve(osActiveProject, ayu(AyuVariant.MIRAGE)) } returns "#OS"
 
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
 
         assertEquals("#OS", applied)
-        verify(exactly = 1) { AccentResolver.resolve(osActiveProject, AyuVariant.MIRAGE) }
-        verify(exactly = 0) { AccentResolver.resolve(lastFocusedProject, any<AyuVariant>()) }
+        verify(exactly = 1) { AccentResolver.resolve(osActiveProject, ayu(AyuVariant.MIRAGE)) }
+        verify(exactly = 0) { AccentResolver.resolve(lastFocusedProject, any<AccentContext>()) }
     }
 
     @Test
@@ -315,12 +332,12 @@ class AccentApplicatorFocusedProjectTest {
         mockkStatic(IdeFocusManager::class)
         every { IdeFocusManager.getGlobalInstance() } returns focusManager
 
-        every { AccentResolver.resolve(lastFocusedProject, AyuVariant.MIRAGE) } returns "#LAST"
+        every { AccentResolver.resolve(lastFocusedProject, ayu(AyuVariant.MIRAGE)) } returns "#LAST"
 
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
 
         assertEquals("#LAST", applied)
-        verify(exactly = 1) { AccentResolver.resolve(lastFocusedProject, AyuVariant.MIRAGE) }
+        verify(exactly = 1) { AccentResolver.resolve(lastFocusedProject, ayu(AyuVariant.MIRAGE)) }
     }
 
     @Test
@@ -345,12 +362,12 @@ class AccentApplicatorFocusedProjectTest {
         every { manager.openProjects } returns arrayOf(healthyProject)
         every { ProjectManager.getInstance() } returns manager
 
-        every { AccentResolver.resolve(healthyProject, AyuVariant.MIRAGE) } returns "#FALLBACK"
+        every { AccentResolver.resolve(healthyProject, ayu(AyuVariant.MIRAGE)) } returns "#FALLBACK"
 
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
 
         assertEquals("#FALLBACK", applied)
-        verify(exactly = 0) { AccentResolver.resolve(disposedProject, any<AyuVariant>()) }
+        verify(exactly = 0) { AccentResolver.resolve(disposedProject, any<AccentContext>()) }
     }
 
     @Test
@@ -373,12 +390,12 @@ class AccentApplicatorFocusedProjectTest {
         mockkStatic(IdeFocusManager::class)
         every { IdeFocusManager.getGlobalInstance() } returns focusManager
 
-        every { AccentResolver.resolve(focusedProject, AyuVariant.MIRAGE) } returns "#FALLBACK"
+        every { AccentResolver.resolve(focusedProject, ayu(AyuVariant.MIRAGE)) } returns "#FALLBACK"
 
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
 
         assertEquals("#FALLBACK", applied)
-        verify(exactly = 1) { AccentResolver.resolve(focusedProject, AyuVariant.MIRAGE) }
+        verify(exactly = 1) { AccentResolver.resolve(focusedProject, ayu(AyuVariant.MIRAGE)) }
     }
 
     @Test
@@ -393,7 +410,7 @@ class AccentApplicatorFocusedProjectTest {
         val projectManager = mockk<ProjectManager>()
         every { projectManager.openProjects } returns emptyArray()
         every { ProjectManager.getInstance() } returns projectManager
-        every { AccentResolver.resolve(null, AyuVariant.MIRAGE) } returns "#GLOBAL"
+        every { AccentResolver.resolve(null, ayu(AyuVariant.MIRAGE)) } returns "#GLOBAL"
 
         val capturedWarns = mutableListOf<String>()
         val processor =
@@ -455,12 +472,12 @@ class AccentApplicatorFocusedProjectTest {
             WindowManager.getInstance().allProjectFrames
         } returns arrayOf(nullProjectFrame, healthyFrame)
 
-        every { AccentResolver.resolve(healthyProject, AyuVariant.MIRAGE) } returns "#HEALTHY"
+        every { AccentResolver.resolve(healthyProject, ayu(AyuVariant.MIRAGE)) } returns "#HEALTHY"
 
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
 
         assertEquals("#HEALTHY", applied)
-        verify(exactly = 1) { AccentResolver.resolve(healthyProject, AyuVariant.MIRAGE) }
+        verify(exactly = 1) { AccentResolver.resolve(healthyProject, ayu(AyuVariant.MIRAGE)) }
     }
 
     @Test
@@ -489,13 +506,13 @@ class AccentApplicatorFocusedProjectTest {
             WindowManager.getInstance().allProjectFrames
         } returns arrayOf(firstFrame, secondFrame)
 
-        every { AccentResolver.resolve(firstProject, AyuVariant.MIRAGE) } returns "#FIRST"
+        every { AccentResolver.resolve(firstProject, ayu(AyuVariant.MIRAGE)) } returns "#FIRST"
 
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
 
         assertEquals("#FIRST", applied)
-        verify(exactly = 1) { AccentResolver.resolve(firstProject, AyuVariant.MIRAGE) }
-        verify(exactly = 0) { AccentResolver.resolve(secondProject, any<AyuVariant>()) }
+        verify(exactly = 1) { AccentResolver.resolve(firstProject, ayu(AyuVariant.MIRAGE)) }
+        verify(exactly = 0) { AccentResolver.resolve(secondProject, any<AccentContext>()) }
     }
 
     @Test
@@ -520,13 +537,13 @@ class AccentApplicatorFocusedProjectTest {
             WindowManager.getInstance().allProjectFrames
         } returns arrayOf(detachedFrame, healthyFrame)
 
-        every { AccentResolver.resolve(healthyProject, AyuVariant.MIRAGE) } returns "#HEALTHY"
+        every { AccentResolver.resolve(healthyProject, ayu(AyuVariant.MIRAGE)) } returns "#HEALTHY"
 
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
 
         assertEquals("#HEALTHY", applied)
-        verify(exactly = 1) { AccentResolver.resolve(healthyProject, AyuVariant.MIRAGE) }
-        verify(exactly = 0) { AccentResolver.resolve(detachedProject, any<AyuVariant>()) }
+        verify(exactly = 1) { AccentResolver.resolve(healthyProject, ayu(AyuVariant.MIRAGE)) }
+        verify(exactly = 0) { AccentResolver.resolve(detachedProject, any<AccentContext>()) }
     }
 
     @Test
@@ -562,13 +579,13 @@ class AccentApplicatorFocusedProjectTest {
         every { projectManager.openProjects } returns arrayOf(projectManagerProject)
         every { ProjectManager.getInstance() } returns projectManager
 
-        every { AccentResolver.resolve(focusedProject, AyuVariant.MIRAGE) } returns "#FOCUS"
+        every { AccentResolver.resolve(focusedProject, ayu(AyuVariant.MIRAGE)) } returns "#FOCUS"
 
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
 
         assertEquals("#FOCUS", applied)
-        verify(exactly = 1) { AccentResolver.resolve(focusedProject, AyuVariant.MIRAGE) }
-        verify(exactly = 0) { AccentResolver.resolve(projectManagerProject, any<AyuVariant>()) }
+        verify(exactly = 1) { AccentResolver.resolve(focusedProject, ayu(AyuVariant.MIRAGE)) }
+        verify(exactly = 0) { AccentResolver.resolve(projectManagerProject, any<AccentContext>()) }
     }
 
     @Test
@@ -589,7 +606,7 @@ class AccentApplicatorFocusedProjectTest {
 
         every { WindowManager.getInstance().allProjectFrames } returns arrayOf(brokenFrame, healthyFrame)
 
-        every { AccentResolver.resolve(healthyProject, AyuVariant.MIRAGE) } returns "#HEALTHY"
+        every { AccentResolver.resolve(healthyProject, ayu(AyuVariant.MIRAGE)) } returns "#HEALTHY"
 
         val loggedErrors = mutableListOf<Throwable?>()
         val processor =
@@ -611,7 +628,7 @@ class AccentApplicatorFocusedProjectTest {
         }
 
         assertEquals("#HEALTHY", applied)
-        verify(exactly = 1) { AccentResolver.resolve(healthyProject, AyuVariant.MIRAGE) }
+        verify(exactly = 1) { AccentResolver.resolve(healthyProject, ayu(AyuVariant.MIRAGE)) }
     }
 
     @Test
@@ -635,7 +652,7 @@ class AccentApplicatorFocusedProjectTest {
         val projectManager = mockk<ProjectManager>()
         every { projectManager.openProjects } returns emptyArray()
         every { ProjectManager.getInstance() } returns projectManager
-        every { AccentResolver.resolve(null, AyuVariant.MIRAGE) } returns "#GLOBAL"
+        every { AccentResolver.resolve(null, ayu(AyuVariant.MIRAGE)) } returns "#GLOBAL"
 
         val capturedWarns = mutableListOf<String>()
         val processor =
@@ -678,7 +695,7 @@ class AccentApplicatorFocusedProjectTest {
         val projectManager = mockk<ProjectManager>()
         every { projectManager.openProjects } returns emptyArray()
         every { ProjectManager.getInstance() } returns projectManager
-        every { AccentResolver.resolve(null, AyuVariant.MIRAGE) } returns "#GLOBAL"
+        every { AccentResolver.resolve(null, ayu(AyuVariant.MIRAGE)) } returns "#GLOBAL"
 
         val capturedWarns = mutableListOf<String>()
         val processor =
@@ -733,7 +750,7 @@ class AccentApplicatorFocusedProjectTest {
         val manager = mockk<ProjectManager>()
         every { manager.openProjects } returns arrayOf(focused)
         every { ProjectManager.getInstance() } returns manager
-        every { AccentResolver.resolve(focused, AyuVariant.MIRAGE) } returns "not-a-hex"
+        every { AccentResolver.resolve(focused, ayu(AyuVariant.MIRAGE)) } returns "not-a-hex"
 
         // Override the recordPrivateCalls=false BeforeTest default: we want the real
         // applyFromHexString to run so its AccentHex.of shape-validation rejects the
@@ -805,6 +822,8 @@ class AccentApplicatorFocusedProjectTest {
         every { project.name } returns name
         return project
     }
+
+    private fun ayu(variant: AyuVariant): AccentContext = AccentContext.Ayu(variant)
 
     private fun stubIdeFrame(
         project: Project,

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorRevertAllIntegrationTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorRevertAllIntegrationTest.kt
@@ -307,6 +307,27 @@ class AccentApplicatorRevertAllIntegrationTest {
     }
 
     @Test
+    fun `syncCodeGlanceProViewport with external permission disabled fires revert path`() {
+        state.cgpIntegrationEnabled = true
+        state.externalThemeEnhancementsEnabled = true
+        state.externalThemeCodeGlanceProEnabled = false
+        val observed = mutableListOf<Triple<String, String, Int>>()
+        AccentApplicator.codeGlanceProRevertHook.set { color, borderColor, borderThickness ->
+            observed += Triple(color, borderColor, borderThickness)
+        }
+        try {
+            CodeGlanceProIntegration.syncCodeGlanceProViewport("#5CCFE6", AccentContext.External)
+        } finally {
+            AccentApplicator.resetCodeGlanceProRevertHookForTests()
+        }
+        assertEquals(
+            listOf(Triple("00FF00", "A0A0A0", 0)),
+            observed,
+            "External CodeGlance Pro permission OFF must reset CGP instead of inheriting Ayu accent.",
+        )
+    }
+
+    @Test
     fun `syncCodeGlanceProViewportForSwap delegates to CodeGlanceProIntegration syncCodeGlanceProViewport`() {
         // Regression lock. Pre-fix: AccentApplicator.syncCodeGlanceProViewportForSwap
         // was a one-line wrapper "verified by association" — its only test was

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
@@ -189,7 +189,7 @@ class AccentApplicatorTest {
         val owner = ownerForName(methodName)
         val method =
             owner.javaClass.declaredMethods
-                .first { it.name == methodName }
+                .first { it.name == methodName && it.parameterCount == args.size }
         method.isAccessible = true
         method.invoke(owner, *args)
     }

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
@@ -900,7 +900,7 @@ class AccentApplicatorTest {
     fun `apply calls applyAlwaysOnUiKeys and applyAlwaysOnEditorKeys on EDT`() {
         mockEpExtensionList(emptyList())
         mockkObject(IndentRainbowSync)
-        every { IndentRainbowSync.apply(any(), any()) } returns Unit
+        every { IndentRainbowSync.apply(any<dev.ayuislands.accent.AyuVariant>(), any()) } returns Unit
         state.cgpIntegrationEnabled = false
 
         AccentApplicator.applyFromHexString("#FFCC66")
@@ -919,13 +919,33 @@ class AccentApplicatorTest {
         // but the old `any()` matcher would still pass. Assert the exact hex flows through.
         mockEpExtensionList(emptyList())
         mockkObject(IndentRainbowSync)
-        every { IndentRainbowSync.apply(any(), any()) } returns Unit
+        every { IndentRainbowSync.apply(any<dev.ayuislands.accent.AyuVariant>(), any()) } returns Unit
         state.cgpIntegrationEnabled = false
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
 
         AccentApplicator.applyFromHexString("#FFCC66")
 
         verify { IndentRainbowSync.apply(AyuVariant.MIRAGE, "#FFCC66") }
+    }
+
+    @Test
+    fun `apply external context syncs integrations without Ayu-only elements or tab underline`() {
+        val element = createFakeAccentElement(AccentElementId.CARET_ROW, "Caret Row")
+        mockEpExtensionList(listOf(element))
+        mockkObject(IndentRainbowSync)
+        every { IndentRainbowSync.apply(any<AccentContext>(), any()) } returns Unit
+        state.cgpIntegrationEnabled = false
+        state.externalThemeEnhancementsEnabled = true
+        every { AyuVariant.detect() } returns null
+
+        AccentApplicator.applyFromHexString("#AABBCC")
+
+        verify(exactly = 1) { IndentRainbowSync.apply(AccentContext.External, "#AABBCC") }
+        verify(exactly = 0) { element.apply(any()) }
+        verify(exactly = 0) { element.revert() }
+        verify(exactly = 0) { element.applyNeutral(any()) }
+        verify(exactly = 0) { UIManager.put("EditorTabs.underlineHeight", any<Int>()) }
+        verify(exactly = 0) { UIManager.put("EditorTabs.underlineArc", any<Int>()) }
     }
 
     @Test
@@ -937,14 +957,14 @@ class AccentApplicatorTest {
 
         AccentApplicator.applyFromHexString("#FFCC66")
 
-        verify(exactly = 0) { IndentRainbowSync.apply(any(), any()) }
+        verify(exactly = 0) { IndentRainbowSync.apply(any<dev.ayuislands.accent.AyuVariant>(), any()) }
     }
 
     @Test
     fun `apply calls repaintAllWindows`() {
         mockEpExtensionList(emptyList())
         mockkObject(IndentRainbowSync)
-        every { IndentRainbowSync.apply(any(), any()) } returns Unit
+        every { IndentRainbowSync.apply(any<dev.ayuislands.accent.AyuVariant>(), any()) } returns Unit
         state.cgpIntegrationEnabled = false
         val mockWindow = mockk<Window>(relaxed = true)
         every { mockWindow.isDisplayable } returns true
@@ -959,7 +979,7 @@ class AccentApplicatorTest {
     fun `apply runs work directly when on EDT`() {
         mockEpExtensionList(emptyList())
         mockkObject(IndentRainbowSync)
-        every { IndentRainbowSync.apply(any(), any()) } returns Unit
+        every { IndentRainbowSync.apply(any<dev.ayuislands.accent.AyuVariant>(), any()) } returns Unit
         state.cgpIntegrationEnabled = false
         every { SwingUtilities.isEventDispatchThread() } returns true
 
@@ -977,7 +997,7 @@ class AccentApplicatorTest {
         // multi-window restores would flicker Gold before each StartupActivity ran.
         mockEpExtensionList(emptyList())
         mockkObject(IndentRainbowSync)
-        every { IndentRainbowSync.apply(any(), any()) } returns Unit
+        every { IndentRainbowSync.apply(any<dev.ayuislands.accent.AyuVariant>(), any()) } returns Unit
         state.cgpIntegrationEnabled = false
 
         AccentApplicator.applyFromHexString("#5CCFE6")
@@ -991,7 +1011,7 @@ class AccentApplicatorTest {
         // ticks, and per-project swaps leave the right color for the next restart.
         mockEpExtensionList(emptyList())
         mockkObject(IndentRainbowSync)
-        every { IndentRainbowSync.apply(any(), any()) } returns Unit
+        every { IndentRainbowSync.apply(any<dev.ayuislands.accent.AyuVariant>(), any()) } returns Unit
         state.cgpIntegrationEnabled = false
 
         AccentApplicator.applyFromHexString("#5CCFE6")
@@ -1012,7 +1032,7 @@ class AccentApplicatorTest {
         // malformed shapes that used to crash the applier.
         mockEpExtensionList(emptyList())
         mockkObject(IndentRainbowSync)
-        every { IndentRainbowSync.apply(any(), any()) } returns Unit
+        every { IndentRainbowSync.apply(any<dev.ayuislands.accent.AyuVariant>(), any()) } returns Unit
         state.cgpIntegrationEnabled = false
 
         // None of these should throw; none should set the cached hex.
@@ -1033,7 +1053,7 @@ class AccentApplicatorTest {
     fun `apply accepts well-formed 6-digit hex with hash prefix`() {
         mockEpExtensionList(emptyList())
         mockkObject(IndentRainbowSync)
-        every { IndentRainbowSync.apply(any(), any()) } returns Unit
+        every { IndentRainbowSync.apply(any<dev.ayuislands.accent.AyuVariant>(), any()) } returns Unit
         state.cgpIntegrationEnabled = false
 
         // Boundary: exactly #RRGGBB with valid hex digits. Must go through the full
@@ -1048,7 +1068,7 @@ class AccentApplicatorTest {
     fun `apply accepts mixed-case hex digits`() {
         mockEpExtensionList(emptyList())
         mockkObject(IndentRainbowSync)
-        every { IndentRainbowSync.apply(any(), any()) } returns Unit
+        every { IndentRainbowSync.apply(any<dev.ayuislands.accent.AyuVariant>(), any()) } returns Unit
         state.cgpIntegrationEnabled = false
 
         // Upper and lower case 0-9A-Fa-f are all valid per Color.decode.
@@ -1083,7 +1103,7 @@ class AccentApplicatorTest {
     fun `apply posts to invokeLater when not on EDT`() {
         mockEpExtensionList(emptyList())
         mockkObject(IndentRainbowSync)
-        every { IndentRainbowSync.apply(any(), any()) } returns Unit
+        every { IndentRainbowSync.apply(any<dev.ayuislands.accent.AyuVariant>(), any()) } returns Unit
         state.cgpIntegrationEnabled = false
         every { SwingUtilities.isEventDispatchThread() } returns false
         every { mockApplication.invokeLater(any(), any<ModalityState>()) } answers {
@@ -1737,7 +1757,7 @@ class AccentApplicatorTest {
         state.glowTabMode = "OFF"
         state.tabUnderlineHeight = 6
 
-        assertEquals(6, AccentApplicator.resolveUnderlineHeight(state))
+        assertEquals(6, resolveUnderlineHeight(state))
     }
 
     @Test
@@ -1746,7 +1766,7 @@ class AccentApplicatorTest {
         state.tabUnderlineGlowSync = false
         state.tabUnderlineHeight = 4
 
-        assertEquals(4, AccentApplicator.resolveUnderlineHeight(state))
+        assertEquals(4, resolveUnderlineHeight(state))
     }
 
     @Test
@@ -1757,7 +1777,7 @@ class AccentApplicatorTest {
         state.glowStyle = "SOFT"
 
         val expected = state.getWidthForStyle(dev.ayuislands.glow.GlowStyle.SOFT)
-        assertEquals(expected, AccentApplicator.resolveUnderlineHeight(state))
+        assertEquals(expected, resolveUnderlineHeight(state))
     }
 
     @Test
@@ -1767,7 +1787,7 @@ class AccentApplicatorTest {
         state.glowEnabled = false
         state.tabUnderlineHeight = 8
 
-        assertEquals(8, AccentApplicator.resolveUnderlineHeight(state))
+        assertEquals(8, resolveUnderlineHeight(state))
     }
 
     // applyTabUnderline tests (merged from applyTabUnderlineStyle +

--- a/src/test/kotlin/dev/ayuislands/accent/AccentContextTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentContextTest.kt
@@ -82,6 +82,17 @@ class AccentContextTest {
     }
 
     @Test
+    fun `detectQuickSwitcher returns null for external context when quick switcher inheritance is disabled`() {
+        state.externalThemeEnhancementsEnabled = true
+        state.externalThemeQuickSwitcherEnabled = false
+        every { AyuVariant.detect() } returns null
+
+        assertEquals(AccentContext.External, AccentContext.detect())
+        assertNull(AccentContext.detectQuickSwitcher())
+        assertFalse(AccentContext.isQuickSwitcherActive())
+    }
+
+    @Test
     fun `ExternalAccentSource fromName returns matching source or Automatic fallback`() {
         assertEquals(ExternalAccentSource.MANUAL, ExternalAccentSource.fromName("MANUAL"))
         assertEquals(ExternalAccentSource.AUTOMATIC, ExternalAccentSource.fromName(null))

--- a/src/test/kotlin/dev/ayuislands/accent/AccentContextTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentContextTest.kt
@@ -1,0 +1,90 @@
+package dev.ayuislands.accent
+
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class AccentContextTest {
+    private lateinit var state: AyuIslandsState
+    private lateinit var settings: AyuIslandsSettings
+
+    @BeforeTest
+    fun setUp() {
+        state = AyuIslandsState()
+        settings = mockk(relaxed = true)
+        every { settings.state } returns state
+
+        mockkObject(AyuIslandsSettings.Companion)
+        every { AyuIslandsSettings.getInstance() } returns settings
+
+        mockkObject(AyuVariant.Companion)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkObject(AyuVariant.Companion)
+        unmockkObject(AyuIslandsSettings.Companion)
+    }
+
+    @Test
+    fun `detect returns Ayu context for active Ayu theme even when external enhancements are disabled`() {
+        state.externalThemeEnhancementsEnabled = false
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+
+        val context = AccentContext.detect()
+
+        assertEquals(AccentContext.Ayu(AyuVariant.MIRAGE), context)
+        assertEquals(AyuVariant.MIRAGE, context?.variant)
+    }
+
+    @Test
+    fun `detect returns null for non-Ayu theme when external enhancements are disabled`() {
+        state.externalThemeEnhancementsEnabled = false
+        every { AyuVariant.detect() } returns null
+
+        assertNull(AccentContext.detect())
+    }
+
+    @Test
+    fun `detect returns External for non-Ayu theme when external enhancements are enabled`() {
+        state.externalThemeEnhancementsEnabled = true
+        every { AyuVariant.detect() } returns null
+
+        val context = AccentContext.detect()
+
+        assertEquals(AccentContext.External, context)
+        assertNull(context?.variant)
+    }
+
+    @Test
+    fun `isAccentActive returns true for Ayu and external contexts`() {
+        state.externalThemeEnhancementsEnabled = false
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        assertTrue(AccentContext.isAccentActive())
+
+        state.externalThemeEnhancementsEnabled = true
+        every { AyuVariant.detect() } returns null
+        assertTrue(AccentContext.isAccentActive())
+
+        state.externalThemeEnhancementsEnabled = false
+        every { AyuVariant.detect() } returns null
+        assertFalse(AccentContext.isAccentActive())
+    }
+
+    @Test
+    fun `ExternalAccentSource fromName returns matching source or Automatic fallback`() {
+        assertEquals(ExternalAccentSource.MANUAL, ExternalAccentSource.fromName("MANUAL"))
+        assertEquals(ExternalAccentSource.AUTOMATIC, ExternalAccentSource.fromName(null))
+        assertEquals(ExternalAccentSource.AUTOMATIC, ExternalAccentSource.fromName("Manual"))
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/accent/AccentResolverExternalTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentResolverExternalTest.kt
@@ -1,0 +1,260 @@
+package dev.ayuislands.accent
+
+import com.intellij.openapi.project.Project
+import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
+import dev.ayuislands.settings.mappings.AccentMappingsSettings
+import dev.ayuislands.settings.mappings.AccentMappingsState
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import java.awt.Color
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AccentResolverExternalTest {
+    @Test
+    fun `external resolve prefers licensed project override over material accent`() {
+        withResolverStubs {
+            val projectPath = File(System.getProperty("java.io.tmpdir"), "external-project").canonicalPath
+            mappingsState.projectAccents[projectPath] = "#112233"
+            state.externalThemeAccent = "#445566"
+            val project = stubProject(File(projectPath))
+
+            withUiColorProvider({ key -> if (key == "material.accent") Color(0xAA, 0xBB, 0xCC) else null }) {
+                assertEquals("#112233", AccentResolver.resolve(project, AccentContext.External))
+                assertEquals(
+                    AccentResolver.Source.PROJECT_OVERRIDE,
+                    AccentResolver.source(project, AccentContext.External),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `external resolve prefers licensed language override over material accent`() {
+        withResolverStubs {
+            mappingsState.languageAccents["kotlin"] = "#223344"
+            state.externalThemeAccent = "#445566"
+            val project = stubProject(File(System.getProperty("java.io.tmpdir"), "external-language"))
+            every { ProjectLanguageDetector.dominant(project) } returns "kotlin"
+
+            withUiColorProvider({ key -> if (key == "material.accent") Color(0xAA, 0xBB, 0xCC) else null }) {
+                assertEquals("#223344", AccentResolver.resolve(project, AccentContext.External))
+                assertEquals(
+                    AccentResolver.Source.LANGUAGE_OVERRIDE,
+                    AccentResolver.source(project, AccentContext.External),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `external automatic resolve uses material accent before stored fallback`() {
+        withResolverStubs {
+            state.externalThemeAccent = "#445566"
+
+            withUiColorProvider({ key -> if (key == "material.accent") Color(0x0A, 0x14, 0x1E) else null }) {
+                assertEquals("#0A141E", AccentResolver.resolve(null, AccentContext.External))
+                assertEquals(
+                    AccentResolver.Source.MATERIAL_THEME,
+                    AccentResolver.source(null, AccentContext.External),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `external automatic resolve uses material accent before later ide accent keys`() {
+        withResolverStubs {
+            state.externalThemeAccent = "#445566"
+
+            withUiColorProvider(
+                { key ->
+                    when (key) {
+                        "material.accent" -> Color(0x0A, 0x14, 0x1E)
+                        "Component.accentColor" -> Color(0xC8, 0x64, 0x32)
+                        "Actions.Blue" -> Color(0x11, 0x22, 0x33)
+                        else -> null
+                    }
+                },
+            ) {
+                assertEquals("#0A141E", AccentResolver.resolve(null, AccentContext.External))
+                assertEquals(
+                    AccentResolver.Source.MATERIAL_THEME,
+                    AccentResolver.source(null, AccentContext.External),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `external automatic resolve uses component accent color before actions blue`() {
+        withResolverStubs {
+            state.externalThemeAccent = "#445566"
+
+            withUiColorProvider(
+                { key ->
+                    when (key) {
+                        "Component.accentColor" -> Color(0xC8, 0x64, 0x32)
+                        "Actions.Blue" -> Color(0x11, 0x22, 0x33)
+                        else -> null
+                    }
+                },
+            ) {
+                assertEquals("#C86432", AccentResolver.resolve(null, AccentContext.External))
+                assertEquals(
+                    AccentResolver.Source.IDE_ACCENT,
+                    AccentResolver.source(null, AccentContext.External),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `external automatic resolve uses actions blue before stored fallback`() {
+        withResolverStubs {
+            state.externalThemeAccent = "#445566"
+
+            withUiColorProvider({ key -> if (key == "Actions.Blue") Color(0x11, 0x22, 0x33) else null }) {
+                assertEquals("#112233", AccentResolver.resolve(null, AccentContext.External))
+                assertEquals(
+                    AccentResolver.Source.IDE_ACCENT,
+                    AccentResolver.source(null, AccentContext.External),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `external automatic resolve falls back to stored external accent`() {
+        withResolverStubs {
+            state.externalThemeAccent = "#445566"
+
+            withUiColorProvider({ null }) {
+                assertEquals("#445566", AccentResolver.resolve(null, AccentContext.External))
+                assertEquals(
+                    AccentResolver.Source.EXTERNAL_ACCENT,
+                    AccentResolver.source(null, AccentContext.External),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `external manual mode uses stored external accent and ignores all automatic sources`() {
+        withResolverStubs {
+            val projectPath = File(System.getProperty("java.io.tmpdir"), "external-manual").canonicalPath
+            mappingsState.projectAccents[projectPath] = "#112233"
+            mappingsState.languageAccents["kotlin"] = "#223344"
+            state.externalThemeAccentSource = ExternalAccentSource.MANUAL.name
+            state.externalThemeAccent = "#13579B"
+            val project = stubProject(File(projectPath))
+            every { ProjectLanguageDetector.dominant(project) } returns "kotlin"
+
+            withUiColorProvider({ key -> if (key == "material.accent") Color(0xAA, 0xBB, 0xCC) else null }) {
+                assertEquals("#13579B", AccentResolver.resolve(project, AccentContext.External))
+                assertEquals(
+                    AccentResolver.Source.EXTERNAL_ACCENT,
+                    AccentResolver.source(project, AccentContext.External),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `external automatic resolve skips unlicensed overrides before material accent`() {
+        withResolverStubs(licensed = false) {
+            val projectPath = File(System.getProperty("java.io.tmpdir"), "external-unlicensed").canonicalPath
+            mappingsState.projectAccents[projectPath] = "#112233"
+            mappingsState.languageAccents["kotlin"] = "#223344"
+            state.externalThemeAccent = "#445566"
+            val project = stubProject(File(projectPath))
+            every { ProjectLanguageDetector.dominant(project) } returns "kotlin"
+
+            withUiColorProvider({ key -> if (key == "material.accent") Color(0xAA, 0xBB, 0xCC) else null }) {
+                assertEquals("#AABBCC", AccentResolver.resolve(project, AccentContext.External))
+                assertEquals(
+                    AccentResolver.Source.MATERIAL_THEME,
+                    AccentResolver.source(project, AccentContext.External),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `invalid stored external accent falls back to mirage default accent`() {
+        withResolverStubs {
+            state.externalThemeAccentSource = ExternalAccentSource.MANUAL.name
+            state.externalThemeAccent = "not-a-hex"
+
+            assertEquals(AyuVariant.MIRAGE.defaultAccent, AccentResolver.resolve(null, AccentContext.External))
+            assertEquals(
+                AccentResolver.Source.EXTERNAL_ACCENT,
+                AccentResolver.source(null, AccentContext.External),
+            )
+        }
+    }
+
+    private fun withResolverStubs(
+        licensed: Boolean = true,
+        block: ResolverStubs.() -> Unit,
+    ) {
+        mockkObject(AyuIslandsSettings.Companion)
+        mockkObject(AccentMappingsSettings.Companion)
+        mockkObject(ProjectLanguageDetector)
+        mockkObject(LicenseChecker)
+        try {
+            val settings = mockk<AyuIslandsSettings>()
+            val state = AyuIslandsState()
+            every { settings.state } returns state
+            every { settings.getAccentForVariant(AyuVariant.MIRAGE) } returns AyuVariant.MIRAGE.defaultAccent
+            every { settings.getAccentForVariant(AyuVariant.DARK) } returns AyuVariant.DARK.defaultAccent
+            every { settings.getAccentForVariant(AyuVariant.LIGHT) } returns AyuVariant.LIGHT.defaultAccent
+            every { AyuIslandsSettings.getInstance() } returns settings
+
+            val mappingsState = AccentMappingsState()
+            val mappingsSettings = mockk<AccentMappingsSettings>()
+            every { mappingsSettings.state } returns mappingsState
+            every { AccentMappingsSettings.getInstance() } returns mappingsSettings
+
+            every { ProjectLanguageDetector.dominant(any()) } returns null
+            every { LicenseChecker.isLicensedOrGrace() } returns licensed
+
+            AccentResolver.resetWarnGatesForTest()
+            AccentResolver.resetUiColorProviderForTest()
+            ResolverStubs(state, mappingsState).block()
+        } finally {
+            AccentResolver.resetWarnGatesForTest()
+            AccentResolver.resetUiColorProviderForTest()
+            unmockkObject(LicenseChecker)
+            unmockkObject(ProjectLanguageDetector)
+            unmockkObject(AccentMappingsSettings.Companion)
+            unmockkObject(AyuIslandsSettings.Companion)
+        }
+    }
+
+    private fun withUiColorProvider(
+        provider: (String) -> Color?,
+        block: () -> Unit,
+    ) {
+        AccentResolver.withUiColorProviderForTest(provider, block)
+    }
+
+    private data class ResolverStubs(
+        val state: AyuIslandsState,
+        val mappingsState: AccentMappingsState,
+    )
+
+    private fun stubProject(baseDir: File): Project {
+        val project = mockk<Project>()
+        every { project.isDefault } returns false
+        every { project.isDisposed } returns false
+        every { project.basePath } returns baseDir.path
+        every { project.name } returns baseDir.name
+        return project
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/accent/AccentResolverSourceLabelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentResolverSourceLabelTest.kt
@@ -38,7 +38,31 @@ class AccentResolverSourceLabelTest {
     }
 
     @Test
-    fun `Source enum size lock - three values exactly`() {
+    fun `sourceLabel for MATERIAL_THEME returns Material Theme`() {
+        assertEquals(
+            "Material Theme",
+            AccentResolver.sourceLabel(AccentResolver.Source.MATERIAL_THEME),
+        )
+    }
+
+    @Test
+    fun `sourceLabel for IDE_ACCENT returns IDE accent`() {
+        assertEquals(
+            "IDE accent",
+            AccentResolver.sourceLabel(AccentResolver.Source.IDE_ACCENT),
+        )
+    }
+
+    @Test
+    fun `sourceLabel for EXTERNAL_ACCENT returns External accent`() {
+        assertEquals(
+            "External accent",
+            AccentResolver.sourceLabel(AccentResolver.Source.EXTERNAL_ACCENT),
+        )
+    }
+
+    @Test
+    fun `Source enum size lock - six values exactly`() {
         // Pattern L regression lock. If you add a new Source value (e.g.
         // REMOTE for remote-environment awareness), this test fails on
         // purpose so you are forced to extend [AccentResolver.sourceLabel]
@@ -46,7 +70,7 @@ class AccentResolverSourceLabelTest {
         // branch would land at runtime as "Global" via a future `else ->`
         // fallback, silently mislabelling every remote-resolved accent.
         assertEquals(
-            3,
+            6,
             AccentResolver.Source.entries.size,
             "AccentResolver.Source enum grew - extend AccentResolver.sourceLabel in the same change",
         )

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
@@ -679,7 +679,7 @@ class ProjectLanguageDetectorTest {
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
         mockkObject(AccentResolver)
-        every { AccentResolver.resolve(any(), any()) } returns "#FFCC66"
+        every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#FFCC66"
         mockkObject(AccentApplicator)
         every { AccentApplicator.apply(any()) } answers { Unit }
         val swapService = mockk<dev.ayuislands.settings.mappings.ProjectAccentSwapService>(relaxed = true)
@@ -706,7 +706,7 @@ class ProjectLanguageDetectorTest {
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
         mockkObject(AccentResolver)
-        every { AccentResolver.resolve(any(), any()) } returns "#FFCC66"
+        every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#FFCC66"
         mockkObject(AccentApplicator)
         every { AccentApplicator.apply(any()) } answers { Unit }
         val swapService = mockk<dev.ayuislands.settings.mappings.ProjectAccentSwapService>(relaxed = true)
@@ -734,7 +734,7 @@ class ProjectLanguageDetectorTest {
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
         mockkObject(AccentResolver)
-        every { AccentResolver.resolve(any(), any()) } returns "#FFCC66"
+        every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#FFCC66"
         mockkObject(AccentApplicator)
         every { AccentApplicator.apply(any()) } throws RuntimeException("LafManager boom")
 
@@ -754,7 +754,7 @@ class ProjectLanguageDetectorTest {
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
         mockkObject(AccentResolver)
-        every { AccentResolver.resolve(any(), any()) } throws RuntimeException("resolver boom")
+        every { AccentResolver.resolve(any(), any<AyuVariant>()) } throws RuntimeException("resolver boom")
 
         mockkObject(AccentApplicator)
         every { AccentApplicator.apply(any()) } answers { Unit }

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentGridTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentGridTest.kt
@@ -42,7 +42,7 @@ class QuickSwitcherAccentGridTest {
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns null
         mockkObject(AccentResolver)
-        every { AccentResolver.resolve(any(), any()) } returns AYU_ACCENT_PRESETS.first().hex
+        every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns AYU_ACCENT_PRESETS.first().hex
         // Quick-actions row + other premium components reach for
         // ApplicationManager.getApplication() during DumbAwareAction init.
         mockkStatic(ApplicationManager::class)

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentGridTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentGridTest.kt
@@ -44,7 +44,7 @@ class QuickSwitcherAccentGridTest {
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns AyuVariant.DARK
         mockkObject(AccentContext.Companion)
-        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.DARK)
+        every { AccentContext.detectQuickSwitcher() } returns AccentContext.Ayu(AyuVariant.DARK)
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns null
         mockkObject(AccentResolver)
@@ -181,7 +181,7 @@ class QuickSwitcherAccentGridTest {
         // click.
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
-        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
+        every { AccentContext.detectQuickSwitcher() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns null
         mockkObject(AccentResolver)
@@ -258,7 +258,7 @@ class QuickSwitcherAccentGridTest {
         // `applyPreset` so cancellation does not mutate accent state.
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
-        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
+        every { AccentContext.detectQuickSwitcher() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns null
         every { AccentApplicator.applyFromHexString(any()) } returns true
@@ -307,7 +307,7 @@ class QuickSwitcherAccentGridTest {
         // produce "#F00AB" and surface here.
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
-        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
+        every { AccentContext.detectQuickSwitcher() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns null
         every { AccentApplicator.applyFromHexString(any()) } returns true
@@ -360,7 +360,7 @@ class QuickSwitcherAccentGridTest {
         // returned a non-null Color.
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
-        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
+        every { AccentContext.detectQuickSwitcher() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns null
         every { AccentApplicator.applyFromHexString(any()) } returns true
@@ -397,7 +397,7 @@ class QuickSwitcherAccentGridTest {
         // tests and only surface as a popup-crash incident in production.
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
-        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
+        every { AccentContext.detectQuickSwitcher() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns null
         mockkObject(AccentResolver)
@@ -460,7 +460,7 @@ class QuickSwitcherAccentGridTest {
 
     @Test
     fun `clicking a swatch in external context persists manual external accent`() {
-        every { AccentContext.detect() } returns AccentContext.External
+        every { AccentContext.detectQuickSwitcher() } returns AccentContext.External
         every { AccentApplicator.applyFromHexString(any()) } returns true
         mockkObject(ProjectAccentSwapService.Companion)
         val swapService = mockk<ProjectAccentSwapService>(relaxed = true)

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentGridTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentGridTest.kt
@@ -4,11 +4,15 @@ import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import dev.ayuislands.accent.AYU_ACCENT_PRESETS
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.accent.ExternalAccentSource
 import dev.ayuislands.accent.toolbar.popup.Density
 import dev.ayuislands.accent.toolbar.popup.PopupSwatch
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 import io.mockk.every
 import io.mockk.mockk
@@ -39,9 +43,12 @@ class QuickSwitcherAccentGridTest {
     fun setUp() {
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns AyuVariant.DARK
+        mockkObject(AccentContext.Companion)
+        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.DARK)
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns null
         mockkObject(AccentResolver)
+        every { AccentResolver.resolve(any(), any<AccentContext>()) } returns AYU_ACCENT_PRESETS.first().hex
         every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns AYU_ACCENT_PRESETS.first().hex
         // Quick-actions row + other premium components reach for
         // ApplicationManager.getApplication() during DumbAwareAction init.
@@ -174,10 +181,11 @@ class QuickSwitcherAccentGridTest {
         // click.
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns null
         mockkObject(AccentResolver)
-        every { AccentResolver.resolve(any(), AyuVariant.MIRAGE) } returns "#FFB454"
+        every { AccentResolver.resolve(any(), any<AccentContext>()) } returns "#FFB454"
         mockkStatic(com.intellij.ui.ColorPicker::class)
         every {
             com.intellij.ui.ColorPicker.showDialog(
@@ -250,11 +258,12 @@ class QuickSwitcherAccentGridTest {
         // `applyPreset` so cancellation does not mutate accent state.
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns null
         every { AccentApplicator.applyFromHexString(any()) } returns true
         mockkObject(AccentResolver)
-        every { AccentResolver.resolve(any(), AyuVariant.MIRAGE) } returns "#FFB454"
+        every { AccentResolver.resolve(any(), any<AccentContext>()) } returns "#FFB454"
         mockkStatic(com.intellij.ui.ColorPicker::class)
         every {
             com.intellij.ui.ColorPicker.showDialog(
@@ -298,11 +307,12 @@ class QuickSwitcherAccentGridTest {
         // produce "#F00AB" and surface here.
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns null
         every { AccentApplicator.applyFromHexString(any()) } returns true
         mockkObject(AccentResolver)
-        every { AccentResolver.resolve(any(), AyuVariant.MIRAGE) } returns "#FFB454"
+        every { AccentResolver.resolve(any(), any<AccentContext>()) } returns "#FFB454"
         mockkObject(ProjectAccentSwapService.Companion)
         val swap = mockk<ProjectAccentSwapService>(relaxed = true)
         every { ProjectAccentSwapService.getInstance() } returns swap
@@ -350,11 +360,12 @@ class QuickSwitcherAccentGridTest {
         // returned a non-null Color.
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns null
         every { AccentApplicator.applyFromHexString(any()) } returns true
         mockkObject(AccentResolver)
-        every { AccentResolver.resolve(any(), AyuVariant.MIRAGE) } returns "#FFB454"
+        every { AccentResolver.resolve(any(), any<AccentContext>()) } returns "#FFB454"
         mockkObject(AccentHex.Companion)
         every { AccentHex.of(any<String>()) } returns null
         mockkStatic(com.intellij.ui.ColorPicker::class)
@@ -386,10 +397,11 @@ class QuickSwitcherAccentGridTest {
         // tests and only surface as a popup-crash incident in production.
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns null
         mockkObject(AccentResolver)
-        every { AccentResolver.resolve(any(), AyuVariant.MIRAGE) } returns "not-a-hex"
+        every { AccentResolver.resolve(any(), any<AccentContext>()) } returns "not-a-hex"
         mockkStatic(com.intellij.ui.ColorPicker::class)
         every {
             com.intellij.ui.ColorPicker.showDialog(
@@ -444,6 +456,30 @@ class QuickSwitcherAccentGridTest {
         assertTrue(swatches[1].selected, "Clicked swatch must be selected after apply")
         // Belt-and-braces: prior selection (index 0 by default) must have cleared.
         assertTrue(!swatches[0].selected || swatches[0].hex.value.equals(secondHex, ignoreCase = true))
+    }
+
+    @Test
+    fun `clicking a swatch in external context persists manual external accent`() {
+        every { AccentContext.detect() } returns AccentContext.External
+        every { AccentApplicator.applyFromHexString(any()) } returns true
+        mockkObject(ProjectAccentSwapService.Companion)
+        val swapService = mockk<ProjectAccentSwapService>(relaxed = true)
+        every { ProjectAccentSwapService.getInstance() } returns swapService
+        val state = AyuIslandsState()
+        val settings = mockk<AyuIslandsSettings>(relaxed = true)
+        every { settings.state } returns state
+        mockkObject(AyuIslandsSettings.Companion)
+        every { AyuIslandsSettings.getInstance() } returns settings
+
+        val grid = QuickSwitcherAccentGrid()
+        val north = (grid.component as JPanel).components.filterIsInstance<JPanel>().first()
+        val firstSwatch = north.components.first() as PopupSwatch
+        firstSwatch.setSize(36, 24)
+        firstSwatch.dispatchEvent(makePress(firstSwatch))
+        firstSwatch.dispatchEvent(makeRelease(firstSwatch))
+
+        assertEquals(AYU_ACCENT_PRESETS.first().hex, state.externalThemeAccent)
+        assertEquals(ExternalAccentSource.MANUAL.name, state.externalThemeAccentSource)
     }
 
     private fun collectActionLinks(

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipComponentTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipComponentTest.kt
@@ -323,8 +323,8 @@ class QuickSwitcherChipComponentTest {
         every { AyuVariant.isAyuActive() } returns active
         every { AyuVariant.detect() } returns if (active) AyuVariant.MIRAGE else null
         mockkObject(AccentContext.Companion)
-        every { AccentContext.isAccentActive() } returns active
-        every { AccentContext.detect() } returns if (active) AccentContext.Ayu(AyuVariant.MIRAGE) else null
+        every { AccentContext.isQuickSwitcherActive() } returns active
+        every { AccentContext.detectQuickSwitcher() } returns if (active) AccentContext.Ayu(AyuVariant.MIRAGE) else null
     }
 
     private fun stubResolver(

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipComponentTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipComponentTest.kt
@@ -137,7 +137,7 @@ class QuickSwitcherChipComponentTest {
         stubAyuActive(true)
         mockkObject(AccentResolver)
         every {
-            AccentResolver.resolve(any(), any())
+            AccentResolver.resolve(any(), any<AyuVariant>())
         } throws RuntimeException("transient mid-LAF-swap")
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns null
@@ -331,7 +331,7 @@ class QuickSwitcherChipComponentTest {
         val mockProject = mockk<Project>(relaxed = true)
         every { AccentApplicator.resolveFocusedProject() } returns mockProject
         mockkObject(AccentResolver)
-        every { AccentResolver.resolve(any(), any()) } returns hex
+        every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns hex
         every { AccentResolver.source(any()) } returns source
         every { AccentResolver.sourceLabel(AccentResolver.Source.PROJECT_OVERRIDE) } returns "Project override"
         every { AccentResolver.sourceLabel(AccentResolver.Source.LANGUAGE_OVERRIDE) } returns "Language override"

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipComponentTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipComponentTest.kt
@@ -10,6 +10,7 @@ import com.intellij.util.messages.MessageBusConnection
 import com.intellij.util.ui.JBUI
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentChangedTopic
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import io.mockk.every
@@ -137,7 +138,7 @@ class QuickSwitcherChipComponentTest {
         stubAyuActive(true)
         mockkObject(AccentResolver)
         every {
-            AccentResolver.resolve(any(), any<AyuVariant>())
+            AccentResolver.resolve(any(), any<AccentContext>())
         } throws RuntimeException("transient mid-LAF-swap")
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns null
@@ -321,6 +322,9 @@ class QuickSwitcherChipComponentTest {
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.isAyuActive() } returns active
         every { AyuVariant.detect() } returns if (active) AyuVariant.MIRAGE else null
+        mockkObject(AccentContext.Companion)
+        every { AccentContext.isAccentActive() } returns active
+        every { AccentContext.detect() } returns if (active) AccentContext.Ayu(AyuVariant.MIRAGE) else null
     }
 
     private fun stubResolver(
@@ -331,7 +335,9 @@ class QuickSwitcherChipComponentTest {
         val mockProject = mockk<Project>(relaxed = true)
         every { AccentApplicator.resolveFocusedProject() } returns mockProject
         mockkObject(AccentResolver)
+        every { AccentResolver.resolve(any(), any<AccentContext>()) } returns hex
         every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns hex
+        every { AccentResolver.source(any(), any<AccentContext>()) } returns source
         every { AccentResolver.source(any()) } returns source
         every { AccentResolver.sourceLabel(AccentResolver.Source.PROJECT_OVERRIDE) } returns "Project override"
         every { AccentResolver.sourceLabel(AccentResolver.Source.LANGUAGE_OVERRIDE) } returns "Language override"

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipContextMenuTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipContextMenuTest.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.util.messages.MessageBus
 import com.intellij.util.messages.MessageBusConnection
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.toolbar.actions.CopyHexAction
 import dev.ayuislands.accent.toolbar.actions.DarkerAccentAction
@@ -62,6 +63,9 @@ class QuickSwitcherChipContextMenuTest {
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.isAyuActive() } returns true
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        mockkObject(AccentContext.Companion)
+        every { AccentContext.isAccentActive() } returns true
+        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
     }
 
     @AfterTest
@@ -151,6 +155,8 @@ class QuickSwitcherChipContextMenuTest {
         // is non-Ayu; the early return in `mousePressed` short-circuits.
         every { AyuVariant.isAyuActive() } returns false
         every { AyuVariant.detect() } returns null
+        every { AccentContext.isAccentActive() } returns false
+        every { AccentContext.detect() } returns null
 
         val chip = QuickSwitcherChipComponent()
         chip.dispatchEvent(rightClick(chip))

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipContextMenuTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipContextMenuTest.kt
@@ -64,8 +64,8 @@ class QuickSwitcherChipContextMenuTest {
         every { AyuVariant.isAyuActive() } returns true
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
         mockkObject(AccentContext.Companion)
-        every { AccentContext.isAccentActive() } returns true
-        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
+        every { AccentContext.isQuickSwitcherActive() } returns true
+        every { AccentContext.detectQuickSwitcher() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
     }
 
     @AfterTest
@@ -155,8 +155,8 @@ class QuickSwitcherChipContextMenuTest {
         // is non-Ayu; the early return in `mousePressed` short-circuits.
         every { AyuVariant.isAyuActive() } returns false
         every { AyuVariant.detect() } returns null
-        every { AccentContext.isAccentActive() } returns false
-        every { AccentContext.detect() } returns null
+        every { AccentContext.isQuickSwitcherActive() } returns false
+        every { AccentContext.detectQuickSwitcher() } returns null
 
         val chip = QuickSwitcherChipComponent()
         chip.dispatchEvent(rightClick(chip))

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipFocusSwapTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipFocusSwapTest.kt
@@ -82,8 +82,8 @@ class QuickSwitcherChipFocusSwapTest {
         every { AyuVariant.isAyuActive() } returns true
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
         mockkObject(AccentContext.Companion)
-        every { AccentContext.isAccentActive() } returns true
-        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
+        every { AccentContext.isQuickSwitcherActive() } returns true
+        every { AccentContext.detectQuickSwitcher() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
 
         mockkObject(AccentResolver)
         every { AccentResolver.sourceLabel(AccentResolver.Source.GLOBAL) } returns "Global"

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipFocusSwapTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipFocusSwapTest.kt
@@ -13,6 +13,7 @@ import com.intellij.util.messages.Topic
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentChangeListener
 import dev.ayuislands.accent.AccentChangedTopic
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
@@ -80,11 +81,15 @@ class QuickSwitcherChipFocusSwapTest {
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.isAyuActive() } returns true
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        mockkObject(AccentContext.Companion)
+        every { AccentContext.isAccentActive() } returns true
+        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
 
         mockkObject(AccentResolver)
         every { AccentResolver.sourceLabel(AccentResolver.Source.GLOBAL) } returns "Global"
         every { AccentResolver.sourceLabel(AccentResolver.Source.PROJECT_OVERRIDE) } returns "Project override"
         every { AccentResolver.sourceLabel(AccentResolver.Source.LANGUAGE_OVERRIDE) } returns "Language override"
+        every { AccentResolver.source(any(), any<AccentContext>()) } returns AccentResolver.Source.GLOBAL
         every { AccentResolver.source(any()) } returns AccentResolver.Source.GLOBAL
 
         mockkObject(AccentApplicator)
@@ -111,8 +116,8 @@ class QuickSwitcherChipFocusSwapTest {
                 every { isDefault } returns false
             }
         every { AccentApplicator.resolveFocusedProject() } returnsMany listOf(projectA, projectB)
-        every { AccentResolver.resolve(projectA, AyuVariant.MIRAGE) } returns "#FFCC66"
-        every { AccentResolver.resolve(projectB, AyuVariant.MIRAGE) } returns "#5CCFE6"
+        every { AccentResolver.resolve(projectA, any<AccentContext>()) } returns "#FFCC66"
+        every { AccentResolver.resolve(projectB, any<AccentContext>()) } returns "#5CCFE6"
 
         val chip = QuickSwitcherChipComponent()
         chip.addNotify() // refreshFromFocusedProject() runs once -> projectA -> #FFCC66
@@ -142,7 +147,7 @@ class QuickSwitcherChipFocusSwapTest {
                 every { isDefault } returns false
             }
         every { AccentApplicator.resolveFocusedProject() } returns project
-        every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returnsMany listOf("#FFCC66", "#DFBFFF")
+        every { AccentResolver.resolve(project, any<AccentContext>()) } returnsMany listOf("#FFCC66", "#DFBFFF")
 
         val chip = QuickSwitcherChipComponent()
         chip.addNotify()
@@ -171,7 +176,7 @@ class QuickSwitcherChipFocusSwapTest {
                 every { isDefault } returns false
             }
         every { AccentApplicator.resolveFocusedProject() } returns project
-        every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returns "#FFCC66"
+        every { AccentResolver.resolve(project, any<AccentContext>()) } returns "#FFCC66"
 
         val chip = QuickSwitcherChipComponent()
         chip.addNotify()

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipPinToggleTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipPinToggleTest.kt
@@ -88,7 +88,7 @@ class QuickSwitcherChipPinToggleTest {
         every { AccentApplicator.applyFromHexString(any()) } returns true
 
         mockkObject(AccentResolver)
-        every { AccentResolver.resolve(any(), any()) } returns "#FFB454"
+        every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#FFB454"
         every { AccentResolver.source(any()) } returns AccentResolver.Source.GLOBAL
         every { AccentResolver.sourceLabel(any()) } returns "Global"
         every { AccentResolver.projectKey(any()) } returns PROJECT_KEY
@@ -132,7 +132,7 @@ class QuickSwitcherChipPinToggleTest {
         // chip re-applies.
         state.projectAccents[PROJECT_KEY] = "#FFB454"
         every { AccentResolver.source(mockProject) } returns AccentResolver.Source.PROJECT_OVERRIDE
-        every { AccentResolver.resolve(any(), any()) } returns "#73D0FF"
+        every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#73D0FF"
 
         val chip = QuickSwitcherChipComponent()
         chip.dispatchEvent(innerClick(chip))
@@ -201,7 +201,7 @@ class QuickSwitcherChipPinToggleTest {
         // override the user thought they were unpinning.
         state.projectAccents[PROJECT_KEY] = "#FFB454"
         every { AccentResolver.source(mockProject) } returns AccentResolver.Source.PROJECT_OVERRIDE
-        every { AccentResolver.resolve(any(), any()) } returns "#73D0FF"
+        every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#73D0FF"
         every { AccentApplicator.applyFromHexString(any()) } returns false
 
         val chip = QuickSwitcherChipComponent()

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipPinToggleTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipPinToggleTest.kt
@@ -8,6 +8,7 @@ import com.intellij.util.messages.MessageBus
 import com.intellij.util.messages.MessageBusConnection
 import com.intellij.util.ui.JBUI
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.licensing.LicenseChecker
@@ -79,6 +80,9 @@ class QuickSwitcherChipPinToggleTest {
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.isAyuActive() } returns true
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        mockkObject(AccentContext.Companion)
+        every { AccentContext.isAccentActive() } returns true
+        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
 
         mockkObject(LicenseChecker)
         every { LicenseChecker.isLicensedOrGrace() } returns true

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipPinToggleTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipPinToggleTest.kt
@@ -179,6 +179,21 @@ class QuickSwitcherChipPinToggleTest {
     }
 
     @Test
+    fun `external inner click opens popup instead of swallowing Ayu-only pin`() {
+        every { AyuVariant.isAyuActive() } returns false
+        every { AyuVariant.detect() } returns null
+        every { AccentContext.isQuickSwitcherActive() } returns true
+        every { AccentContext.detectQuickSwitcher() } returns AccentContext.External
+
+        val chip = QuickSwitcherChipComponent()
+        chip.dispatchEvent(innerClick(chip))
+
+        verify(exactly = 1) { QuickSwitcherPopup.show(chip, chip) }
+        verify(exactly = 0) { AccentApplicator.applyFromHexString(any()) }
+        assertTrue(state.projectAccents.isEmpty(), "External inner click must not write Ayu project pins")
+    }
+
+    @Test
     fun `pin path rolls back projectAccents when applyFromHexString returns false`() {
         // Pin from unpinned + apply rejects (e.g. corrupted upstream
         // settings produce an invalid hex). The pin write must NOT persist

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipPinToggleTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipPinToggleTest.kt
@@ -81,8 +81,8 @@ class QuickSwitcherChipPinToggleTest {
         every { AyuVariant.isAyuActive() } returns true
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
         mockkObject(AccentContext.Companion)
-        every { AccentContext.isAccentActive() } returns true
-        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
+        every { AccentContext.isQuickSwitcherActive() } returns true
+        every { AccentContext.detectQuickSwitcher() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
 
         mockkObject(LicenseChecker)
         every { LicenseChecker.isLicensedOrGrace() } returns true

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherPopupTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherPopupTest.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.ui.popup.ComponentPopupBuilder
 import com.intellij.openapi.ui.popup.JBPopup
 import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.openapi.ui.popup.JBPopupListener
+import dev.ayuislands.AyuLaf
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentResolver
@@ -77,6 +78,19 @@ class QuickSwitcherPopupTest {
     }
 
     @Test
+    fun `show builds popup in external quick-switcher context`() {
+        stubPopupBodyDependencies(
+            context = AccentContext.External,
+            detectedVariant = null,
+        )
+        val (_, popup) = stubPopupBuilder()
+
+        QuickSwitcherPopup.show(JLabel())
+
+        verify(exactly = 1) { popup.showUnderneathOf(any()) }
+    }
+
+    @Test
     fun `show toggles chip popup-attached ring while popup is open`() {
         stubPopupBodyDependencies()
         val (_, popup) = stubPopupBuilder()
@@ -98,22 +112,26 @@ class QuickSwitcherPopupTest {
         assertFalse(chip.isPopupAttached, "Chip must clear attached ring after popup closes")
     }
 
-    private fun stubPopupBodyDependencies() {
+    private fun stubPopupBodyDependencies(
+        context: AccentContext = AccentContext.Ayu(AyuVariant.MIRAGE),
+        detectedVariant: AyuVariant? = AyuVariant.MIRAGE,
+    ) {
         mockkObject(AyuVariant.Companion)
-        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        every { AyuVariant.detect() } returns detectedVariant
         mockkObject(AccentContext.Companion)
-        every { AccentContext.detectQuickSwitcher() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
+        every { AccentContext.detectQuickSwitcher() } returns context
         // The grid resolves the current accent at construction — stub the chain.
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns null
         mockkObject(AccentResolver)
         every { AccentResolver.resolve(any(), any<AccentContext>()) } returns "#FFB454"
         every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#FFB454"
-        // VariantSwitcherRow reads LafManager during construction — stub via relaxed mock.
+        // VariantSwitcherRow reads the active theme name during construction.
         mockkStatic(LafManager::class)
         val lafManager = mockk<LafManager>(relaxed = true)
         every { LafManager.getInstance() } returns lafManager
-        every { lafManager.currentUIThemeLookAndFeel } returns null
+        mockkObject(AyuLaf)
+        every { AyuLaf.currentThemeName(lafManager) } returns ""
         // The premium block reads settings and license state while binding rows.
         val settings = mockk<AyuIslandsSettings>(relaxed = true)
         every { settings.state } returns AyuIslandsState()

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherPopupTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherPopupTest.kt
@@ -102,7 +102,7 @@ class QuickSwitcherPopupTest {
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns null
         mockkObject(AccentResolver)
-        every { AccentResolver.resolve(any(), any()) } returns "#FFB454"
+        every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#FFB454"
         // VariantSwitcherRow reads LafManager during construction — stub via relaxed mock.
         mockkStatic(LafManager::class)
         val lafManager = mockk<LafManager>(relaxed = true)

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherPopupTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherPopupTest.kt
@@ -50,7 +50,7 @@ class QuickSwitcherPopupTest {
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns null
         mockkObject(AccentContext.Companion)
-        every { AccentContext.detect() } returns null
+        every { AccentContext.detectQuickSwitcher() } returns null
         mockkStatic(JBPopupFactory::class)
         val factory = mockk<JBPopupFactory>(relaxed = true)
         every { JBPopupFactory.getInstance() } returns factory
@@ -102,7 +102,7 @@ class QuickSwitcherPopupTest {
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
         mockkObject(AccentContext.Companion)
-        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
+        every { AccentContext.detectQuickSwitcher() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
         // The grid resolves the current accent at construction — stub the chain.
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns null

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherPopupTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherPopupTest.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.ui.popup.JBPopup
 import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.openapi.ui.popup.JBPopupListener
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.licensing.LicenseChecker
@@ -48,6 +49,8 @@ class QuickSwitcherPopupTest {
     fun `show is a no-op when AyuVariant detect returns null`() {
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns null
+        mockkObject(AccentContext.Companion)
+        every { AccentContext.detect() } returns null
         mockkStatic(JBPopupFactory::class)
         val factory = mockk<JBPopupFactory>(relaxed = true)
         every { JBPopupFactory.getInstance() } returns factory
@@ -98,10 +101,13 @@ class QuickSwitcherPopupTest {
     private fun stubPopupBodyDependencies() {
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        mockkObject(AccentContext.Companion)
+        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
         // The grid resolves the current accent at construction — stub the chain.
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns null
         mockkObject(AccentResolver)
+        every { AccentResolver.resolve(any(), any<AccentContext>()) } returns "#FFB454"
         every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#FFB454"
         // VariantSwitcherRow reads LafManager during construction — stub via relaxed mock.
         mockkStatic(LafManager::class)

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherPremiumBlockGateTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherPremiumBlockGateTest.kt
@@ -77,6 +77,24 @@ class QuickSwitcherPremiumBlockGateTest {
         }
     }
 
+    @Test
+    fun `popup source builds variant card only for Ayu context`() {
+        val source = FileUtil.loadFile(File(POPUP_SOURCE_PATH))
+
+        assertTrue(
+            source.contains("AccentContext.External"),
+            "Popup must explicitly support external accent context",
+        )
+        assertTrue(
+            source.contains("is AccentContext.Ayu"),
+            "Variant switcher card must render only for Ayu context",
+        )
+        assertTrue(
+            source.contains("AccentContext.External -> null"),
+            "External context must skip the variant switcher card",
+        )
+    }
+
     private companion object {
         const val POPUP_SOURCE_PATH = "src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherPopup.kt"
     }

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherQuickActionsRowTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherQuickActionsRowTest.kt
@@ -4,6 +4,13 @@ import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.util.ui.JBUI
+import dev.ayuislands.accent.AccentContext
+import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.accent.toolbar.actions.CopyHexAction
+import dev.ayuislands.accent.toolbar.actions.DarkerAccentAction
+import dev.ayuislands.accent.toolbar.actions.LighterAccentAction
+import dev.ayuislands.accent.toolbar.actions.PinAccentAction
+import dev.ayuislands.accent.toolbar.actions.RandomAccentAction
 import dev.ayuislands.accent.toolbar.popup.IconPillButton
 import io.mockk.every
 import io.mockk.mockk
@@ -44,7 +51,7 @@ class QuickSwitcherQuickActionsRowTest {
 
     @Test
     fun `component is a JPanel with FlowLayout LEFT and five children`() {
-        val row = QuickSwitcherQuickActionsRow(anchor)
+        val row = QuickSwitcherQuickActionsRow(anchor, AccentContext.Ayu(AyuVariant.MIRAGE))
         val panel: JPanel = row.component
         val layout = panel.layout
         assertTrue(layout is FlowLayout, "component layout must be FlowLayout, got ${layout?.javaClass?.simpleName}")
@@ -54,7 +61,7 @@ class QuickSwitcherQuickActionsRowTest {
 
     @Test
     fun `all five children are IconPillButton instances 28x28 icon-only with tooltips`() {
-        val row = QuickSwitcherQuickActionsRow(anchor)
+        val row = QuickSwitcherQuickActionsRow(anchor, AccentContext.Ayu(AyuVariant.MIRAGE))
         val children = row.component.components.toList()
         assertEquals(EXPECTED_BUTTON_COUNT, children.size)
         val expectedSize = Dimension(JBUI.scale(28), JBUI.scale(28))
@@ -65,6 +72,26 @@ class QuickSwitcherQuickActionsRowTest {
             assertEquals("", child.text, "Child $index must be icon-only (empty text)")
             assertTrue(child.toolTipText.isNotEmpty(), "Child $index tooltip must be set")
         }
+    }
+
+    @Test
+    fun `external context omits Ayu-only Pin action`() {
+        val row = QuickSwitcherQuickActionsRow(anchor, AccentContext.External)
+        val actions =
+            row.component.components
+                .filterIsInstance<IconPillButton>()
+                .map { it.action::class.java.simpleName }
+
+        assertEquals(
+            listOf(
+                RandomAccentAction::class.java.simpleName,
+                LighterAccentAction::class.java.simpleName,
+                DarkerAccentAction::class.java.simpleName,
+                CopyHexAction::class.java.simpleName,
+            ),
+            actions,
+        )
+        assertTrue(PinAccentAction::class.java.simpleName !in actions)
     }
 
     private companion object {

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherRelatedTogglesSectionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherRelatedTogglesSectionTest.kt
@@ -1,6 +1,7 @@
 package dev.ayuislands.accent.toolbar
 
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.toolbar.popup.Density
@@ -14,6 +15,7 @@ import io.mockk.unmockkAll
 import io.mockk.verify
 import java.awt.Container
 import java.awt.GridLayout
+import java.awt.image.BufferedImage
 import javax.swing.JLabel
 import javax.swing.JPanel
 import kotlin.test.AfterTest
@@ -40,9 +42,12 @@ class QuickSwitcherRelatedTogglesSectionTest {
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns null
         mockkObject(AccentResolver)
+        every { AccentResolver.resolve(any(), any<AccentContext>()) } returns "#FFB454"
         every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#FFB454"
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns AyuVariant.DARK
+        mockkObject(AccentContext.Companion)
+        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.DARK)
     }
 
     @AfterTest
@@ -181,6 +186,32 @@ class QuickSwitcherRelatedTogglesSectionTest {
                 .scale(Density.TILE_GAP)
         assertEquals(expected, layout.hgap)
         assertEquals(expected, layout.vgap)
+    }
+
+    @Test
+    fun `selected toggle paint resolves accent through external context`() {
+        val state = AyuIslandsSettings.getInstance().state
+        state.chromeStatusBar = true
+        every { AccentContext.detect() } returns AccentContext.External
+        every { AccentResolver.resolve(any(), AccentContext.External) } returns "#5CCFE6"
+
+        val section = QuickSwitcherRelatedTogglesSection()
+        val chromeTile =
+            (section.component as JPanel)
+                .components
+                .filterIsInstance<ToggleTile>()
+                .first { tile -> labelOf(tile) == "Chrome tinting" }
+
+        chromeTile.toggleSwitch.setSize(32, 16)
+        val image = BufferedImage(32, 16, BufferedImage.TYPE_INT_ARGB)
+        val graphics = image.createGraphics()
+        try {
+            chromeTile.toggleSwitch.paintForTest(graphics)
+        } finally {
+            graphics.dispose()
+        }
+
+        verify(exactly = 1) { AccentResolver.resolve(any(), AccentContext.External) }
     }
 
     private fun labelOf(tile: ToggleTile): String = findLabelText(tile)

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherRelatedTogglesSectionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherRelatedTogglesSectionTest.kt
@@ -40,7 +40,7 @@ class QuickSwitcherRelatedTogglesSectionTest {
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns null
         mockkObject(AccentResolver)
-        every { AccentResolver.resolve(any(), any()) } returns "#FFB454"
+        every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#FFB454"
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns AyuVariant.DARK
     }

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherRelatedTogglesSectionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherRelatedTogglesSectionTest.kt
@@ -47,7 +47,7 @@ class QuickSwitcherRelatedTogglesSectionTest {
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns AyuVariant.DARK
         mockkObject(AccentContext.Companion)
-        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.DARK)
+        every { AccentContext.detectQuickSwitcher() } returns AccentContext.Ayu(AyuVariant.DARK)
     }
 
     @AfterTest
@@ -192,7 +192,7 @@ class QuickSwitcherRelatedTogglesSectionTest {
     fun `selected toggle paint resolves accent through external context`() {
         val state = AyuIslandsSettings.getInstance().state
         state.chromeStatusBar = true
-        every { AccentContext.detect() } returns AccentContext.External
+        every { AccentContext.detectQuickSwitcher() } returns AccentContext.External
         every { AccentResolver.resolve(any(), AccentContext.External) } returns "#5CCFE6"
 
         val section = QuickSwitcherRelatedTogglesSection()

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherWidgetActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherWidgetActionTest.kt
@@ -23,8 +23,8 @@ import kotlin.test.assertTrue
 
 /**
  * Two-conjunct visibility gate lock. The widget's `update()` must read EXACTLY
- * `AyuVariant.isAyuActive() && state.quickSwitcherWidgetEnabled` — no license
- * predicate (the chip is FREE), no third state field.
+ * `AccentContext.isQuickSwitcherActive() && state.quickSwitcherWidgetEnabled` — no license
+ * predicate (the chip is FREE), no unrelated state field.
  *
  * Pattern J discipline — single-source-of-truth predicate, asserted by toggling
  * each conjunct independently and verifying the presentation flips correctly.
@@ -62,7 +62,7 @@ class QuickSwitcherWidgetActionTest {
     fun `update shows widget for external context when setting enabled`() {
         stubAyuActive(false)
         mockkObject(AccentContext.Companion)
-        every { AccentContext.isAccentActive() } returns true
+        every { AccentContext.isQuickSwitcherActive() } returns true
         stubSettingsState(quickSwitcherEnabled = true)
         val presentation = Presentation()
         val event = mockk<AnActionEvent>(relaxed = true)
@@ -158,7 +158,7 @@ class QuickSwitcherWidgetActionTest {
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.isAyuActive() } returns active
         mockkObject(AccentContext.Companion)
-        every { AccentContext.isAccentActive() } returns active
+        every { AccentContext.isQuickSwitcherActive() } returns active
     }
 
     private fun stubSettingsState(quickSwitcherEnabled: Boolean): AyuIslandsState {

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherWidgetActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherWidgetActionTest.kt
@@ -3,6 +3,7 @@ package dev.ayuislands.accent.toolbar
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.Presentation
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
@@ -55,6 +56,21 @@ class QuickSwitcherWidgetActionTest {
             presentation.isEnabledAndVisible,
             "Both conjuncts true => visible; state=$state",
         )
+    }
+
+    @Test
+    fun `update shows widget for external context when setting enabled`() {
+        stubAyuActive(false)
+        mockkObject(AccentContext.Companion)
+        every { AccentContext.isAccentActive() } returns true
+        stubSettingsState(quickSwitcherEnabled = true)
+        val presentation = Presentation()
+        val event = mockk<AnActionEvent>(relaxed = true)
+        every { event.presentation } returns presentation
+
+        action.update(event)
+
+        assertTrue(presentation.isEnabledAndVisible)
     }
 
     @Test
@@ -141,6 +157,8 @@ class QuickSwitcherWidgetActionTest {
     private fun stubAyuActive(active: Boolean) {
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.isAyuActive() } returns active
+        mockkObject(AccentContext.Companion)
+        every { AccentContext.isAccentActive() } returns active
     }
 
     private fun stubSettingsState(quickSwitcherEnabled: Boolean): AyuIslandsState {

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherWidgetLifecycleTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherWidgetLifecycleTest.kt
@@ -75,7 +75,7 @@ class QuickSwitcherWidgetLifecycleTest {
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns null
         mockkObject(AccentContext.Companion)
-        every { AccentContext.detect() } returns null
+        every { AccentContext.detectQuickSwitcher() } returns null
     }
 
     @AfterEach

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherWidgetLifecycleTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherWidgetLifecycleTest.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.util.messages.MessageBus
 import com.intellij.util.messages.MessageBusConnection
 import dev.ayuislands.accent.AccentChangedTopic
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AyuVariant
 import io.mockk.every
 import io.mockk.mockk
@@ -73,6 +74,8 @@ class QuickSwitcherWidgetLifecycleTest {
         // refresh, not the refresh body itself.
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns null
+        mockkObject(AccentContext.Companion)
+        every { AccentContext.detect() } returns null
     }
 
     @AfterEach

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/VariantSwitcherRowTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/VariantSwitcherRowTest.kt
@@ -46,7 +46,7 @@ class VariantSwitcherRowTest {
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns null
         mockkObject(AccentResolver)
-        every { AccentResolver.resolve(any(), any()) } returns "#FFB454"
+        every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#FFB454"
     }
 
     @AfterTest
@@ -279,7 +279,7 @@ class VariantSwitcherRowTest {
         every { islandsTheme.name } returns "Ayu Mirage (Islands UI)"
         every { lafManager.currentUIThemeLookAndFeel } returns islandsTheme
         every { lafManager.installedThemes } returns sequenceOf(mirageTheme, islandsTheme)
-        every { AccentResolver.resolve(any(), any()) } throws RuntimeException("resolver race")
+        every { AccentResolver.resolve(any(), any<AyuVariant>()) } throws RuntimeException("resolver race")
 
         val row = VariantSwitcherRow(AyuVariant.MIRAGE)
         val pill =
@@ -302,7 +302,7 @@ class VariantSwitcherRowTest {
         } finally {
             g2.dispose()
         }
-        verify(atLeast = 1) { AccentResolver.resolve(any(), any()) }
+        verify(atLeast = 1) { AccentResolver.resolve(any(), any<AyuVariant>()) }
         // Behavior pin — IslandsUiPill resolves to MIRAGE_HEX when the
         // resolver throws; the constant itself is the value the user sees
         // painted in the fallback. Lock the exact literal so any future

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/CopyHexActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/CopyHexActionTest.kt
@@ -47,7 +47,7 @@ class CopyHexActionTest {
         every { AccentApplicator.resolveFocusedProject() } returns mockProject
 
         mockkObject(AccentResolver)
-        every { AccentResolver.resolve(any(), any()) } returns "#FFCC66"
+        every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#FFCC66"
 
         mockkStatic(CopyPasteManager::class)
         every { CopyPasteManager.getInstance() } returns mockClipboard
@@ -116,9 +116,9 @@ class CopyHexActionTest {
         every { mockClipboard.setContents(any()) } answers {
             captured += firstArg<Transferable>()
         }
-        every { AccentResolver.resolve(any(), any()) } returns "#FFCC66"
+        every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#FFCC66"
         CopyHexAction().actionPerformed(newEvent())
-        every { AccentResolver.resolve(any(), any()) } returns "#5CCFE6"
+        every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#5CCFE6"
         CopyHexAction().actionPerformed(newEvent())
         assertEquals(2, captured.size)
         assertEquals("#FFCC66", captured[0].getTransferData(DataFlavor.stringFlavor))

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/CopyHexActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/CopyHexActionTest.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.actionSystem.Presentation
 import com.intellij.openapi.ide.CopyPasteManager
 import com.intellij.openapi.project.Project
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.licensing.LicenseChecker
@@ -39,6 +40,9 @@ class CopyHexActionTest {
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.isAyuActive() } returns true
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        mockkObject(AccentContext.Companion)
+        every { AccentContext.isAccentActive() } returns true
+        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
 
         mockkObject(LicenseChecker)
         every { LicenseChecker.isLicensedOrGrace() } returns true
@@ -47,6 +51,7 @@ class CopyHexActionTest {
         every { AccentApplicator.resolveFocusedProject() } returns mockProject
 
         mockkObject(AccentResolver)
+        every { AccentResolver.resolve(any(), any<AccentContext>()) } returns "#FFCC66"
         every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#FFCC66"
 
         mockkStatic(CopyPasteManager::class)
@@ -77,25 +82,37 @@ class CopyHexActionTest {
         val action = CopyHexAction()
         val event = newEvent()
 
-        every { AyuVariant.isAyuActive() } returns true
+        every { AccentContext.isAccentActive() } returns true
         every { LicenseChecker.isLicensedOrGrace() } returns true
         action.update(event)
         assertTrue(event.presentation.isEnabledAndVisible, "(T,T) must enable")
 
-        every { AyuVariant.isAyuActive() } returns false
+        every { AccentContext.isAccentActive() } returns false
         every { LicenseChecker.isLicensedOrGrace() } returns true
         action.update(event)
         assertFalse(event.presentation.isEnabledAndVisible, "(F,T) inactive variant must disable")
 
-        every { AyuVariant.isAyuActive() } returns true
+        every { AccentContext.isAccentActive() } returns true
         every { LicenseChecker.isLicensedOrGrace() } returns false
         action.update(event)
         assertFalse(event.presentation.isEnabledAndVisible, "(T,F) unlicensed must disable")
 
-        every { AyuVariant.isAyuActive() } returns false
+        every { AccentContext.isAccentActive() } returns false
         every { LicenseChecker.isLicensedOrGrace() } returns false
         action.update(event)
         assertFalse(event.presentation.isEnabledAndVisible, "(F,F) both off must disable — locks AND vs OR")
+    }
+
+    @Test
+    fun `update is visible in external accent context`() {
+        val event = newEvent()
+        every { AyuVariant.isAyuActive() } returns false
+        every { AccentContext.isAccentActive() } returns true
+        every { LicenseChecker.isLicensedOrGrace() } returns true
+
+        CopyHexAction().update(event)
+
+        assertTrue(event.presentation.isEnabledAndVisible)
     }
 
     @Test
@@ -116,9 +133,9 @@ class CopyHexActionTest {
         every { mockClipboard.setContents(any()) } answers {
             captured += firstArg<Transferable>()
         }
-        every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#FFCC66"
+        every { AccentResolver.resolve(any(), any<AccentContext>()) } returns "#FFCC66"
         CopyHexAction().actionPerformed(newEvent())
-        every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#5CCFE6"
+        every { AccentResolver.resolve(any(), any<AccentContext>()) } returns "#5CCFE6"
         CopyHexAction().actionPerformed(newEvent())
         assertEquals(2, captured.size)
         assertEquals("#FFCC66", captured[0].getTransferData(DataFlavor.stringFlavor))
@@ -127,7 +144,7 @@ class CopyHexActionTest {
 
     @Test
     fun `actionPerformed is a no-op when AyuVariant detect returns null (belt-and-braces)`() {
-        every { AyuVariant.detect() } returns null
+        every { AccentContext.detect() } returns null
         CopyHexAction().actionPerformed(newEvent())
         verify(exactly = 0) { mockClipboard.setContents(any()) }
     }

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/CopyHexActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/CopyHexActionTest.kt
@@ -41,8 +41,8 @@ class CopyHexActionTest {
         every { AyuVariant.isAyuActive() } returns true
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
         mockkObject(AccentContext.Companion)
-        every { AccentContext.isAccentActive() } returns true
-        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
+        every { AccentContext.isQuickSwitcherActive() } returns true
+        every { AccentContext.detectQuickSwitcher() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
 
         mockkObject(LicenseChecker)
         every { LicenseChecker.isLicensedOrGrace() } returns true
@@ -82,22 +82,22 @@ class CopyHexActionTest {
         val action = CopyHexAction()
         val event = newEvent()
 
-        every { AccentContext.isAccentActive() } returns true
+        every { AccentContext.isQuickSwitcherActive() } returns true
         every { LicenseChecker.isLicensedOrGrace() } returns true
         action.update(event)
         assertTrue(event.presentation.isEnabledAndVisible, "(T,T) must enable")
 
-        every { AccentContext.isAccentActive() } returns false
+        every { AccentContext.isQuickSwitcherActive() } returns false
         every { LicenseChecker.isLicensedOrGrace() } returns true
         action.update(event)
         assertFalse(event.presentation.isEnabledAndVisible, "(F,T) inactive variant must disable")
 
-        every { AccentContext.isAccentActive() } returns true
+        every { AccentContext.isQuickSwitcherActive() } returns true
         every { LicenseChecker.isLicensedOrGrace() } returns false
         action.update(event)
         assertFalse(event.presentation.isEnabledAndVisible, "(T,F) unlicensed must disable")
 
-        every { AccentContext.isAccentActive() } returns false
+        every { AccentContext.isQuickSwitcherActive() } returns false
         every { LicenseChecker.isLicensedOrGrace() } returns false
         action.update(event)
         assertFalse(event.presentation.isEnabledAndVisible, "(F,F) both off must disable — locks AND vs OR")
@@ -107,7 +107,7 @@ class CopyHexActionTest {
     fun `update is visible in external accent context`() {
         val event = newEvent()
         every { AyuVariant.isAyuActive() } returns false
-        every { AccentContext.isAccentActive() } returns true
+        every { AccentContext.isQuickSwitcherActive() } returns true
         every { LicenseChecker.isLicensedOrGrace() } returns true
 
         CopyHexAction().update(event)
@@ -144,7 +144,7 @@ class CopyHexActionTest {
 
     @Test
     fun `actionPerformed is a no-op when AyuVariant detect returns null (belt-and-braces)`() {
-        every { AccentContext.detect() } returns null
+        every { AccentContext.detectQuickSwitcher() } returns null
         CopyHexAction().actionPerformed(newEvent())
         verify(exactly = 0) { mockClipboard.setContents(any()) }
     }

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/DarkerAccentActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/DarkerAccentActionTest.kt
@@ -44,8 +44,8 @@ class DarkerAccentActionTest {
         every { AyuVariant.isAyuActive() } returns true
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
         mockkObject(AccentContext.Companion)
-        every { AccentContext.isAccentActive() } returns true
-        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
+        every { AccentContext.isQuickSwitcherActive() } returns true
+        every { AccentContext.detectQuickSwitcher() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
 
         mockkObject(LicenseChecker)
         every { LicenseChecker.isLicensedOrGrace() } returns true
@@ -85,22 +85,22 @@ class DarkerAccentActionTest {
         val action = DarkerAccentAction()
         val event = newEvent()
 
-        every { AccentContext.isAccentActive() } returns true
+        every { AccentContext.isQuickSwitcherActive() } returns true
         every { LicenseChecker.isLicensedOrGrace() } returns true
         action.update(event)
         assertTrue(event.presentation.isEnabledAndVisible, "(T,T) must enable")
 
-        every { AccentContext.isAccentActive() } returns false
+        every { AccentContext.isQuickSwitcherActive() } returns false
         every { LicenseChecker.isLicensedOrGrace() } returns true
         action.update(event)
         assertFalse(event.presentation.isEnabledAndVisible, "(F,T) inactive variant must disable")
 
-        every { AccentContext.isAccentActive() } returns true
+        every { AccentContext.isQuickSwitcherActive() } returns true
         every { LicenseChecker.isLicensedOrGrace() } returns false
         action.update(event)
         assertFalse(event.presentation.isEnabledAndVisible, "(T,F) unlicensed must disable")
 
-        every { AccentContext.isAccentActive() } returns false
+        every { AccentContext.isQuickSwitcherActive() } returns false
         every { LicenseChecker.isLicensedOrGrace() } returns false
         action.update(event)
         assertFalse(event.presentation.isEnabledAndVisible, "(F,F) both off must disable — locks AND vs OR")
@@ -110,7 +110,7 @@ class DarkerAccentActionTest {
     fun `update is visible in external accent context`() {
         val event = newEvent()
         every { AyuVariant.isAyuActive() } returns false
-        every { AccentContext.isAccentActive() } returns true
+        every { AccentContext.isQuickSwitcherActive() } returns true
         every { LicenseChecker.isLicensedOrGrace() } returns true
 
         DarkerAccentAction().update(event)

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/DarkerAccentActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/DarkerAccentActionTest.kt
@@ -51,7 +51,7 @@ class DarkerAccentActionTest {
         every { AccentApplicator.applyFromHexString(any()) } returns true
 
         mockkObject(AccentResolver)
-        every { AccentResolver.resolve(any(), any()) } returns "#FFCC66"
+        every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#FFCC66"
 
         mockkStatic(ApplicationManager::class)
         every { ApplicationManager.getApplication() } returns mockApp
@@ -115,7 +115,7 @@ class DarkerAccentActionTest {
     fun `actionPerformed at MIN_LIGHTNESS clamp still calls applyFromHexString with the unchanged hex`() {
         // Test 30
         val floorHex = HslColor.toHex(0f, 0f, AccentHsl.MIN_LIGHTNESS)
-        every { AccentResolver.resolve(any(), any()) } returns floorHex
+        every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns floorHex
         DarkerAccentAction().actionPerformed(newEvent())
         verify(exactly = 1) { AccentApplicator.applyFromHexString(floorHex) }
     }

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/DarkerAccentActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/DarkerAccentActionTest.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
@@ -42,6 +43,9 @@ class DarkerAccentActionTest {
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.isAyuActive() } returns true
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        mockkObject(AccentContext.Companion)
+        every { AccentContext.isAccentActive() } returns true
+        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
 
         mockkObject(LicenseChecker)
         every { LicenseChecker.isLicensedOrGrace() } returns true
@@ -51,6 +55,7 @@ class DarkerAccentActionTest {
         every { AccentApplicator.applyFromHexString(any()) } returns true
 
         mockkObject(AccentResolver)
+        every { AccentResolver.resolve(any(), any<AccentContext>()) } returns "#FFCC66"
         every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#FFCC66"
 
         mockkStatic(ApplicationManager::class)
@@ -80,25 +85,37 @@ class DarkerAccentActionTest {
         val action = DarkerAccentAction()
         val event = newEvent()
 
-        every { AyuVariant.isAyuActive() } returns true
+        every { AccentContext.isAccentActive() } returns true
         every { LicenseChecker.isLicensedOrGrace() } returns true
         action.update(event)
         assertTrue(event.presentation.isEnabledAndVisible, "(T,T) must enable")
 
-        every { AyuVariant.isAyuActive() } returns false
+        every { AccentContext.isAccentActive() } returns false
         every { LicenseChecker.isLicensedOrGrace() } returns true
         action.update(event)
         assertFalse(event.presentation.isEnabledAndVisible, "(F,T) inactive variant must disable")
 
-        every { AyuVariant.isAyuActive() } returns true
+        every { AccentContext.isAccentActive() } returns true
         every { LicenseChecker.isLicensedOrGrace() } returns false
         action.update(event)
         assertFalse(event.presentation.isEnabledAndVisible, "(T,F) unlicensed must disable")
 
-        every { AyuVariant.isAyuActive() } returns false
+        every { AccentContext.isAccentActive() } returns false
         every { LicenseChecker.isLicensedOrGrace() } returns false
         action.update(event)
         assertFalse(event.presentation.isEnabledAndVisible, "(F,F) both off must disable — locks AND vs OR")
+    }
+
+    @Test
+    fun `update is visible in external accent context`() {
+        val event = newEvent()
+        every { AyuVariant.isAyuActive() } returns false
+        every { AccentContext.isAccentActive() } returns true
+        every { LicenseChecker.isLicensedOrGrace() } returns true
+
+        DarkerAccentAction().update(event)
+
+        assertTrue(event.presentation.isEnabledAndVisible)
     }
 
     @Test
@@ -115,7 +132,7 @@ class DarkerAccentActionTest {
     fun `actionPerformed at MIN_LIGHTNESS clamp still calls applyFromHexString with the unchanged hex`() {
         // Test 30
         val floorHex = HslColor.toHex(0f, 0f, AccentHsl.MIN_LIGHTNESS)
-        every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns floorHex
+        every { AccentResolver.resolve(any(), any<AccentContext>()) } returns floorHex
         DarkerAccentAction().actionPerformed(newEvent())
         verify(exactly = 1) { AccentApplicator.applyFromHexString(floorHex) }
     }

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/DarkerAccentActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/DarkerAccentActionTest.kt
@@ -11,9 +11,12 @@ import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.accent.ExternalAccentSource
 import dev.ayuislands.accent.color.AccentHsl
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.rotation.HslColor
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 import io.mockk.every
 import io.mockk.mockk
@@ -126,6 +129,22 @@ class DarkerAccentActionTest {
         DarkerAccentAction().actionPerformed(newEvent())
         verify(exactly = 1) { AccentApplicator.applyFromHexString(expected) }
         verify(exactly = 1) { mockSwap.notifyExternalApply(expected) }
+    }
+
+    @Test
+    fun `actionPerformed in external context persists manual external accent`() {
+        every { AccentContext.detectQuickSwitcher() } returns AccentContext.External
+        val state = AyuIslandsState()
+        val settings = mockk<AyuIslandsSettings>(relaxed = true)
+        every { settings.state } returns state
+        mockkObject(AyuIslandsSettings.Companion)
+        every { AyuIslandsSettings.getInstance() } returns settings
+
+        val expected = AccentHsl.darken(AccentHex.unsafeOf("#FFCC66")).value
+        DarkerAccentAction().actionPerformed(newEvent())
+
+        assertEquals(expected, state.externalThemeAccent)
+        assertEquals(ExternalAccentSource.MANUAL.name, state.externalThemeAccentSource)
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/LighterAccentActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/LighterAccentActionTest.kt
@@ -11,9 +11,12 @@ import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.accent.ExternalAccentSource
 import dev.ayuislands.accent.color.AccentHsl
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.rotation.HslColor
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 import io.mockk.every
 import io.mockk.mockk
@@ -126,6 +129,22 @@ class LighterAccentActionTest {
         LighterAccentAction().actionPerformed(newEvent())
         verify(exactly = 1) { AccentApplicator.applyFromHexString(expected) }
         verify(exactly = 1) { mockSwap.notifyExternalApply(expected) }
+    }
+
+    @Test
+    fun `actionPerformed in external context persists manual external accent`() {
+        every { AccentContext.detectQuickSwitcher() } returns AccentContext.External
+        val state = AyuIslandsState()
+        val settings = mockk<AyuIslandsSettings>(relaxed = true)
+        every { settings.state } returns state
+        mockkObject(AyuIslandsSettings.Companion)
+        every { AyuIslandsSettings.getInstance() } returns settings
+
+        val expected = AccentHsl.lighten(AccentHex.unsafeOf("#FFCC66")).value
+        LighterAccentAction().actionPerformed(newEvent())
+
+        assertEquals(expected, state.externalThemeAccent)
+        assertEquals(ExternalAccentSource.MANUAL.name, state.externalThemeAccentSource)
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/LighterAccentActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/LighterAccentActionTest.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
@@ -42,6 +43,9 @@ class LighterAccentActionTest {
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.isAyuActive() } returns true
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        mockkObject(AccentContext.Companion)
+        every { AccentContext.isAccentActive() } returns true
+        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
 
         mockkObject(LicenseChecker)
         every { LicenseChecker.isLicensedOrGrace() } returns true
@@ -51,6 +55,7 @@ class LighterAccentActionTest {
         every { AccentApplicator.applyFromHexString(any()) } returns true
 
         mockkObject(AccentResolver)
+        every { AccentResolver.resolve(any(), any<AccentContext>()) } returns "#FFCC66"
         every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#FFCC66"
 
         mockkStatic(ApplicationManager::class)
@@ -80,25 +85,37 @@ class LighterAccentActionTest {
         val action = LighterAccentAction()
         val event = newEvent()
 
-        every { AyuVariant.isAyuActive() } returns true
+        every { AccentContext.isAccentActive() } returns true
         every { LicenseChecker.isLicensedOrGrace() } returns true
         action.update(event)
         assertTrue(event.presentation.isEnabledAndVisible, "(T,T) must enable")
 
-        every { AyuVariant.isAyuActive() } returns false
+        every { AccentContext.isAccentActive() } returns false
         every { LicenseChecker.isLicensedOrGrace() } returns true
         action.update(event)
         assertFalse(event.presentation.isEnabledAndVisible, "(F,T) inactive variant must disable")
 
-        every { AyuVariant.isAyuActive() } returns true
+        every { AccentContext.isAccentActive() } returns true
         every { LicenseChecker.isLicensedOrGrace() } returns false
         action.update(event)
         assertFalse(event.presentation.isEnabledAndVisible, "(T,F) unlicensed must disable")
 
-        every { AyuVariant.isAyuActive() } returns false
+        every { AccentContext.isAccentActive() } returns false
         every { LicenseChecker.isLicensedOrGrace() } returns false
         action.update(event)
         assertFalse(event.presentation.isEnabledAndVisible, "(F,F) both off must disable — locks AND vs OR")
+    }
+
+    @Test
+    fun `update is visible in external accent context`() {
+        val event = newEvent()
+        every { AyuVariant.isAyuActive() } returns false
+        every { AccentContext.isAccentActive() } returns true
+        every { LicenseChecker.isLicensedOrGrace() } returns true
+
+        LighterAccentAction().update(event)
+
+        assertTrue(event.presentation.isEnabledAndVisible)
     }
 
     @Test
@@ -116,7 +133,7 @@ class LighterAccentActionTest {
         // At the clamp the action runs; the balloon hint is a future
         // deliverable, not in scope here.
         val ceilingHex = HslColor.toHex(0f, 0f, AccentHsl.MAX_LIGHTNESS)
-        every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns ceilingHex
+        every { AccentResolver.resolve(any(), any<AccentContext>()) } returns ceilingHex
         LighterAccentAction().actionPerformed(newEvent())
         // AccentHsl.lighten at the ceiling returns the input unchanged.
         verify(exactly = 1) { AccentApplicator.applyFromHexString(ceilingHex) }

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/LighterAccentActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/LighterAccentActionTest.kt
@@ -51,7 +51,7 @@ class LighterAccentActionTest {
         every { AccentApplicator.applyFromHexString(any()) } returns true
 
         mockkObject(AccentResolver)
-        every { AccentResolver.resolve(any(), any()) } returns "#FFCC66"
+        every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#FFCC66"
 
         mockkStatic(ApplicationManager::class)
         every { ApplicationManager.getApplication() } returns mockApp
@@ -116,7 +116,7 @@ class LighterAccentActionTest {
         // At the clamp the action runs; the balloon hint is a future
         // deliverable, not in scope here.
         val ceilingHex = HslColor.toHex(0f, 0f, AccentHsl.MAX_LIGHTNESS)
-        every { AccentResolver.resolve(any(), any()) } returns ceilingHex
+        every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns ceilingHex
         LighterAccentAction().actionPerformed(newEvent())
         // AccentHsl.lighten at the ceiling returns the input unchanged.
         verify(exactly = 1) { AccentApplicator.applyFromHexString(ceilingHex) }

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/LighterAccentActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/LighterAccentActionTest.kt
@@ -44,8 +44,8 @@ class LighterAccentActionTest {
         every { AyuVariant.isAyuActive() } returns true
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
         mockkObject(AccentContext.Companion)
-        every { AccentContext.isAccentActive() } returns true
-        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
+        every { AccentContext.isQuickSwitcherActive() } returns true
+        every { AccentContext.detectQuickSwitcher() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
 
         mockkObject(LicenseChecker)
         every { LicenseChecker.isLicensedOrGrace() } returns true
@@ -85,22 +85,22 @@ class LighterAccentActionTest {
         val action = LighterAccentAction()
         val event = newEvent()
 
-        every { AccentContext.isAccentActive() } returns true
+        every { AccentContext.isQuickSwitcherActive() } returns true
         every { LicenseChecker.isLicensedOrGrace() } returns true
         action.update(event)
         assertTrue(event.presentation.isEnabledAndVisible, "(T,T) must enable")
 
-        every { AccentContext.isAccentActive() } returns false
+        every { AccentContext.isQuickSwitcherActive() } returns false
         every { LicenseChecker.isLicensedOrGrace() } returns true
         action.update(event)
         assertFalse(event.presentation.isEnabledAndVisible, "(F,T) inactive variant must disable")
 
-        every { AccentContext.isAccentActive() } returns true
+        every { AccentContext.isQuickSwitcherActive() } returns true
         every { LicenseChecker.isLicensedOrGrace() } returns false
         action.update(event)
         assertFalse(event.presentation.isEnabledAndVisible, "(T,F) unlicensed must disable")
 
-        every { AccentContext.isAccentActive() } returns false
+        every { AccentContext.isQuickSwitcherActive() } returns false
         every { LicenseChecker.isLicensedOrGrace() } returns false
         action.update(event)
         assertFalse(event.presentation.isEnabledAndVisible, "(F,F) both off must disable — locks AND vs OR")
@@ -110,7 +110,7 @@ class LighterAccentActionTest {
     fun `update is visible in external accent context`() {
         val event = newEvent()
         every { AyuVariant.isAyuActive() } returns false
-        every { AccentContext.isAccentActive() } returns true
+        every { AccentContext.isQuickSwitcherActive() } returns true
         every { LicenseChecker.isLicensedOrGrace() } returns true
 
         LighterAccentAction().update(event)

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/PinAccentActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/PinAccentActionTest.kt
@@ -56,7 +56,7 @@ class PinAccentActionTest {
         every { AccentApplicator.applyFromHexString(any()) } returns true
 
         mockkObject(AccentResolver)
-        every { AccentResolver.resolve(any(), any()) } returns "#7F52FF"
+        every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#7F52FF"
         every { AccentResolver.projectKey(any()) } returns "/path/to/project"
 
         mockkObject(AccentMappingsSettings.Companion)

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/PinAccentActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/PinAccentActionTest.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.licensing.LicenseChecker
@@ -47,6 +48,9 @@ class PinAccentActionTest {
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.isAyuActive() } returns true
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        mockkObject(AccentContext.Companion)
+        every { AccentContext.isAccentActive() } returns true
+        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
 
         mockkObject(LicenseChecker)
         every { LicenseChecker.isLicensedOrGrace() } returns true
@@ -56,6 +60,7 @@ class PinAccentActionTest {
         every { AccentApplicator.applyFromHexString(any()) } returns true
 
         mockkObject(AccentResolver)
+        every { AccentResolver.resolve(any(), any<AccentContext>()) } returns "#7F52FF"
         every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#7F52FF"
         every { AccentResolver.projectKey(any()) } returns "/path/to/project"
 
@@ -93,22 +98,22 @@ class PinAccentActionTest {
         val action = PinAccentAction()
         val event = newEvent()
 
-        every { AyuVariant.isAyuActive() } returns true
+        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
         every { LicenseChecker.isLicensedOrGrace() } returns true
         action.update(event)
         assertTrue(event.presentation.isEnabledAndVisible, "Active + licensed must enable")
 
-        every { AyuVariant.isAyuActive() } returns false
+        every { AccentContext.detect() } returns AccentContext.External
         every { LicenseChecker.isLicensedOrGrace() } returns true
         action.update(event)
-        assertFalse(event.presentation.isEnabledAndVisible, "Inactive variant must disable")
+        assertFalse(event.presentation.isEnabledAndVisible, "External context must disable Ayu-only pinning")
 
-        every { AyuVariant.isAyuActive() } returns true
+        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
         every { LicenseChecker.isLicensedOrGrace() } returns false
         action.update(event)
         assertFalse(event.presentation.isEnabledAndVisible, "Unlicensed must disable")
 
-        every { AyuVariant.isAyuActive() } returns false
+        every { AccentContext.detect() } returns null
         every { LicenseChecker.isLicensedOrGrace() } returns false
         action.update(event)
         assertFalse(event.presentation.isEnabledAndVisible, "Both off must disable")

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/RandomAccentActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/RandomAccentActionTest.kt
@@ -43,8 +43,8 @@ class RandomAccentActionTest {
         every { AyuVariant.isAyuActive() } returns true
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
         mockkObject(AccentContext.Companion)
-        every { AccentContext.isAccentActive() } returns true
-        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
+        every { AccentContext.isQuickSwitcherActive() } returns true
+        every { AccentContext.detectQuickSwitcher() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
 
         mockkObject(LicenseChecker)
         every { LicenseChecker.isLicensedOrGrace() } returns true
@@ -82,22 +82,22 @@ class RandomAccentActionTest {
         val action = RandomAccentAction()
         val event = newEvent()
 
-        every { AccentContext.isAccentActive() } returns true
+        every { AccentContext.isQuickSwitcherActive() } returns true
         every { LicenseChecker.isLicensedOrGrace() } returns true
         action.update(event)
         assertTrue(event.presentation.isEnabledAndVisible, "(T,T) must enable")
 
-        every { AccentContext.isAccentActive() } returns false
+        every { AccentContext.isQuickSwitcherActive() } returns false
         every { LicenseChecker.isLicensedOrGrace() } returns true
         action.update(event)
         assertFalse(event.presentation.isEnabledAndVisible, "(F,T) inactive variant must disable")
 
-        every { AccentContext.isAccentActive() } returns true
+        every { AccentContext.isQuickSwitcherActive() } returns true
         every { LicenseChecker.isLicensedOrGrace() } returns false
         action.update(event)
         assertFalse(event.presentation.isEnabledAndVisible, "(T,F) unlicensed must disable")
 
-        every { AccentContext.isAccentActive() } returns false
+        every { AccentContext.isQuickSwitcherActive() } returns false
         every { LicenseChecker.isLicensedOrGrace() } returns false
         action.update(event)
         assertFalse(event.presentation.isEnabledAndVisible, "(F,F) both off must disable — locks AND vs OR")
@@ -107,7 +107,7 @@ class RandomAccentActionTest {
     fun `update is visible in external accent context`() {
         val event = newEvent()
         every { AyuVariant.isAyuActive() } returns false
-        every { AccentContext.isAccentActive() } returns true
+        every { AccentContext.isQuickSwitcherActive() } returns true
         every { LicenseChecker.isLicensedOrGrace() } returns true
 
         RandomAccentAction().update(event)
@@ -132,7 +132,7 @@ class RandomAccentActionTest {
 
     @Test
     fun `actionPerformed in external context persists manual external accent`() {
-        every { AccentContext.detect() } returns AccentContext.External
+        every { AccentContext.detectQuickSwitcher() } returns AccentContext.External
         val state = AyuIslandsState()
         val settings = mockk<AyuIslandsSettings>(relaxed = true)
         every { settings.state } returns state

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/RandomAccentActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/RandomAccentActionTest.kt
@@ -6,9 +6,13 @@ import com.intellij.openapi.actionSystem.Presentation
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.accent.ExternalAccentSource
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.rotation.ContrastAwareColorGenerator
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 import io.mockk.clearMocks
 import io.mockk.every
@@ -38,6 +42,9 @@ class RandomAccentActionTest {
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.isAyuActive() } returns true
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        mockkObject(AccentContext.Companion)
+        every { AccentContext.isAccentActive() } returns true
+        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
 
         mockkObject(LicenseChecker)
         every { LicenseChecker.isLicensedOrGrace() } returns true
@@ -75,25 +82,37 @@ class RandomAccentActionTest {
         val action = RandomAccentAction()
         val event = newEvent()
 
-        every { AyuVariant.isAyuActive() } returns true
+        every { AccentContext.isAccentActive() } returns true
         every { LicenseChecker.isLicensedOrGrace() } returns true
         action.update(event)
         assertTrue(event.presentation.isEnabledAndVisible, "(T,T) must enable")
 
-        every { AyuVariant.isAyuActive() } returns false
+        every { AccentContext.isAccentActive() } returns false
         every { LicenseChecker.isLicensedOrGrace() } returns true
         action.update(event)
         assertFalse(event.presentation.isEnabledAndVisible, "(F,T) inactive variant must disable")
 
-        every { AyuVariant.isAyuActive() } returns true
+        every { AccentContext.isAccentActive() } returns true
         every { LicenseChecker.isLicensedOrGrace() } returns false
         action.update(event)
         assertFalse(event.presentation.isEnabledAndVisible, "(T,F) unlicensed must disable")
 
-        every { AyuVariant.isAyuActive() } returns false
+        every { AccentContext.isAccentActive() } returns false
         every { LicenseChecker.isLicensedOrGrace() } returns false
         action.update(event)
         assertFalse(event.presentation.isEnabledAndVisible, "(F,F) both off must disable — locks AND vs OR")
+    }
+
+    @Test
+    fun `update is visible in external accent context`() {
+        val event = newEvent()
+        every { AyuVariant.isAyuActive() } returns false
+        every { AccentContext.isAccentActive() } returns true
+        every { LicenseChecker.isLicensedOrGrace() } returns true
+
+        RandomAccentAction().update(event)
+
+        assertTrue(event.presentation.isEnabledAndVisible)
     }
 
     @Test
@@ -109,6 +128,21 @@ class RandomAccentActionTest {
         every { AccentApplicator.applyFromHexString(any()) } returns false
         RandomAccentAction().actionPerformed(newEvent())
         verify(exactly = 0) { mockSwap.notifyExternalApply(any()) }
+    }
+
+    @Test
+    fun `actionPerformed in external context persists manual external accent`() {
+        every { AccentContext.detect() } returns AccentContext.External
+        val state = AyuIslandsState()
+        val settings = mockk<AyuIslandsSettings>(relaxed = true)
+        every { settings.state } returns state
+        mockkObject(AyuIslandsSettings.Companion)
+        every { AyuIslandsSettings.getInstance() } returns settings
+
+        RandomAccentAction().actionPerformed(newEvent())
+
+        assertEquals("#5CCFE6", state.externalThemeAccent)
+        assertEquals(ExternalAccentSource.MANUAL.name, state.externalThemeAccentSource)
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/glow/GlowLifecycleGuardTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/GlowLifecycleGuardTest.kt
@@ -12,15 +12,16 @@ import kotlin.test.fail
  * (`DEFAULT_ACCENT_HEX` fallbacks). This test pins the current shape: the head
  * of `updateGlow()` must open with the literal sequence
  *
- *   if (!AyuVariant.isAyuActive()) {
+ *   val context = AccentContext.detect()
+ *   if (context == null) {
  *       removeAllOverlays()
  *       return
  *   }
  *
  * A future agent who silently reorders the steps (e.g. moving `return` before
  * `removeAllOverlays()` so the dispose never runs, or replacing the predicate
- * with `AyuVariant.detect() == null` and bypassing Pattern J) gets a named
- * regression that names this test rather than a generic visual bug report.
+ * with an Ayu-only gate and bypassing external mode) gets a named regression
+ * that names this test rather than a generic visual bug report.
  */
 class GlowLifecycleGuardTest {
     private val source: String by lazy {
@@ -59,24 +60,29 @@ class GlowLifecycleGuardTest {
     }
 
     @Test
-    fun `updateGlow body contains isAyuActive guard before removeAllOverlays and return`() {
+    fun `updateGlow body contains AccentContext guard before removeAllOverlays and return`() {
         val body = extractUpdateGlowBody()
-        // The guardPattern matches `!AyuVariant.isAyuActive()` followed by
+        // The guardPattern matches `AccentContext.detect()` followed by
+        // `if (context == null)` followed by
         // `removeAllOverlays()` followed by `return`, with arbitrary whitespace
         // and the surrounding `if (...) { ... }` braces between them. A regex
         // alternative that allowed `return` before `removeAllOverlays` would
         // accept a broken guard where the function exits without disposing
         // overlays — the whole point of the lifecycle gate.
         val guardPattern =
-            Regex("""!AyuVariant\.isAyuActive\(\)[\s\S]*?removeAllOverlays\(\)[\s\S]*?return""")
+            Regex(
+                """val\s+context\s*=\s*AccentContext\.detect\(\)[\s\S]*?""" +
+                    """if\s*\(\s*context\s*==\s*null\s*\)[\s\S]*?""" +
+                    """removeAllOverlays\(\)[\s\S]*?return""",
+            )
         if (!guardPattern.containsMatchIn(body)) {
             fail(
                 "GlowOverlayManager.updateGlow must open with " +
-                    "`if (!AyuVariant.isAyuActive()) { removeAllOverlays(); return }` " +
+                    "`val context = AccentContext.detect(); " +
+                    "if (context == null) { removeAllOverlays(); return }` " +
                     "as the lifecycle gate. The guard was either missing, used the " +
-                    "wrong predicate (use isAyuActive(), not detect() == null — " +
-                    "Pattern J), or the order of `removeAllOverlays()` and `return` " +
-                    "was inverted. See Pattern L in RECURRING_PITFALLS.md.",
+                    "wrong predicate, or the order of `removeAllOverlays()` and " +
+                    "`return` was inverted. See Pattern L in RECURRING_PITFALLS.md.",
             )
         }
     }

--- a/src/test/kotlin/dev/ayuislands/glow/GlowLifecycleGuardTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/GlowLifecycleGuardTest.kt
@@ -40,8 +40,9 @@ class GlowLifecycleGuardTest {
             .joinToString("\n") { line -> line.replaceFirst(Regex("//.*$"), "") }
     }
 
-    private fun extractUpdateGlowBody(): String {
-        val signaturePrefix = "fun updateGlow("
+    private fun extractUpdateGlowBody(): String = extractFunctionBody("fun updateGlow(")
+
+    private fun extractFunctionBody(signaturePrefix: String): String {
         val start = source.indexOf(signaturePrefix)
         require(start >= 0) { "Could not locate '$signaturePrefix' in stripped source" }
         val openBrace = source.indexOf('{', start)
@@ -84,6 +85,19 @@ class GlowLifecycleGuardTest {
                     "wrong predicate, or the order of `removeAllOverlays()` and " +
                     "`return` was inverted. See Pattern L in RECURRING_PITFALLS.md.",
             )
+        }
+    }
+
+    @Test
+    fun `focus ring and late overlay attach honor external glow allow-list`() {
+        val focusBody = extractFunctionBody("fun initializeFocusRingGlow(")
+        val attachBody = extractFunctionBody("fun attachOverlay(")
+
+        if (!focusBody.contains("isExternalGlowBlocked(context, state, \"initializeFocusRingGlow\")")) {
+            fail("initializeFocusRingGlow must guard AccentContext.External through isExternalGlowBlocked")
+        }
+        if (!attachBody.contains("isExternalGlowBlocked(context, state, \"attachOverlay($")) {
+            fail("attachOverlay must guard AccentContext.External through isExternalGlowBlocked")
         }
     }
 }

--- a/src/test/kotlin/dev/ayuislands/glow/GlowOverlayManagerLifecycleTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/GlowOverlayManagerLifecycleTest.kt
@@ -8,6 +8,7 @@ import com.intellij.util.messages.MessageBus
 import com.intellij.util.messages.MessageBusConnection
 import dev.ayuislands.accent.AccentChangeListener
 import dev.ayuislands.accent.AccentChangedTopic
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
@@ -39,11 +40,9 @@ import kotlin.test.assertTrue
  *
  * Historically `updateGlow()` painted overlays even when no Ayu variant was
  * active, relying on three `else DEFAULT_ACCENT_HEX` fallbacks. The current
- * shape pulls that into a single
- * `if (!AyuVariant.isAyuActive()) { removeAllOverlays(); return }` guard at the
- * head of `updateGlow()` — overlays get disposed when the user switches to a
- * non-Ayu LAF, and the three fallbacks are gone (regression-locked by
- * [GlowFallbackBannedApiGuardTest]).
+ * shape pulls that into a single [AccentContext.detect] guard at the head of
+ * `updateGlow()` — overlays get disposed when no accent context is active, and
+ * the three fallbacks are gone (regression-locked by [GlowFallbackBannedApiGuardTest]).
  */
 class GlowOverlayManagerLifecycleTest {
     private val mockApplication = mockk<com.intellij.openapi.application.Application>(relaxed = true)
@@ -63,6 +62,7 @@ class GlowOverlayManagerLifecycleTest {
         every { AyuIslandsSettings.getInstance() } returns mockSettings
         every { mockSettings.state } returns state
         state.glowEnabled = true
+        state.externalThemeEnhancementsEnabled = false
         state.lastAppliedAccentHex = null
         state.lastApplyOk = false
 
@@ -74,6 +74,7 @@ class GlowOverlayManagerLifecycleTest {
         every { mockProjectManager.openProjects } returns emptyArray()
 
         mockkObject(AccentResolver)
+        every { AccentResolver.resolve(any(), any<AccentContext>()) } returns "#5CCFE6"
         every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#5CCFE6"
 
         mockkObject(AyuVariant.Companion)
@@ -152,6 +153,34 @@ class GlowOverlayManagerLifecycleTest {
     }
 
     @Test
+    fun `updateGlow continues to paint when external context is active`() {
+        state.externalThemeEnhancementsEnabled = true
+        every { AyuVariant.isAyuActive() } returns false
+        every { AyuVariant.detect() } returns null
+
+        val project = stubProject("external-theme-project")
+        val manager = GlowOverlayManager(project)
+        val glassPane = mockk<GlowGlassPane>(relaxed = true)
+        seedOverlaysMapWithMocks(
+            manager,
+            glassPane,
+            host = mockk(relaxed = true),
+            layeredPane = mockk(relaxed = true),
+        )
+
+        every { AccentResolver.resolve(project, AccentContext.External) } returns "#AABBCC"
+
+        manager.updateGlow()
+
+        assertFalse(
+            readOverlaysMap(manager).isEmpty(),
+            "updateGlow with external accent context MUST NOT dispose pre-existing overlays",
+        )
+        verify(exactly = 1) { AccentResolver.resolve(project, AccentContext.External) }
+        verify(exactly = 1) { glassPane.glowColor = Color.decode("#AABBCC") }
+    }
+
+    @Test
     fun `updateGlow paints clean last applied accent instead of project resolver`() {
         // Glow follows the app-global chrome color that was actually painted.
         // A background project may resolve to a different override, but its
@@ -171,13 +200,13 @@ class GlowOverlayManagerLifecycleTest {
             layeredPane = mockk(relaxed = true),
         )
 
-        every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returns "#FFCC66"
+        every { AccentResolver.resolve(project, AccentContext.Ayu(AyuVariant.MIRAGE)) } returns "#FFCC66"
 
         manager.updateGlow()
 
         verify(exactly = 1) { glassPane.glowColor = Color.decode("#5CCFE6") }
         verify(exactly = 0) { glassPane.glowColor = Color.decode("#FFCC66") }
-        verify(exactly = 0) { AccentResolver.resolve(project, AyuVariant.MIRAGE) }
+        verify(exactly = 0) { AccentResolver.resolve(project, AccentContext.Ayu(AyuVariant.MIRAGE)) }
     }
 
     @Test
@@ -202,7 +231,7 @@ class GlowOverlayManagerLifecycleTest {
         every { rootPane.layeredPane } returns layeredPane
         every { SwingUtilities.getRootPane(host) } returns rootPane
         every { SwingUtilities.convertPoint(host, 0, 0, layeredPane) } returns Point(0, 0)
-        every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returns "#FFCC66"
+        every { AccentResolver.resolve(project, AccentContext.Ayu(AyuVariant.MIRAGE)) } returns "#FFCC66"
 
         invokeAttachOverlay(manager, "LateOverlay", host)
 
@@ -211,7 +240,7 @@ class GlowOverlayManagerLifecycleTest {
             readOverlayGlassPane(manager, "LateOverlay").glowColor,
             "new overlays must seed from the clean app-global applied accent, not the project resolver",
         )
-        verify(exactly = 0) { AccentResolver.resolve(project, AyuVariant.MIRAGE) }
+        verify(exactly = 0) { AccentResolver.resolve(project, AccentContext.Ayu(AyuVariant.MIRAGE)) }
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/glow/GlowOverlayManagerLifecycleTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/GlowOverlayManagerLifecycleTest.kt
@@ -155,6 +155,7 @@ class GlowOverlayManagerLifecycleTest {
     @Test
     fun `updateGlow continues to paint when external context is active`() {
         state.externalThemeEnhancementsEnabled = true
+        state.externalThemeGlowEnabled = true
         every { AyuVariant.isAyuActive() } returns false
         every { AyuVariant.detect() } returns null
 
@@ -178,6 +179,33 @@ class GlowOverlayManagerLifecycleTest {
         )
         verify(exactly = 1) { AccentResolver.resolve(project, AccentContext.External) }
         verify(exactly = 1) { glassPane.glowColor = Color.decode("#AABBCC") }
+    }
+
+    @Test
+    fun `updateGlow disposes external overlays when external glow inheritance is disabled`() {
+        state.externalThemeEnhancementsEnabled = true
+        state.externalThemeGlowEnabled = false
+        every { AyuVariant.isAyuActive() } returns false
+        every { AyuVariant.detect() } returns null
+
+        val project = stubProject("external-theme-project")
+        val manager = GlowOverlayManager(project)
+        val glassPane = mockk<GlowGlassPane>(relaxed = true)
+        seedOverlaysMapWithMocks(
+            manager,
+            glassPane,
+            host = mockk(relaxed = true),
+            layeredPane = mockk(relaxed = true),
+        )
+
+        manager.updateGlow()
+
+        assertTrue(
+            readOverlaysMap(manager).isEmpty(),
+            "External Glow permission OFF must dispose overlays instead of painting inherited glow",
+        )
+        verify(exactly = 0) { AccentResolver.resolve(project, AccentContext.External) }
+        verify(exactly = 0) { glassPane.glowColor = any() }
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/glow/GlowOverlayManagerLifecycleTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/GlowOverlayManagerLifecycleTest.kt
@@ -261,14 +261,40 @@ class GlowOverlayManagerLifecycleTest {
         every { SwingUtilities.convertPoint(host, 0, 0, layeredPane) } returns Point(0, 0)
         every { AccentResolver.resolve(project, AccentContext.Ayu(AyuVariant.MIRAGE)) } returns "#FFCC66"
 
-        invokeAttachOverlay(manager, "LateOverlay", host)
+        invokeAttachOverlay(manager, LATE_OVERLAY_KEY, host)
 
         assertEquals(
             Color.decode("#5CCFE6"),
-            readOverlayGlassPane(manager, "LateOverlay").glowColor,
+            readLateOverlayGlassPane(manager).glowColor,
             "new overlays must seed from the clean app-global applied accent, not the project resolver",
         )
         verify(exactly = 0) { AccentResolver.resolve(project, AccentContext.Ayu(AyuVariant.MIRAGE)) }
+    }
+
+    @Test
+    fun `attachOverlay skips external overlays when external glow inheritance is disabled`() {
+        state.externalThemeEnhancementsEnabled = true
+        state.externalThemeGlowEnabled = false
+        every { AyuVariant.detect() } returns null
+        every { SwingUtilities.invokeLater(any()) } answers { firstArg<Runnable>().run() }
+
+        val project = stubProject("external-late-overlay-project")
+        val manager = GlowOverlayManager(project)
+        val host = mockk<javax.swing.JComponent>(relaxed = true)
+        val rootPane = mockk<javax.swing.JRootPane>(relaxed = true)
+        val layeredPane = mockk<javax.swing.JLayeredPane>(relaxed = true)
+        every { host.width } returns 120
+        every { host.height } returns 80
+        every { rootPane.layeredPane } returns layeredPane
+        every { SwingUtilities.getRootPane(host) } returns rootPane
+
+        invokeAttachOverlay(manager, "ExternalLateOverlay", host)
+
+        assertTrue(
+            readOverlaysMap(manager).isEmpty(),
+            "External Glow permission OFF must prevent late attach events from recreating overlays",
+        )
+        verify(exactly = 0) { AccentResolver.resolve(project, AccentContext.External) }
     }
 
     @Test
@@ -449,7 +475,7 @@ class GlowOverlayManagerLifecycleTest {
 
     @Test
     fun `syncGlowForAllProjects disposes every project glow when variant becomes null`() {
-        // When `AyuIslandsLafListener` detects a non-Ayu LAF, it calls
+        // When the LAF listener detects a non-Ayu LAF, it calls
         // `GlowOverlayManager.syncGlowForAllProjects()` which iterates every
         // open project and triggers per-project disposal via the guard. This
         // test pins the multi-project dispatch — without it, only the focused
@@ -506,11 +532,8 @@ class GlowOverlayManagerLifecycleTest {
         return field.get(manager) as Map<*, *>
     }
 
-    private fun readOverlayGlassPane(
-        manager: GlowOverlayManager,
-        key: String,
-    ): GlowGlassPane {
-        val entry = readOverlaysMap(manager)[key] ?: error("Overlay '$key' was not attached")
+    private fun readLateOverlayGlassPane(manager: GlowOverlayManager): GlowGlassPane {
+        val entry = readOverlaysMap(manager)[LATE_OVERLAY_KEY] ?: error("Overlay '$LATE_OVERLAY_KEY' was not attached")
         val field = entry.javaClass.getDeclaredField("glassPane")
         field.isAccessible = true
         return field.get(entry) as GlowGlassPane
@@ -651,5 +674,8 @@ class GlowOverlayManagerLifecycleTest {
 
         /** Sentinel key for the disposal-path test seed. */
         private const val DISPOSAL_TARGET_KEY = "DISPOSAL_TARGET"
+
+        /** Sentinel key for the late-overlay attach-path test. */
+        private const val LATE_OVERLAY_KEY = "LateOverlay"
     }
 }

--- a/src/test/kotlin/dev/ayuislands/glow/GlowOverlayManagerLifecycleTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/GlowOverlayManagerLifecycleTest.kt
@@ -74,7 +74,7 @@ class GlowOverlayManagerLifecycleTest {
         every { mockProjectManager.openProjects } returns emptyArray()
 
         mockkObject(AccentResolver)
-        every { AccentResolver.resolve(any(), any()) } returns "#5CCFE6"
+        every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#5CCFE6"
 
         mockkObject(AyuVariant.Companion)
     }

--- a/src/test/kotlin/dev/ayuislands/indent/IndentPaletteTest.kt
+++ b/src/test/kotlin/dev/ayuislands/indent/IndentPaletteTest.kt
@@ -24,6 +24,14 @@ class IndentPaletteTest {
     }
 
     @Test
+    fun `forExternalAccent uses stable error color and supplied accent`() {
+        val palette = IndentPalette.forExternalAccent("#AABBCC")
+
+        assertEquals("F27983", palette.errorColor)
+        assertEquals("AABBCC", palette.accentColor)
+    }
+
+    @Test
     fun `each variant has non-empty error color`() {
         for (variant in AyuVariant.entries) {
             val palette = IndentPalette.forAccent(testAccent, variant)

--- a/src/test/kotlin/dev/ayuislands/indent/IndentRainbowSyncTest.kt
+++ b/src/test/kotlin/dev/ayuislands/indent/IndentRainbowSyncTest.kt
@@ -7,6 +7,7 @@ import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.application.ApplicationManager
 import dev.ayuislands.AyuPlugin
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
@@ -28,11 +29,12 @@ import kotlin.test.assertTrue
 
 class IndentRainbowSyncTest {
     private val mockSettings = mockk<AyuIslandsSettings>(relaxed = true)
-    private val state = AyuIslandsState()
+    private lateinit var state: AyuIslandsState
     private val mockApplication = mockk<com.intellij.openapi.application.Application>(relaxed = true)
 
     @BeforeTest
     fun setUp() {
+        state = AyuIslandsState()
         mockkStatic(ApplicationManager::class)
         every { ApplicationManager.getApplication() } returns mockApplication
 
@@ -58,6 +60,10 @@ class IndentRainbowSyncTest {
      */
     private fun callApply(variant: AyuVariant = AyuVariant.MIRAGE) {
         IndentRainbowSync.apply(variant, TEST_ACCENT_HEX)
+    }
+
+    private fun callApplyExternal() {
+        IndentRainbowSync.apply(AccentContext.External, "#AABBCC")
     }
 
     private companion object {
@@ -180,6 +186,48 @@ class IndentRainbowSyncTest {
         // Verify number of colors = 11 (IR ignores this field, pass full count)
         verify { mockNumberColorsField.setInt(mockConfig, 11) }
         // Verify cache flush
+        verify { mockUpdateMethod.invoke(mockCompanion, mockConfig) }
+        verify { mockRefreshMethod.invoke(mockColorsInstance) }
+    }
+
+    @Test
+    fun `apply external context writes external palette to mock IR fields`() {
+        state.irIntegrationEnabled = true
+        state.indentPresetName = "AMBIENT"
+
+        val mockConfig = Any()
+        val mockPaletteTypeField = mockField()
+        val mockCustomPaletteField = mockField()
+        val mockNumberColorsField = mockIntField()
+        val mockUpdateMethod = mockMethod()
+        val mockRefreshMethod = mockMethod()
+        val mockCompanion = Any()
+        val mockColorsInstance = Any()
+
+        setPrivateField("methodsResolved", true)
+        setPrivateField("irConfig", mockConfig)
+        setPrivateField("paletteTypeField", mockPaletteTypeField)
+        setPrivateField("customPaletteField", mockCustomPaletteField)
+        setPrivateField("customPaletteNumberColorsField", mockNumberColorsField)
+        setPrivateField("customEnumValue", "CUSTOM_ENUM")
+        setPrivateField("defaultEnumValue", "DEFAULT_ENUM")
+        setPrivateField("cachedDataUpdateMethod", mockUpdateMethod)
+        setPrivateField("cachedDataCompanion", mockCompanion)
+        setPrivateField("refreshMethod", mockRefreshMethod)
+        setPrivateField("irColorsInstance", mockColorsInstance)
+
+        callApplyExternal()
+
+        verify { mockPaletteTypeField[mockConfig] = "CUSTOM_ENUM" }
+        verify {
+            mockCustomPaletteField[mockConfig] =
+                match<String> { palette ->
+                    palette.split(", ").size == 11 &&
+                        palette.contains("F27983") &&
+                        palette.contains("AABBCC")
+                }
+        }
+        verify { mockNumberColorsField.setInt(mockConfig, 11) }
         verify { mockUpdateMethod.invoke(mockCompanion, mockConfig) }
         verify { mockRefreshMethod.invoke(mockColorsInstance) }
     }

--- a/src/test/kotlin/dev/ayuislands/indent/IndentRainbowSyncTest.kt
+++ b/src/test/kotlin/dev/ayuislands/indent/IndentRainbowSyncTest.kt
@@ -193,6 +193,8 @@ class IndentRainbowSyncTest {
     @Test
     fun `apply external context writes external palette to mock IR fields`() {
         state.irIntegrationEnabled = true
+        state.externalThemeEnhancementsEnabled = true
+        state.externalThemeIndentRainbowEnabled = true
         state.indentPresetName = "AMBIENT"
 
         val mockConfig = Any()
@@ -228,6 +230,43 @@ class IndentRainbowSyncTest {
                 }
         }
         verify { mockNumberColorsField.setInt(mockConfig, 11) }
+        verify { mockUpdateMethod.invoke(mockCompanion, mockConfig) }
+        verify { mockRefreshMethod.invoke(mockColorsInstance) }
+    }
+
+    @Test
+    fun `apply external context reverts when external Indent Rainbow inheritance is disabled`() {
+        state.irIntegrationEnabled = true
+        state.externalThemeEnhancementsEnabled = true
+        state.externalThemeIndentRainbowEnabled = false
+        state.indentPresetName = "AMBIENT"
+
+        val mockConfig = Any()
+        val mockPaletteTypeField = mockField()
+        val mockCustomPaletteField = mockField()
+        val mockNumberColorsField = mockIntField()
+        val mockUpdateMethod = mockMethod()
+        val mockRefreshMethod = mockMethod()
+        val mockCompanion = Any()
+        val mockColorsInstance = Any()
+
+        setPrivateField("methodsResolved", true)
+        setPrivateField("irConfig", mockConfig)
+        setPrivateField("paletteTypeField", mockPaletteTypeField)
+        setPrivateField("customPaletteField", mockCustomPaletteField)
+        setPrivateField("customPaletteNumberColorsField", mockNumberColorsField)
+        setPrivateField("customEnumValue", "CUSTOM_ENUM")
+        setPrivateField("defaultEnumValue", "DEFAULT_ENUM")
+        setPrivateField("cachedDataUpdateMethod", mockUpdateMethod)
+        setPrivateField("cachedDataCompanion", mockCompanion)
+        setPrivateField("refreshMethod", mockRefreshMethod)
+        setPrivateField("irColorsInstance", mockColorsInstance)
+
+        callApplyExternal()
+
+        verify { mockPaletteTypeField[mockConfig] = "DEFAULT_ENUM" }
+        verify(exactly = 0) { mockCustomPaletteField[mockConfig] = any<String>() }
+        verify(exactly = 0) { mockNumberColorsField.setInt(mockConfig, any()) }
         verify { mockUpdateMethod.invoke(mockCompanion, mockConfig) }
         verify { mockRefreshMethod.invoke(mockColorsInstance) }
     }

--- a/src/test/kotlin/dev/ayuislands/integration/SettingsConfigurableIntegrationTest.kt
+++ b/src/test/kotlin/dev/ayuislands/integration/SettingsConfigurableIntegrationTest.kt
@@ -2,6 +2,8 @@ package dev.ayuislands.integration
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import dev.ayuislands.settings.AyuIslandsConfigurable
+import java.awt.Container
+import javax.swing.JTabbedPane
 
 class SettingsConfigurableIntegrationTest : BasePlatformTestCase() {
     fun testConfigurableCreatesComponent() {
@@ -25,5 +27,37 @@ class SettingsConfigurableIntegrationTest : BasePlatformTestCase() {
         } finally {
             configurable.disposeUIResources()
         }
+    }
+
+    fun testConfigurableExposesPluginsTabByDefault() {
+        val configurable = AyuIslandsConfigurable()
+        try {
+            val component = configurable.createComponent()
+            val tabTitles =
+                collectTabbedPanes(component)
+                    .flatMap { tabbedPane ->
+                        (0 until tabbedPane.tabCount).map(tabbedPane::getTitleAt)
+                    }
+
+            assertTrue(
+                "Plugins tab must stay reachable when Settings opens outside an Ayu theme",
+                tabTitles.contains("Plugins"),
+            )
+        } finally {
+            configurable.disposeUIResources()
+        }
+    }
+
+    private fun collectTabbedPanes(
+        root: java.awt.Component,
+        found: MutableList<JTabbedPane> = mutableListOf(),
+    ): List<JTabbedPane> {
+        if (root is JTabbedPane) {
+            found += root
+        }
+        if (root is Container) {
+            root.components.forEach { collectTabbedPanes(it, found) }
+        }
+        return found
     }
 }

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseTransitionListenerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseTransitionListenerTest.kt
@@ -43,7 +43,7 @@ class LicenseTransitionListenerTest {
         // Each test re-stubs AyuVariant.detect() when it needs to exercise the
         // null-variant silent-skip branch.
         mockkObject(AccentApplicator)
-        every { AccentApplicator.applyForFocusedProject(any()) } returns "#FFCC66"
+        every { AccentApplicator.applyForFocusedProject(any<dev.ayuislands.accent.AyuVariant>()) } returns "#FFCC66"
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
     }
@@ -192,7 +192,7 @@ class LicenseTransitionListenerTest {
         every { LicenseChecker.isLicensed() } returns true
         LicenseTransitionListener().licenseStateChanged(facade)
 
-        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any()) }
+        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any<dev.ayuislands.accent.AyuVariant>()) }
     }
 
     @Test
@@ -201,7 +201,7 @@ class LicenseTransitionListenerTest {
         // Baseline call: licensed. No apply expected.
         every { LicenseChecker.isLicensed() } returns true
         listener.licenseStateChanged(facade)
-        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any()) }
+        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any<dev.ayuislands.accent.AyuVariant>()) }
 
         // Transition: licensed → unlicensed. Chrome must re-render using the
         // global accent because the resolver now short-circuits overrides.
@@ -219,7 +219,7 @@ class LicenseTransitionListenerTest {
         // Baseline call: unlicensed. No apply expected on initial notification.
         every { LicenseChecker.isLicensed() } returns false
         listener.licenseStateChanged(facade)
-        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any()) }
+        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any<dev.ayuislands.accent.AyuVariant>()) }
 
         // Transition: unlicensed → licensed. BOTH side effects fire:
         //   - wizard re-arm (premiumOnboardingShown flipped to false)
@@ -246,7 +246,7 @@ class LicenseTransitionListenerTest {
         listener.licenseStateChanged(facade)
         listener.licenseStateChanged(facade)
 
-        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any()) }
+        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any<dev.ayuislands.accent.AyuVariant>()) }
     }
 
     @Test
@@ -259,7 +259,7 @@ class LicenseTransitionListenerTest {
         listener.licenseStateChanged(facade)
         listener.licenseStateChanged(facade)
 
-        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any()) }
+        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any<dev.ayuislands.accent.AyuVariant>()) }
     }
 
     @Test
@@ -277,6 +277,6 @@ class LicenseTransitionListenerTest {
         every { LicenseChecker.isLicensed() } returns false
         listener.licenseStateChanged(facade)
 
-        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any()) }
+        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any<dev.ayuislands.accent.AyuVariant>()) }
     }
 }

--- a/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.wm.IdeFrame
 import com.intellij.testFramework.LoggedErrorProcessor
 import dev.ayuislands.accent.AYU_ACCENT_PRESETS
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.glow.GlowOverlayManager
@@ -495,15 +496,15 @@ class AccentRotationServiceTest {
         } returns arrayOf(inactiveProject, osActiveProject)
 
         mockkObject(AccentResolver)
-        every { AccentResolver.resolve(osActiveProject, AyuVariant.MIRAGE) } returns "#5CCFE6"
-        every { AccentResolver.resolve(inactiveProject, any<AyuVariant>()) } returns "#DFBFFF"
-        every { AccentResolver.resolve(null, any<AyuVariant>()) } returns "#GLOBAL"
+        every { AccentResolver.resolve(osActiveProject, AccentContext.Ayu(AyuVariant.MIRAGE)) } returns "#5CCFE6"
+        every { AccentResolver.resolve(inactiveProject, any<AccentContext>()) } returns "#DFBFFF"
+        every { AccentResolver.resolve(null, any<AccentContext>()) } returns "#GLOBAL"
 
         val service = AccentRotationService()
         service.rotateAccent()
 
-        verify(exactly = 1) { AccentResolver.resolve(osActiveProject, AyuVariant.MIRAGE) }
-        verify(exactly = 0) { AccentResolver.resolve(inactiveProject, any<AyuVariant>()) }
+        verify(exactly = 1) { AccentResolver.resolve(osActiveProject, AccentContext.Ayu(AyuVariant.MIRAGE)) }
+        verify(exactly = 0) { AccentResolver.resolve(inactiveProject, any<AccentContext>()) }
         verify(exactly = 1) { AccentApplicator.applyFromHexString("#5CCFE6") }
     }
 

--- a/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
@@ -496,14 +496,14 @@ class AccentRotationServiceTest {
 
         mockkObject(AccentResolver)
         every { AccentResolver.resolve(osActiveProject, AyuVariant.MIRAGE) } returns "#5CCFE6"
-        every { AccentResolver.resolve(inactiveProject, any()) } returns "#DFBFFF"
-        every { AccentResolver.resolve(null, any()) } returns "#GLOBAL"
+        every { AccentResolver.resolve(inactiveProject, any<AyuVariant>()) } returns "#DFBFFF"
+        every { AccentResolver.resolve(null, any<AyuVariant>()) } returns "#GLOBAL"
 
         val service = AccentRotationService()
         service.rotateAccent()
 
         verify(exactly = 1) { AccentResolver.resolve(osActiveProject, AyuVariant.MIRAGE) }
-        verify(exactly = 0) { AccentResolver.resolve(inactiveProject, any()) }
+        verify(exactly = 0) { AccentResolver.resolve(inactiveProject, any<AyuVariant>()) }
         verify(exactly = 1) { AccentApplicator.applyFromHexString("#5CCFE6") }
     }
 

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsChromePanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsChromePanelTest.kt
@@ -75,7 +75,7 @@ class AyuIslandsChromePanelTest {
         every { ChromeDecorationsProbe.isCustomHeaderActive() } returns true
 
         mockkObject(AccentApplicator)
-        every { AccentApplicator.applyForFocusedProject(any()) } returns "#E6B450"
+        every { AccentApplicator.applyForFocusedProject(any<dev.ayuislands.accent.AyuVariant>()) } returns "#E6B450"
 
         // The Kotlin UI DSL `collapsibleGroup { … }` builder resolves the CollapsiblePanel
         // toggle action through `ActionManager.getInstance()` which goes via
@@ -367,7 +367,7 @@ class AyuIslandsChromePanelTest {
         chromePanel.apply()
 
         // No mutation → no re-apply. Prevents DoS on repeated clean apply.
-        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any()) }
+        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any<AyuVariant>()) }
     }
 
     @Test
@@ -381,7 +381,9 @@ class AyuIslandsChromePanelTest {
         val chromePanel = AyuIslandsChromePanel()
         buildPanel(chromePanel, AyuVariant.MIRAGE)
 
-        every { AccentApplicator.applyForFocusedProject(any()) } throws RuntimeException("simulated apply failure")
+        every {
+            AccentApplicator.applyForFocusedProject(any<AyuVariant>())
+        } throws RuntimeException("simulated apply failure")
 
         chromePanel.setPendingChromeStatusBarForTest(true)
         chromePanel.setPendingChromeTintIntensityForTest(35)
@@ -434,7 +436,9 @@ class AyuIslandsChromePanelTest {
         mockkStatic(NotificationGroupManager::class)
         every { NotificationGroupManager.getInstance() } returns groupManager
 
-        every { AccentApplicator.applyForFocusedProject(any()) } throws RuntimeException("simulated apply failure")
+        every {
+            AccentApplicator.applyForFocusedProject(any<AyuVariant>())
+        } throws RuntimeException("simulated apply failure")
 
         val chromePanel = AyuIslandsChromePanel()
         buildPanel(chromePanel, AyuVariant.MIRAGE)
@@ -466,7 +470,7 @@ class AyuIslandsChromePanelTest {
         // invariant survives a notification-subsystem crash.
         mockkStatic(NotificationGroupManager::class)
         every { NotificationGroupManager.getInstance() } throws RuntimeException("notification subsystem boom")
-        every { AccentApplicator.applyForFocusedProject(any()) } throws RuntimeException("apply boom")
+        every { AccentApplicator.applyForFocusedProject(any<AyuVariant>()) } throws RuntimeException("apply boom")
 
         val chromePanel = AyuIslandsChromePanel()
         buildPanel(chromePanel, AyuVariant.MIRAGE)
@@ -509,7 +513,7 @@ class AyuIslandsChromePanelTest {
             chromePanel.getPendingChromeTintIntensityForTest(),
         )
         // Reset must not call the applicator.
-        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any()) }
+        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any<dev.ayuislands.accent.AyuVariant>()) }
     }
 
     // ── Mid-session license flip must not persist ──────────────────────────────
@@ -547,7 +551,7 @@ class AyuIslandsChromePanelTest {
             "Post-license-revocation apply must not persist chromeTintIntensity",
         )
         // No EP re-apply.
-        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any()) }
+        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any<dev.ayuislands.accent.AyuVariant>()) }
     }
 
     // ── Test 9: premium gate ──────────────────────────────────────────────────

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateTest.kt
@@ -310,6 +310,10 @@ class AyuIslandsStateTest {
     fun `external theme accent defaults are disabled automatic and Mirage gold`() {
         val state = freshState()
         assertFalse(state.externalThemeEnhancementsEnabled)
+        assertTrue(state.externalThemeQuickSwitcherEnabled)
+        assertFalse(state.externalThemeGlowEnabled)
+        assertTrue(state.externalThemeCodeGlanceProEnabled)
+        assertTrue(state.externalThemeIndentRainbowEnabled)
         assertEquals(ExternalAccentSource.AUTOMATIC.name, state.externalThemeAccentSource)
         assertEquals("#FFCC66", state.externalThemeAccent)
     }

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateTest.kt
@@ -2,6 +2,7 @@ package dev.ayuislands.settings
 
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.AccentGroup
+import dev.ayuislands.accent.ExternalAccentSource
 import dev.ayuislands.glow.GlowAnimation
 import dev.ayuislands.glow.GlowPreset
 import dev.ayuislands.glow.GlowStyle
@@ -303,6 +304,14 @@ class AyuIslandsStateTest {
         assertEquals("#FFCC66", state.mirageAccent)
         assertEquals("#E6B450", state.darkAccent)
         assertEquals("#F29718", state.lightAccent)
+    }
+
+    @Test
+    fun `external theme accent defaults are disabled automatic and Mirage gold`() {
+        val state = freshState()
+        assertFalse(state.externalThemeEnhancementsEnabled)
+        assertEquals(ExternalAccentSource.AUTOMATIC.name, state.externalThemeAccentSource)
+        assertEquals("#FFCC66", state.externalThemeAccent)
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/settings/FontPresetPanelCustomRegressionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/FontPresetPanelCustomRegressionTest.kt
@@ -110,6 +110,24 @@ class FontPresetPanelCustomRegressionTest {
     }
 
     @Test
+    fun `initState is not modified when stored customizations are absent defaults`() {
+        val state = AyuIslandsState()
+        val settings = mockk<AyuIslandsSettings>(relaxed = true)
+        every { settings.state } returns state
+        mockkObject(AyuIslandsSettings.Companion)
+        every { AyuIslandsSettings.getInstance() } returns settings
+        mockkObject(FontDetector)
+        every { FontDetector.invalidateCache() } returns Unit
+        every { FontDetector.detectAll() } returns emptyMap()
+
+        val panel = FontPresetPanel()
+
+        panel.initState()
+
+        assertFalse(panel.isModified(), "Default decoded font customizations must not dirty a fresh panel")
+    }
+
+    @Test
     fun `previewInstalledFor curated branch returns true for HEALTHY status`() {
         assertTrue(previewInstalledFor(FontPreset.AMBIENT, FontStatus.HEALTHY, true, "anything"))
     }

--- a/src/test/kotlin/dev/ayuislands/settings/PluginsPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/PluginsPanelTest.kt
@@ -10,6 +10,7 @@ import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.conflict.ConflictRegistry
 import dev.ayuislands.indent.IndentPreset
 import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.settings.mappings.AccentSwatchPickerRow
 import dev.ayuislands.syntax.SyntaxIntensityService
 import io.mockk.every
 import io.mockk.mockk
@@ -25,6 +26,7 @@ import javax.swing.JSlider
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -143,6 +145,51 @@ class PluginsPanelTest {
         )
         assertTrue(ignoreCheckbox.isSelected, ".ignore syntax colors default on for the release feature")
         assertFalse(pluginsPanel.isModified(), "Rendering the default-on .ignore toggle must not dirty Settings")
+    }
+
+    @Test
+    fun `external themes group is visible without premium plugin detections`() {
+        every { ConflictRegistry.isIndentRainbowDetected() } returns false
+        every { ConflictRegistry.isCodeGlanceProDetected() } returns false
+        val pluginsPanel = PluginsPanel()
+
+        val dialogPanel = buildDialogPanel(pluginsPanel)
+        val checkbox =
+            descendants(dialogPanel, JCheckBox::class.java)
+                .first { it.text == "Enable Ayu enhancements on other themes" }
+
+        assertTrue(checkbox.isEffectivelyVisibleWithin(dialogPanel))
+        assertFalse(checkbox.isSelected)
+        assertFalse(pluginsPanel.isModified())
+    }
+
+    @Test
+    fun `external theme toggle persists opt-in`() {
+        val pluginsPanel = PluginsPanel()
+        val dialogPanel = buildDialogPanel(pluginsPanel)
+        val checkbox =
+            descendants(dialogPanel, JCheckBox::class.java)
+                .first { it.text == "Enable Ayu enhancements on other themes" }
+
+        checkbox.doClick()
+        pluginsPanel.apply()
+
+        assertTrue(state.externalThemeEnhancementsEnabled)
+        assertFalse(pluginsPanel.isModified())
+    }
+
+    @Test
+    fun `external accent picker renders stored fallback accent`() {
+        state.externalThemeAccent = "#AABBCC"
+        val pluginsPanel = PluginsPanel()
+
+        val dialogPanel = buildDialogPanel(pluginsPanel)
+        val picker =
+            descendants(dialogPanel, AccentSwatchPickerRow::class.java)
+                .first()
+
+        assertEquals("#AABBCC", picker.selectedHex)
+        assertFalse(pluginsPanel.isModified())
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/settings/PluginsPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/PluginsPanelTest.kt
@@ -6,8 +6,11 @@ import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.ui.DialogPanel
 import com.intellij.ui.dsl.builder.panel
+import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.conflict.ConflictRegistry
+import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.indent.IndentPreset
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.mappings.AccentSwatchPickerRow
@@ -222,6 +225,53 @@ class PluginsPanelTest {
 
         assertTrue(state.externalThemeEnhancementsEnabled)
         assertFalse(pluginsPanel.isModified())
+    }
+
+    @Test
+    fun `external theme opt-in applies external context immediately on non-Ayu themes`() {
+        mockkObject(AyuVariant.Companion)
+        every { AyuVariant.detect() } returns null
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.applyForFocusedProject(AccentContext.External) } returns "#AABBCC"
+        mockkObject(GlowOverlayManager)
+        every { GlowOverlayManager.syncGlowForAllProjects() } returns Unit
+
+        val pluginsPanel = PluginsPanel()
+        val dialogPanel = buildDialogPanel(pluginsPanel)
+        val checkbox =
+            descendants(dialogPanel, JCheckBox::class.java)
+                .first { it.text == "Enable Ayu enhancements on other themes" }
+
+        checkbox.doClick()
+        pluginsPanel.apply()
+
+        assertTrue(state.externalThemeEnhancementsEnabled)
+        verify(exactly = 1) { AccentApplicator.applyForFocusedProject(AccentContext.External) }
+        verify(exactly = 1) { GlowOverlayManager.syncGlowForAllProjects() }
+    }
+
+    @Test
+    fun `external theme opt-out reverts inherited surfaces immediately on non-Ayu themes`() {
+        state.externalThemeEnhancementsEnabled = true
+        mockkObject(AyuVariant.Companion)
+        every { AyuVariant.detect() } returns null
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.revertAll() } returns Unit
+        mockkObject(GlowOverlayManager)
+        every { GlowOverlayManager.syncGlowForAllProjects() } returns Unit
+
+        val pluginsPanel = PluginsPanel()
+        val dialogPanel = buildDialogPanel(pluginsPanel)
+        val checkbox =
+            descendants(dialogPanel, JCheckBox::class.java)
+                .first { it.text == "Enable Ayu enhancements on other themes" }
+
+        checkbox.doClick()
+        pluginsPanel.apply()
+
+        assertFalse(state.externalThemeEnhancementsEnabled)
+        verify(exactly = 1) { AccentApplicator.revertAll() }
+        verify(exactly = 1) { GlowOverlayManager.syncGlowForAllProjects() }
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/settings/PluginsPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/PluginsPanelTest.kt
@@ -22,6 +22,7 @@ import io.mockk.verify
 import java.awt.Component
 import java.awt.Container
 import javax.swing.JCheckBox
+import javax.swing.JLabel
 import javax.swing.JSlider
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -102,7 +103,7 @@ class PluginsPanelTest {
         val dialogPanel = buildDialogPanel(pluginsPanel)
         val enabledCheckbox =
             descendants(dialogPanel, JCheckBox::class.java)
-                .first { it.text == "Sync colors with Indent Rainbow" }
+                .first { it.text == "Indent Rainbow guides" }
         val errorCheckbox =
             descendants(dialogPanel, JCheckBox::class.java)
                 .first { it.text == "Highlight indent errors" }
@@ -137,7 +138,7 @@ class PluginsPanelTest {
         val dialogPanel = buildDialogPanel(pluginsPanel)
         val ignoreCheckbox =
             descendants(dialogPanel, JCheckBox::class.java)
-                .first { it.text == "Use Ayu colors for .ignore files" }
+                .first { it.text == ".ignore syntax colors" }
 
         assertTrue(
             ignoreCheckbox.isEffectivelyVisibleWithin(dialogPanel),
@@ -164,6 +165,51 @@ class PluginsPanelTest {
     }
 
     @Test
+    fun `external theme inheritance toggles render with approved defaults`() {
+        val pluginsPanel = PluginsPanel()
+
+        val dialogPanel = buildDialogPanel(pluginsPanel)
+        val checkboxes = descendants(dialogPanel, JCheckBox::class.java)
+        val masterCheckbox = checkboxes.first { it.text == "Enable Ayu enhancements on other themes" }
+        val quickSwitcherCheckbox = checkboxes.first { it.text == "Quick switcher" }
+        val glowCheckbox = checkboxes.first { it.text == "Glow" }
+        val codeGlanceProCheckbox = checkboxes.first { it.text == "CodeGlance Pro" }
+        val indentRainbowCheckbox = checkboxes.first { it.text == "Indent Rainbow" }
+
+        assertTrue(masterCheckbox.isEffectivelyVisibleWithin(dialogPanel))
+        assertTrue(quickSwitcherCheckbox.isEffectivelyVisibleWithin(dialogPanel))
+        assertTrue(glowCheckbox.isEffectivelyVisibleWithin(dialogPanel))
+        assertTrue(codeGlanceProCheckbox.isEffectivelyVisibleWithin(dialogPanel))
+        assertTrue(indentRainbowCheckbox.isEffectivelyVisibleWithin(dialogPanel))
+        assertFalse(masterCheckbox.isSelected)
+        assertTrue(quickSwitcherCheckbox.isSelected)
+        assertFalse(glowCheckbox.isSelected)
+        assertTrue(codeGlanceProCheckbox.isSelected)
+        assertTrue(indentRainbowCheckbox.isSelected)
+        assertFalse(pluginsPanel.isModified())
+    }
+
+    @Test
+    fun `plugins tab renders two approved focus sections`() {
+        val pluginsPanel = PluginsPanel()
+
+        val dialogPanel = buildDialogPanel(pluginsPanel)
+        val labels = descendants(dialogPanel, JLabel::class.java).mapNotNull { it.text }
+
+        assertTrue("External Theme Support" in labels)
+        assertTrue("Plugin Integrations" in labels)
+        assertFalse(".ignore" in labels, ".ignore should render as an integration row, not a standalone group")
+        assertFalse(
+            "CodeGlance Pro" in labels,
+            "CodeGlance Pro should render as an integration row, not a standalone group",
+        )
+        assertFalse(
+            "Indent Rainbow" in labels,
+            "Indent Rainbow should render as an integration row, not a standalone group",
+        )
+    }
+
+    @Test
     fun `external theme toggle persists opt-in`() {
         val pluginsPanel = PluginsPanel()
         val dialogPanel = buildDialogPanel(pluginsPanel)
@@ -175,6 +221,29 @@ class PluginsPanelTest {
         pluginsPanel.apply()
 
         assertTrue(state.externalThemeEnhancementsEnabled)
+        assertFalse(pluginsPanel.isModified())
+    }
+
+    @Test
+    fun `external theme inheritance toggles persist independently`() {
+        val pluginsPanel = PluginsPanel()
+        val dialogPanel = buildDialogPanel(pluginsPanel)
+        val checkboxes = descendants(dialogPanel, JCheckBox::class.java)
+        val quickSwitcherCheckbox = checkboxes.first { it.text == "Quick switcher" }
+        val glowCheckbox = checkboxes.first { it.text == "Glow" }
+        val codeGlanceProCheckbox = checkboxes.first { it.text == "CodeGlance Pro" }
+        val indentRainbowCheckbox = checkboxes.first { it.text == "Indent Rainbow" }
+
+        quickSwitcherCheckbox.doClick()
+        glowCheckbox.doClick()
+        codeGlanceProCheckbox.doClick()
+        indentRainbowCheckbox.doClick()
+        pluginsPanel.apply()
+
+        assertFalse(state.externalThemeQuickSwitcherEnabled)
+        assertTrue(state.externalThemeGlowEnabled)
+        assertFalse(state.externalThemeCodeGlanceProEnabled)
+        assertFalse(state.externalThemeIndentRainbowEnabled)
         assertFalse(pluginsPanel.isModified())
     }
 
@@ -202,7 +271,7 @@ class PluginsPanelTest {
         val dialogPanel = buildDialogPanel(pluginsPanel)
         val ignoreCheckbox =
             descendants(dialogPanel, JCheckBox::class.java)
-                .first { it.text == "Use Ayu colors for .ignore files" }
+                .first { it.text == ".ignore syntax colors" }
 
         ignoreCheckbox.doClick()
         pluginsPanel.apply()
@@ -222,7 +291,7 @@ class PluginsPanelTest {
         val dialogPanel = buildDialogPanel(pluginsPanel)
         val ignoreCheckbox =
             descendants(dialogPanel, JCheckBox::class.java)
-                .first { it.text == "Use Ayu colors for .ignore files" }
+                .first { it.text == ".ignore syntax colors" }
 
         assertFalse(ignoreCheckbox.isSelected, "Stored .ignore opt-out must render unchecked")
 

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/AyuIslandsQuickSwitcherGroupBuilderTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/AyuIslandsQuickSwitcherGroupBuilderTest.kt
@@ -120,7 +120,7 @@ class AyuIslandsQuickSwitcherGroupBuilderTest {
 
         builder.apply()
 
-        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any()) }
+        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any<dev.ayuislands.accent.AyuVariant>()) }
         verify(exactly = 0) { AccentApplicator.applyFromHexString(any()) }
     }
 

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderApplyTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderApplyTest.kt
@@ -71,7 +71,7 @@ class OverridesGroupBuilderApplyTest {
         // still advance and the pending-change listener must still fire, or the
         // settings UI will keep reporting "modified" on already-saved state.
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
-        every { AccentResolver.resolve(any(), any()) } returns "#FFCC66"
+        every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#FFCC66"
         every { AccentApplicator.apply(any()) } throws RuntimeException("LafManager boom")
 
         val builder = OverridesGroupBuilder()
@@ -118,7 +118,7 @@ class OverridesGroupBuilderApplyTest {
         // success path into a swallow. One AccentApplicator.apply call, one
         // swap-service notification, isModified() returns false.
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
-        every { AccentResolver.resolve(any(), any()) } returns "#AABBCC"
+        every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#AABBCC"
         every { AccentApplicator.apply(any()) } answers { Unit }
         val swapService = mockk<ProjectAccentSwapService>(relaxed = true)
         every { ProjectAccentSwapService.getInstance() } returns swapService

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceHexGateShapeTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceHexGateShapeTest.kt
@@ -67,8 +67,9 @@ class ProjectAccentSwapServiceHexGateShapeTest {
             .joinToString("\n") { line -> line.replaceFirst(Regex("//.*$"), "") }
     }
 
-    private fun extractHandleWindowActivatedBody(): String {
-        val signaturePrefix = "fun handleWindowActivated("
+    private fun extractHandleWindowActivatedBody(): String = extractFunctionBody("fun handleWindowActivated(")
+
+    private fun extractFunctionBody(signaturePrefix: String): String {
         val start = source.indexOf(signaturePrefix)
         require(start >= 0) { "Could not locate '$signaturePrefix' in stripped source" }
         val openBrace = source.indexOf('{', start)
@@ -133,20 +134,31 @@ class ProjectAccentSwapServiceHexGateShapeTest {
     @Test
     fun `handleWindowActivated triggers integration refresh on same-hex branch`() {
         val body = extractHandleWindowActivatedBody()
-        // On same-hex swap, handleWindowActivated directly invokes the CGP +
-        // IR apply paths so the per-project accent is pushed into the
-        // app-scoped caches before the tree walk repaints.
+        val refreshBody = extractFunctionBody("fun refreshSameHexIntegrations(")
+        val ayuRefreshBody = extractFunctionBody("fun refreshAyuIntegrations(")
+        val externalRefreshBody = extractFunctionBody("fun refreshExternalIntegrations(")
+
         assertTrue(
-            Regex("""syncCodeGlanceProViewportForSwap\(""").containsMatchIn(body),
-            "handleWindowActivated MUST call AccentApplicator.syncCodeGlanceProViewportForSwap " +
-                "on the same-hex branch — push per-project hex into app-scoped CGP cache " +
-                "so the focused minimap repaints.",
+            body.contains("refreshSameHexIntegrations(effectiveAccent)"),
+            "handleWindowActivated MUST route the same-hex branch through refreshSameHexIntegrations.",
         )
         assertTrue(
-            Regex("""IndentRainbowSync\.apply\(""").containsMatchIn(body),
-            "handleWindowActivated MUST call IndentRainbowSync.apply on the same-hex " +
-                "branch — push per-project hex into app-scoped IR cache so the " +
-                "focused indent palette repaints.",
+            Regex("""syncCodeGlanceProViewportForSwap\(""").containsMatchIn(ayuRefreshBody),
+            "refreshAyuIntegrations MUST push per-project hex into app-scoped CGP cache.",
+        )
+        assertTrue(
+            Regex("""syncCodeGlanceProViewportForSwap\(""").containsMatchIn(externalRefreshBody),
+            "refreshExternalIntegrations MUST push external per-project hex into app-scoped CGP cache.",
+        )
+        assertTrue(
+            Regex("""refreshAyuIntegrations\(""").containsMatchIn(refreshBody) &&
+                Regex("""refreshExternalIntegrations\(""").containsMatchIn(refreshBody),
+            "refreshSameHexIntegrations MUST dispatch both Ayu and external contexts.",
+        )
+        assertTrue(
+            Regex("""IndentRainbowSync\.apply\(""").containsMatchIn(ayuRefreshBody) &&
+                Regex("""IndentRainbowSync\.apply\(""").containsMatchIn(externalRefreshBody),
+            "Same-hex refresh helpers MUST push per-project hex into app-scoped IR cache.",
         )
     }
 

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServicePublishTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServicePublishTest.kt
@@ -73,7 +73,7 @@ class ProjectAccentSwapServicePublishTest {
         mockkObject(IndentRainbowSync)
         every { AccentApplicator.applyFromHexString(any()) } returns true
         every { AccentApplicator.syncCodeGlanceProViewportForSwap(any()) } just Runs
-        every { IndentRainbowSync.apply(any(), any()) } just Runs
+        every { IndentRainbowSync.apply(any<dev.ayuislands.accent.AyuVariant>(), any()) } just Runs
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
         every { ComponentTreeRefresher.walkAndNotify(any(), any()) } just Runs
 

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.wm.IdeFrame
 import com.intellij.openapi.wm.WindowManager
 import com.intellij.testFramework.LoggedErrorProcessor
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.indent.IndentRainbowSync
@@ -74,7 +75,9 @@ class ProjectAccentSwapServiceTest {
         mockkObject(IndentRainbowSync)
         every { AccentApplicator.applyFromHexString(any()) } returns true
         every { AccentApplicator.syncCodeGlanceProViewportForSwap(any()) } just Runs
-        every { IndentRainbowSync.apply(any<dev.ayuislands.accent.AyuVariant>(), any()) } just Runs
+        every { AccentApplicator.syncCodeGlanceProViewportForSwap(any(), any()) } just Runs
+        every { IndentRainbowSync.apply(any<AyuVariant>(), any()) } just Runs
+        every { IndentRainbowSync.apply(any<AccentContext>(), any()) } just Runs
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
         every { ComponentTreeRefresher.walkAndNotify(any(), any()) } just Runs
 
@@ -173,6 +176,44 @@ class ProjectAccentSwapServiceTest {
         verify(exactly = 1) { AyuVariant.detect() }
         verify(exactly = 0) { AccentResolver.resolve(project, any<AyuVariant>()) }
         verify(exactly = 0) { AccentApplicator.applyFromHexString(any()) }
+    }
+
+    @Test
+    fun `onWindowActivated applies external context when non-Ayu theme support is enabled`() {
+        val (window, project) = wireMatchingFrame()
+        state.externalThemeEnhancementsEnabled = true
+        every { AyuVariant.detect() } returns null
+        every { AccentResolver.resolve(project, AccentContext.External) } returns "#AABBCC"
+        val service = ProjectAccentSwapService()
+
+        service.onWindowActivatedForTest(makeEvent(window))
+
+        verify(exactly = 1) { AyuVariant.detect() }
+        verify(exactly = 1) { AccentResolver.resolve(project, AccentContext.External) }
+        verify(exactly = 1) { AccentApplicator.applyFromHexString("#AABBCC") }
+        verify(exactly = 1) { ComponentTreeRefresher.walkAndNotify(project, window) }
+    }
+
+    @Test
+    fun `same-hex external focus swap re-syncs external CGP and IR caches`() {
+        val (window, project) = wireMatchingFrame()
+        state.externalThemeEnhancementsEnabled = true
+        state.externalThemeCodeGlanceProEnabled = true
+        state.externalThemeIndentRainbowEnabled = true
+        every { AyuVariant.detect() } returns null
+        every { AccentResolver.resolve(project, AccentContext.External) } returns "#AABBCC"
+        val service = ProjectAccentSwapService()
+
+        service.notifyExternalApply("#AABBCC")
+        service.onWindowActivatedForTest(makeEvent(window))
+
+        verify(exactly = 1) { AccentResolver.resolve(project, AccentContext.External) }
+        verify(exactly = 0) { AccentApplicator.applyFromHexString(any()) }
+        verify(exactly = 1) {
+            AccentApplicator.syncCodeGlanceProViewportForSwap("#AABBCC", AccentContext.External)
+        }
+        verify(exactly = 1) { IndentRainbowSync.apply(AccentContext.External, "#AABBCC") }
+        verify(exactly = 1) { ComponentTreeRefresher.walkAndNotify(project, window) }
     }
 
     @Test
@@ -332,7 +373,7 @@ class ProjectAccentSwapServiceTest {
         every { AccentApplicator.syncCodeGlanceProViewportForSwap(any()) } just Runs
 
         mockkObject(IndentRainbowSync)
-        every { IndentRainbowSync.apply(any<dev.ayuislands.accent.AyuVariant>(), any()) } just Runs
+        every { IndentRainbowSync.apply(any<AyuVariant>(), any()) } just Runs
 
         val service = ProjectAccentSwapService()
 
@@ -557,7 +598,7 @@ class ProjectAccentSwapServiceTest {
         service.onWindowActivatedForTest(makeEvent(window)) // primes cache
         service.onWindowActivatedForTest(makeEvent(window)) // same-hex branch
 
-        verify(exactly = 0) { IndentRainbowSync.apply(any<dev.ayuislands.accent.AyuVariant>(), any()) }
+        verify(exactly = 0) { IndentRainbowSync.apply(any<AyuVariant>(), any()) }
         // CGP integration call still fires — the gate is IR-only at this
         // call site (CGP gates inside its own `apply`).
         verify(atLeast = 1) { AccentApplicator.syncCodeGlanceProViewportForSwap("#FFCC66") }

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt
@@ -74,7 +74,7 @@ class ProjectAccentSwapServiceTest {
         mockkObject(IndentRainbowSync)
         every { AccentApplicator.applyFromHexString(any()) } returns true
         every { AccentApplicator.syncCodeGlanceProViewportForSwap(any()) } just Runs
-        every { IndentRainbowSync.apply(any(), any()) } just Runs
+        every { IndentRainbowSync.apply(any<dev.ayuislands.accent.AyuVariant>(), any()) } just Runs
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
         every { ComponentTreeRefresher.walkAndNotify(any(), any()) } just Runs
 
@@ -332,7 +332,7 @@ class ProjectAccentSwapServiceTest {
         every { AccentApplicator.syncCodeGlanceProViewportForSwap(any()) } just Runs
 
         mockkObject(IndentRainbowSync)
-        every { IndentRainbowSync.apply(any(), any()) } just Runs
+        every { IndentRainbowSync.apply(any<dev.ayuislands.accent.AyuVariant>(), any()) } just Runs
 
         val service = ProjectAccentSwapService()
 
@@ -557,7 +557,7 @@ class ProjectAccentSwapServiceTest {
         service.onWindowActivatedForTest(makeEvent(window)) // primes cache
         service.onWindowActivatedForTest(makeEvent(window)) // same-hex branch
 
-        verify(exactly = 0) { IndentRainbowSync.apply(any(), any()) }
+        verify(exactly = 0) { IndentRainbowSync.apply(any<dev.ayuislands.accent.AyuVariant>(), any()) }
         // CGP integration call still fires — the gate is IR-only at this
         // call site (CGP gates inside its own `apply`).
         verify(atLeast = 1) { AccentApplicator.syncCodeGlanceProViewportForSwap("#FFCC66") }

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt
@@ -153,7 +153,7 @@ class ProjectAccentSwapServiceTest {
         service.onWindowActivatedForTest(event)
 
         verify(exactly = 0) { AccentApplicator.applyFromHexString(any()) }
-        verify(exactly = 0) { AccentResolver.resolve(any(), any()) }
+        verify(exactly = 0) { AccentResolver.resolve(any(), any<AyuVariant>()) }
         verify(exactly = 0) { AyuVariant.detect() }
     }
 
@@ -171,7 +171,7 @@ class ProjectAccentSwapServiceTest {
         service.onWindowActivatedForTest(makeEvent(window))
 
         verify(exactly = 1) { AyuVariant.detect() }
-        verify(exactly = 0) { AccentResolver.resolve(project, any()) }
+        verify(exactly = 0) { AccentResolver.resolve(project, any<AyuVariant>()) }
         verify(exactly = 0) { AccentApplicator.applyFromHexString(any()) }
     }
 
@@ -185,7 +185,7 @@ class ProjectAccentSwapServiceTest {
 
         service.onWindowActivatedForTest(makeEvent(window))
 
-        verify(exactly = 0) { AccentResolver.resolve(project, any()) }
+        verify(exactly = 0) { AccentResolver.resolve(project, any<AyuVariant>()) }
         verify(exactly = 0) { AccentApplicator.applyFromHexString(any()) }
     }
 


### PR DESCRIPTION
-- Summary ---------------------------------------------------------

Ayu-only accent features were tied to Ayu themes, so users on other JetBrains themes could not reuse Ayu quick-switcher actions, glow, CodeGlance Pro, or Indent Rainbow sync consistently.

This PR adds controlled external-theme support with per-feature inheritance toggles and cleans up the Plugins settings tab so users can choose exactly which Ayu integrations are allowed on non-Ayu themes.

-- Changes ---------------------------------------------------------

- Feat: `src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt`, `AccentContext.kt`, `ExternalAccentSource.kt`
  Resolve external-theme accent sources from project/language pins, Material Theme accent, IDE accent, and fallback accent.

- Feat: `src/main/kotlin/dev/ayuislands/AyuIslandsLafListener.kt`, `AyuIslandsStartupActivity.kt`, `AccentApplicator.kt`
  Apply external-theme accent context on startup and theme changes without treating non-Ayu themes as Ayu themes.

- Feat: `src/main/kotlin/dev/ayuislands/accent/toolbar/...`
  Allow quick-switcher accent actions on external themes when the user enables that inheritance path.

- Feat: `src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt`, `CodeGlanceProIntegration.kt`, `IndentRainbowSync.kt`
  Honor per-integration external-theme toggles for glow, CodeGlance Pro, and Indent Rainbow.

- Feat: `src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt`, `AyuIslandsState.kt`
  Add External Theme Support controls and consolidate `.ignore`, CodeGlance Pro, and Indent Rainbow into one Plugin Integrations section.

- Test: `src/test/kotlin/dev/ayuislands/**`
  Cover external accent resolution, context propagation, settings persistence, toolbar actions, glow lifecycle, CodeGlance Pro sync, and Indent Rainbow sync.

-- Validation ------------------------------------------------------

- `./gradlew test --tests 'dev.ayuislands.settings.PluginsPanelTest'`
  Expected: BUILD SUCCESSFUL

- `./gradlew detekt ktlintCheck`
  Expected: BUILD SUCCESSFUL

- `./gradlew test`
  Expected: BUILD SUCCESSFUL

- `./gradlew build`
  Expected: BUILD SUCCESSFUL

- `$deploy-to-ide`
  Expected: installed into IntelliJIdea2026.1, verified `AccentApplicator`, `GlowOverlayManager`, and `PluginsPanel` bytecode, restarted IDEA from the project cwd, and saw a fresh `Ayu Islands accent applied` log line.

-- Notes -----------------------------------------------------------

- Glow inheritance stays off by default; users must opt into it separately.
- No local design/planning docs are included in the final commit.

## Summary by Sourcery

Add external theme accent context support and settings, and extend Ayu integrations (quick switcher, glow, CodeGlance Pro, Indent Rainbow) to respect user-configurable inheritance when non-Ayu themes are active.

New Features:
- Introduce an AccentContext model and external accent resolution that can derive colors from project overrides, Material Theme, IDE accents, or a manual fallback for use on non-Ayu themes.
- Add External Theme Support controls and per-integration inheritance toggles in the Plugins settings so users can opt specific Ayu features into external themes.
- Enable the quick-switcher popup, actions, and toolbar chip to operate against external accent context when allowed, including persisting manual external accents from interactions.
- Allow glow overlays and focus-ring glow to initialize and update under an external accent context, gated by external glow permissions.
- Extend Indent Rainbow and CodeGlance Pro integrations to sync against external accent context when enabled, including a dedicated external Indent palette.

Enhancements:
- Refactor accent resolution, applicator, and quick-switcher widgets to route through AccentContext rather than Ayu-only variant detection, improving future extensibility.
- Consolidate plugin-related settings into a single Plugin Integrations group and simplify .ignore and integration labels for clearer UX.
- Extract tab underline height resolution into a standalone helper for reuse and improved testability.

Tests:
- Add extensive tests for external accent resolution, AccentContext detection, and UIManager-based accent sourcing.
- Add tests covering external theme settings persistence, PluginsPanel layout, and per-integration external inheritance toggles.
- Extend glow, Indent Rainbow, CodeGlance Pro, quick-switcher, and toolbar action tests to cover external context behavior and guard key lifecycle and gating patterns.