### PR TITLE
chore(release): prepare 2.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Paid
 - [Paid] **Language override diagnostics** — Settings now explains whether a project's language accent is detected, polyglot, forced to a specific language, or using a project fallback.
-- [Paid] **Swift semantic highlighting** — Noctule Swift files now render parameters, labels, properties, functions, and types with distinct Ayu colors across 109 semantic tokens.
 
 ### Free
+- [Free] **Swift semantic highlighting** — Noctule Swift files now render parameters, labels, properties, functions, and types with distinct Ayu colors across 109 semantic tokens.
 - [Free] **Swift syntax colors** — Swift keywords, strings, numbers, and comments use Ayu palette colors in base themes.
 
 ## [2.7.3] - 2026-06-11

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -120,6 +120,8 @@
     <h3>2.7.4</h3>
     <ul>
       <li>[Paid] <b>Language override diagnostics</b> — Settings now explains whether a project's language accent is detected, polyglot, forced to a specific language, or using a project fallback.</li>
+      <li>[Free] <b>Swift semantic highlighting</b> — Noctule Swift files now render parameters, labels, properties, functions, and types with distinct Ayu colors across 109 semantic tokens.</li>
+      <li>[Free] <b>Swift syntax colors</b> — Swift keywords, strings, numbers, and comments use Ayu palette colors in base themes.</li>
     </ul>
     <h3>2.7.3</h3>
     <ul>


### PR DESCRIPTION
## Release 2.7.4

### Changes
- **[Paid] Language override diagnostics** — Settings now explains whether a project's language accent is detected, polyglot, forced to a specific language, or using a project fallback.
- **[Free] Swift semantic highlighting** — Noctule Swift files now render parameters, labels, properties, functions, and types with distinct Ayu colors across 109 semantic tokens.
- **[Free] Swift syntax colors** — Swift keywords, strings, numbers, and comments use Ayu palette colors in base themes.

### Checklist
- [x] Version bumped to 2.7.4 in gradle.properties
- [x] CHANGELOG.md updated
- [x] plugin.xml change-notes updated
- [x] verify-docs passes

## Summary by Sourcery

Document Swift semantic highlighting and syntax color changes for the 2.7.4 release.

Documentation:
- Clarify that Swift semantic highlighting is a free feature in the 2.7.4 changelog.
- Add free Swift semantic highlighting and Swift syntax color notes to the 2.7.4 change notes in plugin metadata.