### PR TITLE
fix(settings): add language icon renderer to overrides table

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -90,7 +90,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "c46a73d"
+          last_verified_sha: "24db3769"
           last_verified_date: "2026-06-15"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -112,7 +112,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "c46a73d"
+          last_verified_sha: "24db3769"
           last_verified_date: "2026-06-15"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -259,7 +259,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "5be58aa2"
+          last_verified_sha: "24db3769"
           last_verified_date: "2026-05-30"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -300,7 +300,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "5be58aa2"
+          last_verified_sha: "24db3769"
           last_verified_date: "2026-05-30"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -352,7 +352,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "5be58aa2"
+          last_verified_sha: "24db3769"
           last_verified_date: "2026-06-12"
           content_sha256: ad849b17308901bc2dac85f895978be656f578c9c31f857b9e9578e5cf4289f2
 
@@ -414,7 +414,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "5be58aa2"
+          last_verified_sha: "24db3769"
           last_verified_date: "2026-05-30"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -90,7 +90,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "24db3769"
+          last_verified_sha: "18d46b88"
           last_verified_date: "2026-06-15"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -112,7 +112,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "24db3769"
+          last_verified_sha: "18d46b88"
           last_verified_date: "2026-06-15"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -259,7 +259,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "24db3769"
+          last_verified_sha: "18d46b88"
           last_verified_date: "2026-05-30"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -300,7 +300,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "24db3769"
+          last_verified_sha: "18d46b88"
           last_verified_date: "2026-05-30"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -352,7 +352,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "24db3769"
+          last_verified_sha: "18d46b88"
           last_verified_date: "2026-06-12"
           content_sha256: ad849b17308901bc2dac85f895978be656f578c9c31f857b9e9578e5cf4289f2
 
@@ -414,7 +414,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "24db3769"
+          last_verified_sha: "18d46b88"
           last_verified_date: "2026-05-30"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -13,6 +13,7 @@ import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.accent.LanguageDetectionRules
 import dev.ayuislands.accent.ProjectLanguageDetectionListener
 import dev.ayuislands.accent.ProjectLanguageDetector
 import dev.ayuislands.accent.ProjectLanguageVerdict
@@ -136,6 +137,9 @@ class OverridesGroupBuilder(
         }
         languageTable.getColumnModel().getColumn(LanguageMappingsTableModel.COLUMN_COLOR).apply {
             cellRenderer = RoundedSwatchRenderer()
+        }
+        languageTable.getColumnModel().getColumn(LanguageMappingsTableModel.COLUMN_LANGUAGE).apply {
+            cellRenderer = LanguageIconRenderer()
         }
     }
 
@@ -868,6 +872,23 @@ class OverridesGroupBuilder(
             } else {
                 toolTipText = null
             }
+            return this
+        }
+    }
+
+    private class LanguageIconRenderer : DefaultTableCellRenderer() {
+        override fun getTableCellRendererComponent(
+            table: JTable,
+            value: Any?,
+            isSelected: Boolean,
+            hasFocus: Boolean,
+            row: Int,
+            column: Int,
+        ): Component {
+            super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column)
+            val model = table.model as? LanguageMappingsTableModel ?: return this
+            val modelRow = table.convertRowIndexToModel(row)
+            icon = model.rowAt(modelRow)?.let { LanguageDetectionRules.iconForLanguageId(it.languageId) }
             return this
         }
     }


### PR DESCRIPTION
## What

Add language icon renderer to the Language Overrides table so programming language icons appear next to language names.

## Why

The project overrides table had renderers for color (RoundedSwatchRenderer) and project name (DimOrphanRenderer), but the language table only had the color renderer. Language names displayed without their associated file type icons.

## How

- Add `LanguageIconRenderer` inner class that resolves the icon from `LanguageMapping.languageId` via `LanguageDetectionRules.iconForLanguageId`
- Wire the renderer to the Language column in the `init` block

## Verification

- ktlintCheck ✅
- detekt ✅

## Summary by Sourcery

Add language icons to the language overrides table so language names display with their associated icons.

Enhancements:
- Introduce a table cell renderer that resolves and displays language icons based on the mapping's language ID.
- Hook the language icon renderer into the Language column of the language overrides table.