### PR TITLE
chore: release 2.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.7.3] - 2026-06-11
+
+### Fixed
+- **Syntax preview** — native highlighting now updates reliably when switching syntax presets and readability options.
+
 ## [2.7.2] - 2026-06-05
 
 ### Paid

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.7.2
+pluginVersion=2.7.3
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
@@ -55,6 +55,10 @@ internal object UpdateNotifier {
 
     private val RELEASE_NOTES =
         mapOf(
+            "2.7.3" to
+                releaseNotes(
+                    "Syntax preview highlighting now updates reliably when switching presets and readability options",
+                ),
             "2.7.2" to
                 releaseNotes(
                     "Pro accent pins can now drive Ayu integrations on non-Ayu themes",

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -113,6 +113,10 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>2.7.3</h3>
+    <ul>
+      <li>[Free] <b>Syntax preview</b> — native highlighting now updates reliably when switching syntax presets and readability options.</li>
+    </ul>
     <h3>2.7.2</h3>
     <ul>
       <li>[Paid] <b>External theme accent inheritance</b> — Pro project and language accent pins can now drive selected Ayu integrations while another IDE theme is active.</li>
@@ -269,7 +273,7 @@
 
     <product-descriptor
             code="PAYUISLANDS"
-            release-date="20260529"
+            release-date="20260611"
             release-version="27"
             optional="true"/>
 


### PR DESCRIPTION
── Summary ─────────────────────────────────
Release 2.7.3 packages the syntax preview highlighting fix after the settings preview work landed on main. The plugin metadata, Marketplace notes, changelog, and in-IDE update notification now point at the same user-visible fix.

── Changes ─────────────────────────────────
- Chore: `gradle.properties` bumps `pluginVersion` to `2.7.3`.
- Docs: `CHANGELOG.md` adds the 2026-06-11 bugfix entry.
- Chore: `src/main/resources/META-INF/plugin.xml` adds 2.7.3 Marketplace notes and updates `release-date` to `20260611`.
- Chore: `src/main/kotlin/dev/ayuislands/UpdateNotifier.kt` adds the 2.7.3 update note.

── Validation ─────────────────────────────────
- `scripts/verify-docs.py` passed (only expected orphaned screenshot-stamp warnings).
- `scripts/verify-theme-xml.py` passed.
- `./gradlew clean buildPlugin` passed.
- `./gradlew verifyPlugin` passed: 12/12 targets compatible.
- `./gradlew detekt ktlintCheck` passed.
- `./gradlew test` passed.

── Notes ─────────────────────────────────
- Direct main push is blocked by repository rules, so this release commit goes through the protected-main PR path before tagging.

## Summary by Sourcery

Prepare the 2.7.3 plugin release that documents and surfaces the syntax preview highlighting fix across metadata and in-IDE messaging.

Bug Fixes:
- Document the syntax preview highlighting bugfix where native highlighting now updates reliably when switching presets and readability options.

Build:
- Bump the plugin version to 2.7.3 in build configuration.

Documentation:
- Add a 2.7.3 changelog entry describing the syntax preview highlighting fix.

Chores:
- Update plugin metadata with 2.7.3 Marketplace change notes and refreshed release date.
- Add the 2.7.3 release note to the in-IDE update notifier.