### PR TITLE
Prepare 2.7.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [2.7.2] - 2026-06-05
+
+### Paid
+- [Paid] **External theme accent inheritance** — Pro project and language accent pins can now drive selected Ayu integrations while another IDE theme is active.
+- [Paid] **Glow on external themes** — Glow can follow Ayu accents on non-Ayu themes when explicitly enabled; external Glow stays off by default.
+- [Paid] **Plugin sync on external themes** — CodeGlance Pro and Indent Rainbow can now sync to Ayu's external accent context on non-Ayu themes.
+- [Paid] **External Quick-Switcher actions** — premium actions like Random, Lighter, and Darker now persist the chosen external accent on non-Ayu themes.
+
+### Free
+- [Free] **External theme support** — use selected Ayu accent enhancements on non-Ayu JetBrains themes without switching the active IDE theme to Ayu.
+- [Free] **Quick-Switcher on external themes** — Quick-Switcher now supports external themes, including accent preset apply and copy flows when external theme support is enabled.
+- [Free] **Automatic external accent sources** — external accents can resolve from Material Theme, IDE accent colors, or a manual fallback.
+
 ## [2.7.1] - 2026-06-01
 
 ### Added

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -90,7 +90,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "44ba0033"
+          last_verified_sha: "e3738091"
           last_verified_date: "2026-05-31"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -112,7 +112,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "44ba0033"
+          last_verified_sha: "e3738091"
           last_verified_date: "2026-05-31"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -247,7 +247,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "3cbd3d0"
+          last_verified_sha: "e3738091"
           last_verified_date: "2026-05-30"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -288,7 +288,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "3cbd3d0"
+          last_verified_sha: "e3738091"
           last_verified_date: "2026-05-30"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -331,7 +331,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "cdf1e135"
+          last_verified_sha: "e3738091"
           last_verified_date: "2026-05-30"
           content_sha256: "fc9ba63b9c9c53893a486a3c9055287bd6dc9c68f5439cae197efe5ae585d17c"
 
@@ -393,7 +393,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "3cbd3d0"
+          last_verified_sha: "e3738091"
           last_verified_date: "2026-05-30"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -182,6 +182,42 @@ categories:
           General. Premium-tier rows (related toggles + quick actions)
           appear inside the popup when the license is active or in trial.
 
+      - id: external-theme-accent-inheritance
+        title: "External theme accent inheritance"
+        keyword: "per-project"
+        introduced: "2.7.2"
+        tier: paid
+        description: >
+          Pro project and language accent pins can drive selected Ayu
+          integrations while a non-Ayu IDE theme is active.
+
+      - id: external-accent-sources
+        title: "Automatic external accent sources"
+        keyword: "accent color"
+        introduced: "2.7.2"
+        tier: free
+        description: >
+          External accents can resolve from Material Theme, IDE accent
+          colors, or a manual fallback when external theme support is enabled.
+
+      - id: quick-switcher-external-themes
+        title: "Quick-Switcher on external themes"
+        keyword: "Quick-Switcher Widget"
+        introduced: "2.7.2"
+        tier: free
+        description: >
+          The Quick-Switcher can apply and copy accents while a non-Ayu
+          IDE theme is active when external theme support is enabled.
+
+      - id: quick-switcher-external-actions
+        title: "External Quick-Switcher actions"
+        keyword: "Quick-Switcher Widget"
+        introduced: "2.7.2"
+        tier: paid
+        description: >
+          Premium Quick-Switcher actions such as Random, Lighter, and
+          Darker persist the chosen external accent on non-Ayu themes.
+
   glow:
     title: "Glow effects"
     features:
@@ -214,6 +250,15 @@ categories:
           last_verified_sha: "3cbd3d0"
           last_verified_date: "2026-05-30"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
+
+      - id: glow-external-themes
+        title: "Glow on external themes"
+        keyword: "Glow"
+        introduced: "2.7.2"
+        tier: paid
+        description: >
+          Glow can follow Ayu accents on non-Ayu themes when explicitly
+          enabled; external Glow stays off by default.
 
   fonts:
     title: "Font presets"
@@ -322,6 +367,15 @@ categories:
         description: >
           Indent Rainbow guides adopt one of three Ayu presets
           (Whisper / Ambient / Neon).
+
+      - id: plugin-sync-external-themes
+        title: "Plugin sync on external themes"
+        keyword: "CodeGlance Pro"
+        introduced: "2.7.2"
+        tier: paid
+        description: >
+          CodeGlance Pro and Indent Rainbow can sync to Ayu's external
+          accent context while a non-Ayu IDE theme is active.
 
       - id: bracket-scope
         title: "Bracket scope gutter stripe"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.7.1
+pluginVersion=2.7.2
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
@@ -55,6 +55,13 @@ internal object UpdateNotifier {
 
     private val RELEASE_NOTES =
         mapOf(
+            "2.7.2" to
+                releaseNotes(
+                    "Pro accent pins can now drive Ayu integrations on non-Ayu themes",
+                    "Glow, CodeGlance Pro, and Indent Rainbow can follow external Ayu accents",
+                    "Quick-Switcher now supports external themes and persists external accent actions",
+                    "External accents can use Material Theme, IDE accent, or manual fallback colors",
+                ),
             "2.7.1" to
                 releaseNotes(
                     "Locked premium Settings controls are now visible as greyed-out previews",

--- a/src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
@@ -24,6 +24,7 @@ import dev.ayuislands.syntax.SyntaxIntensityService
 import javax.swing.JCheckBox
 import javax.swing.JComboBox
 import javax.swing.JLabel
+import javax.swing.JList
 import javax.swing.JSlider
 
 /** Plugin's tab: third-party plugin integrations (CodeGlance Pro, Indent Rainbow). */
@@ -206,7 +207,18 @@ class PluginsPanel : AyuIslandsSettingsPanel {
                             comboBox(ExternalAccentSource.entries.toList())
                                 .component
                         combo.selectedItem = ExternalAccentSource.fromName(pendingSettings.externalAccentSource)
-                        combo.renderer = SimpleListCellRenderer.create("") { it.displayName }
+                        combo.renderer =
+                            object : SimpleListCellRenderer<ExternalAccentSource>() {
+                                override fun customize(
+                                    list: JList<out ExternalAccentSource>,
+                                    value: ExternalAccentSource?,
+                                    index: Int,
+                                    selected: Boolean,
+                                    hasFocus: Boolean,
+                                ) {
+                                    text = value?.displayName.orEmpty()
+                                }
+                            }
                         combo.addActionListener {
                             if (suppressListeners) return@addActionListener
                             pendingSettings =

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -113,6 +113,16 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>2.7.2</h3>
+    <ul>
+      <li>[Paid] <b>External theme accent inheritance</b> — Pro project and language accent pins can now drive selected Ayu integrations while another IDE theme is active.</li>
+      <li>[Paid] <b>Glow on external themes</b> — Glow can follow Ayu accents on non-Ayu themes when explicitly enabled; external Glow stays off by default.</li>
+      <li>[Paid] <b>Plugin sync on external themes</b> — CodeGlance Pro and Indent Rainbow can now sync to Ayu's external accent context on non-Ayu themes.</li>
+      <li>[Paid] <b>External Quick-Switcher actions</b> — premium actions like Random, Lighter, and Darker now persist the chosen external accent on non-Ayu themes.</li>
+      <li>[Free] <b>External theme support</b> — use selected Ayu accent enhancements on non-Ayu JetBrains themes without switching the active IDE theme to Ayu.</li>
+      <li>[Free] <b>Quick-Switcher on external themes</b> — Quick-Switcher now supports external themes, including accent preset apply and copy flows when external theme support is enabled.</li>
+      <li>[Free] <b>Automatic external accent sources</b> — external accents can resolve from Material Theme, IDE accent colors, or a manual fallback.</li>
+    </ul>
     <h3>2.7.1</h3>
     <ul>
       <li><b>Added:</b> when the optional <code>.ignore</code> plugin is installed, its files use dedicated Ayu colors across Dark, Mirage, and Light editor schemes, including Syntax preset transformations and a Plugins-tab opt-out.</li>


### PR DESCRIPTION
-- Summary ---------------------
2.7.2 needs a release-ready metadata pass after external-theme accent support merged. This prepares the Marketplace and IDE-visible release surfaces, docs metadata, and version bump without tagging yet.

-- Changes ---------------------
| Type | Area | Description |
| --- | --- | --- |
| Chore | [gradle.properties](gradle.properties) | Bumps pluginVersion to 2.7.2. |
| Docs | [CHANGELOG.md](CHANGELOG.md) | Adds paid-first, user-facing 2.7.2 release notes. |
| Docs | [plugin.xml](src/main/resources/META-INF/plugin.xml) | Adds Marketplace and IDE change notes for 2.7.2. |
| Chore | [UpdateNotifier.kt](src/main/kotlin/dev/ayuislands/UpdateNotifier.kt) | Adds in-IDE update notes for 2.7.2. |
| Chore | [features.yml](docs/features.yml) | Registers paid and free feature metadata used by docs verification. |
| Fix | [PluginsPanel.kt](src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt) | Replaces a scheduled-for-removal combo renderer API found by plugin verification. |

-- Validation ------------------
- `scripts/verify-docs.py` passed; remaining output is orphaned screenshot last_verified_sha warnings after the squash merge.
- `./gradlew detekt ktlintCheck` passed.
- `./gradlew clean buildPlugin` passed.
- `./gradlew verifyPlugin` passed; 12/12 products compatible.

-- Notes -----------------------
- No v2.7.2 tag has been created yet.
- Release bullets keep paid capabilities first and describe user-visible changes only.

## Summary by Sourcery

Prepare the 2.7.2 plugin release with updated metadata, release notes, and compatibility fixes.

New Features:
- Document and register new external theme accent features across free and paid tiers for version 2.7.2.

Bug Fixes:
- Replace a deprecated combo box renderer API in the plugins settings panel to satisfy plugin verification.

Enhancements:
- Add in-IDE update notifier entries describing the 2.7.2 external theme accent enhancements.

Build:
- Bump the plugin version to 2.7.2 in the Gradle configuration.

Documentation:
- Add 2.7.2 user-facing release notes in the changelog and plugin descriptor, including paid-first and free external theme accent improvements.
- Expand docs feature metadata to cover new external theme accent and external integration capabilities used by documentation verification.