### PR TITLE
chore: bump version to 2.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [2.7.6] - 2026-06-24
+
+- [Fix] **Language override diagnostics** — Quick-Switcher now keeps
+  dominant-language proportions and fallback detail in the expanded resolution
+  chain instead of crowding or overlapping the collapsed widget.
+- [Fix] **Groovy and Jenkinsfile semantic highlighting** — Jenkinsfile
+  pipeline calls, named arguments, dynamic Jenkins bindings (`env`, `params`,
+  `currentBuild`), and unresolved chained calls now resolve to Ayu-native
+  Groovy semantic colors across Dark, Mirage, and Light.
+- [Fix] **Jenkinsfile unresolved references** — pipeline DSL symbols such as
+  `properties`, `parameters`, `podTemplate`, and `containerTemplate` no longer
+  render as near-background text or carry noisy dotted underlines.
+- [Fix] **Focus-based accent refresh** — switching project windows now reapplies
+  project and language accents through IntelliJ's write-safe dispatch path
+  instead of a raw Swing callback.
+- [Fix] **Chrome tinting dividers** — shared IntelliJ divider peers no longer
+  pick up project accent tint and draw a colored editor frame outside the
+  intended accent surfaces.
+
 ## [2.7.5] - 2026-06-18
 
 - [Paid] **Accent Source status-bar widget** — Pro users can add a status-bar

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.7.5
+pluginVersion=2.7.6
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
@@ -55,6 +55,14 @@ internal object UpdateNotifier {
 
     private val RELEASE_NOTES =
         mapOf(
+            "2.7.6" to
+                releaseNotes(
+                    "[Fix] Language override diagnostics keep full details in the compact resolution chain",
+                    "[Fix] Groovy/Jenkinsfile colors cover DSL calls, named args, Jenkins bindings, and chains",
+                    "[Fix] Jenkinsfile unresolved references no longer render as dark text or dotted underlines",
+                    "[Fix] Focus-based accent refreshes now use IntelliJ's write-safe dispatch path",
+                    "[Fix] Chrome tinting no longer colors shared IDE dividers around the editor",
+                ),
             "2.7.5" to
                 releaseNotes(
                     "[Paid] Accent Source status-bar widget shows why the current accent won",

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -117,6 +117,14 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>2.7.6</h3>
+    <ul>
+      <li>[Fix] <b>Language override diagnostics</b> — Quick-Switcher now keeps dominant-language proportions and fallback detail in the expanded resolution chain instead of crowding or overlapping the collapsed widget.</li>
+      <li>[Fix] <b>Groovy and Jenkinsfile semantic highlighting</b> — Jenkinsfile pipeline calls, named arguments, dynamic Jenkins bindings, and unresolved chained calls now resolve to Ayu-native Groovy semantic colors across Dark, Mirage, and Light.</li>
+      <li>[Fix] <b>Jenkinsfile unresolved references</b> — pipeline DSL symbols such as <code>properties</code>, <code>parameters</code>, <code>podTemplate</code>, and <code>containerTemplate</code> no longer render as near-background text or carry noisy dotted underlines.</li>
+      <li>[Fix] <b>Focus-based accent refresh</b> — switching project windows now reapplies project and language accents through IntelliJ's write-safe dispatch path instead of a raw Swing callback.</li>
+      <li>[Fix] <b>Chrome tinting dividers</b> — shared IntelliJ divider peers no longer pick up project accent tint and draw a colored editor frame outside the intended accent surfaces.</li>
+    </ul>
     <h3>2.7.5</h3>
     <ul>
       <li>[Paid] <b>Accent Source status-bar widget</b> — Pro users can add a status-bar widget that shows which accent source won for the current project and opens the full resolution chain.</li>


### PR DESCRIPTION
-- Summary ------------------------------------------------

Prepare the 2.7.6 release metadata after the accent diagnostics and Groovy/Jenkinsfile readability fixes landed on main.

Why: the plugin version, Marketplace change notes, changelog, and in-IDE update notification need to describe the user-visible fixes that will ship in 2.7.6.

-- Changes ------------------------------------------------

| Type | File | Description |
|------|------|-------------|
| Chore | [gradle.properties](gradle.properties#L3) | Bump `pluginVersion` to `2.7.6`. |
| Chore | [CHANGELOG.md](CHANGELOG.md#L3) | Add 2.7.6 user-facing release notes. |
| Chore | [plugin.xml](src/main/resources/META-INF/plugin.xml#L120) | Add 2.7.6 Marketplace change notes. |
| Chore | [UpdateNotifier.kt](src/main/kotlin/dev/ayuislands/UpdateNotifier.kt#L58) | Add 2.7.6 in-IDE update notification notes. |

-- Validation ---------------------------------------------

```bash
scripts/verify-docs.py
./gradlew detekt ktlintCheck
./gradlew clean buildPlugin
./gradlew verifyPlugin
```

All passed. `verifyPlugin` checked 12 IDE targets and reported them compatible for `com.ayuislands.theme:2.7.6`; existing deprecated/experimental API notices remain unchanged release-gate warnings.

-- Notes --------------------------------------------------

No release tag is created in this PR. Tagging `v2.7.6` and pushing it should happen only after this release metadata is on `main`.

## Summary by Sourcery

Prepare 2.7.6 release metadata with updated version and user-visible bug fix notes.

Bug Fixes:
- Document fixes for language override diagnostics layout in Quick-Switcher.
- Document improved Groovy and Jenkinsfile semantic highlighting and Jenkinsfile unresolved reference styling.
- Document focus-based accent refresh behavior using IntelliJ’s write-safe dispatch path.
- Document fix to prevent chrome accent tint from coloring shared IDE dividers around the editor frame.

Chores:
- Bump plugin version to 2.7.6 in build configuration.
- Add 2.7.6 entries to changelog, Marketplace change notes, and in-IDE update notification configuration.