### PR TITLE
fix(codeql): strip carriage return from parsed Kotlin version

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -73,7 +73,7 @@ jobs:
 
           # CodeQL rejects Kotlin versions above its ceiling — detect and auto-downgrade
           if echo "$OUTPUT" | grep -q "too recent"; then
-            MAX_VER=$(echo "$OUTPUT" | sed -n 's/.*below \([0-9]*\.[0-9]*\.[0-9]*\).*/\1/p')
+            MAX_VER=$(echo "$OUTPUT" | sed -n 's/.*below \([0-9]*\.[0-9]*\.[0-9]*\).*/\1/p' | tr -d '\r\n')
             if [ -n "$MAX_VER" ]; then
               echo "::warning::Kotlin too new for CodeQL — temporarily downgrading to $MAX_VER"
               sed -i "s/kotlin(\"jvm\") version \"[^\"]*\"/kotlin(\"jvm\") version \"$MAX_VER\"/" build.gradle.kts


### PR DESCRIPTION
## Follow-up to #222\n\nThe auto-downgrade logic works (logs confirm it parsed `2.3.30` and triggered the warning), but `sed` fails because Gradle output includes `\r`:\n\n```\nsed: -e expression #1, char 61: unterminated `s' command\n```\n\nFix: pipe `MAX_VER` through `tr -d '\r\n'` to sanitize.\n\n**Failed run:** https://github.com/barad1tos/ayu-jetbrains/actions/runs/27602116009

## Summary by Sourcery

Handle Kotlin compilation failures during CodeQL analysis by parsing Gradle output to detect unsupported Kotlin versions, temporarily downgrading to the maximum supported version, and sanitizing the parsed version string before retrying compilation.

Enhancements:
- Add error-handling wrapper around Kotlin compilation in the CodeQL workflow to capture output, detect "too recent" Kotlin version errors, and retry with a temporary version downgrade.
- Sanitize the parsed maximum supported Kotlin version from Gradle output to remove carriage returns and newlines before updating the Gradle build file.