### PR TITLE
chore(release): prepare v2.7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [2.7.7] - 2026-07-01
+
+- [Fix] **Language override diagnostics** — Settings and Quick-Switcher now show
+  the detected project-language breakdown, manual forced-language state,
+  polyglot fallback detail, and the language that actually won accent
+  resolution.
+- [Fix] **Mapped accents in mixed-language projects** — polyglot scans can now
+  choose the highest-weight detected language that has a user accent mapping,
+  so balanced projects can still use a configured language color instead of
+  falling back to the global accent.
+- [Fix] **Swift and Noctule Swift highlighting** — Swift declaration and
+  reference aliases, predefined symbols, and `nil` fallback now use Ayu-native
+  semantic colors across Dark, Mirage, and Light.
+- [Fix] **Project fallback accents** — project fallback resolution now warms and
+  reuses the detector verdict consistently, keeping diagnostics aligned with
+  the accent that gets applied.
+- [Fix] **Font install consent** — Settings and onboarding font installs now
+  require the exact catalog entry that the user approved before any font files
+  are queued for installation.
+
 ## [2.7.6] - 2026-06-24
 
 - [Fix] **Language override diagnostics** — Quick-Switcher now keeps

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.7.6
+pluginVersion=2.7.7
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
@@ -55,6 +55,14 @@ internal object UpdateNotifier {
 
     private val RELEASE_NOTES =
         mapOf(
+            "2.7.7" to
+                releaseNotes(
+                    "[Fix] Language diagnostics show detected breakdowns, manual state, and the winning accent source",
+                    "[Fix] Mapped languages can win in balanced polyglot projects instead of falling back globally",
+                    "[Fix] Swift and Noctule Swift aliases, predefined symbols, and nil fallback use Ayu colors",
+                    "[Fix] Project fallback accents reuse warmed detector verdicts for matching diagnostics",
+                    "[Fix] Font installs require the exact catalog entry approved in the consent dialog",
+                ),
             "2.7.6" to
                 releaseNotes(
                     "[Fix] Language override diagnostics keep full details in the compact resolution chain",

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -117,6 +117,14 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>2.7.7</h3>
+    <ul>
+      <li>[Fix] <b>Language override diagnostics</b> — Settings and Quick-Switcher now show the detected project-language breakdown, manual forced-language state, polyglot fallback detail, and the language that actually won accent resolution.</li>
+      <li>[Fix] <b>Mapped accents in mixed-language projects</b> — polyglot scans can now choose the highest-weight detected language that has a user accent mapping, so balanced projects can still use a configured language color instead of falling back to the global accent.</li>
+      <li>[Fix] <b>Swift and Noctule Swift highlighting</b> — Swift declaration and reference aliases, predefined symbols, and <code>nil</code> fallback now use Ayu-native semantic colors across Dark, Mirage, and Light.</li>
+      <li>[Fix] <b>Project fallback accents</b> — project fallback resolution now warms and reuses the detector verdict consistently, keeping diagnostics aligned with the accent that gets applied.</li>
+      <li>[Fix] <b>Font install consent</b> — Settings and onboarding font installs now require the exact catalog entry that the user approved before any font files are queued for installation.</li>
+    </ul>
     <h3>2.7.6</h3>
     <ul>
       <li>[Fix] <b>Language override diagnostics</b> — Quick-Switcher now keeps dominant-language proportions and fallback detail in the expanded resolution chain instead of crowding or overlapping the collapsed widget.</li>


### PR DESCRIPTION
## Summary
- Bump pluginVersion to 2.7.7
- Add 2.7.7 changelog, Marketplace change notes, and update notification notes
- Keep product-descriptor release-date tied to release-version 27

## Verification
- python3 scripts/tests/test-release-policy.py
- scripts/verify-docs.py
- ./gradlew clean buildPlugin
- ./gradlew verifyPlugin

## Summary by Sourcery

Prepare the 2.7.7 plugin release by bumping the version, updating changelog and in-IDE release notes, and shipping a set of language diagnostics, accent resolution, Swift highlighting, and font consent fixes.

Bug Fixes:
- Improve language override diagnostics visibility across settings and Quick-Switcher.
- Ensure mapped accents can win in balanced polyglot projects instead of falling back to a global accent.
- Align Swift and Noctule Swift syntax highlighting with Ayu-native semantic colors.
- Stabilize project fallback accent resolution to keep diagnostics consistent with applied accents.
- Tighten font installation consent to require the exact catalog entry the user approved.

Enhancements:
- Update in-IDE change notes and update notification messaging for the 2.7.7 release.

Build:
- Bump pluginVersion to 2.7.7 in build configuration.