### PR TITLE
fix(settings): restore language icon in diagnostics panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Paid
 - [Paid] **Language override diagnostics** — Settings now explains whether a project's language accent is detected, polyglot, forced to a specific language, or using a project fallback.
+- [Paid] **Swift semantic highlighting** — Noctule Swift files now render parameters, labels, properties, functions, and types with distinct Ayu colors across 109 semantic tokens.
+
+### Free
+- [Free] **Swift syntax colors** — Swift keywords, strings, numbers, and comments use Ayu palette colors in base themes.
 
 ## [2.7.3] - 2026-06-11
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.7.3
+pluginVersion=2.7.4
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectLanguageResolutionPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectLanguageResolutionPanel.kt
@@ -49,12 +49,25 @@ internal class ProjectLanguageResolutionPanel(
     fun refresh(nextState: State) {
         state = nextState
         removeAll()
-        add(JBLabel(safeLabelText(summaryFor(nextState))).apply { foreground = UIUtil.getContextHelpForeground() })
+        val icon = iconForState(nextState)
+        add(
+            JBLabel(safeLabelText(summaryFor(nextState)), icon, SwingConstants.LEADING).apply {
+                foreground = UIUtil.getContextHelpForeground()
+            },
+        )
         actionSpecsFor(nextState).forEach { action ->
             add(buildActionLabel(action))
         }
         revalidate()
         repaint()
+    }
+
+    private fun iconForState(state: State): Icon? {
+        state.forcedLanguageId?.let { return LanguageDetectionRules.iconForLanguageId(it) }
+        return when (val verdict = state.verdict) {
+            is ProjectLanguageVerdict.Detected -> LanguageDetectionRules.iconForLanguageId(verdict.languageId)
+            else -> null
+        }
     }
 
     @TestOnly


### PR DESCRIPTION
## What

Restore the language icon in the diagnostics panel for language overrides.

## Why

The `ProjectLanguageResolutionPanel` was creating a `JBLabel` with text only, without passing the language icon. The old `OverridesGroupBuilder` proportions panel used to render icons via `LanguageDetectionRules.iconForLanguageId`.

## How

- Add `iconForState()` method that resolves the icon from the verdict's detected language or forced language ID
- Pass the icon to `JBLabel` constructor in `refresh()`

## Verification

- ktlintCheck ✅
- detekt ✅
- ProjectLanguageResolutionPanelTest ✅

## Summary by Sourcery

Restore language icons in the project language diagnostics panel and bump the plugin version.

New Features:
- Document Swift semantic highlighting and syntax coloring capabilities in the changelog.

Bug Fixes:
- Show the appropriate language icon in the ProjectLanguageResolutionPanel based on detected or forced language.

Documentation:
- Update the changelog with new Swift highlighting and syntax color entries.

Chores:
- Bump plugin version from 2.7.3 to 2.7.4.