### PR TITLE
style: standardize editorconfig defaults

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,17 @@
-[*.{kt,kts}]
-max_line_length = 120
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
 indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+max_line_length = 120
+
+[*.{kt,kts}]
+ij_kotlin_code_style_defaults = KOTLIN_OFFICIAL
+ij_kotlin_continuation_indent_size = 4
+
+[*.{yml,yaml}]
+indent_size = 2


### PR DESCRIPTION
-- Summary ------------------------------------------------

Editor behavior was only partially defined for Kotlin files. This adds a repository-level EditorConfig baseline so IDE formatting, line endings, whitespace cleanup, Kotlin style defaults, and YAML indentation stay consistent without changing the existing 120-character line length.

-- Changes ------------------------------------------------

- Chore: [.editorconfig](.editorconfig) - Add repo-wide editor defaults, keep Kotlin line length at 120, set IntelliJ Kotlin official style defaults, and use 2-space YAML indentation.

-- Validation ---------------------------------------------

- `./gradlew ktlintCheck` - passed
- `./gradlew detekt` - passed
- `git diff --check origin/main...HEAD` - passed

-- Notes --------------------------------------------------

Committed with `--no-verify` only for this guarded `.editorconfig` change after explicit approval; the repo hook intentionally blocks linter config files by default.

## Summary by Sourcery

Chores:
- Add a repo-level .editorconfig to define common defaults for indentation, line endings, whitespace cleanup, and Kotlin style settings across the project.