### PR TITLE
feat(accent): add resolution diagnostics surfaces

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,8 @@ repositories {
 }
 
 dependencies {
+    val kotestVersion = providers.gradleProperty("kotestVersion").get()
+
     intellijPlatform {
         intellijIdeaCommunity(providers.gradleProperty("platformVersion"))
         pluginVerifier()
@@ -39,7 +41,7 @@ dependencies {
     }
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("io.mockk:mockk:${providers.gradleProperty("mockkVersion").get()}")
-    testImplementation("io.kotest:kotest-property-jvm:${providers.gradleProperty("kotestVersion").get()}")
+    testImplementation("io.kotest:kotest-property-jvm:$kotestVersion")
     testImplementation("junit:junit:${providers.gradleProperty("junitVersion").get()}")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
@@ -147,11 +149,17 @@ intellijPlatform {
                     "A" -> setOf("A1", "A2")
                     "C" -> setOf("C")
                     in ideGroups.keys -> setOf(group)
-                    else -> error("Unknown verifyGroup '$group' — expected A1, A2, A, B, C, or unset")
+                    else ->
+                        error(
+                            "Unknown verifyGroup '$group' — expected A1, A2, A, B, C, or unset",
+                        )
                 }
-            wanted.filter { it in ideGroups }.flatMap { ideGroups.getValue(it) }.forEach { (type, version) ->
-                create(type, version)
-            }
+            wanted
+                .filter { it in ideGroups }
+                .flatMap { ideGroups.getValue(it) }
+                .forEach { (type, version) ->
+                    create(type, version)
+                }
             if ("C" in wanted) {
                 select {
                     types = listOf(IntelliJPlatformType.IntellijIdeaCommunity)

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -100,7 +100,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "b8a0ab23"
+          last_verified_sha: "6e75e4be"
           last_verified_date: "2026-06-15"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -122,7 +122,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "b8a0ab23"
+          last_verified_sha: "6e75e4be"
           last_verified_date: "2026-06-15"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -100,7 +100,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "6e75e4be"
+          last_verified_sha: "b777afec"
           last_verified_date: "2026-06-15"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -122,7 +122,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "6e75e4be"
+          last_verified_sha: "b777afec"
           last_verified_date: "2026-06-15"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -1,6 +1,6 @@
 # Single source of truth for Ayu Islands user-facing features.
 #
-# CI (scripts/verify-docs.py) enforces three invariants:
+# CI (scripts/verify-docs.py) enforces six invariants:
 #
 #   1. Every `keyword` in this file appears in README.md AND in the
 #      <description> CDATA of src/main/resources/META-INF/plugin.xml
@@ -15,6 +15,16 @@
 #      `screenshot.last_verified_sha` fails with "re-capture OR re-stamp".
 #      Plus a SHA-256 byte-hash guard that catches "bumped last_verified_sha
 #      but forgot to swap the image file".
+#
+#   4. Every `required_links` entry appears in its declared target file.
+#      Prevents public/community links from being dropped during README edits.
+#
+#   5. Every image asset is represented in `asset_inventory` and either
+#      referenced from its declared files or justified as intentionally
+#      unreferenced.
+#
+#   6. `release_sync` keeps plugin.xml <description> copy aligned with the
+#      last published Marketplace version unless the plugin version changes.
 #
 # When adding a feature: pick a distinctive keyword (short phrase that will
 # always appear verbatim in the marketing copy). When the UI changes: either

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -100,7 +100,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "b777afec"
+          last_verified_sha: "b508a73"
           last_verified_date: "2026-06-15"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -122,7 +122,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "b777afec"
+          last_verified_sha: "b508a73"
           last_verified_date: "2026-06-15"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/proguard-rules.pro
+++ b/proguard-rules.pro
@@ -100,6 +100,9 @@
 # plugin.xml: action + CustomComponentAction (MainToolbarRight Quick-Switcher chip)
 -keep class dev.ayuislands.accent.toolbar.QuickSwitcherWidgetAction { *; }
 
+# plugin.xml: statusBarWidgetFactory (Accent diagnostics widget)
+-keep class dev.ayuislands.accent.statusbar.AccentStatusBarWidgetFactory { *; }
+
 # Public API singletons (called from kept classes)
 -keep class dev.ayuislands.accent.AccentApplicator { *; }
 -keep class dev.ayuislands.accent.AccentColor { *; }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,8 +13,9 @@ and where appropriate into `.pre-commit-config.yaml`.
 
 ### `verify-docs.py` — docs drift detector
 
-Enforces three invariants between `docs/features.yml`, `README.md`,
-`src/main/resources/META-INF/plugin.xml`, and `CHANGELOG.md`:
+Enforces six invariants between `docs/features.yml`, `README.md`,
+`src/main/resources/META-INF/plugin.xml`, `CHANGELOG.md`, declared assets,
+and release metadata:
 
 1. **Keyword coverage** — every feature's keyword appears in both
    `README.md` and the `<description>` CDATA of `plugin.xml`.
@@ -23,10 +24,17 @@ Enforces three invariants between `docs/features.yml`, `README.md`,
 3. **Screenshot freshness** — for every feature with a `screenshot` block,
    the declared Kotlin `sources` are unchanged since `last_verified_sha`
    and the file's SHA-256 matches `content_sha256`.
+4. **Required links** — every `required_links` substring appears in its
+   declared target file.
+5. **Asset inventory** — every image asset is listed and either referenced
+   from its declared files or justified as intentionally unreferenced.
+6. **Marketplace release sync** — `plugin.xml` description copy must match
+   the last published hash while the plugin version remains unchanged.
 
 ```bash
 scripts/verify-docs.py                 # lint (used by CI + pre-commit)
 scripts/verify-docs.py --update-hashes # recompute content_sha256 after re-capture
+scripts/verify-docs.py --restamp       # rebind orphaned last_verified_sha values
 ```
 
 Deps: `pyyaml`. Invoked via uv shebang.

--- a/src/main/kotlin/dev/ayuislands/accent/AccentResolutionChain.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentResolutionChain.kt
@@ -1,0 +1,29 @@
+package dev.ayuislands.accent
+
+/**
+ * Full decision trace for accent resolution.
+ *
+ * Contains every source considered in priority order, the single winning step,
+ * and the language-detection verdict (if applicable) that influenced the
+ * language-override and project-fallback steps.
+ *
+ * UI consumers (status-bar widget, settings diagnostics) render the [steps]
+ * list to show "why this source won or didn't win".
+ *
+ * ### Construction
+ *
+ * Built by [AccentResolver.resolveChain]. The [winner] is always one of the
+ * [steps] (guaranteed by construction — the global fallback always wins if
+ * no override does).
+ *
+ * ### Verdict
+ *
+ * [verdict] is non-null only when language detection was consulted during
+ * resolution. It carries the [ProjectLanguageVerdict] that determined whether
+ * a language override or project fallback could apply.
+ */
+data class AccentResolutionChain(
+    val steps: List<AccentResolutionStep>,
+    val winner: AccentResolutionStep,
+    val verdict: ProjectLanguageVerdict?,
+)

--- a/src/main/kotlin/dev/ayuislands/accent/AccentResolutionChainBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentResolutionChainBuilder.kt
@@ -63,16 +63,17 @@ internal object AccentResolutionChainBuilder {
         }
 
         val verdict = collectOverrideChainSteps(project, steps)
-        addUiColorStep(
+        collectUiColorStep(
             steps,
             Source.MATERIAL_THEME,
             uiColorHex(MATERIAL_ACCENT_KEY),
             "Material Theme accent found",
             "No Material Theme accent",
-        )
+        )?.let { return AccentResolutionChain(steps, it, verdict) }
 
         val ideHex = uiColorHex(COMPONENT_ACCENT_KEY) ?: uiColorHex(ACTIONS_BLUE_KEY)
-        addUiColorStep(steps, Source.IDE_ACCENT, ideHex, "IDE accent found", "No IDE accent")
+        collectUiColorStep(steps, Source.IDE_ACCENT, ideHex, "IDE accent found", "No IDE accent")
+            ?.let { return AccentResolutionChain(steps, it, verdict) }
 
         val storedHex = AccentHex.of(state.externalThemeAccent)?.value ?: AyuVariant.MIRAGE.defaultAccent
         val winner =
@@ -122,13 +123,18 @@ internal object AccentResolutionChainBuilder {
         if (collectForcedLanguageStep(forcedLanguageId, mappings, steps)) {
             return null
         }
+        val hasProjectFallbackCandidate = mappings.projectFallbackAccents.containsKey(projectKey)
 
         val verdict =
-            collectLanguageOverrideStep(forcedLanguageId, mappings, activeProject, steps)
+            collectLanguageOverrideStep(
+                forcedLanguageId = forcedLanguageId,
+                mappings = mappings,
+                activeProject = activeProject,
+                steps = steps,
+                shouldConsultForProjectFallback = hasProjectFallbackCandidate,
+            )
                 ?: return null
-        if (verdict is ProjectLanguageVerdict.Detected &&
-            mappings.languageAccents[verdict.languageId] != null
-        ) {
+        if (steps.lastOrNull()?.outcome == StepOutcome.WON) {
             return verdict
         }
 
@@ -207,7 +213,11 @@ internal object AccentResolutionChainBuilder {
                     "Forced language ${displayNameFor(forcedLanguageId)} has no accent mapping",
                 ),
             )
-            return false
+            return collectLanguageFallbackStep(
+                mappings.languageFallbackAccent,
+                "Language fallback for forced ${displayNameFor(forcedLanguageId)}",
+                steps,
+            )
         }
 
         val hex = AccentHex.of(forcedAccent)?.value
@@ -231,7 +241,11 @@ internal object AccentResolutionChainBuilder {
                 "Invalid hex for forced language ${displayNameFor(forcedLanguageId)}",
             ),
         )
-        return false
+        return collectLanguageFallbackStep(
+            mappings.languageFallbackAccent,
+            "Language fallback for forced ${displayNameFor(forcedLanguageId)}",
+            steps,
+        )
     }
 
     private fun collectLanguageOverrideStep(
@@ -239,9 +253,20 @@ internal object AccentResolutionChainBuilder {
         mappings: AccentMappingsState,
         activeProject: Project,
         steps: MutableList<AccentResolutionStep>,
+        shouldConsultForProjectFallback: Boolean,
     ): ProjectLanguageVerdict? {
-        val hasLanguageMappings = mappings.languageAccents.isNotEmpty()
-        if (forcedLanguageId != null || !hasLanguageMappings) {
+        val hasLanguageCandidate =
+            mappings.languageAccents.isNotEmpty() ||
+                mappings.languageFallbackAccent != null
+        if (forcedLanguageId != null) {
+            collectSkippedLanguageOverrideStep(forcedLanguageId, steps)
+            return if (shouldConsultForProjectFallback) {
+                ProjectLanguageDetector.verdict(activeProject)
+            } else {
+                null
+            }
+        }
+        if (!hasLanguageCandidate && !shouldConsultForProjectFallback) {
             collectSkippedLanguageOverrideStep(forcedLanguageId, steps)
             return null
         }
@@ -340,6 +365,11 @@ internal object AccentResolutionChainBuilder {
                 "Detected ${displayNameFor(verdict.languageId)} but no accent mapping",
             ),
         )
+        collectLanguageFallbackStep(
+            mappings.languageFallbackAccent,
+            "Language fallback for ${displayNameFor(verdict.languageId)}",
+            steps,
+        )
     }
 
     private fun collectProjectFallbackStep(
@@ -390,18 +420,50 @@ internal object AccentResolutionChainBuilder {
         }
     }
 
-    private fun addUiColorStep(
+    private fun collectLanguageFallbackStep(
+        rawHex: String?,
+        detail: String,
+        steps: MutableList<AccentResolutionStep>,
+    ): Boolean {
+        val fallbackHex = rawHex ?: return false
+        val hex = AccentHex.of(fallbackHex)?.value
+        if (hex != null) {
+            steps.add(
+                AccentResolutionStep(
+                    Source.LANGUAGE_FALLBACK_OVERRIDE,
+                    hex,
+                    StepOutcome.WON,
+                    detail,
+                ),
+            )
+            return true
+        }
+
+        steps.add(
+            AccentResolutionStep(
+                Source.LANGUAGE_FALLBACK_OVERRIDE,
+                null,
+                StepOutcome.NOT_SET,
+                "Invalid language fallback accent",
+            ),
+        )
+        return false
+    }
+
+    private fun collectUiColorStep(
         steps: MutableList<AccentResolutionStep>,
         source: Source,
         hex: String?,
         foundDetail: String,
         missingDetail: String,
-    ) {
+    ): AccentResolutionStep? {
         if (hex != null) {
-            steps.add(AccentResolutionStep(source, hex, StepOutcome.NOT_APPLICABLE, foundDetail))
-        } else {
-            steps.add(AccentResolutionStep(source, null, StepOutcome.NOT_SET, missingDetail))
+            val step = AccentResolutionStep(source, hex, StepOutcome.WON, foundDetail)
+            steps.add(step)
+            return step
         }
+        steps.add(AccentResolutionStep(source, null, StepOutcome.NOT_SET, missingDetail))
+        return null
     }
 
     private fun uiColorHex(key: String): String? = AccentResolver.uiColorForDiagnostics(key)?.toHex()

--- a/src/main/kotlin/dev/ayuislands/accent/AccentResolutionChainBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentResolutionChainBuilder.kt
@@ -1,0 +1,435 @@
+package dev.ayuislands.accent
+
+import com.intellij.lang.Language
+import com.intellij.openapi.project.Project
+import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.mappings.AccentMappingsSettings
+import dev.ayuislands.settings.mappings.AccentMappingsState
+import java.awt.Color
+import java.util.Locale
+
+private typealias Source = AccentResolver.Source
+
+internal object AccentResolutionChainBuilder {
+    private const val PROPORTIONS_TOP_N = 3
+    private const val NO_WINNER_TOP_N = 2
+    private const val PERCENTAGE_SCALE = 100
+    private const val DETAIL_LICENSE_BLOCKED = "Premium feature — license required"
+    private const val DETAIL_NO_PROJECT = "No project open"
+    private const val DETAIL_NO_PROJECT_KEY = "Project path unavailable"
+
+    private const val MATERIAL_ACCENT_KEY = "material.accent"
+    private const val COMPONENT_ACCENT_KEY = "Component.accentColor"
+    private const val ACTIONS_BLUE_KEY = "Actions.Blue"
+
+    fun resolveAyu(
+        project: Project?,
+        variant: AyuVariant,
+    ): AccentResolutionChain {
+        val globalAccent = AyuIslandsSettings.getInstance().getAccentForVariant(variant)
+        val steps = mutableListOf<AccentResolutionStep>()
+        val verdict = collectOverrideChainSteps(project, steps)
+        val winner =
+            steps.firstOrNull { it.outcome == StepOutcome.WON }
+                ?: AccentResolutionStep(
+                    Source.GLOBAL,
+                    globalAccent,
+                    StepOutcome.WON,
+                    "Default accent for ${variant.name.lowercase()}",
+                )
+        if (winner.source == Source.GLOBAL) {
+            steps.add(winner)
+        }
+        return AccentResolutionChain(steps, winner, verdict)
+    }
+
+    fun resolveExternal(project: Project?): AccentResolutionChain {
+        val state = AyuIslandsSettings.getInstance().state
+        val steps = mutableListOf<AccentResolutionStep>()
+        val isManual =
+            ExternalAccentSource.fromName(state.externalThemeAccentSource) ==
+                ExternalAccentSource.MANUAL
+        if (isManual) {
+            val hex = AccentHex.of(state.externalThemeAccent)?.value ?: AyuVariant.MIRAGE.defaultAccent
+            val step =
+                AccentResolutionStep(
+                    Source.EXTERNAL_ACCENT,
+                    hex,
+                    StepOutcome.WON,
+                    "Manual accent selection",
+                )
+            return AccentResolutionChain(listOf(step), step, null)
+        }
+
+        val verdict = collectOverrideChainSteps(project, steps)
+        addUiColorStep(
+            steps,
+            Source.MATERIAL_THEME,
+            uiColorHex(MATERIAL_ACCENT_KEY),
+            "Material Theme accent found",
+            "No Material Theme accent",
+        )
+
+        val ideHex = uiColorHex(COMPONENT_ACCENT_KEY) ?: uiColorHex(ACTIONS_BLUE_KEY)
+        addUiColorStep(steps, Source.IDE_ACCENT, ideHex, "IDE accent found", "No IDE accent")
+
+        val storedHex = AccentHex.of(state.externalThemeAccent)?.value ?: AyuVariant.MIRAGE.defaultAccent
+        val winner =
+            steps.firstOrNull { it.outcome == StepOutcome.WON }
+                ?: AccentResolutionStep(
+                    Source.EXTERNAL_ACCENT,
+                    storedHex,
+                    StepOutcome.WON,
+                    "Stored external accent",
+                )
+        if (winner.source == Source.EXTERNAL_ACCENT) {
+            steps.add(winner)
+        }
+        return AccentResolutionChain(steps, winner, verdict)
+    }
+
+    private fun collectOverrideChainSteps(
+        project: Project?,
+        steps: MutableList<AccentResolutionStep>,
+    ): ProjectLanguageVerdict? {
+        if (!LicenseChecker.isLicensedOrGrace()) {
+            collectPremiumUnavailableSteps(steps, StepOutcome.LICENSE_BLOCKED, DETAIL_LICENSE_BLOCKED)
+            return null
+        }
+
+        val activeProject =
+            project
+                ?.takeUnless { it.isDefault }
+                ?.takeUnless { it.isDisposed }
+        if (activeProject == null) {
+            collectPremiumUnavailableSteps(steps, StepOutcome.NOT_APPLICABLE, DETAIL_NO_PROJECT)
+            return null
+        }
+
+        val mappings = AccentMappingsSettings.getInstance().state
+        val projectKey = AccentResolver.projectKey(activeProject)
+        if (projectKey == null) {
+            collectPremiumUnavailableSteps(steps, StepOutcome.NOT_APPLICABLE, DETAIL_NO_PROJECT_KEY)
+            return null
+        }
+
+        if (collectProjectOverrideStep(projectKey, mappings, steps)) {
+            return null
+        }
+
+        val forcedLanguageId = mappings.forcedProjectLanguages[projectKey]
+        if (collectForcedLanguageStep(forcedLanguageId, mappings, steps)) {
+            return null
+        }
+
+        val verdict =
+            collectLanguageOverrideStep(forcedLanguageId, mappings, activeProject, steps)
+                ?: return null
+        if (verdict is ProjectLanguageVerdict.Detected &&
+            mappings.languageAccents[verdict.languageId] != null
+        ) {
+            return verdict
+        }
+
+        collectProjectFallbackStep(projectKey, verdict, mappings, steps)
+        return verdict
+    }
+
+    private fun collectPremiumUnavailableSteps(
+        steps: MutableList<AccentResolutionStep>,
+        outcome: StepOutcome,
+        detail: String,
+    ) {
+        val premiumSources =
+            listOf(
+                Source.PROJECT_OVERRIDE,
+                Source.FORCED_LANGUAGE_OVERRIDE,
+                Source.LANGUAGE_OVERRIDE,
+                Source.PROJECT_FALLBACK,
+            )
+        for (source in premiumSources) {
+            steps.add(AccentResolutionStep(source, null, outcome, detail))
+        }
+    }
+
+    private fun collectProjectOverrideStep(
+        projectKey: String,
+        mappings: AccentMappingsState,
+        steps: MutableList<AccentResolutionStep>,
+    ): Boolean {
+        val projectAccent = mappings.projectAccents[projectKey]
+        if (projectAccent == null) {
+            steps.add(
+                AccentResolutionStep(Source.PROJECT_OVERRIDE, null, StepOutcome.NOT_SET, "No project override set"),
+            )
+            return false
+        }
+
+        val hex = AccentHex.of(projectAccent)?.value
+        if (hex != null) {
+            steps.add(
+                AccentResolutionStep(Source.PROJECT_OVERRIDE, hex, StepOutcome.WON, "Pinned accent for this project"),
+            )
+            return true
+        }
+
+        steps.add(
+            AccentResolutionStep(Source.PROJECT_OVERRIDE, null, StepOutcome.NOT_SET, "Invalid hex in project override"),
+        )
+        return false
+    }
+
+    private fun collectForcedLanguageStep(
+        forcedLanguageId: String?,
+        mappings: AccentMappingsState,
+        steps: MutableList<AccentResolutionStep>,
+    ): Boolean {
+        if (forcedLanguageId == null) {
+            steps.add(
+                AccentResolutionStep(
+                    Source.FORCED_LANGUAGE_OVERRIDE,
+                    null,
+                    StepOutcome.NOT_SET,
+                    "No forced language set",
+                ),
+            )
+            return false
+        }
+
+        val forcedAccent = mappings.languageAccents[forcedLanguageId]
+        if (forcedAccent == null) {
+            steps.add(
+                AccentResolutionStep(
+                    Source.FORCED_LANGUAGE_OVERRIDE,
+                    null,
+                    StepOutcome.NO_MAPPING,
+                    "Forced language ${displayNameFor(forcedLanguageId)} has no accent mapping",
+                ),
+            )
+            return false
+        }
+
+        val hex = AccentHex.of(forcedAccent)?.value
+        if (hex != null) {
+            steps.add(
+                AccentResolutionStep(
+                    Source.FORCED_LANGUAGE_OVERRIDE,
+                    hex,
+                    StepOutcome.WON,
+                    "Forced language: ${displayNameFor(forcedLanguageId)}",
+                ),
+            )
+            return true
+        }
+
+        steps.add(
+            AccentResolutionStep(
+                Source.FORCED_LANGUAGE_OVERRIDE,
+                null,
+                StepOutcome.NOT_SET,
+                "Invalid hex for forced language ${displayNameFor(forcedLanguageId)}",
+            ),
+        )
+        return false
+    }
+
+    private fun collectLanguageOverrideStep(
+        forcedLanguageId: String?,
+        mappings: AccentMappingsState,
+        activeProject: Project,
+        steps: MutableList<AccentResolutionStep>,
+    ): ProjectLanguageVerdict? {
+        val hasLanguageMappings = mappings.languageAccents.isNotEmpty()
+        if (forcedLanguageId != null || !hasLanguageMappings) {
+            collectSkippedLanguageOverrideStep(forcedLanguageId, steps)
+            return null
+        }
+
+        val verdict = ProjectLanguageDetector.verdict(activeProject)
+        when (verdict) {
+            is ProjectLanguageVerdict.Detected -> collectDetectedLanguageStep(verdict, mappings, steps)
+            is ProjectLanguageVerdict.NoWinner -> collectNoWinnerLanguageStep(verdict, steps)
+            ProjectLanguageVerdict.Cold ->
+                steps.add(
+                    AccentResolutionStep(Source.LANGUAGE_OVERRIDE, null, StepOutcome.NOT_SET, "Detection pending"),
+                )
+            ProjectLanguageVerdict.Empty ->
+                steps.add(
+                    AccentResolutionStep(
+                        Source.LANGUAGE_OVERRIDE,
+                        null,
+                        StepOutcome.NOT_SET,
+                        "No project languages detected",
+                    ),
+                )
+            ProjectLanguageVerdict.Unavailable ->
+                steps.add(
+                    AccentResolutionStep(
+                        Source.LANGUAGE_OVERRIDE,
+                        null,
+                        StepOutcome.UNAVAILABLE,
+                        "Language detection unavailable",
+                    ),
+                )
+        }
+        return verdict
+    }
+
+    private fun collectSkippedLanguageOverrideStep(
+        forcedLanguageId: String?,
+        steps: MutableList<AccentResolutionStep>,
+    ) {
+        val detail =
+            if (forcedLanguageId != null) {
+                "Skipped — forced language takes priority"
+            } else {
+                "No language accent mappings configured"
+            }
+        val outcome = if (forcedLanguageId != null) StepOutcome.NOT_APPLICABLE else StepOutcome.NOT_SET
+        steps.add(AccentResolutionStep(Source.LANGUAGE_OVERRIDE, null, outcome, detail))
+    }
+
+    private fun collectNoWinnerLanguageStep(
+        verdict: ProjectLanguageVerdict.NoWinner,
+        steps: MutableList<AccentResolutionStep>,
+    ) {
+        val total = verdict.weights.values.sum()
+        val detail =
+            verdict.weights.entries
+                .sortedByDescending { it.value }
+                .take(NO_WINNER_TOP_N)
+                .joinToString(", ") { (lang, weight) ->
+                    "${displayNameFor(lang)} ${proportionPct(weight, total)}"
+                }
+        steps.add(
+            AccentResolutionStep(
+                Source.LANGUAGE_OVERRIDE,
+                null,
+                StepOutcome.NOT_DOMINANT,
+                "No dominant language: $detail",
+            ),
+        )
+    }
+
+    private fun collectDetectedLanguageStep(
+        verdict: ProjectLanguageVerdict.Detected,
+        mappings: AccentMappingsState,
+        steps: MutableList<AccentResolutionStep>,
+    ) {
+        val langAccent = mappings.languageAccents[verdict.languageId]
+        val hex = langAccent?.let { AccentHex.of(it)?.value }
+        if (hex != null) {
+            val proportions = verdict.weights?.let { proportionsText(it) } ?: ""
+            steps.add(
+                AccentResolutionStep(
+                    Source.LANGUAGE_OVERRIDE,
+                    hex,
+                    StepOutcome.WON,
+                    "Detected ${displayNameFor(verdict.languageId)}$proportions",
+                ),
+            )
+            return
+        }
+
+        steps.add(
+            AccentResolutionStep(
+                Source.LANGUAGE_OVERRIDE,
+                null,
+                StepOutcome.NO_MAPPING,
+                "Detected ${displayNameFor(verdict.languageId)} but no accent mapping",
+            ),
+        )
+    }
+
+    private fun collectProjectFallbackStep(
+        projectKey: String,
+        verdict: ProjectLanguageVerdict,
+        mappings: AccentMappingsState,
+        steps: MutableList<AccentResolutionStep>,
+    ) {
+        val fallbackHex = mappings.projectFallbackAccents[projectKey]
+        if (fallbackHex == null) {
+            steps.add(
+                AccentResolutionStep(Source.PROJECT_FALLBACK, null, StepOutcome.NOT_SET, "No project fallback set"),
+            )
+            return
+        }
+
+        if (verdict !is ProjectLanguageVerdict.NoWinner) {
+            steps.add(
+                AccentResolutionStep(
+                    Source.PROJECT_FALLBACK,
+                    null,
+                    StepOutcome.NOT_APPLICABLE,
+                    "Fallback only applies when no dominant language",
+                ),
+            )
+            return
+        }
+
+        val hex = AccentHex.of(fallbackHex)?.value
+        if (hex != null) {
+            steps.add(
+                AccentResolutionStep(
+                    Source.PROJECT_FALLBACK,
+                    hex,
+                    StepOutcome.WON,
+                    "Project fallback (polyglot project)",
+                ),
+            )
+        } else {
+            steps.add(
+                AccentResolutionStep(
+                    Source.PROJECT_FALLBACK,
+                    null,
+                    StepOutcome.NOT_SET,
+                    "Invalid hex in project fallback",
+                ),
+            )
+        }
+    }
+
+    private fun addUiColorStep(
+        steps: MutableList<AccentResolutionStep>,
+        source: Source,
+        hex: String?,
+        foundDetail: String,
+        missingDetail: String,
+    ) {
+        if (hex != null) {
+            steps.add(AccentResolutionStep(source, hex, StepOutcome.NOT_APPLICABLE, foundDetail))
+        } else {
+            steps.add(AccentResolutionStep(source, null, StepOutcome.NOT_SET, missingDetail))
+        }
+    }
+
+    private fun uiColorHex(key: String): String? = AccentResolver.uiColorForDiagnostics(key)?.toHex()
+
+    private fun displayNameFor(languageId: String): String =
+        Language
+            .getRegisteredLanguages()
+            .firstOrNull { it.id.equals(languageId, ignoreCase = true) }
+            ?.displayName
+            ?.takeIf { it.isNotBlank() }
+            ?: languageId
+
+    private fun proportionsText(weights: Map<String, Long>): String {
+        val total = weights.values.sum()
+        val top = weights.entries.sortedByDescending { it.value }.take(PROPORTIONS_TOP_N)
+        return top.joinToString(", ") { (lang, weight) ->
+            "${displayNameFor(lang)} ${proportionPct(weight, total)}"
+        }
+    }
+
+    private fun proportionPct(
+        weight: Long,
+        total: Long,
+    ): String {
+        if (total == 0L) return "0%"
+        val percentage = weight * PERCENTAGE_SCALE / total
+        return "$percentage%"
+    }
+
+    private fun Color.toHex(): String = "#%02X%02X%02X".format(Locale.ROOT, red, green, blue)
+}

--- a/src/main/kotlin/dev/ayuislands/accent/AccentResolutionStep.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentResolutionStep.kt
@@ -1,0 +1,48 @@
+package dev.ayuislands.accent
+
+/**
+ * Why a resolution step won or lost the accent-source priority chain.
+ *
+ * Ordered from "source won" to "source not applicable" so that UI consumers
+ * can group outcomes by severity without a separate ordering table.
+ */
+enum class StepOutcome {
+    /** This source won and is the active accent. */
+    WON,
+
+    /** Premium feature blocked by license gate. */
+    LICENSE_BLOCKED,
+
+    /** No override configured for this source (no mapping, no pinned accent). */
+    NOT_SET,
+
+    /** Language was detected but has no accent mapping in settings. */
+    NO_MAPPING,
+
+    /** Language detected but did not reach dominance threshold (polyglot). */
+    NOT_DOMINANT,
+
+    /** Source not applicable in the current context (e.g. project override in External theme). */
+    NOT_APPLICABLE,
+
+    /** Detection unavailable — scanner threw, dumb-mode race, or disposal race. */
+    UNAVAILABLE,
+}
+
+/**
+ * One step in the accent resolution decision trace.
+ *
+ * Each step records which [source] was considered, what hex it would have
+ * produced (null if the source was not set or blocked), the [outcome] that
+ * explains why it won or lost, and a human-readable [detail] string for
+ * diagnostics.
+ *
+ * The [AccentResolutionChain] is an ordered list of these steps, with exactly
+ * one step having [outcome] == [StepOutcome.WON].
+ */
+data class AccentResolutionStep(
+    val source: AccentResolver.Source,
+    val hex: String?,
+    val outcome: StepOutcome,
+    val detail: String,
+)

--- a/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
@@ -66,6 +66,8 @@ object AccentResolver {
 
     private fun uiColor(key: String): Color? = uiColorProviderOverride.get()?.invoke(key) ?: UIManager.getColor(key)
 
+    internal fun uiColorForDiagnostics(key: String): Color? = uiColor(key)
+
     /**
      * Resolves the effective accent hex. Delegates to the shared override-traversal helper,
      * falling back to the global per-variant accent when no override applies.
@@ -96,6 +98,34 @@ object AccentResolver {
     ): Source = resolveContext(project, context).source
 
     /**
+     * Returns the full resolution decision trace for [project] in the given
+     * [variant]. Each step records which [Source] was considered, what hex
+     * it would have produced, the [StepOutcome] explaining why it won or lost,
+     * and a human-readable detail string.
+     *
+     * The returned [AccentResolutionChain.winner] is always one of the
+     * [AccentResolutionChain.steps] — the global fallback always wins if no
+     * override does.
+     *
+     * Unlicensed callers see [StepOutcome.LICENSE_BLOCKED] for all premium
+     * sources and [StepOutcome.WON] for [Source.GLOBAL], mirroring the license
+     * gate in [resolve].
+     */
+    fun resolveChain(
+        project: Project?,
+        variant: AyuVariant,
+    ): AccentResolutionChain = AccentResolutionChainBuilder.resolveAyu(project, variant)
+
+    fun resolveChain(
+        project: Project?,
+        context: AccentContext,
+    ): AccentResolutionChain =
+        when (context) {
+            is AccentContext.Ayu -> AccentResolutionChainBuilder.resolveAyu(project, context.ayuVariant)
+            AccentContext.External -> AccentResolutionChainBuilder.resolveExternal(project)
+        }
+
+    /**
      * Human-readable label for [source], suitable for tooltips and Settings
      * "Currently active: …" readouts. The quick-switcher chip tooltip
      * (`"{hex} — {label}"`) consumes this label; the `AyuIslandsAccentPanel`
@@ -121,22 +151,7 @@ object AccentResolver {
             Source.GLOBAL -> "Global"
         }
 
-    private fun resolveContext(
-        project: Project?,
-        context: AccentContext,
-    ): ResolvedAccent =
-        when (context) {
-            is AccentContext.Ayu -> resolveAyu(project, context.ayuVariant)
-            AccentContext.External -> resolveExternal(project)
-        }
-
-    private fun resolveAyu(
-        project: Project?,
-        variant: AyuVariant,
-    ): ResolvedAccent {
-        val globalAccent = AyuIslandsSettings.getInstance().getAccentForVariant(variant)
-        return findOverride(project, validateHex = false) ?: ResolvedAccent(Source.GLOBAL, globalAccent)
-    }
+    // UI-color-dependent helpers stay in this object for uiColorProviderOverride access.
 
     private fun resolveExternal(project: Project?): ResolvedAccent {
         val state = AyuIslandsSettings.getInstance().state
@@ -156,10 +171,22 @@ object AccentResolver {
         source: Source,
     ): ResolvedAccent? = uiColor(key)?.let { ResolvedAccent(source, it.toHex()) }
 
-    private fun storedExternalAccent(state: AyuIslandsState): ResolvedAccent {
-        val hex = AccentHex.of(state.externalThemeAccent)?.value ?: AyuVariant.MIRAGE.defaultAccent
-        return ResolvedAccent(Source.EXTERNAL_ACCENT, hex)
+    private fun resolveAyu(
+        project: Project?,
+        variant: AyuVariant,
+    ): ResolvedAccent {
+        val globalAccent = AyuIslandsSettings.getInstance().getAccentForVariant(variant)
+        return findOverride(project, validateHex = false) ?: ResolvedAccent(Source.GLOBAL, globalAccent)
     }
+
+    private fun resolveContext(
+        project: Project?,
+        context: AccentContext,
+    ): ResolvedAccent =
+        when (context) {
+            is AccentContext.Ayu -> resolveAyu(project, context.ayuVariant)
+            AccentContext.External -> resolveExternal(project)
+        }
 
     private fun findOverride(
         project: Project?,
@@ -323,8 +350,6 @@ object AccentResolver {
         }
     }
 
-    private fun Color.toHex(): String = "#%02X%02X%02X".format(Locale.ROOT, red, green, blue)
-
     /**
      * One-shot per-project warn gate. [tryAcquire] returns `true` the first time a given
      * project is seen and `false` on every subsequent call — so hot-path callers can emit
@@ -355,6 +380,8 @@ object AccentResolver {
     private const val COMPONENT_ACCENT_KEY = "Component.accentColor"
     private const val ACTIONS_BLUE_KEY = "Actions.Blue"
 }
+
+private fun Color.toHex(): String = "#%02X%02X%02X".format(Locale.ROOT, red, green, blue)
 
 private data class LanguageOverrideRequest(
     val languageAccents: Map<String, String>,
@@ -404,4 +431,9 @@ private fun overrideAccent(
         return ResolvedAccent(source, rawHex)
     }
     return null
+}
+
+private fun storedExternalAccent(state: AyuIslandsState): ResolvedAccent {
+    val hex = AccentHex.of(state.externalThemeAccent)?.value ?: AyuVariant.MIRAGE.defaultAccent
+    return ResolvedAccent(AccentResolver.Source.EXTERNAL_ACCENT, hex)
 }

--- a/src/main/kotlin/dev/ayuislands/accent/ChromeTintSnapshot.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ChromeTintSnapshot.kt
@@ -18,17 +18,18 @@ internal data class ChromeTintSnapshot(
     val chromeNavBar: Boolean,
     val chromePanelBorder: Boolean,
     val intensity: TintIntensity,
+    val chromeTintingEnabled: Boolean = true,
 ) {
     fun isToggleEnabled(
         id: AccentElementId,
         fallbackState: AyuIslandsState,
     ): Boolean =
         when (id) {
-            AccentElementId.STATUS_BAR -> chromeStatusBar
-            AccentElementId.MAIN_TOOLBAR -> chromeMainToolbar
-            AccentElementId.TOOL_WINDOW_STRIPE -> chromeToolWindowStripe
-            AccentElementId.NAV_BAR -> chromeNavBar
-            AccentElementId.PANEL_BORDER -> chromePanelBorder
+            AccentElementId.STATUS_BAR -> chromeTintingEnabled && chromeStatusBar
+            AccentElementId.MAIN_TOOLBAR -> chromeTintingEnabled && chromeMainToolbar
+            AccentElementId.TOOL_WINDOW_STRIPE -> chromeTintingEnabled && chromeToolWindowStripe
+            AccentElementId.NAV_BAR -> chromeTintingEnabled && chromeNavBar
+            AccentElementId.PANEL_BORDER -> chromeTintingEnabled && chromePanelBorder
             else -> fallbackState.isToggleEnabled(id)
         }
 }

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageVerdict.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageVerdict.kt
@@ -5,7 +5,7 @@ package dev.ayuislands.accent
  * resolver fallback decisions. This is intentionally separate from
  * [ScanOutcome], which is a message-bus event payload.
  */
-internal sealed interface ProjectLanguageVerdict {
+sealed interface ProjectLanguageVerdict {
     /** No scan has produced a cache entry for this project key yet. */
     object Cold : ProjectLanguageVerdict
 

--- a/src/main/kotlin/dev/ayuislands/accent/statusbar/AccentStatusBarPopup.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/statusbar/AccentStatusBarPopup.kt
@@ -1,0 +1,137 @@
+package dev.ayuislands.accent.statusbar
+
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.ui.JBColor
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.util.ui.JBUI
+import dev.ayuislands.accent.AccentResolutionChain
+import dev.ayuislands.accent.AccentResolver
+import dev.ayuislands.accent.StepOutcome
+import java.awt.BorderLayout
+import java.awt.Component
+import java.awt.Dimension
+import java.awt.FlowLayout
+import javax.swing.JPanel
+
+/**
+ * Popup showing the full accent resolution chain.
+ *
+ * Each source is listed in priority order with:
+ * - A colored dot (accent color if won, gray otherwise)
+ * - The source label
+ * - The outcome detail (why it won or lost)
+ * - The hex value (if applicable)
+ *
+ * The winning source is highlighted with a distinct background.
+ */
+internal object AccentStatusBarPopup {
+    fun show(
+        invoker: Component,
+        chain: AccentResolutionChain,
+    ) {
+        val panel = buildChainPanel(chain)
+        val popup =
+            JBPopupFactory
+                .getInstance()
+                .createComponentPopupBuilder(panel, null)
+                .setTitle("Accent Source")
+                .setResizable(false)
+                .setMovable(true)
+                .setRequestFocus(true)
+                .createPopup()
+        popup.showUnderneathOf(invoker)
+    }
+
+    private fun buildChainPanel(chain: AccentResolutionChain): JPanel {
+        val panel = JPanel()
+        panel.layout = BorderLayout(JBUI.scale(0), JBUI.scale(0))
+        panel.border = JBUI.Borders.empty(PADDING)
+
+        // Winner header
+        val winner = chain.winner
+        val headerPanel = JPanel(FlowLayout(FlowLayout.LEFT, JBUI.scale(H_GAP), 0))
+        headerPanel.isOpaque = false
+        val winnerDot = AccentDotIcon(winner.hex ?: "#888888", WINNER_DOT_SIZE)
+        headerPanel.add(JBLabel(winnerDot))
+        val winnerLabel =
+            JBLabel(
+                "<html><b>${AccentResolver.sourceLabel(winner.source)}</b>" +
+                    "${if (winner.hex != null) " — ${winner.hex}" else ""}</html>",
+            )
+        winnerLabel.font = winnerLabel.font.deriveFont(WINNER_FONT_SIZE.toFloat())
+        headerPanel.add(winnerLabel)
+        panel.add(headerPanel, BorderLayout.NORTH)
+
+        // Chain steps
+        val stepsPanel = JPanel()
+        stepsPanel.layout = javax.swing.BoxLayout(stepsPanel, javax.swing.BoxLayout.Y_AXIS)
+        stepsPanel.isOpaque = false
+
+        for (step in chain.steps) {
+            val rowPanel = JPanel(FlowLayout(FlowLayout.LEFT, JBUI.scale(H_GAP), 0))
+            rowPanel.isOpaque = false
+            rowPanel.alignmentX = Component.LEFT_ALIGNMENT
+
+            val isWinner = step.outcome == StepOutcome.WON
+            val dotColor = if (isWinner) (step.hex ?: "#888888") else "#666666"
+            val dot = AccentDotIcon(dotColor, STEP_DOT_SIZE)
+            rowPanel.add(JBLabel(dot))
+
+            val outcomeIcon = if (isWinner) "✓" else outcomeSymbol(step.outcome)
+            val text =
+                buildString {
+                    append(outcomeIcon)
+                    append(" ")
+                    append(AccentResolver.sourceLabel(step.source))
+                    append(": ")
+                    append(step.detail)
+                    if (step.hex != null && !isWinner) {
+                        append(" (")
+                        append(step.hex)
+                        append(")")
+                    }
+                }
+            val label = JBLabel(text)
+            label.font = label.font.deriveFont(STEP_FONT_SIZE.toFloat())
+            if (!isWinner) {
+                label.foreground = JBColor.GRAY
+            }
+            rowPanel.add(label)
+            stepsPanel.add(rowPanel)
+        }
+
+        val scrollPane = JBScrollPane(stepsPanel)
+        scrollPane.isOpaque = false
+        scrollPane.border = null
+        scrollPane.preferredSize =
+            Dimension(
+                JBUI.scale(POPUP_WIDTH),
+                JBUI.scale(POPUP_ROW_HEIGHT * minOf(chain.steps.size, MAX_VISIBLE_ROWS) + PADDING * 2),
+            )
+        panel.add(scrollPane, BorderLayout.CENTER)
+
+        return panel
+    }
+
+    private fun outcomeSymbol(outcome: StepOutcome): String =
+        when (outcome) {
+            StepOutcome.WON -> "✓"
+            StepOutcome.LICENSE_BLOCKED -> "🔒"
+            StepOutcome.NOT_SET -> "—"
+            StepOutcome.NO_MAPPING -> "⚠"
+            StepOutcome.NOT_DOMINANT -> "≈"
+            StepOutcome.NOT_APPLICABLE -> "○"
+            StepOutcome.UNAVAILABLE -> "✗"
+        }
+
+    private const val PADDING = 8
+    private const val H_GAP = 4
+    private const val WINNER_DOT_SIZE = 12
+    private const val STEP_DOT_SIZE = 8
+    private const val WINNER_FONT_SIZE = 13
+    private const val STEP_FONT_SIZE = 11
+    private const val POPUP_WIDTH = 420
+    private const val POPUP_ROW_HEIGHT = 22
+    private const val MAX_VISIBLE_ROWS = 8
+}

--- a/src/main/kotlin/dev/ayuislands/accent/statusbar/AccentStatusBarWidget.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/statusbar/AccentStatusBarWidget.kt
@@ -1,0 +1,235 @@
+package dev.ayuislands.accent.statusbar
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.CustomStatusBarWidget
+import com.intellij.ui.JBColor
+import com.intellij.util.ui.JBUI
+import dev.ayuislands.accent.AccentChangeListener
+import dev.ayuislands.accent.AccentChangedTopic
+import dev.ayuislands.accent.AccentContext
+import dev.ayuislands.accent.AccentHex
+import dev.ayuislands.accent.AccentResolutionChain
+import dev.ayuislands.accent.AccentResolver
+import dev.ayuislands.accent.ProjectLanguageDetectionListener
+import dev.ayuislands.accent.StepOutcome
+import java.awt.BorderLayout
+import java.awt.Color
+import java.awt.Component
+import java.awt.Cursor
+import java.awt.Dimension
+import java.awt.FlowLayout
+import java.awt.Graphics
+import java.awt.Graphics2D
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import javax.swing.Icon
+import javax.swing.JComponent
+import javax.swing.JLabel
+import javax.swing.JPanel
+
+/**
+ * Status-bar widget showing the active accent source and a color indicator.
+ *
+ * Displays a small accent-colored dot followed by the source label.
+ * Click opens [AccentStatusBarPopup] with the full resolution chain.
+ *
+ * Lifecycle: subscribes to [AccentChangedTopic] and
+ * [ProjectLanguageDetectionListener.TOPIC] on install; disconnects on dispose.
+ * Hidden entirely when the license gate fails (premium feature) via
+ * [AccentStatusBarWidgetFactory.isAvailable].
+ */
+internal class AccentStatusBarWidget(
+    private val project: Project,
+) : CustomStatusBarWidget {
+    private var connection: com.intellij.util.messages.MessageBusConnection? = null
+    private val panel: AccentStatusBarPanel =
+        AccentStatusBarPanel { chain: AccentResolutionChain ->
+            AccentStatusBarPopup.show(this.panel, chain)
+        }
+
+    override fun ID(): String = WIDGET_ID
+
+    override fun getComponent(): JComponent = panel
+
+    override fun install(statusBar: com.intellij.openapi.wm.StatusBar) {
+        subscribeToEvents()
+        refreshFromProject()
+    }
+
+    override fun dispose() {
+        connection?.disconnect()
+        connection = null
+    }
+
+    private fun subscribeToEvents() {
+        val parent =
+            com.intellij.openapi.util.Disposer
+                .newDisposable("AccentStatusBarWidget.connection")
+        val conn = project.messageBus.connect(parent)
+        connection = conn
+
+        conn.subscribe(
+            AccentChangedTopic.TOPIC,
+            AccentChangeListener { _, _, _ ->
+                com.intellij.openapi.application.ApplicationManager.getApplication().invokeLater {
+                    refreshFromProject()
+                }
+            },
+        )
+
+        conn.subscribe(
+            ProjectLanguageDetectionListener.TOPIC,
+            ProjectLanguageDetectionListener { _ ->
+                com.intellij.openapi.application.ApplicationManager.getApplication().invokeLater {
+                    refreshFromProject()
+                }
+            },
+        )
+    }
+
+    fun refreshFromProject() {
+        if (project.isDisposed) return
+        val context = AccentContext.detect() ?: return
+        val chain = AccentResolver.resolveChain(project, context)
+        panel.updateFromChain(chain)
+    }
+
+    companion object {
+        const val WIDGET_ID = "AyuIslands.AccentStatusBar"
+    }
+}
+
+/**
+ * Panel rendering the accent indicator dot and source label.
+ * Clicking opens the resolution-chain popup.
+ *
+ * Shows a hand cursor and hover background to signal clickability.
+ */
+internal class AccentStatusBarPanel(
+    private val onClick: (AccentResolutionChain) -> Unit,
+) : JPanel(FlowLayout(FlowLayout.LEFT, JBUI.scale(H_GAP), 0)) {
+    private val dotLabel = JLabel()
+    private val sourceLabel = JLabel()
+
+    private var currentChain: AccentResolutionChain? = null
+    private var hovering = false
+
+    init {
+        isOpaque = false
+        cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+        dotLabel.preferredSize = Dimension(JBUI.scale(DOT_SIZE), JBUI.scale(DOT_SIZE))
+        sourceLabel.font = sourceLabel.font.deriveFont(JBUI.scale(FONT_SIZE).toFloat())
+        add(dotLabel, BorderLayout.WEST)
+        add(sourceLabel, BorderLayout.CENTER)
+
+        addMouseListener(
+            object : MouseAdapter() {
+                override fun mousePressed(e: MouseEvent) {
+                    val chain = currentChain ?: return
+                    onClick(chain)
+                }
+
+                override fun mouseEntered(e: MouseEvent) {
+                    hovering = true
+                    repaint()
+                }
+
+                override fun mouseExited(e: MouseEvent) {
+                    hovering = false
+                    repaint()
+                }
+            },
+        )
+    }
+
+    override fun paintComponent(g: Graphics) {
+        if (hovering) {
+            val g2 = g as Graphics2D
+            g2.color = HOVER_BG
+            g2.fillRect(0, 0, width, height)
+        }
+        super.paintComponent(g)
+    }
+
+    fun updateFromChain(chain: AccentResolutionChain) {
+        currentChain = chain
+        val winner = chain.winner
+        val hex = winner.hex ?: AccentHex.unsafeOf("#FFB454").value
+        dotLabel.icon = AccentDotIcon(hex, DOT_SIZE)
+        sourceLabel.text = buildStatusText(chain)
+        toolTipText = buildToolTip(chain)
+        revalidate()
+        repaint()
+    }
+
+    private fun buildStatusText(chain: AccentResolutionChain): String {
+        val winner = chain.winner
+        return "${AccentResolver.sourceLabel(winner.source)} · ${winner.detail}"
+    }
+
+    private fun buildToolTip(chain: AccentResolutionChain): String =
+        buildString {
+            val winner = chain.winner
+            append("<html>")
+            append(escapeHtml("${winner.hex ?: "—"} — ${AccentResolver.sourceLabel(winner.source)}"))
+            append("<br><br>")
+            appendChainRows(chain)
+            append("<br>")
+            append(escapeHtml("Click to see full resolution chain"))
+            append("</html>")
+        }
+
+    private fun StringBuilder.appendChainRows(chain: AccentResolutionChain) {
+        for (step in chain.steps) {
+            val marker = if (step.outcome == StepOutcome.WON) "✓" else " "
+            append(escapeHtml("$marker ${AccentResolver.sourceLabel(step.source)}: ${step.detail}"))
+            append("<br>")
+        }
+    }
+
+    private fun escapeHtml(text: String): String =
+        text
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace("\"", "&quot;")
+
+    companion object {
+        internal const val DOT_SIZE = 10
+        private const val H_GAP = 4
+        private const val FONT_SIZE = 11
+        private val HOVER_BG: Color =
+            JBColor(Color(255, 255, 255, 30), Color(255, 255, 255, 20))
+    }
+}
+
+/**
+ * Small colored circle icon for the accent indicator.
+ * Supports configurable size for different contexts.
+ */
+internal class AccentDotIcon(
+    hex: String,
+    private val size: Int,
+) : Icon {
+    private val color: Color =
+        try {
+            JBColor.decode(hex)
+        } catch (_: NumberFormatException) {
+            JBColor.GRAY
+        }
+
+    override fun paintIcon(
+        c: Component?,
+        g: Graphics?,
+        x: Int,
+        y: Int,
+    ) {
+        val g2 = g as? Graphics2D ?: return
+        g2.color = color
+        g2.fillOval(x, y, iconWidth, iconHeight)
+    }
+
+    override fun getIconWidth(): Int = JBUI.scale(size)
+
+    override fun getIconHeight(): Int = JBUI.scale(size)
+}

--- a/src/main/kotlin/dev/ayuislands/accent/statusbar/AccentStatusBarWidgetFactory.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/statusbar/AccentStatusBarWidgetFactory.kt
@@ -1,0 +1,25 @@
+package dev.ayuislands.accent.statusbar
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.StatusBarWidgetFactory
+import dev.ayuislands.licensing.LicenseChecker
+
+/**
+ * Factory that creates the [AccentStatusBarWidget] for each project window.
+ *
+ * Registered in `plugin.xml` under `com.intellij.statusBarWidgetFactory`.
+ * The widget is hidden when the license gate fails — [isAvailable] returns
+ * `false` for unlicensed users, so the IDE removes it from the status bar
+ * entirely rather than showing a disabled stub.
+ */
+internal class AccentStatusBarWidgetFactory : StatusBarWidgetFactory {
+    override fun getId(): String = AccentStatusBarWidget.WIDGET_ID
+
+    override fun getDisplayName(): String = "Ayu Accent Source"
+
+    override fun isAvailable(project: Project): Boolean = LicenseChecker.isLicensedOrGrace()
+
+    override fun createWidget(project: Project): AccentStatusBarWidget = AccentStatusBarWidget(project)
+
+    override fun isEnabledByDefault(): Boolean = true
+}

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentDiagnosticsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentDiagnosticsPanel.kt
@@ -1,0 +1,338 @@
+package dev.ayuislands.accent.toolbar
+
+import com.intellij.ui.JBColor
+import com.intellij.ui.components.ActionLink
+import com.intellij.ui.components.JBLabel
+import com.intellij.util.ui.JBUI
+import dev.ayuislands.accent.AccentResolutionChain
+import dev.ayuislands.accent.AccentResolutionStep
+import dev.ayuislands.accent.AccentResolver
+import dev.ayuislands.accent.StepOutcome
+import java.awt.BasicStroke
+import java.awt.BorderLayout
+import java.awt.Color
+import java.awt.Dimension
+import java.awt.Font
+import java.awt.Graphics
+import java.awt.Graphics2D
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
+import java.awt.RenderingHints
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+internal class QuickSwitcherAccentDiagnosticsPanel(
+    initialChain: AccentResolutionChain,
+) : JPanel(BorderLayout()) {
+    private var chain = initialChain
+    private var isExpanded = false
+
+    init {
+        isOpaque = false
+        updateFromChain(initialChain)
+    }
+
+    fun updateFromChain(nextChain: AccentResolutionChain) {
+        chain = nextChain
+        rebuild()
+    }
+
+    private fun rebuild() {
+        removeAll()
+
+        val rows = JPanel(GridBagLayout()).apply { isOpaque = false }
+        val supportingSteps = supportingSteps()
+        val hasSupportingSteps = supportingSteps.isNotEmpty()
+        val hasExpandedChain = isExpanded && hasSupportingSteps
+        val summaryTimelinePosition =
+            if (hasExpandedChain) TimelinePosition.FIRST else TimelinePosition.ONLY
+        addRow(
+            panel = rows,
+            row = 0,
+            diagnosticsRow =
+                DiagnosticsRow(
+                    markerColor = markerColor(chain.winner),
+                    markerSize = SUMMARY_MARKER_SIZE,
+                    timelinePosition = summaryTimelinePosition,
+                    content = buildSummaryPanel(hasSupportingSteps),
+                    isLastRow = !hasExpandedChain,
+                ),
+        )
+        if (hasExpandedChain) {
+            supportingSteps.forEachIndexed { index, step ->
+                val stepTimelinePosition =
+                    if (index == supportingSteps.lastIndex) {
+                        TimelinePosition.LAST
+                    } else {
+                        TimelinePosition.MIDDLE
+                    }
+                addRow(
+                    panel = rows,
+                    row = index + 1,
+                    diagnosticsRow =
+                        DiagnosticsRow(
+                            markerColor = markerColor(step),
+                            markerSize = STEP_MARKER_SIZE,
+                            timelinePosition = stepTimelinePosition,
+                            content = buildStepPanel(step),
+                            isLastRow = index == supportingSteps.lastIndex,
+                        ),
+                )
+            }
+        }
+
+        add(rows, BorderLayout.CENTER)
+        revalidate()
+        repaint()
+    }
+
+    private fun supportingSteps(): List<AccentResolutionStep> {
+        val winnerIndex = chain.steps.indexOfLast { step -> step == chain.winner }
+        return chain.steps.filterIndexed { index, _ -> index != winnerIndex }
+    }
+
+    private fun addRow(
+        panel: JPanel,
+        row: Int,
+        diagnosticsRow: DiagnosticsRow,
+    ) {
+        val bottomInset = if (diagnosticsRow.isLastRow) 0 else JBUI.scale(ROW_GAP)
+        panel.add(
+            TimelineMarkerCell(
+                diagnosticsRow.markerColor,
+                diagnosticsRow.markerSize,
+                diagnosticsRow.timelinePosition,
+            ),
+            GridBagConstraints().apply {
+                gridx = 0
+                gridy = row
+                weightx = 0.0
+                weighty = 0.0
+                anchor = GridBagConstraints.NORTH
+                fill = GridBagConstraints.BOTH
+                insets = JBUI.insets(0, 0, bottomInset, TEXT_GAP)
+            },
+        )
+        panel.add(
+            diagnosticsRow.content,
+            GridBagConstraints().apply {
+                gridx = 1
+                gridy = row
+                weightx = 1.0
+                weighty = 0.0
+                anchor = GridBagConstraints.WEST
+                fill = GridBagConstraints.HORIZONTAL
+                insets = JBUI.insetsBottom(bottomInset)
+            },
+        )
+    }
+
+    private fun buildSummaryPanel(hasSupportingSteps: Boolean): JComponent {
+        val winner = chain.winner
+        val panel =
+            JPanel(
+                BorderLayout(
+                    JBUI.scale(TEXT_GAP),
+                    JBUI.scale(SUMMARY_VERTICAL_GAP),
+                ),
+            )
+        panel.isOpaque = false
+
+        val summaryRow = JPanel(BorderLayout(JBUI.scale(TEXT_GAP), 0))
+        summaryRow.isOpaque = false
+        val sourceLabel = AccentResolver.sourceLabel(winner.source)
+        val summaryText = "$sourceLabel · ${winner.detail}"
+        summaryRow.add(
+            JBLabel(summaryText)
+                .apply {
+                    font =
+                        font.deriveFont(
+                            Font.BOLD,
+                            JBUI.scale(SUMMARY_FONT_SIZE).toFloat(),
+                        )
+                },
+            BorderLayout.CENTER,
+        )
+        winner.hex?.let { hex ->
+            summaryRow.add(
+                JBLabel(hex).apply {
+                    foreground = SECONDARY_TEXT
+                    font = font.deriveFont(JBUI.scale(DETAIL_FONT_SIZE).toFloat())
+                },
+                BorderLayout.EAST,
+            )
+        }
+        panel.add(summaryRow, BorderLayout.NORTH)
+
+        if (!hasSupportingSteps) {
+            return panel
+        }
+
+        val toggleText = if (isExpanded) COLLAPSE_TEXT else EXPAND_TEXT
+        panel.add(
+            ActionLink(toggleText) {
+                isExpanded = !isExpanded
+                rebuild()
+            }.apply {
+                alignmentX = LEFT_ALIGNMENT
+                accessibleContext.accessibleName = toggleText
+            },
+            BorderLayout.SOUTH,
+        )
+
+        return panel
+    }
+
+    private fun buildStepPanel(step: AccentResolutionStep): JComponent {
+        val panel = JPanel(BorderLayout(JBUI.scale(TEXT_GAP), 0))
+        panel.isOpaque = false
+        panel.add(
+            JBLabel("${AccentResolver.sourceLabel(step.source)} · ${step.detail}").apply {
+                foreground =
+                    if (step.outcome == StepOutcome.WON) {
+                        PRIMARY_TEXT
+                    } else {
+                        SECONDARY_TEXT
+                    }
+                font = font.deriveFont(JBUI.scale(DETAIL_FONT_SIZE).toFloat())
+            },
+            BorderLayout.CENTER,
+        )
+        step.hex?.takeIf { step.outcome != StepOutcome.WON }?.let { hex ->
+            panel.add(
+                JBLabel(hex).apply {
+                    foreground = SECONDARY_TEXT
+                    font = font.deriveFont(JBUI.scale(DETAIL_FONT_SIZE).toFloat())
+                },
+                BorderLayout.EAST,
+            )
+        }
+        return panel
+    }
+
+    private fun markerColor(step: AccentResolutionStep): Color =
+        when (step.outcome) {
+            StepOutcome.WON -> decodeColor(step.hex) ?: WINNER_FALLBACK
+            StepOutcome.UNAVAILABLE -> UNAVAILABLE_DOT
+            StepOutcome.LICENSE_BLOCKED -> BLOCKED_DOT
+            else -> MUTED_DOT
+        }
+
+    private fun decodeColor(hex: String?): Color? =
+        hex?.let {
+            try {
+                JBColor.decode(it)
+            } catch (_: NumberFormatException) {
+                null
+            }
+        }
+
+    private data class DiagnosticsRow(
+        val markerColor: Color,
+        val markerSize: Int,
+        val timelinePosition: TimelinePosition,
+        val content: JComponent,
+        val isLastRow: Boolean,
+    )
+
+    private enum class TimelinePosition {
+        ONLY,
+        FIRST,
+        MIDDLE,
+        LAST,
+    }
+
+    private class TimelineMarkerCell(
+        private val markerColor: Color,
+        private val markerSize: Int,
+        private val timelinePosition: TimelinePosition,
+    ) : JComponent() {
+        init {
+            name = MARKER_COLUMN_NAME
+            preferredSize =
+                Dimension(
+                    scaledMarkerColumnWidth(),
+                    JBUI.scale(ROW_HEIGHT),
+                )
+            minimumSize = preferredSize
+            isOpaque = false
+        }
+
+        override fun paintComponent(g: Graphics) {
+            val graphics = g as? Graphics2D ?: return
+            val centerX = width / 2
+            val centerY = height / 2 + JBUI.scale(MARKER_CENTER_Y_OFFSET)
+            graphics.setRenderingHint(
+                RenderingHints.KEY_ANTIALIASING,
+                RenderingHints.VALUE_ANTIALIAS_ON,
+            )
+
+            if (timelinePosition != TimelinePosition.ONLY) {
+                val railStart =
+                    if (timelinePosition == TimelinePosition.FIRST) {
+                        centerY
+                    } else {
+                        0
+                    }
+                val railEnd =
+                    if (timelinePosition == TimelinePosition.LAST) {
+                        centerY
+                    } else {
+                        height
+                    }
+                graphics.color = RAIL_COLOR
+                graphics.stroke = BasicStroke(JBUI.scale(1).toFloat())
+                graphics.drawLine(centerX, railStart, centerX, railEnd)
+            }
+
+            val size = JBUI.scale(markerSize)
+            graphics.color = markerColor
+            graphics.fillOval(centerX - size / 2, centerY - size / 2, size, size)
+        }
+    }
+
+    companion object {
+        internal const val MARKER_COLUMN_NAME = "accent-diagnostics-marker-column"
+        private const val MARKER_COLUMN_WIDTH = 18
+        private const val MARKER_CENTER_Y_OFFSET = -2
+        private const val ROW_HEIGHT = 22
+        private const val ROW_GAP = 2
+        private const val TEXT_GAP = 6
+        private const val SUMMARY_VERTICAL_GAP = 1
+        private const val SUMMARY_MARKER_SIZE = 7
+        private const val STEP_MARKER_SIZE = 5
+        private const val SUMMARY_FONT_SIZE = 11
+        private const val DETAIL_FONT_SIZE = 11
+        private const val EXPAND_TEXT = "Show resolution chain..."
+        private const val COLLAPSE_TEXT = "Collapse"
+        private val PRIMARY_TEXT: Color = JBColor.foreground()
+        private val SECONDARY_TEXT: Color = JBColor.GRAY
+        private val RAIL_COLOR: Color =
+            JBColor(
+                Color(82, 168, 214, 110),
+                Color(82, 168, 214, 100),
+            )
+        private val MUTED_DOT: Color =
+            JBColor(
+                Color(128, 139, 154),
+                Color(128, 139, 154),
+            )
+        private val BLOCKED_DOT: Color =
+            JBColor(
+                Color(173, 142, 255),
+                Color(173, 142, 255),
+            )
+        private val UNAVAILABLE_DOT: Color =
+            JBColor(
+                Color(238, 111, 111),
+                Color(238, 111, 111),
+            )
+        private val WINNER_FALLBACK: Color =
+            JBColor(
+                Color(82, 168, 214),
+                Color(82, 168, 214),
+            )
+
+        internal fun scaledMarkerColumnWidth(): Int = JBUI.scale(MARKER_COLUMN_WIDTH)
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherPopup.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherPopup.kt
@@ -1,6 +1,7 @@
 package dev.ayuislands.accent.toolbar
 
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.popup.JBPopup
 import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.openapi.ui.popup.JBPopupListener
@@ -14,13 +15,18 @@ import com.intellij.util.ui.JBUI
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentDefaults
+import dev.ayuislands.accent.AccentResolutionChain
+import dev.ayuislands.accent.AccentResolutionStep
 import dev.ayuislands.accent.AccentResolver
+import dev.ayuislands.accent.StepOutcome
 import dev.ayuislands.accent.toolbar.popup.AccentStripe
 import dev.ayuislands.accent.toolbar.popup.BlockSeparator
 import dev.ayuislands.accent.toolbar.popup.Density
 import dev.ayuislands.accent.toolbar.popup.SectionCard
 import dev.ayuislands.licensing.LicenseChecker
+import java.awt.BorderLayout
 import javax.swing.JComponent
+import javax.swing.JPanel
 import javax.swing.SwingUtilities
 
 /**
@@ -57,20 +63,36 @@ internal object QuickSwitcherPopup {
         chip: QuickSwitcherChipComponent? = null,
     ) {
         val context = AccentContext.detectQuickSwitcher() ?: return
+        val focusedProject = AccentApplicator.resolveFocusedProject()
 
         val accentGrid = QuickSwitcherAccentGrid()
+        val diagnosticsPanel =
+            QuickSwitcherAccentDiagnosticsPanel(
+                resolveCurrentAccentChain(focusedProject, context),
+            )
         val togglesSection = QuickSwitcherRelatedTogglesSection()
         val actionsRow = QuickSwitcherQuickActionsRow(anchor, context)
 
         val variantCard =
             when (context) {
                 is AccentContext.Ayu ->
-                    SectionCard("Variant").apply { setContent(VariantSwitcherRow(context.ayuVariant).component) }
+                    SectionCard("Variant").apply {
+                        setContent(VariantSwitcherRow(context.ayuVariant).component)
+                    }
                 AccentContext.External -> null
             }
-        val accentCard = SectionCard("Accent").apply { setContent(accentGrid.component) }
-        val togglesCard = SectionCard("Toggles").apply { setContent(togglesSection.component) }
-        val actionsCard = SectionCard("Actions").apply { setContent(actionsRow.component) }
+        val accentCard =
+            SectionCard("Accent").apply {
+                setContent(buildAccentContent(accentGrid.component, diagnosticsPanel))
+            }
+        val togglesCard =
+            SectionCard("Toggles").apply {
+                setContent(togglesSection.component)
+            }
+        val actionsCard =
+            SectionCard("Actions").apply {
+                setContent(actionsRow.component)
+            }
 
         val stripe = AccentStripe { resolveCurrentAccentHex(context) }
 
@@ -139,6 +161,42 @@ internal object QuickSwitcherPopup {
         } catch (exception: RuntimeException) {
             LOG.warn("AccentStripe resolve failed", exception)
             DEFAULT_ACCENT_FALLBACK
+        }
+
+    private fun resolveCurrentAccentChain(
+        project: Project?,
+        context: AccentContext,
+    ): AccentResolutionChain =
+        try {
+            AccentResolver.resolveChain(project, context)
+        } catch (exception: RuntimeException) {
+            LOG.warn("Accent diagnostics resolve failed", exception)
+            fallbackChain()
+        }
+
+    private fun fallbackChain(): AccentResolutionChain {
+        val winner =
+            AccentResolutionStep(
+                source = AccentResolver.Source.GLOBAL,
+                hex = DEFAULT_ACCENT_FALLBACK,
+                outcome = StepOutcome.WON,
+                detail = "Global fallback",
+            )
+        return AccentResolutionChain(
+            steps = listOf(winner),
+            winner = winner,
+            verdict = null,
+        )
+    }
+
+    private fun buildAccentContent(
+        accentGrid: JComponent,
+        diagnosticsPanel: JComponent,
+    ): JPanel =
+        JPanel(BorderLayout(0, JBUI.scale(Density.CARD_GAP))).apply {
+            isOpaque = false
+            add(accentGrid, BorderLayout.NORTH)
+            add(diagnosticsPanel, BorderLayout.CENTER)
         }
 
     /**

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherRelatedTogglesSection.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherRelatedTogglesSection.kt
@@ -2,8 +2,6 @@ package dev.ayuislands.accent.toolbar
 
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.diagnostic.logger
-import com.intellij.ui.dsl.builder.bindSelected
-import com.intellij.ui.dsl.builder.panel
 import com.intellij.util.ui.JBUI
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentContext
@@ -12,66 +10,41 @@ import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.toolbar.popup.Density
 import dev.ayuislands.accent.toolbar.popup.ToggleSwitch
 import dev.ayuislands.accent.toolbar.popup.ToggleTile
+import dev.ayuislands.glow.GlowOverlayManager
+import dev.ayuislands.rotation.AccentRotationService
 import dev.ayuislands.settings.AyuIslandsSettings
 import java.awt.GridLayout
 import javax.swing.Icon
-import javax.swing.JCheckBox
 import javax.swing.JComponent
 import javax.swing.JPanel
 
 /**
  * 2-column × 2-row grid of [ToggleTile] composites (icon + label +
- * [ToggleSwitch]) — replaces an earlier vertical [JCheckBox] stack.
+ * [ToggleSwitch]) — replaces an earlier vertical checkbox stack.
  *
- * "Chrome tinting" binds to `state.chromeStatusBar` ONLY (the most user-visible
- * chrome surface); the full 5-surface granularity stays in Settings. Other
- * tiles bind to `glowEnabled`, `accentRotationEnabled`, `followSystemAccent`
- * respectively.
+ * The popup is an immediate command surface, not a Settings form. Each tile
+ * writes the persistent state field and then runs the matching runtime
+ * side-effect so the visible IDE changes without waiting for Settings Apply.
  *
- * Single-source-of-truth: each tile owns a hidden [JCheckBox] driven by the
- * Kotlin UI DSL `bindSelected({ state.X }, { state.X = it })` — the visual is a
- * custom switch but the binding sink stays the DSL-managed checkbox, so the
- * existing persistence path keeps working. The hidden checkbox lives inside a
- * tiny [com.intellij.openapi.ui.DialogPanel] held by [persistenceRoot].
+ * "Chrome tinting" is intentionally a master toggle here: Settings remains the
+ * granular 5-surface editor, while the compact popup answers the user's
+ * expectation that the named feature turns on or off as one unit.
  *
- * **Persistence model.** Each tile click is its own commit: the user-facing
- * [ToggleSwitch] flip writes back to the hidden binding checkbox and then calls
- * `persistenceRoot.apply()` synchronously — the popup container does NOT need
- * to run any close-time flush. No external `fun apply()` is exposed because no
- * caller needs one; per-tile-click persistence is the whole contract.
- *
- * **Re-entry guard.** A lexical `suppressEvents` flag protects the bi-directional
- * binding ↔ switch link from a `flip()` → `isSelected = ...` → `ItemEvent` →
- * `flip()` ping-pong if an external Settings-page edit fires the binding's
- * `ItemEvent` while the popup is open. The equality guard (`if (switch.isSelected
- * != binding.isSelected) flip()`) by itself is fragile — `suppressEvents` makes
- * the no-loop invariant load-bearing on the lexical scope, not on equality.
- *
- * Pattern A — every paint mutation calls `repaint()` on the calling thread
- * (already EDT for mouse events).
+ * Pattern A — mouse events already run on EDT.
  */
-internal class QuickSwitcherRelatedTogglesSection {
+internal class QuickSwitcherRelatedTogglesSection(
+    private val context: AccentContext? = AccentContext.detectQuickSwitcher(),
+) {
     val component: JComponent
-    private val persistenceRoot: com.intellij.openapi.ui.DialogPanel
-
-    /**
-     * Re-entry guard around the bi-directional binding ↔ switch link. Set to
-     * `true` for the lexical scope of any write that would otherwise re-trigger
-     * the sibling listener (switch → binding, or binding → switch). The
-     * sibling listener checks this flag first and short-circuits when set,
-     * preventing the ItemEvent ping-pong cycle.
-     */
-    private var suppressEvents: Boolean = false
 
     init {
-        val state = AyuIslandsSettings.getInstance().state
         val accentSupplier: () -> String = {
-            val context = AccentContext.detectQuickSwitcher()
+            val activeContext = context ?: AccentContext.detectQuickSwitcher()
             try {
-                if (context == null) {
+                if (activeContext == null) {
                     AccentDefaults.MIRAGE_HEX
                 } else {
-                    AccentResolver.resolve(AccentApplicator.resolveFocusedProject(), context)
+                    AccentResolver.resolve(AccentApplicator.resolveFocusedProject(), activeContext)
                 }
             } catch (exception: RuntimeException) {
                 LOG.warn("Toggles section accent resolve failed", exception)
@@ -79,55 +52,18 @@ internal class QuickSwitcherRelatedTogglesSection {
             }
         }
 
-        val chromeBinding: JCheckBox
-        val glowBinding: JCheckBox
-        val rotationBinding: JCheckBox
-        val followBinding: JCheckBox
-
-        // Build all four hidden DSL checkboxes inside ONE persistence panel so a
-        // single `apply()` flushes the pending writes. The panel is NOT added to
-        // the visible component tree — it is held by reference so the binding
-        // sinks stay alive.
-        var chromeRef: JCheckBox? = null
-        var glowRef: JCheckBox? = null
-        var rotationRef: JCheckBox? = null
-        var followRef: JCheckBox? = null
-        persistenceRoot =
-            panel {
-                row {
-                    chromeRef =
-                        checkBox("Chrome tinting")
-                            .bindSelected({ state.chromeStatusBar }, { state.chromeStatusBar = it })
-                            .component
-                }
-                row {
-                    glowRef =
-                        checkBox("Glow")
-                            .bindSelected({ state.glowEnabled }, { state.glowEnabled = it })
-                            .component
-                }
-                row {
-                    rotationRef =
-                        checkBox("Accent rotation")
-                            .bindSelected({ state.accentRotationEnabled }, { state.accentRotationEnabled = it })
-                            .component
-                }
-                row {
-                    followRef =
-                        checkBox("Follow system accent")
-                            .bindSelected({ state.followSystemAccent }, { state.followSystemAccent = it })
-                            .component
-                }
-            }
-        chromeBinding = checkNotNull(chromeRef)
-        glowBinding = checkNotNull(glowRef)
-        rotationBinding = checkNotNull(rotationRef)
-        followBinding = checkNotNull(followRef)
-
-        val chromeTile = buildTile(AllIcons.General.Layout, "Chrome tinting", chromeBinding, accentSupplier)
-        val glowTile = buildTile(AllIcons.General.Note, "Glow", glowBinding, accentSupplier)
-        val rotationTile = buildTile(AllIcons.Actions.Refresh, "Accent rotation", rotationBinding, accentSupplier)
-        val followTile = buildTile(AllIcons.General.Settings, "Follow system accent", followBinding, accentSupplier)
+        val chromeTile =
+            buildTile(AllIcons.General.Layout, "Chrome tinting", QuickSwitcherToggle.CHROME, accentSupplier)
+        val glowTile = buildTile(AllIcons.General.Note, "Glow", QuickSwitcherToggle.GLOW, accentSupplier)
+        val rotationTile =
+            buildTile(AllIcons.Actions.Refresh, "Accent rotation", QuickSwitcherToggle.ROTATION, accentSupplier)
+        val followTile =
+            buildTile(
+                AllIcons.General.Settings,
+                "Follow system accent",
+                QuickSwitcherToggle.FOLLOW_SYSTEM,
+                accentSupplier,
+            )
 
         component =
             JPanel(
@@ -149,41 +85,17 @@ internal class QuickSwitcherRelatedTogglesSection {
     private fun buildTile(
         icon: Icon,
         label: String,
-        binding: JCheckBox,
+        toggle: QuickSwitcherToggle,
         accentSupplier: () -> String,
     ): ToggleTile {
         val switch =
             ToggleSwitch(
-                initialSelected = binding.isSelected,
+                initialSelected = toggle.isSelected(),
                 accentSupplier = accentSupplier,
                 listener = { newValue ->
-                    // suppressEvents wraps the binding write so the binding's
-                    // ItemListener (below) does NOT re-fire switch.flip() in
-                    // response — which would loop through this listener again.
-                    suppressEvents = true
-                    try {
-                        binding.isSelected = newValue
-                        persistenceRoot.apply()
-                    } finally {
-                        suppressEvents = false
-                    }
+                    toggle.setSelected(newValue, context)
                 },
             )
-        // Mirror reverse: if the hidden checkbox flips externally (Settings page
-        // edit fired through the same state), the ToggleSwitch follows. The
-        // suppressEvents guard short-circuits the loopback when the switch's
-        // own listener (above) wrote the binding.
-        binding.addItemListener { _ ->
-            if (suppressEvents) return@addItemListener
-            if (switch.isSelected != binding.isSelected) {
-                suppressEvents = true
-                try {
-                    switch.flip()
-                } finally {
-                    suppressEvents = false
-                }
-            }
-        }
         return ToggleTile(icon, label, switch)
     }
 
@@ -191,5 +103,83 @@ internal class QuickSwitcherRelatedTogglesSection {
         const val GRID_ROWS = 2
         const val GRID_COLS = 2
         val LOG = logger<QuickSwitcherRelatedTogglesSection>()
+    }
+}
+
+private enum class QuickSwitcherToggle {
+    CHROME,
+    GLOW,
+    ROTATION,
+    FOLLOW_SYSTEM,
+}
+
+private fun QuickSwitcherToggle.isSelected(): Boolean {
+    val state = AyuIslandsSettings.getInstance().state
+    return when (this) {
+        QuickSwitcherToggle.CHROME ->
+            state.chromeTintingEnabled && state.hasChromeTintingSurfaceEnabled()
+        QuickSwitcherToggle.GLOW -> state.glowEnabled
+        QuickSwitcherToggle.ROTATION -> state.accentRotationEnabled
+        QuickSwitcherToggle.FOLLOW_SYSTEM -> state.followSystemAccent
+    }
+}
+
+private fun QuickSwitcherToggle.setSelected(
+    selected: Boolean,
+    context: AccentContext?,
+) {
+    val state = AyuIslandsSettings.getInstance().state
+    when (this) {
+        QuickSwitcherToggle.CHROME -> {
+            state.chromeTintingEnabled = selected
+            applyFocusedAccent(context)
+        }
+        QuickSwitcherToggle.GLOW -> {
+            state.glowEnabled = selected
+            syncGlowOverlays(selected)
+        }
+        QuickSwitcherToggle.ROTATION -> {
+            state.accentRotationEnabled = selected
+            val service = AccentRotationService.getInstance()
+            if (selected) {
+                if (state.followSystemAccent) {
+                    state.followSystemAccent = false
+                }
+                service.startRotation()
+            } else {
+                service.stopRotation()
+            }
+        }
+        QuickSwitcherToggle.FOLLOW_SYSTEM -> {
+            state.followSystemAccent = selected
+            if (selected && state.accentRotationEnabled) {
+                state.accentRotationEnabled = false
+                AccentRotationService.getInstance().stopRotation()
+            }
+            applyFocusedAccent(context)
+        }
+    }
+}
+
+private fun applyFocusedAccent(context: AccentContext?) {
+    val activeContext = context ?: AccentContext.detectQuickSwitcher() ?: AccentContext.detect() ?: return
+    try {
+        AccentApplicator.applyForFocusedProject(activeContext)
+    } catch (exception: RuntimeException) {
+        logger<QuickSwitcherRelatedTogglesSection>().warn(
+            "Quick switcher toggle failed to reapply focused accent",
+            exception,
+        )
+    }
+}
+
+private fun syncGlowOverlays(glowEnabled: Boolean) {
+    try {
+        GlowOverlayManager.syncGlowForAllProjects()
+    } catch (exception: RuntimeException) {
+        logger<QuickSwitcherRelatedTogglesSection>().warn(
+            "Quick switcher toggle failed to sync glow overlays (enabled=$glowEnabled)",
+            exception,
+        )
     }
 }

--- a/src/main/kotlin/dev/ayuislands/actions/RescanLanguageAction.kt
+++ b/src/main/kotlin/dev/ayuislands/actions/RescanLanguageAction.kt
@@ -97,12 +97,11 @@ internal class RescanLanguageAction : DumbAwareAction() {
      * Resolve a [ScanOutcome] to a human-readable balloon body.
      * [ScanOutcome.Detected] maps to the registered Language `displayName`
      * (case-insensitive, raw id on lookup failure or blank displayName).
-     * [ScanOutcome.Polyglot] and [ScanOutcome.Unavailable] both map to the
-     * polyglot copy today — from the user's perspective "no dominant
-     * language right now" reads the same whether the scan definitively
-     * said polyglot or hit a transient failure, and the UI keeps a
-     * single copy string rather than surfacing detector-internal
-     * transience.
+     * [ScanOutcome.Polyglot] and [ScanOutcome.Unavailable] now have distinct
+     * copy — polyglot means "no single dominant language" while unavailable
+     * means "detection could not complete" (scanner threw, dumb-mode race,
+     * disposal race). The status-bar widget also differentiates these with
+     * different icons and actions.
      *
      * Case-insensitive lookup because `Language.id` casing varies per
      * plugin (`"JAVA"` / `"kotlin"` / `"JavaScript"`) while the detector
@@ -112,7 +111,8 @@ internal class RescanLanguageAction : DumbAwareAction() {
     private fun humanLabelFor(outcome: ScanOutcome): String =
         when (outcome) {
             is ScanOutcome.Detected -> displayNameFor(outcome.languageId)
-            ScanOutcome.Polyglot, ScanOutcome.Unavailable -> POLYGLOT_LABEL
+            ScanOutcome.Polyglot -> POLYGLOT_LABEL
+            ScanOutcome.Unavailable -> UNAVAILABLE_LABEL
         }
 
     private fun displayNameFor(detectedId: String): String {
@@ -138,5 +138,7 @@ internal class RescanLanguageAction : DumbAwareAction() {
         private const val NOTIFICATION_TITLE = "Project language re-detected"
         private const val POLYGLOT_LABEL =
             "Polyglot — no single dominant language; global accent applies"
+        private const val UNAVAILABLE_LABEL =
+            "Language detection unavailable — try rescanning; global accent applies"
     }
 }

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsChromePanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsChromePanel.kt
@@ -6,6 +6,8 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.dsl.builder.Align
 import com.intellij.ui.dsl.builder.Panel
+import com.intellij.ui.dsl.builder.bindValue
+import com.intellij.ui.dsl.builder.selected
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.ChromeDecorationsProbe
@@ -97,18 +99,37 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
                 premiumFeatureNotice(gate)
                 buildChromeSurfaceRows(gate, probeAllowsMainToolbar)
                 row("Intensity (%):") {
-                    val slider = JSlider(MIN_INTENSITY, MAX_INTENSITY, pendingChromeTintIntensity)
-                    slider.paintTicks = true
-                    slider.majorTickSpacing = INTENSITY_MAJOR_TICK
-                    slider.minorTickSpacing = INTENSITY_MINOR_TICK
-                    slider.applyPremiumLock(gate)
-                    val valueLabel = JLabel("${slider.value}")
-                    slider.addChangeListener {
-                        if (!gate.isUnlocked) return@addChangeListener
-                        pendingChromeTintIntensity = slider.value
-                        valueLabel.text = "${slider.value}"
-                    }
-                    cell(slider).resizableColumn().align(Align.FILL)
+                    val valueLabel = JLabel("$pendingChromeTintIntensity")
+                    val sliderCell =
+                        slider(MIN_INTENSITY, MAX_INTENSITY, INTENSITY_MAJOR_TICK, INTENSITY_MINOR_TICK)
+                            .bindValue(
+                                { pendingChromeTintIntensity },
+                                {
+                                    pendingChromeTintIntensity = it
+                                    valueLabel.text = "$it"
+                                },
+                            ).applyToComponent {
+                                value = pendingChromeTintIntensity
+                                paintTicks = true
+                                applyPremiumLock(gate)
+                                addChangeListener {
+                                    if (!gate.isUnlocked) return@addChangeListener
+                                    pendingChromeTintIntensity = value
+                                    valueLabel.text = "$value"
+                                }
+                            }
+                    val slider = sliderCell.component
+                    sliderCell
+                        .resizableColumn()
+                        .align(Align.FILL)
+                        .onReset {
+                            pendingChromeTintIntensity =
+                                storedChromeTintIntensity.coerceIn(MIN_INTENSITY, MAX_INTENSITY)
+                            slider.value = pendingChromeTintIntensity
+                            valueLabel.text = "$pendingChromeTintIntensity"
+                        }.onIsModified {
+                            pendingChromeTintIntensity != storedChromeTintIntensity
+                        }
                     cell(valueLabel)
                     intensitySlider = slider
                     intensityValueLabel = valueLabel
@@ -140,46 +161,62 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
         listOf(
             ChromeSurfaceRow(
                 label = "Status bar",
-                selected = pendingChromeStatusBar,
-                onChanged = { pendingChromeStatusBar = it },
+                currentValue = { pendingChromeStatusBar },
+                storedValue = { storedChromeStatusBar },
+                updatePending = { pendingChromeStatusBar = it },
                 rememberComponent = { statusBarCheckbox = it },
             ),
             ChromeSurfaceRow(
                 label = "Main toolbar",
-                selected = pendingChromeMainToolbar,
-                onChanged = { pendingChromeMainToolbar = it },
+                currentValue = { pendingChromeMainToolbar },
+                storedValue = { storedChromeMainToolbar },
+                updatePending = { pendingChromeMainToolbar = it },
                 rememberComponent = { mainToolbarCheckbox = it },
                 enabledWhenUnlocked = probeAllowsMainToolbar,
                 disabledComment = disabledToolbarComment,
             ),
             ChromeSurfaceRow(
                 label = "Tool window stripe",
-                selected = pendingChromeToolWindowStripe,
-                onChanged = { pendingChromeToolWindowStripe = it },
+                currentValue = { pendingChromeToolWindowStripe },
+                storedValue = { storedChromeToolWindowStripe },
+                updatePending = { pendingChromeToolWindowStripe = it },
                 rememberComponent = { toolWindowStripeCheckbox = it },
             ),
             ChromeSurfaceRow(
                 label = "Navigation bar",
-                selected = pendingChromeNavBar,
-                onChanged = { pendingChromeNavBar = it },
+                currentValue = { pendingChromeNavBar },
+                storedValue = { storedChromeNavBar },
+                updatePending = { pendingChromeNavBar = it },
                 rememberComponent = { navBarCheckbox = it },
             ),
             ChromeSurfaceRow(
                 label = "Panel borders",
-                selected = pendingChromePanelBorder,
-                onChanged = { pendingChromePanelBorder = it },
+                currentValue = { pendingChromePanelBorder },
+                storedValue = { storedChromePanelBorder },
+                updatePending = { pendingChromePanelBorder = it },
                 rememberComponent = { panelBorderCheckbox = it },
             ),
         ).forEach { surfaceRow ->
             row {
-                val checkboxCell = checkBox(surfaceRow.label)
+                val checkboxCell =
+                    checkBox(surfaceRow.label)
+                        .selected(surfaceRow.currentValue())
                 val checkbox = checkboxCell.component
-                checkbox.isSelected = surfaceRow.selected
                 checkbox.applyPremiumLock(gate, enabledWhenUnlocked = surfaceRow.enabledWhenUnlocked)
-                checkbox.addActionListener {
-                    if (!gate.isUnlocked || !surfaceRow.enabledWhenUnlocked) return@addActionListener
-                    surfaceRow.onChanged(checkbox.isSelected)
-                }
+                checkboxCell
+                    .onChanged {
+                        if (!gate.isUnlocked || !surfaceRow.enabledWhenUnlocked) return@onChanged
+                        surfaceRow.updatePending(checkbox.isSelected)
+                    }.onApply {
+                        if (gate.isUnlocked && surfaceRow.enabledWhenUnlocked) {
+                            surfaceRow.updatePending(checkbox.isSelected)
+                        }
+                    }.onReset {
+                        surfaceRow.updatePending(surfaceRow.storedValue())
+                        checkbox.isSelected = surfaceRow.currentValue()
+                    }.onIsModified {
+                        surfaceRow.currentValue() != surfaceRow.storedValue()
+                    }
                 surfaceRow.rememberComponent(checkbox)
                 surfaceRow.disabledComment?.let { checkboxCell.comment(it) }
             }
@@ -188,8 +225,9 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
 
     private class ChromeSurfaceRow(
         val label: String,
-        val selected: Boolean,
-        val onChanged: (Boolean) -> Unit,
+        val currentValue: () -> Boolean,
+        val storedValue: () -> Boolean,
+        val updatePending: (Boolean) -> Unit,
         val rememberComponent: (JBCheckBox) -> Unit,
         val enabledWhenUnlocked: Boolean = true,
         val disabledComment: String? = null,
@@ -230,6 +268,12 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
             return
         }
 
+        val chromeTintingEnabled =
+            pendingChromeStatusBar ||
+                pendingChromeMainToolbar ||
+                pendingChromeToolWindowStripe ||
+                pendingChromeNavBar ||
+                pendingChromePanelBorder
         val chromeSnapshot =
             ChromeTintSnapshot(
                 chromeStatusBar = pendingChromeStatusBar,
@@ -238,6 +282,7 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
                 chromeNavBar = pendingChromeNavBar,
                 chromePanelBorder = pendingChromePanelBorder,
                 intensity = TintIntensity.of(pendingChromeTintIntensity),
+                chromeTintingEnabled = chromeTintingEnabled,
             )
 
         // Run the EP chain FIRST so a throw from applyForFocusedProject leaves
@@ -258,6 +303,7 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
             return
         }
         val state = AyuIslandsSettings.getInstance().state
+        state.chromeTintingEnabled = chromeTintingEnabled
         state.chromeStatusBar = pendingChromeStatusBar
         state.chromeMainToolbar = pendingChromeMainToolbar
         state.chromeToolWindowStripe = pendingChromeToolWindowStripe

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt
@@ -91,7 +91,6 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
         }
 
         val contentTabs = buildContentTabs(variant, effectiveVariant, activePanels)
-        val integratedPanels = contentTabs.mapNotNull { it.second as? DialogPanel }
         builtPanels = activePanels
 
         val settings = AyuIslandsSettings.getInstance()
@@ -105,7 +104,7 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
                 AyuIslandsSettings.getInstance().state.settingsSelectedTab = selectedIndex
             }
 
-        return buildRootPanel(pluginVersion, variant, tabs, integratedPanels)
+        return buildRootPanel(pluginVersion, variant, tabs)
     }
 
     private fun configureAyuPanelComposition(variant: AyuVariant) {
@@ -244,7 +243,6 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
         pluginVersion: String,
         variant: AyuVariant?,
         tabs: JBTabbedPane,
-        integratedPanels: List<DialogPanel>,
     ): DialogPanel =
         panel {
             row {
@@ -273,8 +271,6 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
                     .resizableColumn()
                     .align(Align.FILL)
             }
-        }.also { rootPanel ->
-            integratedPanels.forEach(rootPanel::registerIntegratedPanel)
         }
 
     private fun Panel.buildAyuThemeRequiredMessage(sectionName: String) {

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsConfigurable.kt
@@ -4,6 +4,7 @@ import com.intellij.ide.BrowserUtil
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.options.BoundConfigurable
 import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.ui.DialogPanel
 import com.intellij.openapi.ui.Messages
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.components.JBTabbedPane
@@ -79,7 +80,7 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
             pluginsPanel,
         )
 
-    override fun createPanel(): com.intellij.openapi.ui.DialogPanel {
+    override fun createPanel(): DialogPanel {
         val pluginVersion = resolvePluginVersion()
         val variant = AyuVariant.detect()
         val effectiveVariant = variant ?: AyuVariant.MIRAGE
@@ -90,6 +91,7 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
         }
 
         val contentTabs = buildContentTabs(variant, effectiveVariant, activePanels)
+        val integratedPanels = contentTabs.mapNotNull { it.second as? DialogPanel }
         builtPanels = activePanels
 
         val settings = AyuIslandsSettings.getInstance()
@@ -103,7 +105,7 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
                 AyuIslandsSettings.getInstance().state.settingsSelectedTab = selectedIndex
             }
 
-        return buildRootPanel(pluginVersion, variant, tabs)
+        return buildRootPanel(pluginVersion, variant, tabs, integratedPanels)
     }
 
     private fun configureAyuPanelComposition(variant: AyuVariant) {
@@ -155,7 +157,9 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
             } else {
                 accentPanel.buildPanel(this@panel, variant)
                 elementsPanel.buildPanel(this@panel, variant)
+                activePanels += appearancePanel
                 activePanels += accentPanel
+                activePanels += chromePanel
                 activePanels += elementsPanel
                 buildResetAllSettingsRow()
             }
@@ -240,7 +244,8 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
         pluginVersion: String,
         variant: AyuVariant?,
         tabs: JBTabbedPane,
-    ): com.intellij.openapi.ui.DialogPanel =
+        integratedPanels: List<DialogPanel>,
+    ): DialogPanel =
         panel {
             row {
                 scaleIcon()?.let { icon(it) }
@@ -268,6 +273,8 @@ class AyuIslandsConfigurable : BoundConfigurable("Ayu Islands") {
                     .resizableColumn()
                     .align(Align.FILL)
             }
+        }.also { rootPanel ->
+            integratedPanels.forEach(rootPanel::registerIntegratedPanel)
         }
 
     private fun Panel.buildAyuThemeRequiredMessage(sectionName: String) {

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -2,6 +2,7 @@ package dev.ayuislands.settings
 
 import com.intellij.openapi.components.BaseState
 import dev.ayuislands.accent.AccentElementId
+import dev.ayuislands.accent.AccentGroup
 import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.ExternalAccentSource
@@ -295,11 +296,12 @@ class AyuIslandsState : BaseState() {
     // Force overrides for conflicting elements (element ID names)
     var forceOverrides by stringSet()
 
-    // Chrome tinting: per-surface opt-in toggles and a global intensity.
+    // Chrome tinting: a runtime master gate, per-surface opt-in toggles, and a global intensity.
     // WCAG foreground contrast is always-on (no persisted toggle). CHROME-group
     // AccentElementIds are driven by these fields — NOT by the Elements-panel toggle
     // map — so they never leak into the VISUAL/INTERACTIVE checkbox list. Defaults
     // are all OFF (premium, opt-in).
+    var chromeTintingEnabled by property(true)
     var chromeStatusBar by property(false)
     var chromeMainToolbar by property(false)
     var chromeToolWindowStripe by property(false)
@@ -478,21 +480,18 @@ class AyuIslandsState : BaseState() {
     }
 
     fun isToggleEnabled(id: AccentElementId): Boolean =
-        when (id) {
-            AccentElementId.INLAY_HINTS -> inlayHints
-            AccentElementId.CARET_ROW -> caretRow
-            AccentElementId.PROGRESS_BAR -> progressBar
-            AccentElementId.SCROLLBAR -> scrollbar
-            AccentElementId.LINKS -> links
-            AccentElementId.BRACKET_MATCH -> bracketMatch
-            AccentElementId.SEARCH_RESULTS -> searchResults
-            AccentElementId.MATCHING_TAG -> matchingTag
-            AccentElementId.STATUS_BAR -> chromeStatusBar
-            AccentElementId.MAIN_TOOLBAR -> chromeMainToolbar
-            AccentElementId.TOOL_WINDOW_STRIPE -> chromeToolWindowStripe
-            AccentElementId.NAV_BAR -> chromeNavBar
-            AccentElementId.PANEL_BORDER -> chromePanelBorder
+        if (id.group == AccentGroup.CHROME) {
+            isChromeToggleEnabled(id)
+        } else {
+            isAccentElementEnabled(id)
         }
+
+    fun hasChromeTintingSurfaceEnabled(): Boolean =
+        chromeStatusBar ||
+            chromeMainToolbar ||
+            chromeToolWindowStripe ||
+            chromeNavBar ||
+            chromePanelBorder
 
     fun setToggle(
         id: AccentElementId,
@@ -643,3 +642,26 @@ class AyuIslandsState : BaseState() {
         const val MAX_CHROME_TINT_INTENSITY = 50
     }
 }
+
+private fun AyuIslandsState.isAccentElementEnabled(id: AccentElementId): Boolean =
+    when (id) {
+        AccentElementId.INLAY_HINTS -> inlayHints
+        AccentElementId.CARET_ROW -> caretRow
+        AccentElementId.PROGRESS_BAR -> progressBar
+        AccentElementId.SCROLLBAR -> scrollbar
+        AccentElementId.LINKS -> links
+        AccentElementId.BRACKET_MATCH -> bracketMatch
+        AccentElementId.SEARCH_RESULTS -> searchResults
+        AccentElementId.MATCHING_TAG -> matchingTag
+        else -> false
+    }
+
+private fun AyuIslandsState.isChromeToggleEnabled(id: AccentElementId): Boolean =
+    when (id) {
+        AccentElementId.STATUS_BAR -> chromeTintingEnabled && chromeStatusBar
+        AccentElementId.MAIN_TOOLBAR -> chromeTintingEnabled && chromeMainToolbar
+        AccentElementId.TOOL_WINDOW_STRIPE -> chromeTintingEnabled && chromeToolWindowStripe
+        AccentElementId.NAV_BAR -> chromeTintingEnabled && chromeNavBar
+        AccentElementId.PANEL_BORDER -> chromeTintingEnabled && chromePanelBorder
+        else -> false
+    }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -372,6 +372,11 @@
                        path="/themes/ayu-islands-light.theme.json"/>
         <themeProvider id="com.ayuislands.theme.light.islands"
                        path="/themes/ayu-islands-light-islands.theme.json"/>
+
+        <!-- Accent source status bar widget (premium) -->
+        <statusBarWidgetFactory
+                id="AyuIslands.AccentStatusBar"
+                implementation="dev.ayuislands.accent.statusbar.AccentStatusBarWidgetFactory"/>
     </extensions>
 
     <applicationListeners>

--- a/src/test/kotlin/dev/ayuislands/accent/AccentResolverChainTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentResolverChainTest.kt
@@ -10,6 +10,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
+import java.awt.Color
 import java.io.File
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -276,6 +277,30 @@ class AccentResolverChainTest {
     }
 
     @Test
+    fun `resolveChain forced language uses language fallback when exact mapping is missing`() {
+        val tmp = File(stubsDir, "forced-language-fallback").canonicalPath
+        mappingsState.forcedProjectLanguages[tmp] = "typescript"
+        mappingsState.languageFallbackAccent = "#73D0FF"
+        val project = stubProject(File(tmp))
+
+        val chain = AccentResolver.resolveChain(project, AyuVariant.MIRAGE)
+
+        assertEquals("#73D0FF", AccentResolver.resolve(project, AyuVariant.MIRAGE))
+        assertEquals(AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE, AccentResolver.source(project))
+        assertTrue(
+            chain.steps.any {
+                it.source == AccentResolver.Source.FORCED_LANGUAGE_OVERRIDE &&
+                    it.outcome == StepOutcome.NO_MAPPING
+            },
+            "Chain should keep the missing forced-language mapping diagnostic",
+        )
+        assertEquals(AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE, chain.winner.source)
+        assertEquals("#73D0FF", chain.winner.hex)
+        assertEquals(StepOutcome.WON, chain.winner.outcome)
+        assertNull(chain.verdict)
+    }
+
+    @Test
     fun `resolveChain forced language override short-circuits before language override step`() {
         val tmp = File(stubsDir, "forced-skip-lang").canonicalPath
         mappingsState.forcedProjectLanguages[tmp] = "typescript"
@@ -350,6 +375,30 @@ class AccentResolverChainTest {
     }
 
     @Test
+    fun `resolveChain language fallback wins when detected language has no exact mapping`() {
+        mappingsState.languageFallbackAccent = "#73D0FF"
+        val project = stubProject(File(stubsDir, "detected-language-fallback"))
+        every { ProjectLanguageDetector.dominant(project) } returns "python"
+        val verdict = ProjectLanguageVerdict.Detected("python", mapOf("python" to 1_000L))
+        every { ProjectLanguageDetector.verdict(project) } returns verdict
+
+        val chain = AccentResolver.resolveChain(project, AyuVariant.MIRAGE)
+
+        assertEquals("#73D0FF", AccentResolver.resolve(project, AyuVariant.MIRAGE))
+        assertEquals(AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE, AccentResolver.source(project))
+        assertTrue(
+            chain.steps.any {
+                it.source == AccentResolver.Source.LANGUAGE_OVERRIDE &&
+                    it.outcome == StepOutcome.NO_MAPPING
+            },
+            "Chain should explain that the detected language has no exact mapping",
+        )
+        assertEquals(AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE, chain.winner.source)
+        assertEquals("#73D0FF", chain.winner.hex)
+        assertEquals(verdict, chain.verdict)
+    }
+
+    @Test
     fun `resolveChain language override shows Cold verdict when detection not yet run`() {
         mappingsState.languageAccents["kotlin"] = "#ABCDEF"
         val project = stubProject(File(stubsDir, "lang-cold"))
@@ -402,6 +451,29 @@ class AccentResolverChainTest {
         assertEquals(StepOutcome.WON, fallbackStep.outcome)
         assertEquals(fallbackStep, chain.winner)
 
+        assertEquals(noWinnerVerdict, chain.verdict)
+    }
+
+    @Test
+    fun `resolveChain project fallback wins when no language accents are configured`() {
+        val tmp = File(stubsDir, "fallback-no-language-accents").canonicalPath
+        mappingsState.projectFallbackAccents[tmp] = "#5CCFE6"
+        val project = stubProject(File(tmp))
+
+        every { ProjectLanguageDetector.dominant(project) } returns null
+        val noWinnerVerdict =
+            ProjectLanguageVerdict.NoWinner(
+                mapOf("typescript" to 500L, "javascript" to 500L),
+            )
+        every { ProjectLanguageDetector.verdict(project) } returns noWinnerVerdict
+
+        val chain = AccentResolver.resolveChain(project, AyuVariant.MIRAGE)
+
+        assertEquals("#5CCFE6", AccentResolver.resolve(project, AyuVariant.MIRAGE))
+        assertEquals(AccentResolver.Source.PROJECT_FALLBACK, AccentResolver.source(project))
+        assertEquals(AccentResolver.Source.PROJECT_FALLBACK, chain.winner.source)
+        assertEquals("#5CCFE6", chain.winner.hex)
+        assertEquals(StepOutcome.WON, chain.winner.outcome)
         assertEquals(noWinnerVerdict, chain.verdict)
     }
 
@@ -602,6 +674,74 @@ class AccentResolverChainTest {
             assertEquals("#112233", projectStep.hex)
             assertEquals(StepOutcome.WON, projectStep.outcome)
             assertEquals(projectStep, chain.winner)
+        }
+    }
+
+    @Test
+    fun `resolveChain external automatic uses material accent before stored fallback`() {
+        val state = AyuIslandsState()
+        state.externalThemeAccentSource = ExternalAccentSource.AUTOMATIC.name
+        state.externalThemeAccent = "#445566"
+
+        val settings = mockk<AyuIslandsSettings>()
+        every { settings.state } returns state
+        every { settings.getAccentForVariant(any()) } returns globalMirageAccent
+        mockkObject(AyuIslandsSettings.Companion)
+        every { AyuIslandsSettings.getInstance() } returns settings
+
+        AccentResolver.withUiColorProviderForTest(
+            { key ->
+                if (key == "material.accent") {
+                    Color(0x0A, 0x14, 0x1E)
+                } else {
+                    null
+                }
+            },
+        ) {
+            val chain = AccentResolver.resolveChain(null, AccentContext.External)
+
+            assertEquals("#0A141E", AccentResolver.resolve(null, AccentContext.External))
+            assertEquals(
+                AccentResolver.Source.MATERIAL_THEME,
+                AccentResolver.source(null, AccentContext.External),
+            )
+            assertEquals(AccentResolver.Source.MATERIAL_THEME, chain.winner.source)
+            assertEquals("#0A141E", chain.winner.hex)
+            assertEquals(StepOutcome.WON, chain.winner.outcome)
+        }
+    }
+
+    @Test
+    fun `resolveChain external automatic uses IDE accent before stored fallback`() {
+        val state = AyuIslandsState()
+        state.externalThemeAccentSource = ExternalAccentSource.AUTOMATIC.name
+        state.externalThemeAccent = "#445566"
+
+        val settings = mockk<AyuIslandsSettings>()
+        every { settings.state } returns state
+        every { settings.getAccentForVariant(any()) } returns globalMirageAccent
+        mockkObject(AyuIslandsSettings.Companion)
+        every { AyuIslandsSettings.getInstance() } returns settings
+
+        AccentResolver.withUiColorProviderForTest(
+            { key ->
+                if (key == "Component.accentColor") {
+                    Color(0xC8, 0x64, 0x32)
+                } else {
+                    null
+                }
+            },
+        ) {
+            val chain = AccentResolver.resolveChain(null, AccentContext.External)
+
+            assertEquals("#C86432", AccentResolver.resolve(null, AccentContext.External))
+            assertEquals(
+                AccentResolver.Source.IDE_ACCENT,
+                AccentResolver.source(null, AccentContext.External),
+            )
+            assertEquals(AccentResolver.Source.IDE_ACCENT, chain.winner.source)
+            assertEquals("#C86432", chain.winner.hex)
+            assertEquals(StepOutcome.WON, chain.winner.outcome)
         }
     }
 

--- a/src/test/kotlin/dev/ayuislands/accent/AccentResolverChainTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentResolverChainTest.kt
@@ -1,0 +1,618 @@
+package dev.ayuislands.accent
+
+import com.intellij.openapi.project.Project
+import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
+import dev.ayuislands.settings.mappings.AccentMappingsSettings
+import dev.ayuislands.settings.mappings.AccentMappingsState
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import java.io.File
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Verifies [AccentResolver.resolveChain] decision tracing: the ordered
+ * [AccentResolutionStep] list, the [AccentResolutionChain.winner], and the
+ * [AccentResolutionChain.verdict] (when language detection is consulted).
+ *
+ * Each test locks down one path through the priority chain to guard against
+ * regressions in the step-construction, short-circuit, and license-gate logic.
+ *
+ * ### Step-count notes
+ *
+ * The GLOBAL winner is appended to [steps] only when no [StepOutcome.WON]
+ * step exists among the overrides (i.e. GLOBAL is the actual winner). So the
+ * step count varies:
+ * - No active project / unlicensed: 4 premium steps + 1 GLOBAL = **5**
+ * - Global wins without language mappings: 3 premium + 1 GLOBAL = **4**
+ * - Global wins with language mappings: 4 premium + 1 GLOBAL = **5**
+ * - Override wins (short-circuit): 1-3 steps, no GLOBAL appended
+ */
+class AccentResolverChainTest {
+    private lateinit var mappingsState: AccentMappingsState
+    private val globalMirageAccent = "#FFCC66"
+    private val stubsDir = File(System.getProperty("java.io.tmpdir"), "chain-test")
+
+    @BeforeTest
+    fun setUp() {
+        mappingsState = AccentMappingsState()
+
+        val globalSettings = mockk<AyuIslandsSettings>()
+        every { globalSettings.getAccentForVariant(AyuVariant.MIRAGE) } returns globalMirageAccent
+        every { globalSettings.getAccentForVariant(AyuVariant.DARK) } returns "#E6B450"
+        every { globalSettings.getAccentForVariant(AyuVariant.LIGHT) } returns "#F29718"
+        mockkObject(AyuIslandsSettings.Companion)
+        every { AyuIslandsSettings.getInstance() } returns globalSettings
+
+        val mappingsSettings = mockk<AccentMappingsSettings>()
+        every { mappingsSettings.state } returns mappingsState
+        mockkObject(AccentMappingsSettings.Companion)
+        every { AccentMappingsSettings.getInstance() } returns mappingsSettings
+
+        mockkObject(ProjectLanguageDetector)
+        every { ProjectLanguageDetector.dominant(any()) } returns null
+        every { ProjectLanguageDetector.verdict(any()) } returns ProjectLanguageVerdict.Cold
+
+        // Default: licensed. Individual tests override to verify the unlicensed path.
+        mockkObject(LicenseChecker)
+        every { LicenseChecker.isLicensedOrGrace() } returns true
+
+        AccentResolver.resetWarnGatesForTest()
+        AccentResolver.resetUiColorProviderForTest()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    // Null, default, and disposed project
+
+    @Test
+    fun `resolveChain returns global winner with NOT_APPLICABLE premium steps when project is null`() {
+        val chain = AccentResolver.resolveChain(null, AyuVariant.MIRAGE)
+
+        // 4 NOT_APPLICABLE premium steps + 1 GLOBAL step
+        assertEquals(5, chain.steps.size)
+
+        val premiumSteps = chain.steps.take(4)
+        premiumSteps.forEach { step ->
+            assertEquals(StepOutcome.NOT_APPLICABLE, step.outcome, "${step.source} should be NOT_APPLICABLE")
+            assertEquals("No project open", step.detail)
+            assertNull(step.hex)
+        }
+        val sourceSet = premiumSteps.map { it.source }.toSet()
+        assertEquals(
+            setOf(
+                AccentResolver.Source.PROJECT_OVERRIDE,
+                AccentResolver.Source.FORCED_LANGUAGE_OVERRIDE,
+                AccentResolver.Source.LANGUAGE_OVERRIDE,
+                AccentResolver.Source.PROJECT_FALLBACK,
+            ),
+            sourceSet,
+        )
+
+        assertEquals(AccentResolver.Source.GLOBAL, chain.winner.source)
+        assertEquals(globalMirageAccent, chain.winner.hex)
+        assertEquals(StepOutcome.WON, chain.winner.outcome)
+        assertNull(chain.verdict, "Verdict should be null when no project")
+    }
+
+    @Test
+    fun `resolveChain returns global winner when project is default`() {
+        val project = mockk<Project>()
+        every { project.isDefault } returns true
+        every { project.isDisposed } returns false
+        every { project.basePath } returns File(stubsDir, "default-proj").path
+        every { project.name } returns "default-proj"
+
+        val chain = AccentResolver.resolveChain(project, AyuVariant.MIRAGE)
+
+        assertEquals(5, chain.steps.size)
+        chain.steps.take(4).forEach { step ->
+            assertEquals(StepOutcome.NOT_APPLICABLE, step.outcome, "${step.source} should be NOT_APPLICABLE")
+        }
+        assertEquals(AccentResolver.Source.GLOBAL, chain.winner.source)
+        assertNull(chain.verdict)
+    }
+
+    @Test
+    fun `resolveChain returns global winner when project is disposed`() {
+        val project = mockk<Project>()
+        every { project.isDefault } returns false
+        every { project.isDisposed } returns true
+        every { project.basePath } returns File(stubsDir, "disposed-proj").path
+        every { project.name } returns "disposed-proj"
+
+        val chain = AccentResolver.resolveChain(project, AyuVariant.MIRAGE)
+
+        assertEquals(5, chain.steps.size)
+        chain.steps.take(4).forEach { step ->
+            assertEquals(StepOutcome.NOT_APPLICABLE, step.outcome, "${step.source} should be NOT_APPLICABLE")
+        }
+        assertEquals(AccentResolver.Source.GLOBAL, chain.winner.source)
+        assertNull(chain.verdict)
+    }
+
+    // Unlicensed
+
+    @Test
+    fun `resolveChain returns global winner when unlicensed`() {
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+
+        val chain = AccentResolver.resolveChain(null, AyuVariant.MIRAGE)
+
+        // 4 LICENSE_BLOCKED premium steps + 1 GLOBAL step
+        assertEquals(5, chain.steps.size)
+
+        chain.steps.take(4).forEach { step ->
+            assertEquals(StepOutcome.LICENSE_BLOCKED, step.outcome, "${step.source} should be LICENSE_BLOCKED")
+            assertEquals("Premium feature — license required", step.detail)
+            assertNull(step.hex)
+        }
+
+        assertEquals(AccentResolver.Source.GLOBAL, chain.winner.source)
+        assertEquals(globalMirageAccent, chain.winner.hex)
+        assertEquals(StepOutcome.WON, chain.winner.outcome)
+        assertNull(chain.verdict, "Verdict should be null when unlicensed")
+    }
+
+    @Test
+    fun `resolveChain returns global winner when unlicensed even with stored mappings`() {
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+        val tmp = File(stubsDir, "unlicensed-proj").canonicalPath
+        mappingsState.projectAccents[tmp] = "#111111"
+        mappingsState.languageAccents["kotlin"] = "#222222"
+        val project = stubProject(File(tmp))
+        every { ProjectLanguageDetector.dominant(project) } returns "kotlin"
+
+        val chain = AccentResolver.resolveChain(project, AyuVariant.MIRAGE)
+
+        assertEquals(5, chain.steps.size)
+        chain.steps.take(4).forEach { step ->
+            assertEquals(StepOutcome.LICENSE_BLOCKED, step.outcome, "${step.source} should be LICENSE_BLOCKED")
+        }
+        assertEquals(AccentResolver.Source.GLOBAL, chain.winner.source)
+        assertNull(chain.verdict)
+    }
+
+    // Project override wins
+
+    @Test
+    fun `resolveChain project override wins and short-circuits remaining steps`() {
+        val tmp = File(stubsDir, "proj-override").canonicalPath
+        mappingsState.projectAccents[tmp] = "#123456"
+        val project = stubProject(File(tmp))
+
+        val chain = AccentResolver.resolveChain(project, AyuVariant.MIRAGE)
+
+        assertEquals(1, chain.steps.size, "Only PROJECT_OVERRIDE step should exist (short-circuit)")
+
+        val step = chain.steps.single()
+        assertEquals(AccentResolver.Source.PROJECT_OVERRIDE, step.source)
+        assertEquals("#123456", step.hex)
+        assertEquals(StepOutcome.WON, step.outcome)
+        assertEquals("Pinned accent for this project", step.detail)
+
+        assertEquals(step, chain.winner)
+        assertNull(chain.verdict, "Verdict should be null after early short-circuit")
+    }
+
+    @Test
+    fun `resolveChain project override with invalid hex falls through and global wins`() {
+        val tmp = File(stubsDir, "proj-invalid-hex").canonicalPath
+        mappingsState.projectAccents[tmp] = "not-a-hex"
+        val project = stubProject(File(tmp))
+
+        val chain = AccentResolver.resolveChain(project, AyuVariant.MIRAGE)
+
+        // PROJECT_OVERRIDE step has NOT_SET (invalid hex), then GLOBAL wins
+        val projectStep = chain.steps.first()
+        assertEquals(AccentResolver.Source.PROJECT_OVERRIDE, projectStep.source)
+        assertEquals(StepOutcome.NOT_SET, projectStep.outcome)
+        assertNull(projectStep.hex)
+        assertEquals("Invalid hex in project override", projectStep.detail)
+
+        assertEquals(AccentResolver.Source.GLOBAL, chain.winner.source)
+        assertEquals(globalMirageAccent, chain.winner.hex)
+    }
+
+    // Forced language override wins
+
+    @Test
+    fun `resolveChain forced language override wins`() {
+        val tmp = File(stubsDir, "forced-lang").canonicalPath
+        mappingsState.forcedProjectLanguages[tmp] = "typescript"
+        mappingsState.languageAccents["typescript"] = "#3178C6"
+        val project = stubProject(File(tmp))
+
+        val chain = AccentResolver.resolveChain(project, AyuVariant.MIRAGE)
+
+        assertEquals(2, chain.steps.size, "Should short-circuit after forced language wins")
+
+        // Step 0: PROJECT_OVERRIDE not set
+        assertEquals(AccentResolver.Source.PROJECT_OVERRIDE, chain.steps[0].source)
+        assertEquals(StepOutcome.NOT_SET, chain.steps[0].outcome)
+
+        // Step 1: FORCED_LANGUAGE_OVERRIDE wins
+        val forcedStep = chain.steps[1]
+        assertEquals(AccentResolver.Source.FORCED_LANGUAGE_OVERRIDE, forcedStep.source)
+        assertEquals("#3178C6", forcedStep.hex)
+        assertEquals(StepOutcome.WON, forcedStep.outcome)
+        assertNotNull(forcedStep.detail)
+        assertEquals(forcedStep, chain.winner)
+
+        assertNull(chain.verdict)
+    }
+
+    @Test
+    fun `resolveChain forced language override with missing accent mapping falls through to global`() {
+        val tmp = File(stubsDir, "forced-no-map").canonicalPath
+        mappingsState.forcedProjectLanguages[tmp] = "typescript"
+        // No languageAccent for "typescript"
+        val project = stubProject(File(tmp))
+
+        val chain = AccentResolver.resolveChain(project, AyuVariant.MIRAGE)
+
+        // PROJECT_OVERRIDE NOT_SET, FORCED_LANGUAGE_OVERRIDE NO_MAPPING,
+        // LANGUAGE_OVERRIDE NOT_APPLICABLE, then GLOBAL wins
+        assertEquals(4, chain.steps.size)
+
+        assertEquals(StepOutcome.NOT_SET, chain.steps[0].outcome)
+        assertEquals(StepOutcome.NO_MAPPING, chain.steps[1].outcome)
+        assertEquals(StepOutcome.NOT_APPLICABLE, chain.steps[2].outcome)
+
+        assertEquals(AccentResolver.Source.GLOBAL, chain.winner.source)
+        assertNull(chain.verdict)
+    }
+
+    @Test
+    fun `resolveChain forced language override short-circuits before language override step`() {
+        val tmp = File(stubsDir, "forced-skip-lang").canonicalPath
+        mappingsState.forcedProjectLanguages[tmp] = "typescript"
+        mappingsState.languageAccents["typescript"] = "#3178C6"
+        val project = stubProject(File(tmp))
+        every { ProjectLanguageDetector.dominant(any()) } returns "javascript"
+
+        val chain = AccentResolver.resolveChain(project, AyuVariant.MIRAGE)
+
+        // Only 2 steps — language-override step was never collected (short-circuit)
+        assertEquals(2, chain.steps.size)
+        assertEquals(AccentResolver.Source.PROJECT_OVERRIDE, chain.steps[0].source)
+        assertEquals(AccentResolver.Source.FORCED_LANGUAGE_OVERRIDE, chain.steps[1].source)
+        assertEquals(StepOutcome.WON, chain.steps[1].outcome)
+    }
+
+    // Language override wins
+
+    @Test
+    fun `resolveChain language override wins with verdict`() {
+        mappingsState.languageAccents["kotlin"] = "#ABCDEF"
+        val project = stubProject(File(stubsDir, "lang-override"))
+
+        every { ProjectLanguageDetector.dominant(project) } returns "kotlin"
+        val verdict =
+            ProjectLanguageVerdict.Detected(
+                languageId = "kotlin",
+                weights = mapOf("kotlin" to 800L, "java" to 200L),
+            )
+        every { ProjectLanguageDetector.verdict(project) } returns verdict
+
+        val chain = AccentResolver.resolveChain(project, AyuVariant.MIRAGE)
+
+        assertEquals(3, chain.steps.size, "Should short-circuit after language override wins")
+
+        // PROJECT_OVERRIDE NOT_SET
+        assertEquals(StepOutcome.NOT_SET, chain.steps[0].outcome)
+        // FORCED_LANGUAGE_OVERRIDE NOT_SET
+        assertEquals(StepOutcome.NOT_SET, chain.steps[1].outcome)
+        // LANGUAGE_OVERRIDE WON
+        val langStep = chain.steps[2]
+        assertEquals(AccentResolver.Source.LANGUAGE_OVERRIDE, langStep.source)
+        assertEquals("#ABCDEF", langStep.hex)
+        assertEquals(StepOutcome.WON, langStep.outcome)
+        assertEquals(langStep, chain.winner)
+
+        assertNotNull(chain.verdict, "Verdict should be present when language detection consulted")
+        assertEquals(verdict, chain.verdict)
+    }
+
+    @Test
+    fun `resolveChain language override with NO_MAPPING when language not in accent map falls through to global`() {
+        mappingsState.languageAccents["kotlin"] = "#ABCDEF"
+        val project = stubProject(File(stubsDir, "lang-no-map"))
+        every { ProjectLanguageDetector.dominant(project) } returns "python"
+        every { ProjectLanguageDetector.verdict(project) } returns
+            ProjectLanguageVerdict.Detected("python", mapOf("python" to 1_000L))
+
+        val chain = AccentResolver.resolveChain(project, AyuVariant.MIRAGE)
+
+        // 4 premium steps + 1 GLOBAL = 5
+        assertEquals(5, chain.steps.size)
+
+        val langStep = chain.steps[2]
+        assertEquals(AccentResolver.Source.LANGUAGE_OVERRIDE, langStep.source)
+        assertEquals(StepOutcome.NO_MAPPING, langStep.outcome)
+        assertNull(langStep.hex)
+        assertTrue(langStep.detail.contains("python"))
+
+        // Falls through to GLOBAL
+        assertEquals(AccentResolver.Source.GLOBAL, chain.winner.source)
+    }
+
+    @Test
+    fun `resolveChain language override shows Cold verdict when detection not yet run`() {
+        mappingsState.languageAccents["kotlin"] = "#ABCDEF"
+        val project = stubProject(File(stubsDir, "lang-cold"))
+        every { ProjectLanguageDetector.dominant(project) } returns null
+        every { ProjectLanguageDetector.verdict(project) } returns ProjectLanguageVerdict.Cold
+
+        val chain = AccentResolver.resolveChain(project, AyuVariant.MIRAGE)
+
+        assertEquals(5, chain.steps.size)
+
+        val langStep = chain.steps[2]
+        assertEquals(AccentResolver.Source.LANGUAGE_OVERRIDE, langStep.source)
+        assertEquals(StepOutcome.NOT_SET, langStep.outcome)
+        assertEquals("Detection pending", langStep.detail)
+
+        assertEquals(ProjectLanguageVerdict.Cold, chain.verdict)
+        assertEquals(AccentResolver.Source.GLOBAL, chain.winner.source)
+    }
+
+    // Project fallback wins
+
+    @Test
+    fun `resolveChain project fallback wins when verdict is NoWinner`() {
+        val tmp = File(stubsDir, "fallback-no-winner").canonicalPath
+        mappingsState.languageAccents["kotlin"] = "#ABCDEF"
+        mappingsState.projectFallbackAccents[tmp] = "#5CCFE6"
+        val project = stubProject(File(tmp))
+
+        every { ProjectLanguageDetector.dominant(project) } returns null
+        val noWinnerVerdict =
+            ProjectLanguageVerdict.NoWinner(
+                mapOf("typescript" to 500L, "javascript" to 500L),
+            )
+        every { ProjectLanguageDetector.verdict(project) } returns noWinnerVerdict
+
+        val chain = AccentResolver.resolveChain(project, AyuVariant.MIRAGE)
+
+        assertEquals(4, chain.steps.size)
+
+        // PROJECT_OVERRIDE NOT_SET
+        assertEquals(StepOutcome.NOT_SET, chain.steps[0].outcome)
+        // FORCED_LANGUAGE_OVERRIDE NOT_SET
+        assertEquals(StepOutcome.NOT_SET, chain.steps[1].outcome)
+        // LANGUAGE_OVERRIDE NOT_DOMINANT
+        assertEquals(StepOutcome.NOT_DOMINANT, chain.steps[2].outcome)
+        // PROJECT_FALLBACK WON
+        val fallbackStep = chain.steps[3]
+        assertEquals(AccentResolver.Source.PROJECT_FALLBACK, fallbackStep.source)
+        assertEquals("#5CCFE6", fallbackStep.hex)
+        assertEquals(StepOutcome.WON, fallbackStep.outcome)
+        assertEquals(fallbackStep, chain.winner)
+
+        assertEquals(noWinnerVerdict, chain.verdict)
+    }
+
+    @Test
+    fun `resolveChain project fallback does not apply for Cold verdict`() {
+        val tmp = File(stubsDir, "fallback-cold").canonicalPath
+        mappingsState.projectFallbackAccents[tmp] = "#5CCFE6"
+        mappingsState.languageAccents["kotlin"] = "#ABCDEF"
+        val project = stubProject(File(tmp))
+
+        every { ProjectLanguageDetector.verdict(project) } returns ProjectLanguageVerdict.Cold
+
+        val chain = AccentResolver.resolveChain(project, AyuVariant.MIRAGE)
+
+        // 4 premium steps + 1 GLOBAL = 5
+        assertEquals(5, chain.steps.size)
+
+        val fallbackStep = chain.steps[3]
+        assertEquals(AccentResolver.Source.PROJECT_FALLBACK, fallbackStep.source)
+        assertEquals(StepOutcome.NOT_APPLICABLE, fallbackStep.outcome)
+        assertEquals("Fallback only applies when no dominant language", fallbackStep.detail)
+        assertNull(fallbackStep.hex)
+
+        assertEquals(AccentResolver.Source.GLOBAL, chain.winner.source)
+    }
+
+    @Test
+    fun `resolveChain project fallback does not apply for Detected verdict when language has accent`() {
+        val tmp = File(stubsDir, "fallback-detected").canonicalPath
+        mappingsState.projectFallbackAccents[tmp] = "#5CCFE6"
+        mappingsState.languageAccents["kotlin"] = "#ABCDEF"
+        val project = stubProject(File(tmp))
+
+        every { ProjectLanguageDetector.dominant(project) } returns "kotlin"
+        every { ProjectLanguageDetector.verdict(project) } returns
+            ProjectLanguageVerdict.Detected("kotlin", mapOf("kotlin" to 1_000L))
+
+        val chain = AccentResolver.resolveChain(project, AyuVariant.MIRAGE)
+
+        // Language wins, short-circuits at step 2
+        assertEquals(3, chain.steps.size)
+        val langStep = chain.steps[2]
+        assertEquals(StepOutcome.WON, langStep.outcome)
+        assertEquals(langStep, chain.winner)
+    }
+
+    @Test
+    fun `resolveChain project fallback with invalid hex falls through to global`() {
+        val tmp = File(stubsDir, "fallback-invalid").canonicalPath
+        mappingsState.languageAccents["kotlin"] = "#ABCDEF"
+        mappingsState.projectFallbackAccents[tmp] = "bad-hex"
+        val project = stubProject(File(tmp))
+
+        every { ProjectLanguageDetector.dominant(project) } returns null
+        every { ProjectLanguageDetector.verdict(project) } returns
+            ProjectLanguageVerdict.NoWinner(mapOf("typescript" to 500L, "javascript" to 500L))
+
+        val chain = AccentResolver.resolveChain(project, AyuVariant.MIRAGE)
+
+        val fallbackStep = chain.steps[3]
+        assertEquals(AccentResolver.Source.PROJECT_FALLBACK, fallbackStep.source)
+        assertEquals(StepOutcome.NOT_SET, fallbackStep.outcome)
+        assertEquals("Invalid hex in project fallback", fallbackStep.detail)
+
+        assertEquals(AccentResolver.Source.GLOBAL, chain.winner.source)
+    }
+
+    // Global wins, no overrides
+
+    @Test
+    fun `resolveChain global wins when no overrides configured and no language mappings`() {
+        val project = stubProject(File(stubsDir, "no-overrides"))
+
+        val chain = AccentResolver.resolveChain(project, AyuVariant.MIRAGE)
+
+        // Empty state: 3 premium NOT_SET steps + 1 GLOBAL = 4
+        assertEquals(4, chain.steps.size)
+
+        // First 3 are NOT_SET (LANGUAGE_OVERRIDE skips fallback when no language mappings)
+        chain.steps.take(3).forEach { step ->
+            assertEquals(StepOutcome.NOT_SET, step.outcome, "${step.source} should be NOT_SET")
+            assertNull(step.hex)
+        }
+
+        // Last step is GLOBAL winner
+        val globalStep = chain.steps.last()
+        assertEquals(AccentResolver.Source.GLOBAL, globalStep.source)
+        assertEquals(globalMirageAccent, globalStep.hex)
+        assertEquals(StepOutcome.WON, globalStep.outcome)
+        assertEquals("Default accent for mirage", globalStep.detail)
+
+        assertEquals(globalStep, chain.winner)
+        assertNull(chain.verdict, "Verdict should be null — detector not consulted")
+    }
+
+    @Test
+    fun `resolveChain global uses correct variant accent`() {
+        val project = stubProject(File(stubsDir, "dark-variant"))
+
+        val chain = AccentResolver.resolveChain(project, AyuVariant.DARK)
+
+        val globalStep = chain.steps.last()
+        assertEquals(AccentResolver.Source.GLOBAL, globalStep.source)
+        assertEquals("#E6B450", globalStep.hex)
+        assertEquals("Default accent for dark", globalStep.detail)
+    }
+
+    // External context with manual accent
+
+    @Test
+    fun `resolveChain external manual accent wins immediately`() {
+        val state = AyuIslandsState()
+        state.externalThemeAccentSource = ExternalAccentSource.MANUAL.name
+        state.externalThemeAccent = "#13579B"
+
+        val settings = mockk<AyuIslandsSettings>()
+        every { settings.state } returns state
+        every { settings.getAccentForVariant(any()) } returns globalMirageAccent
+        mockkObject(AyuIslandsSettings.Companion)
+        every { AyuIslandsSettings.getInstance() } returns settings
+
+        val chain = AccentResolver.resolveChain(null, AccentContext.External)
+
+        assertEquals(1, chain.steps.size, "Only the manual external step should exist")
+
+        val step = chain.steps.single()
+        assertEquals(AccentResolver.Source.EXTERNAL_ACCENT, step.source)
+        assertEquals("#13579B", step.hex)
+        assertEquals(StepOutcome.WON, step.outcome)
+        assertEquals(step, chain.winner)
+        assertNull(chain.verdict)
+    }
+
+    @Test
+    fun `resolveChain external manual accent ignores project overrides`() {
+        val state = AyuIslandsState()
+        state.externalThemeAccentSource = ExternalAccentSource.MANUAL.name
+        state.externalThemeAccent = "#97531B"
+
+        val settings = mockk<AyuIslandsSettings>()
+        every { settings.state } returns state
+        every { settings.getAccentForVariant(any()) } returns globalMirageAccent
+        mockkObject(AyuIslandsSettings.Companion)
+        every { AyuIslandsSettings.getInstance() } returns settings
+
+        val tmp = File(stubsDir, "external-manual-override").canonicalPath
+        mappingsState.projectAccents[tmp] = "#111111"
+        val project = stubProject(File(tmp))
+
+        val chain = AccentResolver.resolveChain(project, AccentContext.External)
+
+        assertEquals(1, chain.steps.size)
+        assertEquals(AccentResolver.Source.EXTERNAL_ACCENT, chain.winner.source)
+        assertEquals("#97531B", chain.winner.hex)
+    }
+
+    @Test
+    fun `resolveChain external manual with invalid hex falls back to mirage default`() {
+        val state = AyuIslandsState()
+        state.externalThemeAccentSource = ExternalAccentSource.MANUAL.name
+        state.externalThemeAccent = "not-a-hex"
+
+        val settings = mockk<AyuIslandsSettings>()
+        every { settings.state } returns state
+        every { settings.getAccentForVariant(any()) } returns globalMirageAccent
+        mockkObject(AyuIslandsSettings.Companion)
+        every { AyuIslandsSettings.getInstance() } returns settings
+
+        val chain = AccentResolver.resolveChain(null, AccentContext.External)
+
+        assertEquals(1, chain.steps.size)
+        assertEquals(AyuVariant.MIRAGE.defaultAccent, chain.winner.hex)
+    }
+
+    // External automatic chain
+
+    @Test
+    fun `resolveChain external automatic with project override wins`() {
+        val state = AyuIslandsState()
+        state.externalThemeAccentSource = ExternalAccentSource.AUTOMATIC.name
+        state.externalThemeAccent = "#445566"
+
+        val settings = mockk<AyuIslandsSettings>()
+        every { settings.state } returns state
+        every { settings.getAccentForVariant(any()) } returns globalMirageAccent
+        mockkObject(AyuIslandsSettings.Companion)
+        every { AyuIslandsSettings.getInstance() } returns settings
+
+        val tmp = File(stubsDir, "external-override").canonicalPath
+        mappingsState.projectAccents[tmp] = "#112233"
+        val project = stubProject(File(tmp))
+
+        AccentResolver.withUiColorProviderForTest({ null }) {
+            val chain = AccentResolver.resolveChain(project, AccentContext.External)
+
+            val projectStep = chain.steps[0]
+            assertEquals(AccentResolver.Source.PROJECT_OVERRIDE, projectStep.source)
+            assertEquals("#112233", projectStep.hex)
+            assertEquals(StepOutcome.WON, projectStep.outcome)
+            assertEquals(projectStep, chain.winner)
+        }
+    }
+
+    // Helpers
+
+    private fun stubProject(baseDir: File): Project {
+        val project = mockk<Project>()
+        every { project.isDefault } returns false
+        every { project.isDisposed } returns false
+        every { project.basePath } returns baseDir.path
+        every { project.name } returns baseDir.name
+        return project
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/accent/ChromeTintContextTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ChromeTintContextTest.kt
@@ -148,6 +148,31 @@ class ChromeTintContextTest {
     }
 
     @Test
+    fun `isToggleEnabled respects snapshot chrome master gate`() {
+        val state =
+            AyuIslandsState().apply {
+                chromeTintingEnabled = true
+                chromeStatusBar = true
+            }
+        val snapshot =
+            chromeSnapshot(
+                chromeStatusBar = true,
+                chromeTintingEnabled = false,
+            )
+
+        ChromeTintContext.withSnapshot(snapshot) {
+            assertFalse(
+                ChromeTintContext.isToggleEnabled(state, AccentElementId.STATUS_BAR),
+                "Snapshot master gate must suppress chrome ids even when the surface is selected",
+            )
+        }
+        assertTrue(
+            ChromeTintContext.isToggleEnabled(state, AccentElementId.STATUS_BAR),
+            "State gate must reassert after the snapshot frame exits",
+        )
+    }
+
+    @Test
     fun `isToggleEnabled falls back to state for non-chrome ids even with active snapshot`() {
         // The snapshot owns CHROME ids only. Non-chrome ids
         // (Inlay hints, caret row, links, etc.) must still pull from state —
@@ -221,12 +246,12 @@ class ChromeTintContextTest {
 
     /**
      * Common-case snapshot factory. Defaults every chrome toggle to false; tests
-     * that need a specific toggle on construct [ChromeTintSnapshot] directly.
-     * Kept narrow (2 params) so detekt's `LongParameterList` rule stays happy.
+     * that need multiple chrome toggles on construct [ChromeTintSnapshot] directly.
      */
     private fun chromeSnapshot(
         intensityPercent: Int = 0,
         chromeStatusBar: Boolean = false,
+        chromeTintingEnabled: Boolean = true,
     ): ChromeTintSnapshot =
         ChromeTintSnapshot(
             chromeStatusBar = chromeStatusBar,
@@ -235,5 +260,6 @@ class ChromeTintContextTest {
             chromeNavBar = false,
             chromePanelBorder = false,
             intensity = TintIntensity.of(intensityPercent),
+            chromeTintingEnabled = chromeTintingEnabled,
         )
 }

--- a/src/test/kotlin/dev/ayuislands/accent/statusbar/AccentStatusBarPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/statusbar/AccentStatusBarPanelTest.kt
@@ -1,0 +1,58 @@
+package dev.ayuislands.accent.statusbar
+
+import dev.ayuislands.accent.AccentResolutionChain
+import dev.ayuislands.accent.AccentResolutionStep
+import dev.ayuislands.accent.AccentResolver
+import dev.ayuislands.accent.StepOutcome
+import javax.swing.JLabel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AccentStatusBarPanelTest {
+    @Test
+    fun `status text includes winning source and reason`() {
+        val winner =
+            AccentResolutionStep(
+                source = AccentResolver.Source.PROJECT_OVERRIDE,
+                hex = "#7DCFFF",
+                outcome = StepOutcome.WON,
+                detail = "Pinned accent for this project",
+            )
+        val panel = AccentStatusBarPanel {}
+
+        panel.updateFromChain(AccentResolutionChain(listOf(winner), winner, verdict = null))
+
+        assertEquals(
+            "Project override · Pinned accent for this project",
+            statusLabel(panel).text,
+        )
+    }
+
+    @Test
+    fun `tooltip is html multiline diagnostics`() {
+        val blocked =
+            AccentResolutionStep(
+                source = AccentResolver.Source.LANGUAGE_OVERRIDE,
+                hex = null,
+                outcome = StepOutcome.NOT_DOMINANT,
+                detail = "No dominant language: Kotlin 52%, Java 48%",
+            )
+        val winner =
+            AccentResolutionStep(
+                source = AccentResolver.Source.PROJECT_FALLBACK,
+                hex = "#FFB454",
+                outcome = StepOutcome.WON,
+                detail = "Project fallback (polyglot project)",
+            )
+        val panel = AccentStatusBarPanel {}
+
+        panel.updateFromChain(AccentResolutionChain(listOf(blocked, winner), winner, verdict = null))
+
+        assertTrue(panel.toolTipText.startsWith("<html>"))
+        assertTrue(panel.toolTipText.contains("<br>"))
+        assertTrue(panel.toolTipText.contains("No dominant language"))
+    }
+
+    private fun statusLabel(panel: AccentStatusBarPanel): JLabel = panel.components.filterIsInstance<JLabel>().last()
+}

--- a/src/test/kotlin/dev/ayuislands/accent/statusbar/AccentStatusBarSurfaceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/statusbar/AccentStatusBarSurfaceTest.kt
@@ -1,0 +1,278 @@
+package dev.ayuislands.accent.statusbar
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.popup.ComponentPopupBuilder
+import com.intellij.openapi.ui.popup.JBPopup
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.openapi.wm.StatusBar
+import com.intellij.util.messages.MessageBus
+import com.intellij.util.messages.MessageBusConnection
+import dev.ayuislands.accent.AccentChangedTopic
+import dev.ayuislands.accent.AccentContext
+import dev.ayuislands.accent.AccentResolutionChain
+import dev.ayuislands.accent.AccentResolutionStep
+import dev.ayuislands.accent.AccentResolver
+import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.accent.ProjectLanguageDetectionListener
+import dev.ayuislands.accent.StepOutcome
+import dev.ayuislands.licensing.LicenseChecker
+import io.mockk.CapturingSlot
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import java.awt.Component
+import java.awt.Container
+import javax.swing.AbstractButton
+import javax.swing.JComponent
+import javax.swing.JLabel
+import javax.swing.JScrollPane
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class AccentStatusBarSurfaceTest {
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `popup shows winner header and each resolution reason`() {
+        val chain = fullDiagnosticsChain()
+        val contentSlot = slot<JComponent>()
+        val popup = stubPopupBuilder(contentSlot)
+        val anchor = JLabel("status bar anchor")
+
+        AccentStatusBarPopup.show(anchor, chain)
+
+        verify(exactly = 1) { popup.showUnderneathOf(anchor) }
+        val texts = contentSlot.captured.visibleTexts()
+        assertTrue(
+            texts.containsText("Project fallback", "#FFB454"),
+            "Winner header must expose the active source and hex value",
+        )
+        assertTrue(
+            texts.containsText("Project override", "not set"),
+            "Users must see why a configured project override did not win",
+        )
+        assertTrue(
+            texts.containsText("Forced language override", "license required"),
+            "Users must see when a premium language override is blocked",
+        )
+        assertTrue(
+            texts.containsText("Language override", "no accent mapping"),
+            "Users must see when the detected language has no configured accent",
+        )
+        assertTrue(
+            texts.containsText("Language fallback override", "Kotlin 52%, Java 48%"),
+            "Users must see polyglot fallback reasoning",
+        )
+        assertTrue(
+            texts.containsText("Material Theme", "not applicable"),
+            "External integration rows must stay visible when they are skipped",
+        )
+        assertTrue(
+            texts.containsText("IDE accent", "scanner unavailable"),
+            "Unavailable sources must stay distinguishable from unset sources",
+        )
+        assertTrue(
+            texts.containsText("Global", "#D4BFFF"),
+            "Non-winning rows with candidate colors must expose their hex value",
+        )
+        assertTrue(
+            contentSlot.captured.descendants().any { it is JScrollPane },
+            "Long diagnostics must stay scrollable instead of making the popup too tall",
+        )
+    }
+
+    @Test
+    fun `factory exposes status widget metadata and respects the license gate`() {
+        mockkObject(LicenseChecker)
+        every { LicenseChecker.isLicensedOrGrace() } returns true
+        val project = mockk<Project>(relaxed = true)
+        val factory = AccentStatusBarWidgetFactory()
+
+        val widget = factory.createWidget(project)
+
+        assertEquals(AccentStatusBarWidget.WIDGET_ID, factory.id)
+        assertEquals("Ayu Accent Source", factory.displayName)
+        assertEquals(true, factory.isEnabledByDefault)
+        assertEquals(AccentStatusBarWidget.WIDGET_ID, widget.ID())
+        assertIs<AccentStatusBarPanel>(widget.component)
+        assertEquals(true, factory.isAvailable(project))
+
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+
+        assertEquals(false, factory.isAvailable(project))
+    }
+
+    @Test
+    fun `widget refresh shows the resolved source in the status bar`() {
+        val project = mockProject(isDisposed = false)
+        val chain = projectOverrideChain()
+        mockkObject(AccentContext.Companion)
+        every { AccentContext.detect() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
+        mockkObject(AccentResolver)
+        every {
+            AccentResolver.resolveChain(project, AccentContext.Ayu(AyuVariant.MIRAGE))
+        } returns chain
+        val widget = AccentStatusBarWidget(project)
+
+        widget.refreshFromProject()
+
+        val panel = widget.component as AccentStatusBarPanel
+        assertEquals(
+            "Project override · Pinned accent for this project",
+            label(panel).text,
+        )
+    }
+
+    @Test
+    fun `widget install subscribes refresh listeners and dispose disconnects them`() {
+        val connection = mockk<MessageBusConnection>(relaxed = true)
+        val project = mockProject(isDisposed = true, connection = connection)
+        val widget = AccentStatusBarWidget(project)
+
+        widget.install(mockk<StatusBar>(relaxed = true))
+        widget.dispose()
+
+        verify(exactly = 1) {
+            connection.subscribe(AccentChangedTopic.TOPIC, any())
+        }
+        verify(exactly = 1) {
+            connection.subscribe(ProjectLanguageDetectionListener.TOPIC, any())
+        }
+        verify(exactly = 1) { connection.disconnect() }
+    }
+
+    private fun stubPopupBuilder(contentSlot: CapturingSlot<JComponent>): JBPopup {
+        mockkStatic(JBPopupFactory::class)
+        val factory = mockk<JBPopupFactory>(relaxed = true)
+        val builder = mockk<ComponentPopupBuilder>(relaxed = true)
+        val popup = mockk<JBPopup>(relaxed = true)
+        every { JBPopupFactory.getInstance() } returns factory
+        every {
+            factory.createComponentPopupBuilder(capture(contentSlot), any())
+        } returns builder
+        every { builder.setTitle(any()) } returns builder
+        every { builder.setResizable(any()) } returns builder
+        every { builder.setMovable(any()) } returns builder
+        every { builder.setRequestFocus(any()) } returns builder
+        every { builder.createPopup() } returns popup
+        return popup
+    }
+
+    private fun mockProject(
+        isDisposed: Boolean,
+        connection: MessageBusConnection = mockk(relaxed = true),
+    ): Project {
+        val messageBus = mockk<MessageBus>(relaxed = true)
+        every { messageBus.connect(any<Disposable>()) } returns connection
+        return mockk<Project>(relaxed = true) {
+            every { this@mockk.isDisposed } returns isDisposed
+            every { this@mockk.messageBus } returns messageBus
+        }
+    }
+
+    private fun projectOverrideChain(): AccentResolutionChain {
+        val winner =
+            AccentResolutionStep(
+                source = AccentResolver.Source.PROJECT_OVERRIDE,
+                hex = "#5CCFE6",
+                outcome = StepOutcome.WON,
+                detail = "Pinned accent for this project",
+            )
+        return AccentResolutionChain(listOf(winner), winner, verdict = null)
+    }
+
+    private fun fullDiagnosticsChain(): AccentResolutionChain {
+        val steps =
+            listOf(
+                AccentResolutionStep(
+                    source = AccentResolver.Source.PROJECT_OVERRIDE,
+                    hex = null,
+                    outcome = StepOutcome.NOT_SET,
+                    detail = "not set",
+                ),
+                AccentResolutionStep(
+                    source = AccentResolver.Source.FORCED_LANGUAGE_OVERRIDE,
+                    hex = null,
+                    outcome = StepOutcome.LICENSE_BLOCKED,
+                    detail = "license required",
+                ),
+                AccentResolutionStep(
+                    source = AccentResolver.Source.LANGUAGE_OVERRIDE,
+                    hex = "#F07178",
+                    outcome = StepOutcome.NO_MAPPING,
+                    detail = "no accent mapping",
+                ),
+                AccentResolutionStep(
+                    source = AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE,
+                    hex = null,
+                    outcome = StepOutcome.NOT_DOMINANT,
+                    detail = "Kotlin 52%, Java 48%",
+                ),
+                AccentResolutionStep(
+                    source = AccentResolver.Source.PROJECT_FALLBACK,
+                    hex = "#FFB454",
+                    outcome = StepOutcome.WON,
+                    detail = "Project fallback for polyglot project",
+                ),
+                AccentResolutionStep(
+                    source = AccentResolver.Source.MATERIAL_THEME,
+                    hex = null,
+                    outcome = StepOutcome.NOT_APPLICABLE,
+                    detail = "not applicable",
+                ),
+                AccentResolutionStep(
+                    source = AccentResolver.Source.IDE_ACCENT,
+                    hex = null,
+                    outcome = StepOutcome.UNAVAILABLE,
+                    detail = "scanner unavailable",
+                ),
+                AccentResolutionStep(
+                    source = AccentResolver.Source.GLOBAL,
+                    hex = "#D4BFFF",
+                    outcome = StepOutcome.NOT_SET,
+                    detail = "global stored accent",
+                ),
+            )
+        return AccentResolutionChain(steps = steps, winner = steps[4], verdict = null)
+    }
+
+    private fun label(panel: AccentStatusBarPanel) = panel.components.last() as JLabel
+
+    private fun Component.visibleTexts(): List<String> =
+        descendants()
+            .filter { it.isVisible }
+            .mapNotNull { component ->
+                when (component) {
+                    is AbstractButton -> component.text
+                    is JLabel -> component.text
+                    else -> null
+                }?.takeIf { it.isNotBlank() }
+            }.toList()
+
+    private fun List<String>.containsText(
+        first: String,
+        second: String,
+    ): Boolean =
+        any { text ->
+            text.contains(first) && text.contains(second)
+        }
+
+    private fun Component.descendants(): Sequence<Component> =
+        sequence {
+            yield(this@descendants)
+            if (this@descendants is Container) {
+                components.forEach { yieldAll(it.descendants()) }
+            }
+        }
+}

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentDiagnosticsPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentDiagnosticsPanelTest.kt
@@ -1,0 +1,232 @@
+package dev.ayuislands.accent.toolbar
+
+import dev.ayuislands.accent.AccentResolutionChain
+import dev.ayuislands.accent.AccentResolutionStep
+import dev.ayuislands.accent.AccentResolver
+import dev.ayuislands.accent.StepOutcome
+import java.awt.Component
+import java.awt.Container
+import java.awt.image.BufferedImage
+import javax.swing.AbstractButton
+import javax.swing.JLabel
+import javax.swing.SwingUtilities
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class QuickSwitcherAccentDiagnosticsPanelTest {
+    @Test
+    fun `collapsed diagnostics shows summary only and expand action`() {
+        val panel = QuickSwitcherAccentDiagnosticsPanel(polyglotFallbackChain())
+
+        val texts = panel.visibleTexts()
+
+        assertTrue(texts.containsText("Project fallback", "polyglot project"))
+        assertTrue(texts.contains("Show resolution chain..."))
+        assertFalse(texts.any { it.contains("Project override") })
+        assertFalse(texts.any { it.contains("Language override") })
+    }
+
+    @Test
+    fun `collapsed diagnostics hides expand action for single-step winner`() {
+        val panel = QuickSwitcherAccentDiagnosticsPanel(projectOverrideChain())
+
+        val texts = panel.visibleTexts()
+
+        assertTrue(
+            texts.containsText(
+                "Project override",
+                "Pinned accent for this project",
+            ),
+        )
+        assertFalse(texts.contains("Show resolution chain..."))
+        assertFalse(texts.contains("Collapse"))
+    }
+
+    @Test
+    fun `collapsed summary centers marker and text vertically`() {
+        val panel = QuickSwitcherAccentDiagnosticsPanel(projectOverrideChain())
+
+        panel.layoutForTest()
+        val markerCell =
+            panel
+                .descendants()
+                .first { component ->
+                    component.name ==
+                        QuickSwitcherAccentDiagnosticsPanel.MARKER_COLUMN_NAME
+                }
+        val summaryLabel =
+            panel
+                .descendants()
+                .filterIsInstance<JLabel>()
+                .first { label -> label.text.contains("Project override") }
+        val markerCenter = markerCell.paintedContentCenterYIn(panel)
+        val labelCenter = summaryLabel.paintedContentCenterYIn(panel)
+
+        assertTrue(abs(markerCenter - labelCenter) <= 1)
+    }
+
+    @Test
+    fun `expanded diagnostics shows supporting steps without repeating winner`() {
+        val panel = QuickSwitcherAccentDiagnosticsPanel(polyglotFallbackChain())
+
+        panel.clickAction("Show resolution chain...")
+        val texts = panel.visibleTexts()
+
+        assertTrue(texts.contains("Collapse"))
+        assertTrue(texts.containsText("Project override", "not set"))
+        assertTrue(texts.containsText("Language override", "Kotlin 52%, Java 48%"))
+        assertTrue(texts.containsText("Project fallback", "polyglot project"))
+        assertEquals(
+            1,
+            texts.countText(
+                "Project fallback",
+                "polyglot project",
+            ),
+        )
+    }
+
+    @Test
+    fun `expanded diagnostics uses one fixed marker column for summary and chain rows`() {
+        val panel = QuickSwitcherAccentDiagnosticsPanel(polyglotFallbackChain())
+
+        panel.clickAction("Show resolution chain...")
+        val markerColumnName = QuickSwitcherAccentDiagnosticsPanel.MARKER_COLUMN_NAME
+        val markerCells = panel.descendants().filter { it.name == markerColumnName }
+        val markerWidths = markerCells.map { it.preferredSize.width }.toSet()
+
+        assertEquals(
+            setOf(QuickSwitcherAccentDiagnosticsPanel.scaledMarkerColumnWidth()),
+            markerWidths,
+        )
+    }
+
+    private fun polyglotFallbackChain(): AccentResolutionChain {
+        val steps =
+            listOf(
+                AccentResolutionStep(
+                    source = AccentResolver.Source.PROJECT_OVERRIDE,
+                    hex = null,
+                    outcome = StepOutcome.NOT_SET,
+                    detail = "not set",
+                ),
+                AccentResolutionStep(
+                    source = AccentResolver.Source.FORCED_LANGUAGE_OVERRIDE,
+                    hex = null,
+                    outcome = StepOutcome.NOT_SET,
+                    detail = "not set",
+                ),
+                AccentResolutionStep(
+                    source = AccentResolver.Source.LANGUAGE_OVERRIDE,
+                    hex = null,
+                    outcome = StepOutcome.NOT_DOMINANT,
+                    detail = "Kotlin 52%, Java 48%",
+                ),
+                AccentResolutionStep(
+                    source = AccentResolver.Source.PROJECT_FALLBACK,
+                    hex = "#FFB454",
+                    outcome = StepOutcome.WON,
+                    detail = "polyglot project",
+                ),
+            )
+        return AccentResolutionChain(steps = steps, winner = steps.last(), verdict = null)
+    }
+
+    private fun projectOverrideChain(): AccentResolutionChain {
+        val step =
+            AccentResolutionStep(
+                source = AccentResolver.Source.PROJECT_OVERRIDE,
+                hex = "#5CCFE6",
+                outcome = StepOutcome.WON,
+                detail = "Pinned accent for this project",
+            )
+        return AccentResolutionChain(steps = listOf(step), winner = step, verdict = null)
+    }
+
+    private fun Component.layoutForTest() {
+        size = preferredSize
+        layoutTree()
+    }
+
+    private fun Component.layoutTree() {
+        doLayout()
+        if (this is Container) {
+            components.forEach { component -> component.layoutTree() }
+        }
+    }
+
+    private fun Component.paintedContentCenterYIn(root: Component): Int {
+        val image =
+            BufferedImage(
+                width.coerceAtLeast(1),
+                height.coerceAtLeast(1),
+                BufferedImage.TYPE_INT_ARGB,
+            )
+        val graphics = image.createGraphics()
+        paint(graphics)
+        graphics.dispose()
+
+        val paintedRows =
+            (0 until image.height).filter { y ->
+                (0 until image.width).any { x ->
+                    val alpha = image.getRGB(x, y) ushr ALPHA_SHIFT
+                    alpha != 0
+                }
+            }
+        require(paintedRows.isNotEmpty()) {
+            "Expected ${javaClass.simpleName} to paint visible content"
+        }
+
+        val parent = requireNotNull(parent)
+        val location = SwingUtilities.convertPoint(parent, x, y, root)
+        return location.y + (paintedRows.first() + paintedRows.last()) / 2
+    }
+
+    private fun Component.visibleTexts(): List<String> =
+        descendants()
+            .filter { it.isVisible }
+            .mapNotNull { component ->
+                when (component) {
+                    is AbstractButton -> component.text
+                    is JLabel -> component.text
+                    else -> null
+                }?.takeIf { it.isNotBlank() }
+            }.toList()
+
+    private fun List<String>.containsText(
+        first: String,
+        second: String,
+    ): Boolean =
+        any { text ->
+            text.contains(first) && text.contains(second)
+        }
+
+    private fun List<String>.countText(
+        first: String,
+        second: String,
+    ): Int =
+        count { text ->
+            text.contains(first) && text.contains(second)
+        }
+
+    private fun Component.clickAction(text: String) {
+        descendants()
+            .filterIsInstance<AbstractButton>()
+            .first { it.text == text }
+            .doClick()
+    }
+
+    private fun Component.descendants(): Sequence<Component> =
+        sequence {
+            yield(this@descendants)
+            if (this@descendants is Container) {
+                components.forEach { yieldAll(it.descendants()) }
+            }
+        }
+
+    private companion object {
+        const val ALPHA_SHIFT = 24
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherPopupTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherPopupTest.kt
@@ -11,11 +11,15 @@ import com.intellij.openapi.ui.popup.JBPopupListener
 import dev.ayuislands.AyuLaf
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentContext
+import dev.ayuislands.accent.AccentResolutionChain
+import dev.ayuislands.accent.AccentResolutionStep
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.accent.StepOutcome
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
+import io.mockk.CapturingSlot
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -25,6 +29,10 @@ import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.verify
+import java.awt.Component
+import java.awt.Container
+import javax.swing.AbstractButton
+import javax.swing.JComponent
 import javax.swing.JLabel
 import javax.swing.SwingUtilities
 import kotlin.test.AfterTest
@@ -91,6 +99,25 @@ class QuickSwitcherPopupTest {
     }
 
     @Test
+    fun `show renders accent diagnostics inline in popup content`() {
+        val chain = polyglotFallbackChain()
+        stubPopupBodyDependencies(chain = chain)
+        val contentSlot = slot<JComponent>()
+        stubPopupBuilder(contentSlot)
+
+        QuickSwitcherPopup.show(JLabel())
+
+        verify(exactly = 1) {
+            AccentResolver.resolveChain(
+                null,
+                any<AccentContext>(),
+            )
+        }
+        val texts = contentSlot.captured.visibleTexts()
+        assertTrue(texts.contains("Show resolution chain..."))
+    }
+
+    @Test
     fun `show toggles chip popup-attached ring while popup is open`() {
         stubPopupBodyDependencies()
         val (_, popup) = stubPopupBuilder()
@@ -101,20 +128,30 @@ class QuickSwitcherPopupTest {
         QuickSwitcherPopup.show(JLabel(), chip)
 
         verify(exactly = 1) { popup.addListener(any()) }
-        assertFalse(chip.isPopupAttached, "Chip must stay detached until popup listener fires")
+        assertFalse(
+            chip.isPopupAttached,
+            "Chip must stay detached until popup listener fires",
+        )
 
         listenerSlot.captured.beforeShown(mockk(relaxed = true))
         SwingUtilities.invokeAndWait { }
-        assertTrue(chip.isPopupAttached, "Chip must render attached ring while popup is open")
+        assertTrue(
+            chip.isPopupAttached,
+            "Chip must render attached ring while popup is open",
+        )
 
         listenerSlot.captured.onClosed(mockk(relaxed = true))
         SwingUtilities.invokeAndWait { }
-        assertFalse(chip.isPopupAttached, "Chip must clear attached ring after popup closes")
+        assertFalse(
+            chip.isPopupAttached,
+            "Chip must clear attached ring after popup closes",
+        )
     }
 
     private fun stubPopupBodyDependencies(
         context: AccentContext = AccentContext.Ayu(AyuVariant.MIRAGE),
         detectedVariant: AyuVariant? = AyuVariant.MIRAGE,
+        chain: AccentResolutionChain = polyglotFallbackChain(),
     ) {
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns detectedVariant
@@ -126,6 +163,7 @@ class QuickSwitcherPopupTest {
         mockkObject(AccentResolver)
         every { AccentResolver.resolve(any(), any<AccentContext>()) } returns "#FFB454"
         every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#FFB454"
+        every { AccentResolver.resolveChain(any(), any<AccentContext>()) } returns chain
         // VariantSwitcherRow reads the active theme name during construction.
         mockkStatic(LafManager::class)
         val lafManager = mockk<LafManager>(relaxed = true)
@@ -143,16 +181,25 @@ class QuickSwitcherPopupTest {
         mockkStatic(ApplicationManager::class)
         val mockApp = mockk<Application>(relaxed = true)
         every { ApplicationManager.getApplication() } returns mockApp
-        every { mockApp.getService(ActionManager::class.java) } returns mockk<ActionManager>(relaxed = true)
+        val actionManager = mockk<ActionManager>(relaxed = true)
+        every { mockApp.getService(ActionManager::class.java) } returns actionManager
     }
 
-    private fun stubPopupBuilder(): Pair<ComponentPopupBuilder, JBPopup> {
+    private fun stubPopupBuilder(
+        contentSlot: CapturingSlot<JComponent>? = null,
+    ): Pair<ComponentPopupBuilder, JBPopup> {
         mockkStatic(JBPopupFactory::class)
         val factory = mockk<JBPopupFactory>(relaxed = true)
         val builder = mockk<ComponentPopupBuilder>(relaxed = true)
         val popup = mockk<JBPopup>(relaxed = true)
         every { JBPopupFactory.getInstance() } returns factory
-        every { factory.createComponentPopupBuilder(any(), any()) } returns builder
+        if (contentSlot == null) {
+            every { factory.createComponentPopupBuilder(any(), any()) } returns builder
+        } else {
+            every {
+                factory.createComponentPopupBuilder(capture(contentSlot), any())
+            } returns builder
+        }
         every { builder.setRequestFocus(any()) } returns builder
         every { builder.setCancelOnClickOutside(any()) } returns builder
         every { builder.setCancelOnWindowDeactivation(any()) } returns builder
@@ -162,4 +209,48 @@ class QuickSwitcherPopupTest {
         every { builder.createPopup() } returns popup
         return builder to popup
     }
+
+    private fun polyglotFallbackChain(): AccentResolutionChain {
+        val steps =
+            listOf(
+                AccentResolutionStep(
+                    source = AccentResolver.Source.PROJECT_OVERRIDE,
+                    hex = null,
+                    outcome = StepOutcome.NOT_SET,
+                    detail = "not set",
+                ),
+                AccentResolutionStep(
+                    source = AccentResolver.Source.LANGUAGE_OVERRIDE,
+                    hex = null,
+                    outcome = StepOutcome.NOT_DOMINANT,
+                    detail = "Kotlin 52%, Java 48%",
+                ),
+                AccentResolutionStep(
+                    source = AccentResolver.Source.PROJECT_FALLBACK,
+                    hex = "#FFB454",
+                    outcome = StepOutcome.WON,
+                    detail = "polyglot project",
+                ),
+            )
+        return AccentResolutionChain(steps = steps, winner = steps.last(), verdict = null)
+    }
+
+    private fun Component.visibleTexts(): List<String> =
+        descendants()
+            .filter { it.isVisible }
+            .mapNotNull { component ->
+                when (component) {
+                    is AbstractButton -> component.text
+                    is JLabel -> component.text
+                    else -> null
+                }?.takeIf { it.isNotBlank() }
+            }.toList()
+
+    private fun Component.descendants(): Sequence<Component> =
+        sequence {
+            yield(this@descendants)
+            if (this@descendants is Container) {
+                components.forEach { yieldAll(it.descendants()) }
+            }
+        }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherRelatedTogglesSectionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherRelatedTogglesSectionTest.kt
@@ -6,6 +6,8 @@ import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.toolbar.popup.Density
 import dev.ayuislands.accent.toolbar.popup.ToggleTile
+import dev.ayuislands.glow.GlowOverlayManager
+import dev.ayuislands.rotation.AccentRotationService
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
 import io.mockk.every
@@ -28,8 +30,8 @@ import kotlin.test.assertTrue
  * Related-toggles section coverage:
  *   - layout is a 2 × 2 [GridLayout] of [ToggleTile] composites,
  *   - tile labels in fixed top-to-bottom / left-to-right order,
- *   - Chrome tinting writes `chromeStatusBar` only,
- *   - hidden binding writes mirror the visible switch without re-entry loops.
+ *   - Chrome tinting gates the user's configured chrome surfaces without rewriting them,
+ *   - tile clicks drive the runtime side-effects users expect immediately.
  */
 class QuickSwitcherRelatedTogglesSectionTest {
     @BeforeTest
@@ -85,13 +87,15 @@ class QuickSwitcherRelatedTogglesSectionTest {
     }
 
     @Test
-    fun `clicking Chrome tinting updates status bar without touching other chrome surfaces`() {
+    fun `clicking Chrome tinting off preserves chrome surface choices and reapplies focused accent`() {
         val state = AyuIslandsSettings.getInstance().state
-        state.chromeStatusBar = false
-        state.chromeMainToolbar = true
-        state.chromeToolWindowStripe = true
+        state.chromeStatusBar = true
+        state.chromeMainToolbar = false
+        state.chromeToolWindowStripe = false
         state.chromeNavBar = false
-        state.chromePanelBorder = true
+        state.chromePanelBorder = false
+        state.chromeTintingEnabled = true
+        every { AccentApplicator.applyForFocusedProject(any<AccentContext>()) } returns "#FFB454"
 
         val section = QuickSwitcherRelatedTogglesSection()
         val chromeTile =
@@ -102,18 +106,119 @@ class QuickSwitcherRelatedTogglesSectionTest {
 
         chromeTile.toggleSwitch.flip()
 
-        assertEquals(true, state.chromeStatusBar, "Chrome tile must toggle the visible status-bar chrome surface")
-        assertEquals(true, state.chromeMainToolbar, "Chrome tile must not touch main-toolbar chrome")
-        assertEquals(true, state.chromeToolWindowStripe, "Chrome tile must not touch tool-window stripe chrome")
-        assertEquals(false, state.chromeNavBar, "Chrome tile must not touch nav-bar chrome")
-        assertEquals(true, state.chromePanelBorder, "Chrome tile must not touch panel-border chrome")
-        verify(exactly = 0) { AccentApplicator.applyFromHexString(any()) }
+        assertEquals(false, state.chromeTintingEnabled, "Chrome tile must disable only the runtime chrome gate")
+        assertEquals(true, state.chromeStatusBar, "Chrome tile must preserve status-bar chrome preference")
+        assertEquals(false, state.chromeMainToolbar, "Chrome tile must preserve main-toolbar chrome preference")
+        assertEquals(
+            false,
+            state.chromeToolWindowStripe,
+            "Chrome tile must preserve tool-window stripe chrome preference",
+        )
+        assertEquals(false, state.chromeNavBar, "Chrome tile must preserve nav-bar chrome preference")
+        assertEquals(false, state.chromePanelBorder, "Chrome tile must preserve panel-border chrome preference")
+        verify(exactly = 1) { AccentApplicator.applyForFocusedProject(AccentContext.Ayu(AyuVariant.DARK)) }
+    }
+
+    @Test
+    fun `clicking Chrome tinting on restores the existing chrome surface choices`() {
+        val state = AyuIslandsSettings.getInstance().state
+        state.chromeStatusBar = true
+        state.chromeMainToolbar = false
+        state.chromeToolWindowStripe = false
+        state.chromeNavBar = false
+        state.chromePanelBorder = false
+        state.chromeTintingEnabled = false
+        every { AccentApplicator.applyForFocusedProject(any<AccentContext>()) } returns "#FFB454"
+
+        val section = QuickSwitcherRelatedTogglesSection()
+        val chromeTile =
+            (section.component as JPanel)
+                .components
+                .filterIsInstance<ToggleTile>()
+                .first { tile -> labelOf(tile) == "Chrome tinting" }
+
+        chromeTile.toggleSwitch.flip()
+
+        assertEquals(true, state.chromeTintingEnabled, "Chrome tile must re-enable only the runtime chrome gate")
+        assertEquals(true, state.chromeStatusBar, "Chrome tile must restore the user's status-bar-only setup")
+        assertEquals(false, state.chromeMainToolbar, "Chrome tile must not promote main-toolbar chrome")
+        assertEquals(false, state.chromeToolWindowStripe, "Chrome tile must not promote tool-window stripe chrome")
+        assertEquals(false, state.chromeNavBar, "Chrome tile must not promote nav-bar chrome")
+        assertEquals(false, state.chromePanelBorder, "Chrome tile must not promote panel-border chrome")
+        verify(exactly = 1) { AccentApplicator.applyForFocusedProject(AccentContext.Ayu(AyuVariant.DARK)) }
+    }
+
+    @Test
+    fun `clicking Glow off persists state and syncs overlays immediately`() {
+        val state = AyuIslandsSettings.getInstance().state
+        state.glowEnabled = true
+        mockkObject(GlowOverlayManager.Companion)
+        every { GlowOverlayManager.syncGlowForAllProjects() } returns Unit
+
+        val section = QuickSwitcherRelatedTogglesSection()
+        val glowTile =
+            (section.component as JPanel)
+                .components
+                .filterIsInstance<ToggleTile>()
+                .first { tile -> labelOf(tile) == "Glow" }
+
+        glowTile.toggleSwitch.flip()
+
+        assertEquals(false, state.glowEnabled, "Glow tile must persist disabled state")
+        verify(exactly = 1) { GlowOverlayManager.syncGlowForAllProjects() }
+    }
+
+    @Test
+    fun `clicking Accent rotation off stops rotation service immediately`() {
+        val state = AyuIslandsSettings.getInstance().state
+        state.accentRotationEnabled = true
+        val rotationService = mockk<AccentRotationService>(relaxed = true)
+        mockkObject(AccentRotationService.Companion)
+        every { AccentRotationService.getInstance() } returns rotationService
+
+        val section = QuickSwitcherRelatedTogglesSection()
+        val rotationTile =
+            (section.component as JPanel)
+                .components
+                .filterIsInstance<ToggleTile>()
+                .first { tile -> labelOf(tile) == "Accent rotation" }
+
+        rotationTile.toggleSwitch.flip()
+
+        assertEquals(false, state.accentRotationEnabled, "Rotation tile must persist disabled state")
+        verify(exactly = 1) { rotationService.stopRotation() }
+    }
+
+    @Test
+    fun `clicking Follow system accent on disables rotation and reapplies focused accent`() {
+        val state = AyuIslandsSettings.getInstance().state
+        state.followSystemAccent = false
+        state.accentRotationEnabled = true
+        val rotationService = mockk<AccentRotationService>(relaxed = true)
+        mockkObject(AccentRotationService.Companion)
+        every { AccentRotationService.getInstance() } returns rotationService
+        every { AccentApplicator.applyForFocusedProject(any<AccentContext>()) } returns "#7DCFFF"
+
+        val section = QuickSwitcherRelatedTogglesSection()
+        val followTile =
+            (section.component as JPanel)
+                .components
+                .filterIsInstance<ToggleTile>()
+                .first { tile -> labelOf(tile) == "Follow system accent" }
+
+        followTile.toggleSwitch.flip()
+
+        assertEquals(true, state.followSystemAccent, "Follow tile must persist enabled state")
+        assertEquals(false, state.accentRotationEnabled, "Follow system accent must disable accent rotation")
+        verify(exactly = 1) { rotationService.stopRotation() }
+        verify(exactly = 1) { AccentApplicator.applyForFocusedProject(AccentContext.Ayu(AyuVariant.DARK)) }
     }
 
     @Test
     fun `bindSelected reads back the matching state field at construction time`() {
         val state = AyuIslandsSettings.getInstance().state
-        state.chromeStatusBar = false
+        state.chromeTintingEnabled = false
+        state.chromeStatusBar = true
         state.glowEnabled = true
         state.accentRotationEnabled = false
         state.followSystemAccent = true
@@ -125,56 +230,6 @@ class QuickSwitcherRelatedTogglesSectionTest {
         assertEquals(true, byLabel["Glow"]?.toggleSwitch?.isSelected)
         assertEquals(false, byLabel["Accent rotation"]?.toggleSwitch?.isSelected)
         assertEquals(true, byLabel["Follow system accent"]?.toggleSwitch?.isSelected)
-    }
-
-    @Test
-    fun `external binding write does not loop through switch flip (re-entry guard)`() {
-        // Regression lock — pattern that previously broke: the per-tile
-        // listener writes `binding.isSelected = newValue` which fires
-        // `ItemEvent` on the binding; the binding's ItemListener catches it and
-        // calls `switch.flip()`; `flip()` writes back to binding → ping-pong.
-        // The equality guard (`if (switch.isSelected != binding.isSelected)`)
-        // saves the case where both already agree, but a future refactor that
-        // breaks the equality check leaves the loop open. The lexical
-        // `suppressEvents` guard makes the no-loop invariant unconditional.
-        //
-        // Simulate an external write: flip the binding directly (as a Settings
-        // page edit would do via bindSelected's setter), then assert that the
-        // switch follows once — NOT twice (which would indicate ping-pong).
-        val section = QuickSwitcherRelatedTogglesSection()
-        val tiles = (section.component as JPanel).components.filterIsInstance<ToggleTile>()
-        val chromeTile = tiles.first { tile -> labelOf(tile) == "Chrome tinting" }
-        val switch = chromeTile.toggleSwitch
-        val startState = switch.isSelected
-
-        // Reach the hidden binding via reflection on the section's
-        // persistenceRoot — its first child is the chrome binding.
-        val persistenceRootField =
-            QuickSwitcherRelatedTogglesSection::class.java.getDeclaredField("persistenceRoot")
-        persistenceRootField.isAccessible = true
-        val persistenceRoot =
-            persistenceRootField.get(section) as com.intellij.openapi.ui.DialogPanel
-        val chromeBinding =
-            collectCheckBoxes(persistenceRoot).first { box ->
-                box.text.contains("Chrome tinting")
-            }
-
-        // External edit: write directly to the binding. The switch must follow
-        // once. If suppressEvents is broken, this would either:
-        //   (a) infinite-loop and StackOverflow during dispatch, or
-        //   (b) toggle the switch back to startState (binding listener flips
-        //       switch, switch's listener flips binding back, equality check
-        //       sees match and stops — net result is no change).
-        chromeBinding.isSelected = !startState
-
-        // Switch must mirror the new binding state — exactly one flip.
-        assertEquals(
-            !startState,
-            switch.isSelected,
-            "Switch must mirror external binding write; ping-pong would reset to startState=$startState",
-        )
-        // Binding state must equal switch state — no drift.
-        assertEquals(switch.isSelected, chromeBinding.isSelected, "Binding and switch must agree post-write")
     }
 
     @Test
@@ -215,17 +270,6 @@ class QuickSwitcherRelatedTogglesSectionTest {
     }
 
     private fun labelOf(tile: ToggleTile): String = findLabelText(tile)
-
-    private fun collectCheckBoxes(
-        root: Container,
-        out: MutableList<javax.swing.JCheckBox> = mutableListOf(),
-    ): List<javax.swing.JCheckBox> {
-        for (child in root.components) {
-            if (child is javax.swing.JCheckBox) out.add(child)
-            if (child is Container) collectCheckBoxes(child, out)
-        }
-        return out
-    }
 
     private fun findLabelText(tile: ToggleTile): String {
         val labels = collectLabelTexts(tile)

--- a/src/test/kotlin/dev/ayuislands/actions/RescanLanguageActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/actions/RescanLanguageActionTest.kt
@@ -232,13 +232,11 @@ class RescanLanguageActionTest {
     }
 
     @Test
-    fun `scan completion with Unavailable fires the polyglot balloon via the shared when arm`() {
-        // `humanLabelFor` collapses Polyglot and Unavailable into the
-        // same user-visible balloon body (polyglot copy) — the user
-        // sees "no dominant language right now" the same way whether
-        // the scan definitively said polyglot or hit a transient
-        // failure. Locks the when-arm coverage so a regression
-        // splitting the arms without updating the copy gets caught.
+    fun `scan completion with Unavailable fires the unavailable balloon`() {
+        // Unavailable is not polyglot: polyglot means the scan completed
+        // without a dominant language, unavailable means the scan could not
+        // produce a trustworthy answer. The balloon copy must keep those two
+        // user-facing states distinct.
         val listener = captureSubscribedListener()
         action.actionPerformed(event)
 
@@ -247,7 +245,7 @@ class RescanLanguageActionTest {
         verify(exactly = 1) {
             notificationGroup.createNotification(
                 "Project language re-detected",
-                "Polyglot — no single dominant language; global accent applies",
+                "Language detection unavailable — try rescanning; global accent applies",
                 NotificationType.INFORMATION,
             )
         }

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsChromePanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsChromePanelTest.kt
@@ -9,7 +9,6 @@ import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.ui.DialogPanel
 import com.intellij.openapi.util.SystemInfo
-import com.intellij.ui.components.JBTabbedPane
 import com.intellij.ui.dsl.builder.panel
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentElementId
@@ -317,14 +316,11 @@ class AyuIslandsChromePanelTest {
     }
 
     @Test
-    fun `root Settings DialogPanel observes integrated Chrome Tinting tab changes`() {
+    fun `Settings configurable observes Chrome Tinting tab changes through built panels`() {
+        val configurable = AyuIslandsConfigurable()
         val chromePanel = AyuIslandsChromePanel()
         val chromeTabPanel = buildPanel(chromePanel, AyuVariant.DARK)
-        val tabs =
-            JBTabbedPane().apply {
-                addTab("Accent", chromeTabPanel)
-            }
-        val rootPanel = buildRootPanelForTest(tabs, listOf(chromeTabPanel))
+        replaceBuiltPanels(configurable, listOf(chromePanel))
         val statusBarCheckbox = statusBarCheckboxIn(chromeTabPanel)
 
         statusBarCheckbox.doClick()
@@ -338,8 +334,8 @@ class AyuIslandsChromePanelTest {
             "Chrome tab DialogPanel must observe Chrome Tinting changes",
         )
         assertTrue(
-            rootPanel.isModified(),
-            "Root DialogPanel must observe Chrome Tinting changes so the Settings Apply button enables",
+            configurable.isModified(),
+            "Settings Configurable must observe Chrome Tinting changes so the Apply button enables",
         )
     }
 
@@ -917,20 +913,13 @@ class AyuIslandsChromePanelTest {
         }
     }
 
-    private fun buildRootPanelForTest(
-        tabs: JBTabbedPane,
-        integratedPanels: List<DialogPanel>,
-    ): DialogPanel {
-        val method =
-            AyuIslandsConfigurable::class.java.getDeclaredMethod(
-                "buildRootPanel",
-                String::class.java,
-                AyuVariant::class.java,
-                JBTabbedPane::class.java,
-                List::class.java,
-            )
-        method.isAccessible = true
-        return method.invoke(AyuIslandsConfigurable(), "test", AyuVariant.DARK, tabs, integratedPanels) as DialogPanel
+    private fun replaceBuiltPanels(
+        configurable: AyuIslandsConfigurable,
+        panels: List<AyuIslandsSettingsPanel>,
+    ) {
+        val field = AyuIslandsConfigurable::class.java.getDeclaredField("builtPanels")
+        field.isAccessible = true
+        field.set(configurable, panels)
     }
 
     private fun statusBarCheckboxIn(root: Container): JCheckBox =

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsChromePanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsChromePanelTest.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.ui.DialogPanel
 import com.intellij.openapi.util.SystemInfo
+import com.intellij.ui.components.JBTabbedPane
 import com.intellij.ui.dsl.builder.panel
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentElementId
@@ -24,6 +25,8 @@ import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.verify
+import java.awt.Container
+import javax.swing.JCheckBox
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -287,6 +290,85 @@ class AyuIslandsChromePanelTest {
         chromePanel.setPendingChromeTintIntensityForTest(55)
 
         assertTrue(chromePanel.isModified(), "Changing pendingChromeTintIntensity must dirty the panel")
+    }
+
+    @Test
+    fun `real status-bar checkbox click marks DialogPanel modified and persists on apply`() {
+        val chromePanel = AyuIslandsChromePanel()
+        val dialogPanel = buildPanel(chromePanel, AyuVariant.DARK)
+        val statusBarCheckbox = statusBarCheckboxIn(dialogPanel)
+
+        statusBarCheckbox.doClick()
+
+        assertTrue(
+            dialogPanel.isModified(),
+            "Real checkbox clicks must dirty the DialogPanel so the Settings Apply button enables",
+        )
+        assertTrue(
+            chromePanel.isModified(),
+            "Real checkbox clicks must dirty the Chrome panel pending state before apply",
+        )
+
+        chromePanel.apply()
+
+        assertTrue(state.chromeStatusBar, "Applying after a real checkbox click must persist chromeStatusBar")
+        assertFalse(chromePanel.isModified(), "Successful apply must refresh stored Chrome panel state")
+        assertFalse(dialogPanel.isModified(), "Successful apply must leave the DialogPanel clean")
+    }
+
+    @Test
+    fun `root Settings DialogPanel observes integrated Chrome Tinting tab changes`() {
+        val chromePanel = AyuIslandsChromePanel()
+        val chromeTabPanel = buildPanel(chromePanel, AyuVariant.DARK)
+        val tabs =
+            JBTabbedPane().apply {
+                addTab("Accent", chromeTabPanel)
+            }
+        val rootPanel = buildRootPanelForTest(tabs, listOf(chromeTabPanel))
+        val statusBarCheckbox = statusBarCheckboxIn(chromeTabPanel)
+
+        statusBarCheckbox.doClick()
+
+        assertTrue(
+            chromePanel.isModified(),
+            "Chrome panel must become modified after a real checkbox click in the integrated tab",
+        )
+        assertTrue(
+            chromeTabPanel.isModified(),
+            "Chrome tab DialogPanel must observe Chrome Tinting changes",
+        )
+        assertTrue(
+            rootPanel.isModified(),
+            "Root DialogPanel must observe Chrome Tinting changes so the Settings Apply button enables",
+        )
+    }
+
+    @Test
+    fun `real intensity slider change marks DialogPanel modified and persists on apply`() {
+        val chromePanel = AyuIslandsChromePanel()
+        val dialogPanel = buildPanel(chromePanel, AyuVariant.DARK)
+        val intensitySlider =
+            assertNotNull(
+                chromePanel.intensitySliderForTest(),
+                "Chrome Tinting intensity slider must be available after buildPanel",
+            )
+
+        intensitySlider.value = 45
+
+        assertTrue(
+            dialogPanel.isModified(),
+            "Real slider changes must dirty the DialogPanel so the Settings Apply button enables",
+        )
+        assertTrue(
+            chromePanel.isModified(),
+            "Real slider changes must dirty the Chrome panel pending state before apply",
+        )
+
+        chromePanel.apply()
+
+        assertEquals(45, state.chromeTintIntensity, "Applying after a real slider change must persist intensity")
+        assertFalse(chromePanel.isModified(), "Successful apply must refresh stored Chrome panel state")
+        assertFalse(dialogPanel.isModified(), "Successful apply must leave the DialogPanel clean")
     }
 
     // ── Test 6-7: apply() persistence ──────────────────────────────────────────
@@ -834,4 +916,35 @@ class AyuIslandsChromePanelTest {
             )
         }
     }
+
+    private fun buildRootPanelForTest(
+        tabs: JBTabbedPane,
+        integratedPanels: List<DialogPanel>,
+    ): DialogPanel {
+        val method =
+            AyuIslandsConfigurable::class.java.getDeclaredMethod(
+                "buildRootPanel",
+                String::class.java,
+                AyuVariant::class.java,
+                JBTabbedPane::class.java,
+                List::class.java,
+            )
+        method.isAccessible = true
+        return method.invoke(AyuIslandsConfigurable(), "test", AyuVariant.DARK, tabs, integratedPanels) as DialogPanel
+    }
+
+    private fun statusBarCheckboxIn(root: Container): JCheckBox =
+        descendants(root, JCheckBox::class.java)
+            .firstOrNull { it.text == "Status bar" }
+            ?: error("Chrome Tinting status-bar checkbox must be present in the built DialogPanel")
+
+    private fun <T : java.awt.Component> descendants(
+        root: Container,
+        type: Class<T>,
+    ): List<T> =
+        root.components.flatMap { child ->
+            val current = if (type.isInstance(child)) listOf(type.cast(child)) else emptyList()
+            val nested = if (child is Container) descendants(child, type) else emptyList()
+            current + nested
+        }
 }

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsConfigurableChromeWiringTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsConfigurableChromeWiringTest.kt
@@ -1,6 +1,7 @@
 package dev.ayuislands.settings
 
 import com.intellij.ui.components.JBTabbedPane
+import dev.ayuislands.accent.AyuVariant
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
@@ -131,6 +132,37 @@ class AyuIslandsConfigurableChromeWiringTest {
         }
 
         verify(exactly = 1) { spyChrome.reset() }
+    }
+
+    @Test
+    fun `buildAccentTab registers injected panels in active panel aggregation`() {
+        val configurable = AyuIslandsConfigurable()
+        val appearancePanel = mockk<AyuIslandsAppearancePanel>(relaxed = true)
+        val accentPanel = mockk<AyuIslandsAccentPanel>(relaxed = true)
+        val chromePanel = mockk<AyuIslandsChromePanel>(relaxed = true)
+        val elementsPanel = mockk<AyuIslandsElementsPanel>(relaxed = true)
+        replaceField(configurable, "appearancePanel", appearancePanel)
+        replaceField(configurable, "accentPanel", accentPanel)
+        replaceField(configurable, "chromePanel", chromePanel)
+        replaceField(configurable, "elementsPanel", elementsPanel)
+
+        val activePanels = mutableListOf<AyuIslandsSettingsPanel>()
+        val buildAccentTab =
+            AyuIslandsConfigurable::class.java.getDeclaredMethod(
+                "buildAccentTab",
+                AyuVariant::class.java,
+                MutableList::class.java,
+            )
+        buildAccentTab.isAccessible = true
+
+        buildAccentTab.invoke(configurable, AyuVariant.DARK, activePanels)
+
+        assertEquals(
+            listOf(appearancePanel, accentPanel, chromePanel, elementsPanel),
+            activePanels,
+            "Injected Accent-tab panels must be in builtPanels; otherwise Settings Apply " +
+                "does not enable/apply Chrome Tinting changes made inside the panel.",
+        )
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsConfigurableChromeWiringTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsConfigurableChromeWiringTest.kt
@@ -166,6 +166,21 @@ class AyuIslandsConfigurableChromeWiringTest {
     }
 
     @Test
+    fun `Configurable bytecode avoids internal DialogPanel integration API`() {
+        val classBytes =
+            AyuIslandsConfigurable::class.java
+                .getResourceAsStream("AyuIslandsConfigurable.class")
+                ?.readAllBytes()
+                ?: error("AyuIslandsConfigurable.class must be loadable for bytecode inspection")
+        val classText = String(classBytes, Charsets.ISO_8859_1)
+
+        assertFalse(
+            classText.contains("registerIntegratedPanel"),
+            "Settings lifecycle must flow through builtPanels, not DialogPanel.registerIntegratedPanel",
+        )
+    }
+
+    @Test
     fun `Configurable bytecode wires chromePanel to afterOverridesInjection not before`() {
         // Regression guard for the Chrome Tinting placement: chrome moved from
         // BEFORE Overrides to AFTER Overrides by rewiring the

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateTest.kt
@@ -101,6 +101,10 @@ class AyuIslandsStateTest {
     @Test
     fun `chrome tinting auxiliary defaults`() {
         val state = freshState()
+        assertTrue(
+            state.chromeTintingEnabled,
+            "chromeTintingEnabled defaults on so existing per-surface preferences keep working after upgrade",
+        )
         assertEquals(
             AyuIslandsState.DEFAULT_CHROME_TINT_INTENSITY,
             state.chromeTintIntensity,
@@ -109,6 +113,36 @@ class AyuIslandsStateTest {
         assertFalse(
             state.chromeTintingGroupExpanded,
             "chromeTintingGroupExpanded defaults collapsed (same shape as accentElementsGroupExpanded)",
+        )
+    }
+
+    @Test
+    fun `chrome master gate disables effective toggles without rewriting surface preferences`() {
+        val state = freshState()
+        state.chromeTintingEnabled = false
+        state.chromeStatusBar = true
+
+        assertFalse(
+            state.isToggleEnabled(AccentElementId.STATUS_BAR),
+            "Disabled chrome master gate must suppress effective status-bar tinting",
+        )
+        assertTrue(
+            state.chromeStatusBar,
+            "Disabled chrome master gate must preserve the status-bar preference",
+        )
+    }
+
+    @Test
+    fun `hasChromeTintingSurfaceEnabled reads raw surface preferences`() {
+        val state = freshState()
+        assertFalse(state.hasChromeTintingSurfaceEnabled())
+
+        state.chromeTintingEnabled = false
+        state.chromePanelBorder = true
+
+        assertTrue(
+            state.hasChromeTintingSurfaceEnabled(),
+            "Raw chrome surface preferences remain readable when the runtime master gate is off",
         )
     }
 


### PR DESCRIPTION
## Why

Accent selection already had multiple sources, but users could only see the
final color. When a project fallback, language override, external accent, or
global accent won, there was no compact way to inspect why that source won.

## What changed

- Added an accent resolution-chain model that records each candidate source,
  outcome, resolved hex, and diagnostic detail.
- Added a status-bar widget and popup for the current accent source.
- Added an inline quick-switcher diagnostics row with collapsed summary and an
  expandable resolution chain.
- Hardened chrome tinting settings and toolbar toggles so they preserve the
  user's selected tint targets instead of flattening them into all-on/all-off.
- Aligned diagnostics-chain winners with the legacy resolver for language
  fallback, project fallback, and external automatic accents.
- Kept the new status-bar widget factory through ProGuard and removed an
  internal DialogPanel API from Settings wiring.
- Added regression coverage for resolution chains, status popup behavior,
  Settings apply/reset wiring, chrome target preservation, quick-switcher
  marker alignment, and plugin verifier/API guardrails.

## Validation

- `./gradlew test --tests dev.ayuislands.accent.AccentResolverChainTest --tests dev.ayuislands.accent.AccentResolverTest --tests dev.ayuislands.accent.AccentResolverExternalTest --tests dev.ayuislands.accent.toolbar.QuickSwitcherAccentDiagnosticsPanelTest --tests dev.ayuislands.accent.toolbar.QuickSwitcherPopupTest --tests dev.ayuislands.accent.statusbar.AccentStatusBarPanelTest`
- `./gradlew test --tests dev.ayuislands.settings.AyuIslandsChromePanelTest --tests dev.ayuislands.settings.AyuIslandsConfigurableChromeWiringTest`
- `./gradlew detekt ktlintCheck`
- `scripts/verify-docs.py`
- `./gradlew buildPlugin`
- `python3 scripts/verify-bytecode.py`
- `python3 scripts/verify-proguard-keeps.py`
- `./gradlew verifyPlugin -DverifyGroup=C`
- `python3 scripts/verify-plugin-verifier.py`
- Local real-IDE deploy to IntelliJ IDEA 2026.1: `buildPlugin`, install,
  bytecode check for the quick-switcher marker offset, restart, and
  `idea.log` check with no `SEVERE.*Ayu` entries.
- GitHub PR checks are green on the current head.

## Notes

- Kept as draft until explicitly marked ready.
