### PR TITLE
feat(release): enforce semantic update policy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,6 +104,8 @@ jobs:
         run: uv run --project scripts python scripts/tests/test-generate-campaign.py
       - name: Test Plugin Verifier API gate
         run: python3 scripts/tests/test-verify-plugin-verifier.py
+      - name: Test release policy
+        run: python3 scripts/tests/test-release-policy.py
       - name: Verify docs sync (features.yml ↔ README + plugin.xml + CHANGELOG)
         run: scripts/verify-docs.py
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -1,6 +1,6 @@
 # Single source of truth for Ayu Islands user-facing features.
 #
-# CI (scripts/verify-docs.py) enforces six invariants:
+# CI (scripts/verify-docs.py) enforces seven invariants:
 #
 #   1. Every `keyword` in this file appears in README.md AND in the
 #      <description> CDATA of src/main/resources/META-INF/plugin.xml
@@ -25,6 +25,11 @@
 #
 #   6. `release_sync` keeps plugin.xml <description> copy aligned with the
 #      last published Marketplace version unless the plugin version changes.
+#
+#   7. Semantic release policy: a latest release with `features.yml` entries
+#      introduced in that version must be a minor bump; a release with no new
+#      feature entries must be a patch bump. `gradle.properties.pluginVersion`
+#      and plugin.xml change-notes must point at the same latest version.
 #
 # When adding a feature: pick a distinctive keyword (short phrase that will
 # always appear verbatim in the marketing copy). When the UI changes: either

--- a/scripts/tests/test-release-policy.py
+++ b/scripts/tests/test-release-policy.py
@@ -173,6 +173,19 @@ class VerifyReleasePolicyTest(unittest.TestCase):
         self.assertTrue(report.has_errors)
         self.assertIn("must start with an `<h3>X.Y.Z</h3>`", messages(report))
 
+    def test_malformed_version_reports_clear_numeric_error(self) -> None:
+        report = Report()
+
+        bump = changelog.classify_version_bump("2.7.5", "2.7.x", report)
+
+        self.assertIsNone(bump)
+        self.assertTrue(report.has_errors)
+        self.assertIn(
+            "expected numeric X.Y.Z version, got '2.7.x'",
+            messages(report),
+        )
+        self.assertNotIn("invalid literal", messages(report))
+
 
 def make_repository(
     root: Path,

--- a/scripts/tests/test-release-policy.py
+++ b/scripts/tests/test-release-policy.py
@@ -141,6 +141,38 @@ class VerifyReleasePolicyTest(unittest.TestCase):
         self.assertTrue(report.has_errors)
         self.assertIn("plugin.xml change-notes start at 2.7.5", messages(report))
 
+    def test_plugin_xml_change_notes_must_have_parseable_heading(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = make_repository(
+                Path(temporary_directory),
+                plugin_version="2.7.6",
+                plugin_xml_version="2.7.6",
+                changelog_text="""
+                    ## [2.7.6] - 2026-06-24
+
+                    - [Fix] Chrome tinting target preservation.
+
+                    ## [2.7.5] - 2026-06-18
+
+                    - [Fix] Groovy and Jenkinsfile colors.
+                """,
+            )
+            (root / "plugin.xml").write_text(
+                """
+                <idea-plugin>
+                  <change-notes><![CDATA[
+                    <p>No release heading</p>
+                  ]]></change-notes>
+                </idea-plugin>
+                """,
+                encoding="utf-8",
+            )
+
+            report = run_release_policy(root, features_data())
+
+        self.assertTrue(report.has_errors)
+        self.assertIn("must start with an `<h3>X.Y.Z</h3>`", messages(report))
+
 
 def make_repository(
     root: Path,

--- a/scripts/tests/test-release-policy.py
+++ b/scripts/tests/test-release-policy.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Tests for verify-docs semantic release policy."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from verify_docs import changelog  # noqa: E402
+from verify_docs.report import Report  # noqa: E402
+
+
+class VerifyReleasePolicyTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.original_changelog = changelog.CHANGELOG
+        self.original_gradle_properties = changelog.GRADLE_PROPERTIES
+        self.original_plugin_xml = changelog.PLUGIN_XML
+
+    def tearDown(self) -> None:
+        changelog.CHANGELOG = self.original_changelog
+        changelog.GRADLE_PROPERTIES = self.original_gradle_properties
+        changelog.PLUGIN_XML = self.original_plugin_xml
+
+    def test_fix_only_patch_release_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = make_repository(
+                Path(temporary_directory),
+                plugin_version="2.7.6",
+                plugin_xml_version="2.7.6",
+                changelog_text="""
+                    ## [2.7.6] - 2026-06-24
+
+                    - [Fix] Chrome tinting no longer colors shared dividers.
+
+                    ## [2.7.5] - 2026-06-18
+
+                    - [Paid] Accent Source status-bar widget.
+                """,
+            )
+
+            report = run_release_policy(root, features_data())
+
+        self.assertFalse(report.has_errors, report.findings)
+
+    def test_feature_introduced_requires_minor_bump(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = make_repository(
+                Path(temporary_directory),
+                plugin_version="2.7.6",
+                plugin_xml_version="2.7.6",
+                changelog_text="""
+                    ## [2.7.6] - 2026-06-24
+
+                    - [Paid] Accent Source status-bar widget.
+
+                    ## [2.7.5] - 2026-06-18
+
+                    - [Fix] Chrome tinting target preservation.
+                """,
+            )
+
+            report = run_release_policy(
+                root,
+                features_data(feature_id="accent-source-status-widget", introduced="2.7.6"),
+            )
+
+        self.assertTrue(report.has_errors)
+        self.assertIn("expects a minor bump", messages(report))
+
+    def test_feature_introduced_allows_minor_bump(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = make_repository(
+                Path(temporary_directory),
+                plugin_version="2.8.0",
+                plugin_xml_version="2.8.0",
+                changelog_text="""
+                    ## [2.8.0] - 2026-06-24
+
+                    - [Free] Syntax color controls.
+
+                    ## [2.7.6] - 2026-06-18
+
+                    - [Fix] Chrome tinting target preservation.
+                """,
+            )
+
+            report = run_release_policy(
+                root,
+                features_data(feature_id="syntax-color-controls", introduced="2.8.0"),
+            )
+
+        self.assertFalse(report.has_errors, report.findings)
+
+    def test_gradle_version_must_match_latest_changelog(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = make_repository(
+                Path(temporary_directory),
+                plugin_version="2.7.5",
+                plugin_xml_version="2.7.6",
+                changelog_text="""
+                    ## [2.7.6] - 2026-06-24
+
+                    - [Fix] Chrome tinting target preservation.
+
+                    ## [2.7.5] - 2026-06-18
+
+                    - [Fix] Groovy and Jenkinsfile colors.
+                """,
+            )
+
+            report = run_release_policy(root, features_data())
+
+        self.assertTrue(report.has_errors)
+        self.assertIn("pluginVersion is 2.7.5", messages(report))
+
+    def test_plugin_xml_change_notes_must_match_latest_changelog(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = make_repository(
+                Path(temporary_directory),
+                plugin_version="2.7.6",
+                plugin_xml_version="2.7.5",
+                changelog_text="""
+                    ## [2.7.6] - 2026-06-24
+
+                    - [Fix] Chrome tinting target preservation.
+
+                    ## [2.7.5] - 2026-06-18
+
+                    - [Fix] Groovy and Jenkinsfile colors.
+                """,
+            )
+
+            report = run_release_policy(root, features_data())
+
+        self.assertTrue(report.has_errors)
+        self.assertIn("plugin.xml change-notes start at 2.7.5", messages(report))
+
+
+def make_repository(
+    root: Path,
+    *,
+    plugin_version: str,
+    plugin_xml_version: str,
+    changelog_text: str,
+) -> Path:
+    plugin_xml = root / "plugin.xml"
+    plugin_xml.write_text(
+        f"""
+        <idea-plugin>
+          <change-notes><![CDATA[
+            <h3>{plugin_xml_version}</h3>
+          ]]></change-notes>
+        </idea-plugin>
+        """,
+        encoding="utf-8",
+    )
+    (root / "gradle.properties").write_text(
+        f"pluginVersion={plugin_version}\n",
+        encoding="utf-8",
+    )
+    (root / "CHANGELOG.md").write_text(
+        textwrap.dedent(changelog_text).strip() + "\n",
+        encoding="utf-8",
+    )
+    return root
+
+
+def run_release_policy(root: Path, data: dict[str, object]) -> Report:
+    changelog.CHANGELOG = root / "CHANGELOG.md"
+    changelog.GRADLE_PROPERTIES = root / "gradle.properties"
+    changelog.PLUGIN_XML = root / "plugin.xml"
+    report = Report()
+    changelog.check_semantic_release_policy(data, report)
+    return report
+
+
+def features_data(
+    *,
+    feature_id: str = "previous-feature",
+    introduced: str = "2.7.5",
+) -> dict[str, object]:
+    return {
+        "categories": {
+            "accent": {
+                "features": [
+                    {
+                        "id": feature_id,
+                        "introduced": introduced,
+                    }
+                ]
+            }
+        }
+    }
+
+
+def messages(report: Report) -> str:
+    return "\n".join(finding.message for finding in report.findings)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify-docs.py
+++ b/scripts/verify-docs.py
@@ -9,7 +9,7 @@ Thin entry point. All logic lives in the `verify_docs` package:
   plugin_xml     — <description> CDATA extractor
   git_utils      — merge-base / rev-parse / changed-since / SHA-256
   keywords       — Invariant 1 (README + plugin.xml keyword cross-ref)
-  changelog      — Invariant 2 (tier-tagged bullets ↔ introduced version)
+  changelog      — Invariants 2 + 7 (changelog ↔ features ↔ release bump)
   screenshots    — Invariant 3 (source freshness + byte-hash)
   stamps         — --update-hashes / --restamp mutators
   required_links — Invariant 4 (required substring appears in target file)

--- a/scripts/verify_docs/__init__.py
+++ b/scripts/verify_docs/__init__.py
@@ -11,7 +11,7 @@ Module map:
   plugin_xml     — <description> CDATA extractor
   git_utils      — merge-base / rev-parse / changed-since / SHA-256 helpers
   keywords       — Invariant 1 (README + plugin.xml keyword cross-ref)
-  changelog      — Invariant 2 (tier-tagged bullets ↔ introduced version)
+  changelog      — Invariants 2 + 7 (changelog ↔ features ↔ release bump)
   screenshots    — Invariant 3 (source freshness + byte-hash)
   stamps         — --update-hashes / --restamp mutators
   required_links — Invariant 4 (required substring appears in target file)

--- a/scripts/verify_docs/changelog.py
+++ b/scripts/verify_docs/changelog.py
@@ -107,7 +107,14 @@ def check_semantic_release_policy(data: dict[str, Any], report: Report) -> None:
         )
 
     plugin_xml_version = read_plugin_xml_change_notes_version()
-    if plugin_xml_version is not None and plugin_xml_version != latest.version:
+    if plugin_xml_version is None:
+        report.error(
+            "_release_semantics_",
+            "plugin.xml change-notes must start with an `<h3>X.Y.Z</h3>` "
+            "heading so Marketplace release notes point at the latest "
+            "CHANGELOG entry.",
+        )
+    elif plugin_xml_version != latest.version:
         report.error(
             "_release_semantics_",
             f"plugin.xml change-notes start at {plugin_xml_version}, but the "

--- a/scripts/verify_docs/changelog.py
+++ b/scripts/verify_docs/changelog.py
@@ -1,35 +1,71 @@
-"""Invariant 2: tier-tagged bullets in latest changelog map to features."""
+"""Invariant 2: changelog and semantic release policy."""
 
 from __future__ import annotations
 
 import re
-from typing import Any, cast
+from dataclasses import dataclass
+from typing import Any
 
 from .features import iter_features
-from .paths import CHANGELOG
+from .paths import CHANGELOG, GRADLE_PROPERTIES, PLUGIN_XML
 from .report import Report
 
 _VERSION_HEADER = re.compile(r"^##\s*\[(\d+\.\d+\.\d+)]", re.MULTILINE)
-_NEXT_HEADER = re.compile(r"^##\s*\[", re.MULTILINE)
-# `[^\n]+` instead of `.+` — `.+` plus surrounding `\s*` is what static
-# analysers flag as polynomial backtracking. `[^\n]+` is a single-char class
-# with no overlap, so the matcher is linear.
-_TIER_BULLET = re.compile(r"^\s*-\s*\[(Paid|Free)]\s*([^\n]+)$", re.MULTILINE)
+_TIER_TAGS = frozenset({"Paid", "Free"})
+
+
+@dataclass(frozen=True)
+class ChangelogSection:
+    version: str
+    tier_bullets: list[tuple[str, str]]
 
 
 def extract_latest_changelog_section() -> tuple[str, list[tuple[str, str]]]:
     """Return (version, [(tier, bullet_text), ...]) for the latest CHANGELOG section."""
+    latest, _previous = extract_latest_and_previous_changelog_sections()
+    return latest.version, latest.tier_bullets
+
+
+def extract_latest_and_previous_changelog_sections() -> tuple[ChangelogSection, ChangelogSection]:
+    """Return the two newest CHANGELOG sections."""
     text = CHANGELOG.read_text(encoding="utf-8")
-    match = _VERSION_HEADER.search(text)
-    if not match:
-        raise SystemExit("Could not find latest version header in CHANGELOG.md")
-    version: str = match[1]
+    matches = list(_VERSION_HEADER.finditer(text))
+    if len(matches) < 2:
+        raise SystemExit("CHANGELOG.md needs at least two version sections")
+    return (
+        extract_changelog_section(text, matches, 0),
+        extract_changelog_section(text, matches, 1),
+    )
+
+
+def extract_changelog_section(
+    text: str,
+    matches: list[re.Match[str]],
+    index: int,
+) -> ChangelogSection:
+    """Extract one CHANGELOG section from a version-header match list."""
+    match = matches[index]
     start = match.end()
-    next_match = _NEXT_HEADER.search(text, pos=start)
-    end = next_match.start() if next_match else len(text)
+    end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
     section = text[start:end]
-    bullets = cast(list[tuple[str, str]], _TIER_BULLET.findall(section))
-    return version, bullets
+    bullets = extract_tier_bullets(section)
+    return ChangelogSection(version=match[1], tier_bullets=bullets)
+
+
+def extract_tier_bullets(section: str) -> list[tuple[str, str]]:
+    """Return [(tier, bullet_text), ...] for [Paid]/[Free] bullets."""
+    bullets: list[tuple[str, str]] = []
+    for raw_line in section.splitlines():
+        line = raw_line.strip()
+        if not line.startswith("- ["):
+            continue
+        closing_bracket = line.find("]")
+        if closing_bracket < 0:
+            continue
+        tier = line[3:closing_bracket]
+        if tier in _TIER_TAGS:
+            bullets.append((tier, line[closing_bracket + 1 :].strip()))
+    return bullets
 
 
 def check_changelog_cross_ref(data: dict[str, Any], report: Report) -> None:
@@ -50,3 +86,154 @@ def check_changelog_cross_ref(data: dict[str, Any], report: Report) -> None:
             f"no features.yml entry with introduced: {version}. Add one feature "
             f"per new bullet or mark the bullets as bug-fixes (drop [Paid]/[Free]).",
         )
+
+
+def check_semantic_release_policy(data: dict[str, Any], report: Report) -> None:
+    """Invariant 7: features.yml drives semantic patch/minor release bumps."""
+    latest, previous = extract_latest_and_previous_changelog_sections()
+    plugin_version = read_plugin_version()
+    if plugin_version is None:
+        report.error(
+            "_release_semantics_",
+            "gradle.properties is missing a `pluginVersion=X.Y.Z` line — "
+            "semantic release policy cannot compare the release surfaces.",
+        )
+    elif plugin_version != latest.version:
+        report.error(
+            "_release_semantics_",
+            f"gradle.properties pluginVersion is {plugin_version}, but the "
+            f"latest CHANGELOG entry is {latest.version}. Keep the release "
+            "version and update index aligned.",
+        )
+
+    plugin_xml_version = read_plugin_xml_change_notes_version()
+    if plugin_xml_version is not None and plugin_xml_version != latest.version:
+        report.error(
+            "_release_semantics_",
+            f"plugin.xml change-notes start at {plugin_xml_version}, but the "
+            f"latest CHANGELOG entry is {latest.version}. Keep Marketplace "
+            "release notes aligned with the update index.",
+        )
+
+    actual_bump = classify_version_bump(previous.version, latest.version, report)
+    if actual_bump is None:
+        return
+
+    latest_features = [
+        feature
+        for feature in iter_features(data)
+        if feature.get("introduced") == latest.version
+    ]
+    expected_bump = "minor" if latest_features else "patch"
+    if actual_bump == expected_bump:
+        return
+
+    if latest_features:
+        feature_ids = ", ".join(
+            sorted(str(feature.get("id", "<missing-id>")) for feature in latest_features)
+        )
+        report.error(
+            "_release_semantics_",
+            f"features.yml has feature(s) introduced in {latest.version} "
+            f"({feature_ids}), so semantic policy expects a minor bump from "
+            f"{previous.version}; actual bump is {actual_bump}.",
+        )
+        return
+
+    report.error(
+        "_release_semantics_",
+        f"features.yml has no feature introduced in {latest.version}; "
+        f"fix-only releases should be patch bumps from {previous.version}, "
+        f"but actual bump is {actual_bump}.",
+    )
+
+
+def read_plugin_version() -> str | None:
+    """Extract pluginVersion=X.Y.Z from gradle.properties."""
+    for line in GRADLE_PROPERTIES.read_text(encoding="utf-8").splitlines():
+        key, separator, value = line.strip().partition("=")
+        if separator and key.strip() == "pluginVersion":
+            version = value.strip()
+            return version or None
+    return None
+
+
+def read_plugin_xml_change_notes_version() -> str | None:
+    """Return the first <h3>X.Y.Z</h3> version in plugin.xml change-notes."""
+    xml = PLUGIN_XML.read_text(encoding="utf-8")
+    change_notes_start = xml.find("<change-notes")
+    if change_notes_start < 0:
+        return None
+    open_tag_end = xml.find(">", change_notes_start)
+    if open_tag_end < 0:
+        return None
+    change_notes_end = xml.find("</change-notes>", open_tag_end)
+    if change_notes_end < 0:
+        return None
+    return extract_h3_version(xml[open_tag_end + 1 : change_notes_end])
+
+
+def extract_h3_version(text: str) -> str | None:
+    """Return the first exact X.Y.Z heading inside a change-notes block."""
+    heading_start = text.find("<h3>")
+    if heading_start < 0:
+        return None
+    version_start = heading_start + len("<h3>")
+    heading_end = text.find("</h3>", version_start)
+    if heading_end < 0:
+        return None
+    candidate = text[version_start:heading_end].strip()
+    try:
+        parse_version(candidate)
+    except ValueError:
+        return None
+    return candidate
+
+
+def classify_version_bump(previous: str, current: str, report: Report) -> str | None:
+    """Return the single-step semantic bump between two X.Y.Z versions."""
+    try:
+        previous_parts = parse_version(previous)
+        current_parts = parse_version(current)
+    except ValueError as error:
+        report.error("_release_semantics_", str(error))
+        return None
+
+    if current_parts <= previous_parts:
+        report.error(
+            "_release_semantics_",
+            f"latest CHANGELOG version {current} must be newer than {previous}.",
+        )
+        return None
+
+    previous_major, previous_minor, previous_patch = previous_parts
+    current_major, current_minor, current_patch = current_parts
+    if (
+        current_major == previous_major
+        and current_minor == previous_minor
+        and current_patch == previous_patch + 1
+    ):
+        return "patch"
+    if (
+        current_major == previous_major
+        and current_minor == previous_minor + 1
+        and current_patch == 0
+    ):
+        return "minor"
+    if current_major == previous_major + 1 and current_minor == 0 and current_patch == 0:
+        return "major"
+
+    report.error(
+        "_release_semantics_",
+        f"version moved from {previous} to {current}; expected exactly one "
+        "major, minor, or patch step.",
+    )
+    return None
+
+
+def parse_version(version: str) -> tuple[int, int, int]:
+    """Parse an X.Y.Z version into comparable integers."""
+    parts = version.split(".")
+    if len(parts) != 3:
+        raise ValueError(f"expected X.Y.Z version, got {version!r}")
+    return int(parts[0]), int(parts[1]), int(parts[2])

--- a/scripts/verify_docs/changelog.py
+++ b/scripts/verify_docs/changelog.py
@@ -243,4 +243,12 @@ def parse_version(version: str) -> tuple[int, int, int]:
     parts = version.split(".")
     if len(parts) != 3:
         raise ValueError(f"expected X.Y.Z version, got {version!r}")
-    return int(parts[0]), int(parts[1]), int(parts[2])
+    try:
+        major = int(parts[0])
+        minor = int(parts[1])
+        patch = int(parts[2])
+    except ValueError as error:
+        raise ValueError(
+            f"expected numeric X.Y.Z version, got {version!r}"
+        ) from error
+    return major, minor, patch

--- a/scripts/verify_docs/cli.py
+++ b/scripts/verify_docs/cli.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 
-from .changelog import check_changelog_cross_ref
+from .changelog import check_changelog_cross_ref, check_semantic_release_policy
 from .features import load_features
 from .inventory import check_asset_inventory
 from .keywords import check_keywords
@@ -60,6 +60,7 @@ def main() -> int:
     report = Report()
     check_keywords(data, report)
     check_changelog_cross_ref(data, report)
+    check_semantic_release_policy(data, report)
     check_screenshots(data, report)
     check_required_links(data, report)
     check_asset_inventory(data, report)


### PR DESCRIPTION
── Summary ─────────────────────────────────

Release version bumps can drift from the feature manifest when release notes are assembled manually. This adds semantic release validation to the existing `verify-docs.py` gate so `docs/features.yml` remains the source of truth for whether a release is patch-only or feature-bearing.

── Changes ─────────────────────────────────

| Type | File | Description |
|------|------|-------------|
| Feat | [changelog.py](scripts/verify_docs/changelog.py) | Adds release-surface checks for `pluginVersion`, `plugin.xml` change notes, and patch/minor bump consistency from `features.yml`. |
| Test | [test-release-policy.py](scripts/tests/test-release-policy.py) | Covers patch releases, feature-driven minor releases, and mismatched release surfaces. |
| CI | [build.yml](.github/workflows/build.yml) | Runs the release-policy tests before the existing docs sync gate. |
| Docs | [features.yml](docs/features.yml) | Documents the seventh `verify-docs.py` invariant. |

── Validation ──────────────────────────────

```bash
python3 scripts/tests/test-release-policy.py  # 5 tests pass
scripts/verify-docs.py                       # exits 0; existing orphaned SHA warnings remain
python3 scripts/tests/test-verify-plugin-verifier.py  # 4 tests pass
uv run --project scripts python scripts/tests/test-generate-campaign.py  # 41 tests pass
uv run --project scripts --with pyright pyright scripts/verify_docs/changelog.py scripts/tests/test-release-policy.py  # 0 errors
python3 -m compileall scripts/verify_docs scripts/tests/test-release-policy.py

git diff --check
```

── Notes ───────────────────────────────────

`verify-docs.py` remains the only production release-policy gate. The new test file avoids `docs` in its path because the global gitignore pattern `*docs*` blocks new paths with that substring.

## Summary by Sourcery

Enforce a semantic release policy by validating that changelog entries, gradle plugin version, plugin.xml change-notes, and features.yml stay aligned, and gate this via CI and tests.

Enhancements:
- Refine changelog parsing to support multiple sections and tier-tag detection for release validation.

CI:
- Add a CI step to run semantic release policy tests before the docs verification gate.

Documentation:
- Document a seventh verify-docs invariant describing the semantic release policy coupling versions and feature introductions.

Tests:
- Add unit tests covering semantic release policy behavior for patch vs minor releases and cross-file version mismatches.