### PR TITLE
fix(glow): correct editor overlay geometry for pinned-only tabs

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -90,7 +90,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "18d46b88"
+          last_verified_sha: "e5415c04"
           last_verified_date: "2026-06-15"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -112,7 +112,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "18d46b88"
+          last_verified_sha: "e5415c04"
           last_verified_date: "2026-06-15"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -259,7 +259,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "18d46b88"
+          last_verified_sha: "e5415c04"
           last_verified_date: "2026-05-30"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -300,7 +300,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "18d46b88"
+          last_verified_sha: "e5415c04"
           last_verified_date: "2026-05-30"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -352,7 +352,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "18d46b88"
+          last_verified_sha: "e5415c04"
           last_verified_date: "2026-06-12"
           content_sha256: ad849b17308901bc2dac85f895978be656f578c9c31f857b9e9578e5cf4289f2
 
@@ -414,7 +414,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "18d46b88"
+          last_verified_sha: "e5415c04"
           last_verified_date: "2026-05-30"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -90,7 +90,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "cadfd64a"
+          last_verified_sha: "fc6496be"
           last_verified_date: "2026-06-15"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -112,7 +112,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "cadfd64a"
+          last_verified_sha: "fc6496be"
           last_verified_date: "2026-06-15"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -259,7 +259,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "cadfd64a"
+          last_verified_sha: "fc6496be"
           last_verified_date: "2026-06-16"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -300,7 +300,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "cadfd64a"
+          last_verified_sha: "fc6496be"
           last_verified_date: "2026-06-16"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -352,7 +352,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "cadfd64a"
+          last_verified_sha: "fc6496be"
           last_verified_date: "2026-06-12"
           content_sha256: ad849b17308901bc2dac85f895978be656f578c9c31f857b9e9578e5cf4289f2
 
@@ -414,7 +414,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "cadfd64a"
+          last_verified_sha: "fc6496be"
           last_verified_date: "2026-06-16"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -90,7 +90,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "ca4b4f5a"
+          last_verified_sha: "5d6039aa"
           last_verified_date: "2026-06-15"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -112,7 +112,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "ca4b4f5a"
+          last_verified_sha: "5d6039aa"
           last_verified_date: "2026-06-15"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -259,7 +259,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "ca4b4f5a"
+          last_verified_sha: "5d6039aa"
           last_verified_date: "2026-06-16"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -300,7 +300,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "ca4b4f5a"
+          last_verified_sha: "5d6039aa"
           last_verified_date: "2026-06-16"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -352,7 +352,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "ca4b4f5a"
+          last_verified_sha: "5d6039aa"
           last_verified_date: "2026-06-12"
           content_sha256: ad849b17308901bc2dac85f895978be656f578c9c31f857b9e9578e5cf4289f2
 
@@ -414,7 +414,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "ca4b4f5a"
+          last_verified_sha: "5d6039aa"
           last_verified_date: "2026-06-16"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -90,7 +90,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "5d6039aa"
+          last_verified_sha: "cadfd64a"
           last_verified_date: "2026-06-15"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -112,7 +112,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "5d6039aa"
+          last_verified_sha: "cadfd64a"
           last_verified_date: "2026-06-15"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -259,7 +259,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "5d6039aa"
+          last_verified_sha: "cadfd64a"
           last_verified_date: "2026-06-16"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -300,7 +300,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "5d6039aa"
+          last_verified_sha: "cadfd64a"
           last_verified_date: "2026-06-16"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -352,7 +352,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "5d6039aa"
+          last_verified_sha: "cadfd64a"
           last_verified_date: "2026-06-12"
           content_sha256: ad849b17308901bc2dac85f895978be656f578c9c31f857b9e9578e5cf4289f2
 
@@ -414,7 +414,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "5d6039aa"
+          last_verified_sha: "cadfd64a"
           last_verified_date: "2026-06-16"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -90,7 +90,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "e5415c04"
+          last_verified_sha: "ca4b4f5a"
           last_verified_date: "2026-06-15"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -112,7 +112,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "e5415c04"
+          last_verified_sha: "ca4b4f5a"
           last_verified_date: "2026-06-15"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -259,8 +259,8 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "e5415c04"
-          last_verified_date: "2026-05-30"
+          last_verified_sha: "ca4b4f5a"
+          last_verified_date: "2026-06-16"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
       - id: glow-external-themes
@@ -300,8 +300,8 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "e5415c04"
-          last_verified_date: "2026-05-30"
+          last_verified_sha: "ca4b4f5a"
+          last_verified_date: "2026-06-16"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
   workspace:
@@ -352,7 +352,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "e5415c04"
+          last_verified_sha: "ca4b4f5a"
           last_verified_date: "2026-06-12"
           content_sha256: ad849b17308901bc2dac85f895978be656f578c9c31f857b9e9578e5cf4289f2
 
@@ -414,8 +414,8 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "e5415c04"
-          last_verified_date: "2026-05-30"
+          last_verified_sha: "ca4b4f5a"
+          last_verified_date: "2026-06-16"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 
   onboarding:

--- a/src/main/kotlin/dev/ayuislands/glow/EditorTabGeometry.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/EditorTabGeometry.kt
@@ -5,7 +5,9 @@ import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import java.awt.Component
 import java.awt.Container
+import java.awt.Rectangle
 import javax.swing.JComponent
+import javax.swing.SwingUtilities
 
 /**
  * Tab strip height calculation and editor-tab repaint utilities.
@@ -51,6 +53,120 @@ object EditorTabGeometry {
             log.warn("TabLabel not found in EditorTabs, using DEFAULT_TAB_HEIGHT")
         }
         return DEFAULT_TAB_HEIGHT
+    }
+
+    /**
+     * Calculate the editor overlay bounds relative to [host].
+     *
+     * Prefers the selected editor content component bounds (via reflection on
+     * `JBTabsImpl.getSelectedInfo()` → `TabInfo.getComponent()`). Falls back to
+     * the selected `TabLabel` bottom edge, then any visible nested `TabLabel`,
+     * and finally [DEFAULT_TAB_HEIGHT].
+     */
+    fun calculateEditorOverlayBounds(host: JComponent): Rectangle {
+        val editorTabs = findEditorTabsRecursive(host) as? Container
+        if (editorTabs == null) {
+            if (warnedHosts.add("EditorTabsOverlay:${host.javaClass.name}")) {
+                log.warn("EditorTabs not found in ${host.javaClass.name}, using DEFAULT_TAB_HEIGHT for overlay")
+            }
+            val tabStripBottom = DEFAULT_TAB_HEIGHT
+            return Rectangle(0, tabStripBottom, host.width, (host.height - tabStripBottom).coerceAtLeast(0))
+        }
+
+        val selectedContentBounds = findSelectedContentBounds(editorTabs, host)
+        if (selectedContentBounds != null) return selectedContentBounds
+
+        val selectedLabelBottom = findSelectedLabelBottom(editorTabs)
+        if (selectedLabelBottom != null) {
+            return Rectangle(0, selectedLabelBottom, host.width, (host.height - selectedLabelBottom).coerceAtLeast(0))
+        }
+
+        val nestedLabelBottom = findNestedTabLabelBottom(editorTabs)
+        if (nestedLabelBottom != null) {
+            return Rectangle(0, nestedLabelBottom, host.width, (host.height - nestedLabelBottom).coerceAtLeast(0))
+        }
+
+        if (warnedHosts.add("TabLabelOverlay:${editorTabs.javaClass.name}")) {
+            log.warn("TabLabel not found in EditorTabs, using DEFAULT_TAB_HEIGHT for overlay")
+        }
+        val tabStripBottom = DEFAULT_TAB_HEIGHT
+        return Rectangle(0, tabStripBottom, host.width, (host.height - tabStripBottom).coerceAtLeast(0))
+    }
+
+    /**
+     * Find EditorTabs by recursing into the component tree (not just direct children).
+     */
+    private fun findEditorTabsRecursive(component: Component): Component? {
+        if (component.javaClass.name.contains("EditorTabs")) return component
+        if (component is Container) {
+            for (child in component.components) {
+                val found = findEditorTabsRecursive(child)
+                if (found != null) return found
+            }
+        }
+        return null
+    }
+
+    /**
+     * Use reflection to call `getSelectedInfo()` → `getComponent()` and return
+     * the component's bounds converted to [host] coordinates.
+     */
+    private fun findSelectedContentBounds(
+        editorTabs: Container,
+        host: JComponent,
+    ): Rectangle? {
+        try {
+            val getSelectedInfo =
+                editorTabs.javaClass.methods.firstOrNull { it.name == "getSelectedInfo" }
+                    ?: return null
+            val tabInfo = getSelectedInfo(editorTabs) ?: return null
+
+            val getComponent =
+                tabInfo.javaClass.methods.firstOrNull { it.name == "getComponent" }
+                    ?: return null
+            val contentComponent = getComponent(tabInfo) as? JComponent ?: return null
+
+            val contentBounds = contentComponent.bounds
+            @Suppress("ConvertExpressionToRectangleConstructor")
+            return SwingUtilities.convertRectangle(contentComponent.parent, contentBounds, host)
+        } catch (_: ReflectiveOperationException) {
+            return null
+        } catch (_: IllegalArgumentException) {
+            return null
+        }
+    }
+
+    /**
+     * Use reflection to call `getSelectedLabel()` and return its bottom edge (y + height).
+     */
+    private fun findSelectedLabelBottom(editorTabs: Container): Int? {
+        try {
+            val getSelectedLabel =
+                editorTabs.javaClass.methods.firstOrNull { it.name == "getSelectedLabel" }
+                    ?: return null
+            val label = getSelectedLabel(editorTabs) as? JComponent ?: return null
+            return label.y + label.height
+        } catch (_: ReflectiveOperationException) {
+            return null
+        } catch (_: IllegalArgumentException) {
+            return null
+        }
+    }
+
+    /**
+     * Recursively search for a visible TabLabel and return its bottom edge.
+     */
+    private fun findNestedTabLabelBottom(component: Component): Int? {
+        if (component.javaClass.name.contains("TabLabel") && component is JComponent && component.isVisible) {
+            return component.y + component.height
+        }
+        if (component is Container) {
+            for (child in component.components) {
+                val found = findNestedTabLabelBottom(child)
+                if (found != null) return found
+            }
+        }
+        return null
     }
 
     /**

--- a/src/main/kotlin/dev/ayuislands/glow/EditorTabGeometry.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/EditorTabGeometry.kt
@@ -122,18 +122,21 @@ object EditorTabGeometry {
     ): Rectangle? {
         try {
             val getSelectedInfo =
-                editorTabs.javaClass.methods.firstOrNull { it.name == "getSelectedInfo" }
-                    ?: return null
+                editorTabs.javaClass.methods.firstOrNull {
+                    it.name == "getSelectedInfo" && it.parameterCount == 0
+                } ?: return null
             val tabInfo = getSelectedInfo.invoke(editorTabs) ?: return null
 
             val getComponent =
-                tabInfo.javaClass.methods.firstOrNull { it.name == "getComponent" }
-                    ?: return null
+                tabInfo.javaClass.methods.firstOrNull {
+                    it.name == "getComponent" && it.parameterCount == 0
+                } ?: return null
             val contentComponent = getComponent.invoke(tabInfo) as? JComponent ?: return null
 
+            val parent = contentComponent.parent ?: return null
             val contentBounds = contentComponent.bounds
             @Suppress("ConvertExpressionToRectangleConstructor")
-            return SwingUtilities.convertRectangle(contentComponent.parent, contentBounds, host)
+            return SwingUtilities.convertRectangle(parent, contentBounds, host)
         } catch (_: ReflectiveOperationException) {
             return null
         } catch (_: IllegalArgumentException) {
@@ -147,8 +150,9 @@ object EditorTabGeometry {
     private fun findSelectedLabelBottom(editorTabs: Container): Int? {
         try {
             val getSelectedLabel =
-                editorTabs.javaClass.methods.firstOrNull { it.name == "getSelectedLabel" }
-                    ?: return null
+                editorTabs.javaClass.methods.firstOrNull {
+                    it.name == "getSelectedLabel" && it.parameterCount == 0
+                } ?: return null
             val label = getSelectedLabel.invoke(editorTabs) as? JComponent ?: return null
             return label.y + label.height
         } catch (_: ReflectiveOperationException) {

--- a/src/main/kotlin/dev/ayuislands/glow/EditorTabGeometry.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/EditorTabGeometry.kt
@@ -95,12 +95,17 @@ object EditorTabGeometry {
 
     /**
      * Find EditorTabs by recursing into the component tree (not just direct children).
+     * Limited to [maxDepth] levels to avoid expensive traversal on deep Swing trees.
      */
-    private fun findEditorTabsRecursive(component: Component): Component? {
+    private fun findEditorTabsRecursive(
+        component: Component,
+        maxDepth: Int = 8,
+    ): Component? {
+        if (maxDepth <= 0) return null
         if (component.javaClass.name.contains("EditorTabs")) return component
         if (component is Container) {
             for (child in component.components) {
-                val found = findEditorTabsRecursive(child)
+                val found = findEditorTabsRecursive(child, maxDepth - 1)
                 if (found != null) return found
             }
         }
@@ -155,14 +160,19 @@ object EditorTabGeometry {
 
     /**
      * Recursively search for a visible TabLabel and return its bottom edge.
+     * Limited to [maxDepth] levels to avoid expensive traversal on deep Swing trees.
      */
-    private fun findNestedTabLabelBottom(component: Component): Int? {
+    private fun findNestedTabLabelBottom(
+        component: Component,
+        maxDepth: Int = 8,
+    ): Int? {
+        if (maxDepth <= 0) return null
         if (component.javaClass.name.contains("TabLabel") && component is JComponent && component.isVisible) {
             return component.y + component.height
         }
         if (component is Container) {
             for (child in component.components) {
-                val found = findNestedTabLabelBottom(child)
+                val found = findNestedTabLabelBottom(child, maxDepth - 1)
                 if (found != null) return found
             }
         }

--- a/src/main/kotlin/dev/ayuislands/glow/EditorTabGeometry.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/EditorTabGeometry.kt
@@ -119,12 +119,12 @@ object EditorTabGeometry {
             val getSelectedInfo =
                 editorTabs.javaClass.methods.firstOrNull { it.name == "getSelectedInfo" }
                     ?: return null
-            val tabInfo = getSelectedInfo(editorTabs) ?: return null
+            val tabInfo = getSelectedInfo.invoke(editorTabs) ?: return null
 
             val getComponent =
                 tabInfo.javaClass.methods.firstOrNull { it.name == "getComponent" }
                     ?: return null
-            val contentComponent = getComponent(tabInfo) as? JComponent ?: return null
+            val contentComponent = getComponent.invoke(tabInfo) as? JComponent ?: return null
 
             val contentBounds = contentComponent.bounds
             @Suppress("ConvertExpressionToRectangleConstructor")
@@ -144,7 +144,7 @@ object EditorTabGeometry {
             val getSelectedLabel =
                 editorTabs.javaClass.methods.firstOrNull { it.name == "getSelectedLabel" }
                     ?: return null
-            val label = getSelectedLabel(editorTabs) as? JComponent ?: return null
+            val label = getSelectedLabel.invoke(editorTabs) as? JComponent ?: return null
             return label.y + label.height
         } catch (_: ReflectiveOperationException) {
             return null

--- a/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
@@ -181,22 +181,15 @@ class GlowOverlayManager(
 
         connection.subscribe(
             AccentChangedTopic.TOPIC,
-            @Suppress("ObjectLiteralToLambda")
-            object : AccentChangeListener {
-                override fun accentChanged(
-                    project: Project,
-                    hex: AccentHex,
-                    source: AccentResolver.Source,
-                ) {
-                    if (disposed) return
-                    if (project !== this@GlowOverlayManager.project) return
+            AccentChangeListener { project, hex, _ ->
+                if (disposed) return@AccentChangeListener
+                if (project !== this@GlowOverlayManager.project) return@AccentChangeListener
 
-                    if (SwingUtilities.isEventDispatchThread()) {
-                        updateGlow(hex)
-                    } else {
-                        SwingUtilities.invokeLater {
-                            if (!disposed) updateGlow(hex)
-                        }
+                if (SwingUtilities.isEventDispatchThread()) {
+                    updateGlow(hex)
+                } else {
+                    SwingUtilities.invokeLater {
+                        if (!disposed) updateGlow(hex)
                     }
                 }
             },
@@ -270,8 +263,8 @@ class GlowOverlayManager(
         try {
             val point = SwingUtilities.convertPoint(host, 0, 0, layeredPane)
             if (glassPane.isEditorOverlay) {
-                val tabHeight = EditorTabGeometry.calculateTabStripHeight(host)
-                glassPane.setBounds(point.x, point.y + tabHeight, host.width, host.height - tabHeight)
+                val bounds = EditorTabGeometry.calculateEditorOverlayBounds(host)
+                glassPane.setBounds(point.x + bounds.x, point.y + bounds.y, bounds.width, bounds.height)
             } else {
                 glassPane.setBounds(point.x, point.y, host.width, host.height)
             }
@@ -313,7 +306,8 @@ class GlowOverlayManager(
                 isEditorOverlay = isEditorOverlay,
             )
 
-        layeredPane.add(glassPane, JLayeredPane.PALETTE_LAYER)
+        layeredPane.setLayer(glassPane, JLayeredPane.PALETTE_LAYER)
+        layeredPane.add(glassPane)
         updateOverlayBounds(glassPane, host, layeredPane)
 
         val compListener =

--- a/src/test/kotlin/dev/ayuislands/glow/EditorTabGeometryTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/EditorTabGeometryTest.kt
@@ -1,6 +1,7 @@
 package dev.ayuislands.glow
 
 import java.awt.Color
+import java.awt.Rectangle
 import javax.swing.JComponent
 import javax.swing.JLabel
 import javax.swing.JPanel
@@ -74,6 +75,64 @@ class EditorTabGeometryTest {
         panel.add(child)
 
         assertNull(EditorTabGeometry.findEditorTabsComponent(child))
+    }
+
+    // --- calculateEditorOverlayBounds tests ---
+
+    @Test
+    fun `calculateEditorOverlayBounds uses default when no EditorTabs found`() {
+        val host = JPanel()
+        host.setSize(800, 600)
+
+        val bounds = EditorTabGeometry.calculateEditorOverlayBounds(host)
+        val defaultH = EditorTabGeometry.DEFAULT_TAB_HEIGHT
+        assertEquals(Rectangle(0, defaultH, 800, 600 - defaultH), bounds)
+    }
+
+    @Test
+    fun `calculateEditorOverlayBounds finds nested EditorTabs and uses TabLabel bottom`() {
+        val host = JPanel()
+        host.setSize(800, 600)
+
+        val wrapper = JPanel()
+        val editorTabs = MockEditorTabs()
+        val tabLabel = MockTabLabel()
+        tabLabel.setBounds(0, 0, 200, 32)
+        editorTabs.add(tabLabel)
+        wrapper.add(editorTabs)
+        host.add(wrapper)
+
+        val bounds = EditorTabGeometry.calculateEditorOverlayBounds(host)
+        assertEquals(Rectangle(0, 32, 800, 568), bounds)
+    }
+
+    @Test
+    fun `calculateEditorOverlayBounds uses default when EditorTabs has no TabLabel`() {
+        val host = JPanel()
+        host.setSize(800, 600)
+
+        val editorTabs = MockEditorTabs()
+        editorTabs.add(JLabel("not a tab"))
+        host.add(editorTabs)
+
+        val bounds = EditorTabGeometry.calculateEditorOverlayBounds(host)
+        val defaultH = EditorTabGeometry.DEFAULT_TAB_HEIGHT
+        assertEquals(Rectangle(0, defaultH, 800, 600 - defaultH), bounds)
+    }
+
+    @Test
+    fun `calculateEditorOverlayBounds clamps to zero when host is shorter than tab strip`() {
+        val host = JPanel()
+        host.setSize(800, 20)
+
+        val editorTabs = MockEditorTabs()
+        val tabLabel = MockTabLabel()
+        tabLabel.setBounds(0, 0, 200, 32)
+        editorTabs.add(tabLabel)
+        host.add(editorTabs)
+
+        val bounds = EditorTabGeometry.calculateEditorOverlayBounds(host)
+        assertEquals(0, bounds.height)
     }
 
     // Mock classes — javaClass.name contains the substrings that


### PR DESCRIPTION
## Why

When a pinned tab remains and all other editor tabs are closed, the glow overlay used a fallback 28px tab strip height instead of the real editor content bounds. This caused broken top-left geometry visible to the user.

## What

- Add `calculateEditorOverlayBounds(host)` to `EditorTabGeometry` with a 4-tier fallback:
  1. Selected content bounds via reflection (`getSelectedInfo` -> `getComponent`, converted to host coordinates)
  2. Selected `TabLabel` bottom edge via `getSelectedLabel()`
  3. Recursive nested `TabLabel` discovery
  4. `DEFAULT_TAB_HEIGHT` (28px)
- Update `GlowOverlayManager.updateOverlayBounds` to use the new rectangle-returning API instead of raw tab-strip-height arithmetic
- Use `setLayer` + `add(Component)` to avoid `JBLayeredPane` primitive-constraint warning
- Add regression tests for nested EditorTabs, TabLabel fallback, and height-clamping edge case

## Files changed

- `src/main/kotlin/dev/ayuislands/glow/EditorTabGeometry.kt` — new `calculateEditorOverlayBounds` + helpers
- `src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt` — use new geometry API + `setLayer` fix
- `src/test/kotlin/dev/ayuislands/glow/EditorTabGeometryTest.kt` — 4 new regression tests

## Verification

- All glow tests pass (`./gradlew test --tests "dev.ayuislands.glow.*"`)
- detekt + ktlint clean
- Deployed to local IDE 2026.1 — no SEVERE errors, no "TabLabel not found for overlay" warnings, no "Probably incorrect call" warnings
- Accent applied successfully in dogfood

## Summary by Sourcery

Align glow editor overlays and Groovy/Jenkinsfile syntax theming with Ayu design across variants and ensure they are correctly classified and test-covered.

New Features:
- Add Groovy/Jenkinsfile-specific syntax highlighting roles and colors to Ayu Dark, Light, and Mirage baseline and extended schemes, including inlay type hint foregrounds.
- Introduce richer Groovy language classification and primitive category mapping for bare Jenkinsfile/Groovy keys in the syntax registries.
- Provide a new EditorTabGeometry API to compute editor overlay bounds from actual editor content or tab labels instead of a fixed tab strip height.

Bug Fixes:
- Fix editor glow overlay geometry so editor overlays align with the remaining pinned tab content when other tabs are closed.
- Correct Groovy-related theme colors (e.g., instance/static fields, map keys) to match the intended Ayu Groovy/Jenkinsfile palette across variants.

Enhancements:
- Update GlowOverlayManager to use the new overlay bounds API and safer layered-pane integration, and to simplify accent change handling.
- Extend syntax intensity application so Groovy string literals use the Groovy-specific cell and slider rather than ambient fallbacks.

Tests:
- Add regression tests for editor overlay bounds under various EditorTabs/TabLabel configurations and host size edge cases.
- Add baseline and extended scheme tests validating Groovy/Jenkinsfile roles, colors, inlay type hint colors, and language/category classification for Groovy keys.
- Add tests ensuring Groovy string keys honor custom intensity/style settings and are not treated as ambient defaults.