### PR TITLE
fix(fonts): require consent proof for font installs

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -345,7 +345,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "5830d013"
+          last_verified_sha: "4d45e228"
           last_verified_date: "2026-06-16"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -345,7 +345,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "7ebe42d3"
+          last_verified_sha: "5830d013"
           last_verified_date: "2026-06-16"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -345,7 +345,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "4d45e228"
+          last_verified_sha: "bf81955a"
           last_verified_date: "2026-06-16"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 

--- a/src/main/kotlin/dev/ayuislands/font/FontCatalog.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontCatalog.kt
@@ -117,6 +117,13 @@ object FontCatalog {
      */
     fun forPreset(preset: FontPreset): Entry? = entries.firstOrNull { it.preset == preset }
 
+    internal fun requireCanonicalEntry(entry: Entry): Entry {
+        require(forPreset(entry.preset) === entry) {
+            "FontCatalog entry must be the canonical entry for preset ${entry.preset.name}"
+        }
+        return entry
+    }
+
     /**
      * Non-null variant for call sites that statically operate on curated presets
      * only — onboarding cards (which iterate a hardcoded `FONT_PRESETS` list) and

--- a/src/main/kotlin/dev/ayuislands/font/FontInstallConsent.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontInstallConsent.kt
@@ -26,8 +26,18 @@ import org.jetbrains.annotations.TestOnly
  * startup.
  */
 object FontInstallConsent {
+    sealed interface InstallConsent {
+        fun matches(entry: FontCatalog.Entry): Boolean
+    }
+
+    private data class GrantedInstallConsent(
+        private val preset: FontPreset,
+    ) : InstallConsent {
+        override fun matches(entry: FontCatalog.Entry): Boolean = preset == entry.preset
+    }
+
     /**
-     * Show an install consent dialog. Returns `true` if the user accepts.
+     * Show an install consent dialog. Returns a consent proof if the user accepts.
      *
      * @param entry the [FontCatalog.Entry] describing the font to install
      * @param project project scope for the modal; may be `null` in wizards
@@ -39,13 +49,15 @@ object FontInstallConsent {
         entry: FontCatalog.Entry,
         project: Project?,
         compact: Boolean = false,
-    ): Boolean {
+    ): InstallConsent? {
         val message = buildInstallMessage(entry, compact)
-        return MessageDialogBuilder
-            .yesNo("Install ${entry.displayName}?", message)
-            .yesText("Install")
-            .noText("Cancel")
-            .ask(project)
+        val accepted =
+            MessageDialogBuilder
+                .yesNo("Install ${entry.displayName}?", message)
+                .yesText("Install")
+                .noText("Cancel")
+                .ask(project)
+        return if (accepted) GrantedInstallConsent(entry.preset) else null
     }
 
     /**

--- a/src/main/kotlin/dev/ayuislands/font/FontInstallConsent.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontInstallConsent.kt
@@ -41,7 +41,7 @@ object FontInstallConsent {
     /**
      * Show an install consent dialog. Returns a consent proof if the user accepts.
      *
-     * @param entry the [FontCatalog.Entry] describing the font to install
+     * @param entry the canonical [FontCatalog.Entry] describing the font to install
      * @param project project scope for the modal; may be `null` in wizards
      *   that fire before any project window exists
      * @param compact shorter copy suitable for Settings; default is the
@@ -52,6 +52,7 @@ object FontInstallConsent {
         project: Project?,
         compact: Boolean = false,
     ): InstallConsent? {
+        FontCatalog.requireCanonicalEntry(entry)
         val message = buildInstallMessage(entry, compact)
         val accepted =
             MessageDialogBuilder

--- a/src/main/kotlin/dev/ayuislands/font/FontInstallConsent.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontInstallConsent.kt
@@ -30,10 +30,12 @@ object FontInstallConsent {
         fun matches(entry: FontCatalog.Entry): Boolean
     }
 
-    private data class GrantedInstallConsent(
-        private val preset: FontPreset,
+    private class GrantedInstallConsent(
+        private val entry: FontCatalog.Entry,
     ) : InstallConsent {
-        override fun matches(entry: FontCatalog.Entry): Boolean = preset == entry.preset
+        // Consent is for the exact catalog entry shown in the dialog; a
+        // structural copy must not drift install metadata away from consent.
+        override fun matches(entry: FontCatalog.Entry): Boolean = this.entry === entry
     }
 
     /**
@@ -57,7 +59,7 @@ object FontInstallConsent {
                 .yesText("Install")
                 .noText("Cancel")
                 .ask(project)
-        return if (accepted) GrantedInstallConsent(entry.preset) else null
+        return if (accepted) GrantedInstallConsent(entry) else null
     }
 
     /**

--- a/src/main/kotlin/dev/ayuislands/font/FontInstaller.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontInstaller.kt
@@ -56,15 +56,6 @@ object FontInstaller {
         PERMISSION_DENIED,
         DROPDOWN_STALE,
         APPLY_FAILED,
-
-        /**
-         * Caller invoked install/uninstall with a non-curated preset (CUSTOM)
-         * that has no install pipeline. Distinguishes "we deliberately skipped
-         * this" from `UNKNOWN` ("we have no idea what went wrong"). Notification
-         * code paths that route on `UNKNOWN` to "please file a bug" must not
-         * route on `NON_CURATED` — this is intentional plugin behaviour.
-         */
-        NON_CURATED,
         UNKNOWN,
     }
 
@@ -85,31 +76,18 @@ object FontInstaller {
      * or [InstallResult.Failure].
      */
     fun install(
-        preset: FontPreset,
+        entry: FontCatalog.Entry,
+        consent: FontInstallConsent.InstallConsent,
         project: Project?,
         onComplete: (InstallResult) -> Unit,
     ) {
-        // Non-curated presets (CUSTOM) have no install pipeline — the user
-        // already chose their own font. Reaching this from UI requires a
-        // visibility-gate bypass; log + fire onComplete with a Failure so
-        // callers that track progress (e.g. an onboarding spinner backed by
-        // installingFonts) don't hang waiting for a callback that never came.
-        val entry =
-            FontCatalog.forPreset(preset)
-                ?: run {
-                    LOG.warn("FontInstaller.install called for non-curated preset $preset; ignoring")
-                    onComplete(
-                        InstallResult.Failure(
-                            kind = FailureKind.NON_CURATED,
-                            message = "No catalog entry for preset ${preset.name} (non-curated)",
-                        ),
-                    )
-                    return
-                }
+        require(consent.matches(entry)) {
+            "Install consent does not match ${entry.preset.name}"
+        }
         val task =
             object : Task.Backgroundable(project, "Installing ${entry.displayName}…", true) {
                 override fun run(indicator: ProgressIndicator) {
-                    runPipeline(entry, preset, project, indicator, onComplete)
+                    runPipeline(entry, entry.preset, project, indicator, onComplete)
                 }
             }
         ProgressManager.getInstance().run(task)
@@ -444,9 +422,6 @@ object FontInstaller {
             FailureKind.APPLY_FAILED ->
                 "Installed, but couldn't apply automatically. " +
                     "Open Settings → Editor → Font to pick ${entry.familyName}."
-            FailureKind.NON_CURATED ->
-                "This preset has no install pipeline — set the editor font manually " +
-                    "in Settings → Editor → Font."
             FailureKind.UNKNOWN ->
                 "Unexpected error. Please report at $GH_ISSUES_URL."
         }

--- a/src/main/kotlin/dev/ayuislands/font/FontInstaller.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontInstaller.kt
@@ -37,8 +37,9 @@ import javax.net.ssl.SSLException
  * The entire pipeline (download + extract + copy + register) runs on a
  * [Task.Backgroundable] pool thread. Only the final apply step hops to the EDT.
  *
- * Every failure mode maps to a distinct notification; no exception ever escapes
- * to the caller.
+ * Runtime pipeline failures map to distinct notifications. Invalid caller
+ * preconditions, such as a non-canonical catalog entry or mismatched install
+ * consent, fail fast before a background task is queued.
  */
 object FontInstaller {
     private val LOG = logger<FontInstaller>()
@@ -74,6 +75,10 @@ object FontInstaller {
      * Full install pipeline. Shows background progress, runs off-EDT, fires
      * the [onComplete] callback on the EDT with either a [InstallResult.Success]
      * or [InstallResult.Failure].
+     *
+     * @throws IllegalArgumentException before dispatch when [entry] is not the
+     *   canonical catalog entry for its preset, or [consent] was not granted for
+     *   that exact entry
      */
     fun install(
         entry: FontCatalog.Entry,
@@ -81,6 +86,7 @@ object FontInstaller {
         project: Project?,
         onComplete: (InstallResult) -> Unit,
     ) {
+        FontCatalog.requireCanonicalEntry(entry)
         require(consent.matches(entry)) {
             "Install consent does not match ${entry.preset.name}"
         }

--- a/src/main/kotlin/dev/ayuislands/onboarding/PremiumOnboardingPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/onboarding/PremiumOnboardingPanel.kt
@@ -586,7 +586,7 @@ internal class PremiumOnboardingPanel(
                     if (!project.isDisposed) refreshFontRow()
                 }
             }
-        } catch (exception: RuntimeException) {
+        } catch (exception: IllegalArgumentException) {
             LOG.warn("Font install dispatch failed for ${preset.name}", exception)
             installingFonts.remove(preset)
             refreshFontRow()

--- a/src/main/kotlin/dev/ayuislands/onboarding/PremiumOnboardingPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/onboarding/PremiumOnboardingPanel.kt
@@ -576,14 +576,20 @@ internal class PremiumOnboardingPanel(
             FontInstaller.applyOnly(preset, project)
             return
         }
-        if (!FontInstallConsent.confirmInstall(entry, project)) return
+        val consent = FontInstallConsent.confirmInstall(entry, project) ?: return
         installingFonts.add(preset)
         refreshFontRow()
-        FontInstaller.install(preset, project) {
-            installingFonts.remove(preset)
-            ApplicationManager.getApplication().invokeLater {
-                if (!project.isDisposed) refreshFontRow()
+        try {
+            FontInstaller.install(entry, consent, project) {
+                installingFonts.remove(preset)
+                ApplicationManager.getApplication().invokeLater {
+                    if (!project.isDisposed) refreshFontRow()
+                }
             }
+        } catch (exception: RuntimeException) {
+            LOG.warn("Font install dispatch failed for ${preset.name}", exception)
+            installingFonts.remove(preset)
+            refreshFontRow()
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
@@ -293,8 +293,8 @@ class FontPresetPanel : AyuIslandsSettingsPanel {
                 if (!FontInstallConsent.confirmUninstall(entry, project, absPath)) return
                 FontUninstaller.uninstall(preset, project) { refresh() }
             } else {
-                if (!FontInstallConsent.confirmInstall(entry, project, compact = true)) return
-                FontInstaller.install(preset, project) { refresh() }
+                val consent = FontInstallConsent.confirmInstall(entry, project, compact = true) ?: return
+                FontInstaller.install(entry, consent, project) { refresh() }
             }
         } catch (e: RuntimeException) {
             LOG.warn("Font lifecycle action failed (uninstall=$uninstall, preset=$pendingPreset)", e)

--- a/src/test/kotlin/dev/ayuislands/font/FontInstallConsentTest.kt
+++ b/src/test/kotlin/dev/ayuislands/font/FontInstallConsentTest.kt
@@ -1,6 +1,9 @@
 package dev.ayuislands.font
 
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.MessageDialogBuilder
 import io.mockk.every
+import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import kotlin.test.AfterTest
@@ -23,6 +26,17 @@ class FontInstallConsentTest {
         unmockkAll()
     }
 
+    private fun acceptedInstallConsent(entry: FontCatalog.Entry): FontInstallConsent.InstallConsent {
+        mockkObject(MessageDialogBuilder.Companion)
+        val project = mockk<Project>(relaxed = true)
+        val dialog = mockk<MessageDialogBuilder.YesNo>(relaxed = true)
+        every { MessageDialogBuilder.yesNo(any<String>(), any<String>()) } returns dialog
+        every { dialog.yesText(any()) } returns dialog
+        every { dialog.noText(any()) } returns dialog
+        every { dialog.ask(project) } returns true
+        return FontInstallConsent.confirmInstall(entry, project) ?: error("Accepted dialog must return install consent")
+    }
+
     @Test
     fun `install message full copy includes license and path`() {
         val message = FontInstallConsent.buildInstallMessage(mapleEntry, compact = false)
@@ -41,6 +55,14 @@ class FontInstallConsentTest {
         assertTrue(message.contains("${mapleEntry.approxSizeMb} MB"))
         assertTrue(message.contains(mapleEntry.displayName))
         assertTrue(message.contains("~/Library/Fonts"))
+    }
+
+    @Test
+    fun `install consent proof matches only originating entry`() {
+        val consent = acceptedInstallConsent(mapleEntry)
+
+        assertTrue(consent.matches(mapleEntry))
+        assertFalse(consent.matches(FontCatalog.requirePreset(FontPreset.WHISPER)))
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/font/FontInstallConsentTest.kt
+++ b/src/test/kotlin/dev/ayuislands/font/FontInstallConsentTest.kt
@@ -9,6 +9,7 @@ import io.mockk.unmockkAll
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -49,6 +50,16 @@ class FontInstallConsentTest {
         val consent = installConsentForDialogAnswer(mapleEntry, accepted = false)
 
         assertNull(consent)
+    }
+
+    @Test
+    fun `install consent rejects copied catalog entry before dialog`() {
+        val error =
+            assertFailsWith<IllegalArgumentException> {
+                FontInstallConsent.confirmInstall(mapleEntry.copy(), project = null)
+            }
+
+        assertTrue(error.message?.contains("canonical entry") == true)
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/font/FontInstallConsentTest.kt
+++ b/src/test/kotlin/dev/ayuislands/font/FontInstallConsentTest.kt
@@ -10,6 +10,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class FontInstallConsentTest {
@@ -26,15 +27,28 @@ class FontInstallConsentTest {
         unmockkAll()
     }
 
-    private fun acceptedInstallConsent(entry: FontCatalog.Entry): FontInstallConsent.InstallConsent {
+    private fun installConsentForDialogAnswer(
+        entry: FontCatalog.Entry,
+        accepted: Boolean,
+    ): FontInstallConsent.InstallConsent? {
         mockkObject(MessageDialogBuilder.Companion)
         val project = mockk<Project>(relaxed = true)
         val dialog = mockk<MessageDialogBuilder.YesNo>(relaxed = true)
         every { MessageDialogBuilder.yesNo(any<String>(), any<String>()) } returns dialog
         every { dialog.yesText(any()) } returns dialog
         every { dialog.noText(any()) } returns dialog
-        every { dialog.ask(project) } returns true
-        return FontInstallConsent.confirmInstall(entry, project) ?: error("Accepted dialog must return install consent")
+        every { dialog.ask(project) } returns accepted
+        return FontInstallConsent.confirmInstall(entry, project)
+    }
+
+    private fun acceptedInstallConsent(entry: FontCatalog.Entry): FontInstallConsent.InstallConsent =
+        installConsentForDialogAnswer(entry, accepted = true) ?: error("Accepted dialog must return install consent")
+
+    @Test
+    fun `cancelled install dialog returns no consent proof`() {
+        val consent = installConsentForDialogAnswer(mapleEntry, accepted = false)
+
+        assertNull(consent)
     }
 
     @Test
@@ -60,9 +74,16 @@ class FontInstallConsentTest {
     @Test
     fun `install consent proof matches only originating entry`() {
         val consent = acceptedInstallConsent(mapleEntry)
+        val fabricatedEntry =
+            mapleEntry.copy(
+                fallbackUrl = "https://example.test/MapleMono-TTF.zip",
+                filesToKeep = listOf(".*InjectedFont\\.ttf$".toRegex()),
+            )
 
         assertTrue(consent.matches(mapleEntry))
+        assertFalse(consent.matches(mapleEntry.copy()))
         assertFalse(consent.matches(FontCatalog.requirePreset(FontPreset.WHISPER)))
+        assertFalse(consent.matches(fabricatedEntry))
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/font/FontInstallerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/font/FontInstallerTest.kt
@@ -330,6 +330,27 @@ class FontInstallerTest {
     }
 
     @Test
+    fun `install rejects copied entry even when preset still matches consent`() {
+        mockkStatic(com.intellij.openapi.progress.ProgressManager::class)
+        val progressMgr = mockk<com.intellij.openapi.progress.ProgressManager>(relaxed = true)
+        every {
+            com.intellij.openapi.progress.ProgressManager
+                .getInstance()
+        } returns progressMgr
+        val entry = FontCatalog.requirePreset(FontPreset.AMBIENT)
+        val copiedEntry = entry.copy()
+        val consent = acceptedInstallConsent(entry)
+
+        val error =
+            assertFailsWith<IllegalArgumentException> {
+                FontInstaller.install(copiedEntry, consent, project = null) { }
+            }
+
+        assertEquals("Install consent does not match AMBIENT", error.message)
+        verify(exactly = 0) { progressMgr.run(any<com.intellij.openapi.progress.Task.Backgroundable>()) }
+    }
+
+    @Test
     fun `applyOnly invokes applicator with CUSTOM-decoded settings for non-curated preset`() {
         // Assert applicator runs with the RIGHT preset, not any preset. An
         // earlier version used `any()` and would pass on a future refactor

--- a/src/test/kotlin/dev/ayuislands/font/FontInstallerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/font/FontInstallerTest.kt
@@ -1,6 +1,7 @@
 package dev.ayuislands.font
 
 import com.intellij.notification.Notification
+import com.intellij.notification.NotificationType
 import com.intellij.notification.Notifications
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
@@ -30,13 +31,12 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 /**
- * Unit tests for [FontInstaller] helpers. The full [FontInstaller.install] pipeline
- * requires a real [com.intellij.openapi.project.Project] and live HTTP, so it is
- * tested only indirectly by exercising the internal helpers that `runPipeline`
- * delegates to.
+ * Unit tests for [FontInstaller] helper branches plus the cache-backed failure path
+ * reachable from the queued [FontInstaller.install] task.
  */
 class FontInstallerTest {
     private val tmpRoot: File = createTempDirectory("ayu-font-installer-test").toFile()
@@ -52,6 +52,7 @@ class FontInstallerTest {
         entries: Map<String, ByteArray>,
     ): File {
         val file = File(tmpRoot, name)
+        file.parentFile?.mkdirs()
         ZipOutputStream(file.outputStream().buffered()).use { zip ->
             for ((entryName, data) in entries) {
                 zip.putNextEntry(ZipEntry(entryName))
@@ -307,6 +308,59 @@ class FontInstallerTest {
         FontInstaller.install(entry, consent, project = null) { }
 
         verify(exactly = 1) { progressMgr.run(any<com.intellij.openapi.progress.Task.Backgroundable>()) }
+    }
+
+    @Test
+    fun `install queued task reports asset missing when cached archive lacks font file`() {
+        mockkStatic(com.intellij.openapi.progress.ProgressManager::class)
+        mockkStatic(PathManager::class)
+        mockkStatic(ApplicationManager::class)
+        mockkStatic(Notifications.Bus::class)
+        val progressMgr = mockk<com.intellij.openapi.progress.ProgressManager>(relaxed = true)
+        val appMock = mockk<Application>(relaxed = true)
+        val capturedTasks = mutableListOf<com.intellij.openapi.progress.Task.Backgroundable>()
+        every {
+            com.intellij.openapi.progress.ProgressManager
+                .getInstance()
+        } returns progressMgr
+        every { progressMgr.run(any<com.intellij.openapi.progress.Task.Backgroundable>()) } answers {
+            capturedTasks += firstArg<com.intellij.openapi.progress.Task.Backgroundable>()
+        }
+        every { PathManager.getTempPath() } returns tmpRoot.absolutePath
+        every { ApplicationManager.getApplication() } returns appMock
+        every { appMock.invokeLater(any()) } answers { firstArg<Runnable>().run() }
+        every { Notifications.Bus.notify(any<Notification>(), null) } answers { }
+        val entry =
+            FontCatalog.requirePreset(FontPreset.AMBIENT).copy(
+                fallbackUrl = "https://example.invalid/stale-maple.zip",
+                useDirectUrl = true,
+            )
+        val consent = acceptedInstallConsent(entry)
+        // Seed the exact cache path cachedZipFile derives from fallbackUrl; the existing
+        // non-empty zip keeps downloadZip offline and drives extraction into ASSET_NOT_FOUND.
+        val cachedZip = makeZip("ayu-fonts/stale-maple.zip", mapOf("README.md" to "docs".toByteArray()))
+        assertEquals(cachedZip.absolutePath, FontInstaller.cachedZipFile(entry.fallbackUrl, entry.preset).absolutePath)
+        var result: FontInstaller.InstallResult? = null
+
+        FontInstaller.install(entry, consent, project = null) { result = it }
+        capturedTasks.single().run(mockk(relaxed = true))
+
+        val completedResult = assertNotNull(result, "Install task should report a result")
+        assertTrue(
+            completedResult is FontInstaller.InstallResult.Failure,
+            "Expected install failure, got: $completedResult",
+        )
+        val failure = completedResult
+        assertEquals(FontInstaller.FailureKind.ASSET_NOT_FOUND, failure.kind)
+        verify(exactly = 1) {
+            Notifications.Bus.notify(
+                match<Notification> {
+                    it.type == NotificationType.ERROR &&
+                        it.content.contains("GitHub didn't return the expected asset")
+                },
+                null,
+            )
+        }
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/font/FontInstallerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/font/FontInstallerTest.kt
@@ -330,15 +330,11 @@ class FontInstallerTest {
         every { ApplicationManager.getApplication() } returns appMock
         every { appMock.invokeLater(any()) } answers { firstArg<Runnable>().run() }
         every { Notifications.Bus.notify(any<Notification>(), null) } answers { }
-        val entry =
-            FontCatalog.requirePreset(FontPreset.AMBIENT).copy(
-                fallbackUrl = "https://example.invalid/stale-maple.zip",
-                useDirectUrl = true,
-            )
+        val entry = FontCatalog.requirePreset(FontPreset.WHISPER)
         val consent = acceptedInstallConsent(entry)
         // Seed the exact cache path cachedZipFile derives from fallbackUrl; the existing
         // non-empty zip keeps downloadZip offline and drives extraction into ASSET_NOT_FOUND.
-        val cachedZip = makeZip("ayu-fonts/stale-maple.zip", mapOf("README.md" to "docs".toByteArray()))
+        val cachedZip = makeZip("ayu-fonts/VictorMonoAll.zip", mapOf("README.md" to "docs".toByteArray()))
         assertEquals(cachedZip.absolutePath, FontInstaller.cachedZipFile(entry.fallbackUrl, entry.preset).absolutePath)
         var result: FontInstaller.InstallResult? = null
 
@@ -384,7 +380,7 @@ class FontInstallerTest {
     }
 
     @Test
-    fun `install rejects copied entry even when preset still matches consent`() {
+    fun `install rejects copied catalog entry before queuing background task`() {
         mockkStatic(com.intellij.openapi.progress.ProgressManager::class)
         val progressMgr = mockk<com.intellij.openapi.progress.ProgressManager>(relaxed = true)
         every {
@@ -400,7 +396,7 @@ class FontInstallerTest {
                 FontInstaller.install(copiedEntry, consent, project = null) { }
             }
 
-        assertEquals("Install consent does not match AMBIENT", error.message)
+        assertTrue(error.message?.contains("canonical entry") == true)
         verify(exactly = 0) { progressMgr.run(any<com.intellij.openapi.progress.Task.Backgroundable>()) }
     }
 

--- a/src/test/kotlin/dev/ayuislands/font/FontInstallerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/font/FontInstallerTest.kt
@@ -5,6 +5,8 @@ import com.intellij.notification.Notifications
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.MessageDialogBuilder
 import com.intellij.openapi.util.SystemInfo
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
@@ -26,6 +28,7 @@ import kotlin.io.path.createTempDirectory
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -57,6 +60,17 @@ class FontInstallerTest {
             }
         }
         return file
+    }
+
+    private fun acceptedInstallConsent(entry: FontCatalog.Entry): FontInstallConsent.InstallConsent {
+        mockkObject(MessageDialogBuilder.Companion)
+        val project = mockk<Project>(relaxed = true)
+        val dialog = mockk<MessageDialogBuilder.YesNo>(relaxed = true)
+        every { MessageDialogBuilder.yesNo(any<String>(), any<String>()) } returns dialog
+        every { dialog.yesText(any()) } returns dialog
+        every { dialog.noText(any()) } returns dialog
+        every { dialog.ask(project) } returns true
+        return FontInstallConsent.confirmInstall(entry, project) ?: error("Accepted dialog must return install consent")
     }
 
     @Test
@@ -280,25 +294,38 @@ class FontInstallerTest {
     }
 
     @Test
-    fun `install fires NON_CURATED Failure callback and skips ProgressManager`() {
-        // Visibility-gate bypass with CUSTOM must NOT hang the caller waiting
-        // for a callback that never fires. Failure must use the typed
-        // NON_CURATED kind (not UNKNOWN — that copy reads "Please report",
-        // misleading users about an intentional skip). Task is never queued.
+    fun `install with matching consent queues background task`() {
         mockkStatic(com.intellij.openapi.progress.ProgressManager::class)
         val progressMgr = mockk<com.intellij.openapi.progress.ProgressManager>(relaxed = true)
         every {
             com.intellij.openapi.progress.ProgressManager
                 .getInstance()
         } returns progressMgr
+        val entry = FontCatalog.requirePreset(FontPreset.AMBIENT)
+        val consent = acceptedInstallConsent(entry)
 
-        var captured: FontInstaller.InstallResult? = null
-        FontInstaller.install(FontPreset.CUSTOM, project = null) { captured = it }
+        FontInstaller.install(entry, consent, project = null) { }
 
-        val failure = captured as? FontInstaller.InstallResult.Failure
-        assertTrue(failure != null, "non-curated install must fire Failure callback, got: $captured")
-        assertEquals(FontInstaller.FailureKind.NON_CURATED, failure.kind)
-        assertTrue(failure.message.contains("non-curated"), "message must signal non-curated origin")
+        verify(exactly = 1) { progressMgr.run(any<com.intellij.openapi.progress.Task.Backgroundable>()) }
+    }
+
+    @Test
+    fun `install with mismatched consent fails before queuing background task`() {
+        mockkStatic(com.intellij.openapi.progress.ProgressManager::class)
+        val progressMgr = mockk<com.intellij.openapi.progress.ProgressManager>(relaxed = true)
+        every {
+            com.intellij.openapi.progress.ProgressManager
+                .getInstance()
+        } returns progressMgr
+        val entry = FontCatalog.requirePreset(FontPreset.AMBIENT)
+        val consent = acceptedInstallConsent(FontCatalog.requirePreset(FontPreset.WHISPER))
+
+        val error =
+            assertFailsWith<IllegalArgumentException> {
+                FontInstaller.install(entry, consent, project = null) { }
+            }
+
+        assertTrue(error.message?.contains("Install consent does not match") == true)
         verify(exactly = 0) { progressMgr.run(any<com.intellij.openapi.progress.Task.Backgroundable>()) }
     }
 

--- a/src/test/kotlin/dev/ayuislands/settings/FontPresetPanelCustomRegressionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/FontPresetPanelCustomRegressionTest.kt
@@ -2,7 +2,9 @@ package dev.ayuislands.settings
 
 import com.intellij.openapi.observable.properties.AtomicBooleanProperty
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.font.FontCatalog
 import dev.ayuislands.font.FontDetector
+import dev.ayuislands.font.FontInstallConsent
 import dev.ayuislands.font.FontInstaller
 import dev.ayuislands.font.FontPreset
 import dev.ayuislands.font.FontStatus
@@ -246,7 +248,14 @@ class FontPresetPanelCustomRegressionTest {
         method.invoke(panel, false) // install attempt
         method.invoke(panel, true) // uninstall attempt
 
-        verify(exactly = 0) { FontInstaller.install(any(), any(), any()) }
+        verify(exactly = 0) {
+            FontInstaller.install(
+                any<FontCatalog.Entry>(),
+                any<FontInstallConsent.InstallConsent>(),
+                any(),
+                any(),
+            )
+        }
         verify(exactly = 0) { FontUninstaller.uninstall(any(), any(), any()) }
     }
 


### PR DESCRIPTION
── Summary ─────────────────────────────────

Font installation now has an explicit consent boundary at the installer API, not only at the current UI call sites.

**Why**: the settings and onboarding flows already showed confirmation dialogs, but `FontInstaller.install` could still be called later without proof that consent was obtained for the same curated font entry.

── Changes ─────────────────────────────────

| Type | File | Description |
|------|------|-------------|
| Fix | [FontInstallConsent.kt](src/main/kotlin/dev/ayuislands/font/FontInstallConsent.kt) | Return an opaque install consent token only after the user accepts the dialog. |
| Fix | [FontInstaller.kt](src/main/kotlin/dev/ayuislands/font/FontInstaller.kt) | Require a matching `FontCatalog.Entry` + consent token before queueing font installation. |
| Fix | [FontPresetPanel.kt](src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt) | Pass the consent token from the settings dialog into the installer. |
| Fix | [PremiumOnboardingPanel.kt](src/main/kotlin/dev/ayuislands/onboarding/PremiumOnboardingPanel.kt) | Pass consent from onboarding and clean up installing state if dispatch fails. |
| Test | [FontInstallerTest.kt](src/test/kotlin/dev/ayuislands/font/FontInstallerTest.kt) | Cover matching and mismatched consent behavior. |
| Test | [FontInstallConsentTest.kt](src/test/kotlin/dev/ayuislands/font/FontInstallConsentTest.kt) | Cover consent proof matching for its originating catalog entry. |
| Docs | [features.yml](docs/features.yml) | Re-stamp the font-install feature manifest after non-visual source changes. |

── Validation ──────────────────────────────

```bash
./gradlew detekt ktlintCheck
# BUILD SUCCESSFUL

./gradlew test --tests "dev.ayuislands.font.FontInstallConsentTest" --tests "dev.ayuislands.font.FontInstallerTest" --tests "dev.ayuislands.settings.FontPresetPanelCustomRegressionTest"
# BUILD SUCCESSFUL

./gradlew test
# BUILD SUCCESSFUL

scripts/verify-docs.py
# docs/features.yml in sync with README + plugin.xml + CHANGELOG
```

Local IDE verification:

```bash
./gradlew buildPlugin --no-build-cache --rerun-tasks
# BUILD SUCCESSFUL
```

Installed `ayu-jetbrains-2.7.6.jar` into `IntelliJIdea2026.1`, verified key classes with `javap`, and restarted IntelliJ successfully.

── Notes ───────────────────────────────────

No screenshot asset was recaptured because this changes the consent contract and call-site safety, not the visible font presets UI. `content_sha256` stays unchanged; only `last_verified_sha` is re-stamped for the affected feature.

## Summary by Sourcery

Enforce explicit, entry-bound consent for curated font installations and update callers, error handling, tests, and documentation accordingly.

Bug Fixes:
- Require an opaque install consent token that matches the requested font catalog entry before queuing installation tasks.
- Remove support for invoking installation on non-curated presets and ensure mismatched consent fails fast without starting background work.
- Ensure onboarding and settings panels pass through consent tokens to the installer and clean up installing state when dispatch fails.

Enhancements:
- Introduce an install consent abstraction that encodes which curated preset was approved and validates it against catalog entries.
- Adjust font lifecycle UI flows to work with entry-based installation rather than preset-only calls.

Documentation:
- Restamp the font-install feature manifest metadata to reflect the updated consent and installation behavior.

Tests:
- Add tests covering consent token creation, matching behavior, and installer behavior for matching vs mismatched consent.
- Update regression tests to assert that custom presets do not attempt to invoke the installer under the new API.