### PR TITLE
chore: bump version to 2.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## [2.7.5] - 2026-06-18
+
+- [Paid] **Accent Source status-bar widget** — Pro users can add a status-bar
+  widget that shows which accent source won for the current project and opens
+  the full resolution chain.
+- [Paid] **Language override controls** — language accent detection now shows
+  dominance and fallback details in Settings, and forced language or fallback
+  choices take precedence before the global accent.
+- [Free] **Quick-Switcher accent diagnostics** — the toolbar widget now shows
+  the resolved accent source inline, with an expandable chain for project pins,
+  language overrides, fallbacks, external themes, and global accents.
+- [Free] **Groovy and Jenkinsfile syntax colors** — Groovy and Jenkinsfile roles
+  now have explicit Ayu colors across Dark, Mirage, and Light, including
+  methods, fields, map keys, strings, GStrings, keywords, documentation, and
+  inlay type hints.
+- [Fix] **Quick-Switcher widget buttons** — related toggle buttons now apply
+  Chrome tinting, Glow, Accent rotation, and Follow system accent changes
+  reliably from the widget.
+- [Fix] **Chrome tinting target preservation** — widget toggles and Settings
+  Apply now preserve the exact chrome tint targets you selected instead of
+  turning every tint surface on or off together.
+- [Fix] **Language override precedence** — forced-language and fallback choices
+  now win before project/global fallback when resolving the active accent.
+- [Fix] **Accent diagnostics accuracy** — Quick-Switcher and status-bar
+  diagnostics now match the actual resolver for language fallback, project
+  fallback, and external automatic accents.
+- [Fix] **Editor Glow with pinned tabs** — Glow overlays now align with editor
+  content when only pinned tabs remain, instead of using a fixed tab-strip
+  fallback.
+
 ## [2.7.4] - 2026-06-15
 
 ### Paid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   the full resolution chain.
 - [Paid] **Language override controls** — language accent detection now shows
   dominance and fallback details in Settings, and forced language or fallback
-  choices take precedence before the global accent.
+  choices take precedence over the global accent.
 - [Free] **Quick-Switcher accent diagnostics** — the toolbar widget now shows
   the resolved accent source inline, with an expandable chain for project pins,
   language overrides, fallbacks, external themes, and global accents.
@@ -22,7 +22,8 @@
   Apply now preserve the exact chrome tint targets you selected instead of
   turning every tint surface on or off together.
 - [Fix] **Language override precedence** — forced-language and fallback choices
-  now win before project/global fallback when resolving the active accent.
+  now take precedence over project/global fallback when resolving the active
+  accent.
 - [Fix] **Accent diagnostics accuracy** — Quick-Switcher and status-bar
   diagnostics now match the actual resolver for language fallback, project
   fallback, and external automatic accents.

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -178,7 +178,7 @@ categories:
         description: >
           Language accent detection shows dominance and fallback details in
           Settings, and forced language or fallback choices take precedence
-          before the global accent.
+          over the global accent.
 
       - id: chrome-tinting
         title: "Peacock-parity chrome tinting"

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -160,6 +160,26 @@ categories:
           keep the default dominance logic while still choosing a project
           fallback or forced language when needed.
 
+      - id: accent-source-status-widget
+        title: "Accent Source status-bar widget"
+        keyword: "status bar"
+        introduced: "2.7.5"
+        tier: paid
+        description: >
+          Pro users can add a status-bar widget that shows which accent
+          source won for the current project and opens the full resolution
+          chain.
+
+      - id: language-override-controls
+        title: "Language override controls"
+        keyword: "language override diagnostics"
+        introduced: "2.7.5"
+        tier: paid
+        description: >
+          Language accent detection shows dominance and fallback details in
+          Settings, and forced language or fallback choices take precedence
+          before the global accent.
+
       - id: chrome-tinting
         title: "Peacock-parity chrome tinting"
         keyword: "chrome tinting"
@@ -203,6 +223,16 @@ categories:
           workflows. Hide the widget from Settings → Ayu Islands →
           General. Premium-tier rows (related toggles + quick actions)
           appear inside the popup when the license is active or in trial.
+
+      - id: quick-switcher-accent-diagnostics
+        title: "Quick-Switcher accent diagnostics"
+        keyword: "Quick-Switcher Widget"
+        introduced: "2.7.5"
+        tier: free
+        description: >
+          The toolbar widget shows the resolved accent source inline, with
+          an expandable chain for project pins, language overrides,
+          fallbacks, external themes, and global accents.
 
       - id: external-theme-accent-inheritance
         title: "External theme accent inheritance"
@@ -470,6 +500,16 @@ categories:
         description: >
           Hand-tuned syntax highlighting for 40+ languages and formats,
           with Ayu palette defaults for anything unlisted.
+
+      - id: groovy-jenkinsfile-syntax-colors
+        title: "Groovy and Jenkinsfile syntax colors"
+        keyword: "40+ individually crafted language syntaxes"
+        introduced: "2.7.5"
+        tier: free
+        description: >
+          Groovy and Jenkinsfile roles have explicit Ayu colors across Dark,
+          Mirage, and Light, including methods, fields, map keys, strings,
+          GStrings, keywords, documentation, and inlay type hints.
 
       - id: terminal-scheme
         title: "16-color terminal scheme + VCS/diff palette"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.7.4
+pluginVersion=2.7.5
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
@@ -55,6 +55,14 @@ internal object UpdateNotifier {
 
     private val RELEASE_NOTES =
         mapOf(
+            "2.7.5" to
+                releaseNotes(
+                    "[Paid] Accent Source status-bar widget shows why the current accent won",
+                    "[Paid] Language override controls now show dominance and fallback details",
+                    "[Free] Quick-Switcher diagnostics and Groovy/Jenkinsfile colors are expanded",
+                    "[Fix] Widget buttons and Settings Apply now preserve chrome tinting choices",
+                    "[Fix] Language fallback precedence and pinned-tab Glow alignment are corrected",
+                ),
             "2.7.3" to
                 releaseNotes(
                     "Syntax preview highlighting now updates reliably when switching presets and readability options",

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -117,6 +117,18 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>2.7.5</h3>
+    <ul>
+      <li>[Paid] <b>Accent Source status-bar widget</b> — Pro users can add a status-bar widget that shows which accent source won for the current project and opens the full resolution chain.</li>
+      <li>[Paid] <b>Language override controls</b> — language accent detection now shows dominance and fallback details in Settings, and forced language or fallback choices take precedence before the global accent.</li>
+      <li>[Free] <b>Quick-Switcher accent diagnostics</b> — the toolbar widget now shows the resolved accent source inline, with an expandable chain for project pins, language overrides, fallbacks, external themes, and global accents.</li>
+      <li>[Free] <b>Groovy and Jenkinsfile syntax colors</b> — Groovy and Jenkinsfile roles now have explicit Ayu colors across Dark, Mirage, and Light, including methods, fields, map keys, strings, GStrings, keywords, documentation, and inlay type hints.</li>
+      <li>[Fix] <b>Quick-Switcher widget buttons</b> — related toggle buttons now apply Chrome tinting, Glow, Accent rotation, and Follow system accent changes reliably from the widget.</li>
+      <li>[Fix] <b>Chrome tinting target preservation</b> — widget toggles and Settings Apply now preserve the exact chrome tint targets you selected instead of turning every tint surface on or off together.</li>
+      <li>[Fix] <b>Language override precedence</b> — forced-language and fallback choices now win before project/global fallback when resolving the active accent.</li>
+      <li>[Fix] <b>Accent diagnostics accuracy</b> — Quick-Switcher and status-bar diagnostics now match the actual resolver for language fallback, project fallback, and external automatic accents.</li>
+      <li>[Fix] <b>Editor Glow with pinned tabs</b> — Glow overlays now align with editor content when only pinned tabs remain, instead of using a fixed tab-strip fallback.</li>
+    </ul>
     <h3>2.7.4</h3>
     <ul>
       <li>[Paid] <b>Language override diagnostics</b> — Settings now explains whether a project's language accent is detected, polyglot, forced to a specific language, or using a project fallback.</li>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -120,12 +120,12 @@
     <h3>2.7.5</h3>
     <ul>
       <li>[Paid] <b>Accent Source status-bar widget</b> — Pro users can add a status-bar widget that shows which accent source won for the current project and opens the full resolution chain.</li>
-      <li>[Paid] <b>Language override controls</b> — language accent detection now shows dominance and fallback details in Settings, and forced language or fallback choices take precedence before the global accent.</li>
+      <li>[Paid] <b>Language override controls</b> — language accent detection now shows dominance and fallback details in Settings, and forced language or fallback choices take precedence over the global accent.</li>
       <li>[Free] <b>Quick-Switcher accent diagnostics</b> — the toolbar widget now shows the resolved accent source inline, with an expandable chain for project pins, language overrides, fallbacks, external themes, and global accents.</li>
       <li>[Free] <b>Groovy and Jenkinsfile syntax colors</b> — Groovy and Jenkinsfile roles now have explicit Ayu colors across Dark, Mirage, and Light, including methods, fields, map keys, strings, GStrings, keywords, documentation, and inlay type hints.</li>
       <li>[Fix] <b>Quick-Switcher widget buttons</b> — related toggle buttons now apply Chrome tinting, Glow, Accent rotation, and Follow system accent changes reliably from the widget.</li>
       <li>[Fix] <b>Chrome tinting target preservation</b> — widget toggles and Settings Apply now preserve the exact chrome tint targets you selected instead of turning every tint surface on or off together.</li>
-      <li>[Fix] <b>Language override precedence</b> — forced-language and fallback choices now win before project/global fallback when resolving the active accent.</li>
+      <li>[Fix] <b>Language override precedence</b> — forced-language and fallback choices now take precedence over project/global fallback when resolving the active accent.</li>
       <li>[Fix] <b>Accent diagnostics accuracy</b> — Quick-Switcher and status-bar diagnostics now match the actual resolver for language fallback, project fallback, and external automatic accents.</li>
       <li>[Fix] <b>Editor Glow with pinned tabs</b> — Glow overlays now align with editor content when only pinned tabs remain, instead of using a fixed tab-strip fallback.</li>
     </ul>


### PR DESCRIPTION
-- Summary ------------------------------------------------

Prepare the 2.7.5 Marketplace release after the diagnostics and Groovy/Jenkinsfile work landed on `main`. This bumps the plugin version and aligns user-facing release notes across the changelog, plugin metadata, feature manifest, and in-IDE update notification.

-- Changes ------------------------------------------------

- Chore: `gradle.properties` - bump `pluginVersion` to `2.7.5`.
- Docs: `CHANGELOG.md`, `plugin.xml`, `UpdateNotifier.kt` - add `[Paid]`, `[Free]`, and `[Fix]` release notes for 2.7.5.
- Docs: `docs/features.yml` - register the 2.7.5 user-facing feature metadata needed by the docs verifier.

-- Validation ---------------------------------------------

- `git diff --check` - passed.
- `scripts/verify-docs.py` - passed; only existing orphaned screenshot SHA warnings remain from squash-merge history.
- `./gradlew clean buildPlugin` - passed; produced `build/distributions/ayu-jetbrains-2.7.5.zip`.
- `./gradlew verifyPlugin` - passed; 12/12 Plugin Verifier verdicts are `Compatible`.

-- Notes --------------------------------------------------

Direct push to `main` is blocked by the repository ruleset, so this release bump is going through a PR before the `v2.7.5` tag is pushed.

## Summary by Sourcery

Prepare the 2.7.5 release by bumping the plugin version and updating user-facing release information.

New Features:
- Document new accent diagnostics UI, status-bar widget, and language override controls for the 2.7.5 release.
- Document new Groovy and Jenkinsfile syntax color support introduced in 2.7.5.

Bug Fixes:
- Document fixes to Quick-Switcher widget buttons, chrome tinting targets, language override precedence, accent diagnostics accuracy, and editor glow behavior for the 2.7.5 release.

Build:
- Bump plugin version to 2.7.5 in the Gradle configuration.

Documentation:
- Add 2.7.5 release notes to the changelog, plugin metadata, feature manifest, and in-IDE update notification so user-facing documentation is consistent.