### PR TITLE
fix(codeql): decrement CodeQL ceiling to get real Kotlin version

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -73,7 +73,9 @@ jobs:
 
           # CodeQL rejects Kotlin versions above its ceiling — detect and auto-downgrade
           if echo "$OUTPUT" | grep -q "too recent"; then
-            MAX_VER=$(echo "$OUTPUT" | grep -m1 -oE "below [0-9]+\.[0-9]+\.[0-9]+" | grep -oE "[0-9]+\.[0-9]+\.[0-9]+")
+            # CodeQL reports "below X.Y.Z" — decrement minor by 10 to get a real Kotlin release
+            CEILING=$(echo "$OUTPUT" | grep -m1 -oE "below [0-9]+\.[0-9]+\.[0-9]+" | grep -oE "[0-9]+\.[0-9]+\.[0-9]+")
+            MAX_VER=$(echo "$CEILING" | awk -F. '{p=$3-10; if(p<0)p=0; printf "%s.%s.%d",$1,$2,p}')
             if [ -n "$MAX_VER" ]; then
               echo "::warning::Kotlin too new for CodeQL — temporarily downgrading to $MAX_VER"
               sed -i "s/kotlin(\"jvm\") version \"[^\"]*\"/kotlin(\"jvm\") version \"$MAX_VER\"/" build.gradle.kts


### PR DESCRIPTION
## Follow-up to #222–#224\n\nCodeQL reports _"below 2.3.30"_ but that version doesn't exist in Maven Central — the retry build fails with:\n\n```\nPlugin [id: 'org.jetbrains.kotlin.jvm', version: '2.3.30'] was not found\n```\n\nFix: decrement the minor segment by 10 to land on an actual Kotlin release (2.3.30 → 2.3.20).\n\n**Failed run:** https://github.com/barad1tos/ayu-jetbrains/actions/runs/27603020203

## Summary by Sourcery

CI:
- Update CodeQL GitHub Actions workflow to derive a valid maximum Kotlin version by decrementing the reported patch component instead of using the reported unsupported ceiling directly.