### PR TITLE
fix(codeql): take only first version match from error output

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -73,7 +73,7 @@ jobs:
 
           # CodeQL rejects Kotlin versions above its ceiling — detect and auto-downgrade
           if echo "$OUTPUT" | grep -q "too recent"; then
-            MAX_VER=$(echo "$OUTPUT" | sed -n 's/.*below \([0-9]*\.[0-9]*\.[0-9]*\).*/\1/p' | tr -d '\r\n')
+            MAX_VER=$(echo "$OUTPUT" | grep -m1 -oE "below [0-9]+\.[0-9]+\.[0-9]+" | grep -oE "[0-9]+\.[0-9]+\.[0-9]+")
             if [ -n "$MAX_VER" ]; then
               echo "::warning::Kotlin too new for CodeQL — temporarily downgrading to $MAX_VER"
               sed -i "s/kotlin(\"jvm\") version \"[^\"]*\"/kotlin(\"jvm\") version \"$MAX_VER\"/" build.gradle.kts


### PR DESCRIPTION
## Follow-up to #222 and #223\n\n`sed -n 's/.../p'` prints every match from Gradle output (which repeats the error line). `tr -d '\r\n'` then concatenates them into `2.3.302.3.302.3.30`.\n\nFix: use `grep -m1` to grab only the first occurrence.\n\n**Failed run:** https://github.com/barad1tos/ayu-jetbrains/actions/runs/27602472323

## Summary by Sourcery

Bug Fixes:
- Fix Kotlin version parsing in the CodeQL workflow by selecting only the first matching version from the error output.