### PR TITLE
ci(codeql): auto-downgrade Kotlin when CodeQL rejects current version

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,7 +60,31 @@ jobs:
 
       - if: matrix.language == 'java-kotlin'
         name: Compile Kotlin for CodeQL tracing
-        run: ./gradlew compileKotlin compileTestKotlin --no-daemon
+        run: |
+          set +e
+          OUTPUT=$(./gradlew compileKotlin compileTestKotlin --no-daemon 2>&1)
+          EXIT_CODE=$?
+          set -e
+
+          if [ $EXIT_CODE -eq 0 ]; then
+            echo "$OUTPUT"
+            exit 0
+          fi
+
+          # CodeQL rejects Kotlin versions above its ceiling — detect and auto-downgrade
+          if echo "$OUTPUT" | grep -q "too recent"; then
+            MAX_VER=$(echo "$OUTPUT" | sed -n 's/.*below \([0-9]*\.[0-9]*\.[0-9]*\).*/\1/p')
+            if [ -n "$MAX_VER" ]; then
+              echo "::warning::Kotlin too new for CodeQL — temporarily downgrading to $MAX_VER"
+              sed -i "s/kotlin(\"jvm\") version \"[^\"]*\"/kotlin(\"jvm\") version \"$MAX_VER\"/" build.gradle.kts
+              ./gradlew compileKotlin compileTestKotlin --no-daemon
+              exit $?
+            fi
+          fi
+
+          # Different failure — surface original output and fail
+          echo "$OUTPUT"
+          exit $EXIT_CODE
 
       - uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -78,7 +78,11 @@ jobs:
               echo "::warning::Kotlin too new for CodeQL — temporarily downgrading to $MAX_VER"
               sed -i "s/kotlin(\"jvm\") version \"[^\"]*\"/kotlin(\"jvm\") version \"$MAX_VER\"/" build.gradle.kts
               ./gradlew compileKotlin compileTestKotlin --no-daemon
-              exit $?
+              RETRY_EXIT=$?
+              git restore build.gradle.kts
+              exit $RETRY_EXIT
+            else
+              echo "::warning::Kotlin too new for CodeQL but could not parse max supported version — review the error above"
             fi
           fi
 


### PR DESCRIPTION
## Problem

CodeQL `java-kotlin` job fails when Kotlin version exceeds CodeQL's ceiling:

```
Kotlin version 2.4.0 is too recent. CodeQL currently supports versions below 2.3.30
```

This will keep happening every time Kotlin bumps past what CodeQL supports — requiring a manual fix each time.

**Failed run:** https://github.com/barad1tos/ayu-jetbrains/actions/runs/27599466425/job/81599487059

## Solution

Wrap the CodeQL compile step in a try-catch-retry pattern:

1. Try `compileKotlin` with the current Kotlin version
2. If CodeQL rejects it as _"too recent"_, parse the max supported version from the error message
3. `sed`-downgrade `build.gradle.kts` to that version and retry

Changes to `build.gradle.kts` are ephemeral (CI runner only) — nothing gets committed.

**Self-healing:** when CodeQL adds support for newer Kotlin, the workflow auto-upgrades without any changes.

## Summary by Sourcery

CI:
- Wrap the Kotlin compilation step in the CodeQL workflow with logic that detects CodeQL "too recent" errors, temporarily downgrades the Kotlin version in build.gradle.kts, and retries compilation while preserving other failures.