### PR TITLE
fix(release): align product descriptor date

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -273,9 +273,13 @@
     <depends optional="true" config-file="codeglance-pro.xml">com.nasller.CodeGlancePro</depends>
     <depends optional="true" config-file="indent-rainbow.xml">indent-rainbow.indent-rainbow</depends>
 
+    <!-- JetBrains ties release-date to the paid product release-version. Keep
+         this date aligned with the existing Marketplace entry for the same
+         release-version; changing it without bumping release-version makes
+         Marketplace reject the upload. -->
     <product-descriptor
             code="PAYUISLANDS"
-            release-date="20260611"
+            release-date="20260529"
             release-version="27"
             optional="true"/>
 


### PR DESCRIPTION
## Summary
- Keep the 2.7.x paid product descriptor on the existing JetBrains release date for release-version 27.
- Unblocks Marketplace upload for 2.7.3, which rejected the previous descriptor because release-version 27 already exists with release-date 20260529.

## Verification
- ./gradlew clean buildPlugin verifyPlugin
- Confirmed build/distributions/ayu-jetbrains-2.7.3.zip contains plugin.xml with version 2.7.3, release-date 20260529, release-version 27.

## Summary by Sourcery

Bug Fixes:
- Correct the paid product descriptor release date to match the existing JetBrains release for release-version 27.