### PR TITLE
feat(accent): tune language override diagnostics

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -90,7 +90,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "fe29ab56"
+          last_verified_sha: "db2d795f"
           last_verified_date: "2026-06-15"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -112,7 +112,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "fe29ab56"
+          last_verified_sha: "db2d795f"
           last_verified_date: "2026-06-15"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -90,7 +90,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "db2d795f"
+          last_verified_sha: "b8a0ab23"
           last_verified_date: "2026-06-15"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -112,7 +112,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "db2d795f"
+          last_verified_sha: "b8a0ab23"
           last_verified_date: "2026-06-15"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -90,7 +90,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "fc6496be"
+          last_verified_sha: "7ebe42d3"
           last_verified_date: "2026-06-15"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -112,7 +112,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "fc6496be"
+          last_verified_sha: "7ebe42d3"
           last_verified_date: "2026-06-15"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -259,7 +259,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "fc6496be"
+          last_verified_sha: "7ebe42d3"
           last_verified_date: "2026-06-16"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -300,7 +300,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "fc6496be"
+          last_verified_sha: "7ebe42d3"
           last_verified_date: "2026-06-16"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -352,7 +352,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "fc6496be"
+          last_verified_sha: "7ebe42d3"
           last_verified_date: "2026-06-12"
           content_sha256: ad849b17308901bc2dac85f895978be656f578c9c31f857b9e9578e5cf4289f2
 
@@ -414,7 +414,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "fc6496be"
+          last_verified_sha: "7ebe42d3"
           last_verified_date: "2026-06-16"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -90,7 +90,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "7ebe42d3"
+          last_verified_sha: "fe29ab56"
           last_verified_date: "2026-06-15"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -112,7 +112,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "7ebe42d3"
+          last_verified_sha: "fe29ab56"
           last_verified_date: "2026-06-15"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -23,6 +23,7 @@ import dev.ayuislands.projectview.ProjectViewScrollbarManager
 import dev.ayuislands.rotation.AccentRotationService
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.mappings.AccentMappingsSettings
+import dev.ayuislands.settings.mappings.AccentMappingsState
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 import dev.ayuislands.syntax.SyntaxIntensityMigrationNotifier
 import dev.ayuislands.syntax.SyntaxIntensityService
@@ -83,21 +84,20 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
         runStartupAccentOnEdt(project, variant)
 
         // Warm the language-detector cache so Settings → Accent → Overrides
-        // shows real per-language proportions on first open. Gated on the same
-        // `languageAccents.isNotEmpty()` predicate `AccentResolver.findOverride`
-        // uses: users with no language pins never paid for the scan before this
-        // feature landed, and still shouldn't pay for it just because the
-        // Settings panel has a new informational row. When no pins exist the
-        // panel's own `buildGroup` warmup (EDT-safe bail-out) handles the first
-        // open with one extra cache miss. Both the `AccentMappingsSettings`
-        // state read and the detector call run under the same runCatching so a
-        // transient failure in either (corrupt persistent-state XML, plugin
-        // unload race, disposed scanner, etc.) can't short-circuit the rest of
-        // startup — ModuleRootListener subscription, font-preset apply, license
-        // checks, and onboarding all live below this block.
+        // shows real per-language proportions on first open. Gated on language
+        // resolution work the resolver may actually do: exact language overrides
+        // or language fallback. Users with no language pins/fallback never paid
+        // for the scan before this feature landed, and still shouldn't pay for
+        // it just because the Settings panel has a new informational row. Both
+        // the `AccentMappingsSettings` state read and the detector call run
+        // under the same runCatching so a transient failure in either (corrupt
+        // persistent-state XML, plugin unload race, disposed scanner, etc.)
+        // can't short-circuit the rest of startup — ModuleRootListener
+        // subscription, font-preset apply, license checks, and onboarding all
+        // live below this block.
         runCatchingPreservingCancellation {
-            val pinnedLanguages = AccentMappingsSettings.getInstance().state.languageAccents
-            if (pinnedLanguages.isNotEmpty()) {
+            val mappings = AccentMappingsSettings.getInstance().state
+            if (shouldWarmLanguageDetector(mappings)) {
                 ProjectLanguageDetector.dominant(project)
             }
         }.onFailure { exception ->
@@ -460,6 +460,13 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
         name: String,
         block: () -> Unit,
     ) = runStep(name, block)
+
+    private fun shouldWarmLanguageDetector(state: AccentMappingsState): Boolean =
+        state.languageAccents.isNotEmpty() || !state.languageFallbackAccent.isNullOrBlank()
+
+    @org.jetbrains.annotations.TestOnly
+    internal fun shouldWarmLanguageDetectorForTest(state: AccentMappingsState): Boolean =
+        shouldWarmLanguageDetector(state)
 
     companion object {
         private val LOG = logger<AyuIslandsStartupActivity>()

--- a/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
@@ -6,7 +6,6 @@ import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
 import dev.ayuislands.settings.mappings.AccentMappingsSettings
-import dev.ayuislands.settings.mappings.AccentMappingsState
 import org.jetbrains.annotations.TestOnly
 import java.awt.Color
 import java.io.File
@@ -24,9 +23,10 @@ import javax.swing.UIManager
  *     canonical base path.
  *  2. **Forced language override** — per-project language id mapped to a language accent.
  *  3. **Language override** — dominant language of the project via [ProjectLanguageDetector].
- *  4. **Project fallback** — applied only when [ProjectLanguageDetector.verdict] is
+ *  4. **Language fallback override** — default language accent for detected ids without an exact mapping.
+ *  5. **Project fallback** — applied only when [ProjectLanguageDetector.verdict] is
  *     [ProjectLanguageVerdict.NoWinner].
- *  5. **Global** — [AyuIslandsSettings.getAccentForVariant] (which itself honors
+ *  6. **Global** — [AyuIslandsSettings.getAccentForVariant] (which itself honors
  *     follow-system-accent and per-variant stored hex).
  *
  * Per-project and per-language overrides are premium features: when the license check
@@ -42,6 +42,7 @@ object AccentResolver {
         PROJECT_OVERRIDE,
         FORCED_LANGUAGE_OVERRIDE,
         LANGUAGE_OVERRIDE,
+        LANGUAGE_FALLBACK_OVERRIDE,
         PROJECT_FALLBACK,
         MATERIAL_THEME,
         IDE_ACCENT,
@@ -103,7 +104,7 @@ object AccentResolver {
      * Pure pattern-match over the closed [Source] enum; no IO, no reflection.
      * Pattern L regression lock lives in `AccentResolverSourceLabelTest` —
      * adding a new [Source] value without extending this helper fails the
-     * `Source.entries.size == 8` assertion so silent "Global" fallback drift
+     * `Source.entries.size == 9` assertion so silent "Global" fallback drift
      * cannot land.
      */
     fun sourceLabel(source: Source): String =
@@ -111,6 +112,7 @@ object AccentResolver {
             Source.PROJECT_OVERRIDE -> "Project override"
             Source.FORCED_LANGUAGE_OVERRIDE -> "Forced language override"
             Source.LANGUAGE_OVERRIDE -> "Language override"
+            Source.LANGUAGE_FALLBACK_OVERRIDE -> "Language fallback override"
             Source.PROJECT_FALLBACK -> "Project fallback"
             Source.MATERIAL_THEME -> "Material Theme"
             Source.IDE_ACCENT -> "IDE accent"
@@ -174,26 +176,21 @@ object AccentResolver {
         mappings.projectAccents[projectKey]
             ?.let { rawHex -> overrideAccent(Source.PROJECT_OVERRIDE, rawHex, validateHex)?.let { return it } }
 
-        val hasForcedLanguageEntry = mappings.forcedProjectLanguages.containsKey(projectKey)
-        val forcedLanguageAccent =
-            mappings.forcedProjectLanguages[projectKey]
-                ?.let { forcedLanguageId -> mappings.languageAccents[forcedLanguageId] }
+        val languageRequest =
+            LanguageOverrideRequest(
+                languageAccents = mappings.languageAccents,
+                hasForcedLanguageEntry = mappings.forcedProjectLanguages.containsKey(projectKey),
+                forcedLanguageId = mappings.forcedProjectLanguages[projectKey]?.trim()?.takeIf { it.isNotEmpty() },
+                languageFallbackAccent = mappings.languageFallbackAccent?.trim()?.takeIf { it.isNotEmpty() },
+                validateHex = validateHex,
+            )
         val hasProjectFallbackCandidate = mappings.projectFallbackAccents.containsKey(projectKey)
-        val hasLanguageWork =
-            listOf(
-                forcedLanguageAccent != null,
-                !hasForcedLanguageEntry && mappings.languageAccents.isNotEmpty(),
-                hasProjectFallbackCandidate,
-            ).any { it }
-        if (!hasLanguageWork) return null
+        if (!languageRequest.hasResolutionWork && !hasProjectFallbackCandidate) return null
 
         val (languageOverride, detectorConsulted) =
             resolveLanguageOverride(
-                mappings = mappings,
                 project = activeProject,
-                hasForcedLanguageEntry = hasForcedLanguageEntry,
-                forcedLanguageAccent = forcedLanguageAccent,
-                validateHex = validateHex,
+                request = languageRequest,
             )
         languageOverride?.let { return it }
         mappings.projectFallbackAccents[projectKey]
@@ -207,35 +204,33 @@ object AccentResolver {
     }
 
     private fun resolveLanguageOverride(
-        mappings: AccentMappingsState,
         project: Project,
-        hasForcedLanguageEntry: Boolean,
-        forcedLanguageAccent: String?,
-        validateHex: Boolean,
+        request: LanguageOverrideRequest,
     ): Pair<ResolvedAccent?, Boolean> {
-        forcedLanguageAccent
-            ?.let { rawHex ->
-                overrideAccent(Source.FORCED_LANGUAGE_OVERRIDE, rawHex, validateHex)
-                    ?.let { return it to false }
+        request.forcedLanguageId
+            ?.let { languageId ->
+                overrideAccentForLanguage(
+                    languageAccents = request.languageAccents,
+                    languageFallbackAccent = request.languageFallbackAccent,
+                    languageId = languageId,
+                    exactSource = Source.FORCED_LANGUAGE_OVERRIDE,
+                    validateHex = request.validateHex,
+                )?.let { return it to false }
             }
-        if (hasForcedLanguageEntry || mappings.languageAccents.isEmpty()) return null to false
+        if (!request.shouldDetectLanguage) return null to false
         val resolvedAccent =
             ProjectLanguageDetector
                 .dominant(project)
-                ?.let { languageId -> mappings.languageAccents[languageId] }
-                ?.let { rawHex -> overrideAccent(Source.LANGUAGE_OVERRIDE, rawHex, validateHex) }
+                ?.let { languageId ->
+                    overrideAccentForLanguage(
+                        languageAccents = request.languageAccents,
+                        languageFallbackAccent = request.languageFallbackAccent,
+                        languageId = languageId,
+                        exactSource = Source.LANGUAGE_OVERRIDE,
+                        validateHex = request.validateHex,
+                    )
+                }
         return resolvedAccent to true
-    }
-
-    private fun overrideAccent(
-        source: Source,
-        rawHex: String,
-        validateHex: Boolean,
-    ): ResolvedAccent? {
-        if (!validateHex) {
-            return ResolvedAccent(source, rawHex)
-        }
-        return AccentHex.of(rawHex)?.let { ResolvedAccent(source, it.value) }
     }
 
     /**
@@ -329,11 +324,6 @@ object AccentResolver {
 
     private fun Color.toHex(): String = "#%02X%02X%02X".format(Locale.ROOT, red, green, blue)
 
-    private data class ResolvedAccent(
-        val source: Source,
-        val hex: String,
-    )
-
     /**
      * One-shot per-project warn gate. [tryAcquire] returns `true` the first time a given
      * project is seen and `false` on every subsequent call — so hot-path callers can emit
@@ -363,4 +353,50 @@ object AccentResolver {
     private const val MATERIAL_ACCENT_KEY = "material.accent"
     private const val COMPONENT_ACCENT_KEY = "Component.accentColor"
     private const val ACTIONS_BLUE_KEY = "Actions.Blue"
+}
+
+private data class LanguageOverrideRequest(
+    val languageAccents: Map<String, String>,
+    val hasForcedLanguageEntry: Boolean,
+    val forcedLanguageId: String?,
+    val languageFallbackAccent: String?,
+    val validateHex: Boolean,
+) {
+    private val hasLanguageCandidate = languageAccents.isNotEmpty() || languageFallbackAccent != null
+
+    val hasResolutionWork: Boolean =
+        hasLanguageCandidate && (forcedLanguageId != null || !hasForcedLanguageEntry)
+
+    val shouldDetectLanguage: Boolean =
+        hasLanguageCandidate && !hasForcedLanguageEntry
+}
+
+private data class ResolvedAccent(
+    val source: AccentResolver.Source,
+    val hex: String,
+)
+
+private fun overrideAccentForLanguage(
+    languageAccents: Map<String, String>,
+    languageFallbackAccent: String?,
+    languageId: String,
+    exactSource: AccentResolver.Source,
+    validateHex: Boolean,
+): ResolvedAccent? {
+    languageAccents[languageId]
+        ?.let { rawHex -> overrideAccent(exactSource, rawHex, validateHex) }
+        ?.let { return it }
+    return languageFallbackAccent
+        ?.let { rawHex -> overrideAccent(AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE, rawHex, validateHex) }
+}
+
+private fun overrideAccent(
+    source: AccentResolver.Source,
+    rawHex: String,
+    validateHex: Boolean,
+): ResolvedAccent? {
+    if (!validateHex) {
+        return ResolvedAccent(source, rawHex)
+    }
+    return AccentHex.of(rawHex)?.let { ResolvedAccent(source, it.value) }
 }

--- a/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
@@ -23,7 +23,8 @@ import javax.swing.UIManager
  *     canonical base path.
  *  2. **Forced language override** — per-project language id mapped to a language accent.
  *  3. **Language override** — dominant language of the project via [ProjectLanguageDetector].
- *  4. **Language fallback override** — default language accent for detected ids without an exact mapping.
+ *  4. **Language fallback override** — default language accent for forced or detected ids
+ *     without an exact mapping.
  *  5. **Project fallback** — applied only when [ProjectLanguageDetector.verdict] is
  *     [ProjectLanguageVerdict.NoWinner].
  *  6. **Global** — [AyuIslandsSettings.getAccentForVariant] (which itself honors
@@ -395,8 +396,12 @@ private fun overrideAccent(
     rawHex: String,
     validateHex: Boolean,
 ): ResolvedAccent? {
-    if (!validateHex) {
+    val accent = AccentHex.of(rawHex)
+    if (accent != null) {
+        return ResolvedAccent(source, accent.value)
+    }
+    if (!validateHex && source != AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE) {
         return ResolvedAccent(source, rawHex)
     }
-    return AccentHex.of(rawHex)?.let { ResolvedAccent(source, it.value) }
+    return null
 }

--- a/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
@@ -16,6 +16,46 @@ import javax.swing.Icon
  * and depends on no IntelliJ platform singletons.
  */
 internal object LanguageDetectionRules {
+    data class ResolutionPolicy(
+        val dominanceThreshold: Double = DEFAULT_DOMINANCE_THRESHOLD,
+        val dominanceMarginRatio: Double = DOMINANCE_MARGIN_RATIO,
+        val dominanceFloor: Double = DOMINANCE_FLOOR,
+        val tiebreakMinShare: Double = TIE_BREAK_MIN_SHARE,
+    ) {
+        init {
+            require(dominanceThreshold in SHARE_RANGE) { "dominanceThreshold must be between 0 and 1" }
+            require(dominanceMarginRatio >= MIN_MARGIN_RATIO) { "dominanceMarginRatio must be at least 1" }
+            require(dominanceFloor in SHARE_RANGE) { "dominanceFloor must be between 0 and 1" }
+            require(tiebreakMinShare in SHARE_RANGE) { "tiebreakMinShare must be between 0 and 1" }
+        }
+
+        companion object {
+            val DEFAULT = ResolutionPolicy()
+
+            fun fromStored(
+                dominanceThreshold: Double,
+                dominanceMarginRatio: Double,
+                dominanceFloor: Double,
+                tiebreakMinShare: Double,
+            ): ResolutionPolicy =
+                ResolutionPolicy(
+                    dominanceThreshold = dominanceThreshold.normalizedShare(DEFAULT.dominanceThreshold),
+                    dominanceMarginRatio = dominanceMarginRatio.normalizedMargin(DEFAULT.dominanceMarginRatio),
+                    dominanceFloor = dominanceFloor.normalizedShare(DEFAULT.dominanceFloor),
+                    tiebreakMinShare = tiebreakMinShare.normalizedShare(DEFAULT.tiebreakMinShare),
+                )
+        }
+    }
+
+    private fun Double.normalizedShare(defaultValue: Double): Double =
+        takeIf { !it.isNaN() && !it.isInfinite() }
+            ?.coerceIn(SHARE_RANGE)
+            ?: defaultValue
+
+    private fun Double.normalizedMargin(defaultValue: Double): Double =
+        takeIf { !it.isNaN() && !it.isInfinite() && it >= MIN_MARGIN_RATIO }
+            ?: defaultValue
+
     /**
      * Language ids (lowercased) that represent markup / config / data rather than
      * a project's "primary code language". Used by
@@ -129,6 +169,9 @@ internal object LanguageDetectionRules {
      * "kotlin" but the scan has no strong signal either way.
      */
     const val TIE_BREAK_MIN_SHARE: Double = 0.20
+
+    private const val MIN_MARGIN_RATIO: Double = 1.0
+    private val SHARE_RANGE = 0.0..1.0
 
     /**
      * Max named language entries in the Settings status-line proportions display
@@ -401,6 +444,17 @@ internal object LanguageDetectionRules {
         val base = codeWeights.ifEmpty { allWeights }
         return pickDominantFromWeights(base, threshold, marginRatio, floor)
     }
+
+    fun pickDominantFromAllWeights(
+        allWeights: Map<String, Long>,
+        policy: ResolutionPolicy,
+    ): String? =
+        pickDominantFromAllWeights(
+            allWeights = allWeights,
+            threshold = policy.dominanceThreshold,
+            marginRatio = policy.dominanceMarginRatio,
+            floor = policy.dominanceFloor,
+        )
 
     /**
      * Human-readable top-N summary of language proportions for Settings display.

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
+import dev.ayuislands.settings.mappings.AccentMappingsSettings
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
@@ -23,9 +24,10 @@ import javax.swing.SwingUtilities
  *     and [LanguageDetectionRules.pickDominantFromAllWeights] returns the language
  *     whose share clears the primary threshold OR passes the leading-plurality rule.
  *  2. **Legacy SDK/module heuristic as polyglot tiebreaker** — only consulted when the
- *     scan produced weights but no winner, AND the legacy hint has ≥20% share in the
- *     scan's code weights. Protects against the v2.5 → v2.6 upgrade regression where
- *     a 50/50 Java/Kotlin JVM project would silently drop its "kotlin" override.
+ *     scan produced weights but no winner, AND the legacy hint clears the configured
+ *     minimum share in the scan's code weights. Protects against the v2.5 → v2.6
+ *     upgrade regression where a 50/50 Java/Kotlin JVM project would silently drop its
+ *     "kotlin" override.
  *  3. **Legacy SDK/module heuristic as fallback** — used only when the scan found zero
  *     recognized source files: brand-new project, docs-only-after-filtering, or
  *     pre-indexing state.
@@ -368,8 +370,9 @@ object ProjectLanguageDetector {
         val weights =
             ProjectLanguageScanner.scan(project)
                 ?: return DetectionResult(ProjectLanguageVerdict.Unavailable, cacheable = false)
+        val policy = AccentMappingsSettings.getInstance().state.languageResolutionPolicy()
         if (weights.isNotEmpty()) {
-            val scanWinner = LanguageDetectionRules.pickDominantFromAllWeights(weights)
+            val scanWinner = LanguageDetectionRules.pickDominantFromAllWeights(weights, policy)
             if (scanWinner != null) {
                 return DetectionResult(
                     ProjectLanguageVerdict.Detected(scanWinner, weights),
@@ -378,10 +381,10 @@ object ProjectLanguageDetector {
             }
             // Scan found weights but no clear or plurality winner. Consult the
             // legacy heuristic as a tiebreaker — but only accept its answer when
-            // that language is already represented in the scan's code weights at
-            // TIE_BREAK_MIN_SHARE. Guards against the SDK confidently reporting
+            // that language is already represented in the scan's code weights at the
+            // configured tiebreak floor. Guards against the SDK confidently reporting
             // a language that the scan didn't even find.
-            resolveTiebreakFromLegacy(project, weights)?.let {
+            resolveTiebreakFromLegacy(project, weights, policy)?.let {
                 return DetectionResult(
                     ProjectLanguageVerdict.Detected(it, weights),
                     cacheable = true,
@@ -394,13 +397,14 @@ object ProjectLanguageDetector {
 
     /**
      * When the proportional scan is polyglot, fall back to the legacy SDK / module
-     * heuristic — but only if the language it names has a foothold (≥
-     * [LanguageDetectionRules.TIE_BREAK_MIN_SHARE]) in the scan's code weights.
+     * heuristic — but only if the language it names has a foothold in the scan's
+     * code weights according to [LanguageDetectionRules.ResolutionPolicy.tiebreakMinShare].
      * Returns null when the hint doesn't meet that bar.
      */
     private fun resolveTiebreakFromLegacy(
         project: Project,
         weights: Map<String, Long>,
+        policy: LanguageDetectionRules.ResolutionPolicy,
     ): String? {
         val hint =
             (legacySdkModuleDetection(project).verdict as? ProjectLanguageVerdict.Detected)
@@ -412,7 +416,7 @@ object ProjectLanguageDetector {
         if (total <= 0L) return null
         val hintWeight = base[hint] ?: 0L
         val share = hintWeight.toDouble() / total.toDouble()
-        return if (share >= LanguageDetectionRules.TIE_BREAK_MIN_SHARE) hint else null
+        return if (share >= policy.tiebreakMinShare) hint else null
     }
 
     private fun legacySdkModuleDetection(project: Project): DetectionResult {

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
@@ -13,9 +13,9 @@ import java.util.concurrent.ConcurrentHashMap
 import javax.swing.SwingUtilities
 
 /**
- * Detector for the dominant language of a project, used only when an exact language
- * override, language fallback, or project fallback needs a language verdict (the
- * [AccentResolver] gates this).
+ * Detector for the dominant language of a project. Resolver calls are gated to
+ * exact language overrides, language fallback, or project fallback work; Settings
+ * diagnostics and explicit rescans may read or refresh the cached verdict directly.
  *
  * Detection strategy (most-authoritative-first):
  *

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
@@ -13,8 +13,9 @@ import java.util.concurrent.ConcurrentHashMap
 import javax.swing.SwingUtilities
 
 /**
- * Detector for the dominant language of a project, used only when the language-accent
- * override map is non-empty (the [AccentResolver] gates this).
+ * Detector for the dominant language of a project, used only when an exact language
+ * override, language fallback, or project fallback needs a language verdict (the
+ * [AccentResolver] gates this).
  *
  * Detection strategy (most-authoritative-first):
  *
@@ -415,6 +416,7 @@ object ProjectLanguageDetector {
         val total = base.values.sum()
         if (total <= 0L) return null
         val hintWeight = base[hint] ?: 0L
+        if (hintWeight <= 0L) return null
         val share = hintWeight.toDouble() / total.toDouble()
         return if (share >= policy.tiebreakMinShare) hint else null
     }

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -83,7 +83,7 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
         // window the user is visually on (same cascade rotation + apply paths use). Do
         // NOT substitute `ProjectManager.openProjects.firstOrNull { … }` — that silently
         // binds to the enumeration-first project in multi-window setups, so "Currently
-        // active:" and "Detected:" read out the wrong project.
+        // active:" and "Language scan:" read out the wrong project.
         contextProject = AccentApplicator.resolveFocusedProject()
         val colorPanel = createAccentColorPanel()
         applyInitialSelection(colorPanel, storedAccent)
@@ -284,6 +284,7 @@ class AyuIslandsAccentPanel : AyuIslandsSettingsPanel {
                 "project override for \"${contextProject?.name ?: "?"}\""
             AccentResolver.Source.LANGUAGE_OVERRIDE -> AccentResolver.sourceLabel(source)
             AccentResolver.Source.FORCED_LANGUAGE_OVERRIDE,
+            AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE,
             AccentResolver.Source.PROJECT_FALLBACK,
             AccentResolver.Source.MATERIAL_THEME,
             AccentResolver.Source.IDE_ACCENT,

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/AccentMappingsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/AccentMappingsState.kt
@@ -1,18 +1,35 @@
 package dev.ayuislands.settings.mappings
 
 import com.intellij.openapi.components.BaseState
+import dev.ayuislands.accent.LanguageDetectionRules
 
 /**
  * Persisted application-level accent overrides resolved in priority order:
- * project (by canonical path) > language (by lowercase Language.id) > global.
+ * project (by canonical path) > forced/detected language > language fallback >
+ * project fallback for polyglot no-winner scans > global.
  *
  * Display names are kept alongside project paths so orphaned rows (path no longer
  * exists on disk) can still render meaningfully in the settings table.
  */
 class AccentMappingsState : BaseState() {
-    var projectAccents by map<String, String>()
-    var languageAccents by map<String, String>()
-    var projectDisplayNames by map<String, String>()
-    var projectFallbackAccents by map<String, String>()
-    var forcedProjectLanguages by map<String, String>()
+    var projectAccents: MutableMap<String, String> by map()
+    var languageAccents: MutableMap<String, String> by map()
+    var projectDisplayNames: MutableMap<String, String> by map()
+    var projectFallbackAccents: MutableMap<String, String> by map()
+    var forcedProjectLanguages: MutableMap<String, String> by map()
+    var languageFallbackAccent: String? by string(null)
+    var dominanceThreshold: Float by property(LanguageDetectionRules.DEFAULT_DOMINANCE_THRESHOLD.toFloat())
+    var dominanceMarginRatio: Float by property(LanguageDetectionRules.DOMINANCE_MARGIN_RATIO.toFloat())
+    var dominanceFloor: Float by property(LanguageDetectionRules.DOMINANCE_FLOOR.toFloat())
+    var tiebreakMinShare: Float by property(LanguageDetectionRules.TIE_BREAK_MIN_SHARE.toFloat())
+
+    internal fun languageResolutionPolicy(): LanguageDetectionRules.ResolutionPolicy =
+        LanguageDetectionRules.ResolutionPolicy.fromStored(
+            dominanceThreshold = dominanceThreshold.toStoredDouble(),
+            dominanceMarginRatio = dominanceMarginRatio.toStoredDouble(),
+            dominanceFloor = dominanceFloor.toStoredDouble(),
+            tiebreakMinShare = tiebreakMinShare.toStoredDouble(),
+        )
 }
+
+private fun Float.toStoredDouble(): Double = toString().toDouble()

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -41,7 +41,7 @@ import javax.swing.table.TableModel
 /**
  * Builds the "Overrides" group inside the Accent settings tab. Hosts a segmented
  * toggle between Projects and Languages, each backed by its own [JBTable] and
- * [ToolbarDecorator] with add / pin-current / edit-color / remove actions.
+ * toolbar controls with add / pin-current / edit-color / remove actions.
  *
  * All mutations happen on an in-memory pending model; callers use [isModified],
  * [apply], and [reset] to participate in the usual settings lifecycle. [addPendingChangeListener]
@@ -60,8 +60,10 @@ class OverridesGroupBuilder(
     private var storedLanguages: List<LanguageMapping> = emptyList()
     private val pendingFallbackAccents: MutableMap<String, String> = linkedMapOf()
     private val pendingForcedLanguages: MutableMap<String, String> = linkedMapOf()
+    private var pendingLanguageFallbackAccent: String? = null
     private var storedFallbackAccents: Map<String, String> = emptyMap()
     private var storedForcedLanguages: Map<String, String> = emptyMap()
+    private var storedLanguageFallbackAccent: String? = null
     private val listeners: MutableList<Runnable> = mutableListOf()
     private val diagnosticsRefreshListener = Runnable { refreshResolutionPanel() }
 
@@ -318,6 +320,7 @@ class OverridesGroupBuilder(
         if (currentLanguages != storedLanguagesFingerprint) return true
 
         if (pendingFallbackAccents != storedFallbackAccents) return true
+        if (pendingLanguageFallbackAccent != storedLanguageFallbackAccent) return true
         return pendingForcedLanguages != storedForcedLanguages
     }
 
@@ -338,6 +341,7 @@ class OverridesGroupBuilder(
         state.projectFallbackAccents.putAll(pendingFallbackAccents)
         state.forcedProjectLanguages.clear()
         state.forcedProjectLanguages.putAll(pendingForcedLanguages)
+        state.languageFallbackAccent = pendingLanguageFallbackAccent
 
         // Re-apply the committed mapping set via resolver → applicator → swap-cache sync.
         // Keep the focus-swap cache consistent so the next WINDOW_ACTIVATED event evaluates
@@ -364,10 +368,7 @@ class OverridesGroupBuilder(
         }.onFailure { exception ->
             LOG.warn("Re-apply after overrides commit failed; persisted state is saved, UI may need reopen", exception)
         }
-        storedProjects = projectModel.snapshot().map { ProjectMapping(it.canonicalPath, it.displayName, it.hex) }
-        storedLanguages = languageModel.snapshot().map { LanguageMapping(it.languageId, it.displayName, it.hex) }
-        storedFallbackAccents = pendingFallbackAccents.toMap()
-        storedForcedLanguages = pendingForcedLanguages.toMap()
+        captureStoredSnapshot()
         fireChanged()
     }
 
@@ -378,6 +379,7 @@ class OverridesGroupBuilder(
         pendingFallbackAccents.putAll(storedFallbackAccents)
         pendingForcedLanguages.clear()
         pendingForcedLanguages.putAll(storedForcedLanguages)
+        pendingLanguageFallbackAccent = storedLanguageFallbackAccent
         refreshResolutionPanel()
         fireChanged()
     }
@@ -424,18 +426,7 @@ class OverridesGroupBuilder(
             ?.let { return PendingResolvedAccent(AccentResolver.Source.PROJECT_OVERRIDE, it.hex) }
 
         val languageAccents = languageModel.snapshot().associate { it.languageId to it.hex }
-        val hasForcedLanguageEntry = pendingForcedLanguages.containsKey(projectKey)
-        val forcedLanguageAccent =
-            pendingForcedLanguages[projectKey]
-                ?.let { forcedLanguageId -> languageAccents[forcedLanguageId] }
         val hasProjectFallbackCandidate = pendingFallbackAccents.containsKey(projectKey)
-
-        forcedLanguageAccent?.let {
-            return PendingResolvedAccent(AccentResolver.Source.FORCED_LANGUAGE_OVERRIDE, it)
-        }
-
-        val shouldDetectLanguage = !hasForcedLanguageEntry && languageAccents.isNotEmpty()
-        if (!shouldDetectLanguage && !hasProjectFallbackCandidate) return null
 
         val cachedVerdict =
             if (warmDetector) {
@@ -443,21 +434,63 @@ class OverridesGroupBuilder(
             } else {
                 ProjectLanguageDetector.verdict(activeProject)
             }
-        var detectorConsulted = false
-        if (shouldDetectLanguage) {
-            detectorConsulted = true
-            pendingDetectedLanguageId(activeProject, cachedVerdict, warmDetector)
-                ?.let { languageId -> languageAccents[languageId] }
-                ?.let { return PendingResolvedAccent(AccentResolver.Source.LANGUAGE_OVERRIDE, it) }
-        }
+        val languageOverride =
+            findPendingLanguageOverride(
+                activeProject = activeProject,
+                projectKey = projectKey,
+                languageAccents = languageAccents,
+                cachedVerdict = cachedVerdict,
+                warmDetector = warmDetector,
+            )
+        languageOverride.accent?.let { return it }
+        if (!languageOverride.hasResolutionWork && !hasProjectFallbackCandidate) return null
 
         return findPendingFallbackOverride(
             activeProject = activeProject,
             projectKey = projectKey,
-            detectorConsulted = detectorConsulted,
+            detectorConsulted = languageOverride.detectorConsulted,
             cachedVerdict = cachedVerdict,
             warmDetector = warmDetector,
         )
+    }
+
+    private fun findPendingLanguageOverride(
+        activeProject: Project,
+        projectKey: String,
+        languageAccents: Map<String, String>,
+        cachedVerdict: ProjectLanguageVerdict?,
+        warmDetector: Boolean,
+    ): PendingLanguageOverrideResult {
+        val hasForcedLanguageEntry = pendingForcedLanguages.containsKey(projectKey)
+        val hasLanguageCandidate = languageAccents.isNotEmpty() || pendingLanguageFallbackAccent != null
+        pendingForcedLanguages[projectKey]
+            ?.let { languageId ->
+                pendingAccentForLanguage(
+                    languageAccents = languageAccents,
+                    languageId = languageId,
+                    exactSource = AccentResolver.Source.FORCED_LANGUAGE_OVERRIDE,
+                )
+            }?.let { return PendingLanguageOverrideResult(it, hasResolutionWork = true, detectorConsulted = false) }
+
+        val shouldDetectLanguage = !hasForcedLanguageEntry && hasLanguageCandidate
+        if (!shouldDetectLanguage) {
+            return PendingLanguageOverrideResult(
+                accent = null,
+                hasResolutionWork = hasLanguageCandidate && !hasForcedLanguageEntry,
+                detectorConsulted = false,
+            )
+        }
+
+        val accent =
+            pendingDetectedLanguageId(activeProject, cachedVerdict, warmDetector)
+                ?.let { languageId ->
+                    pendingAccentForLanguage(
+                        languageAccents = languageAccents,
+                        languageId = languageId,
+                        exactSource = AccentResolver.Source.LANGUAGE_OVERRIDE,
+                    )
+                }
+        return PendingLanguageOverrideResult(accent, hasResolutionWork = true, detectorConsulted = true)
     }
 
     private fun pendingDetectedLanguageId(
@@ -550,11 +583,20 @@ class OverridesGroupBuilder(
         if (forcedLanguageId != null && forcedLanguageId in languageIds) {
             return AccentResolver.Source.FORCED_LANGUAGE_OVERRIDE
         }
+        if (forcedLanguageId != null && pendingLanguageFallbackAccent != null) {
+            return AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE
+        }
         if (forcedLanguageId == null &&
             verdict is ProjectLanguageVerdict.Detected &&
             verdict.languageId in languageIds
         ) {
             return AccentResolver.Source.LANGUAGE_OVERRIDE
+        }
+        if (forcedLanguageId == null &&
+            verdict is ProjectLanguageVerdict.Detected &&
+            pendingLanguageFallbackAccent != null
+        ) {
+            return AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE
         }
         return fallbackDiagnosticsSource(projectKey, verdict)
     }
@@ -671,14 +713,23 @@ class OverridesGroupBuilder(
     }
 
     @org.jetbrains.annotations.TestOnly
+    internal fun setPendingLanguageFallbackAccent(hex: String?) {
+        pendingLanguageFallbackAccent = normalizedLanguageFallbackAccent(hex, warn = LOG::warn)
+        refreshResolutionPanel()
+        fireChanged()
+    }
+
+    @org.jetbrains.annotations.TestOnly
     internal fun seedResolutionOverridesForTest(
         fallbackAccents: Map<String, String> = emptyMap(),
         forcedLanguages: Map<String, String> = emptyMap(),
+        languageFallbackAccent: String? = null,
     ) {
         pendingFallbackAccents.clear()
         pendingFallbackAccents.putAll(normalizedFallbackAccents(fallbackAccents))
         pendingForcedLanguages.clear()
         pendingForcedLanguages.putAll(normalizedForcedLanguages(forcedLanguages))
+        pendingLanguageFallbackAccent = normalizedLanguageFallbackAccent(languageFallbackAccent)
     }
 
     @org.jetbrains.annotations.TestOnly
@@ -686,6 +737,9 @@ class OverridesGroupBuilder(
 
     @org.jetbrains.annotations.TestOnly
     internal fun forcedLanguagesForTest(): Map<String, String> = pendingForcedLanguages.toMap()
+
+    @org.jetbrains.annotations.TestOnly
+    internal fun languageFallbackAccentForTest(): String? = pendingLanguageFallbackAccent
 
     /**
      * Legacy-named seam: lazily builds the diagnostics panel on first call,
@@ -755,13 +809,19 @@ class OverridesGroupBuilder(
         pendingFallbackAccents.putAll(normalizedFallbackAccents(state.projectFallbackAccents, warn = LOG::warn))
         pendingForcedLanguages.clear()
         pendingForcedLanguages.putAll(normalizedForcedLanguages(state.forcedProjectLanguages, warn = LOG::warn))
+        pendingLanguageFallbackAccent = normalizedLanguageFallbackAccent(state.languageFallbackAccent, warn = LOG::warn)
+        captureStoredSnapshot()
+    }
+
+    private val fireChanged: () -> Unit = { listeners.forEach { it.run() } }
+
+    private fun captureStoredSnapshot() {
         storedProjects = projectModel.snapshot().map { ProjectMapping(it.canonicalPath, it.displayName, it.hex) }
         storedLanguages = languageModel.snapshot().map { LanguageMapping(it.languageId, it.displayName, it.hex) }
         storedFallbackAccents = pendingFallbackAccents.toMap()
         storedForcedLanguages = pendingForcedLanguages.toMap()
+        storedLanguageFallbackAccent = pendingLanguageFallbackAccent
     }
-
-    private val fireChanged: () -> Unit = { listeners.forEach { it.run() } }
 
     companion object {
         private val LOG = logger<OverridesGroupBuilder>()
@@ -853,6 +913,22 @@ class OverridesGroupBuilder(
         val hex: String,
     )
 
+    private data class PendingLanguageOverrideResult(
+        val accent: PendingResolvedAccent?,
+        val hasResolutionWork: Boolean,
+        val detectorConsulted: Boolean,
+    )
+
+    private fun pendingAccentForLanguage(
+        languageAccents: Map<String, String>,
+        languageId: String,
+        exactSource: AccentResolver.Source,
+    ): PendingResolvedAccent? =
+        languageAccents[languageId]
+            ?.let { PendingResolvedAccent(exactSource, it) }
+            ?: pendingLanguageFallbackAccent
+                ?.let { PendingResolvedAccent(AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE, it) }
+
     private class DimOrphanRenderer(
         private val orphanProbe: (Int) -> Boolean,
     ) : DefaultTableCellRenderer() {
@@ -920,6 +996,19 @@ private fun normalizedFallbackAccents(
     entries
         .mapNotNull { (projectKey, hex) -> normalizedFallbackAccent(projectKey, hex, warn) }
         .toMap()
+
+private fun normalizedLanguageFallbackAccent(
+    hex: String?,
+    warn: (String) -> Unit = {},
+): String? =
+    hex
+        ?.takeIf { it.isNotBlank() }
+        ?.let { rawHex ->
+            AccentHex.of(rawHex)?.value ?: run {
+                warn("Dropping malformed language fallback override accent")
+                null
+            }
+        }
 
 private fun normalizedFallbackAccent(
     projectKey: String,

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectLanguageResolutionPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectLanguageResolutionPanel.kt
@@ -1,5 +1,6 @@
 package dev.ayuislands.settings.mappings
 
+import com.intellij.ui.components.ActionLink
 import com.intellij.ui.components.JBLabel
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
@@ -7,20 +8,21 @@ import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.LanguageDetectionRules
 import dev.ayuislands.accent.ProjectLanguageVerdict
 import org.jetbrains.annotations.TestOnly
+import java.awt.Component
+import java.awt.Container
 import java.awt.Cursor
 import java.awt.FlowLayout
-import java.awt.event.MouseAdapter
-import java.awt.event.MouseEvent
+import javax.swing.BoxLayout
 import javax.swing.Icon
 import javax.swing.JPanel
 import javax.swing.SwingConstants
 
 /**
- * Focused diagnostics row for project-language accent resolution.
+ * Focused diagnostics strip for project-language accent resolution.
  *
  * The panel is deliberately state-only: [OverridesGroupBuilder] owns project
  * lookup, pending override maps, license gates, and detector reads. This class
- * formats that snapshot into one summary label plus optional action labels.
+ * formats that snapshot into compact source, scan, and action rows.
  */
 internal class ProjectLanguageResolutionPanel(
     private val currentAccentHex: () -> String?,
@@ -30,7 +32,8 @@ internal class ProjectLanguageResolutionPanel(
     private val onClearFallback: () -> Unit,
     private val onRescan: () -> Unit,
     private val canRescanNow: () -> Boolean,
-) : JPanel(FlowLayout(FlowLayout.LEFT, JBUI.scale(ENTRY_GAP_PX), 0)) {
+    private val languageIconForId: (String) -> Icon? = LanguageDetectionRules::iconForLanguageId,
+) : JPanel() {
     private var state: State =
         State(
             verdict = ProjectLanguageVerdict.Unavailable,
@@ -42,6 +45,7 @@ internal class ProjectLanguageResolutionPanel(
         )
 
     init {
+        layout = BoxLayout(this, BoxLayout.Y_AXIS)
         isOpaque = false
         border = null
     }
@@ -49,35 +53,64 @@ internal class ProjectLanguageResolutionPanel(
     fun refresh(nextState: State) {
         state = nextState
         removeAll()
-        val icon = iconForState(nextState)
+
         add(
-            JBLabel(safeLabelText(summaryFor(nextState)), icon, SwingConstants.LEADING).apply {
-                foreground = UIUtil.getContextHelpForeground()
-            },
+            buildTextRow(
+                prefix = SOURCE_PREFIX,
+                value = sourceText(nextState),
+                icon = null,
+            ),
         )
-        actionSpecsFor(nextState).forEach { action ->
-            add(buildActionLabel(action))
+        add(
+            buildTextRow(
+                prefix = SCAN_PREFIX,
+                value = scanStatusText(nextState),
+                icon = iconForState(nextState),
+            ),
+        )
+        scanDetailText(nextState)?.let { detail ->
+            val weights =
+                when (val verdict = nextState.verdict) {
+                    is ProjectLanguageVerdict.Detected ->
+                        verdict.weights?.takeIf { LanguageDetectionRules.pickDisplayEntries(it).size > 1 }
+                    is ProjectLanguageVerdict.NoWinner -> verdict.weights
+                    ProjectLanguageVerdict.Cold,
+                    ProjectLanguageVerdict.Empty,
+                    ProjectLanguageVerdict.Unavailable,
+                    -> null
+                }
+            add(buildDetailRow(detail, weights))
         }
+        val actions = actionSpecsFor(nextState)
+        if (actions.isNotEmpty()) {
+            add(buildActionsRow(actions))
+        }
+
         revalidate()
         repaint()
     }
 
     private fun iconForState(state: State): Icon? {
-        state.forcedLanguageId?.let { return LanguageDetectionRules.iconForLanguageId(it) }
+        state.forcedLanguageId?.let { return languageIconForId(it) }
         return when (val verdict = state.verdict) {
-            is ProjectLanguageVerdict.Detected -> LanguageDetectionRules.iconForLanguageId(verdict.languageId)
+            is ProjectLanguageVerdict.Detected -> languageIconForId(verdict.languageId)
             else -> null
         }
     }
 
     @TestOnly
-    internal fun currentSummaryForTest(): String = summaryFor(state)
+    internal fun currentSummaryForTest(): String = summaryLinesFor(state).joinToString("\n")
 
     @TestOnly
     internal fun labelsForTest(): List<Triple<Icon?, String, String?>> =
-        components.filterIsInstance<JBLabel>().map { label ->
-            Triple(label.icon, label.text, label.toolTipText)
-        }
+        descendants()
+            .mapNotNull { component ->
+                when (component) {
+                    is JBLabel -> Triple(component.icon, component.text, component.toolTipText)
+                    is ActionLink -> Triple(null, component.text, component.toolTipText)
+                    else -> null
+                }
+            }.toList()
 
     @TestOnly
     internal fun triggerActionForTest(text: String) {
@@ -87,21 +120,39 @@ internal class ProjectLanguageResolutionPanel(
         action.onClick()
     }
 
-    private fun summaryFor(state: State): String {
-        val source = sourceText(state)
+    private fun summaryLinesFor(state: State): List<String> =
+        buildList {
+            add("$SOURCE_PREFIX: ${sourceText(state)}")
+            add("$SCAN_PREFIX: ${scanStatusText(state)}")
+            scanDetailText(state)?.let(::add)
+        }
+
+    private fun scanStatusText(state: State): String {
         state.forcedLanguageId?.let { languageId ->
-            return "Forced language: ${displayName(languageId)} - using $source"
+            return "Forced ${displayName(languageId)}"
         }
         return when (val verdict = state.verdict) {
-            is ProjectLanguageVerdict.Detected ->
-                "Detected: ${detectedText(verdict)} - using $source"
-            is ProjectLanguageVerdict.NoWinner ->
-                "No dominant language: ${proportionsText(verdict.weights)} - using $source"
-            ProjectLanguageVerdict.Cold -> "Detection pending - using $source"
-            ProjectLanguageVerdict.Empty -> "No project languages detected - using $source"
-            ProjectLanguageVerdict.Unavailable -> "Project language detection unavailable - using $source"
+            is ProjectLanguageVerdict.Detected -> {
+                val hasBreakdown =
+                    verdict.weights?.let { LanguageDetectionRules.pickDisplayEntries(it).size > 1 } == true
+                if (hasBreakdown) "Dominant ${displayName(verdict.languageId)}" else detectedText(verdict)
+            }
+            is ProjectLanguageVerdict.NoWinner -> "No dominant language"
+            ProjectLanguageVerdict.Cold -> "Detection pending"
+            ProjectLanguageVerdict.Empty -> "No project languages detected"
+            ProjectLanguageVerdict.Unavailable -> "Project language detection unavailable"
         }
     }
+
+    private fun scanDetailText(state: State): String? =
+        when (val verdict = state.verdict) {
+            is ProjectLanguageVerdict.Detected ->
+                verdict.weights
+                    ?.takeIf { LanguageDetectionRules.pickDisplayEntries(it).size > 1 }
+                    ?.let(::proportionsText)
+            is ProjectLanguageVerdict.NoWinner -> proportionsText(verdict.weights)
+            else -> null
+        }
 
     private fun detectedText(verdict: ProjectLanguageVerdict.Detected): String {
         val percent =
@@ -193,6 +244,7 @@ internal class ProjectLanguageResolutionPanel(
             specs +=
                 ActionSpec(
                     text = SET_FALLBACK_LABEL,
+                    tooltip = SET_FALLBACK_TOOLTIP,
                     onClick = {
                         currentAccentHex()?.let(onSetFallback)
                     },
@@ -207,6 +259,7 @@ internal class ProjectLanguageResolutionPanel(
     private fun forceLanguageSpec(languageId: String): ActionSpec =
         ActionSpec(
             text = "Force ${displayName(languageId)}",
+            tooltip = "Treat this project as ${displayName(languageId)} for language accent resolution.",
             onClick = {
                 onSetForcedLanguage(languageId)
             },
@@ -226,18 +279,77 @@ internal class ProjectLanguageResolutionPanel(
         return topId.takeUnless { hasTopTie }
     }
 
-    private fun buildActionLabel(action: ActionSpec): JBLabel =
-        JBLabel(safeLabelText(action.text), null, SwingConstants.LEADING).apply {
-            toolTipText = action.tooltip?.let(::safeLabelText)
-            foreground = UIUtil.getContextHelpForeground()
-            cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
-            addMouseListener(
-                object : MouseAdapter() {
-                    override fun mouseClicked(event: MouseEvent) {
-                        action.onClick()
-                    }
+    private fun buildTextRow(
+        prefix: String,
+        value: String,
+        icon: Icon?,
+    ): JPanel =
+        buildRow().apply {
+            add(
+                JBLabel(safeLabelText("$prefix:")).apply {
+                    foreground = UIUtil.getContextHelpForeground()
                 },
             )
+            add(
+                JBLabel(safeLabelText(value), icon, SwingConstants.LEADING).apply {
+                    foreground = UIUtil.getLabelForeground()
+                },
+            )
+        }
+
+    private fun buildDetailRow(
+        detail: String,
+        weights: Map<String, Long>?,
+    ): JPanel =
+        buildRow().apply {
+            val entries = weights?.let(LanguageDetectionRules::pickDisplayEntries).orEmpty()
+            if (entries.isEmpty()) {
+                add(
+                    JBLabel(safeLabelText(detail), null, SwingConstants.LEADING).apply {
+                        foreground = UIUtil.getContextHelpForeground()
+                    },
+                )
+            } else {
+                entries.forEachIndexed { index, entry ->
+                    if (index > 0) {
+                        add(
+                            JBLabel(ENTRY_SEPARATOR.trim()).apply {
+                                foreground = UIUtil.getContextHelpForeground()
+                            },
+                        )
+                    }
+                    add(
+                        JBLabel(
+                            safeLabelText("${entry.label} ${entry.percent}%"),
+                            entry.id?.let(languageIconForId),
+                            SwingConstants.LEADING,
+                        ).apply {
+                            foreground = UIUtil.getContextHelpForeground()
+                        },
+                    )
+                }
+            }
+        }
+
+    private fun buildActionsRow(actions: List<ActionSpec>): JPanel =
+        buildRow().apply {
+            actions.forEach { action ->
+                add(
+                    ActionLink(safeLabelText(action.text)) {
+                        action.onClick()
+                    }.apply {
+                        toolTipText = action.tooltip?.let(::safeLabelText)
+                        cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+                    },
+                )
+            }
+        }
+
+    private fun buildRow(): JPanel =
+        JPanel(FlowLayout(FlowLayout.LEFT, JBUI.scale(ENTRY_GAP_PX), 0)).apply {
+            alignmentX = LEFT_ALIGNMENT
+            border = JBUI.Borders.emptyBottom(ROW_GAP_PX)
+            isOpaque = false
         }
 
     private fun displayName(languageId: String): String = LanguageDetectionRules.displayNameForLanguageId(languageId)
@@ -259,14 +371,19 @@ internal class ProjectLanguageResolutionPanel(
     )
 
     companion object {
-        const val SET_FALLBACK_LABEL: String = "Set fallback to current accent"
+        const val SET_FALLBACK_LABEL: String = "Use current accent as fallback"
         const val CLEAR_FORCED_LANGUAGE_LABEL: String = "Clear forced language"
         const val CLEAR_FALLBACK_LABEL: String = "Clear fallback"
         const val RESCAN_LABEL: String = "Rescan"
         const val RESCAN_TOOLTIP: String = "Re-detect the dominant language of this project"
 
-        private const val ENTRY_GAP_PX: Int = 12
-        private const val ENTRY_SEPARATOR: String = " - "
+        private const val SOURCE_PREFIX: String = "Accent source"
+        private const val SCAN_PREFIX: String = "Language scan"
+        private const val SET_FALLBACK_TOOLTIP: String =
+            "Use the current accent when this project has no dominant language."
+        private const val ENTRY_GAP_PX: Int = 8
+        private const val ENTRY_SEPARATOR: String = " · "
+        private const val ROW_GAP_PX: Int = 2
     }
 }
 
@@ -275,3 +392,13 @@ private fun safeLabelText(text: String): String =
         .replace("&", "&amp;")
         .replace("<", "&lt;")
         .replace(">", "&gt;")
+
+private fun Component.descendants(): Sequence<Component> =
+    sequence {
+        yield(this@descendants)
+        if (this@descendants is Container) {
+            this@descendants.components.forEach { child ->
+                yieldAll(child.descendants())
+            }
+        }
+    }

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
@@ -4,6 +4,7 @@ import com.intellij.testFramework.LoggedErrorProcessor
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
+import dev.ayuislands.settings.mappings.AccentMappingsState
 import dev.ayuislands.vcs.VcsColorApplier
 import io.mockk.every
 import io.mockk.mockk
@@ -14,6 +15,7 @@ import java.util.EnumSet
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -89,6 +91,38 @@ class AyuIslandsStartupActivityTest {
 
         assertEquals(1, captured.size)
         assertEquals("License startup step 'step-link' failed with Error", captured.single().first)
+    }
+
+    @Test
+    fun `startup language detector warmup includes exact language overrides`() {
+        val state = AccentMappingsState()
+        state.languageAccents["kotlin"] = "#73D0FF"
+
+        assertTrue(
+            activity.shouldWarmLanguageDetectorForTest(state),
+            "Language pins should warm the detector so first Settings open shows proportions immediately",
+        )
+    }
+
+    @Test
+    fun `startup language detector warmup includes fallback-only language resolution`() {
+        val state = AccentMappingsState()
+        state.languageFallbackAccent = "#73D0FF"
+
+        assertTrue(
+            activity.shouldWarmLanguageDetectorForTest(state),
+            "A fallback-only language policy still needs a detected language before it can apply",
+        )
+    }
+
+    @Test
+    fun `startup language detector warmup stays off without language resolution work`() {
+        val state = AccentMappingsState()
+
+        assertFalse(
+            activity.shouldWarmLanguageDetectorForTest(state),
+            "Projects without language pins or fallback should not pay the startup scan cost",
+        )
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.wm.WindowManager
 import com.intellij.testFramework.LoggedErrorProcessor
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 import io.mockk.every
+import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
@@ -53,7 +54,7 @@ class AccentApplicatorFocusedProjectTest {
         mockkObject(AccentResolver)
         mockkObject(AccentApplicator, recordPrivateCalls = false)
         every { AccentApplicator.applyFromHexString(any()) } returns true
-        every { AccentApplicator.apply(any()) } answers { Unit }
+        justRun { AccentApplicator.apply(any()) }
 
         mockkObject(ProjectAccentSwapService.Companion)
         swapService = mockk(relaxed = true)

--- a/src/test/kotlin/dev/ayuislands/accent/AccentResolverExternalTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentResolverExternalTest.kt
@@ -53,6 +53,24 @@ class AccentResolverExternalTest {
     }
 
     @Test
+    fun `external resolve prefers language fallback over material accent`() {
+        withResolverStubs {
+            mappingsState.languageFallbackAccent = "#73D0FF"
+            state.externalThemeAccent = "#445566"
+            val project = stubProject(File(System.getProperty("java.io.tmpdir"), "external-language-fallback"))
+            every { ProjectLanguageDetector.dominant(project) } returns "terraform"
+
+            withUiColorProvider({ key -> if (key == "material.accent") Color(0xAA, 0xBB, 0xCC) else null }) {
+                assertEquals("#73D0FF", AccentResolver.resolve(project, AccentContext.External))
+                assertEquals(
+                    AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE,
+                    AccentResolver.source(project, AccentContext.External),
+                )
+            }
+        }
+    }
+
+    @Test
     fun `external automatic source uses forced language override before material accent`() {
         withResolverStubs {
             val projectPath = File(System.getProperty("java.io.tmpdir"), "external-forced-language").canonicalPath

--- a/src/test/kotlin/dev/ayuislands/accent/AccentResolverExternalTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentResolverExternalTest.kt
@@ -71,6 +71,24 @@ class AccentResolverExternalTest {
     }
 
     @Test
+    fun `external resolve skips invalid language fallback before material accent`() {
+        withResolverStubs {
+            mappingsState.languageFallbackAccent = "not-a-hex"
+            state.externalThemeAccent = "#445566"
+            val project = stubProject(File(System.getProperty("java.io.tmpdir"), "external-invalid-language-fallback"))
+            every { ProjectLanguageDetector.dominant(project) } returns "terraform"
+
+            withUiColorProvider({ key -> if (key == "material.accent") Color(0xAA, 0xBB, 0xCC) else null }) {
+                assertEquals("#AABBCC", AccentResolver.resolve(project, AccentContext.External))
+                assertEquals(
+                    AccentResolver.Source.MATERIAL_THEME,
+                    AccentResolver.source(project, AccentContext.External),
+                )
+            }
+        }
+    }
+
+    @Test
     fun `external automatic source uses forced language override before material accent`() {
         withResolverStubs {
             val projectPath = File(System.getProperty("java.io.tmpdir"), "external-forced-language").canonicalPath

--- a/src/test/kotlin/dev/ayuislands/accent/AccentResolverSourceLabelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentResolverSourceLabelTest.kt
@@ -38,6 +38,14 @@ class AccentResolverSourceLabelTest {
     }
 
     @Test
+    fun `sourceLabel for LANGUAGE_FALLBACK_OVERRIDE returns Language fallback override`() {
+        assertEquals(
+            "Language fallback override",
+            AccentResolver.sourceLabel(AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE),
+        )
+    }
+
+    @Test
     fun `sourceLabel for PROJECT_FALLBACK returns Project fallback`() {
         assertEquals(
             "Project fallback",
@@ -78,7 +86,7 @@ class AccentResolverSourceLabelTest {
     }
 
     @Test
-    fun `Source enum size lock - eight values exactly`() {
+    fun `Source enum size lock - nine values exactly`() {
         // Pattern L regression lock. If you add a new Source value (e.g.
         // REMOTE for remote-environment awareness), this test fails on
         // purpose so you are forced to extend [AccentResolver.sourceLabel]
@@ -86,7 +94,7 @@ class AccentResolverSourceLabelTest {
         // branch would land at runtime as "Global" via a future `else ->`
         // fallback, silently mislabelling every remote-resolved accent.
         assertEquals(
-            8,
+            9,
             AccentResolver.Source.entries.size,
             "AccentResolver.Source enum grew - extend AccentResolver.sourceLabel in the same change",
         )

--- a/src/test/kotlin/dev/ayuislands/accent/AccentResolverTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentResolverTest.kt
@@ -169,6 +169,18 @@ class AccentResolverTest {
     }
 
     @Test
+    fun `invalid language fallback does not override native global accent`() {
+        val tmp = File(System.getProperty("java.io.tmpdir"), "invalid-language-fallback").canonicalPath
+        mappingsState.languageFallbackAccent = "not-a-hex"
+
+        val project = stubProject(File(tmp))
+        every { ProjectLanguageDetector.dominant(project) } returns "typescript"
+
+        assertEquals(globalMirageAccent, AccentResolver.resolve(project, AyuVariant.MIRAGE))
+        assertEquals(AccentResolver.Source.GLOBAL, AccentResolver.source(project))
+    }
+
+    @Test
     fun `project fallback applies only for definitive no-winner verdict`() {
         val tmp = File(System.getProperty("java.io.tmpdir"), "fallback-no-winner").canonicalPath
         mappingsState.projectFallbackAccents[tmp] = "#5CCFE6"

--- a/src/test/kotlin/dev/ayuislands/accent/AccentResolverTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentResolverTest.kt
@@ -92,6 +92,28 @@ class AccentResolverTest {
     }
 
     @Test
+    fun `resolve uses language fallback override when detected language is unmapped`() {
+        mappingsState.languageAccents["kotlin"] = "#ABCDEF"
+        mappingsState.languageFallbackAccent = "#73D0FF"
+        val project = stubProject(File(System.getProperty("java.io.tmpdir"), "typescript-fallback"))
+        every { ProjectLanguageDetector.dominant(project) } returns "typescript"
+
+        assertEquals("#73D0FF", AccentResolver.resolve(project, AyuVariant.MIRAGE))
+        assertEquals(AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE, AccentResolver.source(project))
+    }
+
+    @Test
+    fun `resolve keeps exact language override ahead of language fallback`() {
+        mappingsState.languageAccents["kotlin"] = "#ABCDEF"
+        mappingsState.languageFallbackAccent = "#73D0FF"
+        val project = stubProject(File(System.getProperty("java.io.tmpdir"), "kotlin-exact-fallback"))
+        every { ProjectLanguageDetector.dominant(project) } returns "kotlin"
+
+        assertEquals("#ABCDEF", AccentResolver.resolve(project, AyuVariant.MIRAGE))
+        assertEquals(AccentResolver.Source.LANGUAGE_OVERRIDE, AccentResolver.source(project))
+    }
+
+    @Test
     fun `resolve prefers project override over language override`() {
         val tmp = File(System.getProperty("java.io.tmpdir"), "both-overrides").canonicalPath
         mappingsState.projectAccents[tmp] = "#111111"
@@ -130,6 +152,20 @@ class AccentResolverTest {
         assertEquals(AccentResolver.Source.GLOBAL, AccentResolver.source(project))
         io.mockk.verify(exactly = 0) { ProjectLanguageDetector.dominant(any()) }
         io.mockk.verify(exactly = 0) { ProjectLanguageDetector.verdict(any()) }
+    }
+
+    @Test
+    fun `forced language uses fallback when exact language accent is not mapped`() {
+        val tmp = File(System.getProperty("java.io.tmpdir"), "forced-fallback").canonicalPath
+        mappingsState.forcedProjectLanguages[tmp] = "typescript"
+        mappingsState.languageFallbackAccent = "#73D0FF"
+
+        val project = stubProject(File(tmp))
+        every { ProjectLanguageDetector.dominant(project) } returns "javascript"
+
+        assertEquals("#73D0FF", AccentResolver.resolve(project, AyuVariant.MIRAGE))
+        assertEquals(AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE, AccentResolver.source(project))
+        io.mockk.verify(exactly = 0) { ProjectLanguageDetector.dominant(any()) }
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/accent/LanguageDetectionRulesTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/LanguageDetectionRulesTest.kt
@@ -371,6 +371,39 @@ class LanguageDetectionRulesTest {
         assertEquals(0.20, LanguageDetectionRules.TIE_BREAK_MIN_SHARE, 0.0001)
     }
 
+    @Test
+    fun `resolution policy overload drives dominance thresholds`() {
+        val policy =
+            LanguageDetectionRules.ResolutionPolicy(
+                dominanceThreshold = 0.80,
+                dominanceMarginRatio = 3.0,
+                dominanceFloor = 0.40,
+            )
+
+        assertNull(
+            LanguageDetectionRules.pickDominantFromAllWeights(
+                mapOf("kotlin" to 700L, "java" to 300L),
+                policy,
+            ),
+        )
+    }
+
+    @Test
+    fun `resolution policy normalizes malformed stored values to safe bounds`() {
+        val policy =
+            LanguageDetectionRules.ResolutionPolicy.fromStored(
+                dominanceThreshold = Double.NaN,
+                dominanceMarginRatio = 0.5,
+                dominanceFloor = 2.0,
+                tiebreakMinShare = -1.0,
+            )
+
+        assertEquals(LanguageDetectionRules.DEFAULT_DOMINANCE_THRESHOLD, policy.dominanceThreshold, 0.0001)
+        assertEquals(LanguageDetectionRules.DOMINANCE_MARGIN_RATIO, policy.dominanceMarginRatio, 0.0001)
+        assertEquals(1.0, policy.dominanceFloor, 0.0001)
+        assertEquals(0.0, policy.tiebreakMinShare, 0.0001)
+    }
+
     // ── Deterministic tie-break (alphabetical) ───────────────────────────────────────
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/accent/LanguageDetectionRulesTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/LanguageDetectionRulesTest.kt
@@ -404,6 +404,22 @@ class LanguageDetectionRulesTest {
         assertEquals(0.0, policy.tiebreakMinShare, 0.0001)
     }
 
+    @Test
+    fun `resolution policy normalizes infinite stored values to defaults`() {
+        val policy =
+            LanguageDetectionRules.ResolutionPolicy.fromStored(
+                dominanceThreshold = Double.POSITIVE_INFINITY,
+                dominanceMarginRatio = Double.NEGATIVE_INFINITY,
+                dominanceFloor = Double.NEGATIVE_INFINITY,
+                tiebreakMinShare = Double.POSITIVE_INFINITY,
+            )
+
+        assertEquals(LanguageDetectionRules.DEFAULT_DOMINANCE_THRESHOLD, policy.dominanceThreshold, 0.0001)
+        assertEquals(LanguageDetectionRules.DOMINANCE_MARGIN_RATIO, policy.dominanceMarginRatio, 0.0001)
+        assertEquals(LanguageDetectionRules.DOMINANCE_FLOOR, policy.dominanceFloor, 0.0001)
+        assertEquals(LanguageDetectionRules.TIE_BREAK_MIN_SHARE, policy.tiebreakMinShare, 0.0001)
+    }
+
     // ── Deterministic tie-break (alphabetical) ───────────────────────────────────────
 
     @Test
@@ -836,6 +852,25 @@ class LanguageDetectionRulesTest {
         assertEquals(listOf("kotlin", "java", "scala", null), entries.map { it.id })
         assertEquals(listOf(78, 15, 4, 3), entries.map { it.percent })
         // The "other" bucket carries the literal label — NOT a language display name.
+        assertEquals("other", entries.last().label)
+    }
+
+    @Test
+    fun `pickDisplayEntries keeps a large trailing other bucket visible`() {
+        // A real mixed repo should not look like "Terraform 40%" with the rest
+        // silently missing; the remainder stays visible as an explicit bucket.
+        val entries =
+            LanguageDetectionRules.pickDisplayEntries(
+                mapOf(
+                    "terraform" to 400L,
+                    "go" to 200L,
+                    "python" to 200L,
+                    "ruby" to 200L,
+                ),
+            )
+
+        assertEquals(listOf("terraform", "go", "python", null), entries.map { it.id })
+        assertEquals(listOf(40, 20, 20, 20), entries.map { it.percent })
         assertEquals("other", entries.last().label)
     }
 

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageCacheInvalidatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageCacheInvalidatorTest.kt
@@ -5,6 +5,8 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.projectRoots.SdkTypeId
 import com.intellij.openapi.roots.ProjectRootManager
+import dev.ayuislands.settings.mappings.AccentMappingsSettings
+import dev.ayuislands.settings.mappings.AccentMappingsState
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -30,6 +32,10 @@ class ProjectLanguageCacheInvalidatorTest {
         mockkStatic(ModuleManager::class)
         mockkObject(ProjectLanguageScanner)
         every { ProjectLanguageScanner.scan(any()) } returns emptyMap()
+        val mappingsSettings = mockk<AccentMappingsSettings>()
+        every { mappingsSettings.state } returns AccentMappingsState()
+        mockkObject(AccentMappingsSettings.Companion)
+        every { AccentMappingsSettings.getInstance() } returns mappingsSettings
         ProjectLanguageDetector.clear()
     }
 

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
@@ -6,7 +6,10 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.projectRoots.SdkTypeId
 import com.intellij.openapi.roots.ProjectRootManager
+import dev.ayuislands.settings.mappings.AccentMappingsSettings
+import dev.ayuislands.settings.mappings.AccentMappingsState
 import io.mockk.every
+import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
@@ -39,6 +42,10 @@ class ProjectLanguageDetectorTest {
         // fallback is what they're really asserting against.
         mockkObject(ProjectLanguageScanner)
         every { ProjectLanguageScanner.scan(any()) } returns emptyMap()
+        val mappingsSettings = mockk<AccentMappingsSettings>()
+        every { mappingsSettings.state } returns AccentMappingsState()
+        mockkObject(AccentMappingsSettings.Companion)
+        every { AccentMappingsSettings.getInstance() } returns mappingsSettings
         ProjectLanguageDetector.clear()
     }
 
@@ -302,6 +309,26 @@ class ProjectLanguageDetectorTest {
         assertEquals("kotlin", ProjectLanguageDetector.dominant(project))
         // Legacy detection must NOT have been consulted — scan was decisive.
         verify(exactly = 0) { ProjectRootManager.getInstance(project) }
+    }
+
+    @Test
+    fun `content scan honors stored dominance policy`() {
+        val policyState =
+            AccentMappingsState().apply {
+                dominanceThreshold = 0.80f
+                dominanceMarginRatio = 3.0f
+                dominanceFloor = 0.40f
+            }
+        val mappingsSettings = AccentMappingsSettings.getInstance()
+        every { mappingsSettings.state } returns policyState
+
+        val project = stubProject("/tmp/scan-policy-${System.nanoTime()}")
+        every { ProjectLanguageScanner.scan(project) } returns
+            mapOf("kotlin" to 700L, "java" to 300L)
+        wireProjectRootManager(project, sdkName = null)
+        wireModuleManager(project, moduleNames = emptyList())
+
+        assertNull(ProjectLanguageDetector.dominant(project))
     }
 
     @Test
@@ -721,7 +748,7 @@ class ProjectLanguageDetectorTest {
         mockkObject(AccentResolver)
         every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#FFCC66"
         mockkObject(AccentApplicator)
-        every { AccentApplicator.apply(any()) } answers { Unit }
+        justRun { AccentApplicator.apply(any()) }
         val swapService = mockk<dev.ayuislands.settings.mappings.ProjectAccentSwapService>(relaxed = true)
         mockkObject(dev.ayuislands.settings.mappings.ProjectAccentSwapService.Companion)
         every {
@@ -748,7 +775,7 @@ class ProjectLanguageDetectorTest {
         mockkObject(AccentResolver)
         every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#FFCC66"
         mockkObject(AccentApplicator)
-        every { AccentApplicator.apply(any()) } answers { Unit }
+        justRun { AccentApplicator.apply(any()) }
         val swapService = mockk<dev.ayuislands.settings.mappings.ProjectAccentSwapService>(relaxed = true)
         mockkObject(dev.ayuislands.settings.mappings.ProjectAccentSwapService.Companion)
         every {
@@ -797,7 +824,7 @@ class ProjectLanguageDetectorTest {
         every { AccentResolver.resolve(any(), any<AyuVariant>()) } throws RuntimeException("resolver boom")
 
         mockkObject(AccentApplicator)
-        every { AccentApplicator.apply(any()) } answers { Unit }
+        justRun { AccentApplicator.apply(any()) }
 
         val project = stubProject("/tmp/refresh-settings-boom-${System.nanoTime()}")
         every { AccentApplicator.resolveFocusedProject() } returns project
@@ -819,7 +846,7 @@ class ProjectLanguageDetectorTest {
         every { AyuVariant.detect() } returns null
 
         mockkObject(AccentApplicator)
-        every { AccentApplicator.apply(any()) } answers { Unit }
+        justRun { AccentApplicator.apply(any()) }
 
         val project = stubProject("/tmp/refresh-null-variant-${System.nanoTime()}")
         every { AccentApplicator.resolveFocusedProject() } returns project
@@ -837,7 +864,7 @@ class ProjectLanguageDetectorTest {
         val focusedProject = stubProject("/tmp/refresh-new-focus-${System.nanoTime()}")
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns focusedProject
-        every { AccentApplicator.apply(any()) } answers { Unit }
+        justRun { AccentApplicator.apply(any()) }
 
         ProjectLanguageDetector.refreshAccentOnEdt(scannedProject)
 
@@ -851,7 +878,7 @@ class ProjectLanguageDetectorTest {
         // keeps the applicator from writing UIManager entries for a dead
         // project's swap-cache.
         mockkObject(AccentApplicator)
-        every { AccentApplicator.apply(any()) } answers { Unit }
+        justRun { AccentApplicator.apply(any()) }
 
         val project = stubProject("/tmp/refresh-disposed-${System.nanoTime()}")
         every { project.isDisposed } returns true
@@ -982,7 +1009,7 @@ class ProjectLanguageDetectorTest {
         every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returns "#FFCC66"
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns project
-        every { AccentApplicator.apply(any()) } answers { Unit }
+        justRun { AccentApplicator.apply(any()) }
 
         ProjectLanguageDetector.rescan(project)
 
@@ -1036,7 +1063,7 @@ class ProjectLanguageDetectorTest {
         every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returns "#FFCC66"
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns project
-        every { AccentApplicator.apply(any()) } answers { Unit }
+        justRun { AccentApplicator.apply(any()) }
         val swapService = mockk<dev.ayuislands.settings.mappings.ProjectAccentSwapService>(relaxed = true)
         mockkObject(dev.ayuislands.settings.mappings.ProjectAccentSwapService.Companion)
         every {

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
@@ -332,6 +332,42 @@ class ProjectLanguageDetectorTest {
     }
 
     @Test
+    fun `content scan honors stored tiebreak floor`() {
+        val policyState =
+            AccentMappingsState().apply {
+                tiebreakMinShare = 0.60f
+            }
+        val mappingsSettings = AccentMappingsSettings.getInstance()
+        every { mappingsSettings.state } returns policyState
+
+        val project = stubProject("/tmp/scan-tiebreak-floor-${System.nanoTime()}")
+        every { ProjectLanguageScanner.scan(project) } returns
+            mapOf("kotlin" to 500L, "java" to 500L)
+        wireProjectRootManager(project, sdkName = "KotlinSdkType")
+        wireModuleManager(project, moduleNames = emptyList())
+
+        assertNull(ProjectLanguageDetector.dominant(project))
+    }
+
+    @Test
+    fun `content scan ignores absent SDK hint even when stored tiebreak floor is zero`() {
+        val policyState =
+            AccentMappingsState().apply {
+                tiebreakMinShare = 0.0f
+            }
+        val mappingsSettings = AccentMappingsSettings.getInstance()
+        every { mappingsSettings.state } returns policyState
+
+        val project = stubProject("/tmp/scan-zero-floor-absent-hint-${System.nanoTime()}")
+        every { ProjectLanguageScanner.scan(project) } returns
+            mapOf("java" to 500L, "python" to 500L)
+        wireProjectRootManager(project, sdkName = "KotlinSdkType")
+        wireModuleManager(project, moduleNames = emptyList())
+
+        assertNull(ProjectLanguageDetector.dominant(project))
+    }
+
+    @Test
     fun `content scan polyglot uses SDK tiebreak when hint has code-weight foothold`() {
         // 50/50 Kotlin/Java: scan alone produces no winner. The SDK tiebreak kicks
         // in — "KotlinSdkType" resolves to "kotlin", which has a 50% share of the

--- a/src/test/kotlin/dev/ayuislands/licensing/TrialLifecycleIntegrationTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/TrialLifecycleIntegrationTest.kt
@@ -16,6 +16,7 @@ import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
 import io.mockk.every
 import io.mockk.just
+import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
@@ -45,7 +46,7 @@ import kotlin.test.assertTrue
  *
  * Real [LicenseChecker.getTrialDaysRemaining] anchors in `LocalDate.now(UTC)`, so
  * seeding expiration = `dateFromNow(daysRemaining)` yields exactly `daysRemaining`
- * — see the matching helper in [LicenseCheckerTrialExpiryTest.kt].
+ * see the matching helper in [LicenseCheckerTrialExpiryTest].
  *
  * Grace-window transitions (Day 31 + 49 h) switch to mocking `System.currentTimeMillis`
  * directly since that path does not hit the facade.
@@ -94,7 +95,7 @@ class TrialLifecycleIntegrationTest {
         System.clearProperty("ayu.islands.dev")
 
         mockkObject(AccentApplicator)
-        every { AccentApplicator.apply(any()) } answers { Unit }
+        justRun { AccentApplicator.apply(any()) }
 
         mockkObject(GlowOverlayManager.Companion)
         every { GlowOverlayManager.syncGlowForAllProjects() } just runs

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateSnapshotTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateSnapshotTest.kt
@@ -9,6 +9,7 @@ import dev.ayuislands.rotation.AccentRotationService
 import dev.ayuislands.testing.SnapshotAssert.assertMatchesSnapshot
 import io.mockk.every
 import io.mockk.just
+import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
@@ -25,7 +26,7 @@ class AyuIslandsStateSnapshotTest {
         mockkObject(AccentApplicator)
         mockkObject(GlowOverlayManager.Companion)
         mockkStatic(ApplicationManager::class)
-        every { AccentApplicator.apply(any()) } answers { Unit }
+        justRun { AccentApplicator.apply(any()) }
         every { GlowOverlayManager.syncGlowForAllProjects() } just runs
         val rotationService = mockk<AccentRotationService>(relaxed = true)
         val appMock = mockk<com.intellij.openapi.application.Application>(relaxed = true)

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/AccentMappingsStateTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/AccentMappingsStateTest.kt
@@ -1,5 +1,6 @@
 package dev.ayuislands.settings.mappings
 
+import dev.ayuislands.accent.LanguageDetectionRules
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -19,6 +20,8 @@ class AccentMappingsStateTest {
         assertTrue(state.projectDisplayNames.isEmpty())
         assertTrue(state.projectFallbackAccents.isEmpty())
         assertTrue(state.forcedProjectLanguages.isEmpty())
+        assertEquals(null, state.languageFallbackAccent)
+        assertEquals(LanguageDetectionRules.ResolutionPolicy.DEFAULT, state.languageResolutionPolicy())
     }
 
     @Test
@@ -29,11 +32,26 @@ class AccentMappingsStateTest {
         state.languageAccents["kotlin"] = "#222222"
         state.projectFallbackAccents["/tmp/a"] = "#333333"
         state.forcedProjectLanguages["/tmp/a"] = "typescript"
+        state.languageFallbackAccent = "#444444"
+        state.dominanceThreshold = 0.75f
+        state.dominanceMarginRatio = 2.0f
+        state.dominanceFloor = 0.55f
+        state.tiebreakMinShare = 0.35f
 
         assertEquals("#111111", state.projectAccents["/tmp/a"])
         assertEquals("Alpha", state.projectDisplayNames["/tmp/a"])
         assertEquals("#222222", state.languageAccents["kotlin"])
         assertEquals("#333333", state.projectFallbackAccents["/tmp/a"])
         assertEquals("typescript", state.forcedProjectLanguages["/tmp/a"])
+        assertEquals("#444444", state.languageFallbackAccent)
+        assertEquals(
+            LanguageDetectionRules.ResolutionPolicy(
+                dominanceThreshold = 0.75,
+                dominanceMarginRatio = 2.0,
+                dominanceFloor = 0.55,
+                tiebreakMinShare = 0.35,
+            ),
+            state.languageResolutionPolicy(),
+        )
     }
 }

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderApplyTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderApplyTest.kt
@@ -9,7 +9,7 @@ import dev.ayuislands.licensing.LicenseChecker
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
-import io.mockk.unmockkAll
+import io.mockk.unmockkObject
 import javax.swing.JTable
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -58,7 +58,13 @@ class OverridesGroupBuilderApplyTest {
 
     @AfterTest
     fun tearDown() {
-        unmockkAll()
+        unmockkObject(AccentMappingsSettings.Companion)
+        unmockkObject(ProjectLanguageDetector)
+        unmockkObject(AyuVariant.Companion)
+        unmockkObject(AccentResolver)
+        unmockkObject(AccentApplicator)
+        unmockkObject(ProjectAccentSwapService.Companion)
+        unmockkObject(LicenseChecker)
     }
 
     @Test
@@ -154,15 +160,18 @@ class OverridesGroupBuilderApplyTest {
             OverridesGroupBuilder().apply {
                 setPendingFallbackAccent("/tmp/apply-resolution-overrides", "#5CCFE6")
                 setPendingForcedLanguage("/tmp/apply-resolution-overrides", "TypeScript")
+                setPendingLanguageFallbackAccent(" #73D0FF ")
             }
 
         assertEquals(mapOf("/tmp/apply-resolution-overrides" to "typescript"), builder.forcedLanguagesForTest())
+        assertEquals("#73D0FF", builder.languageFallbackAccentForTest())
         assertTrue(builder.isModified(), "pending resolution overrides must participate in isModified")
 
         builder.apply()
 
         assertEquals(mapOf("/tmp/apply-resolution-overrides" to "#5CCFE6"), mappingsState.projectFallbackAccents)
         assertEquals(mapOf("/tmp/apply-resolution-overrides" to "typescript"), mappingsState.forcedProjectLanguages)
+        assertEquals("#73D0FF", mappingsState.languageFallbackAccent)
         assertFalse(builder.isModified(), "apply() must advance stored resolution override snapshots")
     }
 
@@ -170,12 +179,14 @@ class OverridesGroupBuilderApplyTest {
     fun `reset() restores fallback accents and forced languages from stored state`() {
         mappingsState.projectFallbackAccents["/tmp/reset-resolution-overrides"] = "#5CCFE6"
         mappingsState.forcedProjectLanguages["/tmp/reset-resolution-overrides"] = "typescript"
+        mappingsState.languageFallbackAccent = "#73D0FF"
         val builder = OverridesGroupBuilder().apply { loadFromState() }
 
         builder.setPendingFallbackAccent("/tmp/reset-resolution-overrides", "#FFB454")
         builder.setPendingFallbackAccent("/tmp/reset-cleared", "#D2A6FF")
         builder.setPendingForcedLanguage("/tmp/reset-resolution-overrides", "Kotlin")
         builder.setPendingForcedLanguage("/tmp/reset-cleared", " ")
+        builder.setPendingLanguageFallbackAccent("#FFB454")
 
         assertTrue(builder.isModified(), "pending resolution override edits must mark settings modified")
 
@@ -183,6 +194,7 @@ class OverridesGroupBuilderApplyTest {
 
         assertEquals(mapOf("/tmp/reset-resolution-overrides" to "#5CCFE6"), builder.fallbackAccentsForTest())
         assertEquals(mapOf("/tmp/reset-resolution-overrides" to "typescript"), builder.forcedLanguagesForTest())
+        assertEquals("#73D0FF", builder.languageFallbackAccentForTest())
         assertFalse(builder.isModified(), "reset() must restore stored resolution override snapshots")
     }
 
@@ -194,11 +206,13 @@ class OverridesGroupBuilderApplyTest {
         mappingsState.forcedProjectLanguages["/tmp/load-valid-forced"] = " TypeScript "
         mappingsState.forcedProjectLanguages["/tmp/load-blank-forced"] = " "
         mappingsState.forcedProjectLanguages[""] = "kotlin"
+        mappingsState.languageFallbackAccent = " #73D0FF "
 
         val builder = OverridesGroupBuilder().apply { loadFromState() }
 
         assertEquals(mapOf("/tmp/load-valid-fallback" to "#5CCFE6"), builder.fallbackAccentsForTest())
         assertEquals(mapOf("/tmp/load-valid-forced" to "typescript"), builder.forcedLanguagesForTest())
+        assertEquals("#73D0FF", builder.languageFallbackAccentForTest())
         assertFalse(builder.isModified(), "sanitized loaded resolution overrides become the stored snapshot")
     }
 
@@ -256,8 +270,8 @@ class OverridesGroupBuilderApplyTest {
         table(builder, "projectTable").selectionModel.setSelectionInterval(0, 0)
         table(builder, "languageTable").selectionModel.setSelectionInterval(0, 0)
 
-        val projectActions = actions(builder, "projectActions", licensed = false)
-        val languageActions = actions(builder, "languageActions", licensed = false)
+        val projectActions = unlicensedActions(builder, "projectActions")
+        val languageActions = unlicensedActions(builder, "languageActions")
 
         assertFalse(projectActions.removeEnabled(), "locked project preview rows must not enable Remove")
         assertFalse(languageActions.removeEnabled(), "locked language preview rows must not enable Remove")
@@ -319,17 +333,16 @@ class OverridesGroupBuilderApplyTest {
         return field.get(builder) as JTable
     }
 
-    private fun actions(
+    private fun unlicensedActions(
         builder: OverridesGroupBuilder,
         methodName: String,
-        licensed: Boolean,
     ): TableActionHandle {
         val tableActionsField = OverridesGroupBuilder::class.java.getDeclaredField("tableActions")
         tableActionsField.isAccessible = true
         val tableActions = tableActionsField.get(builder)
         val method = tableActions.javaClass.getDeclaredMethod(methodName, Boolean::class.javaPrimitiveType)
         method.isAccessible = true
-        return TableActionHandle(method.invoke(tableActions, licensed))
+        return TableActionHandle(method.invoke(tableActions, false))
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderPendingTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderPendingTest.kt
@@ -74,6 +74,34 @@ class OverridesGroupBuilderPendingTest {
     }
 
     @Test
+    fun `resolvePending uses language fallback when detected language is unmapped`() {
+        mappingsState.languageAccents["kotlin"] = "#112233"
+        mappingsState.languageFallbackAccent = "#73D0FF"
+        val project = stubProject(File(System.getProperty("java.io.tmpdir"), "pending-language-fallback"))
+        every { ProjectLanguageDetector.dominant(project) } returns "typescript"
+
+        val builder = OverridesGroupBuilder().apply { loadFromState() }
+
+        assertEquals("#73D0FF", builder.resolvePending(project, "#FFCC66"))
+        assertEquals(AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE, builder.sourcePending(project))
+    }
+
+    @Test
+    fun `cache-only pending preview uses language fallback for detected unmapped language`() {
+        mappingsState.languageFallbackAccent = "#73D0FF"
+        val project = stubProject(File(System.getProperty("java.io.tmpdir"), "pending-cache-language-fallback"))
+        every { ProjectLanguageDetector.verdict(project) } returns
+            ProjectLanguageVerdict.Detected("typescript", mapOf("typescript" to 1_000L))
+        every { ProjectLanguageDetector.dominant(project) } throws AssertionError("dominant must not be read")
+
+        val builder = OverridesGroupBuilder().apply { loadFromState() }
+
+        assertEquals("#73D0FF", builder.resolvePending(project, "#FFCC66", cacheOnly = true))
+        assertEquals(AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE, builder.sourcePending(project, cacheOnly = true))
+        io.mockk.verify(exactly = 0) { ProjectLanguageDetector.dominant(project) }
+    }
+
+    @Test
     fun `cache-only pending preview uses detected verdict without dominant warmup`() {
         mappingsState.languageAccents["kotlin"] = "#112233"
         val project = stubProject(File(System.getProperty("java.io.tmpdir"), "pending-cache-lang"))
@@ -212,6 +240,25 @@ class OverridesGroupBuilderPendingTest {
         assertEquals(AccentResolver.Source.GLOBAL, builder.sourcePending(project))
         io.mockk.verify(exactly = 0) { ProjectLanguageDetector.dominant(project) }
         io.mockk.verify(exactly = 0) { ProjectLanguageDetector.verdict(project) }
+    }
+
+    @Test
+    fun `resolvePending forced language uses fallback when exact language is unmapped`() {
+        val tmp = File(System.getProperty("java.io.tmpdir"), "pending-forced-language-fallback").canonicalPath
+        val project = stubProject(File(tmp))
+        every { ProjectLanguageDetector.dominant(project) } returns "javascript"
+
+        val builder =
+            OverridesGroupBuilder().apply {
+                seedResolutionOverridesForTest(
+                    forcedLanguages = mapOf(tmp to "typescript"),
+                    languageFallbackAccent = "#73D0FF",
+                )
+            }
+
+        assertEquals("#73D0FF", builder.resolvePending(project, "#FFCC66"))
+        assertEquals(AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE, builder.sourcePending(project))
+        io.mockk.verify(exactly = 0) { ProjectLanguageDetector.dominant(project) }
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderProportionsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderProportionsTest.kt
@@ -4,8 +4,9 @@ import com.intellij.openapi.Disposable
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.application.CoroutineSupport
 import com.intellij.openapi.project.Project
+import com.intellij.ui.components.ActionLink
+import com.intellij.ui.components.JBLabel
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.util.messages.MessageBus
 import com.intellij.util.messages.MessageBusConnection
@@ -23,9 +24,12 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
+import java.awt.Component
+import java.awt.Container
 import java.awt.Cursor
 import java.awt.event.MouseEvent
 import java.io.File
+import javax.swing.AbstractButton
 import javax.swing.JComponent
 import javax.swing.JPanel
 import kotlin.test.AfterTest
@@ -99,7 +103,37 @@ class OverridesGroupBuilderProportionsTest {
             }
 
         assertEquals(
-            "Detected: Kotlin 90% - using Language override",
+            "Accent source: Language override\nLanguage scan: Dominant Kotlin\nKotlin 90% · Java 10%",
+            builder.currentProportionsTextForTest(),
+        )
+        verify(exactly = 0) { ProjectLanguageDetector.proportions(any()) }
+    }
+
+    @Test
+    fun `currentProportionsTextForTest renders language fallback source for unmapped detected language`() {
+        val project = stubProject(tmpKey("resolution-language-fallback"))
+        every { ProjectLanguageDetector.verdict(project) } returns
+            ProjectLanguageVerdict.Detected(
+                languageId = "typescript",
+                weights = mapOf("typescript" to 900L, "javascript" to 100L),
+            )
+        every { ProjectLanguageDetector.dominant(project) } returns "typescript"
+
+        val builder =
+            OverridesGroupBuilder().apply {
+                setParentProjectForTest(project)
+                seedPendingForTest(
+                    languages = listOf(LanguageMapping("kotlin", "Kotlin", "#FFCC66")),
+                )
+                seedResolutionOverridesForTest(languageFallbackAccent = "#73D0FF")
+            }
+
+        assertEquals(
+            listOf(
+                "Accent source: Language fallback override",
+                "Language scan: Dominant TypeScript",
+                "TypeScript 90% · JavaScript 10%",
+            ).joinToString("\n"),
             builder.currentProportionsTextForTest(),
         )
         verify(exactly = 0) { ProjectLanguageDetector.proportions(any()) }
@@ -119,7 +153,11 @@ class OverridesGroupBuilderProportionsTest {
             }
 
         assertEquals(
-            "No dominant language: JavaScript 50% - TypeScript 50% - using Project fallback #5CCFE6",
+            listOf(
+                "Accent source: Project fallback #5CCFE6",
+                "Language scan: No dominant language",
+                "JavaScript 50% · TypeScript 50%",
+            ).joinToString("\n"),
             builder.currentProportionsTextForTest(),
         )
         verify(exactly = 0) { ProjectLanguageDetector.proportions(any()) }
@@ -135,12 +173,35 @@ class OverridesGroupBuilderProportionsTest {
 
         assertEquals(
             listOf(
-                "No dominant language: JavaScript 50% - TypeScript 50% - using Global",
+                "Accent source:",
+                "Global",
+                "Language scan:",
+                "No dominant language",
+                "JavaScript 50%",
+                "·",
+                "TypeScript 50%",
                 ProjectLanguageResolutionPanel.SET_FALLBACK_LABEL,
                 ProjectLanguageResolutionPanel.RESCAN_LABEL,
             ),
             builder.proportionsPanelLabelsForTest().map { it.second },
         )
+    }
+
+    @Test
+    fun `proportionsPanelLabelsForTest keeps source iconless and splits language percentages`() {
+        val project = stubProject(tmpKey("resolution-icons"))
+        every { ProjectLanguageDetector.verdict(project) } returns
+            ProjectLanguageVerdict.NoWinner(mapOf("kotlin" to 700L, "java" to 300L))
+
+        val labels =
+            OverridesGroupBuilder()
+                .apply { setParentProjectForTest(project) }
+                .proportionsPanelLabelsForTest()
+
+        assertNull(labels.first { it.second == "Global" }.first)
+        assertTrue(labels.any { it.second == "Kotlin 70%" })
+        assertTrue(labels.any { it.second == "Java 30%" })
+        assertNull(labels.first { it.second == "·" }.first)
     }
 
     @Test
@@ -158,7 +219,7 @@ class OverridesGroupBuilderProportionsTest {
             }
 
         assertEquals(
-            "Forced language: TypeScript - using Forced language override",
+            "Accent source: Forced language override\nLanguage scan: Forced TypeScript",
             builder.currentProportionsTextForTest(),
         )
         assertTrue(
@@ -183,14 +244,14 @@ class OverridesGroupBuilderProportionsTest {
             }
 
         assertEquals(
-            "Detected: Kotlin 100% - using Language override",
+            "Accent source: Language override\nLanguage scan: Kotlin 100%",
             builder.currentProportionsTextForTest(),
         )
 
         every { LicenseChecker.isLicensedOrGrace() } returns false
 
         assertEquals(
-            "Detected: Kotlin 100% - using Global",
+            "Accent source: Global\nLanguage scan: Kotlin 100%",
             builder.currentProportionsTextForTest(),
         )
         val labels = builder.proportionsPanelLabelsForTest().map { it.second }
@@ -238,7 +299,7 @@ class OverridesGroupBuilderProportionsTest {
             }
 
         assertEquals(
-            "Detected: Kotlin 100% - using Language override",
+            "Accent source: Language override\nLanguage scan: Kotlin 100%",
             builder.currentProportionsTextForTest(),
         )
         builder.proportionsPanelLabelsForTest()
@@ -265,7 +326,11 @@ class OverridesGroupBuilderProportionsTest {
             }
 
         assertEquals(
-            "No dominant language: JavaScript 50% - TypeScript 50% - using Project fallback #5CCFE6",
+            listOf(
+                "Accent source: Project fallback #5CCFE6",
+                "Language scan: No dominant language",
+                "JavaScript 50% · TypeScript 50%",
+            ).joinToString("\n"),
             builder.currentProportionsTextForTest(),
         )
         builder.proportionsPanelLabelsForTest()
@@ -542,16 +607,27 @@ class OverridesGroupBuilderProportionsTest {
                 .getDeclaredField("proportionsPanel")
                 .apply { isAccessible = true }
                 .get(builder) as JPanel
-        return panel.components
-            .filterIsInstance<com.intellij.ui.components.JBLabel>()
-            .firstOrNull { it.text == text }
+        val renderedTexts =
+            panel
+                .descendants()
+                .filterIsInstance<JComponent>()
+                .mapNotNull(::componentText)
+                .toList()
+        return panel
+            .descendants()
+            .filterIsInstance<JComponent>()
+            .firstOrNull { componentText(it) == text }
             ?: error(
                 "Label '$text' missing; got " +
-                    panel.components.map { (it as? com.intellij.ui.components.JBLabel)?.text },
+                    renderedTexts,
             )
     }
 
     private fun click(component: JComponent) {
+        if (component is AbstractButton) {
+            component.doClick()
+            return
+        }
         val event =
             MouseEvent(
                 component,
@@ -564,19 +640,29 @@ class OverridesGroupBuilderProportionsTest {
                 false,
             )
         component.mouseListeners
-            .filter { it.javaClass.name.startsWith("dev.ayuislands") }
             .forEach { it.mouseClicked(event) }
     }
+
+    private fun componentText(component: JComponent): String? =
+        when (component) {
+            is JBLabel -> component.text
+            is ActionLink -> component.text
+            is AbstractButton -> component.text
+            else -> null
+        }
 
     private fun installApplicationActionManager() {
         mockkStatic(ApplicationManager::class)
         val application = mockk<Application>(relaxed = true)
         val actionManager = mockk<ActionManager>(relaxed = true)
-        val coroutineSupport = mockk<CoroutineSupport>(relaxed = true)
         every { ApplicationManager.getApplication() } returns application
         every { application.getService(ActionManager::class.java) } returns actionManager
-        every { application.getService(CoroutineSupport::class.java) } returns coroutineSupport
         every { actionManager.getAction(any()) } returns null
+
+        @Suppress("UNCHECKED_CAST")
+        val coroutineSupportClass = Class.forName("com.intellij.openapi.application.CoroutineSupport") as Class<Any>
+        val coroutineSupport = mockkClass(coroutineSupportClass.kotlin, relaxed = true)
+        every { application.getService(coroutineSupportClass) } returns coroutineSupport
 
         @Suppress("UNCHECKED_CAST")
         val experimentalUiClass = Class.forName("com.intellij.ui.ExperimentalUI") as Class<Any>
@@ -600,3 +686,13 @@ class OverridesGroupBuilderProportionsTest {
             .apply { isAccessible = true }
             .get(builder) as MessageBusConnection?
 }
+
+private fun Component.descendants(): Sequence<Component> =
+    sequence {
+        yield(this@descendants)
+        if (this@descendants is Container) {
+            this@descendants.components.forEach { child ->
+                yieldAll(child.descendants())
+            }
+        }
+    }

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectLanguageResolutionPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectLanguageResolutionPanelTest.kt
@@ -302,6 +302,32 @@ class ProjectLanguageResolutionPanelTest {
     }
 
     @Test
+    fun `no winner without current accent hides fallback action`() {
+        val calls = ResolutionCalls()
+        val panel = panel(calls = calls, currentAccentHex = { null })
+
+        panel.refresh(
+            ProjectLanguageResolutionPanel.State(
+                verdict =
+                    ProjectLanguageVerdict.NoWinner(
+                        mapOf("typescript" to 700L, "javascript" to 300L),
+                    ),
+                forcedLanguageId = null,
+                fallbackHex = null,
+                activeSource = AccentResolver.Source.GLOBAL,
+                canMutate = true,
+                canRescan = false,
+                canSetFallbackToCurrentAccent = false,
+            ),
+        )
+
+        val labels = panel.labelsForTest().map { it.second }
+        assertFalse(ProjectLanguageResolutionPanel.SET_FALLBACK_LABEL in labels)
+        assertTrue("Force TypeScript" in labels)
+        assertEquals(emptyList(), calls.fallbacks)
+    }
+
+    @Test
     fun `no winner actions force unique top language`() {
         val calls = ResolutionCalls()
         val panel = panel(calls = calls)
@@ -326,6 +352,28 @@ class ProjectLanguageResolutionPanelTest {
         panel.triggerActionForTest("Force TypeScript")
 
         assertEquals(listOf("typescript"), calls.forcedLanguages)
+    }
+
+    @Test
+    fun `empty no-winner scan explains unresolved proportions`() {
+        val panel = panel()
+
+        panel.refresh(
+            ProjectLanguageResolutionPanel.State(
+                verdict = ProjectLanguageVerdict.NoWinner(emptyMap()),
+                forcedLanguageId = null,
+                fallbackHex = null,
+                activeSource = AccentResolver.Source.GLOBAL,
+                canMutate = true,
+                canRescan = false,
+            ),
+        )
+
+        assertEquals(
+            "Accent source: Global\nLanguage scan: No dominant language\nunresolved",
+            panel.currentSummaryForTest(),
+        )
+        assertTrue("unresolved" in panel.labelsForTest().map { it.second })
     }
 
     @Test
@@ -380,6 +428,27 @@ class ProjectLanguageResolutionPanelTest {
     }
 
     @Test
+    fun `rescan action ignores duplicate click while detector is busy`() {
+        val calls = ResolutionCalls()
+        val panel = panel(calls = calls, canRescanNow = { false })
+
+        panel.refresh(
+            ProjectLanguageResolutionPanel.State(
+                verdict = ProjectLanguageVerdict.Cold,
+                forcedLanguageId = null,
+                fallbackHex = null,
+                activeSource = AccentResolver.Source.GLOBAL,
+                canMutate = true,
+                canRescan = true,
+            ),
+        )
+
+        panel.triggerActionForTest(ProjectLanguageResolutionPanel.RESCAN_LABEL)
+
+        assertEquals(0, calls.rescanCount)
+    }
+
+    @Test
     fun `clear actions clear existing forced language and fallback`() {
         val calls = ResolutionCalls()
         val panel = panel(calls = calls)
@@ -427,6 +496,30 @@ class ProjectLanguageResolutionPanelTest {
 
         val labels = panel.labelsForTest().map { it.second }
         assertFalse(labels.any { it.contains("<html", ignoreCase = true) })
+    }
+
+    @Test
+    fun `diagnostics labels escape ampersands in language ids`() {
+        val panel = panel()
+
+        panel.refresh(
+            ProjectLanguageResolutionPanel.State(
+                verdict =
+                    ProjectLanguageVerdict.Detected(
+                        languageId = "bridge&router",
+                        weights = mapOf("bridge&router" to 1_000L),
+                    ),
+                forcedLanguageId = null,
+                fallbackHex = null,
+                activeSource = AccentResolver.Source.LANGUAGE_OVERRIDE,
+                canMutate = true,
+                canRescan = false,
+            ),
+        )
+
+        val labels = panel.labelsForTest().map { it.second }
+        assertTrue(labels.any { it.contains("Bridge&amp;router") })
+        assertFalse(labels.any { it.contains("Bridge&router") })
     }
 
     private fun panel(

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectLanguageResolutionPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectLanguageResolutionPanelTest.kt
@@ -1,10 +1,13 @@
 package dev.ayuislands.settings.mappings
 
+import com.intellij.util.ui.EmptyIcon
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.ProjectLanguageVerdict
+import javax.swing.Icon
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class ProjectLanguageResolutionPanelTest {
@@ -28,7 +31,90 @@ class ProjectLanguageResolutionPanelTest {
         )
 
         assertEquals(
-            "Detected: Kotlin 90% - using Language override",
+            "Accent source: Language override\nLanguage scan: Dominant Kotlin\nKotlin 90% · Java 10%",
+            panel.currentSummaryForTest(),
+        )
+    }
+
+    @Test
+    fun `detected language icon renders beside scan value instead of source value`() {
+        val icon = EmptyIcon.create(16)
+        val panel = panel(languageIconForId = { icon })
+
+        panel.refresh(
+            ProjectLanguageResolutionPanel.State(
+                verdict =
+                    ProjectLanguageVerdict.Detected(
+                        languageId = "java",
+                        weights = mapOf("java" to 1_000L),
+                    ),
+                forcedLanguageId = null,
+                fallbackHex = null,
+                activeSource = AccentResolver.Source.PROJECT_OVERRIDE,
+                canMutate = true,
+                canRescan = false,
+            ),
+        )
+
+        val labels = panel.labelsForTest()
+
+        assertNull(labels.first { it.second == "Project override" }.first)
+        assertEquals(icon, labels.first { it.second == "Java 100%" }.first)
+    }
+
+    @Test
+    fun `detected language with visible tail renders icon-per-entry breakdown`() {
+        val icon = EmptyIcon.create(16)
+        val panel = panel(languageIconForId = { icon })
+
+        panel.refresh(
+            ProjectLanguageResolutionPanel.State(
+                verdict =
+                    ProjectLanguageVerdict.Detected(
+                        languageId = "kotlin",
+                        weights = mapOf("kotlin" to 900L, "java" to 100L),
+                    ),
+                forcedLanguageId = null,
+                fallbackHex = null,
+                activeSource = AccentResolver.Source.LANGUAGE_OVERRIDE,
+                canMutate = true,
+                canRescan = false,
+            ),
+        )
+
+        val labels = panel.labelsForTest()
+
+        assertEquals(icon, labels.first { it.second == "Dominant Kotlin" }.first)
+        assertEquals(icon, labels.first { it.second == "Kotlin 90%" }.first)
+        assertEquals(icon, labels.first { it.second == "Java 10%" }.first)
+        assertNull(labels.first { it.second == "·" }.first)
+    }
+
+    @Test
+    fun `summary renders detected winner with language fallback source`() {
+        val panel = panel()
+
+        panel.refresh(
+            ProjectLanguageResolutionPanel.State(
+                verdict =
+                    ProjectLanguageVerdict.Detected(
+                        languageId = "typescript",
+                        weights = mapOf("typescript" to 900L, "javascript" to 100L),
+                    ),
+                forcedLanguageId = null,
+                fallbackHex = null,
+                activeSource = AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE,
+                canMutate = true,
+                canRescan = false,
+            ),
+        )
+
+        assertEquals(
+            listOf(
+                "Accent source: Language fallback override",
+                "Language scan: Dominant TypeScript",
+                "TypeScript 90% · JavaScript 10%",
+            ).joinToString("\n"),
             panel.currentSummaryForTest(),
         )
     }
@@ -52,9 +138,35 @@ class ProjectLanguageResolutionPanelTest {
         )
 
         assertEquals(
-            "No dominant language: JavaScript 50% - TypeScript 50% - using Global",
+            "Accent source: Global\nLanguage scan: No dominant language\nJavaScript 50% · TypeScript 50%",
             panel.currentSummaryForTest(),
         )
+    }
+
+    @Test
+    fun `no winner detail renders language icons beside each named percentage`() {
+        val icon = EmptyIcon.create(16)
+        val panel = panel(languageIconForId = { icon })
+
+        panel.refresh(
+            ProjectLanguageResolutionPanel.State(
+                verdict =
+                    ProjectLanguageVerdict.NoWinner(
+                        mapOf("kotlin" to 700L, "java" to 300L),
+                    ),
+                forcedLanguageId = null,
+                fallbackHex = null,
+                activeSource = AccentResolver.Source.GLOBAL,
+                canMutate = true,
+                canRescan = false,
+            ),
+        )
+
+        val labels = panel.labelsForTest()
+
+        assertEquals(icon, labels.first { it.second == "Kotlin 70%" }.first)
+        assertEquals(icon, labels.first { it.second == "Java 30%" }.first)
+        assertNull(labels.first { it.second == "·" }.first)
     }
 
     @Test
@@ -77,7 +189,7 @@ class ProjectLanguageResolutionPanelTest {
         )
 
         assertEquals(
-            "Forced language: TypeScript - using Forced language override",
+            "Accent source: Forced language override\nLanguage scan: Forced TypeScript",
             panel.currentSummaryForTest(),
         )
     }
@@ -101,7 +213,11 @@ class ProjectLanguageResolutionPanelTest {
         )
 
         assertEquals(
-            "No dominant language: JavaScript 50% - TypeScript 50% - using Project fallback #5CCFE6",
+            listOf(
+                "Accent source: Project fallback #5CCFE6",
+                "Language scan: No dominant language",
+                "JavaScript 50% · TypeScript 50%",
+            ).joinToString("\n"),
             panel.currentSummaryForTest(),
         )
     }
@@ -120,7 +236,10 @@ class ProjectLanguageResolutionPanelTest {
                 canRescan = false,
             ),
         )
-        assertEquals("Detection pending - using Global", panel.currentSummaryForTest())
+        assertEquals(
+            "Accent source: Global\nLanguage scan: Detection pending",
+            panel.currentSummaryForTest(),
+        )
 
         panel.refresh(
             ProjectLanguageResolutionPanel.State(
@@ -132,7 +251,10 @@ class ProjectLanguageResolutionPanelTest {
                 canRescan = false,
             ),
         )
-        assertEquals("No project languages detected - using Global", panel.currentSummaryForTest())
+        assertEquals(
+            "Accent source: Global\nLanguage scan: No project languages detected",
+            panel.currentSummaryForTest(),
+        )
 
         panel.refresh(
             ProjectLanguageResolutionPanel.State(
@@ -144,7 +266,10 @@ class ProjectLanguageResolutionPanelTest {
                 canRescan = false,
             ),
         )
-        assertEquals("Project language detection unavailable - using Global", panel.currentSummaryForTest())
+        assertEquals(
+            "Accent source: Global\nLanguage scan: Project language detection unavailable",
+            panel.currentSummaryForTest(),
+        )
     }
 
     @Test
@@ -308,6 +433,7 @@ class ProjectLanguageResolutionPanelTest {
         calls: ResolutionCalls = ResolutionCalls(),
         currentAccentHex: () -> String? = { "#5CCFE6" },
         canRescanNow: () -> Boolean = { true },
+        languageIconForId: (String) -> Icon? = { null },
     ): ProjectLanguageResolutionPanel =
         ProjectLanguageResolutionPanel(
             currentAccentHex = currentAccentHex,
@@ -317,6 +443,7 @@ class ProjectLanguageResolutionPanelTest {
             onClearFallback = { calls.clearFallbackCount += 1 },
             onRescan = { calls.rescanCount += 1 },
             canRescanNow = canRescanNow,
+            languageIconForId = languageIconForId,
         )
 
     private data class ResolutionCalls(


### PR DESCRIPTION
── Summary ─────────────────────────────────

Polyglot projects could still fall through to the global accent with little explanation, especially around 50/50 language mixes or language misses. This PR makes language override resolution tunable and observable: settings can persist threshold/fallback controls, the resolver has explicit fallback behavior, and the settings UI shows a compact source + language scan breakdown.

── Changes ─────────────────────────────────

- Feat: [AccentMappingsState.kt](src/main/kotlin/dev/ayuislands/settings/mappings/AccentMappingsState.kt) and [LanguageDetectionRules.kt](src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt) — Persist language detection tuning fields and centralize default/clamped rule behavior.
- Fix: [AccentResolver.kt](src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt) and [ProjectLanguageDetector.kt](src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt) — Respect forced language and fallback overrides before falling back to the global accent.
- Feat: [OverridesGroupBuilder.kt](src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt) and [ProjectLanguageResolutionPanel.kt](src/main/kotlin/dev/ayuislands/settings/mappings/ProjectLanguageResolutionPanel.kt) — Show active source, dominant-language scan state, compact per-language percentages, and fallback/force/rescan actions.
- Test: [accent tests](src/test/kotlin/dev/ayuislands/accent) and [mappings tests](src/test/kotlin/dev/ayuislands/settings/mappings) — Cover threshold tuning, catch-all fallback, cache-only diagnostics, pending UI state, licensing, action wiring, and icon placement.
- Chore: [docs/features.yml](docs/features.yml) — Re-stamp feature manifest after tracked Kotlin source changes.

── Validation ──────────────────────────────

```bash
./gradlew compileKotlin compileTestKotlin --no-build-cache
./gradlew test --tests dev.ayuislands.settings.mappings.ProjectLanguageResolutionPanelTest --tests dev.ayuislands.settings.mappings.OverridesGroupBuilderProportionsTest --no-build-cache
./gradlew detekt ktlintCheck --no-build-cache
./gradlew buildPlugin --no-build-cache
scripts/verify-docs.py
```

Manual verification:

```text
$deploy-to-ide
Installed ayu-jetbrains-2.7.4 into IntelliJIdea2026.1
Verified installed composed JAR with javap
Confirmed Ayu Islands loaded and GlowOverlayManager initialized in idea.log
Confirmed no SEVERE.*Ayu / Ayu.*SEVERE entries after restart
```

── Notes ───────────────────────────────────

Focus review on the resolver/source precedence and the settings diagnostics presenter. The UI intentionally keeps single-language detections compact while showing the per-language breakdown when a detected winner still has a visible tail.

## Summary by Sourcery

Tune project language accent resolution to support configurable dominance policies, a language-level fallback accent, and clearer UI diagnostics for how a project’s accent was chosen.

New Features:
- Persist language detection resolution policy and a configurable language fallback accent in accent mapping settings.
- Expose language scan source, dominant-language status, per-language percentages, and language icons in the overrides diagnostics panel, with actionable controls for forcing, fallback, and rescan.

Bug Fixes:
- Ensure forced language and language fallback overrides are honored ahead of project fallbacks and the global accent during resolution.

Enhancements:
- Refine language detection to honor stored dominance thresholds and tiebreak shares, feeding those into project language verdicts and cache invalidation.
- Improve settings UI layout and copy for accent resolution diagnostics, including more precise source labels and tooltips, and more robust test utilities.
- Harden mock wiring and state handling in tests around accent application, licensing, and project language detection.

Documentation:
- Update feature manifest metadata to track the latest verified accent and settings sources.

Tests:
- Extend accent resolver, mappings, and detector tests to cover dominance policy tuning, language fallback behavior, cache-only previews, UI rendering of icons and breakdowns, and licensing-gated actions.