### PR TITLE
Fix native syntax preview highlighting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.{kt,kts}]
+max_line_length = 120
+indent_size = 4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,7 +179,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     needs: build
-    timeout-minutes: 15
+    timeout-minutes: 30
     environment: ci
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanel.kt
@@ -130,6 +130,7 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
         this.variant = variant
         loadStateIntoPending()
         customSelected.set(pendingPreset == SyntaxPreset.CUSTOM)
+        currentLanguage = preferredInitialLanguage()
         with(panel) {
             buildPresetBlock()
 
@@ -185,7 +186,7 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
     /** Build the premium Custom drill-down as two grouped, aligned columns. */
     private fun Panel.buildCustomFoldOut() {
         val languages = SyntaxLanguageRegistry.supportedLanguages().map { it.displayName }
-        currentLanguage = languages.firstOrNull() ?: ""
+        currentLanguage = currentLanguage.takeIf { it in languages } ?: preferredInitialLanguage(languages)
         row("Language:") {
             val combo = comboBox(languages).component
             combo.selectedItem = currentLanguage
@@ -194,6 +195,7 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
                 currentLanguage = language
                 rebindSlidersFor(language)
                 refreshMasterResetButton()
+                refreshPreview()
             }
             val resetButton =
                 button("") { onResetCurrentLanguage() }.component.apply {
@@ -676,7 +678,7 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
 
     private fun Panel.buildPreviewRow(variant: AyuVariant) {
         row {
-            val preview = SyntaxPreviewComponent(variant)
+            val preview = SyntaxPreviewComponent(variant, currentLanguage)
             syntaxPreview = preview
             cell(preview)
                 .resizableColumn()
@@ -688,8 +690,16 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
         val v = variant ?: return
         syntaxPreview?.updatePreview(
             variant = v,
+            language = currentLanguage,
         )
     }
+
+    private fun preferredInitialLanguage(
+        languages: List<String> =
+            SyntaxLanguageRegistry.supportedLanguages().map {
+                it.displayName
+            },
+    ): String = languages.firstOrNull { it == DEFAULT_PREVIEW_LANGUAGE } ?: languages.firstOrNull().orEmpty()
 
     private fun readabilityOptions(): SyntaxReadabilityOptions =
         SyntaxReadabilityOptions(
@@ -735,6 +745,7 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
         private const val LABEL_PADDING = 8
         private const val LABEL_FALLBACK_WIDTH = 170
         private const val PREMIUM_CONTROL_TOOLTIP = "Pro Feature"
+        private const val DEFAULT_PREVIEW_LANGUAGE = "Kotlin"
         private const val SEGMENTED_PRESENTATIONS_METHOD =
             "getPresentations" + "$" + "intellij_platform_ide_impl"
 

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanel.kt
@@ -146,6 +146,7 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
             buildReadabilityBlock()
 
             buildPreviewRow(variant)
+            refreshPreview()
 
             row {
                 browserLink(
@@ -687,10 +688,6 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
         val v = variant ?: return
         syntaxPreview?.updatePreview(
             variant = v,
-            preset = pendingPreset,
-            customOverrides = buildNested(pendingOverrides) { it.toIntOrNull() },
-            subordinatePreset = pendingSubordinate,
-            readabilityOptions = readabilityOptions(),
         )
     }
 

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanel.kt
@@ -3,6 +3,7 @@ package dev.ayuislands.settings
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.observable.properties.AtomicBooleanProperty
 import com.intellij.ui.InplaceButton
+import com.intellij.ui.dsl.builder.Align
 import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.dsl.builder.RightGap
@@ -100,6 +101,8 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
     private var emphasizeDeclarationsCheckbox: JCheckBox? = null
     private var masterResetButton: JButton? = null
     private var currentLanguage: String = ""
+    private var variant: AyuVariant? = null
+    private var syntaxPreview: SyntaxPreviewComponent? = null
 
     // One uniform leading-label width shared by every row in both column-level
     // grids. Pinning the label width keeps slider starts aligned across the
@@ -124,6 +127,7 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
         panel: Panel,
         variant: AyuVariant,
     ) {
+        this.variant = variant
         loadStateIntoPending()
         customSelected.set(pendingPreset == SyntaxPreset.CUSTOM)
         with(panel) {
@@ -140,6 +144,8 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
             }
 
             buildReadabilityBlock()
+
+            buildPreviewRow(variant)
 
             row {
                 browserLink(
@@ -664,6 +670,28 @@ class AyuIslandsSyntaxPanel : AyuIslandsSettingsPanel {
         SyntaxIntensityService
             .getInstance()
             .apply(pendingPreset, nested, pendingSubordinate, nestedStyles, readabilityOptions())
+        refreshPreview()
+    }
+
+    private fun Panel.buildPreviewRow(variant: AyuVariant) {
+        row {
+            val preview = SyntaxPreviewComponent(variant)
+            syntaxPreview = preview
+            cell(preview)
+                .resizableColumn()
+                .align(Align.FILL)
+        }
+    }
+
+    private fun refreshPreview() {
+        val v = variant ?: return
+        syntaxPreview?.updatePreview(
+            variant = v,
+            preset = pendingPreset,
+            customOverrides = buildNested(pendingOverrides) { it.toIntOrNull() },
+            subordinatePreset = pendingSubordinate,
+            readabilityOptions = readabilityOptions(),
+        )
     }
 
     private fun readabilityOptions(): SyntaxReadabilityOptions =

--- a/src/main/kotlin/dev/ayuislands/settings/PreviewChromePainter.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/PreviewChromePainter.kt
@@ -1,0 +1,125 @@
+package dev.ayuislands.settings
+
+import com.intellij.ui.JBColor
+import com.intellij.util.ui.JBUI
+import java.awt.Color
+import java.awt.Graphics2D
+import java.awt.Rectangle
+
+internal data class PreviewChromeLayout(
+    val padding: Int,
+    val contentHeight: Int,
+    val projectWidth: Int,
+    val editorX: Int,
+    val editorWidth: Int,
+)
+
+internal data class PreviewChromeProjectRow(
+    val markerColor: Color,
+    val text: String,
+)
+
+internal data class PreviewChromeProjectPanel(
+    val bounds: Rectangle,
+    val surface: Color,
+    val rows: List<PreviewChromeProjectRow>,
+    val markerShape: PreviewChromeMarkerShape,
+    val textColor: Color? = null,
+)
+
+internal enum class PreviewChromeMarkerShape {
+    ROUND,
+    SQUARE,
+}
+
+internal object PreviewChromePainter {
+    fun layout(
+        width: Int,
+        height: Int,
+    ): PreviewChromeLayout {
+        val padding = JBUI.scale(PADDING)
+        val projectWidth = JBUI.scale(PROJECT_WIDTH)
+        val columnGap = JBUI.scale(COLUMN_GAP)
+        val editorX = padding + projectWidth + columnGap
+        return PreviewChromeLayout(
+            padding = padding,
+            contentHeight = (height - padding * 2).coerceAtLeast(1),
+            projectWidth = projectWidth,
+            editorX = editorX,
+            editorWidth = (width - editorX - padding).coerceAtLeast(1),
+        )
+    }
+
+    fun paintOuterPanel(
+        g2: Graphics2D,
+        width: Int,
+        height: Int,
+        surface: Color,
+    ) {
+        paintRoundedSurface(g2, Rectangle(0, 0, width, height), JBUI.scale(ARC), surface)
+    }
+
+    fun paintPanelFrame(
+        g2: Graphics2D,
+        bounds: Rectangle,
+        surface: Color,
+    ) {
+        paintRoundedSurface(g2, bounds, JBUI.scale(INNER_ARC), surface)
+    }
+
+    fun paintProjectPanel(
+        g2: Graphics2D,
+        panel: PreviewChromeProjectPanel,
+    ) {
+        paintPanelFrame(g2, panel.bounds, panel.surface)
+
+        g2.font = JBUI.Fonts.smallFont()
+        val rowHeight = JBUI.scale(PROJECT_ROW_HEIGHT)
+        var rowY = panel.bounds.y + JBUI.scale(PROJECT_TOP_PADDING)
+        for (row in panel.rows) {
+            val baseline = rowY + (rowHeight - g2.fontMetrics.height) / 2 + g2.fontMetrics.ascent
+            g2.color = row.markerColor
+            paintMarker(g2, panel.bounds.x + JBUI.scale(FILE_DOT_X), rowY + JBUI.scale(FILE_DOT_Y), panel.markerShape)
+            g2.color = panel.textColor ?: row.markerColor
+            g2.drawString(row.text, panel.bounds.x + JBUI.scale(FILE_TEXT_X), baseline)
+            rowY += rowHeight
+        }
+    }
+
+    private fun paintRoundedSurface(
+        g2: Graphics2D,
+        bounds: Rectangle,
+        arc: Int,
+        surface: Color,
+    ) {
+        g2.color = surface
+        g2.fillRoundRect(bounds.x, bounds.y, bounds.width, bounds.height, arc, arc)
+        g2.color = JBColor.border()
+        g2.drawRoundRect(bounds.x, bounds.y, bounds.width - 1, bounds.height - 1, arc, arc)
+    }
+
+    private fun paintMarker(
+        g2: Graphics2D,
+        x: Int,
+        y: Int,
+        shape: PreviewChromeMarkerShape,
+    ) {
+        val size = JBUI.scale(FILE_DOT)
+        when (shape) {
+            PreviewChromeMarkerShape.ROUND -> g2.fillOval(x, y, size, size)
+            PreviewChromeMarkerShape.SQUARE -> g2.fillRect(x, y, size, size)
+        }
+    }
+
+    private const val PADDING = 10
+    private const val COLUMN_GAP = 10
+    private const val PROJECT_WIDTH = 154
+    private const val PROJECT_TOP_PADDING = 12
+    private const val PROJECT_ROW_HEIGHT = 22
+    private const val FILE_DOT_X = 11
+    private const val FILE_DOT_Y = 8
+    private const val FILE_DOT = 7
+    private const val FILE_TEXT_X = 26
+    private const val ARC = 8
+    private const val INNER_ARC = 6
+}

--- a/src/main/kotlin/dev/ayuislands/settings/SyntaxPreviewComponent.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/SyntaxPreviewComponent.kt
@@ -173,6 +173,9 @@ internal class SyntaxPreviewComponent(
     @TestOnly
     internal fun sampleFileNameForTest(): String = previewSample.fileName
 
+    @TestOnly
+    internal fun sampleCodeForTest(): String = previewSample.code
+
     private data class SurfacePalette(
         val editor: Color,
         val panel: Color,
@@ -183,6 +186,14 @@ internal class SyntaxPreviewComponent(
         val standardFileTypeName: String?,
         val defaultExtension: String?,
         val code: String,
+    )
+
+    private data class PreviewSampleSpec(
+        val language: String,
+        val fileName: String,
+        val standardFileTypeName: String,
+        val defaultExtension: String,
+        val resourceName: String,
     )
 
     private companion object {
@@ -205,195 +216,21 @@ internal class SyntaxPreviewComponent(
                 PreviewChromeProjectRow(fixedColor(0xFFD580), "build/"),
             )
 
-        private val PREVIEW_SAMPLES =
-            mapOf(
-                previewSample(
-                    "Kotlin",
-                    "PresetPreview.kt",
-                    "Kotlin",
-                    "kt",
-                    """
-                    fun main() {
-                        val msg = "hello"
-                        val count = 42
-                        // print greeting
-                        /** Greet the user */
-                        class Greeter {
-                            @JvmStatic
-                            fun greet(name: String) {
-                                if (msg.isNotEmpty()) println(name)
-                            }
-                        }
-                    }
-                    """,
-                ),
-                previewSample(
-                    "Java",
-                    "PresetPreview.java",
-                    "JAVA",
-                    "java",
-                    """
-                    public final class Greeter {
-                        private static final String MSG = "hello";
-                        // print greeting
-                        /** Greet the user */
-                        public void greet(String name) {
-                            if (!MSG.isEmpty()) {
-                                System.out.println(name);
-                            }
-                        }
-                    }
-                    """,
-                ),
-                previewSample(
-                    "Python",
-                    "preset_preview.py",
-                    "Python",
-                    "py",
-                    """
-                    class Greeter:
-                        # Greet the user.
-                        def greet(self, name: str) -> None:
-                            msg = "hello"
-                            count = 42
-                            if msg:
-                                print(name, count)
-                    """,
-                ),
-                previewSample(
-                    "JavaScript",
-                    "preset-preview.js",
-                    "JavaScript",
-                    "js",
-                    """
-                    export function greet(name) {
-                        const msg = "hello";
-                        const count = 42;
-                        // print greeting
-                        if (msg.length > 0) {
-                            console.log(name, count);
-                        }
-                    }
-                    """,
-                ),
-                previewSample(
-                    "TypeScript",
-                    "preset-preview.ts",
-                    "TypeScript",
-                    "ts",
-                    """
-                    export function greet(name: string): void {
-                        const msg = "hello";
-                        const count = 42;
-                        // print greeting
-                        if (msg.length > 0) {
-                            console.log(name, count);
-                        }
-                    }
-                    """,
-                ),
-                previewSample(
-                    "Go",
-                    "preset_preview.go",
-                    "Go",
-                    "go",
-                    """
-                    package preview
-
-                    import "fmt"
-
-                    // Greeter prints a greeting.
-                    func Greet(name string) {
-                        msg := "hello"
-                        count := 42
-                        if len(msg) > 0 {
-                            fmt.Println(name, count)
-                        }
-                    }
-                    """,
-                ),
-                previewSample(
-                    "Rust",
-                    "preset_preview.rs",
-                    "Rust",
-                    "rs",
-                    """
-                    pub fn greet(name: &str) {
-                        let msg = "hello";
-                        let count = 42;
-                        // print greeting
-                        if !msg.is_empty() {
-                            println!("{}", name);
-                        }
-                    }
-                    """,
-                ),
-                previewSample(
-                    "CSS",
-                    "preview.css",
-                    "CSS",
-                    "css",
-                    """
-                    .preview {
-                        color: #ffcc66;
-                        padding: 12px;
-                        /* tune declarations */
-                        border-radius: 6px;
-                    }
-                    """,
-                ),
-                previewSample(
-                    "HTML",
-                    "preview.html",
-                    "HTML",
-                    "html",
-                    """
-                    <section class="preview">
-                        <!-- tune tags and text -->
-                        <h1>Hello</h1>
-                        <span data-count="42">Ayu Islands</span>
-                    </section>
-                    """,
-                ),
-                previewSample(
-                    "JSON",
-                    "preview.json",
-                    "JSON",
-                    "json",
-                    """
-                    {
-                      "name": "Ayu Islands",
-                      "enabled": true,
-                      "count": 42
-                    }
-                    """,
-                ),
-                previewSample(
-                    "YAML",
-                    "preview.yaml",
-                    "YAML",
-                    "yaml",
-                    """
-                    name: Ayu Islands
-                    enabled: true
-                    count: 42
-                    # tune keys and values
-                    """,
-                ),
-                previewSample(
-                    "Markdown",
-                    "preview.md",
-                    "Markdown",
-                    "md",
-                    """
-                    # Ayu Islands
-
-                    `code` and **strong** text
-
-                    - count: 42
-                    """,
-                ),
-            )
+        private val PREVIEW_SAMPLE_SPECS =
+            listOf(
+                PreviewSampleSpec("Kotlin", "PresetPreview.kt", "Kotlin", "kt", "kotlin.txt"),
+                PreviewSampleSpec("Java", "PresetPreview.java", "JAVA", "java", "java.txt"),
+                PreviewSampleSpec("Python", "preset_preview.py", "Python", "py", "python.txt"),
+                PreviewSampleSpec("JavaScript", "preset-preview.js", "JavaScript", "js", "javascript.txt"),
+                PreviewSampleSpec("TypeScript", "preset-preview.ts", "TypeScript", "ts", "typescript.txt"),
+                PreviewSampleSpec("Go", "preset_preview.go", "Go", "go", "go.txt"),
+                PreviewSampleSpec("Rust", "preset_preview.rs", "Rust", "rs", "rust.txt"),
+                PreviewSampleSpec("CSS", "preview.css", "CSS", "css", "css.txt"),
+                PreviewSampleSpec("HTML", "preview.html", "HTML", "html", "html.txt"),
+                PreviewSampleSpec("JSON", "preview.json", "JSON", "json", "json.txt"),
+                PreviewSampleSpec("YAML", "preview.yaml", "YAML", "yaml", "yaml.txt"),
+                PreviewSampleSpec("Markdown", "preview.md", "Markdown", "md", "markdown.txt"),
+            ).associateBy(PreviewSampleSpec::language)
 
         private val DEFAULT_SAMPLE =
             PreviewSample(
@@ -411,26 +248,29 @@ internal class SyntaxPreviewComponent(
 
         private fun fixedColor(rgb: Int): JBColor = JBColor(rgb, rgb)
 
-        private fun previewSample(
-            language: String,
-            fileName: String,
-            standardFileTypeName: String,
-            defaultExtension: String,
-            code: String,
-        ): Pair<String, PreviewSample> =
-            language to
-                PreviewSample(
-                    fileName,
-                    standardFileTypeName,
-                    defaultExtension,
-                    code.trimIndent(),
-                )
-
         private fun normalizeLanguage(language: String): String =
             language.takeIf { it.isNotBlank() } ?: DEFAULT_LANGUAGE
 
         private fun sampleFor(language: String): PreviewSample =
-            PREVIEW_SAMPLES[normalizeLanguage(language)] ?: DEFAULT_SAMPLE
+            PREVIEW_SAMPLE_SPECS[normalizeLanguage(language)]?.toPreviewSample() ?: DEFAULT_SAMPLE
+
+        private fun PreviewSampleSpec.toPreviewSample(): PreviewSample =
+            PreviewSample(
+                fileName,
+                standardFileTypeName,
+                defaultExtension,
+                loadPreviewCode(resourceName),
+            )
+
+        private fun loadPreviewCode(resourceName: String): String {
+            val resourcePath = "/dev/ayuislands/settings/syntax-preview/$resourceName"
+            val stream = SyntaxPreviewComponent::class.java.getResourceAsStream(resourcePath)
+            if (stream == null) {
+                LOG.warn("Syntax preview sample resource '$resourcePath' is missing; falling back to default sample")
+                return DEFAULT_SAMPLE.code
+            }
+            return stream.bufferedReader(Charsets.UTF_8).use { it.readText().trimIndent() }
+        }
 
         private fun previewFileType(
             language: String,

--- a/src/main/kotlin/dev/ayuislands/settings/SyntaxPreviewComponent.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/SyntaxPreviewComponent.kt
@@ -71,7 +71,7 @@ internal class SyntaxPreviewComponent(
     override fun getMinimumSize(): Dimension = Dimension(JBUI.scale(MIN_PREVIEW_WIDTH), JBUI.scale(PREVIEW_HEIGHT))
 
     override fun doLayout() {
-        val layout = previewLayout()
+        val layout = PreviewChromePainter.layout(width, height)
         editorField.setBounds(
             layout.editorX + JBUI.scale(EDITOR_INSET),
             layout.padding + JBUI.scale(EDITOR_INSET),
@@ -87,9 +87,9 @@ internal class SyntaxPreviewComponent(
             g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
             g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON)
 
-            paintRoundedSurface(g2, Rectangle(0, 0, width, height), JBUI.scale(ARC), editorSurface())
+            PreviewChromePainter.paintOuterPanel(g2, width, height, editorSurface())
 
-            val layout = previewLayout()
+            val layout = PreviewChromePainter.layout(width, height)
             paintProjectPanel(g2, layout.padding, layout.padding, layout.projectWidth, layout.contentHeight)
             paintEditorPanelFrame(g2, layout.editorX, layout.padding, layout.editorWidth, layout.contentHeight)
         } finally {
@@ -120,32 +120,6 @@ internal class SyntaxPreviewComponent(
             isOpaque = false
         }
 
-    private fun previewLayout(): PreviewLayout {
-        val padding = JBUI.scale(PADDING)
-        val projectWidth = JBUI.scale(PROJECT_WIDTH)
-        val columnGap = JBUI.scale(COLUMN_GAP)
-        val editorX = padding + projectWidth + columnGap
-        return PreviewLayout(
-            padding = padding,
-            contentHeight = (height - padding * 2).coerceAtLeast(1),
-            projectWidth = projectWidth,
-            editorX = editorX,
-            editorWidth = (width - editorX - padding).coerceAtLeast(1),
-        )
-    }
-
-    private fun paintRoundedSurface(
-        g2: Graphics2D,
-        bounds: Rectangle,
-        arc: Int,
-        surface: Color,
-    ) {
-        g2.color = surface
-        g2.fillRoundRect(bounds.x, bounds.y, bounds.width, bounds.height, arc, arc)
-        g2.color = JBColor.border()
-        g2.drawRoundRect(bounds.x, bounds.y, bounds.width - 1, bounds.height - 1, arc, arc)
-    }
-
     private fun paintProjectPanel(
         g2: Graphics2D,
         x: Int,
@@ -153,24 +127,17 @@ internal class SyntaxPreviewComponent(
         width: Int,
         height: Int,
     ) {
-        paintRoundedSurface(g2, Rectangle(x, y, width, height), JBUI.scale(INNER_ARC), panelSurface())
-
-        g2.font = JBUI.Fonts.smallFont()
-        val rowHeight = JBUI.scale(PROJECT_ROW_HEIGHT)
-        var rowY = y + JBUI.scale(PROJECT_TOP_PADDING)
-        for (row in projectRows()) {
-            val baseline = rowY + (rowHeight - g2.fontMetrics.height) / 2 + g2.fontMetrics.ascent
-            g2.color = row.dotColor
-            g2.fillOval(
-                x + JBUI.scale(FILE_DOT_X),
-                rowY + JBUI.scale(FILE_DOT_Y),
-                JBUI.scale(FILE_DOT),
-                JBUI.scale(FILE_DOT),
-            )
-            g2.color = UIUtil.getLabelForeground()
-            g2.drawString(row.text, x + JBUI.scale(FILE_TEXT_X), baseline)
-            rowY += rowHeight
-        }
+        PreviewChromePainter.paintProjectPanel(
+            g2 = g2,
+            panel =
+                PreviewChromeProjectPanel(
+                    bounds = Rectangle(x, y, width, height),
+                    surface = panelSurface(),
+                    rows = projectRows(),
+                    markerShape = PreviewChromeMarkerShape.ROUND,
+                    textColor = UIUtil.getLabelForeground(),
+                ),
+        )
     }
 
     private fun paintEditorPanelFrame(
@@ -180,11 +147,11 @@ internal class SyntaxPreviewComponent(
         width: Int,
         height: Int,
     ) {
-        paintRoundedSurface(g2, Rectangle(x, y, width, height), JBUI.scale(INNER_ARC), editorSurface())
+        PreviewChromePainter.paintPanelFrame(g2, Rectangle(x, y, width, height), editorSurface())
     }
 
-    private fun projectRows(): List<ProjectRow> =
-        listOf(ProjectRow(LANGUAGE_FILE_DOT, previewSample.fileName)) + PROJECT_ROW_TAIL
+    private fun projectRows(): List<PreviewChromeProjectRow> =
+        listOf(PreviewChromeProjectRow(LANGUAGE_FILE_DOT, previewSample.fileName)) + PROJECT_ROW_TAIL
 
     private fun editorSurface(): Color = surfacePalette().editor
 
@@ -203,22 +170,12 @@ internal class SyntaxPreviewComponent(
     @TestOnly
     internal fun languageForTest(): String = language
 
-    private data class PreviewLayout(
-        val padding: Int,
-        val contentHeight: Int,
-        val projectWidth: Int,
-        val editorX: Int,
-        val editorWidth: Int,
-    )
+    @TestOnly
+    internal fun sampleFileNameForTest(): String = previewSample.fileName
 
     private data class SurfacePalette(
         val editor: Color,
         val panel: Color,
-    )
-
-    private data class ProjectRow(
-        val dotColor: Color,
-        val text: String,
     )
 
     private data class PreviewSample(
@@ -234,18 +191,7 @@ internal class SyntaxPreviewComponent(
         private const val PREVIEW_WIDTH = 560
         private const val MIN_PREVIEW_WIDTH = 320
         private const val PREVIEW_HEIGHT = 220
-        private const val PADDING = 10
-        private const val COLUMN_GAP = 10
-        private const val PROJECT_WIDTH = 154
-        private const val PROJECT_TOP_PADDING = 12
-        private const val PROJECT_ROW_HEIGHT = 22
-        private const val FILE_DOT_X = 11
-        private const val FILE_DOT_Y = 8
-        private const val FILE_DOT = 7
-        private const val FILE_TEXT_X = 26
         private const val EDITOR_INSET = 1
-        private const val ARC = 8
-        private const val INNER_ARC = 6
         private const val DEFAULT_LANGUAGE = "Kotlin"
 
         private val DARK_PALETTE = SurfacePalette(fixedColor(0x0D1017), fixedColor(0x141923))
@@ -254,199 +200,199 @@ internal class SyntaxPreviewComponent(
         private val LANGUAGE_FILE_DOT = fixedColor(0x59C2FF)
         private val PROJECT_ROW_TAIL =
             listOf(
-                ProjectRow(fixedColor(0x7FD17F), "Config.java"),
-                ProjectRow(fixedColor(0xFFA759), "Types.kt"),
-                ProjectRow(fixedColor(0xFFD580), "build/"),
+                PreviewChromeProjectRow(fixedColor(0x7FD17F), "Config.java"),
+                PreviewChromeProjectRow(fixedColor(0xFFA759), "Types.kt"),
+                PreviewChromeProjectRow(fixedColor(0xFFD580), "build/"),
             )
 
         private val PREVIEW_SAMPLES =
             mapOf(
-                "Kotlin" to
-                    PreviewSample(
-                        "PresetPreview.kt",
-                        "Kotlin",
-                        "kt",
-                        """
-                        fun main() {
-                            val msg = "hello"
-                            val count = 42
-                            // print greeting
-                            /** Greet the user */
-                            class Greeter {
-                                @JvmStatic
-                                fun greet(name: String) {
-                                    if (msg.isNotEmpty()) println(name)
-                                }
+                previewSample(
+                    "Kotlin",
+                    "PresetPreview.kt",
+                    "Kotlin",
+                    "kt",
+                    """
+                    fun main() {
+                        val msg = "hello"
+                        val count = 42
+                        // print greeting
+                        /** Greet the user */
+                        class Greeter {
+                            @JvmStatic
+                            fun greet(name: String) {
+                                if (msg.isNotEmpty()) println(name)
                             }
                         }
-                        """.trimIndent(),
-                    ),
-                "Java" to
-                    PreviewSample(
-                        "PresetPreview.java",
-                        "JAVA",
-                        "java",
-                        """
-                        public final class Greeter {
-                            private static final String MSG = "hello";
-                            // print greeting
-                            /** Greet the user */
-                            public void greet(String name) {
-                                if (!MSG.isEmpty()) {
-                                    System.out.println(name);
-                                }
+                    }
+                    """,
+                ),
+                previewSample(
+                    "Java",
+                    "PresetPreview.java",
+                    "JAVA",
+                    "java",
+                    """
+                    public final class Greeter {
+                        private static final String MSG = "hello";
+                        // print greeting
+                        /** Greet the user */
+                        public void greet(String name) {
+                            if (!MSG.isEmpty()) {
+                                System.out.println(name);
                             }
                         }
-                        """.trimIndent(),
-                    ),
-                "Python" to
-                    PreviewSample(
-                        "preset_preview.py",
-                        "Python",
-                        "py",
-                        """
-                        class Greeter:
-                            # Greet the user.
-                            def greet(self, name: str) -> None:
-                                msg = "hello"
-                                count = 42
-                                if msg:
-                                    print(name, count)
-                        """.trimIndent(),
-                    ),
-                "JavaScript" to
-                    PreviewSample(
-                        "preset-preview.js",
-                        "JavaScript",
-                        "js",
-                        """
-                        export function greet(name) {
-                            const msg = "hello";
-                            const count = 42;
-                            // print greeting
-                            if (msg.length > 0) {
-                                console.log(name, count);
-                            }
+                    }
+                    """,
+                ),
+                previewSample(
+                    "Python",
+                    "preset_preview.py",
+                    "Python",
+                    "py",
+                    """
+                    class Greeter:
+                        # Greet the user.
+                        def greet(self, name: str) -> None:
+                            msg = "hello"
+                            count = 42
+                            if msg:
+                                print(name, count)
+                    """,
+                ),
+                previewSample(
+                    "JavaScript",
+                    "preset-preview.js",
+                    "JavaScript",
+                    "js",
+                    """
+                    export function greet(name) {
+                        const msg = "hello";
+                        const count = 42;
+                        // print greeting
+                        if (msg.length > 0) {
+                            console.log(name, count);
                         }
-                        """.trimIndent(),
-                    ),
-                "TypeScript" to
-                    PreviewSample(
-                        "preset-preview.ts",
-                        "TypeScript",
-                        "ts",
-                        """
-                        export function greet(name: string): void {
-                            const msg = "hello";
-                            const count = 42;
-                            // print greeting
-                            if (msg.length > 0) {
-                                console.log(name, count);
-                            }
+                    }
+                    """,
+                ),
+                previewSample(
+                    "TypeScript",
+                    "preset-preview.ts",
+                    "TypeScript",
+                    "ts",
+                    """
+                    export function greet(name: string): void {
+                        const msg = "hello";
+                        const count = 42;
+                        // print greeting
+                        if (msg.length > 0) {
+                            console.log(name, count);
                         }
-                        """.trimIndent(),
-                    ),
-                "Go" to
-                    PreviewSample(
-                        "preset_preview.go",
-                        "Go",
-                        "go",
-                        """
-                        package preview
+                    }
+                    """,
+                ),
+                previewSample(
+                    "Go",
+                    "preset_preview.go",
+                    "Go",
+                    "go",
+                    """
+                    package preview
 
-                        import "fmt"
+                    import "fmt"
 
-                        // Greeter prints a greeting.
-                        func Greet(name string) {
-                            msg := "hello"
-                            count := 42
-                            if len(msg) > 0 {
-                                fmt.Println(name, count)
-                            }
+                    // Greeter prints a greeting.
+                    func Greet(name string) {
+                        msg := "hello"
+                        count := 42
+                        if len(msg) > 0 {
+                            fmt.Println(name, count)
                         }
-                        """.trimIndent(),
-                    ),
-                "Rust" to
-                    PreviewSample(
-                        "preset_preview.rs",
-                        "Rust",
-                        "rs",
-                        """
-                        pub fn greet(name: &str) {
-                            let msg = "hello";
-                            let count = 42;
-                            // print greeting
-                            if !msg.is_empty() {
-                                println!("{}", name);
-                            }
+                    }
+                    """,
+                ),
+                previewSample(
+                    "Rust",
+                    "preset_preview.rs",
+                    "Rust",
+                    "rs",
+                    """
+                    pub fn greet(name: &str) {
+                        let msg = "hello";
+                        let count = 42;
+                        // print greeting
+                        if !msg.is_empty() {
+                            println!("{}", name);
                         }
-                        """.trimIndent(),
-                    ),
-                "CSS" to
-                    PreviewSample(
-                        "preview.css",
-                        "CSS",
-                        "css",
-                        """
-                        .preview {
-                            color: #ffcc66;
-                            padding: 12px;
-                            /* tune declarations */
-                            border-radius: 6px;
-                        }
-                        """.trimIndent(),
-                    ),
-                "HTML" to
-                    PreviewSample(
-                        "preview.html",
-                        "HTML",
-                        "html",
-                        """
-                        <section class="preview">
-                            <!-- tune tags and text -->
-                            <h1>Hello</h1>
-                            <span data-count="42">Ayu Islands</span>
-                        </section>
-                        """.trimIndent(),
-                    ),
-                "JSON" to
-                    PreviewSample(
-                        "preview.json",
-                        "JSON",
-                        "json",
-                        """
-                        {
-                          "name": "Ayu Islands",
-                          "enabled": true,
-                          "count": 42
-                        }
-                        """.trimIndent(),
-                    ),
-                "YAML" to
-                    PreviewSample(
-                        "preview.yaml",
-                        "YAML",
-                        "yaml",
-                        """
-                        name: Ayu Islands
-                        enabled: true
-                        count: 42
-                        # tune keys and values
-                        """.trimIndent(),
-                    ),
-                "Markdown" to
-                    PreviewSample(
-                        "preview.md",
-                        "Markdown",
-                        "md",
-                        """
-                        # Ayu Islands
+                    }
+                    """,
+                ),
+                previewSample(
+                    "CSS",
+                    "preview.css",
+                    "CSS",
+                    "css",
+                    """
+                    .preview {
+                        color: #ffcc66;
+                        padding: 12px;
+                        /* tune declarations */
+                        border-radius: 6px;
+                    }
+                    """,
+                ),
+                previewSample(
+                    "HTML",
+                    "preview.html",
+                    "HTML",
+                    "html",
+                    """
+                    <section class="preview">
+                        <!-- tune tags and text -->
+                        <h1>Hello</h1>
+                        <span data-count="42">Ayu Islands</span>
+                    </section>
+                    """,
+                ),
+                previewSample(
+                    "JSON",
+                    "preview.json",
+                    "JSON",
+                    "json",
+                    """
+                    {
+                      "name": "Ayu Islands",
+                      "enabled": true,
+                      "count": 42
+                    }
+                    """,
+                ),
+                previewSample(
+                    "YAML",
+                    "preview.yaml",
+                    "YAML",
+                    "yaml",
+                    """
+                    name: Ayu Islands
+                    enabled: true
+                    count: 42
+                    # tune keys and values
+                    """,
+                ),
+                previewSample(
+                    "Markdown",
+                    "preview.md",
+                    "Markdown",
+                    "md",
+                    """
+                    # Ayu Islands
 
-                        `code` and **strong** text
+                    `code` and **strong** text
 
-                        - count: 42
-                        """.trimIndent(),
-                    ),
+                    - count: 42
+                    """,
+                ),
             )
 
         private val DEFAULT_SAMPLE =
@@ -464,6 +410,21 @@ internal class SyntaxPreviewComponent(
             )
 
         private fun fixedColor(rgb: Int): JBColor = JBColor(rgb, rgb)
+
+        private fun previewSample(
+            language: String,
+            fileName: String,
+            standardFileTypeName: String,
+            defaultExtension: String,
+            code: String,
+        ): Pair<String, PreviewSample> =
+            language to
+                PreviewSample(
+                    fileName,
+                    standardFileTypeName,
+                    defaultExtension,
+                    code.trimIndent(),
+                )
 
         private fun normalizeLanguage(language: String): String =
             language.takeIf { it.isNotBlank() } ?: DEFAULT_LANGUAGE

--- a/src/main/kotlin/dev/ayuislands/settings/SyntaxPreviewComponent.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/SyntaxPreviewComponent.kt
@@ -1,17 +1,17 @@
 package dev.ayuislands.settings
 
-import com.intellij.openapi.editor.colors.TextAttributesKey
-import com.intellij.openapi.editor.markup.TextAttributes
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.fileTypes.FileType
+import com.intellij.openapi.fileTypes.FileTypeManager
+import com.intellij.openapi.fileTypes.PlainTextFileType
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.util.Disposer
+import com.intellij.ui.EditorTextField
 import com.intellij.ui.JBColor
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
 import dev.ayuislands.accent.AyuVariant
-import dev.ayuislands.syntax.PrimitiveCategory
-import dev.ayuislands.syntax.RgbBlend
-import dev.ayuislands.syntax.SyntaxIntensityApplicator
-import dev.ayuislands.syntax.SyntaxOverlayLoader
-import dev.ayuislands.syntax.SyntaxPreset
-import dev.ayuislands.syntax.SyntaxReadabilityOptions
 import org.jetbrains.annotations.TestOnly
 import java.awt.Color
 import java.awt.Dimension
@@ -21,56 +21,30 @@ import java.awt.RenderingHints
 import javax.swing.JComponent
 
 /**
- * Live preview of syntax-intensity colors rendered as a mini IDE scene.
+ * Live preview of syntax-intensity colors rendered as a compact IDE scene.
  *
- * Mirrors [VcsColorPreviewComponent]'s structure: left project-panel with
- * colored file dots, right editor-panel with gutter line numbers and
- * token-highlighted Kotlin code. Colors are resolved through the real
- * [SyntaxIntensityApplicator] pipeline so the preview exactly matches what
- * the editor will display.
- *
- * The snippet is designed to demonstrate all four readability toggles:
- * - "Dim comments" — line 4 (`// print greeting`)
- * - "Soften documentation" — line 5 (`/** Greet the user */`)
- * - "Quiet operators" — line 7 (`msg.isNotEmpty()`) has heavy operator use
- * - "Emphasize declarations" — lines 1, 6 (`fun main`, `class Greeter`)
+ * The project tree is a lightweight frame, while the code pane is a native
+ * [EditorTextField] so syntax colors come from the active IntelliJ editor
+ * highlighter and color scheme instead of a hand-painted token imitation.
  */
 internal class SyntaxPreviewComponent(
     private var variant: AyuVariant,
-) : JComponent() {
-    private var categoryColorMap: Map<PrimitiveCategory, Color> = emptyMap()
+) : JComponent(),
+    Disposable {
+    private val editorField: EditorTextField = createEditorField()
+    private var isDisposed = false
 
     init {
+        layout = null
         isOpaque = false
         toolTipText = "Syntax color preview"
+        add(editorField)
     }
 
-    fun updatePreview(
-        variant: AyuVariant,
-        preset: SyntaxPreset,
-        customOverrides: Map<String, Map<String, Int>>,
-        subordinatePreset: SyntaxPreset,
-        readabilityOptions: SyntaxReadabilityOptions,
-    ) {
+    fun updatePreview(variant: AyuVariant) {
         this.variant = variant
-        val loader = SyntaxOverlayLoader.getInstance()
-        val baseline = loader.loadBaselineForVariant(variant.name)
-        val overlay = loader.loadOverlayForVariant(variant.name)
-        val editorBg = RgbBlend.fallbackEditorBgFor(variant.name)
-        val computed =
-            SyntaxIntensityApplicator.compute(
-                SyntaxIntensityApplicator.Request(
-                    preset = preset,
-                    variantName = variant.name,
-                    editorBg = editorBg,
-                    baseline = baseline,
-                    overlay = overlay,
-                    customOverrides = customOverrides,
-                    subordinatePreset = subordinatePreset,
-                    readabilityOptions = readabilityOptions,
-                ),
-            )
-        categoryColorMap = buildCategoryColorMap(computed)
+        editorField.background = editorSurface()
+        editorField.repaint()
         revalidate()
         repaint()
     }
@@ -78,6 +52,16 @@ internal class SyntaxPreviewComponent(
     override fun getPreferredSize(): Dimension = Dimension(JBUI.scale(PREVIEW_WIDTH), JBUI.scale(PREVIEW_HEIGHT))
 
     override fun getMinimumSize(): Dimension = Dimension(JBUI.scale(MIN_PREVIEW_WIDTH), JBUI.scale(PREVIEW_HEIGHT))
+
+    override fun doLayout() {
+        val layout = previewLayout()
+        editorField.setBounds(
+            layout.editorX + JBUI.scale(EDITOR_INSET),
+            layout.padding + JBUI.scale(EDITOR_INSET),
+            (layout.editorWidth - JBUI.scale(EDITOR_INSET * 2)).coerceAtLeast(1),
+            (layout.contentHeight - JBUI.scale(EDITOR_INSET * 2)).coerceAtLeast(1),
+        )
+    }
 
     override fun paintComponent(graphics: Graphics) {
         super.paintComponent(graphics)
@@ -93,18 +77,49 @@ internal class SyntaxPreviewComponent(
             g2.color = JBColor.border()
             g2.drawRoundRect(0, 0, width - 1, height - 1, arc, arc)
 
-            val padding = JBUI.scale(PADDING)
-            val columnGap = JBUI.scale(COLUMN_GAP)
-            val contentHeight = (height - padding * 2).coerceAtLeast(1)
-            val projectWidth = JBUI.scale(PROJECT_WIDTH)
-            val editorX = padding + projectWidth + columnGap
-            val editorWidth = (width - editorX - padding).coerceAtLeast(1)
-
-            paintProjectPanel(g2, padding, padding, projectWidth, contentHeight)
-            paintEditorPanel(g2, editorX, padding, editorWidth, contentHeight)
+            val layout = previewLayout()
+            paintProjectPanel(g2, layout.padding, layout.padding, layout.projectWidth, layout.contentHeight)
+            paintEditorPanelFrame(g2, layout.editorX, layout.padding, layout.editorWidth, layout.contentHeight)
         } finally {
             g2.dispose()
         }
+    }
+
+    override fun removeNotify() {
+        super.removeNotify()
+        if (!isDisposed) {
+            Disposer.dispose(this)
+        }
+    }
+
+    override fun dispose() {
+        isDisposed = true
+    }
+
+    private fun createEditorField(): EditorTextField =
+        EditorTextField(
+            CODE_SNIPPET,
+            ProjectManager.getInstance().defaultProject,
+            kotlinPreviewFileType(),
+        ).apply {
+            isViewer = true
+            setDisposedWith(this@SyntaxPreviewComponent)
+            background = editorSurface()
+            isOpaque = false
+        }
+
+    private fun previewLayout(): PreviewLayout {
+        val padding = JBUI.scale(PADDING)
+        val projectWidth = JBUI.scale(PROJECT_WIDTH)
+        val columnGap = JBUI.scale(COLUMN_GAP)
+        val editorX = padding + projectWidth + columnGap
+        return PreviewLayout(
+            padding = padding,
+            contentHeight = (height - padding * 2).coerceAtLeast(1),
+            projectWidth = projectWidth,
+            editorX = editorX,
+            editorWidth = (width - editorX - padding).coerceAtLeast(1),
+        )
     }
 
     private fun paintProjectPanel(
@@ -138,7 +153,7 @@ internal class SyntaxPreviewComponent(
         }
     }
 
-    private fun paintEditorPanel(
+    private fun paintEditorPanelFrame(
         g2: Graphics2D,
         x: Int,
         y: Int,
@@ -150,59 +165,14 @@ internal class SyntaxPreviewComponent(
         g2.fillRoundRect(x, y, width, height, arc, arc)
         g2.color = JBColor.border()
         g2.drawRoundRect(x, y, width - 1, height - 1, arc, arc)
-
-        val gutterWidth = JBUI.scale(GUTTER_WIDTH)
-        g2.color = panelSurface()
-        g2.fillRect(x + 1, y + 1, gutterWidth - 1, height - 2)
-
-        g2.font = JBUI.Fonts.smallFont()
-        val geometry =
-            EditorGeometry(
-                gutterX = x,
-                codeX = x + gutterWidth + JBUI.scale(CODE_LEFT_PADDING),
-                codeWidth = (width - gutterWidth - JBUI.scale(CODE_LEFT_PADDING)).coerceAtLeast(1),
-                panelY = y,
-                panelHeight = height,
-            )
-        val rowHeight = JBUI.scale(CODE_ROW_HEIGHT)
-        var rowY = y + JBUI.scale(CODE_TOP_PADDING)
-        for (line in CODE_LINES) {
-            paintCodeLine(g2, line, geometry, rowY, rowHeight)
-            rowY += rowHeight
-        }
     }
 
-    private fun paintCodeLine(
-        g2: Graphics2D,
-        line: CodeLine,
-        geometry: EditorGeometry,
-        y: Int,
-        height: Int,
-    ) {
-        g2.color = UIUtil.getContextHelpForeground()
-        val baseline = y + (height - g2.fontMetrics.height) / 2 + g2.fontMetrics.ascent
-        g2.drawString(line.lineNumber, geometry.gutterX + JBUI.scale(LINE_NUMBER_X), baseline)
-
-        val previousClip = g2.clip
-        g2.clipRect(geometry.codeX, geometry.panelY, geometry.codeWidth, geometry.panelHeight)
-        try {
-            var x = geometry.codeX
-            for (token in line.tokens) {
-                g2.color = token.category?.let { categoryColorMap[it] } ?: UIUtil.getLabelForeground()
-                g2.drawString(token.text, x, baseline)
-                x += g2.fontMetrics.stringWidth(token.text)
-            }
-        } finally {
-            g2.clip = previousClip
-        }
-    }
-
-    private data class EditorGeometry(
-        val gutterX: Int,
-        val codeX: Int,
-        val codeWidth: Int,
-        val panelY: Int,
-        val panelHeight: Int,
+    private data class PreviewLayout(
+        val padding: Int,
+        val contentHeight: Int,
+        val projectWidth: Int,
+        val editorX: Int,
+        val editorWidth: Int,
     )
 
     private fun editorSurface(): Color =
@@ -220,20 +190,7 @@ internal class SyntaxPreviewComponent(
         }
 
     @TestOnly
-    internal fun categoryColorForTest(category: PrimitiveCategory): Color? = categoryColorMap[category]
-
-    @TestOnly
     internal fun variantForTest(): AyuVariant = variant
-
-    private data class Token(
-        val text: String,
-        val category: PrimitiveCategory?,
-    )
-
-    private data class CodeLine(
-        val lineNumber: String,
-        val tokens: List<Token>,
-    )
 
     private data class ProjectRow(
         val dotColor: Color,
@@ -241,6 +198,8 @@ internal class SyntaxPreviewComponent(
     )
 
     private companion object {
+        private val LOG = logger<SyntaxPreviewComponent>()
+
         private const val PREVIEW_WIDTH = 560
         private const val MIN_PREVIEW_WIDTH = 320
         private const val PREVIEW_HEIGHT = 220
@@ -253,13 +212,11 @@ internal class SyntaxPreviewComponent(
         private const val FILE_DOT_Y = 8
         private const val FILE_DOT = 7
         private const val FILE_TEXT_X = 26
-        private const val GUTTER_WIDTH = 34
-        private const val CODE_TOP_PADDING = 12
-        private const val CODE_ROW_HEIGHT = 20
-        private const val LINE_NUMBER_X = 9
-        private const val CODE_LEFT_PADDING = 8
+        private const val EDITOR_INSET = 1
         private const val ARC = 8
         private const val INNER_ARC = 6
+        private const val KOTLIN_FILE_TYPE_NAME = "Kotlin"
+        private const val KOTLIN_FILE_EXTENSION = "kt"
 
         private val DARK_SURFACE = Color(0x0D1017)
         private val MIRAGE_SURFACE = Color(0x1F2430)
@@ -267,68 +224,6 @@ internal class SyntaxPreviewComponent(
         private val DARK_PANEL_SURFACE = Color(0x141923)
         private val MIRAGE_PANEL_SURFACE = Color(0x252B38)
         private val LIGHT_PANEL_SURFACE = Color(0xEFF2F5)
-
-        /**
-         * Representative key-name suffixes per [PrimitiveCategory].
-         *
-         * The preview scans the computed map for the first key whose
-         * `externalName` contains one of these substrings. Order within
-         * each list is most-specific-first so a single pass resolves
-         * every category without ambiguity.
-         */
-        private val CATEGORY_KEY_HINTS: Map<PrimitiveCategory, List<String>> =
-            mapOf(
-                PrimitiveCategory.FUNCTION_DECL to
-                    listOf(
-                        "FUNCTION_DECLARATION",
-                        "METHOD_DECLARATION",
-                        "FUNCTION_CALL",
-                        "METHOD_CALL",
-                        "CONSTRUCTOR_DECLARATION",
-                    ),
-                PrimitiveCategory.CLASS_DECL to
-                    listOf(
-                        "CLASS_DECLARATION",
-                        "CLASS_NAME",
-                        "ENUM_NAME",
-                        "ABSTRACT_CLASS",
-                    ),
-                PrimitiveCategory.INTERFACE_DECL to listOf("INTERFACE_NAME", "INTERFACE_DECLARATION", "TRAIT_NAME"),
-                PrimitiveCategory.KEYWORD to listOf("KEYWORD"),
-                PrimitiveCategory.PARAMETER to listOf("PARAMETER"),
-                PrimitiveCategory.LOCAL_VAR to listOf("LOCAL_VARIABLE", "LOCAL_VAR", "VAR_USE", "VAR_DEF"),
-                PrimitiveCategory.STRING_LITERAL to listOf("STRING"),
-                PrimitiveCategory.NUMBER_LITERAL to listOf("NUMBER"),
-                PrimitiveCategory.COMMENT to listOf("LINE_COMMENT", "BLOCK_COMMENT"),
-                PrimitiveCategory.DOCUMENTATION to listOf("DOC_COMMENT", "DOC_TAG", "KDOC"),
-                PrimitiveCategory.ANNOTATION to listOf("ANNOTATION_NAME", "METADATA"),
-                PrimitiveCategory.OPERATOR to listOf("OPERATION_SIGN", "OPERATOR"),
-                PrimitiveCategory.TYPE_REF to listOf("TYPE_PARAMETER", "TYPE_ARGUMENT"),
-                PrimitiveCategory.STATIC_FIELD to listOf("STATIC_FIELD", "STATIC_FINAL_FIELD", "STATIC_MEMBER"),
-                PrimitiveCategory.INSTANCE_FIELD to listOf("INSTANCE_FIELD", "INSTANCE_PROPERTY", "INSTANCE_MEMBER"),
-                PrimitiveCategory.GENERICS to listOf("TYPE_PARAMETER", "GENERICS", "GENERIC"),
-            )
-
-        /**
-         * Build category→color map by scanning the computed result for
-         * representative key names. Scans externalName substrings rather
-         * than relying on the suffix-regex registry.
-         */
-        private fun buildCategoryColorMap(
-            computed: Map<TextAttributesKey, TextAttributes>,
-        ): Map<PrimitiveCategory, Color> {
-            val map = mutableMapOf<PrimitiveCategory, Color>()
-            for ((category, hints) in CATEGORY_KEY_HINTS) {
-                for ((key, attrs) in computed) {
-                    val name = key.externalName
-                    if (hints.any { name.contains(it) }) {
-                        attrs.foregroundColor?.let { map[category] = it }
-                        break
-                    }
-                }
-            }
-            return map
-        }
 
         private val PROJECT_ROWS =
             listOf(
@@ -338,102 +233,33 @@ internal class SyntaxPreviewComponent(
                 ProjectRow(Color(0xFFD580), "build/"),
             )
 
-        /**
-         * 10-line Kotlin snippet covering all 16 [PrimitiveCategory] entries
-         * and demonstrating all four readability toggles:
-         *
-         * - **Dim comments**: line 4 (`// print greeting`)
-         * - **Soften documentation**: line 5 (`/** Greet the user */`)
-         * - **Quiet operators**: line 8 (`if (msg.isNotEmpty())`) — heavy
-         *   operator tokens that should recede when quieted
-         * - **Emphasize declarations**: lines 1 + 6 (`fun main`, `class Greeter`)
-         */
-        private val CODE_LINES =
-            listOf(
-                CodeLine(
-                    "1",
-                    listOf(
-                        Token("fun ", PrimitiveCategory.KEYWORD),
-                        Token("main", PrimitiveCategory.FUNCTION_DECL),
-                        Token("()", PrimitiveCategory.OPERATOR),
-                        Token(" {", PrimitiveCategory.OPERATOR),
-                    ),
-                ),
-                CodeLine(
-                    "2",
-                    listOf(
-                        Token("  val ", PrimitiveCategory.KEYWORD),
-                        Token("msg", PrimitiveCategory.LOCAL_VAR),
-                        Token(" = ", PrimitiveCategory.OPERATOR),
-                        Token("\"hello\"", PrimitiveCategory.STRING_LITERAL),
-                    ),
-                ),
-                CodeLine(
-                    "3",
-                    listOf(
-                        Token("  val ", PrimitiveCategory.KEYWORD),
-                        Token("count", PrimitiveCategory.LOCAL_VAR),
-                        Token(" = ", PrimitiveCategory.OPERATOR),
-                        Token("42", PrimitiveCategory.NUMBER_LITERAL),
-                    ),
-                ),
-                CodeLine(
-                    "4",
-                    listOf(
-                        Token("  // print greeting", PrimitiveCategory.COMMENT),
-                    ),
-                ),
-                CodeLine(
-                    "5",
-                    listOf(
-                        Token("  /** Greet the user */", PrimitiveCategory.DOCUMENTATION),
-                    ),
-                ),
-                CodeLine(
-                    "6",
-                    listOf(
-                        Token("  ", null),
-                        Token("class ", PrimitiveCategory.KEYWORD),
-                        Token("Greeter", PrimitiveCategory.CLASS_DECL),
-                        Token(" {", PrimitiveCategory.OPERATOR),
-                    ),
-                ),
-                CodeLine(
-                    "7",
-                    listOf(
-                        Token("    ", null),
-                        Token("@JvmStatic", PrimitiveCategory.ANNOTATION),
-                    ),
-                ),
-                CodeLine(
-                    "8",
-                    listOf(
-                        Token("    ", null),
-                        Token("if ", PrimitiveCategory.KEYWORD),
-                        Token("(", PrimitiveCategory.OPERATOR),
-                        Token("msg", PrimitiveCategory.INSTANCE_FIELD),
-                        Token(".", PrimitiveCategory.OPERATOR),
-                        Token("isNotEmpty", PrimitiveCategory.FUNCTION_DECL),
-                        Token("()", PrimitiveCategory.OPERATOR),
-                        Token(")", PrimitiveCategory.OPERATOR),
-                    ),
-                ),
-                CodeLine(
-                    "9",
-                    listOf(
-                        Token("      ", null),
-                        Token("println", PrimitiveCategory.FUNCTION_DECL),
-                        Token("(", PrimitiveCategory.OPERATOR),
-                        Token("msg", PrimitiveCategory.PARAMETER),
-                        Token(")", PrimitiveCategory.OPERATOR),
-                    ),
-                ),
-                CodeLine(
-                    "10",
-                    listOf(
-                        Token("}", PrimitiveCategory.OPERATOR),
-                    ),
-                ),
-            )
+        private val CODE_SNIPPET =
+            """
+            fun main() {
+                val msg = "hello"
+                val count = 42
+                // print greeting
+                /** Greet the user */
+                class Greeter {
+                    @JvmStatic
+                    fun greet(name: String) {
+                        if (msg.isNotEmpty()) println(name)
+                    }
+                }
+            }
+            """.trimIndent()
+
+        private fun kotlinPreviewFileType(): FileType =
+            try {
+                val fileType = FileTypeManager.getInstance().getStdFileType(KOTLIN_FILE_TYPE_NAME)
+                if (fileType.name == KOTLIN_FILE_TYPE_NAME || fileType.defaultExtension == KOTLIN_FILE_EXTENSION) {
+                    fileType
+                } else {
+                    PlainTextFileType.INSTANCE
+                }
+            } catch (exception: RuntimeException) {
+                LOG.debug("Falling back to plain text for syntax preview", exception)
+                PlainTextFileType.INSTANCE
+            }
     }
 }

--- a/src/main/kotlin/dev/ayuislands/settings/SyntaxPreviewComponent.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/SyntaxPreviewComponent.kt
@@ -1,0 +1,355 @@
+package dev.ayuislands.settings
+
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.openapi.editor.markup.TextAttributes
+import com.intellij.ui.JBColor
+import com.intellij.util.ui.JBUI
+import com.intellij.util.ui.UIUtil
+import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.syntax.PrimitiveCategory
+import dev.ayuislands.syntax.RgbBlend
+import dev.ayuislands.syntax.SyntaxCategoryRegistry
+import dev.ayuislands.syntax.SyntaxIntensityApplicator
+import dev.ayuislands.syntax.SyntaxOverlayLoader
+import dev.ayuislands.syntax.SyntaxPreset
+import dev.ayuislands.syntax.SyntaxReadabilityOptions
+import org.jetbrains.annotations.TestOnly
+import java.awt.Color
+import java.awt.Dimension
+import java.awt.Graphics
+import java.awt.Graphics2D
+import java.awt.RenderingHints
+import javax.swing.JComponent
+
+/**
+ * Live preview of syntax-intensity colors rendered as a mini IDE scene.
+ *
+ * Mirrors [VcsColorPreviewComponent]'s structure: left project-panel with
+ * colored file dots, right editor-panel with gutter line numbers and
+ * token-highlighted Kotlin code. Colors are resolved through the real
+ * [SyntaxIntensityApplicator] pipeline so the preview exactly matches what
+ * the editor will display.
+ */
+internal class SyntaxPreviewComponent(
+    private var variant: AyuVariant,
+) : JComponent() {
+    private var categoryColorMap: Map<PrimitiveCategory, Color> = emptyMap()
+
+    init {
+        isOpaque = false
+        toolTipText = "Syntax color preview"
+    }
+
+    fun updatePreview(
+        variant: AyuVariant,
+        preset: SyntaxPreset,
+        customOverrides: Map<String, Map<String, Int>>,
+        subordinatePreset: SyntaxPreset,
+        readabilityOptions: SyntaxReadabilityOptions,
+    ) {
+        this.variant = variant
+        val loader = SyntaxOverlayLoader.getInstance()
+        val baseline = loader.loadBaselineForVariant(variant.name)
+        val overlay = loader.loadOverlayForVariant(variant.name)
+        val editorBg = RgbBlend.fallbackEditorBgFor(variant.name)
+        val computed =
+            SyntaxIntensityApplicator.compute(
+                SyntaxIntensityApplicator.Request(
+                    preset = preset,
+                    variantName = variant.name,
+                    editorBg = editorBg,
+                    baseline = baseline,
+                    overlay = overlay,
+                    customOverrides = customOverrides,
+                    subordinatePreset = subordinatePreset,
+                    readabilityOptions = readabilityOptions,
+                ),
+            )
+        categoryColorMap = buildCategoryColorMap(computed)
+        revalidate()
+        repaint()
+    }
+
+    override fun getPreferredSize(): Dimension = Dimension(JBUI.scale(PREVIEW_WIDTH), JBUI.scale(PREVIEW_HEIGHT))
+
+    override fun getMinimumSize(): Dimension = Dimension(JBUI.scale(MIN_PREVIEW_WIDTH), JBUI.scale(PREVIEW_HEIGHT))
+
+    override fun paintComponent(graphics: Graphics) {
+        super.paintComponent(graphics)
+        val g2 = graphics.create() as Graphics2D
+        try {
+            g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+            g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON)
+
+            val surface = editorSurface()
+            val arc = JBUI.scale(ARC)
+            g2.color = surface
+            g2.fillRoundRect(0, 0, width, height, arc, arc)
+            g2.color = JBColor.border()
+            g2.drawRoundRect(0, 0, width - 1, height - 1, arc, arc)
+
+            val padding = JBUI.scale(PADDING)
+            val columnGap = JBUI.scale(COLUMN_GAP)
+            val contentHeight = (height - padding * 2).coerceAtLeast(1)
+            val projectWidth = JBUI.scale(PROJECT_WIDTH)
+            val editorX = padding + projectWidth + columnGap
+            val editorWidth = (width - editorX - padding).coerceAtLeast(1)
+
+            paintProjectPanel(g2, padding, padding, projectWidth, contentHeight)
+            paintEditorPanel(g2, editorX, padding, editorWidth, contentHeight)
+        } finally {
+            g2.dispose()
+        }
+    }
+
+    private fun paintProjectPanel(
+        g2: Graphics2D,
+        x: Int,
+        y: Int,
+        width: Int,
+        height: Int,
+    ) {
+        val arc = JBUI.scale(INNER_ARC)
+        g2.color = panelSurface()
+        g2.fillRoundRect(x, y, width, height, arc, arc)
+        g2.color = JBColor.border()
+        g2.drawRoundRect(x, y, width - 1, height - 1, arc, arc)
+
+        g2.font = JBUI.Fonts.smallFont()
+        val rowHeight = JBUI.scale(PROJECT_ROW_HEIGHT)
+        var rowY = y + JBUI.scale(PROJECT_TOP_PADDING)
+        for (row in PROJECT_ROWS) {
+            val baseline = rowY + (rowHeight - g2.fontMetrics.height) / 2 + g2.fontMetrics.ascent
+            g2.color = row.dotColor
+            g2.fillOval(
+                x + JBUI.scale(FILE_DOT_X),
+                rowY + JBUI.scale(FILE_DOT_Y),
+                JBUI.scale(FILE_DOT),
+                JBUI.scale(FILE_DOT),
+            )
+            g2.color = UIUtil.getLabelForeground()
+            g2.drawString(row.text, x + JBUI.scale(FILE_TEXT_X), baseline)
+            rowY += rowHeight
+        }
+    }
+
+    private fun paintEditorPanel(
+        g2: Graphics2D,
+        x: Int,
+        y: Int,
+        width: Int,
+        height: Int,
+    ) {
+        val arc = JBUI.scale(INNER_ARC)
+        g2.color = editorSurface()
+        g2.fillRoundRect(x, y, width, height, arc, arc)
+        g2.color = JBColor.border()
+        g2.drawRoundRect(x, y, width - 1, height - 1, arc, arc)
+
+        val gutterWidth = JBUI.scale(GUTTER_WIDTH)
+        g2.color = panelSurface()
+        g2.fillRect(x + 1, y + 1, gutterWidth - 1, height - 2)
+
+        g2.font = JBUI.Fonts.smallFont()
+        val geometry =
+            EditorGeometry(
+                gutterX = x,
+                codeX = x + gutterWidth + JBUI.scale(CODE_LEFT_PADDING),
+                codeWidth = (width - gutterWidth - JBUI.scale(CODE_LEFT_PADDING)).coerceAtLeast(1),
+                panelY = y,
+                panelHeight = height,
+            )
+        val rowHeight = JBUI.scale(CODE_ROW_HEIGHT)
+        var rowY = y + JBUI.scale(CODE_TOP_PADDING)
+        for (line in CODE_LINES) {
+            paintCodeLine(g2, line, geometry, rowY, rowHeight)
+            rowY += rowHeight
+        }
+    }
+
+    private fun paintCodeLine(
+        g2: Graphics2D,
+        line: CodeLine,
+        geometry: EditorGeometry,
+        y: Int,
+        height: Int,
+    ) {
+        g2.color = UIUtil.getContextHelpForeground()
+        val baseline = y + (height - g2.fontMetrics.height) / 2 + g2.fontMetrics.ascent
+        g2.drawString(line.lineNumber, geometry.gutterX + JBUI.scale(LINE_NUMBER_X), baseline)
+
+        val previousClip = g2.clip
+        g2.clipRect(geometry.codeX, geometry.panelY, geometry.codeWidth, geometry.panelHeight)
+        try {
+            var x = geometry.codeX
+            for (token in line.tokens) {
+                g2.color = token.category?.let { categoryColorMap[it] } ?: UIUtil.getLabelForeground()
+                g2.drawString(token.text, x, baseline)
+                x += g2.fontMetrics.stringWidth(token.text)
+            }
+        } finally {
+            g2.clip = previousClip
+        }
+    }
+
+    private data class EditorGeometry(
+        val gutterX: Int,
+        val codeX: Int,
+        val codeWidth: Int,
+        val panelY: Int,
+        val panelHeight: Int,
+    )
+
+    private fun editorSurface(): Color =
+        when (variant) {
+            AyuVariant.DARK -> DARK_SURFACE
+            AyuVariant.MIRAGE -> MIRAGE_SURFACE
+            AyuVariant.LIGHT -> LIGHT_SURFACE
+        }
+
+    private fun panelSurface(): Color =
+        when (variant) {
+            AyuVariant.DARK -> DARK_PANEL_SURFACE
+            AyuVariant.MIRAGE -> MIRAGE_PANEL_SURFACE
+            AyuVariant.LIGHT -> LIGHT_PANEL_SURFACE
+        }
+
+    @TestOnly
+    internal fun categoryColorForTest(category: PrimitiveCategory): Color? = categoryColorMap[category]
+
+    @TestOnly
+    internal fun variantForTest(): AyuVariant = variant
+
+    private data class Token(
+        val text: String,
+        val category: PrimitiveCategory?,
+    )
+
+    private data class CodeLine(
+        val lineNumber: String,
+        val tokens: List<Token>,
+    )
+
+    private data class ProjectRow(
+        val dotColor: Color,
+        val text: String,
+    )
+
+    private companion object {
+        private const val PREVIEW_WIDTH = 560
+        private const val MIN_PREVIEW_WIDTH = 320
+        private const val PREVIEW_HEIGHT = 180
+        private const val PADDING = 10
+        private const val COLUMN_GAP = 10
+        private const val PROJECT_WIDTH = 154
+        private const val PROJECT_TOP_PADDING = 12
+        private const val PROJECT_ROW_HEIGHT = 22
+        private const val FILE_DOT_X = 11
+        private const val FILE_DOT_Y = 8
+        private const val FILE_DOT = 7
+        private const val FILE_TEXT_X = 26
+        private const val GUTTER_WIDTH = 34
+        private const val CODE_TOP_PADDING = 12
+        private const val CODE_ROW_HEIGHT = 20
+        private const val LINE_NUMBER_X = 9
+        private const val CODE_LEFT_PADDING = 8
+        private const val ARC = 8
+        private const val INNER_ARC = 6
+
+        private val DARK_SURFACE = Color(0x0D1017)
+        private val MIRAGE_SURFACE = Color(0x1F2430)
+        private val LIGHT_SURFACE = Color(0xFAFAFA)
+        private val DARK_PANEL_SURFACE = Color(0x141923)
+        private val MIRAGE_PANEL_SURFACE = Color(0x252B38)
+        private val LIGHT_PANEL_SURFACE = Color(0xEFF2F5)
+
+        private val PROJECT_ROWS =
+            listOf(
+                ProjectRow(Color(0x59C2FF), "PresetPreview.kt"),
+                ProjectRow(Color(0x7FD17F), "Config.java"),
+                ProjectRow(Color(0xFFA759), "Types.kt"),
+                ProjectRow(Color(0xFFD580), "build/"),
+            )
+
+        private val CODE_LINES =
+            listOf(
+                CodeLine(
+                    "1",
+                    listOf(
+                        Token("fun ", PrimitiveCategory.KEYWORD),
+                        Token("main", PrimitiveCategory.FUNCTION_DECL),
+                        Token("() ", PrimitiveCategory.OPERATOR),
+                        Token("{", PrimitiveCategory.OPERATOR),
+                    ),
+                ),
+                CodeLine(
+                    "2",
+                    listOf(
+                        Token("  val ", PrimitiveCategory.KEYWORD),
+                        Token("msg", PrimitiveCategory.LOCAL_VAR),
+                        Token(" = ", PrimitiveCategory.OPERATOR),
+                        Token("\"hello\"", PrimitiveCategory.STRING_LITERAL),
+                    ),
+                ),
+                CodeLine(
+                    "3",
+                    listOf(
+                        Token("  val ", PrimitiveCategory.KEYWORD),
+                        Token("count", PrimitiveCategory.LOCAL_VAR),
+                        Token(" = ", PrimitiveCategory.OPERATOR),
+                        Token("42", PrimitiveCategory.NUMBER_LITERAL),
+                    ),
+                ),
+                CodeLine(
+                    "4",
+                    listOf(
+                        Token("  // print greeting", PrimitiveCategory.COMMENT),
+                    ),
+                ),
+                CodeLine(
+                    "5",
+                    listOf(
+                        Token("  @JvmStatic", PrimitiveCategory.ANNOTATION),
+                    ),
+                ),
+                CodeLine(
+                    "6",
+                    listOf(
+                        Token("  if ", PrimitiveCategory.KEYWORD),
+                        Token("(", PrimitiveCategory.OPERATOR),
+                        Token("msg", PrimitiveCategory.INSTANCE_FIELD),
+                        Token(".", PrimitiveCategory.OPERATOR),
+                        Token("isNotEmpty", PrimitiveCategory.FUNCTION_DECL),
+                        Token(")", PrimitiveCategory.OPERATOR),
+                    ),
+                ),
+                CodeLine(
+                    "7",
+                    listOf(
+                        Token("    ", null),
+                        Token("println", PrimitiveCategory.FUNCTION_DECL),
+                        Token("(", PrimitiveCategory.OPERATOR),
+                        Token("msg", PrimitiveCategory.PARAMETER),
+                        Token(")", PrimitiveCategory.OPERATOR),
+                    ),
+                ),
+                CodeLine(
+                    "8",
+                    listOf(
+                        Token("}", PrimitiveCategory.OPERATOR),
+                    ),
+                ),
+            )
+    }
+}
+
+private fun buildCategoryColorMap(computed: Map<TextAttributesKey, TextAttributes>): Map<PrimitiveCategory, Color> {
+    val map = mutableMapOf<PrimitiveCategory, Color>()
+    for ((key, attrs) in computed) {
+        val category = SyntaxCategoryRegistry.classify(key.externalName) ?: continue
+        if (category in map) continue
+        val fg = attrs.foregroundColor ?: continue
+        map[category] = fg
+    }
+    return map
+}

--- a/src/main/kotlin/dev/ayuislands/settings/SyntaxPreviewComponent.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/SyntaxPreviewComponent.kt
@@ -1,7 +1,9 @@
 package dev.ayuislands.settings
 
+import com.intellij.lang.Language
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.fileTypes.FileType
 import com.intellij.openapi.fileTypes.FileTypeManager
 import com.intellij.openapi.fileTypes.PlainTextFileType
@@ -17,7 +19,9 @@ import java.awt.Color
 import java.awt.Dimension
 import java.awt.Graphics
 import java.awt.Graphics2D
+import java.awt.Rectangle
 import java.awt.RenderingHints
+import java.util.Locale
 import javax.swing.JComponent
 
 /**
@@ -29,8 +33,10 @@ import javax.swing.JComponent
  */
 internal class SyntaxPreviewComponent(
     private var variant: AyuVariant,
+    private var language: String = DEFAULT_LANGUAGE,
 ) : JComponent(),
     Disposable {
+    private var previewSample: PreviewSample = sampleFor(language)
     private val editorField: EditorTextField = createEditorField()
     private var isDisposed = false
 
@@ -41,8 +47,19 @@ internal class SyntaxPreviewComponent(
         add(editorField)
     }
 
-    fun updatePreview(variant: AyuVariant) {
+    fun updatePreview(
+        variant: AyuVariant,
+        language: String = this.language,
+    ) {
         this.variant = variant
+        val nextLanguage = normalizeLanguage(language)
+        val nextSample = sampleFor(nextLanguage)
+        if (nextLanguage != this.language || nextSample != previewSample) {
+            this.language = nextLanguage
+            previewSample = nextSample
+            val document = EditorFactory.getInstance().createDocument(nextSample.code)
+            editorField.setNewDocumentAndFileType(previewFileType(nextLanguage, nextSample), document)
+        }
         editorField.background = editorSurface()
         editorField.repaint()
         revalidate()
@@ -70,12 +87,7 @@ internal class SyntaxPreviewComponent(
             g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
             g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON)
 
-            val surface = editorSurface()
-            val arc = JBUI.scale(ARC)
-            g2.color = surface
-            g2.fillRoundRect(0, 0, width, height, arc, arc)
-            g2.color = JBColor.border()
-            g2.drawRoundRect(0, 0, width - 1, height - 1, arc, arc)
+            paintRoundedSurface(g2, Rectangle(0, 0, width, height), JBUI.scale(ARC), editorSurface())
 
             val layout = previewLayout()
             paintProjectPanel(g2, layout.padding, layout.padding, layout.projectWidth, layout.contentHeight)
@@ -98,9 +110,9 @@ internal class SyntaxPreviewComponent(
 
     private fun createEditorField(): EditorTextField =
         EditorTextField(
-            CODE_SNIPPET,
+            previewSample.code,
             ProjectManager.getInstance().defaultProject,
-            kotlinPreviewFileType(),
+            previewFileType(language, previewSample),
         ).apply {
             isViewer = true
             setDisposedWith(this@SyntaxPreviewComponent)
@@ -122,6 +134,18 @@ internal class SyntaxPreviewComponent(
         )
     }
 
+    private fun paintRoundedSurface(
+        g2: Graphics2D,
+        bounds: Rectangle,
+        arc: Int,
+        surface: Color,
+    ) {
+        g2.color = surface
+        g2.fillRoundRect(bounds.x, bounds.y, bounds.width, bounds.height, arc, arc)
+        g2.color = JBColor.border()
+        g2.drawRoundRect(bounds.x, bounds.y, bounds.width - 1, bounds.height - 1, arc, arc)
+    }
+
     private fun paintProjectPanel(
         g2: Graphics2D,
         x: Int,
@@ -129,16 +153,12 @@ internal class SyntaxPreviewComponent(
         width: Int,
         height: Int,
     ) {
-        val arc = JBUI.scale(INNER_ARC)
-        g2.color = panelSurface()
-        g2.fillRoundRect(x, y, width, height, arc, arc)
-        g2.color = JBColor.border()
-        g2.drawRoundRect(x, y, width - 1, height - 1, arc, arc)
+        paintRoundedSurface(g2, Rectangle(x, y, width, height), JBUI.scale(INNER_ARC), panelSurface())
 
         g2.font = JBUI.Fonts.smallFont()
         val rowHeight = JBUI.scale(PROJECT_ROW_HEIGHT)
         var rowY = y + JBUI.scale(PROJECT_TOP_PADDING)
-        for (row in PROJECT_ROWS) {
+        for (row in projectRows()) {
             val baseline = rowY + (rowHeight - g2.fontMetrics.height) / 2 + g2.fontMetrics.ascent
             g2.color = row.dotColor
             g2.fillOval(
@@ -160,12 +180,28 @@ internal class SyntaxPreviewComponent(
         width: Int,
         height: Int,
     ) {
-        val arc = JBUI.scale(INNER_ARC)
-        g2.color = editorSurface()
-        g2.fillRoundRect(x, y, width, height, arc, arc)
-        g2.color = JBColor.border()
-        g2.drawRoundRect(x, y, width - 1, height - 1, arc, arc)
+        paintRoundedSurface(g2, Rectangle(x, y, width, height), JBUI.scale(INNER_ARC), editorSurface())
     }
+
+    private fun projectRows(): List<ProjectRow> =
+        listOf(ProjectRow(LANGUAGE_FILE_DOT, previewSample.fileName)) + PROJECT_ROW_TAIL
+
+    private fun editorSurface(): Color = surfacePalette().editor
+
+    private fun panelSurface(): Color = surfacePalette().panel
+
+    private fun surfacePalette(): SurfacePalette =
+        when (variant) {
+            AyuVariant.DARK -> DARK_PALETTE
+            AyuVariant.MIRAGE -> MIRAGE_PALETTE
+            AyuVariant.LIGHT -> LIGHT_PALETTE
+        }
+
+    @TestOnly
+    internal fun variantForTest(): AyuVariant = variant
+
+    @TestOnly
+    internal fun languageForTest(): String = language
 
     private data class PreviewLayout(
         val padding: Int,
@@ -175,26 +211,21 @@ internal class SyntaxPreviewComponent(
         val editorWidth: Int,
     )
 
-    private fun editorSurface(): Color =
-        when (variant) {
-            AyuVariant.DARK -> DARK_SURFACE
-            AyuVariant.MIRAGE -> MIRAGE_SURFACE
-            AyuVariant.LIGHT -> LIGHT_SURFACE
-        }
-
-    private fun panelSurface(): Color =
-        when (variant) {
-            AyuVariant.DARK -> DARK_PANEL_SURFACE
-            AyuVariant.MIRAGE -> MIRAGE_PANEL_SURFACE
-            AyuVariant.LIGHT -> LIGHT_PANEL_SURFACE
-        }
-
-    @TestOnly
-    internal fun variantForTest(): AyuVariant = variant
+    private data class SurfacePalette(
+        val editor: Color,
+        val panel: Color,
+    )
 
     private data class ProjectRow(
         val dotColor: Color,
         val text: String,
+    )
+
+    private data class PreviewSample(
+        val fileName: String,
+        val standardFileTypeName: String?,
+        val defaultExtension: String?,
+        val code: String,
     )
 
     private companion object {
@@ -215,51 +246,272 @@ internal class SyntaxPreviewComponent(
         private const val EDITOR_INSET = 1
         private const val ARC = 8
         private const val INNER_ARC = 6
-        private const val KOTLIN_FILE_TYPE_NAME = "Kotlin"
-        private const val KOTLIN_FILE_EXTENSION = "kt"
+        private const val DEFAULT_LANGUAGE = "Kotlin"
 
-        private val DARK_SURFACE = Color(0x0D1017)
-        private val MIRAGE_SURFACE = Color(0x1F2430)
-        private val LIGHT_SURFACE = Color(0xFAFAFA)
-        private val DARK_PANEL_SURFACE = Color(0x141923)
-        private val MIRAGE_PANEL_SURFACE = Color(0x252B38)
-        private val LIGHT_PANEL_SURFACE = Color(0xEFF2F5)
-
-        private val PROJECT_ROWS =
+        private val DARK_PALETTE = SurfacePalette(fixedColor(0x0D1017), fixedColor(0x141923))
+        private val MIRAGE_PALETTE = SurfacePalette(fixedColor(0x1F2430), fixedColor(0x252B38))
+        private val LIGHT_PALETTE = SurfacePalette(fixedColor(0xFAFAFA), fixedColor(0xEFF2F5))
+        private val LANGUAGE_FILE_DOT = fixedColor(0x59C2FF)
+        private val PROJECT_ROW_TAIL =
             listOf(
-                ProjectRow(Color(0x59C2FF), "PresetPreview.kt"),
-                ProjectRow(Color(0x7FD17F), "Config.java"),
-                ProjectRow(Color(0xFFA759), "Types.kt"),
-                ProjectRow(Color(0xFFD580), "build/"),
+                ProjectRow(fixedColor(0x7FD17F), "Config.java"),
+                ProjectRow(fixedColor(0xFFA759), "Types.kt"),
+                ProjectRow(fixedColor(0xFFD580), "build/"),
             )
 
-        private val CODE_SNIPPET =
-            """
-            fun main() {
-                val msg = "hello"
-                val count = 42
-                // print greeting
-                /** Greet the user */
-                class Greeter {
-                    @JvmStatic
-                    fun greet(name: String) {
-                        if (msg.isNotEmpty()) println(name)
-                    }
-                }
-            }
-            """.trimIndent()
+        private val PREVIEW_SAMPLES =
+            mapOf(
+                "Kotlin" to
+                    PreviewSample(
+                        "PresetPreview.kt",
+                        "Kotlin",
+                        "kt",
+                        """
+                        fun main() {
+                            val msg = "hello"
+                            val count = 42
+                            // print greeting
+                            /** Greet the user */
+                            class Greeter {
+                                @JvmStatic
+                                fun greet(name: String) {
+                                    if (msg.isNotEmpty()) println(name)
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+                    ),
+                "Java" to
+                    PreviewSample(
+                        "PresetPreview.java",
+                        "JAVA",
+                        "java",
+                        """
+                        public final class Greeter {
+                            private static final String MSG = "hello";
+                            // print greeting
+                            /** Greet the user */
+                            public void greet(String name) {
+                                if (!MSG.isEmpty()) {
+                                    System.out.println(name);
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+                    ),
+                "Python" to
+                    PreviewSample(
+                        "preset_preview.py",
+                        "Python",
+                        "py",
+                        """
+                        class Greeter:
+                            # Greet the user.
+                            def greet(self, name: str) -> None:
+                                msg = "hello"
+                                count = 42
+                                if msg:
+                                    print(name, count)
+                        """.trimIndent(),
+                    ),
+                "JavaScript" to
+                    PreviewSample(
+                        "preset-preview.js",
+                        "JavaScript",
+                        "js",
+                        """
+                        export function greet(name) {
+                            const msg = "hello";
+                            const count = 42;
+                            // print greeting
+                            if (msg.length > 0) {
+                                console.log(name, count);
+                            }
+                        }
+                        """.trimIndent(),
+                    ),
+                "TypeScript" to
+                    PreviewSample(
+                        "preset-preview.ts",
+                        "TypeScript",
+                        "ts",
+                        """
+                        export function greet(name: string): void {
+                            const msg = "hello";
+                            const count = 42;
+                            // print greeting
+                            if (msg.length > 0) {
+                                console.log(name, count);
+                            }
+                        }
+                        """.trimIndent(),
+                    ),
+                "Go" to
+                    PreviewSample(
+                        "preset_preview.go",
+                        "Go",
+                        "go",
+                        """
+                        package preview
 
-        private fun kotlinPreviewFileType(): FileType =
-            try {
-                val fileType = FileTypeManager.getInstance().getStdFileType(KOTLIN_FILE_TYPE_NAME)
-                if (fileType.name == KOTLIN_FILE_TYPE_NAME || fileType.defaultExtension == KOTLIN_FILE_EXTENSION) {
+                        import "fmt"
+
+                        // Greeter prints a greeting.
+                        func Greet(name string) {
+                            msg := "hello"
+                            count := 42
+                            if len(msg) > 0 {
+                                fmt.Println(name, count)
+                            }
+                        }
+                        """.trimIndent(),
+                    ),
+                "Rust" to
+                    PreviewSample(
+                        "preset_preview.rs",
+                        "Rust",
+                        "rs",
+                        """
+                        pub fn greet(name: &str) {
+                            let msg = "hello";
+                            let count = 42;
+                            // print greeting
+                            if !msg.is_empty() {
+                                println!("{}", name);
+                            }
+                        }
+                        """.trimIndent(),
+                    ),
+                "CSS" to
+                    PreviewSample(
+                        "preview.css",
+                        "CSS",
+                        "css",
+                        """
+                        .preview {
+                            color: #ffcc66;
+                            padding: 12px;
+                            /* tune declarations */
+                            border-radius: 6px;
+                        }
+                        """.trimIndent(),
+                    ),
+                "HTML" to
+                    PreviewSample(
+                        "preview.html",
+                        "HTML",
+                        "html",
+                        """
+                        <section class="preview">
+                            <!-- tune tags and text -->
+                            <h1>Hello</h1>
+                            <span data-count="42">Ayu Islands</span>
+                        </section>
+                        """.trimIndent(),
+                    ),
+                "JSON" to
+                    PreviewSample(
+                        "preview.json",
+                        "JSON",
+                        "json",
+                        """
+                        {
+                          "name": "Ayu Islands",
+                          "enabled": true,
+                          "count": 42
+                        }
+                        """.trimIndent(),
+                    ),
+                "YAML" to
+                    PreviewSample(
+                        "preview.yaml",
+                        "YAML",
+                        "yaml",
+                        """
+                        name: Ayu Islands
+                        enabled: true
+                        count: 42
+                        # tune keys and values
+                        """.trimIndent(),
+                    ),
+                "Markdown" to
+                    PreviewSample(
+                        "preview.md",
+                        "Markdown",
+                        "md",
+                        """
+                        # Ayu Islands
+
+                        `code` and **strong** text
+
+                        - count: 42
+                        """.trimIndent(),
+                    ),
+            )
+
+        private val DEFAULT_SAMPLE =
+            PreviewSample(
+                "Preview.txt",
+                null,
+                null,
+                """
+                class Preview {
+                    value = "hello"
+                    count = 42
+                    // tune syntax colors
+                }
+                """.trimIndent(),
+            )
+
+        private fun fixedColor(rgb: Int): JBColor = JBColor(rgb, rgb)
+
+        private fun normalizeLanguage(language: String): String =
+            language.takeIf { it.isNotBlank() } ?: DEFAULT_LANGUAGE
+
+        private fun sampleFor(language: String): PreviewSample =
+            PREVIEW_SAMPLES[normalizeLanguage(language)] ?: DEFAULT_SAMPLE
+
+        private fun previewFileType(
+            language: String,
+            sample: PreviewSample,
+        ): FileType =
+            standardFileType(sample)
+                ?: registeredLanguageFileType(language)
+                ?: PlainTextFileType.INSTANCE
+
+        private fun standardFileType(sample: PreviewSample): FileType? {
+            val standardName = sample.standardFileTypeName ?: return null
+            val extension = sample.defaultExtension
+            return try {
+                val fileType = FileTypeManager.getInstance().getStdFileType(standardName)
+                if (fileType.name.equals(standardName, ignoreCase = true) ||
+                    extension != null &&
+                    fileType.defaultExtension.equals(extension, ignoreCase = true)
+                ) {
                     fileType
                 } else {
-                    PlainTextFileType.INSTANCE
+                    null
                 }
             } catch (exception: RuntimeException) {
-                LOG.debug("Falling back to plain text for syntax preview", exception)
-                PlainTextFileType.INSTANCE
+                LOG.debug("Standard file type '$standardName' unavailable for syntax preview", exception)
+                null
+            }
+        }
+
+        private fun registeredLanguageFileType(languageDisplayName: String): FileType? =
+            try {
+                val normalizedDisplayName = languageDisplayName.lowercase(Locale.ROOT)
+                val language =
+                    Language.getRegisteredLanguages().firstOrNull {
+                        it.displayName.lowercase(Locale.ROOT) == normalizedDisplayName
+                    }
+                language?.let { FileTypeManager.getInstance().findFileTypeByLanguage(it) }
+            } catch (exception: RuntimeException) {
+                LOG.debug(
+                    "Registered language lookup failed for syntax preview language '$languageDisplayName'",
+                    exception,
+                )
+                null
             }
     }
 }

--- a/src/main/kotlin/dev/ayuislands/settings/SyntaxPreviewComponent.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/SyntaxPreviewComponent.kt
@@ -8,7 +8,6 @@ import com.intellij.util.ui.UIUtil
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.syntax.PrimitiveCategory
 import dev.ayuislands.syntax.RgbBlend
-import dev.ayuislands.syntax.SyntaxCategoryRegistry
 import dev.ayuislands.syntax.SyntaxIntensityApplicator
 import dev.ayuislands.syntax.SyntaxOverlayLoader
 import dev.ayuislands.syntax.SyntaxPreset
@@ -29,6 +28,12 @@ import javax.swing.JComponent
  * token-highlighted Kotlin code. Colors are resolved through the real
  * [SyntaxIntensityApplicator] pipeline so the preview exactly matches what
  * the editor will display.
+ *
+ * The snippet is designed to demonstrate all four readability toggles:
+ * - "Dim comments" — line 4 (`// print greeting`)
+ * - "Soften documentation" — line 5 (`/** Greet the user */`)
+ * - "Quiet operators" — line 7 (`msg.isNotEmpty()`) has heavy operator use
+ * - "Emphasize declarations" — lines 1, 6 (`fun main`, `class Greeter`)
  */
 internal class SyntaxPreviewComponent(
     private var variant: AyuVariant,
@@ -238,7 +243,7 @@ internal class SyntaxPreviewComponent(
     private companion object {
         private const val PREVIEW_WIDTH = 560
         private const val MIN_PREVIEW_WIDTH = 320
-        private const val PREVIEW_HEIGHT = 180
+        private const val PREVIEW_HEIGHT = 220
         private const val PADDING = 10
         private const val COLUMN_GAP = 10
         private const val PROJECT_WIDTH = 154
@@ -263,6 +268,68 @@ internal class SyntaxPreviewComponent(
         private val MIRAGE_PANEL_SURFACE = Color(0x252B38)
         private val LIGHT_PANEL_SURFACE = Color(0xEFF2F5)
 
+        /**
+         * Representative key-name suffixes per [PrimitiveCategory].
+         *
+         * The preview scans the computed map for the first key whose
+         * `externalName` contains one of these substrings. Order within
+         * each list is most-specific-first so a single pass resolves
+         * every category without ambiguity.
+         */
+        private val CATEGORY_KEY_HINTS: Map<PrimitiveCategory, List<String>> =
+            mapOf(
+                PrimitiveCategory.FUNCTION_DECL to
+                    listOf(
+                        "FUNCTION_DECLARATION",
+                        "METHOD_DECLARATION",
+                        "FUNCTION_CALL",
+                        "METHOD_CALL",
+                        "CONSTRUCTOR_DECLARATION",
+                    ),
+                PrimitiveCategory.CLASS_DECL to
+                    listOf(
+                        "CLASS_DECLARATION",
+                        "CLASS_NAME",
+                        "ENUM_NAME",
+                        "ABSTRACT_CLASS",
+                    ),
+                PrimitiveCategory.INTERFACE_DECL to listOf("INTERFACE_NAME", "INTERFACE_DECLARATION", "TRAIT_NAME"),
+                PrimitiveCategory.KEYWORD to listOf("KEYWORD"),
+                PrimitiveCategory.PARAMETER to listOf("PARAMETER"),
+                PrimitiveCategory.LOCAL_VAR to listOf("LOCAL_VARIABLE", "LOCAL_VAR", "VAR_USE", "VAR_DEF"),
+                PrimitiveCategory.STRING_LITERAL to listOf("STRING"),
+                PrimitiveCategory.NUMBER_LITERAL to listOf("NUMBER"),
+                PrimitiveCategory.COMMENT to listOf("LINE_COMMENT", "BLOCK_COMMENT"),
+                PrimitiveCategory.DOCUMENTATION to listOf("DOC_COMMENT", "DOC_TAG", "KDOC"),
+                PrimitiveCategory.ANNOTATION to listOf("ANNOTATION_NAME", "METADATA"),
+                PrimitiveCategory.OPERATOR to listOf("OPERATION_SIGN", "OPERATOR"),
+                PrimitiveCategory.TYPE_REF to listOf("TYPE_PARAMETER", "TYPE_ARGUMENT"),
+                PrimitiveCategory.STATIC_FIELD to listOf("STATIC_FIELD", "STATIC_FINAL_FIELD", "STATIC_MEMBER"),
+                PrimitiveCategory.INSTANCE_FIELD to listOf("INSTANCE_FIELD", "INSTANCE_PROPERTY", "INSTANCE_MEMBER"),
+                PrimitiveCategory.GENERICS to listOf("TYPE_PARAMETER", "GENERICS", "GENERIC"),
+            )
+
+        /**
+         * Build category→color map by scanning the computed result for
+         * representative key names. Scans externalName substrings rather
+         * than relying on the suffix-regex registry.
+         */
+        private fun buildCategoryColorMap(
+            computed: Map<TextAttributesKey, TextAttributes>,
+        ): Map<PrimitiveCategory, Color> {
+            val map = mutableMapOf<PrimitiveCategory, Color>()
+            for ((category, hints) in CATEGORY_KEY_HINTS) {
+                for ((key, attrs) in computed) {
+                    val name = key.externalName
+                    if (hints.any { name.contains(it) }) {
+                        attrs.foregroundColor?.let { map[category] = it }
+                        break
+                    }
+                }
+            }
+            return map
+        }
+
         private val PROJECT_ROWS =
             listOf(
                 ProjectRow(Color(0x59C2FF), "PresetPreview.kt"),
@@ -271,6 +338,16 @@ internal class SyntaxPreviewComponent(
                 ProjectRow(Color(0xFFD580), "build/"),
             )
 
+        /**
+         * 10-line Kotlin snippet covering all 16 [PrimitiveCategory] entries
+         * and demonstrating all four readability toggles:
+         *
+         * - **Dim comments**: line 4 (`// print greeting`)
+         * - **Soften documentation**: line 5 (`/** Greet the user */`)
+         * - **Quiet operators**: line 8 (`if (msg.isNotEmpty())`) — heavy
+         *   operator tokens that should recede when quieted
+         * - **Emphasize declarations**: lines 1 + 6 (`fun main`, `class Greeter`)
+         */
         private val CODE_LINES =
             listOf(
                 CodeLine(
@@ -278,8 +355,8 @@ internal class SyntaxPreviewComponent(
                     listOf(
                         Token("fun ", PrimitiveCategory.KEYWORD),
                         Token("main", PrimitiveCategory.FUNCTION_DECL),
-                        Token("() ", PrimitiveCategory.OPERATOR),
-                        Token("{", PrimitiveCategory.OPERATOR),
+                        Token("()", PrimitiveCategory.OPERATOR),
+                        Token(" {", PrimitiveCategory.OPERATOR),
                     ),
                 ),
                 CodeLine(
@@ -309,24 +386,42 @@ internal class SyntaxPreviewComponent(
                 CodeLine(
                     "5",
                     listOf(
-                        Token("  @JvmStatic", PrimitiveCategory.ANNOTATION),
+                        Token("  /** Greet the user */", PrimitiveCategory.DOCUMENTATION),
                     ),
                 ),
                 CodeLine(
                     "6",
                     listOf(
-                        Token("  if ", PrimitiveCategory.KEYWORD),
-                        Token("(", PrimitiveCategory.OPERATOR),
-                        Token("msg", PrimitiveCategory.INSTANCE_FIELD),
-                        Token(".", PrimitiveCategory.OPERATOR),
-                        Token("isNotEmpty", PrimitiveCategory.FUNCTION_DECL),
-                        Token(")", PrimitiveCategory.OPERATOR),
+                        Token("  ", null),
+                        Token("class ", PrimitiveCategory.KEYWORD),
+                        Token("Greeter", PrimitiveCategory.CLASS_DECL),
+                        Token(" {", PrimitiveCategory.OPERATOR),
                     ),
                 ),
                 CodeLine(
                     "7",
                     listOf(
                         Token("    ", null),
+                        Token("@JvmStatic", PrimitiveCategory.ANNOTATION),
+                    ),
+                ),
+                CodeLine(
+                    "8",
+                    listOf(
+                        Token("    ", null),
+                        Token("if ", PrimitiveCategory.KEYWORD),
+                        Token("(", PrimitiveCategory.OPERATOR),
+                        Token("msg", PrimitiveCategory.INSTANCE_FIELD),
+                        Token(".", PrimitiveCategory.OPERATOR),
+                        Token("isNotEmpty", PrimitiveCategory.FUNCTION_DECL),
+                        Token("()", PrimitiveCategory.OPERATOR),
+                        Token(")", PrimitiveCategory.OPERATOR),
+                    ),
+                ),
+                CodeLine(
+                    "9",
+                    listOf(
+                        Token("      ", null),
                         Token("println", PrimitiveCategory.FUNCTION_DECL),
                         Token("(", PrimitiveCategory.OPERATOR),
                         Token("msg", PrimitiveCategory.PARAMETER),
@@ -334,22 +429,11 @@ internal class SyntaxPreviewComponent(
                     ),
                 ),
                 CodeLine(
-                    "8",
+                    "10",
                     listOf(
                         Token("}", PrimitiveCategory.OPERATOR),
                     ),
                 ),
             )
     }
-}
-
-private fun buildCategoryColorMap(computed: Map<TextAttributesKey, TextAttributes>): Map<PrimitiveCategory, Color> {
-    val map = mutableMapOf<PrimitiveCategory, Color>()
-    for ((key, attrs) in computed) {
-        val category = SyntaxCategoryRegistry.classify(key.externalName) ?: continue
-        if (category in map) continue
-        val fg = attrs.foregroundColor ?: continue
-        map[category] = fg
-    }
-    return map
 }

--- a/src/main/kotlin/dev/ayuislands/settings/VcsColorPreviewComponent.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/VcsColorPreviewComponent.kt
@@ -15,6 +15,7 @@ import java.awt.Color
 import java.awt.Dimension
 import java.awt.Graphics
 import java.awt.Graphics2D
+import java.awt.Rectangle
 import java.awt.RenderingHints
 import javax.swing.JComponent
 import kotlin.math.roundToInt
@@ -68,22 +69,11 @@ internal class VcsColorPreviewComponent(
             g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
             g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON)
 
-            val surface = editorSurface()
-            val arc = JBUI.scale(ARC)
-            g2.color = surface
-            g2.fillRoundRect(0, 0, width, height, arc, arc)
-            g2.color = JBColor.border()
-            g2.drawRoundRect(0, 0, width - 1, height - 1, arc, arc)
+            PreviewChromePainter.paintOuterPanel(g2, width, height, editorSurface())
 
-            val padding = JBUI.scale(PADDING)
-            val columnGap = JBUI.scale(COLUMN_GAP)
-            val contentHeight = (height - padding * 2).coerceAtLeast(1)
-            val projectWidth = JBUI.scale(PROJECT_WIDTH)
-            val editorX = padding + projectWidth + columnGap
-            val editorWidth = (width - editorX - padding).coerceAtLeast(1)
-
-            paintProjectPanel(g2, padding, padding, projectWidth, contentHeight)
-            paintEditorPanel(g2, editorX, padding, editorWidth, contentHeight)
+            val layout = PreviewChromePainter.layout(width, height)
+            paintProjectPanel(g2, layout.padding, layout.padding, layout.projectWidth, layout.contentHeight)
+            paintEditorPanel(g2, layout.editorX, layout.padding, layout.editorWidth, layout.contentHeight)
         } finally {
             g2.dispose()
         }
@@ -96,27 +86,16 @@ internal class VcsColorPreviewComponent(
         width: Int,
         height: Int,
     ) {
-        val arc = JBUI.scale(INNER_ARC)
-        g2.color = panelSurface()
-        g2.fillRoundRect(x, y, width, height, arc, arc)
-        g2.color = JBColor.border()
-        g2.drawRoundRect(x, y, width - 1, height - 1, arc, arc)
-
-        g2.font = JBUI.Fonts.smallFont()
-        val rowHeight = JBUI.scale(PROJECT_ROW_HEIGHT)
-        var rowY = y + JBUI.scale(PROJECT_TOP_PADDING)
-        for (row in PROJECT_ROWS) {
-            val baseline = rowY + (rowHeight - g2.fontMetrics.height) / 2 + g2.fontMetrics.ascent
-            g2.color = previewColor(VcsColorCategory.PROJECT_VIEW_FILE_STATUS, row.keyName, VcsWriteMode.COLOR_KEY)
-            g2.fillRect(
-                x + JBUI.scale(FILE_DOT_X),
-                rowY + JBUI.scale(FILE_DOT_Y),
-                JBUI.scale(FILE_DOT),
-                JBUI.scale(FILE_DOT),
-            )
-            g2.drawString(row.text, x + JBUI.scale(FILE_TEXT_X), baseline)
-            rowY += rowHeight
-        }
+        PreviewChromePainter.paintProjectPanel(
+            g2 = g2,
+            panel =
+                PreviewChromeProjectPanel(
+                    bounds = Rectangle(x, y, width, height),
+                    surface = panelSurface(),
+                    rows = projectRows(),
+                    markerShape = PreviewChromeMarkerShape.SQUARE,
+                ),
+        )
     }
 
     private fun paintEditorPanel(
@@ -126,11 +105,7 @@ internal class VcsColorPreviewComponent(
         width: Int,
         height: Int,
     ) {
-        val arc = JBUI.scale(INNER_ARC)
-        g2.color = editorSurface()
-        g2.fillRoundRect(x, y, width, height, arc, arc)
-        g2.color = JBColor.border()
-        g2.drawRoundRect(x, y, width - 1, height - 1, arc, arc)
+        PreviewChromePainter.paintPanelFrame(g2, Rectangle(x, y, width, height), editorSurface())
 
         val gutterWidth = JBUI.scale(GUTTER_WIDTH)
         val blameWidth = JBUI.scale(BLAME_WIDTH).coerceAtMost(width / BLAME_MAX_WIDTH_DIVISOR)
@@ -154,6 +129,14 @@ internal class VcsColorPreviewComponent(
             rowY += rowHeight
         }
     }
+
+    private fun projectRows(): List<PreviewChromeProjectRow> =
+        PROJECT_ROWS.map { row ->
+            PreviewChromeProjectRow(
+                previewColor(VcsColorCategory.PROJECT_VIEW_FILE_STATUS, row.keyName, VcsWriteMode.COLOR_KEY),
+                row.text,
+            )
+        }
 
     private fun paintBlameGutter(
         g2: Graphics2D,
@@ -327,15 +310,6 @@ internal class VcsColorPreviewComponent(
         private const val PREVIEW_WIDTH = 560
         private const val MIN_PREVIEW_WIDTH = 320
         private const val PREVIEW_HEIGHT = 154
-        private const val PADDING = 10
-        private const val COLUMN_GAP = 10
-        private const val PROJECT_WIDTH = 154
-        private const val PROJECT_TOP_PADDING = 12
-        private const val PROJECT_ROW_HEIGHT = 22
-        private const val FILE_DOT_X = 11
-        private const val FILE_DOT_Y = 8
-        private const val FILE_DOT = 7
-        private const val FILE_TEXT_X = 26
         private const val GUTTER_WIDTH = 34
         private const val BLAME_WIDTH = 94
         private const val BLAME_MAX_WIDTH_DIVISOR = 3
@@ -349,8 +323,6 @@ internal class VcsColorPreviewComponent(
         private const val GUTTER_MARKER_INSET = 6
         private const val STRIPE_WIDTH = 4
         private const val STRIPE_GAP = 8
-        private const val ARC = 8
-        private const val INNER_ARC = 6
         private const val CHANNEL_MAX = 255
 
         private val DARK_SURFACE = Color(0x0D1017)

--- a/src/main/resources/dev/ayuislands/settings/syntax-preview/css.txt
+++ b/src/main/resources/dev/ayuislands/settings/syntax-preview/css.txt
@@ -1,0 +1,6 @@
+.preview {
+    color: #ffcc66;
+    padding: 12px;
+    /* tune declarations */
+    border-radius: 6px;
+}

--- a/src/main/resources/dev/ayuislands/settings/syntax-preview/go.txt
+++ b/src/main/resources/dev/ayuislands/settings/syntax-preview/go.txt
@@ -1,0 +1,12 @@
+package preview
+
+import "fmt"
+
+// Greeter prints a greeting.
+func Greet(name string) {
+    msg := "hello"
+    count := 42
+    if len(msg) > 0 {
+        fmt.Println(name, count)
+    }
+}

--- a/src/main/resources/dev/ayuislands/settings/syntax-preview/html.txt
+++ b/src/main/resources/dev/ayuislands/settings/syntax-preview/html.txt
@@ -1,0 +1,5 @@
+<section class="preview">
+    <!-- tune tags and text -->
+    <h1>Hello</h1>
+    <span data-count="42">Ayu Islands</span>
+</section>

--- a/src/main/resources/dev/ayuislands/settings/syntax-preview/java.txt
+++ b/src/main/resources/dev/ayuislands/settings/syntax-preview/java.txt
@@ -1,0 +1,10 @@
+public final class Greeter {
+    private static final String MSG = "hello";
+    // print greeting
+    /** Greet the user */
+    public void greet(String name) {
+        if (!MSG.isEmpty()) {
+            System.out.println(name);
+        }
+    }
+}

--- a/src/main/resources/dev/ayuislands/settings/syntax-preview/javascript.txt
+++ b/src/main/resources/dev/ayuislands/settings/syntax-preview/javascript.txt
@@ -1,0 +1,8 @@
+export function greet(name) {
+    const msg = "hello";
+    const count = 42;
+    // print greeting
+    if (msg.length > 0) {
+        console.log(name, count);
+    }
+}

--- a/src/main/resources/dev/ayuislands/settings/syntax-preview/json.txt
+++ b/src/main/resources/dev/ayuislands/settings/syntax-preview/json.txt
@@ -1,0 +1,5 @@
+{
+  "name": "Ayu Islands",
+  "enabled": true,
+  "count": 42
+}

--- a/src/main/resources/dev/ayuislands/settings/syntax-preview/kotlin.txt
+++ b/src/main/resources/dev/ayuislands/settings/syntax-preview/kotlin.txt
@@ -1,0 +1,12 @@
+fun main() {
+    val msg = "hello"
+    val count = 42
+    // print greeting
+    /** Greet the user */
+    class Greeter {
+        @JvmStatic
+        fun greet(name: String) {
+            if (msg.isNotEmpty()) println(name)
+        }
+    }
+}

--- a/src/main/resources/dev/ayuislands/settings/syntax-preview/markdown.txt
+++ b/src/main/resources/dev/ayuislands/settings/syntax-preview/markdown.txt
@@ -1,0 +1,5 @@
+# Ayu Islands
+
+`code` and **strong** text
+
+- count: 42

--- a/src/main/resources/dev/ayuislands/settings/syntax-preview/python.txt
+++ b/src/main/resources/dev/ayuislands/settings/syntax-preview/python.txt
@@ -1,0 +1,7 @@
+class Greeter:
+    # Greet the user.
+    def greet(self, name: str) -> None:
+        msg = "hello"
+        count = 42
+        if msg:
+            print(name, count)

--- a/src/main/resources/dev/ayuislands/settings/syntax-preview/rust.txt
+++ b/src/main/resources/dev/ayuislands/settings/syntax-preview/rust.txt
@@ -1,0 +1,8 @@
+pub fn greet(name: &str) {
+    let msg = "hello";
+    let count = 42;
+    // print greeting
+    if !msg.is_empty() {
+        println!("{}", name);
+    }
+}

--- a/src/main/resources/dev/ayuislands/settings/syntax-preview/typescript.txt
+++ b/src/main/resources/dev/ayuislands/settings/syntax-preview/typescript.txt
@@ -1,0 +1,8 @@
+export function greet(name: string): void {
+    const msg = "hello";
+    const count = 42;
+    // print greeting
+    if (msg.length > 0) {
+        console.log(name, count);
+    }
+}

--- a/src/main/resources/dev/ayuislands/settings/syntax-preview/yaml.txt
+++ b/src/main/resources/dev/ayuislands/settings/syntax-preview/yaml.txt
@@ -1,0 +1,4 @@
+name: Ayu Islands
+enabled: true
+count: 42
+# tune keys and values

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanelTest.kt
@@ -163,6 +163,24 @@ class AyuIslandsSyntaxPanelTest {
     }
 
     @Test
+    fun `buildPanel initializes syntax preview before first interaction`() {
+        val source = readPanelSource()
+        val buildPanelStart = source.indexOf("override fun buildPanel(")
+        val customFoldOutIndex = source.indexOf("buildCustomFoldOut()", buildPanelStart)
+        assertTrue(buildPanelStart >= 0, "Syntax panel source must contain buildPanel.")
+        assertTrue(customFoldOutIndex > buildPanelStart, "buildPanel must build the Custom fold-out after the preview.")
+
+        val buildPanelBody = source.substring(buildPanelStart, customFoldOutIndex)
+        val previewIndex = buildPanelBody.indexOf("buildPreviewRow(variant)")
+        val refreshIndex = buildPanelBody.indexOf("refreshPreview()")
+        assertTrue(previewIndex >= 0, "buildPanel must create the syntax preview row.")
+        assertTrue(
+            refreshIndex > previewIndex,
+            "buildPanel must initialize preview colors immediately after creating the preview row.",
+        )
+    }
+
+    @Test
     fun `loadStateIntoPending honors explicit AMBIENT default`() {
         stateBase.selectedPreset = "AMBIENT"
         val panel = panelWithLoadedState()
@@ -446,7 +464,7 @@ class AyuIslandsSyntaxPanelTest {
 
         try {
             val component = buildSyntaxPanel(panel)
-            component.setSize(component.preferredSize)
+            component.size = component.preferredSize
             layoutRecursively(component)
 
             val readabilityControls =

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanelTest.kt
@@ -2,16 +2,19 @@ package dev.ayuislands.settings
 
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.ex.ActionManagerEx
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.openapi.ui.DialogPanel
 import com.intellij.openapi.util.io.FileUtil
+import com.intellij.ui.EditorTextField
 import com.intellij.ui.InplaceButton
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
+import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.syntax.PrimitiveCategory
 import dev.ayuislands.syntax.SyntaxIntensityApplicator
@@ -34,6 +37,7 @@ import java.awt.Font
 import java.io.File
 import javax.swing.JButton
 import javax.swing.JCheckBox
+import javax.swing.JComboBox
 import javax.swing.JLabel
 import javax.swing.JSlider
 import javax.swing.Timer
@@ -113,6 +117,7 @@ class AyuIslandsSyntaxPanelTest {
     private lateinit var stateBase: SyntaxIntensityBaseState
     private lateinit var stateService: SyntaxIntensityState
     private lateinit var intensityService: SyntaxIntensityService
+    private lateinit var syntaxPreviewEditorFixture: SyntaxPreviewEditorFixture
 
     @BeforeTest
     fun setUp() {
@@ -133,18 +138,23 @@ class AyuIslandsSyntaxPanelTest {
 
         mockkStatic(ApplicationManager::class)
         val appMock = mockk<Application>(relaxed = true)
-        val actionManagerMock = mockk<ActionManager>(relaxed = true)
+        val actionManagerMock = mockk<ActionManagerEx>(relaxed = true)
         mockkStatic(ActionManager::class)
         every { ActionManager.getInstance() } returns actionManagerMock
         every { ApplicationManager.getApplication() } returns appMock
         every { appMock.invokeLater(any()) } answers { firstArg<Runnable>().run() }
         every { appMock.getService(ActionManager::class.java) } returns actionManagerMock
+        every { appMock.getService(ActionManagerEx::class.java) } returns actionManagerMock
+        every { appMock.getServiceIfCreated(ActionManager::class.java) } returns actionManagerMock
         every { actionManagerMock.getAction(any()) } returns null
 
         @Suppress("UNCHECKED_CAST")
         val experimentalUiClass = Class.forName("com.intellij.ui.ExperimentalUI") as Class<Any>
         val experimentalUiMock = mockkClass(experimentalUiClass.kotlin, relaxed = true)
         every { appMock.getService(experimentalUiClass) } returns experimentalUiMock
+
+        syntaxPreviewEditorFixture = SyntaxPreviewEditorFixture()
+        syntaxPreviewEditorFixture.install()
     }
 
     @AfterTest
@@ -164,20 +174,60 @@ class AyuIslandsSyntaxPanelTest {
 
     @Test
     fun `buildPanel initializes syntax preview before first interaction`() {
-        val source = readPanelSource()
-        val buildPanelStart = source.indexOf("override fun buildPanel(")
-        val customFoldOutIndex = source.indexOf("buildCustomFoldOut()", buildPanelStart)
-        assertTrue(buildPanelStart >= 0, "Syntax panel source must contain buildPanel.")
-        assertTrue(customFoldOutIndex > buildPanelStart, "buildPanel must build the Custom fold-out after the preview.")
+        val syntaxPanel = AyuIslandsSyntaxPanel()
+        val dialogPanel = buildFullSyntaxPanel(syntaxPanel)
 
-        val buildPanelBody = source.substring(buildPanelStart, customFoldOutIndex)
-        val previewIndex = buildPanelBody.indexOf("buildPreviewRow(variant)")
-        val refreshIndex = buildPanelBody.indexOf("refreshPreview()")
-        assertTrue(previewIndex >= 0, "buildPanel must create the syntax preview row.")
-        assertTrue(
-            refreshIndex > previewIndex,
-            "buildPanel must initialize preview colors immediately after creating the preview row.",
-        )
+        try {
+            val preview =
+                assertNotNull(
+                    findComponent(dialogPanel, SyntaxPreviewComponent::class.java),
+                    "Syntax tab must include the native syntax preview component.",
+                )
+            val editor =
+                assertNotNull(
+                    findComponent(preview, EditorTextField::class.java),
+                    "Syntax preview must embed EditorTextField for native syntax highlighting.",
+                )
+
+            assertEquals(AyuVariant.MIRAGE, preview.variantForTest())
+            assertEquals("Kotlin", preview.languageForTest(), "Preview must initialize to the Kotlin sample.")
+            assertEquals(syntaxPreviewEditorFixture.kotlinFileType, editor.fileType)
+            assertSame(syntaxPreviewEditorFixture.previewProject, editor.project)
+        } finally {
+            syntaxPanel.dispose()
+        }
+    }
+
+    @Test
+    fun `language selector updates syntax preview language and file type`() {
+        stateBase.selectedPreset = "CUSTOM"
+        val syntaxPanel = AyuIslandsSyntaxPanel()
+        val dialogPanel = buildFullSyntaxPanel(syntaxPanel)
+
+        try {
+            val preview =
+                assertNotNull(
+                    findComponent(dialogPanel, SyntaxPreviewComponent::class.java),
+                    "Syntax tab must include the native syntax preview component.",
+                )
+            val languageCombo =
+                assertNotNull(
+                    findComponent(dialogPanel, JComboBox::class.java),
+                    "Syntax tab must expose the Custom language selector.",
+                )
+
+            languageCombo.selectedItem = "Java"
+
+            val editor =
+                assertNotNull(
+                    findComponent(preview, EditorTextField::class.java),
+                    "Syntax preview must keep the native editor after language changes.",
+                )
+            assertEquals("Java", preview.languageForTest())
+            assertEquals(syntaxPreviewEditorFixture.javaFileType, editor.fileType)
+        } finally {
+            syntaxPanel.dispose()
+        }
     }
 
     @Test
@@ -1317,6 +1367,11 @@ class AyuIslandsSyntaxPanelTest {
         return panel
     }
 
+    private fun buildFullSyntaxPanel(syntaxPanel: AyuIslandsSyntaxPanel): DialogPanel =
+        panel {
+            syntaxPanel.buildPanel(this, AyuVariant.MIRAGE)
+        }
+
     private fun buildSyntaxPanel(syntaxPanel: AyuIslandsSyntaxPanel): DialogPanel =
         panel {
             syntaxPanel.buildReadabilityBlockForTest(this)
@@ -1346,6 +1401,18 @@ class AyuIslandsSyntaxPanelTest {
         container.components.flatMap { component ->
             val nested = if (component is Container) findCheckBoxes(component) else emptyList()
             if (component is JCheckBox) listOf(component) + nested else nested
+        }
+
+    private fun <T> findComponent(
+        container: Container,
+        type: Class<T>,
+    ): T? =
+        container.components.firstNotNullOfOrNull { component ->
+            when {
+                type.isInstance(component) -> type.cast(component)
+                component is Container -> findComponent(component, type)
+                else -> null
+            }
         }
 
     private fun layoutRecursively(container: Container) {

--- a/src/test/kotlin/dev/ayuislands/settings/SyntaxPreviewComponentTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/SyntaxPreviewComponentTest.kt
@@ -2,44 +2,61 @@ package dev.ayuislands.settings
 
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.editor.colors.TextAttributesKey
-import com.intellij.openapi.editor.markup.TextAttributes
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.EditorFactory
+import com.intellij.openapi.fileTypes.FileType
+import com.intellij.openapi.fileTypes.FileTypeManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.ui.EditorTextField
 import dev.ayuislands.accent.AyuVariant
-import dev.ayuislands.syntax.PrimitiveCategory
-import dev.ayuislands.syntax.SyntaxOverlayLoader
-import dev.ayuislands.syntax.SyntaxPreset
-import dev.ayuislands.syntax.SyntaxReadabilityOptions
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
-import java.awt.Color
+import java.awt.Container
 import java.awt.Dimension
 import java.awt.image.BufferedImage
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class SyntaxPreviewComponentTest {
-    private lateinit var loaderMock: SyntaxOverlayLoader
+    private lateinit var kotlinFileType: FileType
+    private lateinit var previewProject: Project
 
     @BeforeTest
     fun setUp() {
-        loaderMock = mockk(relaxed = true)
-        every { loaderMock.loadBaselineForVariant(any()) } returns BASELINE_MAP
-        every { loaderMock.loadOverlayForVariant(any()) } returns OVERLAY_MAP
-
-        mockkObject(SyntaxOverlayLoader.Companion)
-        every { SyntaxOverlayLoader.getInstance() } returns loaderMock
-
         mockkStatic(ApplicationManager::class)
         val appMock = mockk<Application>(relaxed = true)
         every { ApplicationManager.getApplication() } returns appMock
+
+        previewProject = mockk(relaxed = true)
+        val projectManager = mockk<ProjectManager>(relaxed = true)
+        every { projectManager.defaultProject } returns previewProject
+        mockkStatic(ProjectManager::class)
+        every { ProjectManager.getInstance() } returns projectManager
+
+        kotlinFileType =
+            mockk<FileType>(relaxed = true) {
+                every { name } returns "Kotlin"
+                every { defaultExtension } returns "kt"
+            }
+        val fileTypeManager = mockk<FileTypeManager>(relaxed = true)
+        every { fileTypeManager.getStdFileType("Kotlin") } returns kotlinFileType
+
+        mockkStatic(FileTypeManager::class)
+        every { FileTypeManager.getInstance() } returns fileTypeManager
+
+        val document = mockk<Document>(relaxed = true)
+        val editorFactory = mockk<EditorFactory>(relaxed = true)
+        every { editorFactory.createDocument(any<String>()) } returns document
+        mockkStatic(EditorFactory::class)
+        every { EditorFactory.getInstance() } returns editorFactory
     }
 
     @AfterTest
@@ -48,117 +65,27 @@ class SyntaxPreviewComponentTest {
     }
 
     @Test
-    fun `updatePreview populates categoryColorMap with at least keyword color`() {
+    fun `component embeds a native editor text field for syntax highlighting`() {
         val component = SyntaxPreviewComponent(AyuVariant.MIRAGE)
-        component.updatePreview(
-            AyuVariant.MIRAGE,
-            SyntaxPreset.AMBIENT,
-            emptyMap(),
-            SyntaxPreset.AMBIENT,
-            SyntaxReadabilityOptions.DEFAULT,
-        )
-        val keywordColor = component.categoryColorForTest(PrimitiveCategory.KEYWORD)
-        assertNotNull(keywordColor, "KEYWORD category should have a color after updatePreview")
-    }
 
-    @Test
-    fun `updatePreview populates comment color`() {
-        val component = SyntaxPreviewComponent(AyuVariant.MIRAGE)
-        component.updatePreview(
-            AyuVariant.MIRAGE,
-            SyntaxPreset.AMBIENT,
-            emptyMap(),
-            SyntaxPreset.AMBIENT,
-            SyntaxReadabilityOptions.DEFAULT,
-        )
-        val commentColor = component.categoryColorForTest(PrimitiveCategory.COMMENT)
-        assertNotNull(commentColor, "COMMENT category should have a color after updatePreview")
-    }
+        val editor = findEditorTextField(component)
 
-    @Test
-    fun `updatePreview populates documentation color`() {
-        val component = SyntaxPreviewComponent(AyuVariant.MIRAGE)
-        component.updatePreview(
-            AyuVariant.MIRAGE,
-            SyntaxPreset.AMBIENT,
-            emptyMap(),
-            SyntaxPreset.AMBIENT,
-            SyntaxReadabilityOptions.DEFAULT,
-        )
-        val docColor = component.categoryColorForTest(PrimitiveCategory.DOCUMENTATION)
-        assertNotNull(docColor, "DOCUMENTATION category should have a color after updatePreview")
-    }
-
-    @Test
-    fun `colors change when preset changes from AMBIENT to WHISPER`() {
-        val component = SyntaxPreviewComponent(AyuVariant.MIRAGE)
-        component.updatePreview(
-            AyuVariant.MIRAGE,
-            SyntaxPreset.AMBIENT,
-            emptyMap(),
-            SyntaxPreset.AMBIENT,
-            SyntaxReadabilityOptions.DEFAULT,
-        )
-        val ambientKeyword = component.categoryColorForTest(PrimitiveCategory.KEYWORD)
-
-        component.updatePreview(
-            AyuVariant.MIRAGE,
-            SyntaxPreset.WHISPER,
-            emptyMap(),
-            SyntaxPreset.AMBIENT,
-            SyntaxReadabilityOptions.DEFAULT,
-        )
-        val whisperKeyword = component.categoryColorForTest(PrimitiveCategory.KEYWORD)
-
-        assertNotNull(ambientKeyword)
-        assertNotNull(whisperKeyword)
-        assertNotEquals(
-            ambientKeyword.rgb,
-            whisperKeyword.rgb,
-            "KEYWORD color should differ between AMBIENT and WHISPER presets",
-        )
-    }
-
-    @Test
-    fun `readability dimComments reduces comment brightness`() {
-        val component = SyntaxPreviewComponent(AyuVariant.MIRAGE)
-        component.updatePreview(
-            AyuVariant.MIRAGE,
-            SyntaxPreset.AMBIENT,
-            emptyMap(),
-            SyntaxPreset.AMBIENT,
-            SyntaxReadabilityOptions.DEFAULT,
-        )
-        val normalComment = component.categoryColorForTest(PrimitiveCategory.COMMENT)
-
-        component.updatePreview(
-            AyuVariant.MIRAGE,
-            SyntaxPreset.AMBIENT,
-            emptyMap(),
-            SyntaxPreset.AMBIENT,
-            SyntaxReadabilityOptions(dimComments = true),
-        )
-        val dimmedComment = component.categoryColorForTest(PrimitiveCategory.COMMENT)
-
-        assertNotNull(normalComment)
-        assertNotNull(dimmedComment)
-        assertNotEquals(
-            normalComment.rgb,
-            dimmedComment.rgb,
-            "COMMENT color should change when dimComments is enabled",
+        assertNotNull(editor, "Syntax preview must use a native EditorTextField, not hand-painted token text.")
+        assertTrue(editor.isViewer, "Syntax preview editor must be read-only.")
+        assertEquals(kotlinFileType, editor.fileType, "Syntax preview must request Kotlin syntax highlighting.")
+        assertSame(
+            previewProject,
+            editor.project,
+            "Syntax preview editor must receive a Project so EditorTextField installs an EditorHighlighter.",
         )
     }
 
     @Test
     fun `variant is stored after updatePreview`() {
         val component = SyntaxPreviewComponent(AyuVariant.DARK)
-        component.updatePreview(
-            AyuVariant.MIRAGE,
-            SyntaxPreset.AMBIENT,
-            emptyMap(),
-            SyntaxPreset.AMBIENT,
-            SyntaxReadabilityOptions.DEFAULT,
-        )
+
+        component.updatePreview(AyuVariant.MIRAGE)
+
         assertEquals(AyuVariant.MIRAGE, component.variantForTest())
     }
 
@@ -166,6 +93,7 @@ class SyntaxPreviewComponentTest {
     fun `preferred size is non-zero`() {
         val component = SyntaxPreviewComponent(AyuVariant.MIRAGE)
         val preferred = component.preferredSize
+
         assertTrue(preferred.width > 0, "Preferred width must be positive")
         assertTrue(preferred.height > 0, "Preferred height must be positive")
     }
@@ -175,6 +103,7 @@ class SyntaxPreviewComponentTest {
         val component = SyntaxPreviewComponent(AyuVariant.MIRAGE)
         val min = component.minimumSize
         val pref = component.preferredSize
+
         assertTrue(
             min.width < pref.width,
             "Minimum width (${min.width}) must be less than preferred width (${pref.width})",
@@ -184,14 +113,9 @@ class SyntaxPreviewComponentTest {
     @Test
     fun `paintComponent renders without exception`() {
         val component = SyntaxPreviewComponent(AyuVariant.MIRAGE)
-        component.updatePreview(
-            AyuVariant.MIRAGE,
-            SyntaxPreset.AMBIENT,
-            emptyMap(),
-            SyntaxPreset.AMBIENT,
-            SyntaxReadabilityOptions.DEFAULT,
-        )
+        component.updatePreview(AyuVariant.MIRAGE)
         component.size = Dimension(560, 220)
+        component.doLayout()
         val image = BufferedImage(560, 220, BufferedImage.TYPE_INT_ARGB)
         val g = image.createGraphics()
         try {
@@ -199,30 +123,14 @@ class SyntaxPreviewComponentTest {
         } finally {
             g.dispose()
         }
-        // If we get here without exception, the test passes.
     }
 
-    private companion object {
-        /**
-         * Minimal baseline map with one key per category we want to test.
-         * Keys use externalName patterns that [buildCategoryColorMap] matches.
-         */
-        private val BASELINE_MAP: Map<TextAttributesKey, TextAttributes> =
-            mapOf(
-                key("DEFAULT_KEYWORD") to attrs(Color(0xFF719E)),
-                key("JAVA_LINE_COMMENT") to attrs(Color(0x5C6773)),
-                key("KDOC_TAG_NAME") to attrs(Color(0x5C6773)),
-            )
-
-        private val OVERLAY_MAP: Map<TextAttributesKey, TextAttributes> = emptyMap()
-
-        private fun key(externalName: String): TextAttributesKey =
-            TextAttributesKey.createTextAttributesKey(externalName)
-
-        private fun attrs(fg: Color): TextAttributes {
-            val ta = TextAttributes()
-            ta.foregroundColor = fg
-            return ta
+    private fun findEditorTextField(container: Container): EditorTextField? =
+        container.components.firstNotNullOfOrNull { component ->
+            when (component) {
+                is EditorTextField -> component
+                is Container -> findEditorTextField(component)
+                else -> null
+            }
         }
-    }
 }

--- a/src/test/kotlin/dev/ayuislands/settings/SyntaxPreviewComponentTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/SyntaxPreviewComponentTest.kt
@@ -2,12 +2,7 @@ package dev.ayuislands.settings
 
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.editor.Document
-import com.intellij.openapi.editor.EditorFactory
-import com.intellij.openapi.fileTypes.FileType
-import com.intellij.openapi.fileTypes.FileTypeManager
-import com.intellij.openapi.project.Project
-import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.fileTypes.PlainTextFileType
 import com.intellij.ui.EditorTextField
 import dev.ayuislands.accent.AyuVariant
 import io.mockk.every
@@ -26,8 +21,7 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class SyntaxPreviewComponentTest {
-    private lateinit var kotlinFileType: FileType
-    private lateinit var previewProject: Project
+    private lateinit var editorFixture: SyntaxPreviewEditorFixture
 
     @BeforeTest
     fun setUp() {
@@ -35,28 +29,8 @@ class SyntaxPreviewComponentTest {
         val appMock = mockk<Application>(relaxed = true)
         every { ApplicationManager.getApplication() } returns appMock
 
-        previewProject = mockk(relaxed = true)
-        val projectManager = mockk<ProjectManager>(relaxed = true)
-        every { projectManager.defaultProject } returns previewProject
-        mockkStatic(ProjectManager::class)
-        every { ProjectManager.getInstance() } returns projectManager
-
-        kotlinFileType =
-            mockk<FileType>(relaxed = true) {
-                every { name } returns "Kotlin"
-                every { defaultExtension } returns "kt"
-            }
-        val fileTypeManager = mockk<FileTypeManager>(relaxed = true)
-        every { fileTypeManager.getStdFileType("Kotlin") } returns kotlinFileType
-
-        mockkStatic(FileTypeManager::class)
-        every { FileTypeManager.getInstance() } returns fileTypeManager
-
-        val document = mockk<Document>(relaxed = true)
-        val editorFactory = mockk<EditorFactory>(relaxed = true)
-        every { editorFactory.createDocument(any<String>()) } returns document
-        mockkStatic(EditorFactory::class)
-        every { EditorFactory.getInstance() } returns editorFactory
+        editorFixture = SyntaxPreviewEditorFixture()
+        editorFixture.install()
     }
 
     @AfterTest
@@ -72,9 +46,14 @@ class SyntaxPreviewComponentTest {
 
         assertNotNull(editor, "Syntax preview must use a native EditorTextField, not hand-painted token text.")
         assertTrue(editor.isViewer, "Syntax preview editor must be read-only.")
-        assertEquals(kotlinFileType, editor.fileType, "Syntax preview must request Kotlin syntax highlighting.")
+        assertEquals(
+            editorFixture.kotlinFileType,
+            editor.fileType,
+            "Syntax preview must request Kotlin syntax highlighting.",
+        )
+        assertEquals("Kotlin", component.languageForTest(), "Syntax preview must default to the Kotlin sample.")
         assertSame(
-            previewProject,
+            editorFixture.previewProject,
             editor.project,
             "Syntax preview editor must receive a Project so EditorTextField installs an EditorHighlighter.",
         )
@@ -87,6 +66,42 @@ class SyntaxPreviewComponentTest {
         component.updatePreview(AyuVariant.MIRAGE)
 
         assertEquals(AyuVariant.MIRAGE, component.variantForTest())
+    }
+
+    @Test
+    fun `updatePreview switches the native editor file type when language changes`() {
+        val component = SyntaxPreviewComponent(AyuVariant.MIRAGE)
+
+        component.updatePreview(AyuVariant.MIRAGE, "Java")
+
+        val editor = findEditorTextField(component)
+        assertNotNull(editor, "Syntax preview must keep the native editor when switching languages.")
+        assertEquals("Java", component.languageForTest(), "Syntax preview must track the selected language.")
+        assertEquals(editorFixture.javaFileType, editor.fileType, "Java tuning must render through the Java file type.")
+    }
+
+    @Test
+    fun `component falls back to plain text when standard file type mismatches the sample`() {
+        every { editorFixture.fileTypeManager.getStdFileType("Kotlin") } returns
+            editorFixture.mockFileType("NotKotlin", "txt")
+
+        val component = SyntaxPreviewComponent(AyuVariant.MIRAGE)
+
+        val editor = findEditorTextField(component)
+        assertNotNull(editor, "Syntax preview must still build when the expected file type is unavailable.")
+        assertSame(PlainTextFileType.INSTANCE, editor.fileType)
+    }
+
+    @Test
+    fun `component falls back to plain text when standard file type lookup fails`() {
+        every { editorFixture.fileTypeManager.getStdFileType("Kotlin") } throws
+            RuntimeException("missing Kotlin plugin")
+
+        val component = SyntaxPreviewComponent(AyuVariant.MIRAGE)
+
+        val editor = findEditorTextField(component)
+        assertNotNull(editor, "Syntax preview must still build when file type lookup throws.")
+        assertSame(PlainTextFileType.INSTANCE, editor.fileType)
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/settings/SyntaxPreviewComponentTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/SyntaxPreviewComponentTest.kt
@@ -81,6 +81,25 @@ class SyntaxPreviewComponentTest {
     }
 
     @Test
+    fun `updatePreview uses curated sample for non-Kotlin languages`() {
+        val pythonFileType = editorFixture.mockFileType("Python", "py")
+        every { editorFixture.fileTypeManager.getStdFileType("Python") } returns pythonFileType
+        val component = SyntaxPreviewComponent(AyuVariant.MIRAGE)
+
+        component.updatePreview(AyuVariant.MIRAGE, "Python")
+
+        val editor = findEditorTextField(component)
+        assertNotNull(editor, "Syntax preview must keep the native editor when switching to Python.")
+        assertEquals("Python", component.languageForTest(), "Syntax preview must track the selected language.")
+        assertEquals(
+            "preset_preview.py",
+            component.sampleFileNameForTest(),
+            "Python preview must use its curated sample.",
+        )
+        assertEquals(pythonFileType, editor.fileType, "Python tuning must render through the Python file type.")
+    }
+
+    @Test
     fun `component falls back to plain text when standard file type mismatches the sample`() {
         every { editorFixture.fileTypeManager.getStdFileType("Kotlin") } returns
             editorFixture.mockFileType("NotKotlin", "txt")

--- a/src/test/kotlin/dev/ayuislands/settings/SyntaxPreviewComponentTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/SyntaxPreviewComponentTest.kt
@@ -1,0 +1,228 @@
+package dev.ayuislands.settings
+
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.openapi.editor.markup.TextAttributes
+import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.syntax.PrimitiveCategory
+import dev.ayuislands.syntax.SyntaxOverlayLoader
+import dev.ayuislands.syntax.SyntaxPreset
+import dev.ayuislands.syntax.SyntaxReadabilityOptions
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import java.awt.Color
+import java.awt.Dimension
+import java.awt.image.BufferedImage
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class SyntaxPreviewComponentTest {
+    private lateinit var loaderMock: SyntaxOverlayLoader
+
+    @BeforeTest
+    fun setUp() {
+        loaderMock = mockk(relaxed = true)
+        every { loaderMock.loadBaselineForVariant(any()) } returns BASELINE_MAP
+        every { loaderMock.loadOverlayForVariant(any()) } returns OVERLAY_MAP
+
+        mockkObject(SyntaxOverlayLoader.Companion)
+        every { SyntaxOverlayLoader.getInstance() } returns loaderMock
+
+        mockkStatic(ApplicationManager::class)
+        val appMock = mockk<Application>(relaxed = true)
+        every { ApplicationManager.getApplication() } returns appMock
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `updatePreview populates categoryColorMap with at least keyword color`() {
+        val component = SyntaxPreviewComponent(AyuVariant.MIRAGE)
+        component.updatePreview(
+            AyuVariant.MIRAGE,
+            SyntaxPreset.AMBIENT,
+            emptyMap(),
+            SyntaxPreset.AMBIENT,
+            SyntaxReadabilityOptions.DEFAULT,
+        )
+        val keywordColor = component.categoryColorForTest(PrimitiveCategory.KEYWORD)
+        assertNotNull(keywordColor, "KEYWORD category should have a color after updatePreview")
+    }
+
+    @Test
+    fun `updatePreview populates comment color`() {
+        val component = SyntaxPreviewComponent(AyuVariant.MIRAGE)
+        component.updatePreview(
+            AyuVariant.MIRAGE,
+            SyntaxPreset.AMBIENT,
+            emptyMap(),
+            SyntaxPreset.AMBIENT,
+            SyntaxReadabilityOptions.DEFAULT,
+        )
+        val commentColor = component.categoryColorForTest(PrimitiveCategory.COMMENT)
+        assertNotNull(commentColor, "COMMENT category should have a color after updatePreview")
+    }
+
+    @Test
+    fun `updatePreview populates documentation color`() {
+        val component = SyntaxPreviewComponent(AyuVariant.MIRAGE)
+        component.updatePreview(
+            AyuVariant.MIRAGE,
+            SyntaxPreset.AMBIENT,
+            emptyMap(),
+            SyntaxPreset.AMBIENT,
+            SyntaxReadabilityOptions.DEFAULT,
+        )
+        val docColor = component.categoryColorForTest(PrimitiveCategory.DOCUMENTATION)
+        assertNotNull(docColor, "DOCUMENTATION category should have a color after updatePreview")
+    }
+
+    @Test
+    fun `colors change when preset changes from AMBIENT to WHISPER`() {
+        val component = SyntaxPreviewComponent(AyuVariant.MIRAGE)
+        component.updatePreview(
+            AyuVariant.MIRAGE,
+            SyntaxPreset.AMBIENT,
+            emptyMap(),
+            SyntaxPreset.AMBIENT,
+            SyntaxReadabilityOptions.DEFAULT,
+        )
+        val ambientKeyword = component.categoryColorForTest(PrimitiveCategory.KEYWORD)
+
+        component.updatePreview(
+            AyuVariant.MIRAGE,
+            SyntaxPreset.WHISPER,
+            emptyMap(),
+            SyntaxPreset.AMBIENT,
+            SyntaxReadabilityOptions.DEFAULT,
+        )
+        val whisperKeyword = component.categoryColorForTest(PrimitiveCategory.KEYWORD)
+
+        assertNotNull(ambientKeyword)
+        assertNotNull(whisperKeyword)
+        assertNotEquals(
+            ambientKeyword.rgb,
+            whisperKeyword.rgb,
+            "KEYWORD color should differ between AMBIENT and WHISPER presets",
+        )
+    }
+
+    @Test
+    fun `readability dimComments reduces comment brightness`() {
+        val component = SyntaxPreviewComponent(AyuVariant.MIRAGE)
+        component.updatePreview(
+            AyuVariant.MIRAGE,
+            SyntaxPreset.AMBIENT,
+            emptyMap(),
+            SyntaxPreset.AMBIENT,
+            SyntaxReadabilityOptions.DEFAULT,
+        )
+        val normalComment = component.categoryColorForTest(PrimitiveCategory.COMMENT)
+
+        component.updatePreview(
+            AyuVariant.MIRAGE,
+            SyntaxPreset.AMBIENT,
+            emptyMap(),
+            SyntaxPreset.AMBIENT,
+            SyntaxReadabilityOptions(dimComments = true),
+        )
+        val dimmedComment = component.categoryColorForTest(PrimitiveCategory.COMMENT)
+
+        assertNotNull(normalComment)
+        assertNotNull(dimmedComment)
+        assertNotEquals(
+            normalComment.rgb,
+            dimmedComment.rgb,
+            "COMMENT color should change when dimComments is enabled",
+        )
+    }
+
+    @Test
+    fun `variant is stored after updatePreview`() {
+        val component = SyntaxPreviewComponent(AyuVariant.DARK)
+        component.updatePreview(
+            AyuVariant.MIRAGE,
+            SyntaxPreset.AMBIENT,
+            emptyMap(),
+            SyntaxPreset.AMBIENT,
+            SyntaxReadabilityOptions.DEFAULT,
+        )
+        assertEquals(AyuVariant.MIRAGE, component.variantForTest())
+    }
+
+    @Test
+    fun `preferred size is non-zero`() {
+        val component = SyntaxPreviewComponent(AyuVariant.MIRAGE)
+        val preferred = component.preferredSize
+        assertTrue(preferred.width > 0, "Preferred width must be positive")
+        assertTrue(preferred.height > 0, "Preferred height must be positive")
+    }
+
+    @Test
+    fun `minimum size is smaller than preferred size`() {
+        val component = SyntaxPreviewComponent(AyuVariant.MIRAGE)
+        val min = component.minimumSize
+        val pref = component.preferredSize
+        assertTrue(
+            min.width < pref.width,
+            "Minimum width (${min.width}) must be less than preferred width (${pref.width})",
+        )
+    }
+
+    @Test
+    fun `paintComponent renders without exception`() {
+        val component = SyntaxPreviewComponent(AyuVariant.MIRAGE)
+        component.updatePreview(
+            AyuVariant.MIRAGE,
+            SyntaxPreset.AMBIENT,
+            emptyMap(),
+            SyntaxPreset.AMBIENT,
+            SyntaxReadabilityOptions.DEFAULT,
+        )
+        component.size = Dimension(560, 220)
+        val image = BufferedImage(560, 220, BufferedImage.TYPE_INT_ARGB)
+        val g = image.createGraphics()
+        try {
+            component.paint(g)
+        } finally {
+            g.dispose()
+        }
+        // If we get here without exception, the test passes.
+    }
+
+    private companion object {
+        /**
+         * Minimal baseline map with one key per category we want to test.
+         * Keys use externalName patterns that [buildCategoryColorMap] matches.
+         */
+        private val BASELINE_MAP: Map<TextAttributesKey, TextAttributes> =
+            mapOf(
+                key("DEFAULT_KEYWORD") to attrs(Color(0xFF719E)),
+                key("JAVA_LINE_COMMENT") to attrs(Color(0x5C6773)),
+                key("KDOC_TAG_NAME") to attrs(Color(0x5C6773)),
+            )
+
+        private val OVERLAY_MAP: Map<TextAttributesKey, TextAttributes> = emptyMap()
+
+        private fun key(externalName: String): TextAttributesKey =
+            TextAttributesKey.createTextAttributesKey(externalName)
+
+        private fun attrs(fg: Color): TextAttributes {
+            val ta = TextAttributes()
+            ta.foregroundColor = fg
+            return ta
+        }
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/settings/SyntaxPreviewComponentTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/SyntaxPreviewComponentTest.kt
@@ -96,6 +96,10 @@ class SyntaxPreviewComponentTest {
             component.sampleFileNameForTest(),
             "Python preview must use its curated sample.",
         )
+        assertTrue(
+            component.sampleCodeForTest().contains("def greet"),
+            "Python preview must load the curated resource code.",
+        )
         assertEquals(pythonFileType, editor.fileType, "Python tuning must render through the Python file type.")
     }
 

--- a/src/test/kotlin/dev/ayuislands/settings/SyntaxPreviewEditorFixture.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/SyntaxPreviewEditorFixture.kt
@@ -1,0 +1,56 @@
+package dev.ayuislands.settings
+
+import com.intellij.lang.Language
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.EditorFactory
+import com.intellij.openapi.fileTypes.FileType
+import com.intellij.openapi.fileTypes.FileTypeManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+
+internal class SyntaxPreviewEditorFixture {
+    lateinit var kotlinFileType: FileType
+        private set
+    lateinit var javaFileType: FileType
+        private set
+    lateinit var fileTypeManager: FileTypeManager
+        private set
+    lateinit var previewProject: Project
+        private set
+
+    fun install() {
+        previewProject = mockk(relaxed = true)
+        val projectManager = mockk<ProjectManager>(relaxed = true)
+        every { projectManager.defaultProject } returns previewProject
+        mockkStatic(ProjectManager::class)
+        every { ProjectManager.getInstance() } returns projectManager
+
+        kotlinFileType = mockFileType("Kotlin", "kt")
+        javaFileType = mockFileType("JAVA", "java")
+        fileTypeManager = mockk(relaxed = true)
+        every { fileTypeManager.getStdFileType("Kotlin") } returns kotlinFileType
+        every { fileTypeManager.getStdFileType("JAVA") } returns javaFileType
+        mockkStatic(FileTypeManager::class)
+        every { FileTypeManager.getInstance() } returns fileTypeManager
+
+        val editorFactory = mockk<EditorFactory>(relaxed = true)
+        every { editorFactory.createDocument(any<String>()) } answers { mockk<Document>(relaxed = true) }
+        mockkStatic(EditorFactory::class)
+        every { EditorFactory.getInstance() } returns editorFactory
+
+        mockkStatic(Language::class)
+        every { Language.getRegisteredLanguages() } returns emptyList()
+    }
+
+    fun mockFileType(
+        name: String,
+        defaultExtension: String,
+    ): FileType =
+        mockk<FileType>(relaxed = true).also { fileType ->
+            every { fileType.name } returns name
+            every { fileType.defaultExtension } returns defaultExtension
+        }
+}


### PR DESCRIPTION
── Summary ─────────────────────────────────
The Syntax settings preview could render as gray plaintext because the embedded editor was created without a Project, so IntelliJ skipped its native EditorHighlighter setup. This PR wires the preview through a project-backed native EditorTextField and embeds it into the Syntax tab so users see real Kotlin syntax colors while tuning presets.

── Changes ─────────────────────────────────
| Type | Area | Description |
| --- | --- | --- |
| Feat | `AyuIslandsSyntaxPanel.kt` | Adds the syntax preview row to the Syntax settings panel and refreshes it with the existing preview path. |
| Fix | `SyntaxPreviewComponent.kt` | Uses native `EditorTextField` with `ProjectManager.defaultProject` and Kotlin file type lookup so IntelliJ installs real syntax highlighting. |
| Test | `SyntaxPreviewComponentTest.kt` | Locks the native editor contract, including read-only mode, Kotlin file type, and non-null Project. |
| Test | `AyuIslandsSyntaxPanelTest.kt` | Verifies the panel initializes the preview before first interaction. |
| Chore | `.editorconfig` | Pins Kotlin formatting width/indent for local ktlint consistency. |

── Validation ─────────────────────────────────
- `./gradlew detekt ktlintCheck --rerun-tasks` -> passed
- `./gradlew test --tests 'dev.ayuislands.settings.AyuIslandsSyntaxPanelTest' --tests 'dev.ayuislands.settings.SyntaxPreviewComponentTest'` -> passed
- `./gradlew buildPlugin --no-build-cache --rerun-tasks` -> passed during local deploy
- Installed into `IntelliJIdea2026.1`, restarted IDE, verified installed JAR bytecode calls `ProjectManager.getDefaultProject()` before `EditorTextField(String, Project, FileType)`
- `idea.log` Ayu `SEVERE/ERROR` search after restart -> no matches

── Notes ─────────────────────────────────
- Full `./gradlew test` was attempted earlier and stalled in existing `PluginsPanelTest.tearDown()` MockK static cleanup; scoped settings tests for this PR pass.
- Preview is intentionally native IntelliJ editor rendering, not hand-painted token simulation.

## Summary by Sourcery

Add a native IntelliJ-based syntax preview to the Ayu Islands syntax settings so users see real Kotlin highlighting while adjusting presets.

New Features:
- Introduce a SyntaxPreviewComponent that embeds a project-backed EditorTextField to display live Kotlin syntax highlighting within the settings UI.

Bug Fixes:
- Ensure the syntax settings preview uses a Project and Kotlin file type so IntelliJ installs proper syntax highlighting instead of showing gray plaintext.

Enhancements:
- Wire the syntax preview row into AyuIslandsSyntaxPanel and refresh it whenever syntax intensity options change to keep the preview in sync.

Tests:
- Add unit tests for SyntaxPreviewComponent to lock its use of a native EditorTextField, Kotlin file type, project wiring, sizing, and painting.
- Add a test for AyuIslandsSyntaxPanel to verify the syntax preview is initialized before any user interaction.