### PR TITLE
feat(scripts): add marketing campaign generator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,8 +100,10 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: scripts/uv.lock
+      - name: Test campaign generator
+        run: uv run --project scripts python scripts/tests/test-generate-campaign.py
       - name: Test Plugin Verifier API gate
-        run: python3 scripts/test-verify-plugin-verifier.py
+        run: python3 scripts/tests/test-verify-plugin-verifier.py
       - name: Verify docs sync (features.yml ↔ README + plugin.xml + CHANGELOG)
         run: scripts/verify-docs.py
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ local.properties
 samples/
 src/main/resources/META-INF/ayu-dev-mode
 .worktrees/
+.marketing/
 __pycache__/
 *.py[cod]
 *.egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ local.properties
 samples/
 src/main/resources/META-INF/ayu-dev-mode
 .worktrees/
+__pycache__/
+*.py[cod]
+*.egg-info/

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -33,9 +33,10 @@ Deps: `pyyaml`. Invoked via uv shebang.
 
 ### `generate-campaign` — private campaign draft generator
 
-Renders ignored `.marketing/templates/*.md` files with facts from
-`.marketing/config.yaml`, `docs/features.yml`, and `CHANGELOG.md`, then writes
-drafts plus review support files to `.marketing/generated/<date>-<name>/`.
+Renders the `.marketing/templates/*.md` files selected by
+`.marketing/config.yaml` with facts from `docs/features.yml` and
+`CHANGELOG.md`, then writes drafts plus review support files to
+`.marketing/generated/<date>-<slugified-name>/`.
 
 ```bash
 uv run --project scripts generate-campaign --mode soft-organic --name launch-copy

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -31,6 +31,18 @@ scripts/verify-docs.py --update-hashes # recompute content_sha256 after re-captu
 
 Deps: `pyyaml`. Invoked via uv shebang.
 
+### `generate-campaign` — private campaign draft generator
+
+Renders ignored `.marketing/templates/*.md` files with facts from
+`.marketing/config.yaml`, `docs/features.yml`, and `CHANGELOG.md`, then writes
+drafts plus review support files to `.marketing/generated/<date>-<name>/`.
+
+```bash
+uv run --project scripts generate-campaign --mode soft-organic --name launch-copy
+```
+
+Deps: `pyyaml`. Invoked through the `generate-campaign` console entry point.
+
 ### `verify-theme-xml.py` — XML scheme cross-variant consistency
 
 Parses `AyuIslandsMirage.xml`, `AyuIslandsDark.xml`, `AyuIslandsLight.xml`
@@ -86,7 +98,7 @@ After `./gradlew verifyPlugin`, enforces the project API policy:
 
 ```bash
 python3 scripts/verify-plugin-verifier.py
-python3 scripts/test-verify-plugin-verifier.py
+python3 scripts/tests/test-verify-plugin-verifier.py
 ```
 
 Deps: stdlib only. Plain `python3`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -38,6 +38,10 @@ Renders the `.marketing/templates/*.md` files selected by
 `CHANGELOG.md`, then writes drafts plus review support files to
 `.marketing/generated/<date>-<slugified-name>/`.
 
+Requires a local ignored `.marketing/` tree with `config.yaml` and the selected
+templates before running; those campaign inputs and generated drafts are not
+tracked.
+
 ```bash
 uv run --project scripts generate-campaign --mode soft-organic --name launch-copy
 ```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,8 +1,9 @@
 # Ayu Islands maintenance scripts
 
 All Python scripts run from the repo root. Dependencies are declared in
-`pyproject.toml` and pinned in `uv.lock` — run `uv sync` inside `scripts/`
-once to set up the local environment.
+`pyproject.toml` and pinned in `uv.lock` inside `scripts/`. Run
+`uv sync --project scripts` from the repo root, or `uv sync` from inside
+`scripts/`, once to set up the local environment.
 
 ## Scripts
 

--- a/scripts/generate_campaign.py
+++ b/scripts/generate_campaign.py
@@ -189,7 +189,7 @@ def reject_duplicate_yaml_keys(
     source_name: str,
     active_nodes: set[int] | None = None,
 ) -> None:
-    node_stack = set() if active_nodes is None else active_nodes
+    node_stack: set[int] = set() if active_nodes is None else active_nodes
 
     if isinstance(node, yaml.nodes.MappingNode):
         ensure_yaml_node_is_not_recursive(node, source_name, node_stack)
@@ -237,7 +237,7 @@ def normalize_yaml(
     if value is None or isinstance(value, (str, int, float, bool)):
         return value
 
-    value_stack = set() if active_values is None else active_values
+    value_stack: set[int] = set() if active_values is None else active_values
     if is_object_list(value):
         ensure_yaml_value_is_not_recursive(value, source_name, value_stack)
         try:

--- a/scripts/generate_campaign.py
+++ b/scripts/generate_campaign.py
@@ -160,7 +160,7 @@ def load_yaml_mapping(path: Path) -> YamlMapping:
         if parsed_yaml is not None:
             reject_duplicate_yaml_keys(parsed_yaml, path.name)
         loaded_yaml: object = yaml.safe_load(raw_content)
-    except OSError as file_error:
+    except (OSError, UnicodeError) as file_error:
         raise SystemExit(f"Failed to read YAML file {path}: {file_error}") from file_error
     except yaml.YAMLError as yaml_error:
         raise SystemExit(f"Failed to parse YAML file {path}: {yaml_error}") from yaml_error
@@ -336,11 +336,17 @@ def require_mapping(source: YamlMapping, key: str) -> YamlMapping:
 
 def require_string_mapping(source: YamlMapping, key: str) -> StringMapping:
     value = require_mapping(source, key)
-    result: StringMapping = {
-        item_key: scalar_to_string(item_value, f"{key}.{item_key}")
+    return {
+        item_key: read_mapping_scalar(item_value, f"{key}.{item_key}")
         for item_key, item_value in value.items()
     }
-    return result
+
+
+def read_mapping_scalar(value: YamlValue, location: str) -> str:
+    string_value = scalar_to_string(value, location)
+    if location.startswith("pricing.") or string_value.strip():
+        return string_value
+    raise SystemExit(f"Expected `{location}` to be a non-empty scalar.")
 
 
 def read_string_list(source: YamlMapping, key: str) -> list[str]:
@@ -434,9 +440,14 @@ def scalar_to_string(value: YamlValue, location: str) -> str:
 def read_conditional_claims(guardrails: YamlMapping) -> list[YamlMapping]:
     conditional_claims = read_required_mapping_list(guardrails, "conditional_claims")
     for index, conditional_claim in enumerate(conditional_claims):
-        read_required_string(conditional_claim, "phrase", f"conditional_claims[{index}]")
+        location = f"conditional_claims[{index}]"
+        read_required_string(conditional_claim, "phrase", location)
         if "message" in conditional_claim:
-            read_required_string(conditional_claim, "message", f"conditional_claims[{index}]")
+            read_required_string(conditional_claim, "message", location)
+        requires = conditional_claim.get("requires")
+        if isinstance(requires, dict):
+            read_required_string(requires, "path", f"{location}.requires")
+            read_required_string(requires, "value", f"{location}.requires")
     return conditional_claims
 
 
@@ -526,7 +537,13 @@ def read_latest_changelog() -> LatestChangelog:
     latest_version: str | None = None
     summary_lines: list[str] = []
 
-    for line in CHANGELOG_PATH.read_text(encoding="utf-8").splitlines():
+    try:
+        changelog_content = CHANGELOG_PATH.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as changelog_error:
+        failed_changelog = f"TODO_VERIFY: failed to read CHANGELOG.md: {changelog_error}"
+        return LatestChangelog(failed_changelog, f"- {failed_changelog}")
+
+    for line in changelog_content.splitlines():
         if match := MARKDOWN_HEADING_PATTERN.match(line):
             if latest_version is not None:
                 break

--- a/scripts/generate_campaign.py
+++ b/scripts/generate_campaign.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 import argparse
 import re
 import sys
-from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
-from typing import TypeAlias
+from typing import TypeAlias, TypeGuard
 
 try:
     import yaml
@@ -41,6 +40,10 @@ METRIC_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\b\d[\d,.]*\s+(downloads|installs|reviews|users|stars)\b", re.I),
     re.compile(r"\b(revenue|conversion)\b.{0,48}\b\d[\d,.%]*", re.I),
 )
+SUPPORT_FILE_NAMES: frozenset[str] = frozenset(
+    {"README.md", "FACT_CHECK.md", "CHECKLIST.md", "POSTING_PLAN.md"}
+)
+UNRESOLVED_PLACEHOLDER_PREFIX = "TODO_VERIFY: unresolved placeholder"
 
 
 @dataclass(frozen=True, slots=True)
@@ -64,20 +67,18 @@ class GuardReport:
     warnings: list[str]
 
 
-def as_object_list(value: object) -> list[object] | None:
-    return list(value) if isinstance(value, list) else None
+@dataclass(frozen=True, slots=True)
+class LatestChangelog:
+    version: str
+    summary: str
 
 
-def as_object_dict(value: object) -> dict[object, object] | None:
-    return dict(value) if isinstance(value, dict) else None
+def is_object_list(value: object) -> TypeGuard[list[object]]:
+    return isinstance(value, list)
 
 
-def as_object_mapping(value: object) -> Mapping[object, object] | None:
-    return value if isinstance(value, Mapping) else None
-
-
-def as_yaml_mapping(value: YamlValue) -> YamlMapping | None:
-    return value if isinstance(value, dict) else None
+def is_object_dict(value: object) -> TypeGuard[dict[object, object]]:
+    return isinstance(value, dict)
 
 
 def main() -> int:
@@ -93,7 +94,9 @@ def main() -> int:
     guard_report = evaluate_guardrails(config_data, features_data, rendered_files)
 
     output_directory = GENERATED_DIR / f"{date.today().isoformat()}-{campaign_name}"
-    output_directory.mkdir(parents=True, exist_ok=True)
+    if output_directory.exists():
+        raise SystemExit(f"Campaign output already exists: {output_directory}")
+    output_directory.mkdir(parents=True)
 
     for rendered_file in rendered_files + build_support_files(
         template_names,
@@ -146,27 +149,24 @@ def load_yaml_mapping(path: Path) -> YamlMapping:
     except yaml.YAMLError as yaml_error:
         raise SystemExit(f"Failed to parse YAML file {path}: {yaml_error}") from yaml_error
 
-    raw_yaml = loaded_yaml if loaded_yaml is not None else {}
+    raw_yaml: object = loaded_yaml if loaded_yaml is not None else {}
     normalized_yaml = normalize_yaml(raw_yaml, path.name)
-    normalized_mapping = as_yaml_mapping(normalized_yaml)
-    if normalized_mapping is None:
+    if not isinstance(normalized_yaml, dict):
         raise SystemExit(f"Expected YAML mapping at top level in {path}")
 
-    return normalized_mapping
+    return normalized_yaml
 
 
 def normalize_yaml(value: object, source_name: str) -> YamlValue:
     if value is None or isinstance(value, (str, int, float, bool)):
         return value
 
-    raw_list = as_object_list(value)
-    if raw_list is not None:
-        return [normalize_yaml(item, source_name) for item in raw_list]
+    if is_object_list(value):
+        return [normalize_yaml(item, source_name) for item in value]
 
-    raw_mapping = as_object_dict(value)
-    if raw_mapping is not None:
+    if is_object_dict(value):
         normalized_mapping: YamlMapping = {}
-        for key, item_value in raw_mapping.items():
+        for key, item_value in value.items():
             if not isinstance(key, str):
                 raise SystemExit(f"Expected string YAML keys in {source_name}: {key!r}")
             normalized_mapping[key] = normalize_yaml(item_value, source_name)
@@ -194,14 +194,33 @@ def read_template_names(campaign_mode: YamlMapping, mode: str) -> list[str]:
     for raw_template_name in raw_templates:
         if not isinstance(raw_template_name, str):
             raise SystemExit(f"Campaign mode `{mode}` contains a non-string template name.")
-        if not raw_template_name.endswith(".md"):
-            raise SystemExit(f"Template `{raw_template_name}` must be a Markdown file.")
-        template_names.append(raw_template_name)
+        template_name = validate_template_name(raw_template_name)
+        if template_name in template_names:
+            raise SystemExit(f"Template `{template_name}` is selected more than once.")
+        if template_name in SUPPORT_FILE_NAMES:
+            raise SystemExit(f"Template `{template_name}` conflicts with a generated support file.")
+        template_names.append(template_name)
 
     if not template_names:
         raise SystemExit(f"Campaign mode `{mode}` does not select any templates.")
 
     return template_names
+
+
+def validate_template_name(template_name: str) -> str:
+    template_path = Path(template_name)
+    if (
+        template_path.is_absolute()
+        or template_name != template_path.name
+        or "\\" in template_name
+    ):
+        raise SystemExit(f"Template `{template_name}` must be a file name in .marketing/templates.")
+    if template_path.suffix != ".md":
+        raise SystemExit(f"Template `{template_name}` must be a Markdown file.")
+    if not template_path.stem:
+        raise SystemExit(f"Template `{template_name}` must include a file name.")
+
+    return template_name
 
 
 def build_context(
@@ -217,6 +236,9 @@ def build_context(
     feature_summary = summarize_features(features_data)
     manual_verification = read_string_list(config_data, "manual_verification")
     social_proof = format_social_proof(read_mapping_list(config_data, "social_proof"))
+    latest_changelog = read_latest_changelog()
+    pricing_summary = format_pricing_summary(pricing)
+    launch_status_summary = format_status_summary(launch_status)
 
     verification_todos = (
         "\n".join(
@@ -234,11 +256,22 @@ def build_context(
     }
     facts = {
         **feature_summary,
-        "latest_version": read_latest_changelog_version(),
-        "latest_changelog_summary": read_latest_changelog_summary(),
-        "pricing_summary": format_pricing_summary(pricing),
-        "launch_status_summary": format_status_summary(launch_status),
+        "latest_version": latest_changelog.version,
+        "latest_changelog_summary": latest_changelog.summary,
+        "pricing_summary": pricing_summary,
+        "launch_status_summary": launch_status_summary,
         "social_proof_summary": social_proof,
+    }
+    pricing_context = {
+        **pricing,
+        "summary": pricing_summary,
+    }
+    launch_status_context = {
+        **launch_status,
+        "summary": launch_status_summary,
+    }
+    social_proof_context = {
+        "summary": social_proof,
     }
     verification = {
         "todos": verification_todos,
@@ -248,8 +281,9 @@ def build_context(
         "product": product,
         "campaign": campaign,
         "facts": facts,
-        "pricing": pricing,
-        "launch_status": launch_status,
+        "pricing": pricing_context,
+        "launch_status": launch_status_context,
+        "social_proof": social_proof_context,
         "verification": verification,
     }
 
@@ -385,35 +419,27 @@ def format_inline_features(feature_records: list[FeatureRecord]) -> str:
     return ", ".join(feature_record.title for feature_record in feature_records[:5])
 
 
-def read_latest_changelog_version() -> str:
+def read_latest_changelog() -> LatestChangelog:
     if not CHANGELOG_PATH.exists():
-        return "TODO_VERIFY: CHANGELOG.md not found"
+        missing_changelog = "TODO_VERIFY: CHANGELOG.md not found"
+        return LatestChangelog(missing_changelog, f"- {missing_changelog}")
+
+    latest_version: str | None = None
+    summary_lines: list[str] = []
 
     for line in CHANGELOG_PATH.read_text(encoding="utf-8").splitlines():
         if match := MARKDOWN_HEADING_PATTERN.match(line):
-            return match.group(1)
-
-    return "TODO_VERIFY: no changelog version heading found"
-
-
-def read_latest_changelog_summary() -> str:
-    if not CHANGELOG_PATH.exists():
-        return "- TODO_VERIFY: CHANGELOG.md not found"
-
-    lines = CHANGELOG_PATH.read_text(encoding="utf-8").splitlines()
-    in_latest_section = False
-    summary_lines: list[str] = []
-
-    for line in lines:
-        if line.startswith("## "):
-            if in_latest_section:
+            if latest_version is not None:
                 break
-            in_latest_section = True
+            latest_version = match.group(1)
             continue
-        if in_latest_section and line.strip():
+        if latest_version is not None and line.strip():
             summary_lines.append(line)
 
-    return "\n".join(summary_lines) if summary_lines else "- TODO_VERIFY: no latest changelog body found"
+    return LatestChangelog(
+        latest_version or "TODO_VERIFY: no changelog version heading found",
+        "\n".join(summary_lines) if summary_lines else "- TODO_VERIFY: no latest changelog body found",
+    )
 
 
 def format_pricing_summary(pricing: StringMapping) -> str:
@@ -484,21 +510,12 @@ def render_text(template_content: str, context: RenderContext) -> str:
 
 
 def lookup_render_value(context: RenderContext, path: str) -> RenderableValue | None:
-    current_value: object = context
+    section_name, separator, value_name = path.partition(".")
+    if not separator or not section_name or not value_name or "." in value_name:
+        return None
 
-    for segment in path.split("."):
-        current_mapping = as_object_mapping(current_value)
-        if current_mapping is None:
-            return None
-        if segment not in current_mapping:
-            return None
-        next_value = current_mapping[segment]
-        current_value = next_value
-
-    if isinstance(current_value, (str, int, float, bool)):
-        return current_value
-
-    return None
+    section = context.get(section_name)
+    return None if section is None else section.get(value_name)
 
 
 def evaluate_guardrails(
@@ -537,6 +554,14 @@ def evaluate_guardrails(
             for unresolved_marker in find_unresolved_markers(
                 rendered_file.content
             )
+            if UNRESOLVED_PLACEHOLDER_PREFIX not in unresolved_marker
+        )
+        hard_blocks.extend(
+            f"{rendered_file.name}: {unresolved_marker}"
+            for unresolved_marker in find_unresolved_markers(
+                rendered_file.content
+            )
+            if UNRESOLVED_PLACEHOLDER_PREFIX in unresolved_marker
         )
         warnings.extend(
             f"{rendered_file.name}: TODO_VERIFY: metric claim `{metric_claim}` needs a source"
@@ -569,7 +594,11 @@ def evaluate_conditional_claim(
 
     requires = conditional_claim.get("requires")
     if isinstance(requires, dict):
+        if "path" not in requires or "value" not in requires:
+            return message
         path = read_optional_string(requires, "path", "")
+        if not path:
+            return message
         expected_value = read_optional_string(requires, "value", "")
         actual_value = lookup_yaml_value(config_data, path)
         if yaml_value_matches(actual_value, expected_value):
@@ -584,10 +613,9 @@ def lookup_yaml_value(source: YamlMapping, path: str) -> YamlValue | None:
 
     current_value: YamlValue = source
     for segment in path.split("."):
-        current_mapping = as_yaml_mapping(current_value)
-        if current_mapping is None:
+        if not isinstance(current_value, dict):
             return None
-        next_value = current_mapping.get(segment)
+        next_value = current_value.get(segment)
         if next_value is None:
             return None
         current_value = next_value
@@ -597,7 +625,7 @@ def lookup_yaml_value(source: YamlMapping, path: str) -> YamlValue | None:
 
 def yaml_value_matches(actual_value: YamlValue | None, expected_value: str) -> bool:
     if actual_value is None:
-        return not expected_value
+        return False
     if isinstance(actual_value, (str, int, float, bool)):
         return str(actual_value) == expected_value
     return False

--- a/scripts/generate_campaign.py
+++ b/scripts/generate_campaign.py
@@ -98,6 +98,7 @@ def main() -> int:
     rendered_files = render_templates(template_names, context)
     guard_report = evaluate_guardrails(config_data, features_data, rendered_files)
 
+    ensure_generated_output_root_is_safe()
     output_directory = GENERATED_DIR / f"{date.today().isoformat()}-{campaign_name}"
     if output_directory.exists():
         raise SystemExit(f"Campaign output already exists: {output_directory}")
@@ -160,55 +161,114 @@ def load_yaml_mapping(path: Path) -> YamlMapping:
         if parsed_yaml is not None:
             reject_duplicate_yaml_keys(parsed_yaml, path.name)
         loaded_yaml: object = yaml.safe_load(raw_content)
+        raw_yaml: object = loaded_yaml if loaded_yaml is not None else {}
+        normalized_yaml = normalize_yaml(raw_yaml, path.name)
     except (OSError, UnicodeError) as file_error:
         raise SystemExit(f"Failed to read YAML file {path}: {file_error}") from file_error
     except yaml.YAMLError as yaml_error:
         raise SystemExit(f"Failed to parse YAML file {path}: {yaml_error}") from yaml_error
+    except RecursionError as recursion_error:
+        raise SystemExit(
+            f"Failed to parse YAML file {path}: recursive aliases are not supported."
+        ) from recursion_error
 
-    raw_yaml: object = loaded_yaml if loaded_yaml is not None else {}
-    normalized_yaml = normalize_yaml(raw_yaml, path.name)
     if not isinstance(normalized_yaml, dict):
         raise SystemExit(f"Expected YAML mapping at top level in {path}")
 
     return normalized_yaml
 
 
-def reject_duplicate_yaml_keys(node: object, source_name: str) -> None:
+def ensure_generated_output_root_is_safe() -> None:
+    for output_root in (MARKETING_ROOT, GENERATED_DIR):
+        if output_root.is_symlink():
+            raise SystemExit(f"Campaign output root must not be a symlink: {output_root}")
+
+
+def reject_duplicate_yaml_keys(
+    node: object,
+    source_name: str,
+    active_nodes: set[int] | None = None,
+) -> None:
+    node_stack = set() if active_nodes is None else active_nodes
+
     if isinstance(node, yaml.nodes.MappingNode):
-        seen_keys: set[str] = set()
-        for key_node, value_node in node.value:
-            if isinstance(key_node, yaml.nodes.ScalarNode):
-                key_name = key_node.value
-                if key_name in seen_keys:
-                    line_number = key_node.start_mark.line + 1
-                    raise SystemExit(
-                        f"Duplicate YAML key `{key_name}` in {source_name}:{line_number}."
-                    )
-                seen_keys.add(key_name)
-            reject_duplicate_yaml_keys(value_node, source_name)
-        return
+        ensure_yaml_node_is_not_recursive(node, source_name, node_stack)
+        try:
+            seen_keys: set[str] = set()
+            for key_node, value_node in node.value:
+                if isinstance(key_node, yaml.nodes.ScalarNode):
+                    key_name = key_node.value
+                    if key_name in seen_keys:
+                        line_number = key_node.start_mark.line + 1
+                        raise SystemExit(
+                            f"Duplicate YAML key `{key_name}` in {source_name}:{line_number}."
+                        )
+                    seen_keys.add(key_name)
+                reject_duplicate_yaml_keys(value_node, source_name, node_stack)
+            return
+        finally:
+            node_stack.remove(id(node))
 
     if isinstance(node, yaml.nodes.SequenceNode):
-        for value_node in node.value:
-            reject_duplicate_yaml_keys(value_node, source_name)
+        ensure_yaml_node_is_not_recursive(node, source_name, node_stack)
+        try:
+            for value_node in node.value:
+                reject_duplicate_yaml_keys(value_node, source_name, node_stack)
+        finally:
+            node_stack.remove(id(node))
 
 
-def normalize_yaml(value: object, source_name: str) -> YamlValue:
+def ensure_yaml_node_is_not_recursive(
+    node: yaml.nodes.CollectionNode,
+    source_name: str,
+    active_nodes: set[int],
+) -> None:
+    node_id = id(node)
+    if node_id in active_nodes:
+        raise SystemExit(f"Recursive YAML aliases are not supported in {source_name}.")
+    active_nodes.add(node_id)
+
+
+def normalize_yaml(
+    value: object,
+    source_name: str,
+    active_values: set[int] | None = None,
+) -> YamlValue:
     if value is None or isinstance(value, (str, int, float, bool)):
         return value
 
+    value_stack = set() if active_values is None else active_values
     if is_object_list(value):
-        return [normalize_yaml(item, source_name) for item in value]
+        ensure_yaml_value_is_not_recursive(value, source_name, value_stack)
+        try:
+            return [normalize_yaml(item, source_name, value_stack) for item in value]
+        finally:
+            value_stack.remove(id(value))
 
     if is_object_dict(value):
-        normalized_mapping: YamlMapping = {}
-        for key, item_value in value.items():
-            if not isinstance(key, str):
-                raise SystemExit(f"Expected string YAML keys in {source_name}: {key!r}")
-            normalized_mapping[key] = normalize_yaml(item_value, source_name)
-        return normalized_mapping
+        ensure_yaml_value_is_not_recursive(value, source_name, value_stack)
+        try:
+            normalized_mapping: YamlMapping = {}
+            for key, item_value in value.items():
+                if not isinstance(key, str):
+                    raise SystemExit(f"Expected string YAML keys in {source_name}: {key!r}")
+                normalized_mapping[key] = normalize_yaml(item_value, source_name, value_stack)
+            return normalized_mapping
+        finally:
+            value_stack.remove(id(value))
 
     raise SystemExit(f"Unsupported YAML value in {source_name}: {type(value).__name__}")
+
+
+def ensure_yaml_value_is_not_recursive(
+    value: list[object] | dict[object, object],
+    source_name: str,
+    active_values: set[int],
+) -> None:
+    value_id = id(value)
+    if value_id in active_values:
+        raise SystemExit(f"Recursive YAML aliases are not supported in {source_name}.")
+    active_values.add(value_id)
 
 
 def get_campaign_mode(config_data: YamlMapping, mode: str) -> YamlMapping:
@@ -597,7 +657,7 @@ def format_social_proof(social_proof_entries: list[YamlMapping]) -> str:
         source = read_required_string(entry, "source", location)
         label = read_optional_string(entry, "label", "social proof")
         quote = read_required_string(entry, "quote", location)
-        status = read_optional_string(entry, "status", "TODO_VERIFY")
+        status = read_optional_non_empty_string(entry, "status", "TODO_VERIFY", location)
         verified_entries.append(f'- {label}: "{quote}" (source: {source}, status: {status})')
 
     if not verified_entries:

--- a/scripts/generate_campaign.py
+++ b/scripts/generate_campaign.py
@@ -35,6 +35,7 @@ TEMPLATES_DIR = MARKETING_ROOT / "templates"
 GENERATED_DIR = MARKETING_ROOT / "generated"
 
 PLACEHOLDER_PATTERN: re.Pattern[str] = re.compile(r"{{\s*([a-zA-Z0-9_.-]+)\s*}}")
+RAW_PLACEHOLDER_PATTERN: re.Pattern[str] = re.compile(r"{{[^{}]*}}")
 MARKDOWN_HEADING_PATTERN: re.Pattern[str] = re.compile(r"^## \[?([^]\s]+)]?")
 METRIC_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\b\d[\d,.]*\s+(downloads|installs|reviews|users|stars)\b", re.I),
@@ -546,6 +547,7 @@ def evaluate_guardrails(
 ) -> GuardReport:
     guardrails = require_mapping(config_data, "guardrails")
     blocked_phrases = read_string_list(guardrails, "blocked_phrases")
+    risky_phrases = read_string_list(guardrails, "risky_phrases")
     conditional_claims = read_mapping_list(guardrails, "conditional_claims")
     feature_records = flatten_features(features_data)
     hard_blocks: list[str] = []
@@ -560,6 +562,11 @@ def evaluate_guardrails(
             f"{rendered_file.name}: blocked phrase `{blocked_phrase}`"
             for blocked_phrase in blocked_phrases
             if blocked_phrase.lower() in lower_content
+        )
+        warnings.extend(
+            f"{rendered_file.name}: TODO_VERIFY: risky phrase `{risky_phrase}` needs review"
+            for risky_phrase in risky_phrases
+            if risky_phrase.lower() in lower_content
         )
         for conditional_claim in conditional_claims:
             if warning := evaluate_conditional_claim(
@@ -583,6 +590,10 @@ def evaluate_guardrails(
                 rendered_file.content
             )
             if UNRESOLVED_PLACEHOLDER_PREFIX in unresolved_marker
+        )
+        hard_blocks.extend(
+            f"{rendered_file.name}: raw template placeholder `{raw_placeholder}` was not rendered"
+            for raw_placeholder in find_raw_placeholders(rendered_file.content)
         )
         warnings.extend(
             f"{rendered_file.name}: TODO_VERIFY: metric claim `{metric_claim}` needs a source"
@@ -653,7 +664,14 @@ def yaml_value_matches(actual_value: YamlValue | None, expected_value: str) -> b
 
 
 def find_unresolved_markers(content: str) -> list[str]:
-    return [line.strip() for line in content.splitlines() if "TODO_VERIFY:" in line]
+    return [line.strip() for line in content.splitlines() if "TODO_VERIFY" in line]
+
+
+def find_raw_placeholders(content: str) -> list[str]:
+    return sorted(
+        raw_placeholder.strip()
+        for raw_placeholder in RAW_PLACEHOLDER_PATTERN.findall(content)
+    )
 
 
 def find_metric_claims(content: str) -> list[str]:

--- a/scripts/generate_campaign.py
+++ b/scripts/generate_campaign.py
@@ -8,7 +8,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
-from typing import TypeAlias, TypeGuard, cast
+from typing import TypeAlias
 
 try:
     import yaml
@@ -64,16 +64,28 @@ class GuardReport:
     warnings: list[str]
 
 
-def is_object_list(value: object) -> TypeGuard[list[object]]:
-    return isinstance(value, list)
+def as_object_list(value: object) -> list[object] | None:
+    if isinstance(value, list):
+        return list(value)
+    return None
 
 
-def is_object_dict(value: object) -> TypeGuard[dict[object, object]]:
-    return isinstance(value, dict)
+def as_object_dict(value: object) -> dict[object, object] | None:
+    if isinstance(value, dict):
+        return dict(value)
+    return None
 
 
-def is_object_mapping(value: object) -> TypeGuard[Mapping[object, object]]:
-    return isinstance(value, Mapping)
+def as_object_mapping(value: object) -> Mapping[object, object] | None:
+    if isinstance(value, Mapping):
+        return value
+    return None
+
+
+def as_yaml_mapping(value: YamlValue) -> YamlMapping | None:
+    if isinstance(value, dict):
+        return value
+    return None
 
 
 def main() -> int:
@@ -142,24 +154,27 @@ def load_yaml_mapping(path: Path) -> YamlMapping:
     except yaml.YAMLError as yaml_error:
         raise SystemExit(f"Failed to parse YAML file {path}: {yaml_error}") from yaml_error
 
-    raw_yaml = cast(object, loaded_yaml if loaded_yaml is not None else {})
+    raw_yaml = loaded_yaml if loaded_yaml is not None else {}
     normalized_yaml = normalize_yaml(raw_yaml, path.name)
-    if not isinstance(cast(object, normalized_yaml), dict):
+    normalized_mapping = as_yaml_mapping(normalized_yaml)
+    if normalized_mapping is None:
         raise SystemExit(f"Expected YAML mapping at top level in {path}")
 
-    return cast(YamlMapping, normalized_yaml)
+    return normalized_mapping
 
 
 def normalize_yaml(value: object, source_name: str) -> YamlValue:
     if value is None or isinstance(value, (str, int, float, bool)):
         return value
 
-    if is_object_list(value):
-        return [normalize_yaml(cast(object, item), source_name) for item in value]
+    raw_list = as_object_list(value)
+    if raw_list is not None:
+        return [normalize_yaml(item, source_name) for item in raw_list]
 
-    if is_object_dict(value):
+    raw_mapping = as_object_dict(value)
+    if raw_mapping is not None:
         normalized_mapping: YamlMapping = {}
-        for key, item_value in value.items():
+        for key, item_value in raw_mapping.items():
             if not isinstance(key, str):
                 raise SystemExit(f"Expected string YAML keys in {source_name}: {key!r}")
             normalized_mapping[key] = normalize_yaml(item_value, source_name)
@@ -295,11 +310,10 @@ def read_optional_string(source: YamlMapping, key: str, default: str) -> str:
 
 
 def scalar_to_string(value: YamlValue, location: str) -> str:
-    value_object = cast(object, value)
-    if value_object is None:
+    if value is None:
         return ""
-    if isinstance(value_object, (str, int, float, bool)):
-        return str(value_object)
+    if isinstance(value, (str, int, float, bool)):
+        return str(value)
     raise SystemExit(f"Expected scalar value at `{location}`.")
 
 
@@ -477,11 +491,12 @@ def lookup_render_value(context: RenderContext, path: str) -> RenderableValue | 
     current_value: object = context
 
     for segment in path.split("."):
-        if not is_object_mapping(current_value):
+        current_mapping = as_object_mapping(current_value)
+        if current_mapping is None:
             return None
-        if segment not in current_value:
+        if segment not in current_mapping:
             return None
-        next_value = current_value[segment]
+        next_value = current_mapping[segment]
         current_value = next_value
 
     if isinstance(current_value, (str, int, float, bool)):
@@ -571,10 +586,10 @@ def lookup_yaml_value(source: YamlMapping, path: str) -> YamlValue | None:
 
     current_value: YamlValue = source
     for segment in path.split("."):
-        current_object = cast(object, current_value)
-        if not isinstance(current_object, dict):
+        current_mapping = as_yaml_mapping(current_value)
+        if current_mapping is None:
             return None
-        next_value = cast(YamlMapping, current_object).get(segment)
+        next_value = current_mapping.get(segment)
         if next_value is None:
             return None
         current_value = next_value
@@ -583,11 +598,10 @@ def lookup_yaml_value(source: YamlMapping, path: str) -> YamlValue | None:
 
 
 def yaml_value_matches(actual_value: YamlValue | None, expected_value: str) -> bool:
-    actual_object = cast(object, actual_value)
-    if actual_object is None:
+    if actual_value is None:
         return not expected_value
-    if isinstance(actual_object, (str, int, float, bool)):
-        return str(actual_object) == expected_value
+    if isinstance(actual_value, (str, int, float, bool)):
+        return str(actual_value) == expected_value
     return False
 
 

--- a/scripts/generate_campaign.py
+++ b/scripts/generate_campaign.py
@@ -43,6 +43,10 @@ METRIC_PATTERNS: tuple[re.Pattern[str], ...] = (
 SUPPORT_FILE_NAMES: frozenset[str] = frozenset(
     {"README.md", "FACT_CHECK.md", "CHECKLIST.md", "POSTING_PLAN.md"}
 )
+SUPPORT_FILE_NAME_KEYS: frozenset[str] = frozenset(
+    support_file_name.casefold() for support_file_name in SUPPORT_FILE_NAMES
+)
+FEATURE_TIERS: frozenset[str] = frozenset({"free", "paid"})
 UNRESOLVED_PLACEHOLDER_PREFIX = "TODO_VERIFY: unresolved placeholder"
 
 
@@ -191,14 +195,17 @@ def read_template_names(campaign_mode: YamlMapping, mode: str) -> list[str]:
         raise SystemExit(f"Campaign mode `{mode}` must define a `templates` list.")
 
     template_names: list[str] = []
+    template_name_keys: set[str] = set()
     for raw_template_name in raw_templates:
         if not isinstance(raw_template_name, str):
             raise SystemExit(f"Campaign mode `{mode}` contains a non-string template name.")
         template_name = validate_template_name(raw_template_name)
-        if template_name in template_names:
+        template_name_key = template_name.casefold()
+        if template_name_key in template_name_keys:
             raise SystemExit(f"Template `{template_name}` is selected more than once.")
-        if template_name in SUPPORT_FILE_NAMES:
+        if template_name_key in SUPPORT_FILE_NAME_KEYS:
             raise SystemExit(f"Template `{template_name}` conflicts with a generated support file.")
+        template_name_keys.add(template_name_key)
         template_names.append(template_name)
 
     if not template_names:
@@ -339,6 +346,16 @@ def read_optional_string(source: YamlMapping, key: str, default: str) -> str:
     return default if value is None else scalar_to_string(value, key)
 
 
+def read_required_string(source: YamlMapping, key: str, location: str) -> str:
+    if key not in source:
+        raise SystemExit(f"Expected `{location}.{key}` to be a non-empty scalar.")
+
+    value = scalar_to_string(source[key], f"{location}.{key}").strip()
+    if not value:
+        raise SystemExit(f"Expected `{location}.{key}` to be a non-empty scalar.")
+    return value
+
+
 def scalar_to_string(value: YamlValue, location: str) -> str:
     if value is None:
         return ""
@@ -384,16 +401,22 @@ def flatten_features(features_data: YamlMapping) -> list[FeatureRecord]:
                 raise SystemExit(
                     f"Expected feature `{category_name}.features[{index}]` to be a YAML mapping."
                 )
-            feature_records.append(normalize_feature_entry(raw_feature))
+            feature_records.append(
+                normalize_feature_entry(raw_feature, f"{category_name}.features[{index}]")
+            )
 
     return feature_records
 
 
-def normalize_feature_entry(feature_data: YamlMapping) -> FeatureRecord:
-    feature_id = read_optional_string(feature_data, "id", "unknown-feature")
-    title = read_optional_string(feature_data, "title", feature_id)
-    tier = read_optional_string(feature_data, "tier", "free").lower()
-    introduced = read_optional_string(feature_data, "introduced", "unknown")
+def normalize_feature_entry(feature_data: YamlMapping, location: str) -> FeatureRecord:
+    feature_id = read_required_string(feature_data, "id", location)
+    title = read_required_string(feature_data, "title", location)
+    tier = read_required_string(feature_data, "tier", location).lower()
+    introduced = read_required_string(feature_data, "introduced", location)
+
+    if tier not in FEATURE_TIERS:
+        allowed_tiers = ", ".join(sorted(FEATURE_TIERS))
+        raise SystemExit(f"Expected `{location}.tier` to be one of: {allowed_tiers}.")
 
     return FeatureRecord(
         feature_id=feature_id,
@@ -462,11 +485,9 @@ def format_status_summary(statuses: StringMapping) -> str:
 
 def format_social_proof(social_proof_entries: list[YamlMapping]) -> str:
     verified_entries: list[str] = []
-    for entry in social_proof_entries:
-        source = read_optional_string(entry, "source", "")
-        if not source:
-            continue
-
+    for index, entry in enumerate(social_proof_entries):
+        location = f"social_proof[{index}]"
+        source = read_required_string(entry, "source", location)
         label = read_optional_string(entry, "label", "social proof")
         quote = read_optional_string(entry, "quote", "")
         status = read_optional_string(entry, "status", "TODO_VERIFY")

--- a/scripts/generate_campaign.py
+++ b/scripts/generate_campaign.py
@@ -1,0 +1,711 @@
+#!/usr/bin/env -S uv run --script --project scripts
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import TypeAlias, TypeGuard, cast
+
+try:
+    import yaml
+except ImportError as import_error:
+    raise SystemExit(
+        "PyYAML is required. Run `uv sync --project scripts` from the repository root."
+    ) from import_error
+
+
+YamlScalar: TypeAlias = str | int | float | bool | None
+YamlValue: TypeAlias = YamlScalar | list["YamlValue"] | dict[str, "YamlValue"]
+YamlMapping: TypeAlias = dict[str, YamlValue]
+RenderableValue: TypeAlias = str | int | float | bool
+StringMapping: TypeAlias = dict[str, str]
+RenderContext: TypeAlias = dict[str, StringMapping]
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent
+MARKETING_ROOT = REPO_ROOT / ".marketing"
+FEATURES_PATH = REPO_ROOT / "docs" / "features.yml"
+CONFIG_PATH = MARKETING_ROOT / "config.yaml"
+CHANGELOG_PATH = REPO_ROOT / "CHANGELOG.md"
+TEMPLATES_DIR = MARKETING_ROOT / "templates"
+GENERATED_DIR = MARKETING_ROOT / "generated"
+
+PLACEHOLDER_PATTERN: re.Pattern[str] = re.compile(r"{{\s*([a-zA-Z0-9_.-]+)\s*}}")
+MARKDOWN_HEADING_PATTERN: re.Pattern[str] = re.compile(r"^## \[?([^\]\s]+)\]?")
+METRIC_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\b\d[\d,.]*\s+(downloads|installs|reviews|users|stars)\b", re.I),
+    re.compile(r"\b(revenue|conversion)\b.{0,48}\b\d[\d,.%]*", re.I),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class FeatureRecord:
+    feature_id: str
+    title: str
+    tier: str
+    introduced: str
+
+
+@dataclass(frozen=True, slots=True)
+class RenderedFile:
+    name: str
+    content: str
+    is_public_draft: bool
+
+
+@dataclass(frozen=True, slots=True)
+class GuardReport:
+    hard_blocks: list[str]
+    warnings: list[str]
+
+
+def is_object_list(value: object) -> TypeGuard[list[object]]:
+    return isinstance(value, list)
+
+
+def is_object_dict(value: object) -> TypeGuard[dict[object, object]]:
+    return isinstance(value, dict)
+
+
+def is_object_mapping(value: object) -> TypeGuard[Mapping[object, object]]:
+    return isinstance(value, Mapping)
+
+
+def main() -> int:
+    arguments = parse_args()
+    campaign_name = slugify(arguments.name)
+    config_data = load_yaml_mapping(CONFIG_PATH)
+    features_data = load_yaml_mapping(FEATURES_PATH)
+    campaign_mode = get_campaign_mode(config_data, arguments.mode)
+    template_names = read_template_names(campaign_mode, arguments.mode)
+    context = build_context(config_data, features_data, campaign_mode, arguments.mode, campaign_name)
+
+    rendered_files = render_templates(template_names, context)
+    guard_report = evaluate_guardrails(config_data, features_data, rendered_files)
+
+    output_directory = GENERATED_DIR / f"{date.today().isoformat()}-{campaign_name}"
+    output_directory.mkdir(parents=True, exist_ok=True)
+
+    for rendered_file in rendered_files + build_support_files(
+        template_names,
+        context,
+        guard_report,
+    ):
+        (output_directory / rendered_file.name).write_text(
+            rendered_file.content,
+            encoding="utf-8",
+        )
+
+    print(f"Generated campaign: {output_directory}")
+    print(f"Rendered drafts: {', '.join(template_names)}")
+    print(f"Warnings: {len(guard_report.warnings)}")
+    print(f"Hard blocks: {len(guard_report.hard_blocks)}")
+
+    if guard_report.hard_blocks:
+        print("Hard-blocked claims were found. Review FACT_CHECK.md.", file=sys.stderr)
+        return 2
+
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate private Ayu Islands marketing campaign drafts.",
+    )
+    parser.add_argument(
+        "--mode",
+        required=True,
+        help="Campaign mode from .marketing/config.yaml.",
+    )
+    parser.add_argument(
+        "--name",
+        required=True,
+        help="Human-readable campaign name. It will be slugified for the output path.",
+    )
+    return parser.parse_args()
+
+
+def load_yaml_mapping(path: Path) -> YamlMapping:
+    if not path.exists():
+        raise SystemExit(f"Required YAML file is missing: {path}")
+
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            loaded_yaml: object = yaml.safe_load(handle)
+    except OSError as file_error:
+        raise SystemExit(f"Failed to read YAML file {path}: {file_error}") from file_error
+    except yaml.YAMLError as yaml_error:
+        raise SystemExit(f"Failed to parse YAML file {path}: {yaml_error}") from yaml_error
+
+    raw_yaml = cast(object, loaded_yaml if loaded_yaml is not None else {})
+    normalized_yaml = normalize_yaml(raw_yaml, path.name)
+    if not isinstance(cast(object, normalized_yaml), dict):
+        raise SystemExit(f"Expected YAML mapping at top level in {path}")
+
+    return cast(YamlMapping, normalized_yaml)
+
+
+def normalize_yaml(value: object, source_name: str) -> YamlValue:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+
+    if is_object_list(value):
+        return [normalize_yaml(cast(object, item), source_name) for item in value]
+
+    if is_object_dict(value):
+        normalized_mapping: YamlMapping = {}
+        for key, item_value in value.items():
+            if not isinstance(key, str):
+                raise SystemExit(f"Expected string YAML keys in {source_name}: {key!r}")
+            normalized_mapping[key] = normalize_yaml(item_value, source_name)
+        return normalized_mapping
+
+    raise SystemExit(f"Unsupported YAML value in {source_name}: {type(value).__name__}")
+
+
+def get_campaign_mode(config_data: YamlMapping, mode: str) -> YamlMapping:
+    campaign_modes = require_mapping(config_data, "campaign_modes")
+    selected_mode = campaign_modes.get(mode)
+    if isinstance(selected_mode, dict):
+        return selected_mode
+
+    available_modes = ", ".join(sorted(campaign_modes))
+    raise SystemExit(f"Unknown campaign mode `{mode}`. Available modes: {available_modes}")
+
+
+def read_template_names(campaign_mode: YamlMapping, mode: str) -> list[str]:
+    raw_templates = campaign_mode.get("templates")
+    if not isinstance(raw_templates, list):
+        raise SystemExit(f"Campaign mode `{mode}` must define a `templates` list.")
+
+    template_names: list[str] = []
+    for raw_template_name in raw_templates:
+        if not isinstance(raw_template_name, str):
+            raise SystemExit(f"Campaign mode `{mode}` contains a non-string template name.")
+        if not raw_template_name.endswith(".md"):
+            raise SystemExit(f"Template `{raw_template_name}` must be a Markdown file.")
+        template_names.append(raw_template_name)
+
+    if not template_names:
+        raise SystemExit(f"Campaign mode `{mode}` does not select any templates.")
+
+    return template_names
+
+
+def build_context(
+    config_data: YamlMapping,
+    features_data: YamlMapping,
+    campaign_mode: YamlMapping,
+    mode: str,
+    campaign_name: str,
+) -> RenderContext:
+    product = require_string_mapping(config_data, "product")
+    pricing = require_string_mapping(config_data, "pricing")
+    launch_status = require_string_mapping(config_data, "launch_status")
+    feature_summary = summarize_features(features_data)
+    manual_verification = read_string_list(config_data, "manual_verification")
+    social_proof = format_social_proof(read_mapping_list(config_data, "social_proof"))
+
+    verification_todos = "\n".join(
+            f"- TODO_VERIFY: {verification_item}" for verification_item in manual_verification
+        ) or "- TODO_VERIFY: no manual verification checklist configured"
+
+    campaign = {
+        "mode": mode,
+        "name": campaign_name,
+        "generated_date": date.today().isoformat(),
+        "description": read_optional_string(campaign_mode, "description", ""),
+    }
+    facts = {
+        **feature_summary,
+        "latest_version": read_latest_changelog_version(),
+        "latest_changelog_summary": read_latest_changelog_summary(),
+        "pricing_summary": format_pricing_summary(pricing),
+        "launch_status_summary": format_status_summary(launch_status),
+        "social_proof_summary": social_proof,
+    }
+    verification = {
+        "todos": verification_todos,
+    }
+
+    return {
+        "product": product,
+        "campaign": campaign,
+        "facts": facts,
+        "pricing": pricing,
+        "launch_status": launch_status,
+        "verification": verification,
+    }
+
+
+def require_mapping(source: YamlMapping, key: str) -> YamlMapping:
+    value = source.get(key)
+    if isinstance(value, dict):
+        return value
+    raise SystemExit(f"Expected `{key}` to be a YAML mapping.")
+
+
+def require_string_mapping(source: YamlMapping, key: str) -> StringMapping:
+    value = require_mapping(source, key)
+    result: StringMapping = {
+        item_key: scalar_to_string(item_value, f"{key}.{item_key}")
+        for item_key, item_value in value.items()
+    }
+    return result
+
+
+def read_string_list(source: YamlMapping, key: str) -> list[str]:
+    value = source.get(key)
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise SystemExit(f"Expected `{key}` to be a YAML list.")
+
+    strings: list[str] = []
+    strings.extend(
+        scalar_to_string(item, f"{key}[{index}]")
+        for index, item in enumerate(value)
+    )
+    return strings
+
+
+def read_mapping_list(source: YamlMapping, key: str) -> list[YamlMapping]:
+    value = source.get(key)
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise SystemExit(f"Expected `{key}` to be a YAML list.")
+
+    mappings: list[YamlMapping] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, dict):
+            raise SystemExit(f"Expected `{key}[{index}]` to be a YAML mapping.")
+        mappings.append(item)
+    return mappings
+
+
+def read_optional_string(source: YamlMapping, key: str, default: str) -> str:
+    value = source.get(key)
+    return default if value is None else scalar_to_string(value, key)
+
+
+def scalar_to_string(value: YamlValue, location: str) -> str:
+    value_object = cast(object, value)
+    if value_object is None:
+        return ""
+    if isinstance(value_object, (str, int, float, bool)):
+        return str(value_object)
+    raise SystemExit(f"Expected scalar value at `{location}`.")
+
+
+def summarize_features(features_data: YamlMapping) -> StringMapping:
+    feature_records = flatten_features(features_data)
+    free_features = [
+        feature_record for feature_record in feature_records if feature_record.tier == "free"
+    ]
+    paid_features = [
+        feature_record for feature_record in feature_records if feature_record.tier == "paid"
+    ]
+
+    return {
+        "free_feature_summary": format_feature_bullets(free_features),
+        "paid_feature_summary": format_feature_bullets(paid_features),
+        "free_feature_summary_inline": format_inline_features(free_features),
+        "paid_feature_summary_inline": format_inline_features(paid_features),
+        "released_feature_ids": ", ".join(feature_record.feature_id for feature_record in feature_records),
+    }
+
+
+def flatten_features(features_data: YamlMapping) -> list[FeatureRecord]:
+    categories = require_mapping(features_data, "categories")
+    feature_records: list[FeatureRecord] = []
+
+    for category_name, category_data in categories.items():
+        if not isinstance(category_data, dict):
+            raise SystemExit(f"Expected category `{category_name}` to be a YAML mapping.")
+
+        raw_features = category_data.get("features")
+        if raw_features is None:
+            continue
+        if not isinstance(raw_features, list):
+            raise SystemExit(f"Expected category `{category_name}` features to be a YAML list.")
+
+        for index, raw_feature in enumerate(raw_features):
+            if not isinstance(raw_feature, dict):
+                raise SystemExit(
+                    f"Expected feature `{category_name}.features[{index}]` to be a YAML mapping."
+                )
+            feature_records.append(normalize_feature_entry(raw_feature))
+
+    return feature_records
+
+
+def normalize_feature_entry(feature_data: YamlMapping) -> FeatureRecord:
+    feature_id = read_optional_string(feature_data, "id", "unknown-feature")
+    title = read_optional_string(feature_data, "title", feature_id)
+    tier = read_optional_string(feature_data, "tier", "free").lower()
+    introduced = read_optional_string(feature_data, "introduced", "unknown")
+
+    return FeatureRecord(
+        feature_id=feature_id,
+        title=title,
+        tier=tier,
+        introduced=introduced,
+    )
+
+
+def format_feature_bullets(feature_records: list[FeatureRecord]) -> str:
+    if not feature_records:
+        return "- TODO_VERIFY: no released features found"
+
+    return "\n".join(
+        f"- {feature_record.title} ({feature_record.tier}, introduced {feature_record.introduced})"
+        for feature_record in feature_records
+    )
+
+
+def format_inline_features(feature_records: list[FeatureRecord]) -> str:
+    if not feature_records:
+        return "TODO_VERIFY: no released features found"
+    return ", ".join(feature_record.title for feature_record in feature_records[:5])
+
+
+def read_latest_changelog_version() -> str:
+    if not CHANGELOG_PATH.exists():
+        return "TODO_VERIFY: CHANGELOG.md not found"
+
+    for line in CHANGELOG_PATH.read_text(encoding="utf-8").splitlines():
+        if match := MARKDOWN_HEADING_PATTERN.match(line):
+            return match.group(1)
+
+    return "TODO_VERIFY: no changelog version heading found"
+
+
+def read_latest_changelog_summary() -> str:
+    if not CHANGELOG_PATH.exists():
+        return "- TODO_VERIFY: CHANGELOG.md not found"
+
+    lines = CHANGELOG_PATH.read_text(encoding="utf-8").splitlines()
+    in_latest_section = False
+    summary_lines: list[str] = []
+
+    for line in lines:
+        if line.startswith("## "):
+            if in_latest_section:
+                break
+            in_latest_section = True
+            continue
+        if in_latest_section and line.strip():
+            summary_lines.append(line)
+
+    return "\n".join(summary_lines) if summary_lines else "- TODO_VERIFY: no latest changelog body found"
+
+
+def format_pricing_summary(pricing: StringMapping) -> str:
+    public_claim_status = pricing.get("public_claim_status", "not_ready")
+    if public_claim_status != "ready":
+        return "TODO_VERIFY: pricing copy is not ready for public use"
+
+    individual = pricing.get("individual", "TODO_VERIFY")
+    commercial = pricing.get("commercial", "TODO_VERIFY")
+    model = pricing.get("model", "TODO_VERIFY")
+    return f"{individual} individual / {commercial} commercial, {model}"
+
+
+def format_status_summary(statuses: StringMapping) -> str:
+    if not statuses:
+        return "- TODO_VERIFY: no launch status configured"
+
+    return "\n".join(f"- {key}: {value}" for key, value in statuses.items())
+
+
+def format_social_proof(social_proof_entries: list[YamlMapping]) -> str:
+    verified_entries: list[str] = []
+    for entry in social_proof_entries:
+        source = read_optional_string(entry, "source", "")
+        if not source:
+            continue
+
+        label = read_optional_string(entry, "label", "social proof")
+        quote = read_optional_string(entry, "quote", "")
+        status = read_optional_string(entry, "status", "TODO_VERIFY")
+        verified_entries.append(f'- {label}: "{quote}" (source: {source}, status: {status})')
+
+    if not verified_entries:
+        return "- TODO_VERIFY: no sourced social proof configured"
+
+    return "\n".join(verified_entries)
+
+
+def render_templates(template_names: list[str], context: RenderContext) -> list[RenderedFile]:
+    rendered_files: list[RenderedFile] = []
+
+    for template_name in template_names:
+        template_path = TEMPLATES_DIR / template_name
+        if not template_path.exists():
+            raise SystemExit(f"Selected template is missing: {template_path}")
+
+        template_content = template_path.read_text(encoding="utf-8")
+        rendered_files.append(
+            RenderedFile(
+                name=template_name,
+                content=render_text(template_content, context),
+                is_public_draft=True,
+            )
+        )
+
+    return rendered_files
+
+
+def render_text(template_content: str, context: RenderContext) -> str:
+    def replace_placeholder(match: re.Match[str]) -> str:
+        placeholder = match.group(1)
+        value = lookup_render_value(context, placeholder)
+        if value is None:
+            return f"TODO_VERIFY: unresolved placeholder {placeholder}"
+        return str(value)
+
+    return PLACEHOLDER_PATTERN.sub(replace_placeholder, template_content)
+
+
+def lookup_render_value(context: RenderContext, path: str) -> RenderableValue | None:
+    current_value: object = context
+
+    for segment in path.split("."):
+        if not is_object_mapping(current_value):
+            return None
+        if segment not in current_value:
+            return None
+        next_value = current_value[segment]
+        current_value = next_value
+
+    if isinstance(current_value, (str, int, float, bool)):
+        return current_value
+
+    return None
+
+
+def evaluate_guardrails(
+    config_data: YamlMapping,
+    features_data: YamlMapping,
+    rendered_files: list[RenderedFile],
+) -> GuardReport:
+    guardrails = require_mapping(config_data, "guardrails")
+    blocked_phrases = read_string_list(guardrails, "blocked_phrases")
+    conditional_claims = read_mapping_list(guardrails, "conditional_claims")
+    feature_records = flatten_features(features_data)
+    hard_blocks: list[str] = []
+    warnings: list[str] = []
+
+    for rendered_file in rendered_files:
+        if not rendered_file.is_public_draft:
+            continue
+
+        lower_content = rendered_file.content.lower()
+        hard_blocks.extend(
+            f"{rendered_file.name}: blocked phrase `{blocked_phrase}`"
+            for blocked_phrase in blocked_phrases
+            if blocked_phrase.lower() in lower_content
+        )
+        for conditional_claim in conditional_claims:
+            if warning := evaluate_conditional_claim(
+                config_data,
+                feature_records,
+                conditional_claim,
+                lower_content,
+            ):
+                warnings.append(f"{rendered_file.name}: {warning}")
+
+        warnings.extend(
+            f"{rendered_file.name}: {unresolved_marker}"
+            for unresolved_marker in find_unresolved_markers(
+                rendered_file.content
+            )
+        )
+        warnings.extend(
+            f"{rendered_file.name}: TODO_VERIFY: metric claim `{metric_claim}` needs a source"
+            for metric_claim in find_metric_claims(rendered_file.content)
+        )
+    return GuardReport(hard_blocks=hard_blocks, warnings=warnings)
+def evaluate_conditional_claim(
+    config_data: YamlMapping,
+    feature_records: list[FeatureRecord],
+    conditional_claim: YamlMapping,
+    lower_content: str,
+) -> str | None:
+    phrase = read_optional_string(conditional_claim, "phrase", "")
+    if not phrase or phrase.lower() not in lower_content:
+        return None
+
+    message = read_optional_string(
+        conditional_claim,
+        "message",
+        f"TODO_VERIFY: conditional claim `{phrase}` requires manual verification.",
+    )
+    if required_feature_id := read_optional_string(
+        conditional_claim, "requires_feature_id", ""
+    ):
+        if any(feature_record.feature_id == required_feature_id for feature_record in feature_records):
+            return None
+        return message
+
+    requires = conditional_claim.get("requires")
+    if isinstance(requires, dict):
+        path = read_optional_string(requires, "path", "")
+        expected_value = read_optional_string(requires, "value", "")
+        actual_value = lookup_yaml_value(config_data, path)
+        if yaml_value_matches(actual_value, expected_value):
+            return None
+
+    return message
+
+
+def lookup_yaml_value(source: YamlMapping, path: str) -> YamlValue | None:
+    if not path:
+        return None
+
+    current_value: YamlValue = source
+    for segment in path.split("."):
+        current_object = cast(object, current_value)
+        if not isinstance(current_object, dict):
+            return None
+        next_value = cast(YamlMapping, current_object).get(segment)
+        if next_value is None:
+            return None
+        current_value = next_value
+
+    return current_value
+
+
+def yaml_value_matches(actual_value: YamlValue | None, expected_value: str) -> bool:
+    actual_object = cast(object, actual_value)
+    if actual_object is None:
+        return not expected_value
+    if isinstance(actual_object, (str, int, float, bool)):
+        return str(actual_object) == expected_value
+    return False
+
+
+def find_unresolved_markers(content: str) -> list[str]:
+    return [line.strip() for line in content.splitlines() if "TODO_VERIFY:" in line]
+
+
+def find_metric_claims(content: str) -> list[str]:
+    metric_claims: set[str] = set()
+    for metric_pattern in METRIC_PATTERNS:
+        for match in metric_pattern.finditer(content):
+            metric_claims.add(match.group(0).strip())
+    return sorted(metric_claims)
+
+
+def build_support_files(
+    template_names: list[str],
+    context: RenderContext,
+    guard_report: GuardReport,
+) -> list[RenderedFile]:
+    campaign_name = context["campaign"]["name"]
+    campaign_mode = context["campaign"]["mode"]
+    verification_todos = context["verification"]["todos"]
+    draft_file_list = "\n".join(f"- `{template_name}`" for template_name in template_names)
+
+    readme_content = "\n".join(
+        [
+            f"# {campaign_name}",
+            "",
+            f"Mode: `{campaign_mode}`",
+            "",
+            "Generated files:",
+            "",
+            draft_file_list,
+            "",
+            "Fact-check summary:",
+            "",
+            f"- Warnings: {len(guard_report.warnings)}",
+            f"- Hard blocks: {len(guard_report.hard_blocks)}",
+            "",
+            "Review `FACT_CHECK.md` before publishing anything.",
+            "",
+        ]
+    )
+    fact_check_content = "\n".join(
+        [
+            "# Fact Check",
+            "",
+            "## Hard Blocks",
+            "",
+            format_report_lines(guard_report.hard_blocks, "No hard blocks."),
+            "",
+            "## Warnings",
+            "",
+            format_report_lines(guard_report.warnings, "No warnings."),
+            "",
+            "## Manual Verification",
+            "",
+            verification_todos,
+            "",
+        ]
+    )
+    checklist_content = "\n".join(
+        [
+            "# Campaign Checklist",
+            "",
+            "## Before Publishing",
+            "",
+            verification_todos,
+            "",
+            "## Safety",
+            "",
+            "- Confirm all generated files are reviewable Markdown.",
+            "- Confirm no API posting integration is involved.",
+            "- Confirm no secrets or `.env` files were read.",
+            "- Confirm public claims match released features in `docs/features.yml`.",
+            "",
+        ]
+    )
+    posting_plan_content = "\n".join(
+        [
+            "# Posting Plan",
+            "",
+            f"Campaign mode: `{campaign_mode}`",
+            "",
+            "Draft files:",
+            "",
+            draft_file_list,
+            "",
+            "Manual channel routing:",
+            "",
+            "- Copy only after `FACT_CHECK.md` is clean.",
+            "- Paste manually into the target channel.",
+            "- Re-check final preview in the target platform UI.",
+            "",
+        ]
+    )
+
+    return [
+        RenderedFile("README.md", readme_content, False),
+        RenderedFile("FACT_CHECK.md", fact_check_content, False),
+        RenderedFile("CHECKLIST.md", checklist_content, False),
+        RenderedFile("POSTING_PLAN.md", posting_plan_content, False),
+    ]
+
+
+def format_report_lines(lines: list[str], empty_message: str) -> str:
+    if not lines:
+        return f"- {empty_message}"
+    return "\n".join(f"- {line}" for line in lines)
+
+
+def slugify(value: str) -> str:
+    if slug := re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-"):
+        return slug
+    else:
+        raise SystemExit("Campaign name must contain at least one ASCII letter or number.")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_campaign.py
+++ b/scripts/generate_campaign.py
@@ -36,7 +36,7 @@ TEMPLATES_DIR = MARKETING_ROOT / "templates"
 GENERATED_DIR = MARKETING_ROOT / "generated"
 
 PLACEHOLDER_PATTERN: re.Pattern[str] = re.compile(r"{{\s*([a-zA-Z0-9_.-]+)\s*}}")
-MARKDOWN_HEADING_PATTERN: re.Pattern[str] = re.compile(r"^## \[?([^\]\s]+)\]?")
+MARKDOWN_HEADING_PATTERN: re.Pattern[str] = re.compile(r"^## \[?([^]\s]+)]?")
 METRIC_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\b\d[\d,.]*\s+(downloads|installs|reviews|users|stars)\b", re.I),
     re.compile(r"\b(revenue|conversion)\b.{0,48}\b\d[\d,.%]*", re.I),
@@ -65,27 +65,19 @@ class GuardReport:
 
 
 def as_object_list(value: object) -> list[object] | None:
-    if isinstance(value, list):
-        return list(value)
-    return None
+    return list(value) if isinstance(value, list) else None
 
 
 def as_object_dict(value: object) -> dict[object, object] | None:
-    if isinstance(value, dict):
-        return dict(value)
-    return None
+    return dict(value) if isinstance(value, dict) else None
 
 
 def as_object_mapping(value: object) -> Mapping[object, object] | None:
-    if isinstance(value, Mapping):
-        return value
-    return None
+    return value if isinstance(value, Mapping) else None
 
 
 def as_yaml_mapping(value: YamlValue) -> YamlMapping | None:
-    if isinstance(value, dict):
-        return value
-    return None
+    return value if isinstance(value, dict) else None
 
 
 def main() -> int:

--- a/scripts/generate_campaign.py
+++ b/scripts/generate_campaign.py
@@ -341,7 +341,14 @@ def read_string_list(source: YamlMapping, key: str) -> list[str]:
         return []
     if not isinstance(value, list):
         raise SystemExit(f"Expected `{key}` to be a YAML list.")
+    return parse_string_list(value, key)
 
+
+def read_required_string_list(source: YamlMapping, key: str) -> list[str]:
+    return parse_string_list(require_yaml_list(source, key), key)
+
+
+def parse_string_list(value: list[YamlValue], key: str) -> list[str]:
     strings: list[str] = []
     for index, item in enumerate(value):
         if string_value := scalar_to_string(item, f"{key}[{index}]").strip():
@@ -357,7 +364,24 @@ def read_mapping_list(source: YamlMapping, key: str) -> list[YamlMapping]:
         return []
     if not isinstance(value, list):
         raise SystemExit(f"Expected `{key}` to be a YAML list.")
+    return parse_mapping_list(value, key)
 
+
+def read_required_mapping_list(source: YamlMapping, key: str) -> list[YamlMapping]:
+    return parse_mapping_list(require_yaml_list(source, key), key)
+
+
+def require_yaml_list(source: YamlMapping, key: str) -> list[YamlValue]:
+    if key not in source:
+        raise SystemExit(f"Expected `{key}` to be a YAML list.")
+
+    value = source[key]
+    if isinstance(value, list):
+        return value
+    raise SystemExit(f"Expected `{key}` to be a YAML list.")
+
+
+def parse_mapping_list(value: list[YamlValue], key: str) -> list[YamlMapping]:
     mappings: list[YamlMapping] = []
     for index, item in enumerate(value):
         if not isinstance(item, dict):
@@ -377,8 +401,18 @@ def read_required_string(source: YamlMapping, key: str, location: str) -> str:
 
     if value := scalar_to_string(source[key], f"{location}.{key}").strip():
         return value
-    else:
-        raise SystemExit(f"Expected `{location}.{key}` to be a non-empty scalar.")
+    raise SystemExit(f"Expected `{location}.{key}` to be a non-empty scalar.")
+
+
+def read_optional_non_empty_string(
+    source: YamlMapping,
+    key: str,
+    default: str,
+    location: str,
+) -> str:
+    if key not in source:
+        return default
+    return read_required_string(source, key, location)
 
 
 def scalar_to_string(value: YamlValue, location: str) -> str:
@@ -390,9 +424,11 @@ def scalar_to_string(value: YamlValue, location: str) -> str:
 
 
 def read_conditional_claims(guardrails: YamlMapping) -> list[YamlMapping]:
-    conditional_claims = read_mapping_list(guardrails, "conditional_claims")
+    conditional_claims = read_required_mapping_list(guardrails, "conditional_claims")
     for index, conditional_claim in enumerate(conditional_claims):
         read_required_string(conditional_claim, "phrase", f"conditional_claims[{index}]")
+        if "message" in conditional_claim:
+            read_required_string(conditional_claim, "message", f"conditional_claims[{index}]")
     return conditional_claims
 
 
@@ -502,10 +538,16 @@ def format_pricing_summary(pricing: StringMapping) -> str:
     if public_claim_status != "ready":
         return "TODO_VERIFY: pricing copy is not ready for public use"
 
-    individual = pricing.get("individual", "TODO_VERIFY")
-    commercial = pricing.get("commercial", "TODO_VERIFY")
-    model = pricing.get("model", "TODO_VERIFY")
+    individual = pricing_summary_value(pricing, "individual")
+    commercial = pricing_summary_value(pricing, "commercial")
+    model = pricing_summary_value(pricing, "model")
     return f"{individual} individual / {commercial} commercial, {model}"
+
+
+def pricing_summary_value(pricing: StringMapping, key: str) -> str:
+    if value := pricing.get(key, "").strip():
+        return value
+    return f"TODO_VERIFY {key}"
 
 
 def format_status_summary(statuses: StringMapping) -> str:
@@ -577,8 +619,8 @@ def evaluate_guardrails(
     rendered_files: list[RenderedFile],
 ) -> GuardReport:
     guardrails = require_mapping(config_data, "guardrails")
-    blocked_phrases = read_string_list(guardrails, "blocked_phrases")
-    risky_phrases = read_string_list(guardrails, "risky_phrases")
+    blocked_phrases = read_required_string_list(guardrails, "blocked_phrases")
+    risky_phrases = read_required_string_list(guardrails, "risky_phrases")
     conditional_claims = read_conditional_claims(guardrails)
     feature_records = flatten_features(features_data)
     hard_blocks: list[str] = []
@@ -643,10 +685,11 @@ def evaluate_conditional_claim(
     if phrase.lower() not in lower_content:
         return None
 
-    message = read_optional_string(
+    message = read_optional_non_empty_string(
         conditional_claim,
         "message",
         f"TODO_VERIFY: conditional claim `{phrase}` requires manual verification.",
+        "conditional_claim",
     )
     if required_feature_id := read_optional_string(
         conditional_claim, "requires_feature_id", ""

--- a/scripts/generate_campaign.py
+++ b/scripts/generate_campaign.py
@@ -7,7 +7,7 @@ import sys
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
-from typing import TypeAlias, TypeGuard
+from typing import TypeAlias, TypeGuard, cast
 
 try:
     import yaml
@@ -38,7 +38,7 @@ PLACEHOLDER_PATTERN: re.Pattern[str] = re.compile(r"{{\s*([a-zA-Z0-9_.-]+)\s*}}"
 RAW_PLACEHOLDER_PATTERN: re.Pattern[str] = re.compile(r"{{[^{}]*}}")
 MARKDOWN_HEADING_PATTERN: re.Pattern[str] = re.compile(r"^## \[?([^]\s]+)]?")
 METRIC_PATTERNS: tuple[re.Pattern[str], ...] = (
-    re.compile(r"\b\d[\d,.]*\s+(downloads|installs|reviews|users|stars)\b", re.I),
+    re.compile(r"\b\d[\d,.]*\+?\s+(downloads|installs|reviews|users|stars)\b", re.I),
     re.compile(r"\b(revenue|conversion)\b.{0,48}\b\d[\d,.%]*", re.I),
 )
 SUPPORT_FILE_NAMES: frozenset[str] = frozenset(
@@ -147,8 +147,11 @@ def load_yaml_mapping(path: Path) -> YamlMapping:
         raise SystemExit(f"Required YAML file is missing: {path}")
 
     try:
-        with path.open("r", encoding="utf-8") as handle:
-            loaded_yaml: object = yaml.safe_load(handle)
+        raw_content = path.read_text(encoding="utf-8")
+        parsed_yaml = cast(object | None, yaml.compose(raw_content))  # pyright: ignore[reportUnknownMemberType]
+        if parsed_yaml is not None:
+            reject_duplicate_yaml_keys(parsed_yaml, path.name)
+        loaded_yaml: object = yaml.safe_load(raw_content)
     except OSError as file_error:
         raise SystemExit(f"Failed to read YAML file {path}: {file_error}") from file_error
     except yaml.YAMLError as yaml_error:
@@ -160,6 +163,26 @@ def load_yaml_mapping(path: Path) -> YamlMapping:
         raise SystemExit(f"Expected YAML mapping at top level in {path}")
 
     return normalized_yaml
+
+
+def reject_duplicate_yaml_keys(node: object, source_name: str) -> None:
+    if isinstance(node, yaml.nodes.MappingNode):
+        seen_keys: set[str] = set()
+        for key_node, value_node in node.value:
+            if isinstance(key_node, yaml.nodes.ScalarNode):
+                key_name = key_node.value
+                if key_name in seen_keys:
+                    line_number = key_node.start_mark.line + 1
+                    raise SystemExit(
+                        f"Duplicate YAML key `{key_name}` in {source_name}:{line_number}."
+                    )
+                seen_keys.add(key_name)
+            reject_duplicate_yaml_keys(value_node, source_name)
+        return
+
+    if isinstance(node, yaml.nodes.SequenceNode):
+        for value_node in node.value:
+            reject_duplicate_yaml_keys(value_node, source_name)
 
 
 def normalize_yaml(value: object, source_name: str) -> YamlValue:
@@ -320,10 +343,11 @@ def read_string_list(source: YamlMapping, key: str) -> list[str]:
         raise SystemExit(f"Expected `{key}` to be a YAML list.")
 
     strings: list[str] = []
-    strings.extend(
-        scalar_to_string(item, f"{key}[{index}]")
-        for index, item in enumerate(value)
-    )
+    for index, item in enumerate(value):
+        if string_value := scalar_to_string(item, f"{key}[{index}]").strip():
+            strings.append(string_value)
+        else:
+            raise SystemExit(f"Expected `{key}[{index}]` to be a non-empty scalar.")
     return strings
 
 
@@ -351,10 +375,10 @@ def read_required_string(source: YamlMapping, key: str, location: str) -> str:
     if key not in source:
         raise SystemExit(f"Expected `{location}.{key}` to be a non-empty scalar.")
 
-    value = scalar_to_string(source[key], f"{location}.{key}").strip()
-    if not value:
+    if value := scalar_to_string(source[key], f"{location}.{key}").strip():
+        return value
+    else:
         raise SystemExit(f"Expected `{location}.{key}` to be a non-empty scalar.")
-    return value
 
 
 def scalar_to_string(value: YamlValue, location: str) -> str:
@@ -363,6 +387,13 @@ def scalar_to_string(value: YamlValue, location: str) -> str:
     if isinstance(value, (str, int, float, bool)):
         return str(value)
     raise SystemExit(f"Expected scalar value at `{location}`.")
+
+
+def read_conditional_claims(guardrails: YamlMapping) -> list[YamlMapping]:
+    conditional_claims = read_mapping_list(guardrails, "conditional_claims")
+    for index, conditional_claim in enumerate(conditional_claims):
+        read_required_string(conditional_claim, "phrase", f"conditional_claims[{index}]")
+    return conditional_claims
 
 
 def summarize_features(features_data: YamlMapping) -> StringMapping:
@@ -490,7 +521,7 @@ def format_social_proof(social_proof_entries: list[YamlMapping]) -> str:
         location = f"social_proof[{index}]"
         source = read_required_string(entry, "source", location)
         label = read_optional_string(entry, "label", "social proof")
-        quote = read_optional_string(entry, "quote", "")
+        quote = read_required_string(entry, "quote", location)
         status = read_optional_string(entry, "status", "TODO_VERIFY")
         verified_entries.append(f'- {label}: "{quote}" (source: {source}, status: {status})')
 
@@ -548,7 +579,7 @@ def evaluate_guardrails(
     guardrails = require_mapping(config_data, "guardrails")
     blocked_phrases = read_string_list(guardrails, "blocked_phrases")
     risky_phrases = read_string_list(guardrails, "risky_phrases")
-    conditional_claims = read_mapping_list(guardrails, "conditional_claims")
+    conditional_claims = read_conditional_claims(guardrails)
     feature_records = flatten_features(features_data)
     hard_blocks: list[str] = []
     warnings: list[str] = []
@@ -608,8 +639,8 @@ def evaluate_conditional_claim(
     conditional_claim: YamlMapping,
     lower_content: str,
 ) -> str | None:
-    phrase = read_optional_string(conditional_claim, "phrase", "")
-    if not phrase or phrase.lower() not in lower_content:
+    phrase = read_required_string(conditional_claim, "phrase", "conditional_claim")
+    if phrase.lower() not in lower_content:
         return None
 
     message = read_optional_string(
@@ -668,10 +699,19 @@ def find_unresolved_markers(content: str) -> list[str]:
 
 
 def find_raw_placeholders(content: str) -> list[str]:
-    return sorted(
+    raw_placeholders = {
         raw_placeholder.strip()
         for raw_placeholder in RAW_PLACEHOLDER_PATTERN.findall(content)
-    )
+    }
+    for line in content.splitlines():
+        open_index = line.find("{{")
+        while open_index != -1:
+            close_index = line.find("}}", open_index + 2)
+            if close_index == -1:
+                raw_placeholders.add(line[open_index:].strip())
+                break
+            open_index = line.find("{{", close_index + 2)
+    return sorted(raw_placeholders)
 
 
 def find_metric_claims(content: str) -> list[str]:

--- a/scripts/generate_campaign.py
+++ b/scripts/generate_campaign.py
@@ -226,9 +226,13 @@ def build_context(
     manual_verification = read_string_list(config_data, "manual_verification")
     social_proof = format_social_proof(read_mapping_list(config_data, "social_proof"))
 
-    verification_todos = "\n".join(
-            f"- TODO_VERIFY: {verification_item}" for verification_item in manual_verification
-        ) or "- TODO_VERIFY: no manual verification checklist configured"
+    verification_todos = (
+        "\n".join(
+            f"- TODO_VERIFY: {verification_item}"
+            for verification_item in manual_verification
+        )
+        or "- TODO_VERIFY: no manual verification checklist configured"
+    )
 
     campaign = {
         "mode": mode,
@@ -547,6 +551,8 @@ def evaluate_guardrails(
             for metric_claim in find_metric_claims(rendered_file.content)
         )
     return GuardReport(hard_blocks=hard_blocks, warnings=warnings)
+
+
 def evaluate_conditional_claim(
     config_data: YamlMapping,
     feature_records: list[FeatureRecord],

--- a/scripts/generate_campaign.py
+++ b/scripts/generate_campaign.py
@@ -444,8 +444,16 @@ def read_conditional_claims(guardrails: YamlMapping) -> list[YamlMapping]:
         read_required_string(conditional_claim, "phrase", location)
         if "message" in conditional_claim:
             read_required_string(conditional_claim, "message", location)
+        if "requires_feature_id" in conditional_claim:
+            read_required_string(conditional_claim, "requires_feature_id", location)
+        if "requires_feature_id" in conditional_claim and "requires" in conditional_claim:
+            raise SystemExit(
+                f"Expected `{location}` to define only one requirement type."
+            )
         requires = conditional_claim.get("requires")
-        if isinstance(requires, dict):
+        if requires is not None and not isinstance(requires, dict):
+            raise SystemExit(f"Expected `{location}.requires` to be a YAML mapping.")
+        if requires is not None:
             read_required_string(requires, "path", f"{location}.requires")
             read_required_string(requires, "value", f"{location}.requires")
     return conditional_claims

--- a/scripts/generate_campaign.py
+++ b/scripts/generate_campaign.py
@@ -101,17 +101,25 @@ def main() -> int:
     output_directory = GENERATED_DIR / f"{date.today().isoformat()}-{campaign_name}"
     if output_directory.exists():
         raise SystemExit(f"Campaign output already exists: {output_directory}")
-    output_directory.mkdir(parents=True)
+    try:
+        output_directory.mkdir(parents=True)
+    except OSError as output_error:
+        raise SystemExit(
+            f"Failed to create campaign output directory {output_directory}: {output_error}"
+        ) from output_error
 
     for rendered_file in rendered_files + build_support_files(
         template_names,
         context,
         guard_report,
     ):
-        (output_directory / rendered_file.name).write_text(
-            rendered_file.content,
-            encoding="utf-8",
-        )
+        output_path = output_directory / rendered_file.name
+        try:
+            output_path.write_text(rendered_file.content, encoding="utf-8")
+        except OSError as output_error:
+            raise SystemExit(
+                f"Failed to write campaign file {output_path}: {output_error}"
+            ) from output_error
 
     print(f"Generated campaign: {output_directory}")
     print(f"Rendered drafts: {', '.join(template_names)}")
@@ -581,7 +589,12 @@ def render_templates(template_names: list[str], context: RenderContext) -> list[
         if not template_path.exists():
             raise SystemExit(f"Selected template is missing: {template_path}")
 
-        template_content = template_path.read_text(encoding="utf-8")
+        try:
+            template_content = template_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as template_error:
+            raise SystemExit(
+                f"Failed to read selected template {template_path}: {template_error}"
+            ) from template_error
         rendered_files.append(
             RenderedFile(
                 name=template_name,
@@ -610,7 +623,11 @@ def lookup_render_value(context: RenderContext, path: str) -> RenderableValue | 
         return None
 
     section = context.get(section_name)
-    return None if section is None else section.get(value_name)
+    if section is None:
+        return None
+
+    value = section.get(value_name)
+    return None if isinstance(value, str) and not value.strip() else value
 
 
 def evaluate_guardrails(
@@ -781,7 +798,7 @@ def build_support_files(
             "",
             f"Mode: `{campaign_mode}`",
             "",
-            "Generated files:",
+            "Draft files:",
             "",
             draft_file_list,
             "",

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -35,8 +35,8 @@ pythonVersion = "3.11"
 # script's directory to sys.path at runtime, but pyright's static analyzer
 # needs an explicit hint. `.` = the scripts/ dir (where pyproject.toml lives).
 extraPaths = ["."]
-# Strict mode catches partially-unknown types (YAML `dict.get()` returning
-# `Any | str` etc.) so docs-lint stays type-safe end-to-end.
+# Strict mode catches partially-unknown types across maintenance scripts,
+# including YAML config parsing and sibling helper imports.
 typeCheckingMode = "strict"
 # types-defusedxml ships stubs only (no source) — suppress the spurious
 # "source not found" warning that would otherwise fire on every import.

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "scripts"
 version = "0.1.0"
-description = "Ayu Islands maintenance scripts — docs drift lint, screenshot freshness checks"
+description = "Ayu Islands maintenance scripts — docs drift lint, campaign drafts, release gates"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=69"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "scripts"
 version = "0.1.0"
@@ -12,6 +16,9 @@ dependencies = [
     "defusedxml>=0.7.1",
 ]
 
+[project.scripts]
+generate-campaign = "generate_campaign:main"
+
 [dependency-groups]
 dev = [
     # Type stubs for defusedxml; PyYAML stubs aren't needed (pyright finds them
@@ -19,10 +26,11 @@ dev = [
     "types-defusedxml>=0.7.0",
 ]
 
-[tool.uv]
-package = false
+[tool.setuptools]
+py-modules = ["generate_campaign"]
 
 [tool.pyright]
+pythonVersion = "3.11"
 # Scripts import sibling modules (e.g. _plugin_xml) — Python auto-adds the
 # script's directory to sys.path at runtime, but pyright's static analyzer
 # needs an explicit hint. `.` = the scripts/ dir (where pyproject.toml lives).

--- a/scripts/tests/test-generate-campaign.py
+++ b/scripts/tests/test-generate-campaign.py
@@ -124,6 +124,24 @@ class GenerateCampaignTest(unittest.TestCase):
             self.assertIn("- `follow-up.md`", posting_plan)
             self.assertIn("Draft files:", readme)
 
+    def test_guardrails_evaluate_every_selected_template(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            make_repository(
+                repository_root,
+                ["launch.md", "follow-up.md"],
+                {
+                    "launch.md": "Launch: {{ product.name }}\n",
+                    "follow-up.md": "guaranteed productivity\n",
+                },
+            )
+
+            result = run_generator(repository_root)
+
+            self.assertEqual(2, result.returncode)
+            fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
+            self.assertIn("follow-up.md: blocked phrase `guaranteed productivity`", fact_check)
+
     def test_warning_only_guardrails_are_written_without_failing_generation(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             repository_root = Path(temporary_directory)
@@ -252,11 +270,10 @@ class GenerateCampaignTest(unittest.TestCase):
                 """,
             )
 
-            result = run_generator(repository_root)
-
-            self.assertEqual(2, result.returncode)
-            fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
-            self.assertIn("unresolved placeholder product.name", fact_check)
+            self.assert_generation_fails_with(
+                repository_root,
+                "Expected `product.name` to be a non-empty scalar",
+            )
 
     def test_guardrails_fail_blocked_phrase_and_report_malformed_requires(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -279,6 +296,7 @@ class GenerateCampaignTest(unittest.TestCase):
                     message: "TODO_VERIFY: lifetime access requires manual verification."
                     requires:
                       path: pricing.missing
+                      value: ready
                 """,
             )
 
@@ -518,6 +536,23 @@ class GenerateCampaignTest(unittest.TestCase):
                 draft_content="Public trial is open.\n",
             )
 
+    def test_conditional_claim_requires_value_must_not_be_blank(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            self.assert_guardrail_config_fails(
+                temporary_directory,
+                """
+                blocked_phrases: []
+                risky_phrases: []
+                conditional_claims:
+                  - phrase: public trial
+                    requires:
+                      path: launch_status.trial_status
+                      value: ""
+                """,
+                "Expected `conditional_claims[0].requires.value`",
+                draft_content="Public trial is open.\n",
+            )
+
     def test_existing_campaign_directory_is_not_overwritten(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             repository_root = Path(temporary_directory)
@@ -546,6 +581,40 @@ class GenerateCampaignTest(unittest.TestCase):
             self.assertNotEqual(0, result.returncode)
             self.assertIn("Required YAML file is missing", result.stderr)
             self.assertIn(".marketing/config.yaml", result.stderr)
+
+    def test_invalid_yaml_encoding_reports_config_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            make_repository(
+                repository_root,
+                ["launch.md"],
+                {"launch.md": "Ready: {{ product.name }}\n"},
+            )
+            (repository_root / ".marketing" / "config.yaml").write_bytes(b"\xff")
+
+            result = run_generator(repository_root)
+
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("Failed to read YAML file", result.stderr)
+            self.assertIn(".marketing/config.yaml", result.stderr)
+            self.assertNotIn("Traceback", result.stderr)
+
+    def test_unreadable_changelog_becomes_fact_check_warning(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            make_repository(
+                repository_root,
+                ["launch.md"],
+                {"launch.md": "{{ facts.latest_changelog_summary }}\n"},
+            )
+            (repository_root / "CHANGELOG.md").write_bytes(b"\xff")
+
+            result = run_generator(repository_root)
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
+            self.assertIn("failed to read CHANGELOG.md", fact_check)
+            self.assertNotIn("Traceback", result.stderr)
 
     def test_unreadable_selected_template_reports_template_path(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/scripts/tests/test-generate-campaign.py
+++ b/scripts/tests/test-generate-campaign.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""CLI-boundary tests for generate_campaign.py."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from collections.abc import Mapping, Sequence
+from datetime import date
+from pathlib import Path
+
+SOURCE_SCRIPT = Path(__file__).resolve().parent.parent / "generate_campaign.py"
+
+DEFAULT_GUARDRAILS = """
+blocked_phrases:
+  - guaranteed productivity
+conditional_claims: []
+"""
+
+
+class GenerateCampaignTest(unittest.TestCase):
+    def test_generates_drafts_with_summary_alias_placeholders(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            make_repository(
+                repository_root,
+                ["launch.md"],
+                {
+                    "launch.md": """
+                    # {{ product.name }}
+
+                    Pricing: {{ pricing.summary }}
+                    Status:
+                    {{ launch_status.summary }}
+                    Proof:
+                    {{ social_proof.summary }}
+                    Version: {{ facts.latest_version }}
+                    Changes:
+                    {{ facts.latest_changelog_summary }}
+                    """
+                },
+            )
+
+            result = run_generator(repository_root)
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            draft = read_generated_file(repository_root, "launch.md")
+            self.assertIn("Ayu Islands", draft)
+            self.assertIn("12 USD individual / 30 USD commercial", draft)
+            self.assertIn("- marketplace: released", draft)
+            self.assertIn("[Free] Accent overrides", draft)
+            self.assertNotIn("unresolved placeholder", draft)
+
+    def test_unresolved_template_placeholders_fail_generation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            make_repository(
+                repository_root,
+                ["launch.md"],
+                {"launch.md": "{{ product.name }} {{ missing.value }}\n"},
+            )
+
+            result = run_generator(repository_root)
+
+            self.assertEqual(2, result.returncode)
+            self.assertIn("Hard-blocked claims were found", result.stderr)
+            fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
+            self.assertIn("unresolved placeholder missing.value", fact_check)
+
+    def test_guardrails_fail_blocked_phrase_and_report_malformed_requires(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            make_repository(
+                repository_root,
+                ["launch.md"],
+                {
+                    "launch.md": """
+                    guaranteed productivity
+                    lifetime access
+                    """
+                },
+                guardrails="""
+                blocked_phrases:
+                  - guaranteed productivity
+                conditional_claims:
+                  - phrase: lifetime access
+                    message: "TODO_VERIFY: lifetime access requires manual verification."
+                    requires:
+                      path: pricing.missing
+                """,
+            )
+
+            result = run_generator(repository_root)
+
+            self.assertEqual(2, result.returncode)
+            fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
+            self.assertIn("blocked phrase `guaranteed productivity`", fact_check)
+            self.assertIn("lifetime access requires manual verification", fact_check)
+
+    def test_existing_campaign_directory_is_not_overwritten(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            make_repository(
+                repository_root,
+                ["launch.md"],
+                {"launch.md": "Ready: {{ product.name }}\n"},
+            )
+            output_directory = generated_directory(repository_root)
+            output_directory.mkdir(parents=True)
+            sentinel = output_directory / "README.md"
+            sentinel.write_text("keep this review note\n", encoding="utf-8")
+
+            result = run_generator(repository_root)
+
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("Campaign output already exists", result.stderr)
+            self.assertEqual("keep this review note\n", sentinel.read_text(encoding="utf-8"))
+
+    def test_template_paths_cannot_escape_templates_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            make_repository(
+                repository_root,
+                ["../README.md"],
+                {},
+            )
+
+            result = run_generator(repository_root)
+
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("must be a file name in .marketing/templates", result.stderr)
+
+    def test_template_names_cannot_conflict_with_support_files(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            make_repository(
+                repository_root,
+                ["README.md"],
+                {"README.md": "This draft would be overwritten.\n"},
+            )
+
+            result = run_generator(repository_root)
+
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("conflicts with a generated support file", result.stderr)
+
+
+def make_repository(
+    repository_root: Path,
+    template_names: Sequence[str],
+    templates: Mapping[str, str],
+    guardrails: str = DEFAULT_GUARDRAILS,
+) -> None:
+    scripts_dir = repository_root / "scripts"
+    scripts_dir.mkdir(parents=True)
+    shutil.copy2(SOURCE_SCRIPT, scripts_dir / "generate_campaign.py")
+
+    docs_dir = repository_root / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "features.yml").write_text(
+        textwrap.dedent(
+            """
+            categories:
+              accent:
+                features:
+                  - id: accent-overrides
+                    title: Accent overrides
+                    tier: free
+                    introduced: 2.7.4
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    (repository_root / "CHANGELOG.md").write_text(
+        textwrap.dedent(
+            """
+            # Changelog
+
+            ## [2.7.4]
+            - [Free] Accent overrides
+
+            ## [2.7.3]
+            - Previous release
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+
+    marketing_root = repository_root / ".marketing"
+    templates_dir = marketing_root / "templates"
+    templates_dir.mkdir(parents=True)
+    for template_name, template_content in templates.items():
+        (templates_dir / template_name).write_text(
+            textwrap.dedent(template_content).lstrip(),
+            encoding="utf-8",
+        )
+
+    template_list = "\n".join(f"      - {json.dumps(name)}" for name in template_names)
+    config = f"""
+product:
+  name: Ayu Islands
+  category: JetBrains theme
+pricing:
+  public_claim_status: ready
+  individual: 12 USD
+  commercial: 30 USD
+  model: annual license
+launch_status:
+  marketplace: released
+manual_verification:
+  - Confirm generated copy against Marketplace listing.
+social_proof:
+  - source: https://example.com/review
+    label: Maintainer quote
+    quote: Looks sharp
+    status: verified
+campaign_modes:
+  launch:
+    description: Launch copy
+    templates:
+{template_list}
+guardrails:
+{textwrap.indent(textwrap.dedent(guardrails).strip(), "  ")}
+"""
+    (marketing_root / "config.yaml").write_text(
+        textwrap.dedent(config).lstrip(),
+        encoding="utf-8",
+    )
+
+
+def run_generator(repository_root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(repository_root / "scripts" / "generate_campaign.py"),
+            "--mode",
+            "launch",
+            "--name",
+            "Launch Plan",
+        ],
+        check=False,
+        cwd=repository_root,
+        text=True,
+        capture_output=True,
+    )
+
+
+def generated_directory(repository_root: Path) -> Path:
+    return repository_root / ".marketing" / "generated" / f"{date.today().isoformat()}-launch-plan"
+
+
+def read_generated_file(repository_root: Path, file_name: str) -> str:
+    return (generated_directory(repository_root) / file_name).read_text(encoding="utf-8")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test-generate-campaign.py
+++ b/scripts/tests/test-generate-campaign.py
@@ -91,14 +91,14 @@ class GenerateCampaignTest(unittest.TestCase):
             make_repository(
                 repository_root,
                 ["launch.md"],
-                {"launch.md": "Ayu Islands has 10,000 downloads.\n"},
+                {"launch.md": "Ayu Islands has 10,000+ downloads.\n"},
             )
 
             result = run_generator(repository_root)
 
             self.assertEqual(0, result.returncode, result.stderr)
             fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
-            self.assertIn("metric claim `10,000 downloads` needs a source", fact_check)
+            self.assertIn("metric claim `10,000+ downloads` needs a source", fact_check)
             self.assertIn("- Hard blocks: 0", read_generated_file(repository_root, "README.md"))
 
     def test_risky_phrases_are_written_as_warnings(self) -> None:
@@ -159,6 +159,21 @@ class GenerateCampaignTest(unittest.TestCase):
             fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
             self.assertIn("raw template placeholder `{{ product name }}` was not rendered", fact_check)
 
+    def test_unclosed_template_placeholders_fail_generation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            make_repository(
+                repository_root,
+                ["launch.md"],
+                {"launch.md": "Bad placeholder: {{ product.name\n"},
+            )
+
+            result = run_generator(repository_root)
+
+            self.assertEqual(2, result.returncode)
+            fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
+            self.assertIn("raw template placeholder `{{ product.name` was not rendered", fact_check)
+
     def test_unresolved_template_placeholders_fail_generation(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             repository_root = Path(temporary_directory)
@@ -204,6 +219,179 @@ class GenerateCampaignTest(unittest.TestCase):
             fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
             self.assertIn("blocked phrase `guaranteed productivity`", fact_check)
             self.assertIn("lifetime access requires manual verification", fact_check)
+
+    def test_blank_guardrail_phrases_fail_before_generation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            make_repository(
+                repository_root,
+                ["launch.md"],
+                {"launch.md": "Ayu Islands launch copy.\n"},
+                guardrails="""
+                blocked_phrases:
+                  - ""
+                risky_phrases: []
+                conditional_claims: []
+                """,
+            )
+
+            result = run_generator(repository_root)
+
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("Expected `blocked_phrases[0]`", result.stderr)
+
+    def test_duplicate_guardrail_keys_fail_before_generation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            make_repository(
+                repository_root,
+                ["launch.md"],
+                {"launch.md": "guaranteed productivity\n"},
+                guardrails="""
+                blocked_phrases:
+                  - guaranteed productivity
+                blocked_phrases: []
+                risky_phrases: []
+                conditional_claims: []
+                """,
+            )
+
+            result = run_generator(repository_root)
+
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("Duplicate YAML key `blocked_phrases`", result.stderr)
+
+    def test_conditional_claim_requires_feature_id_warns_when_feature_is_absent(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            make_repository(
+                repository_root,
+                ["launch.md"],
+                {"launch.md": "External accent sources are ready.\n"},
+                guardrails="""
+                blocked_phrases: []
+                risky_phrases: []
+                conditional_claims:
+                  - phrase: external accent sources
+                    message: "TODO_VERIFY: external accent sources require released feature metadata."
+                    requires_feature_id: external-accent-sources
+                """,
+            )
+
+            result = run_generator(repository_root)
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
+            self.assertIn("external accent sources require released feature metadata", fact_check)
+
+    def test_conditional_claim_requires_feature_id_allows_released_feature(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            make_repository(
+                repository_root,
+                ["launch.md"],
+                {"launch.md": "External accent sources are ready.\n"},
+                features_yaml="""
+                categories:
+                  accent:
+                    features:
+                      - id: external-accent-sources
+                        title: External accent sources
+                        tier: paid
+                        introduced: 2.8.0
+                """,
+                guardrails="""
+                blocked_phrases: []
+                risky_phrases: []
+                conditional_claims:
+                  - phrase: external accent sources
+                    message: "TODO_VERIFY: external accent sources require released feature metadata."
+                    requires_feature_id: external-accent-sources
+                """,
+            )
+
+            result = run_generator(repository_root)
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
+            self.assertIn("No warnings.", fact_check)
+
+    def test_conditional_claim_requires_path_value_warns_when_unmatched(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            make_repository(
+                repository_root,
+                ["launch.md"],
+                {"launch.md": "Public trial is open.\n"},
+                guardrails="""
+                blocked_phrases: []
+                risky_phrases: []
+                conditional_claims:
+                  - phrase: public trial
+                    message: "TODO_VERIFY: public trial requires confirmed launch status."
+                    requires:
+                      path: launch_status.trial_status
+                      value: confirmed
+                """,
+            )
+
+            result = run_generator(repository_root)
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
+            self.assertIn("public trial requires confirmed launch status", fact_check)
+
+    def test_conditional_claim_requires_path_value_allows_matching_config(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            make_repository(
+                repository_root,
+                ["launch.md"],
+                {"launch.md": "Public trial is open.\n"},
+                launch_status="""
+                marketplace: released
+                trial_status: confirmed
+                """,
+                guardrails="""
+                blocked_phrases: []
+                risky_phrases: []
+                conditional_claims:
+                  - phrase: public trial
+                    message: "TODO_VERIFY: public trial requires confirmed launch status."
+                    requires:
+                      path: launch_status.trial_status
+                      value: confirmed
+                """,
+            )
+
+            result = run_generator(repository_root)
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
+            self.assertIn("No warnings.", fact_check)
+
+    def test_conditional_claims_must_have_a_phrase(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            make_repository(
+                repository_root,
+                ["launch.md"],
+                {"launch.md": "Public trial is open.\n"},
+                guardrails="""
+                blocked_phrases: []
+                risky_phrases: []
+                conditional_claims:
+                  - message: "TODO_VERIFY: public trial requires confirmed launch status."
+                    requires:
+                      path: launch_status.trial_status
+                      value: confirmed
+                """,
+            )
+
+            result = run_generator(repository_root)
+
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("Expected `conditional_claims[0].phrase`", result.stderr)
 
     def test_existing_campaign_directory_is_not_overwritten(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -293,6 +481,25 @@ class GenerateCampaignTest(unittest.TestCase):
             self.assertNotEqual(0, result.returncode)
             self.assertIn("Expected `social_proof[0].source`", result.stderr)
 
+    def test_social_proof_quote_must_not_be_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            make_repository(
+                repository_root,
+                ["launch.md"],
+                {"launch.md": "{{ social_proof.summary }}\n"},
+                social_proof="""
+                - source: https://example.com/review
+                  label: Missing quote
+                  status: verified
+                """,
+            )
+
+            result = run_generator(repository_root)
+
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("Expected `social_proof[0].quote`", result.stderr)
+
 
 def make_repository(
     repository_root: Path,
@@ -306,6 +513,9 @@ def make_repository(
     individual: 12 USD
     commercial: 30 USD
     model: annual license
+    """,
+    launch_status: str = """
+    marketplace: released
     """,
 ) -> None:
     scripts_dir = repository_root / "scripts"
@@ -350,7 +560,7 @@ product:
 pricing:
 {textwrap.indent(textwrap.dedent(pricing).strip(), "  ")}
 launch_status:
-  marketplace: released
+{textwrap.indent(textwrap.dedent(launch_status).strip(), "  ")}
 manual_verification:
   - Confirm generated copy against Marketplace listing.
 social_proof:

--- a/scripts/tests/test-generate-campaign.py
+++ b/scripts/tests/test-generate-campaign.py
@@ -159,7 +159,7 @@ class GenerateCampaignTest(unittest.TestCase):
 
     def test_risky_phrases_are_written_as_warnings(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
-            fact_check = self.render_guardrail_fact_check(
+            fact_check = self.assert_guardrail_fact_check_contains(
                 temporary_directory,
                 "No telemetry and no Sentry by design.\n",
                 """
@@ -175,7 +175,7 @@ class GenerateCampaignTest(unittest.TestCase):
 
     def test_bare_todo_verify_markers_are_written_as_warnings(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
-            self.render_pricing_fact_check(
+            self.assert_pricing_fact_check_contains(
                 temporary_directory,
                 """
                 public_claim_status: ready
@@ -187,7 +187,7 @@ class GenerateCampaignTest(unittest.TestCase):
 
     def test_unready_pricing_status_is_written_as_warning(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
-            self.render_pricing_fact_check(
+            self.assert_pricing_fact_check_contains(
                 temporary_directory,
                 """
                 individual: 12 USD
@@ -199,7 +199,7 @@ class GenerateCampaignTest(unittest.TestCase):
 
     def test_blank_ready_pricing_fields_are_written_as_warnings(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
-            self.render_pricing_fact_check(
+            self.assert_pricing_fact_check_contains(
                 temporary_directory,
                 """
                 public_claim_status: ready
@@ -342,7 +342,7 @@ class GenerateCampaignTest(unittest.TestCase):
                 draft_content="guaranteed productivity\n",
             )
 
-    def render_pricing_fact_check(
+    def assert_pricing_fact_check_contains(
         self,
         temporary_directory: str,
         pricing: str,
@@ -359,7 +359,7 @@ class GenerateCampaignTest(unittest.TestCase):
 
     def test_conditional_claim_requires_feature_id_warns_when_feature_is_absent(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
-            self.render_guardrail_fact_check(
+            self.assert_guardrail_fact_check_contains(
                 temporary_directory,
                 "External accent sources are ready.\n",
                 """
@@ -404,7 +404,7 @@ class GenerateCampaignTest(unittest.TestCase):
 
     def test_conditional_claim_requires_path_value_warns_when_unmatched(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
-            self.render_guardrail_fact_check(
+            self.assert_guardrail_fact_check_contains(
                 temporary_directory,
                 "Public trial is open.\n",
                 """
@@ -428,14 +428,25 @@ class GenerateCampaignTest(unittest.TestCase):
     ) -> str:
         result = run_generator(repository_root)
         self.assertEqual(0, result.returncode, result.stderr)
-        content = read_generated_file(repository_root, file_name)
+        self.assertEqual("", result.stderr)
+        self.assertIn("Generated campaign: ", result.stdout)
+        self.assertIn("Rendered drafts: ", result.stdout)
+        self.assertIn("Warnings: ", result.stdout)
+        self.assertIn("Hard blocks: 0", result.stdout)
+        content = read_generated_file_from_stdout(result, file_name)
         self.assertIn(expected_text, content)
         return content
 
-    def assert_generation_fails_with(self, repository_root: Path, expected_stderr: str) -> None:
+    def assert_generation_fails_with(
+        self,
+        repository_root: Path,
+        expected_stderr: str,
+        expected_exit_code: int = 1,
+    ) -> None:
         result = run_generator(repository_root)
-        self.assertNotEqual(0, result.returncode)
+        self.assertEqual(expected_exit_code, result.returncode, result.stderr)
         self.assertIn(expected_stderr, result.stderr)
+        self.assertNotIn("Traceback", result.stderr)
 
     def assert_hard_blocked_fact_check_contains(
         self,
@@ -445,9 +456,11 @@ class GenerateCampaignTest(unittest.TestCase):
     ) -> str:
         result = run_generator(repository_root)
         self.assertEqual(2, result.returncode)
+        self.assertIn("Generated campaign: ", result.stdout)
+        self.assertIn("Hard blocks: ", result.stdout)
         if expected_stderr is not None:
             self.assertIn(expected_stderr, result.stderr)
-        fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
+        fact_check = read_generated_file_from_stdout(result, "FACT_CHECK.md")
         self.assertIn(expected_text, fact_check)
         return fact_check
 
@@ -478,7 +491,7 @@ class GenerateCampaignTest(unittest.TestCase):
                 repository_root, "FACT_CHECK.md", "No warnings."
             )
 
-    def render_guardrail_fact_check(
+    def assert_guardrail_fact_check_contains(
         self,
         temporary_directory: str,
         draft_content: str,
@@ -655,6 +668,24 @@ class GenerateCampaignTest(unittest.TestCase):
             self.assertIn(".marketing/config.yaml", result.stderr)
             self.assertNotIn("Traceback", result.stderr)
 
+    def test_recursive_yaml_alias_reports_config_error(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            make_repository(
+                repository_root,
+                ["launch.md"],
+                {"launch.md": "Ready: {{ product.name }}\n"},
+            )
+            (repository_root / ".marketing" / "config.yaml").write_text(
+                "recursive: &recursive\n  - *recursive\n",
+                encoding="utf-8",
+            )
+
+            self.assert_generation_fails_with(
+                repository_root,
+                "Recursive YAML aliases are not supported in config.yaml",
+            )
+
     def test_unreadable_changelog_becomes_fact_check_warning(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             repository_root = Path(temporary_directory)
@@ -706,6 +737,27 @@ class GenerateCampaignTest(unittest.TestCase):
                 repository_root,
                 "Failed to create campaign output directory",
             )
+
+    def test_generated_output_root_cannot_be_symlink(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory) / "repository"
+            outside_root = Path(temporary_directory) / "outside-generated"
+            outside_root.mkdir()
+            make_repository(
+                repository_root,
+                ["launch.md"],
+                {"launch.md": "Ready: {{ product.name }}\n"},
+            )
+            (repository_root / ".marketing" / "generated").symlink_to(
+                outside_root,
+                target_is_directory=True,
+            )
+
+            self.assert_generation_fails_with(
+                repository_root,
+                "Campaign output root must not be a symlink",
+            )
+            self.assertEqual([], list(outside_root.iterdir()))
 
     def test_template_paths_cannot_escape_templates_directory(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -793,6 +845,26 @@ class GenerateCampaignTest(unittest.TestCase):
             self.assert_generation_fails_with(
                 repository_root,
                 "Expected `social_proof[0].quote`",
+            )
+
+    def test_social_proof_status_must_not_be_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            make_repository(
+                repository_root,
+                ["launch.md"],
+                {"launch.md": "{{ social_proof.summary }}\n"},
+                social_proof="""
+                - source: https://example.com/review
+                  label: Blank status
+                  quote: Looks sharp
+                  status: ""
+                """,
+            )
+
+            self.assert_generation_fails_with(
+                repository_root,
+                "Expected `social_proof[0].status`",
             )
 
 
@@ -900,6 +972,21 @@ def generated_directory(repository_root: Path) -> Path:
 
 def read_generated_file(repository_root: Path, file_name: str) -> str:
     return (generated_directory(repository_root) / file_name).read_text(encoding="utf-8")
+
+
+def read_generated_file_from_stdout(
+    result: subprocess.CompletedProcess[str],
+    file_name: str,
+) -> str:
+    return (generated_directory_from_stdout(result) / file_name).read_text(encoding="utf-8")
+
+
+def generated_directory_from_stdout(result: subprocess.CompletedProcess[str]) -> Path:
+    prefix = "Generated campaign: "
+    for output_line in result.stdout.splitlines():
+        if output_line.startswith(prefix):
+            return Path(output_line.removeprefix(prefix))
+    raise AssertionError(f"Missing generated campaign path in stdout: {result.stdout}")
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test-generate-campaign.py
+++ b/scripts/tests/test-generate-campaign.py
@@ -75,11 +75,9 @@ class GenerateCampaignTest(unittest.TestCase):
                 },
             )
 
-            result = run_generator(repository_root)
-
-            self.assertEqual(0, result.returncode, result.stderr)
-            draft = read_generated_file(repository_root, "launch.md")
-            self.assertIn("Ayu Islands", draft)
+            draft = self.assert_success_file_contains(
+                repository_root, "launch.md", "Ayu Islands"
+            )
             self.assertIn("12 USD individual / 30 USD commercial", draft)
             self.assertIn("- marketplace: released", draft)
             self.assertIn("[Free] Accent overrides", draft)
@@ -94,55 +92,65 @@ class GenerateCampaignTest(unittest.TestCase):
                 {"launch.md": "Ayu Islands has 10,000+ downloads.\n"},
             )
 
-            result = run_generator(repository_root)
-
-            self.assertEqual(0, result.returncode, result.stderr)
-            fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
-            self.assertIn("metric claim `10,000+ downloads` needs a source", fact_check)
+            self.assert_success_file_contains(
+                repository_root,
+                "FACT_CHECK.md",
+                "metric claim `10,000+ downloads` needs a source",
+            )
             self.assertIn("- Hard blocks: 0", read_generated_file(repository_root, "README.md"))
 
     def test_risky_phrases_are_written_as_warnings(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
-            repository_root = Path(temporary_directory)
-            make_repository(
-                repository_root,
-                ["launch.md"],
-                {"launch.md": "No telemetry and no Sentry by design.\n"},
-                guardrails="""
+            fact_check = self.render_guardrail_fact_check(
+                temporary_directory,
+                "No telemetry and no Sentry by design.\n",
+                """
                 blocked_phrases: []
                 risky_phrases:
                   - telemetry
                   - Sentry
                 conditional_claims: []
                 """,
+                "risky phrase `telemetry` needs review",
             )
-
-            result = run_generator(repository_root)
-
-            self.assertEqual(0, result.returncode, result.stderr)
-            fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
-            self.assertIn("risky phrase `telemetry` needs review", fact_check)
             self.assertIn("risky phrase `Sentry` needs review", fact_check)
 
     def test_bare_todo_verify_markers_are_written_as_warnings(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
-            repository_root = Path(temporary_directory)
-            make_repository(
-                repository_root,
-                ["launch.md"],
-                {"launch.md": "Pricing: {{ pricing.summary }}\n"},
-                pricing="""
+            self.render_pricing_fact_check(
+                temporary_directory,
+                """
                 public_claim_status: ready
                 commercial: 30 USD
                 model: annual license
                 """,
+                "Pricing: TODO_VERIFY individual",
             )
 
-            result = run_generator(repository_root)
+    def test_unready_pricing_status_is_written_as_warning(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            self.render_pricing_fact_check(
+                temporary_directory,
+                """
+                individual: 12 USD
+                commercial: 30 USD
+                model: annual license
+                """,
+                "pricing copy is not ready for public use",
+            )
 
-            self.assertEqual(0, result.returncode, result.stderr)
-            fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
-            self.assertIn("Pricing: TODO_VERIFY individual", fact_check)
+    def test_blank_ready_pricing_fields_are_written_as_warnings(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            self.render_pricing_fact_check(
+                temporary_directory,
+                """
+                public_claim_status: ready
+                individual: ""
+                commercial: 30 USD
+                model: annual license
+                """,
+                "Pricing: TODO_VERIFY individual",
+            )
 
     def test_malformed_template_placeholders_fail_generation(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -205,6 +213,7 @@ class GenerateCampaignTest(unittest.TestCase):
                 guardrails="""
                 blocked_phrases:
                   - guaranteed productivity
+                risky_phrases: []
                 conditional_claims:
                   - phrase: lifetime access
                     message: "TODO_VERIFY: lifetime access requires manual verification."
@@ -222,53 +231,65 @@ class GenerateCampaignTest(unittest.TestCase):
 
     def test_blank_guardrail_phrases_fail_before_generation(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
-            repository_root = Path(temporary_directory)
-            make_repository(
-                repository_root,
-                ["launch.md"],
-                {"launch.md": "Ayu Islands launch copy.\n"},
-                guardrails="""
+            self.assert_guardrail_config_fails(
+                temporary_directory,
+                """
                 blocked_phrases:
                   - ""
                 risky_phrases: []
                 conditional_claims: []
                 """,
+                "Expected `blocked_phrases[0]`",
             )
-
-            result = run_generator(repository_root)
-
-            self.assertNotEqual(0, result.returncode)
-            self.assertIn("Expected `blocked_phrases[0]`", result.stderr)
 
     def test_duplicate_guardrail_keys_fail_before_generation(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
-            repository_root = Path(temporary_directory)
-            make_repository(
-                repository_root,
-                ["launch.md"],
-                {"launch.md": "guaranteed productivity\n"},
-                guardrails="""
+            self.assert_guardrail_config_fails(
+                temporary_directory,
+                """
                 blocked_phrases:
                   - guaranteed productivity
                 blocked_phrases: []
                 risky_phrases: []
                 conditional_claims: []
                 """,
+                "Duplicate YAML key `blocked_phrases`",
+                draft_content="guaranteed productivity\n",
             )
 
-            result = run_generator(repository_root)
+    def test_guardrails_must_define_required_keys(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            self.assert_guardrail_config_fails(
+                temporary_directory,
+                """
+                risky_phrases: []
+                conditional_claims: []
+                """,
+                "Expected `blocked_phrases` to be a YAML list",
+                draft_content="guaranteed productivity\n",
+            )
 
-            self.assertNotEqual(0, result.returncode)
-            self.assertIn("Duplicate YAML key `blocked_phrases`", result.stderr)
+    def render_pricing_fact_check(
+        self,
+        temporary_directory: str,
+        pricing: str,
+        expected_text: str,
+    ) -> str:
+        repository_root = Path(temporary_directory)
+        make_repository(
+            repository_root,
+            ["launch.md"],
+            {"launch.md": "Pricing: {{ pricing.summary }}\n"},
+            pricing=pricing,
+        )
+        return self.assert_success_file_contains(repository_root, "FACT_CHECK.md", expected_text)
 
     def test_conditional_claim_requires_feature_id_warns_when_feature_is_absent(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
-            repository_root = Path(temporary_directory)
-            make_repository(
-                repository_root,
-                ["launch.md"],
-                {"launch.md": "External accent sources are ready.\n"},
-                guardrails="""
+            self.render_guardrail_fact_check(
+                temporary_directory,
+                "External accent sources are ready.\n",
+                """
                 blocked_phrases: []
                 risky_phrases: []
                 conditional_claims:
@@ -276,13 +297,8 @@ class GenerateCampaignTest(unittest.TestCase):
                     message: "TODO_VERIFY: external accent sources require released feature metadata."
                     requires_feature_id: external-accent-sources
                 """,
+                "external accent sources require released feature metadata",
             )
-
-            result = run_generator(repository_root)
-
-            self.assertEqual(0, result.returncode, result.stderr)
-            fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
-            self.assertIn("external accent sources require released feature metadata", fact_check)
 
     def test_conditional_claim_requires_feature_id_allows_released_feature(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -309,21 +325,16 @@ class GenerateCampaignTest(unittest.TestCase):
                     requires_feature_id: external-accent-sources
                 """,
             )
-
-            result = run_generator(repository_root)
-
-            self.assertEqual(0, result.returncode, result.stderr)
-            fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
-            self.assertIn("No warnings.", fact_check)
+            self.assert_success_file_contains(
+                repository_root, "FACT_CHECK.md", "No warnings."
+            )
 
     def test_conditional_claim_requires_path_value_warns_when_unmatched(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
-            repository_root = Path(temporary_directory)
-            make_repository(
-                repository_root,
-                ["launch.md"],
-                {"launch.md": "Public trial is open.\n"},
-                guardrails="""
+            self.render_guardrail_fact_check(
+                temporary_directory,
+                "Public trial is open.\n",
+                """
                 blocked_phrases: []
                 risky_phrases: []
                 conditional_claims:
@@ -333,13 +344,25 @@ class GenerateCampaignTest(unittest.TestCase):
                       path: launch_status.trial_status
                       value: confirmed
                 """,
+                "public trial requires confirmed launch status",
             )
 
-            result = run_generator(repository_root)
+    def assert_success_file_contains(
+        self,
+        repository_root: Path,
+        file_name: str,
+        expected_text: str,
+    ) -> str:
+        result = run_generator(repository_root)
+        self.assertEqual(0, result.returncode, result.stderr)
+        content = read_generated_file(repository_root, file_name)
+        self.assertIn(expected_text, content)
+        return content
 
-            self.assertEqual(0, result.returncode, result.stderr)
-            fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
-            self.assertIn("public trial requires confirmed launch status", fact_check)
+    def assert_generation_fails_with(self, repository_root: Path, expected_stderr: str) -> None:
+        result = run_generator(repository_root)
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn(expected_stderr, result.stderr)
 
     def test_conditional_claim_requires_path_value_allows_matching_config(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -364,20 +387,47 @@ class GenerateCampaignTest(unittest.TestCase):
                 """,
             )
 
-            result = run_generator(repository_root)
+            self.assert_success_file_contains(
+                repository_root, "FACT_CHECK.md", "No warnings."
+            )
 
-            self.assertEqual(0, result.returncode, result.stderr)
-            fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
-            self.assertIn("No warnings.", fact_check)
+    def render_guardrail_fact_check(
+        self,
+        temporary_directory: str,
+        draft_content: str,
+        guardrails: str,
+        expected_text: str,
+    ) -> str:
+        repository_root = Path(temporary_directory)
+        make_repository(
+            repository_root,
+            ["launch.md"],
+            {"launch.md": draft_content},
+            guardrails=guardrails,
+        )
+        return self.assert_success_file_contains(repository_root, "FACT_CHECK.md", expected_text)
+
+    def assert_guardrail_config_fails(
+        self,
+        temporary_directory: str,
+        guardrails: str,
+        expected_stderr: str,
+        draft_content: str = "Ayu Islands launch copy.\n",
+    ) -> None:
+        repository_root = Path(temporary_directory)
+        make_repository(
+            repository_root,
+            ["launch.md"],
+            {"launch.md": draft_content},
+            guardrails=guardrails,
+        )
+        self.assert_generation_fails_with(repository_root, expected_stderr)
 
     def test_conditional_claims_must_have_a_phrase(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
-            repository_root = Path(temporary_directory)
-            make_repository(
-                repository_root,
-                ["launch.md"],
-                {"launch.md": "Public trial is open.\n"},
-                guardrails="""
+            self.assert_guardrail_config_fails(
+                temporary_directory,
+                """
                 blocked_phrases: []
                 risky_phrases: []
                 conditional_claims:
@@ -386,12 +436,27 @@ class GenerateCampaignTest(unittest.TestCase):
                       path: launch_status.trial_status
                       value: confirmed
                 """,
+                "Expected `conditional_claims[0].phrase`",
+                draft_content="Public trial is open.\n",
             )
 
-            result = run_generator(repository_root)
-
-            self.assertNotEqual(0, result.returncode)
-            self.assertIn("Expected `conditional_claims[0].phrase`", result.stderr)
+    def test_conditional_claims_must_not_have_blank_messages(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            self.assert_guardrail_config_fails(
+                temporary_directory,
+                """
+                blocked_phrases: []
+                risky_phrases: []
+                conditional_claims:
+                  - phrase: public trial
+                    message: ""
+                    requires:
+                      path: launch_status.trial_status
+                      value: confirmed
+                """,
+                "Expected `conditional_claims[0].message`",
+                draft_content="Public trial is open.\n",
+            )
 
     def test_existing_campaign_directory_is_not_overwritten(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -406,10 +471,7 @@ class GenerateCampaignTest(unittest.TestCase):
             sentinel = output_directory / "README.md"
             sentinel.write_text("keep this review note\n", encoding="utf-8")
 
-            result = run_generator(repository_root)
-
-            self.assertNotEqual(0, result.returncode)
-            self.assertIn("Campaign output already exists", result.stderr)
+            self.assert_generation_fails_with(repository_root, "Campaign output already exists")
             self.assertEqual("keep this review note\n", sentinel.read_text(encoding="utf-8"))
 
     def test_template_paths_cannot_escape_templates_directory(self) -> None:
@@ -421,10 +483,10 @@ class GenerateCampaignTest(unittest.TestCase):
                 {},
             )
 
-            result = run_generator(repository_root)
-
-            self.assertNotEqual(0, result.returncode)
-            self.assertIn("must be a file name in .marketing/templates", result.stderr)
+            self.assert_generation_fails_with(
+                repository_root,
+                "must be a file name in .marketing/templates",
+            )
 
     def test_template_names_cannot_conflict_with_support_files(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -435,10 +497,10 @@ class GenerateCampaignTest(unittest.TestCase):
                 {"readme.md": "This draft would be overwritten on case-insensitive filesystems.\n"},
             )
 
-            result = run_generator(repository_root)
-
-            self.assertNotEqual(0, result.returncode)
-            self.assertIn("conflicts with a generated support file", result.stderr)
+            self.assert_generation_fails_with(
+                repository_root,
+                "conflicts with a generated support file",
+            )
 
     def test_feature_metadata_must_be_complete(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -457,10 +519,10 @@ class GenerateCampaignTest(unittest.TestCase):
                 """,
             )
 
-            result = run_generator(repository_root)
-
-            self.assertNotEqual(0, result.returncode)
-            self.assertIn("Expected `accent.features[0].tier`", result.stderr)
+            self.assert_generation_fails_with(
+                repository_root,
+                "Expected `accent.features[0].tier`",
+            )
 
     def test_social_proof_entries_must_not_be_silently_dropped(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -476,10 +538,10 @@ class GenerateCampaignTest(unittest.TestCase):
                 """,
             )
 
-            result = run_generator(repository_root)
-
-            self.assertNotEqual(0, result.returncode)
-            self.assertIn("Expected `social_proof[0].source`", result.stderr)
+            self.assert_generation_fails_with(
+                repository_root,
+                "Expected `social_proof[0].source`",
+            )
 
     def test_social_proof_quote_must_not_be_empty(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -495,10 +557,10 @@ class GenerateCampaignTest(unittest.TestCase):
                 """,
             )
 
-            result = run_generator(repository_root)
-
-            self.assertNotEqual(0, result.returncode)
-            self.assertIn("Expected `social_proof[0].quote`", result.stderr)
+            self.assert_generation_fails_with(
+                repository_root,
+                "Expected `social_proof[0].quote`",
+            )
 
 
 def make_repository(

--- a/scripts/tests/test-generate-campaign.py
+++ b/scripts/tests/test-generate-campaign.py
@@ -83,6 +83,46 @@ class GenerateCampaignTest(unittest.TestCase):
             self.assertIn("[Free] Accent overrides", draft)
             self.assertNotIn("unresolved placeholder", draft)
 
+    def test_generates_all_selected_templates_and_support_files(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            make_repository(
+                repository_root,
+                ["launch.md", "follow-up.md"],
+                {
+                    "launch.md": "Launch: {{ product.name }}\n",
+                    "follow-up.md": "Follow-up: {{ facts.free_feature_summary_inline }}\n",
+                },
+            )
+
+            self.assert_success_file_contains(repository_root, "launch.md", "Launch: Ayu Islands")
+
+            generated_files = {
+                file_path.name
+                for file_path in generated_directory(repository_root).iterdir()
+            }
+            self.assertEqual(
+                {
+                    "CHECKLIST.md",
+                    "FACT_CHECK.md",
+                    "POSTING_PLAN.md",
+                    "README.md",
+                    "follow-up.md",
+                    "launch.md",
+                },
+                generated_files,
+            )
+            self.assertIn(
+                "Follow-up: Accent overrides",
+                read_generated_file(repository_root, "follow-up.md"),
+            )
+            readme = read_generated_file(repository_root, "README.md")
+            posting_plan = read_generated_file(repository_root, "POSTING_PLAN.md")
+            self.assertIn("- `launch.md`", readme)
+            self.assertIn("- `follow-up.md`", readme)
+            self.assertIn("- `launch.md`", posting_plan)
+            self.assertIn("- `follow-up.md`", posting_plan)
+
     def test_warning_only_guardrails_are_written_without_failing_generation(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             repository_root = Path(temporary_directory)
@@ -473,6 +513,19 @@ class GenerateCampaignTest(unittest.TestCase):
 
             self.assert_generation_fails_with(repository_root, "Campaign output already exists")
             self.assertEqual("keep this review note\n", sentinel.read_text(encoding="utf-8"))
+
+    def test_missing_local_marketing_config_reports_required_file(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            scripts_dir = repository_root / "scripts"
+            scripts_dir.mkdir(parents=True)
+            shutil.copy2(SOURCE_SCRIPT, scripts_dir / "generate_campaign.py")
+
+            result = run_generator(repository_root)
+
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("Required YAML file is missing", result.stderr)
+            self.assertIn(".marketing/config.yaml", result.stderr)
 
     def test_template_paths_cannot_escape_templates_directory(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/scripts/tests/test-generate-campaign.py
+++ b/scripts/tests/test-generate-campaign.py
@@ -136,11 +136,10 @@ class GenerateCampaignTest(unittest.TestCase):
                 },
             )
 
-            result = run_generator(repository_root)
-
-            self.assertEqual(2, result.returncode)
-            fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
-            self.assertIn("follow-up.md: blocked phrase `guaranteed productivity`", fact_check)
+            self.assert_hard_blocked_fact_check_contains(
+                repository_root,
+                "follow-up.md: blocked phrase `guaranteed productivity`",
+            )
 
     def test_warning_only_guardrails_are_written_without_failing_generation(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -220,11 +219,10 @@ class GenerateCampaignTest(unittest.TestCase):
                 {"launch.md": "Bad placeholder: {{ product name }}\n"},
             )
 
-            result = run_generator(repository_root)
-
-            self.assertEqual(2, result.returncode)
-            fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
-            self.assertIn("raw template placeholder `{{ product name }}` was not rendered", fact_check)
+            self.assert_hard_blocked_fact_check_contains(
+                repository_root,
+                "raw template placeholder `{{ product name }}` was not rendered",
+            )
 
     def test_unclosed_template_placeholders_fail_generation(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -235,11 +233,10 @@ class GenerateCampaignTest(unittest.TestCase):
                 {"launch.md": "Bad placeholder: {{ product.name\n"},
             )
 
-            result = run_generator(repository_root)
-
-            self.assertEqual(2, result.returncode)
-            fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
-            self.assertIn("raw template placeholder `{{ product.name` was not rendered", fact_check)
+            self.assert_hard_blocked_fact_check_contains(
+                repository_root,
+                "raw template placeholder `{{ product.name` was not rendered",
+            )
 
     def test_unresolved_template_placeholders_fail_generation(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -250,12 +247,11 @@ class GenerateCampaignTest(unittest.TestCase):
                 {"launch.md": "{{ product.name }} {{ missing.value }}\n"},
             )
 
-            result = run_generator(repository_root)
-
-            self.assertEqual(2, result.returncode)
-            self.assertIn("Hard-blocked claims were found", result.stderr)
-            fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
-            self.assertIn("unresolved placeholder missing.value", fact_check)
+            self.assert_hard_blocked_fact_check_contains(
+                repository_root,
+                "unresolved placeholder missing.value",
+                expected_stderr="Hard-blocked claims were found",
+            )
 
     def test_blank_public_placeholder_values_fail_generation(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -300,11 +296,10 @@ class GenerateCampaignTest(unittest.TestCase):
                 """,
             )
 
-            result = run_generator(repository_root)
-
-            self.assertEqual(2, result.returncode)
-            fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
-            self.assertIn("blocked phrase `guaranteed productivity`", fact_check)
+            fact_check = self.assert_hard_blocked_fact_check_contains(
+                repository_root,
+                "blocked phrase `guaranteed productivity`",
+            )
             self.assertIn("lifetime access requires manual verification", fact_check)
 
     def test_blank_guardrail_phrases_fail_before_generation(self) -> None:
@@ -352,7 +347,7 @@ class GenerateCampaignTest(unittest.TestCase):
         temporary_directory: str,
         pricing: str,
         expected_text: str,
-    ) -> str:
+    ) -> None:
         repository_root = Path(temporary_directory)
         make_repository(
             repository_root,
@@ -360,7 +355,7 @@ class GenerateCampaignTest(unittest.TestCase):
             {"launch.md": "Pricing: {{ pricing.summary }}\n"},
             pricing=pricing,
         )
-        return self.assert_success_file_contains(repository_root, "FACT_CHECK.md", expected_text)
+        self.assert_success_file_contains(repository_root, "FACT_CHECK.md", expected_text)
 
     def test_conditional_claim_requires_feature_id_warns_when_feature_is_absent(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -441,6 +436,20 @@ class GenerateCampaignTest(unittest.TestCase):
         result = run_generator(repository_root)
         self.assertNotEqual(0, result.returncode)
         self.assertIn(expected_stderr, result.stderr)
+
+    def assert_hard_blocked_fact_check_contains(
+        self,
+        repository_root: Path,
+        expected_text: str,
+        expected_stderr: str | None = None,
+    ) -> str:
+        result = run_generator(repository_root)
+        self.assertEqual(2, result.returncode)
+        if expected_stderr is not None:
+            self.assertIn(expected_stderr, result.stderr)
+        fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
+        self.assertIn(expected_text, fact_check)
+        return fact_check
 
     def test_conditional_claim_requires_path_value_allows_matching_config(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -551,6 +560,53 @@ class GenerateCampaignTest(unittest.TestCase):
                 """,
                 "Expected `conditional_claims[0].requires.value`",
                 draft_content="Public trial is open.\n",
+            )
+
+    def test_conditional_claim_requires_must_be_mapping_even_when_inactive(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            self.assert_guardrail_config_fails(
+                temporary_directory,
+                """
+                blocked_phrases: []
+                risky_phrases: []
+                conditional_claims:
+                  - phrase: unavailable claim
+                    requires: launch_status.trial_status
+                """,
+                "Expected `conditional_claims[0].requires` to be a YAML mapping",
+            )
+
+    def test_conditional_claim_feature_id_must_be_scalar_even_when_inactive(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            self.assert_guardrail_config_fails(
+                temporary_directory,
+                """
+                blocked_phrases: []
+                risky_phrases: []
+                conditional_claims:
+                  - phrase: unavailable claim
+                    requires_feature_id:
+                      - accent-overrides
+                """,
+                "Expected scalar value at `conditional_claims[0].requires_feature_id`",
+            )
+
+    def test_conditional_claim_cannot_mix_requirement_types(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            self.assert_guardrail_config_fails(
+                temporary_directory,
+                """
+                blocked_phrases: []
+                risky_phrases: []
+                conditional_claims:
+                  - phrase: external accent sources
+                    requires_feature_id: accent-overrides
+                    requires:
+                      path: launch_status.marketplace
+                      value: unreleased
+                """,
+                "Expected `conditional_claims[0]` to define only one requirement type",
+                draft_content="External accent sources are ready.\n",
             )
 
     def test_existing_campaign_directory_is_not_overwritten(self) -> None:

--- a/scripts/tests/test-generate-campaign.py
+++ b/scripts/tests/test-generate-campaign.py
@@ -15,15 +15,43 @@ from datetime import date
 from pathlib import Path
 
 SOURCE_SCRIPT = Path(__file__).resolve().parent.parent / "generate_campaign.py"
+REPO_ROOT = SOURCE_SCRIPT.parent.parent
 
 DEFAULT_GUARDRAILS = """
 blocked_phrases:
   - guaranteed productivity
 conditional_claims: []
 """
+DEFAULT_FEATURES_YAML = """
+categories:
+  accent:
+    features:
+      - id: accent-overrides
+        title: Accent overrides
+        tier: free
+        introduced: 2.7.4
+"""
+DEFAULT_SOCIAL_PROOF = """
+- source: https://example.com/review
+  label: Maintainer quote
+  quote: Looks sharp
+  status: verified
+"""
 
 
 class GenerateCampaignTest(unittest.TestCase):
+    def test_console_entrypoint_matches_documented_command(self) -> None:
+        result = subprocess.run(
+            ["uv", "run", "--project", "scripts", "generate-campaign", "--help"],
+            check=False,
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+        )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("Generate private Ayu Islands marketing campaign drafts", result.stdout)
+
     def test_generates_drafts_with_summary_alias_placeholders(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             repository_root = Path(temporary_directory)
@@ -55,6 +83,22 @@ class GenerateCampaignTest(unittest.TestCase):
             self.assertIn("- marketplace: released", draft)
             self.assertIn("[Free] Accent overrides", draft)
             self.assertNotIn("unresolved placeholder", draft)
+
+    def test_warning_only_guardrails_are_written_without_failing_generation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            make_repository(
+                repository_root,
+                ["launch.md"],
+                {"launch.md": "Ayu Islands has 10,000 downloads.\n"},
+            )
+
+            result = run_generator(repository_root)
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
+            self.assertIn("metric claim `10,000 downloads` needs a source", fact_check)
+            self.assertIn("- Hard blocks: 0", read_generated_file(repository_root, "README.md"))
 
     def test_unresolved_template_placeholders_fail_generation(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -140,8 +184,8 @@ class GenerateCampaignTest(unittest.TestCase):
             repository_root = Path(temporary_directory)
             make_repository(
                 repository_root,
-                ["README.md"],
-                {"README.md": "This draft would be overwritten.\n"},
+                ["readme.md"],
+                {"readme.md": "This draft would be overwritten on case-insensitive filesystems.\n"},
             )
 
             result = run_generator(repository_root)
@@ -149,12 +193,55 @@ class GenerateCampaignTest(unittest.TestCase):
             self.assertNotEqual(0, result.returncode)
             self.assertIn("conflicts with a generated support file", result.stderr)
 
+    def test_feature_metadata_must_be_complete(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            make_repository(
+                repository_root,
+                ["launch.md"],
+                {"launch.md": "{{ facts.free_feature_summary }}\n"},
+                features_yaml="""
+                categories:
+                  accent:
+                    features:
+                      - id: accent-overrides
+                        title: Accent overrides
+                        introduced: 2.7.4
+                """,
+            )
+
+            result = run_generator(repository_root)
+
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("Expected `accent.features[0].tier`", result.stderr)
+
+    def test_social_proof_entries_must_not_be_silently_dropped(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            make_repository(
+                repository_root,
+                ["launch.md"],
+                {"launch.md": "{{ social_proof.summary }}\n"},
+                social_proof="""
+                - label: Missing source
+                  quote: Looks sharp
+                  status: verified
+                """,
+            )
+
+            result = run_generator(repository_root)
+
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("Expected `social_proof[0].source`", result.stderr)
+
 
 def make_repository(
     repository_root: Path,
     template_names: Sequence[str],
     templates: Mapping[str, str],
     guardrails: str = DEFAULT_GUARDRAILS,
+    features_yaml: str = DEFAULT_FEATURES_YAML,
+    social_proof: str = DEFAULT_SOCIAL_PROOF,
 ) -> None:
     scripts_dir = repository_root / "scripts"
     scripts_dir.mkdir(parents=True)
@@ -163,17 +250,7 @@ def make_repository(
     docs_dir = repository_root / "docs"
     docs_dir.mkdir()
     (docs_dir / "features.yml").write_text(
-        textwrap.dedent(
-            """
-            categories:
-              accent:
-                features:
-                  - id: accent-overrides
-                    title: Accent overrides
-                    tier: free
-                    introduced: 2.7.4
-            """
-        ).lstrip(),
+        textwrap.dedent(features_yaml).lstrip(),
         encoding="utf-8",
     )
     (repository_root / "CHANGELOG.md").write_text(
@@ -215,10 +292,7 @@ launch_status:
 manual_verification:
   - Confirm generated copy against Marketplace listing.
 social_proof:
-  - source: https://example.com/review
-    label: Maintainer quote
-    quote: Looks sharp
-    status: verified
+{textwrap.indent(textwrap.dedent(social_proof).strip(), "  ")}
 campaign_modes:
   launch:
     description: Launch copy

--- a/scripts/tests/test-generate-campaign.py
+++ b/scripts/tests/test-generate-campaign.py
@@ -20,6 +20,7 @@ REPO_ROOT = SOURCE_SCRIPT.parent.parent
 DEFAULT_GUARDRAILS = """
 blocked_phrases:
   - guaranteed productivity
+risky_phrases: []
 conditional_claims: []
 """
 DEFAULT_FEATURES_YAML = """
@@ -99,6 +100,64 @@ class GenerateCampaignTest(unittest.TestCase):
             fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
             self.assertIn("metric claim `10,000 downloads` needs a source", fact_check)
             self.assertIn("- Hard blocks: 0", read_generated_file(repository_root, "README.md"))
+
+    def test_risky_phrases_are_written_as_warnings(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            make_repository(
+                repository_root,
+                ["launch.md"],
+                {"launch.md": "No telemetry and no Sentry by design.\n"},
+                guardrails="""
+                blocked_phrases: []
+                risky_phrases:
+                  - telemetry
+                  - Sentry
+                conditional_claims: []
+                """,
+            )
+
+            result = run_generator(repository_root)
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
+            self.assertIn("risky phrase `telemetry` needs review", fact_check)
+            self.assertIn("risky phrase `Sentry` needs review", fact_check)
+
+    def test_bare_todo_verify_markers_are_written_as_warnings(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            make_repository(
+                repository_root,
+                ["launch.md"],
+                {"launch.md": "Pricing: {{ pricing.summary }}\n"},
+                pricing="""
+                public_claim_status: ready
+                commercial: 30 USD
+                model: annual license
+                """,
+            )
+
+            result = run_generator(repository_root)
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
+            self.assertIn("Pricing: TODO_VERIFY individual", fact_check)
+
+    def test_malformed_template_placeholders_fail_generation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            make_repository(
+                repository_root,
+                ["launch.md"],
+                {"launch.md": "Bad placeholder: {{ product name }}\n"},
+            )
+
+            result = run_generator(repository_root)
+
+            self.assertEqual(2, result.returncode)
+            fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
+            self.assertIn("raw template placeholder `{{ product name }}` was not rendered", fact_check)
 
     def test_unresolved_template_placeholders_fail_generation(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -242,6 +301,12 @@ def make_repository(
     guardrails: str = DEFAULT_GUARDRAILS,
     features_yaml: str = DEFAULT_FEATURES_YAML,
     social_proof: str = DEFAULT_SOCIAL_PROOF,
+    pricing: str = """
+    public_claim_status: ready
+    individual: 12 USD
+    commercial: 30 USD
+    model: annual license
+    """,
 ) -> None:
     scripts_dir = repository_root / "scripts"
     scripts_dir.mkdir(parents=True)
@@ -283,10 +348,7 @@ product:
   name: Ayu Islands
   category: JetBrains theme
 pricing:
-  public_claim_status: ready
-  individual: 12 USD
-  commercial: 30 USD
-  model: annual license
+{textwrap.indent(textwrap.dedent(pricing).strip(), "  ")}
 launch_status:
   marketplace: released
 manual_verification:

--- a/scripts/tests/test-generate-campaign.py
+++ b/scripts/tests/test-generate-campaign.py
@@ -122,6 +122,7 @@ class GenerateCampaignTest(unittest.TestCase):
             self.assertIn("- `follow-up.md`", readme)
             self.assertIn("- `launch.md`", posting_plan)
             self.assertIn("- `follow-up.md`", posting_plan)
+            self.assertIn("Draft files:", readme)
 
     def test_warning_only_guardrails_are_written_without_failing_generation(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -237,6 +238,25 @@ class GenerateCampaignTest(unittest.TestCase):
             self.assertIn("Hard-blocked claims were found", result.stderr)
             fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
             self.assertIn("unresolved placeholder missing.value", fact_check)
+
+    def test_blank_public_placeholder_values_fail_generation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            make_repository(
+                repository_root,
+                ["launch.md"],
+                {"launch.md": "Product: {{ product.name }}\n"},
+                product="""
+                name: ""
+                category: JetBrains theme
+                """,
+            )
+
+            result = run_generator(repository_root)
+
+            self.assertEqual(2, result.returncode)
+            fact_check = read_generated_file(repository_root, "FACT_CHECK.md")
+            self.assertIn("unresolved placeholder product.name", fact_check)
 
     def test_guardrails_fail_blocked_phrase_and_report_malformed_requires(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -527,6 +547,41 @@ class GenerateCampaignTest(unittest.TestCase):
             self.assertIn("Required YAML file is missing", result.stderr)
             self.assertIn(".marketing/config.yaml", result.stderr)
 
+    def test_unreadable_selected_template_reports_template_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            make_repository(
+                repository_root,
+                ["launch.md"],
+                {"launch.md": "Ready: {{ product.name }}\n"},
+            )
+            template_path = repository_root / ".marketing" / "templates" / "launch.md"
+            template_path.unlink()
+            template_path.mkdir()
+
+            self.assert_generation_fails_with(
+                repository_root,
+                "Failed to read selected template",
+            )
+
+    def test_output_directory_parent_file_reports_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            make_repository(
+                repository_root,
+                ["launch.md"],
+                {"launch.md": "Ready: {{ product.name }}\n"},
+            )
+            (repository_root / ".marketing" / "generated").write_text(
+                "not a directory\n",
+                encoding="utf-8",
+            )
+
+            self.assert_generation_fails_with(
+                repository_root,
+                "Failed to create campaign output directory",
+            )
+
     def test_template_paths_cannot_escape_templates_directory(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             repository_root = Path(temporary_directory)
@@ -623,6 +678,10 @@ def make_repository(
     guardrails: str = DEFAULT_GUARDRAILS,
     features_yaml: str = DEFAULT_FEATURES_YAML,
     social_proof: str = DEFAULT_SOCIAL_PROOF,
+    product: str = """
+    name: Ayu Islands
+    category: JetBrains theme
+    """,
     pricing: str = """
     public_claim_status: ready
     individual: 12 USD
@@ -670,8 +729,7 @@ def make_repository(
     template_list = "\n".join(f"      - {json.dumps(name)}" for name in template_names)
     config = f"""
 product:
-  name: Ayu Islands
-  category: JetBrains theme
+{textwrap.indent(textwrap.dedent(product).strip(), "  ")}
 pricing:
 {textwrap.indent(textwrap.dedent(pricing).strip(), "  ")}
 launch_status:

--- a/scripts/tests/test-verify-plugin-verifier.py
+++ b/scripts/tests/test-verify-plugin-verifier.py
@@ -9,7 +9,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-SCRIPT = Path(__file__).resolve().parent / "verify-plugin-verifier.py"
+SCRIPT = Path(__file__).resolve().parent.parent / "verify-plugin-verifier.py"
 
 
 class VerifyPluginVerifierTest(unittest.TestCase):

--- a/scripts/uv.lock
+++ b/scripts/uv.lock
@@ -69,7 +69,7 @@ wheels = [
 [[package]]
 name = "scripts"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "defusedxml" },
     { name = "pyyaml" },


### PR DESCRIPTION
── Summary ─────────────────────────────────

Local marketing campaign drafts depend on private `.marketing` inputs and had no repeatable checked-in generator. This adds a maintenance CLI that renders local templates against repo metadata, emits fact-check support files, and fails closed when drafts would be unsafe to publish or overwrite existing work.

── Changes ─────────────────────────────────

| Type | File | Description |
|------|------|-------------|
| Feat | [generate_campaign.py:1](scripts/generate_campaign.py#L1) | Render local campaign drafts and support files. |
| Fix | [generate_campaign.py:97](scripts/generate_campaign.py#L97) | Refuse overwrites, unsafe templates, support-file collisions, malformed placeholders, and incomplete metadata. |
| Test | [test-generate-campaign.py:1](scripts/tests/test-generate-campaign.py#L1) | Cover generator behavior through CLI-boundary tests. |
| CI | [build.yml:104](.github/workflows/build.yml#L104) | Run campaign generator tests in GitHub Actions. |
| Build | [pyproject.toml:1](scripts/pyproject.toml#L1) | Package scripts as an editable uv project. |
| Docs | [README.md:31](scripts/README.md#L31) | Document the `generate-campaign` invocation. |
| Chore | [.gitignore:13](.gitignore#L13) | Ignore Python cache/package artifacts. |

── Validation ──────────────────────────────

```bash
python3 -m py_compile scripts/generate_campaign.py scripts/tests/test-generate-campaign.py scripts/tests/test-verify-plugin-verifier.py
uv run --project scripts python scripts/tests/test-generate-campaign.py  # 13 tests OK
python3 scripts/tests/test-verify-plugin-verifier.py                    # 4 tests OK
uv run --project scripts pyright -p scripts scripts/generate_campaign.py scripts/tests/test-generate-campaign.py
uv run --project scripts pyright scripts
uv run --project scripts generate-campaign --help
python3 scripts/generate_campaign.py --mode soft-organic --name codex-smoke-round5
scripts/verify-docs.py
```

Observed campaign smoke output: `Warnings: 28`, `Hard blocks: 0`.

── Notes ───────────────────────────────────

- `.marketing/` remains local-only and globally ignored; this PR does not add private campaign inputs or generated drafts.
- The generator only writes Markdown files under `.marketing/generated/`; it does not post to external platforms.