### PR TITLE
Harden quality backlog checks and coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,11 +35,3 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
-    ignore:
-      # IntelliJ Platform Gradle Plugin 2.14.0 regressed TestFrameworkType.Platform
-      # — com.intellij.testFramework.LoggedErrorProcessor disappears from test classpath,
-      # breaking LicenseTransitionListenerTest + AccentRotationServiceTest (see PR #123).
-      # Lift when 2.14.x fixes resolution or after verifying an alternative
-      # TestFrameworkType variant exposes the class.
-      - dependency-name: "org.jetbrains.intellij.platform"
-        versions: [">= 2.14.0"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,6 +104,10 @@ jobs:
         run: uv run --project scripts python scripts/tests/test-generate-campaign.py
       - name: Test Plugin Verifier API gate
         run: python3 scripts/tests/test-verify-plugin-verifier.py
+      - name: Test font fallback URL smoke
+        run: python3 scripts/tests/test-verify-font-fallback-urls.py
+      - name: Verify font fallback URLs
+        run: python3 scripts/verify-font-fallback-urls.py
       - name: Test release policy
         run: python3 scripts/tests/test-release-policy.py
       - name: Verify docs sync (features.yml ↔ README + plugin.xml + CHANGELOG)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -279,7 +279,7 @@ jobs:
     if: github.event_name != 'push'
     runs-on: ubuntu-latest
     needs: build
-    timeout-minutes: 20
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,6 +45,9 @@ jobs:
           persist-credentials: false
 
       - if: matrix.language == 'java-kotlin'
+        uses: ./.github/actions/free-disk-space
+
+      - if: matrix.language == 'java-kotlin'
         uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
         with:
           distribution: temurin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ buildscript {
 }
 
 plugins {
-    id("org.jetbrains.intellij.platform") version "2.13.1"
+    id("org.jetbrains.intellij.platform") version "2.17.0"
     kotlin("jvm") version "2.4.0"
     id("org.jetbrains.kotlinx.kover") version "0.9.8"
     id("org.jlleitschuh.gradle.ktlint") version "14.2.0"

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "eac4ceae"
+          last_verified_sha: "c3c5dfd8"
           last_verified_date: "2026-06-30"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "eac4ceae"
+          last_verified_sha: "c3c5dfd8"
           last_verified_date: "2026-06-30"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -345,7 +345,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "541e2d7d"
+          last_verified_sha: "94d81354"
           last_verified_date: "2026-06-16"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "35cb40ad"
+          last_verified_sha: "c4e78c94"
           last_verified_date: "2026-06-30"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "35cb40ad"
+          last_verified_sha: "c4e78c94"
           last_verified_date: "2026-06-30"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "c3c5dfd8"
+          last_verified_sha: "35cb40ad"
           last_verified_date: "2026-06-30"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "c3c5dfd8"
+          last_verified_sha: "35cb40ad"
           last_verified_date: "2026-06-30"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "c4e78c94"
+          last_verified_sha: "00b24139"
           last_verified_date: "2026-06-30"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "c4e78c94"
+          last_verified_sha: "00b24139"
           last_verified_date: "2026-06-30"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/scripts/tests/test-verify-font-fallback-urls.py
+++ b/scripts/tests/test-verify-font-fallback-urls.py
@@ -139,6 +139,56 @@ class VerifyFontFallbackUrlsTest(unittest.TestCase):
         self.assertEqual("BAD_URL", results[0].constant_name)
         self.assertIn("URL can't contain control characters", results[0].error)
 
+    def test_checker_retries_transient_exception_then_succeeds(self) -> None:
+        attempts = 0
+        slept: list[float] = []
+
+        def flaky_opener(
+            _request: urllib.request.Request,
+            _timeout: float,
+        ) -> FakeResponse:
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise urllib.error.URLError("temporary timeout")
+            return FakeResponse(200)
+
+        results = verifier.check_fallback_urls(
+            [verifier.FallbackUrl("FLAKY_URL", "https://example.com/flaky.zip")],
+            opener=flaky_opener,
+            retries=2,
+            retry_delay_seconds=0.25,
+            sleeper=slept.append,
+        )
+
+        self.assertEqual(2, attempts)
+        self.assertEqual([0.25], slept)
+        self.assertEqual(1, len(results))
+        self.assertTrue(results[0].is_success)
+
+    def test_checker_does_not_retry_non_retryable_http_status(self) -> None:
+        attempts = 0
+
+        def missing_opener(
+            _request: urllib.request.Request,
+            _timeout: float,
+        ) -> FakeResponse:
+            nonlocal attempts
+            attempts += 1
+            return FakeResponse(404)
+
+        results = verifier.check_fallback_urls(
+            [verifier.FallbackUrl("MISSING_URL", "https://example.com/missing.zip")],
+            opener=missing_opener,
+            retries=2,
+            sleeper=lambda _delay: self.fail("404 must not retry"),
+        )
+
+        self.assertEqual(1, attempts)
+        self.assertEqual(1, len(results))
+        self.assertFalse(results[0].is_success)
+        self.assertEqual("HTTP 404", results[0].error)
+
     def test_main_returns_0_for_http_200_success(self) -> None:
         requests: list[tuple[urllib.request.Request, float]] = []
 
@@ -211,6 +261,7 @@ def run_main(
             exit_code = verifier.main(
                 ["--font-catalog", str(catalog_path), "--timeout", "3.0"],
                 opener=opener,
+                sleeper=lambda _delay: None,
             )
 
     return exit_code, stdout.getvalue(), stderr.getvalue()

--- a/scripts/tests/test-verify-font-fallback-urls.py
+++ b/scripts/tests/test-verify-font-fallback-urls.py
@@ -166,6 +166,17 @@ class VerifyFontFallbackUrlsTest(unittest.TestCase):
         self.assertEqual(1, len(results))
         self.assertTrue(results[0].is_success)
 
+    def test_checker_treats_http_204_as_success(self) -> None:
+        results = verifier.check_fallback_urls(
+            [verifier.FallbackUrl("NO_BODY_URL", "https://example.com/no-body.zip")],
+            opener=lambda _request, _timeout: FakeResponse(204),
+            retries=0,
+        )
+
+        self.assertEqual(1, len(results))
+        self.assertTrue(results[0].is_success)
+        self.assertIsNone(results[0].error)
+
     def test_checker_does_not_retry_non_retryable_http_status(self) -> None:
         attempts = 0
 
@@ -189,6 +200,45 @@ class VerifyFontFallbackUrlsTest(unittest.TestCase):
         self.assertFalse(results[0].is_success)
         self.assertEqual("HTTP 404", results[0].error)
 
+    def test_main_rejects_non_positive_timeout(self) -> None:
+        exit_code, _stdout, stderr = run_main_args(
+            ["--timeout", "0", "--retries", "0", "--retry-delay", "0"],
+        )
+
+        self.assertEqual(2, exit_code)
+        self.assertIn("--timeout must be greater than 0", stderr)
+
+    def test_main_rejects_negative_retries(self) -> None:
+        exit_code, _stdout, stderr = run_main_args(
+            ["--timeout", "10", "--retries", "-1", "--retry-delay", "0"],
+        )
+
+        self.assertEqual(2, exit_code)
+        self.assertIn("--retries must be greater than or equal to 0", stderr)
+
+    def test_main_rejects_negative_retry_delay(self) -> None:
+        exit_code, _stdout, stderr = run_main_args(
+            ["--timeout", "10", "--retries", "0", "--retry-delay", "-1"],
+        )
+
+        self.assertEqual(2, exit_code)
+        self.assertIn("--retry-delay must be greater than or equal to 0", stderr)
+
+    def test_check_fallback_urls_rejects_negative_retries(self) -> None:
+        with self.assertRaisesRegex(ValueError, "retries"):
+            verifier.check_fallback_urls(
+                [verifier.FallbackUrl("GOOD_URL", "https://example.com/good.zip")],
+                retries=-1,
+            )
+
+    def test_check_fallback_urls_rejects_negative_retry_delay(self) -> None:
+        with self.assertRaisesRegex(ValueError, "retry_delay_seconds"):
+            verifier.check_fallback_urls(
+                [verifier.FallbackUrl("GOOD_URL", "https://example.com/good.zip")],
+                retries=0,
+                retry_delay_seconds=-1,
+            )
+
     def test_main_returns_0_for_http_200_success(self) -> None:
         requests: list[tuple[urllib.request.Request, float]] = []
 
@@ -208,6 +258,10 @@ class VerifyFontFallbackUrlsTest(unittest.TestCase):
         self.assertIn("1 URL(s) checked", stdout)
         self.assertEqual("HEAD", requests[0][0].get_method())
         self.assertEqual(3.0, requests[0][1])
+        self.assertEqual(
+            verifier.USER_AGENT,
+            requests[0][0].headers["User-agent"],
+        )
 
 
 class FakeResponse:
@@ -263,6 +317,21 @@ def run_main(
                 opener=opener,
                 sleeper=lambda _delay: None,
             )
+
+    return exit_code, stdout.getvalue(), stderr.getvalue()
+
+
+def run_main_args(
+    argv: list[str],
+) -> tuple[int, str, str]:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with redirect_stdout(stdout), redirect_stderr(stderr):
+        exit_code = verifier.main(
+            argv,
+            opener=successful_opener,
+            sleeper=lambda _delay: None,
+        )
 
     return exit_code, stdout.getvalue(), stderr.getvalue()
 

--- a/scripts/tests/test-verify-font-fallback-urls.py
+++ b/scripts/tests/test-verify-font-fallback-urls.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Tests for verify-font-fallback-urls.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import http.client
+import io
+import sys
+import tempfile
+import textwrap
+import unittest
+import urllib.error
+import urllib.request
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import TracebackType
+from typing import Callable
+
+SCRIPT = Path(__file__).resolve().parent.parent / "verify-font-fallback-urls.py"
+
+spec = importlib.util.spec_from_file_location("verify_font_fallback_urls", SCRIPT)
+if spec is None or spec.loader is None:
+    raise RuntimeError(f"Unable to load {SCRIPT}")
+verifier = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = verifier
+spec.loader.exec_module(verifier)
+
+
+class VerifyFontFallbackUrlsTest(unittest.TestCase):
+    def test_extracts_only_constants_referenced_as_fallback_url(self) -> None:
+        entries = verifier.extract_fallback_urls(
+            """
+            object FontCatalog {
+                private const val USED_URL = "https://example.com/used.zip"
+                private const val UNUSED_URL = "https://example.com/unused.zip"
+                private const val SECOND_URL =
+                    "https://example.com/second.zip"
+
+                val entries = listOf(
+                    Entry(fallbackUrl = USED_URL),
+                    Entry(fallbackUrl = SECOND_URL),
+                    Entry(fallbackUrl = USED_URL),
+                )
+            }
+            """
+        )
+
+        self.assertEqual(
+            [
+                ("USED_URL", "https://example.com/used.zip"),
+                ("SECOND_URL", "https://example.com/second.zip"),
+            ],
+            [(entry.constant_name, entry.url) for entry in entries],
+        )
+
+    def test_missing_referenced_constant_is_metadata_error(self) -> None:
+        with self.assertRaises(verifier.MetadataError) as context:
+            verifier.extract_fallback_urls(
+                """
+                object FontCatalog {
+                    val entries = listOf(Entry(fallbackUrl = MISSING_URL))
+                }
+                """
+            )
+
+        self.assertIn("MISSING_URL", str(context.exception))
+
+    def test_main_returns_2_when_no_fallback_urls_are_found(self) -> None:
+        exit_code, _stdout, stderr = run_main(
+            """
+            object FontCatalog {
+                private const val UNUSED_URL = "https://example.com/unused.zip"
+                val entries = emptyList<Entry>()
+            }
+            """,
+            opener=successful_opener,
+        )
+
+        self.assertEqual(2, exit_code)
+        self.assertIn("No fallbackUrl assignments found", stderr)
+
+    def test_main_returns_1_for_non_200_result(self) -> None:
+        exit_code, _stdout, stderr = run_main(
+            catalog_with_fallback_url("BROKEN_URL", "https://example.com/broken.zip"),
+            opener=lambda _request, _timeout: FakeResponse(404),
+        )
+
+        self.assertEqual(1, exit_code)
+        self.assertIn("BROKEN_URL", stderr)
+        self.assertIn("HTTP 404", stderr)
+
+    def test_main_returns_1_for_request_exception(self) -> None:
+        def failing_opener(
+            _request: urllib.request.Request,
+            _timeout: float,
+        ) -> FakeResponse:
+            raise urllib.error.URLError("timed out")
+
+        exit_code, _stdout, stderr = run_main(
+            catalog_with_fallback_url("SLOW_URL", "https://example.com/slow.zip"),
+            opener=failing_opener,
+        )
+
+        self.assertEqual(1, exit_code)
+        self.assertIn("SLOW_URL", stderr)
+        self.assertIn("timed out", stderr)
+
+    def test_main_returns_2_for_malformed_http_url_metadata(self) -> None:
+        def unexpected_opener(
+            _request: urllib.request.Request,
+            _timeout: float,
+        ) -> FakeResponse:
+            self.fail("Malformed metadata must fail before making a request.")
+
+        exit_code, _stdout, stderr = run_main(
+            catalog_with_fallback_url("BAD_URL", "https://exa mple.com/font.zip"),
+            opener=unexpected_opener,
+        )
+
+        self.assertEqual(2, exit_code)
+        self.assertIn("BAD_URL", stderr)
+        self.assertIn("must not contain whitespace", stderr)
+
+    def test_checker_reports_malformed_request_exception(self) -> None:
+        def failing_opener(
+            _request: urllib.request.Request,
+            _timeout: float,
+        ) -> FakeResponse:
+            raise http.client.InvalidURL("URL can't contain control characters")
+
+        results = verifier.check_fallback_urls(
+            [verifier.FallbackUrl("BAD_URL", "https://exa mple.com/font.zip")],
+            opener=failing_opener,
+        )
+
+        self.assertEqual(1, len(results))
+        self.assertFalse(results[0].is_success)
+        self.assertEqual("BAD_URL", results[0].constant_name)
+        self.assertIn("URL can't contain control characters", results[0].error)
+
+    def test_main_returns_0_for_http_200_success(self) -> None:
+        requests: list[tuple[urllib.request.Request, float]] = []
+
+        def recording_opener(
+            request: urllib.request.Request,
+            timeout: float,
+        ) -> FakeResponse:
+            requests.append((request, timeout))
+            return FakeResponse(200)
+
+        exit_code, stdout, _stderr = run_main(
+            catalog_with_fallback_url("GOOD_URL", "https://example.com/good.zip"),
+            opener=recording_opener,
+        )
+
+        self.assertEqual(0, exit_code)
+        self.assertIn("1 URL(s) checked", stdout)
+        self.assertEqual("HEAD", requests[0][0].get_method())
+        self.assertEqual(3.0, requests[0][1])
+
+
+class FakeResponse:
+    def __init__(self, status_code: int) -> None:
+        self.status_code = status_code
+
+    def __enter__(self) -> FakeResponse:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        return None
+
+    def getcode(self) -> int:
+        return self.status_code
+
+
+def catalog_with_fallback_url(constant_name: str, url: str) -> str:
+    return f"""
+    object FontCatalog {{
+        private const val {constant_name} = "{url}"
+
+        val entries = listOf(Entry(fallbackUrl = {constant_name}))
+    }}
+    """
+
+
+def successful_opener(
+    _request: urllib.request.Request,
+    _timeout: float,
+) -> FakeResponse:
+    return FakeResponse(200)
+
+
+def run_main(
+    font_catalog: str,
+    *,
+    opener: Callable[[urllib.request.Request, float], FakeResponse],
+) -> tuple[int, str, str]:
+    with tempfile.TemporaryDirectory() as temporary_directory:
+        catalog_path = Path(temporary_directory) / "FontCatalog.kt"
+        catalog_path.write_text(textwrap.dedent(font_catalog), encoding="utf-8")
+
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            exit_code = verifier.main(
+                ["--font-catalog", str(catalog_path), "--timeout", "3.0"],
+                opener=opener,
+            )
+
+    return exit_code, stdout.getvalue(), stderr.getvalue()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify-font-fallback-urls.py
+++ b/scripts/verify-font-fallback-urls.py
@@ -83,7 +83,11 @@ class UrlCheckResult:
 
     @property
     def is_success(self) -> bool:
-        return self.status_code == 200 and self.error is None
+        return (
+            self.error is None
+            and self.status_code is not None
+            and 200 <= self.status_code < 300
+        )
 
 
 def extract_fallback_urls(font_catalog_source: str) -> list[FallbackUrl]:
@@ -201,11 +205,12 @@ def check_fallback_url_once(
             status_code=None,
             error=f"request failed: {exc}",
         )
+    is_success_status = 200 <= status_code < 300
     return UrlCheckResult(
         constant_name=fallback_url.constant_name,
         url=fallback_url.url,
         status_code=status_code,
-        error=None if status_code == 200 else f"HTTP {status_code}",
+        error=None if is_success_status else f"HTTP {status_code}",
     )
 
 

--- a/scripts/verify-font-fallback-urls.py
+++ b/scripts/verify-font-fallback-urls.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Smoke-check FontCatalog fallback font download URLs."""
+
+from __future__ import annotations
+
+import argparse
+import http.client
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from types import TracebackType
+from typing import Protocol
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_FONT_CATALOG = (
+    REPO_ROOT
+    / "src"
+    / "main"
+    / "kotlin"
+    / "dev"
+    / "ayuislands"
+    / "font"
+    / "FontCatalog.kt"
+)
+DEFAULT_TIMEOUT_SECONDS = 10.0
+USER_AGENT = "ayu-islands-font-fallback-smoke/1.0"
+
+CONSTANT_PATTERN = re.compile(
+    r'^\s*(?:(?:private|internal|public)\s+)?const\s+val\s+'
+    r'([A-Za-z_][A-Za-z0-9_]*)\s*=\s*"([^"]+)"',
+    re.MULTILINE,
+)
+FALLBACK_ASSIGNMENT_PATTERN = re.compile(r"\bfallbackUrl\s*=\s*([^,\n)]+)")
+IDENTIFIER_PATTERN = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+WHITESPACE_PATTERN = re.compile(r"\s")
+
+
+class MetadataError(Exception):
+    """Raised when FontCatalog fallback URL metadata cannot be parsed."""
+
+
+class HeadResponse(Protocol):
+    def __enter__(self) -> HeadResponse:
+        """Return the open HTTP response."""
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool | None:
+        """Close the open HTTP response."""
+
+    def getcode(self) -> int:
+        """Return the final HTTP status code after redirects."""
+
+
+UrlOpener = Callable[[urllib.request.Request, float], HeadResponse]
+
+
+@dataclass(frozen=True)
+class FallbackUrl:
+    constant_name: str
+    url: str
+
+
+@dataclass(frozen=True)
+class UrlCheckResult:
+    constant_name: str
+    url: str
+    status_code: int | None
+    error: str | None = None
+
+    @property
+    def is_success(self) -> bool:
+        return self.status_code == 200 and self.error is None
+
+
+def extract_fallback_urls(font_catalog_source: str) -> list[FallbackUrl]:
+    """Return URL constants referenced by `fallbackUrl = ...` assignments."""
+    constants = {
+        constant_name: value
+        for constant_name, value in CONSTANT_PATTERN.findall(font_catalog_source)
+    }
+    expressions = [
+        expression.strip()
+        for expression in FALLBACK_ASSIGNMENT_PATTERN.findall(font_catalog_source)
+    ]
+    if not expressions:
+        raise MetadataError("No fallbackUrl assignments found in FontCatalog.kt.")
+
+    fallback_urls: list[FallbackUrl] = []
+    seen_constants: set[str] = set()
+    missing_constants: list[str] = []
+    for expression in expressions:
+        if not IDENTIFIER_PATTERN.fullmatch(expression):
+            raise MetadataError(
+                "Unsupported fallbackUrl expression in FontCatalog.kt: "
+                f"{expression!r}. Expected a constant reference.",
+            )
+        if expression in seen_constants:
+            continue
+
+        seen_constants.add(expression)
+        url = constants.get(expression)
+        if url is None:
+            missing_constants.append(expression)
+            continue
+        validate_fallback_url_metadata(expression, url)
+
+        fallback_urls.append(FallbackUrl(constant_name=expression, url=url))
+
+    if missing_constants:
+        missing = ", ".join(sorted(missing_constants))
+        raise MetadataError(f"fallbackUrl references undefined constant(s): {missing}.")
+
+    if not fallback_urls:
+        raise MetadataError("No fallback URL constants resolved from FontCatalog.kt.")
+
+    return fallback_urls
+
+
+def validate_fallback_url_metadata(constant_name: str, url: str) -> None:
+    """Validate URL shape before the live HTTP smoke runs."""
+    if WHITESPACE_PATTERN.search(url):
+        raise MetadataError(
+            f"fallbackUrl constant {constant_name} must not contain whitespace, got {url!r}.",
+        )
+
+    try:
+        parsed_url = urllib.parse.urlsplit(url)
+        _port = parsed_url.port
+    except ValueError as exc:
+        raise MetadataError(
+            f"fallbackUrl constant {constant_name} is not a valid URL: {exc}.",
+        ) from exc
+
+    if parsed_url.scheme.lower() not in {"http", "https"}:
+        raise MetadataError(
+            f"fallbackUrl constant {constant_name} must be an HTTP(S) URL, got {url!r}.",
+        )
+    if not parsed_url.netloc:
+        raise MetadataError(
+            f"fallbackUrl constant {constant_name} must include a network location, got {url!r}.",
+        )
+
+
+def open_head(request: urllib.request.Request, timeout_seconds: float) -> HeadResponse:
+    return urllib.request.urlopen(request, timeout=timeout_seconds)
+
+
+def check_fallback_urls(
+    fallback_urls: Sequence[FallbackUrl],
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    opener: UrlOpener = open_head,
+) -> list[UrlCheckResult]:
+    """Run live HEAD checks for each fallback URL."""
+    results: list[UrlCheckResult] = []
+    for fallback_url in fallback_urls:
+        try:
+            request = urllib.request.Request(
+                fallback_url.url,
+                headers={"User-Agent": USER_AGENT},
+                method="HEAD",
+            )
+            with opener(request, timeout_seconds) as response:
+                status_code = response.getcode()
+        except urllib.error.HTTPError as exc:
+            results.append(
+                UrlCheckResult(
+                    constant_name=fallback_url.constant_name,
+                    url=fallback_url.url,
+                    status_code=exc.code,
+                    error=f"HTTP {exc.code}",
+                )
+            )
+        except urllib.error.URLError as exc:
+            results.append(
+                UrlCheckResult(
+                    constant_name=fallback_url.constant_name,
+                    url=fallback_url.url,
+                    status_code=None,
+                    error=f"request failed: {exc.reason}",
+                )
+            )
+        except http.client.HTTPException as exc:
+            results.append(
+                UrlCheckResult(
+                    constant_name=fallback_url.constant_name,
+                    url=fallback_url.url,
+                    status_code=None,
+                    error=f"request failed: {exc}",
+                )
+            )
+        except OSError as exc:
+            results.append(
+                UrlCheckResult(
+                    constant_name=fallback_url.constant_name,
+                    url=fallback_url.url,
+                    status_code=None,
+                    error=f"request failed: {exc}",
+                )
+            )
+        else:
+            results.append(
+                UrlCheckResult(
+                    constant_name=fallback_url.constant_name,
+                    url=fallback_url.url,
+                    status_code=status_code,
+                    error=None if status_code == 200 else f"HTTP {status_code}",
+                )
+            )
+
+    return results
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    opener: UrlOpener = open_head,
+) -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--font-catalog",
+        type=Path,
+        default=DEFAULT_FONT_CATALOG,
+        help="Path to FontCatalog.kt.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        help="HEAD request timeout in seconds.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.timeout <= 0:
+        print("ERROR: --timeout must be greater than 0.", file=sys.stderr)
+        return 2
+
+    try:
+        source = args.font_catalog.read_text(encoding="utf-8")
+        fallback_urls = extract_fallback_urls(source)
+    except OSError as exc:
+        print(f"ERROR: unable to read {args.font_catalog}: {exc}", file=sys.stderr)
+        return 2
+    except MetadataError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    results = check_fallback_urls(
+        fallback_urls,
+        timeout_seconds=args.timeout,
+        opener=opener,
+    )
+    failures = [result for result in results if not result.is_success]
+    if failures:
+        print("ERROR: Font fallback URL smoke failed.", file=sys.stderr)
+        for failure in failures:
+            detail = failure.error or "unknown failure"
+            print(
+                f"- {failure.constant_name}: {failure.url} -> {detail}",
+                file=sys.stderr,
+            )
+        return 1
+
+    print(f"Font fallback URL smoke passed: {len(results)} URL(s) checked.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify-font-fallback-urls.py
+++ b/scripts/verify-font-fallback-urls.py
@@ -7,6 +7,7 @@ import argparse
 import http.client
 import re
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -28,7 +29,10 @@ DEFAULT_FONT_CATALOG = (
     / "FontCatalog.kt"
 )
 DEFAULT_TIMEOUT_SECONDS = 10.0
+DEFAULT_RETRY_COUNT = 2
+DEFAULT_RETRY_DELAY_SECONDS = 0.5
 USER_AGENT = "ayu-islands-font-fallback-smoke/1.0"
+RETRYABLE_STATUS_CODES = {408, 429, 500, 502, 503, 504}
 
 CONSTANT_PATTERN = re.compile(
     r'^\s*(?:(?:private|internal|public)\s+)?const\s+val\s+'
@@ -61,6 +65,7 @@ class HeadResponse(Protocol):
 
 
 UrlOpener = Callable[[urllib.request.Request, float], HeadResponse]
+Sleeper = Callable[[float], None]
 
 
 @dataclass(frozen=True)
@@ -154,68 +159,94 @@ def open_head(request: urllib.request.Request, timeout_seconds: float) -> HeadRe
     return urllib.request.urlopen(request, timeout=timeout_seconds)
 
 
+def check_fallback_url_once(
+    fallback_url: FallbackUrl,
+    *,
+    timeout_seconds: float,
+    opener: UrlOpener,
+) -> UrlCheckResult:
+    request = urllib.request.Request(
+        fallback_url.url,
+        headers={"User-Agent": USER_AGENT},
+        method="HEAD",
+    )
+    try:
+        with opener(request, timeout_seconds) as response:
+            status_code = response.getcode()
+    except urllib.error.HTTPError as exc:
+        return UrlCheckResult(
+            constant_name=fallback_url.constant_name,
+            url=fallback_url.url,
+            status_code=exc.code,
+            error=f"HTTP {exc.code}",
+        )
+    except urllib.error.URLError as exc:
+        return UrlCheckResult(
+            constant_name=fallback_url.constant_name,
+            url=fallback_url.url,
+            status_code=None,
+            error=f"request failed: {exc.reason}",
+        )
+    except http.client.HTTPException as exc:
+        return UrlCheckResult(
+            constant_name=fallback_url.constant_name,
+            url=fallback_url.url,
+            status_code=None,
+            error=f"request failed: {exc}",
+        )
+    except OSError as exc:
+        return UrlCheckResult(
+            constant_name=fallback_url.constant_name,
+            url=fallback_url.url,
+            status_code=None,
+            error=f"request failed: {exc}",
+        )
+    return UrlCheckResult(
+        constant_name=fallback_url.constant_name,
+        url=fallback_url.url,
+        status_code=status_code,
+        error=None if status_code == 200 else f"HTTP {status_code}",
+    )
+
+
+def should_retry(result: UrlCheckResult) -> bool:
+    if result.is_success:
+        return False
+    return result.status_code is None or result.status_code in RETRYABLE_STATUS_CODES
+
+
 def check_fallback_urls(
     fallback_urls: Sequence[FallbackUrl],
     *,
     timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
     opener: UrlOpener = open_head,
+    retries: int = DEFAULT_RETRY_COUNT,
+    retry_delay_seconds: float = DEFAULT_RETRY_DELAY_SECONDS,
+    sleeper: Sleeper = time.sleep,
 ) -> list[UrlCheckResult]:
     """Run live HEAD checks for each fallback URL."""
+    if retries < 0:
+        raise ValueError("retries must be greater than or equal to 0.")
+    if retry_delay_seconds < 0:
+        raise ValueError("retry_delay_seconds must be greater than or equal to 0.")
+
     results: list[UrlCheckResult] = []
     for fallback_url in fallback_urls:
-        try:
-            request = urllib.request.Request(
-                fallback_url.url,
-                headers={"User-Agent": USER_AGENT},
-                method="HEAD",
+        result = check_fallback_url_once(
+            fallback_url,
+            timeout_seconds=timeout_seconds,
+            opener=opener,
+        )
+        for _attempt in range(retries):
+            if not should_retry(result):
+                break
+            sleeper(retry_delay_seconds)
+            result = check_fallback_url_once(
+                fallback_url,
+                timeout_seconds=timeout_seconds,
+                opener=opener,
             )
-            with opener(request, timeout_seconds) as response:
-                status_code = response.getcode()
-        except urllib.error.HTTPError as exc:
-            results.append(
-                UrlCheckResult(
-                    constant_name=fallback_url.constant_name,
-                    url=fallback_url.url,
-                    status_code=exc.code,
-                    error=f"HTTP {exc.code}",
-                )
-            )
-        except urllib.error.URLError as exc:
-            results.append(
-                UrlCheckResult(
-                    constant_name=fallback_url.constant_name,
-                    url=fallback_url.url,
-                    status_code=None,
-                    error=f"request failed: {exc.reason}",
-                )
-            )
-        except http.client.HTTPException as exc:
-            results.append(
-                UrlCheckResult(
-                    constant_name=fallback_url.constant_name,
-                    url=fallback_url.url,
-                    status_code=None,
-                    error=f"request failed: {exc}",
-                )
-            )
-        except OSError as exc:
-            results.append(
-                UrlCheckResult(
-                    constant_name=fallback_url.constant_name,
-                    url=fallback_url.url,
-                    status_code=None,
-                    error=f"request failed: {exc}",
-                )
-            )
-        else:
-            results.append(
-                UrlCheckResult(
-                    constant_name=fallback_url.constant_name,
-                    url=fallback_url.url,
-                    status_code=status_code,
-                    error=None if status_code == 200 else f"HTTP {status_code}",
-                )
-            )
+        results.append(result)
 
     return results
 
@@ -224,6 +255,7 @@ def main(
     argv: Sequence[str] | None = None,
     *,
     opener: UrlOpener = open_head,
+    sleeper: Sleeper = time.sleep,
 ) -> int:
     """CLI entry point."""
     parser = argparse.ArgumentParser(description=__doc__)
@@ -239,10 +271,28 @@ def main(
         default=DEFAULT_TIMEOUT_SECONDS,
         help="HEAD request timeout in seconds.",
     )
+    parser.add_argument(
+        "--retries",
+        type=int,
+        default=DEFAULT_RETRY_COUNT,
+        help="Number of retries for transient URL smoke failures.",
+    )
+    parser.add_argument(
+        "--retry-delay",
+        type=float,
+        default=DEFAULT_RETRY_DELAY_SECONDS,
+        help="Delay in seconds between URL smoke retries.",
+    )
     args = parser.parse_args(argv)
 
     if args.timeout <= 0:
         print("ERROR: --timeout must be greater than 0.", file=sys.stderr)
+        return 2
+    if args.retries < 0:
+        print("ERROR: --retries must be greater than or equal to 0.", file=sys.stderr)
+        return 2
+    if args.retry_delay < 0:
+        print("ERROR: --retry-delay must be greater than or equal to 0.", file=sys.stderr)
         return 2
 
     try:
@@ -259,6 +309,9 @@ def main(
         fallback_urls,
         timeout_seconds=args.timeout,
         opener=opener,
+        retries=args.retries,
+        retry_delay_seconds=args.retry_delay,
+        sleeper=sleeper,
     )
     failures = [result for result in results if not result.is_success]
     if failures:

--- a/src/main/kotlin/dev/ayuislands/accent/CancellationSafeRunCatching.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/CancellationSafeRunCatching.kt
@@ -1,9 +1,11 @@
 package dev.ayuislands.accent
 
+import com.intellij.openapi.progress.ProcessCanceledException
+import kotlin.coroutines.cancellation.CancellationException
+
 /**
- * [kotlin.runCatching] variant that rethrows
- * [kotlin.coroutines.cancellation.CancellationException] instead of capturing it in the
- * returned [Result].
+ * [kotlin.runCatching] variant that rethrows platform and coroutine cancellation
+ * instead of capturing it in the returned [Result].
  *
  * The resolver chain ([AccentResolver.projectKey], [ProjectLanguageDetector.dominant]) is
  * reachable from `AyuIslandsStartupActivity.execute`'s coroutine body; swallowing
@@ -24,6 +26,7 @@ package dev.ayuislands.accent
 internal inline fun <T> runCatchingPreservingCancellation(block: () -> T): Result<T> {
     val result = runCatching(block)
     val cause = result.exceptionOrNull()
-    if (cause is kotlin.coroutines.cancellation.CancellationException) throw cause
+    if (cause is ProcessCanceledException) throw cause
+    if (cause is CancellationException) throw cause
     return result
 }

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
@@ -51,7 +51,7 @@ import javax.swing.SwingUtilities
 object ProjectLanguageDetector {
     private val LOG = logger<ProjectLanguageDetector>()
 
-    private val verdictCache = ConcurrentHashMap<String, ProjectLanguageVerdict>()
+    private val verdictCache = ConcurrentHashMap<String, VerdictCacheEntry>()
 
     /**
      * Dominant language id for [project], cached per canonical path.
@@ -72,14 +72,14 @@ object ProjectLanguageDetector {
             ?.lowercase(Locale.ROOT)
             ?.let { return it }
         verdictCache[key]?.let { cached ->
-            return (cached as? ProjectLanguageVerdict.Detected)?.languageId
+            return (cached.verdict as? ProjectLanguageVerdict.Detected)?.languageId
         }
 
         if (isOnEdt()) {
             scheduleBackgroundDetection(project, key)
             return null
         }
-        return (detectAndCache(project, key) as? ProjectLanguageVerdict.Detected)?.languageId
+        return (detectAndCache(project, key).verdict as? ProjectLanguageVerdict.Detected)?.languageId
     }
 
     /**
@@ -117,13 +117,13 @@ object ProjectLanguageDetector {
         warmCache: Boolean = false,
     ): ProjectLanguageVerdict {
         val key = AccentResolver.projectKey(project) ?: return ProjectLanguageVerdict.Unavailable
-        verdictCache[key]?.let { return it }
+        verdictCache[key]?.let { return it.verdict }
         if (!warmCache) return ProjectLanguageVerdict.Cold
         if (isOnEdt()) {
             scheduleBackgroundDetection(project, key)
             return ProjectLanguageVerdict.Cold
         }
-        return detectAndCache(project, key)
+        return detectAndCache(project, key).verdict
     }
 
     /**
@@ -210,16 +210,41 @@ object ProjectLanguageDetector {
     )
 
     /**
+     * Identity-based cache generation token. Do not make this a data class or
+     * override equality: stale disposal cleanup relies on removing only the
+     * exact entry created by the scan that is being dropped.
+     */
+    private class VerdictCacheEntry(
+        val verdict: ProjectLanguageVerdict,
+    )
+
+    private data class CachedDetection(
+        val verdict: ProjectLanguageVerdict,
+        val cacheEntry: VerdictCacheEntry?,
+    )
+
+    /**
      * EDT-safe detection wrapper. Off-EDT callers invoke this directly;
      * [dominant] routes EDT callers through [scheduleBackgroundDetection] instead.
      */
     private fun detectAndCache(
         project: Project,
         key: String,
-    ): ProjectLanguageVerdict {
+    ): CachedDetection {
         val detection = detectInternal(project)
+        if (project.isDisposed) {
+            LOG.debug("Scan for $key finished after project disposal; dropping cache write")
+            return CachedDetection(ProjectLanguageVerdict.Unavailable, cacheEntry = null)
+        }
         if (detection.cacheable) {
-            verdictCache[key] = detection.verdict
+            val entry = VerdictCacheEntry(detection.verdict)
+            verdictCache[key] = entry
+            if (project.isDisposed) {
+                verdictCache.remove(key, entry)
+                LOG.debug("Scan for $key cached during project disposal; removed stale verdict")
+                return CachedDetection(ProjectLanguageVerdict.Unavailable, cacheEntry = null)
+            }
+            return CachedDetection(detection.verdict, entry)
         } else {
             // Forensic breadcrumb: a non-cacheable result means the scan hit
             // dumb mode, a disposed project, or the scanner threw. The caller
@@ -231,7 +256,7 @@ object ProjectLanguageDetector {
             // a paper trail in idea.log.
             LOG.debug("Scan for $key returned non-cacheable result; caller will re-scan on next call")
         }
-        return detection.verdict
+        return CachedDetection(detection.verdict, cacheEntry = null)
     }
 
     /**
@@ -259,12 +284,18 @@ object ProjectLanguageDetector {
             LOG.debug("scheduleBackgroundDetection skipped for $key: DumbService.isDumb == true")
             return
         }
-        ProjectLanguageScanAsync.schedule(key) {
+        ProjectLanguageScanAsync.schedule(project, key) {
             if (project.isDisposed) {
                 LOG.debug("scheduleBackgroundDetection task aborted for $key: project disposed before scan body ran")
-                return@schedule
+                return@schedule ProjectLanguageScanAsync.ScanResult.Unavailable
             }
-            val verdict = detectAndCache(project, key)
+            val cachedDetection = detectAndCache(project, key)
+            val verdict = cachedDetection.verdict
+            if (project.isDisposed) {
+                cachedDetection.cacheEntry?.let { verdictCache.remove(key, it) }
+                LOG.debug("scheduleBackgroundDetection task aborted for $key: project disposed after scan")
+                return@schedule ProjectLanguageScanAsync.ScanResult.Unavailable
+            }
             val outcome: ScanOutcome =
                 when (verdict) {
                     is ProjectLanguageVerdict.Detected -> ScanOutcome.Detected(verdict.languageId)
@@ -285,7 +316,13 @@ object ProjectLanguageDetector {
                 ProjectLanguageVerdict.Unavailable,
                 -> Unit
             }
-            publishScanCompleted(project, outcome)
+            publishScanCompleted(project, outcome, key, cachedDetection.cacheEntry)
+            when (outcome) {
+                is ScanOutcome.Detected,
+                ScanOutcome.Polyglot,
+                -> ProjectLanguageScanAsync.ScanResult.Completed
+                ScanOutcome.Unavailable -> ProjectLanguageScanAsync.ScanResult.Unavailable
+            }
         }
     }
 
@@ -297,18 +334,29 @@ object ProjectLanguageDetector {
      * arbitrary subscriber code, and keeping that off the scan pool prevents
      * a misbehaving subscriber from stalling the shared executor. Double
      * dispose-guard (before and after invokeLater) because project disposal
-     * can race with a late-arriving scan completion.
+     * can race with a late-arriving scan completion. [cacheKey] and
+     * [cacheEntry] are a cleanup handle and must be passed together; when a
+     * late cacheable publish is dropped, the exact entry is removed without
+     * touching a newer value-equal verdict for the same project path.
      */
     private fun publishScanCompleted(
         project: Project,
         outcome: ScanOutcome,
+        cacheKey: String? = null,
+        cacheEntry: VerdictCacheEntry? = null,
     ) {
         if (project.isDisposed) {
+            if (cacheKey != null && cacheEntry != null) {
+                verdictCache.remove(cacheKey, cacheEntry)
+            }
             LOG.debug("publishScanCompleted dropped before invokeLater: project already disposed")
             return
         }
         SwingUtilities.invokeLater {
             if (project.isDisposed) {
+                if (cacheKey != null && cacheEntry != null) {
+                    verdictCache.remove(cacheKey, cacheEntry)
+                }
                 LOG.debug("publishScanCompleted dropped inside invokeLater: project disposed during EDT hop")
                 return@invokeLater
             }
@@ -388,6 +436,9 @@ object ProjectLanguageDetector {
         val weights =
             ProjectLanguageScanner.scan(project)
                 ?: return DetectionResult(ProjectLanguageVerdict.Unavailable, cacheable = false)
+        if (project.isDisposed) {
+            return DetectionResult(ProjectLanguageVerdict.Unavailable, cacheable = false)
+        }
         val mappings = AccentMappingsSettings.getInstance().state
         val policy = mappings.languageResolutionPolicy()
         if (weights.isNotEmpty()) {

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
@@ -238,7 +238,16 @@ object ProjectLanguageDetector {
         }
         if (detection.cacheable) {
             val entry = VerdictCacheEntry(detection.verdict)
-            verdictCache[key] = entry
+            val cachedEntry =
+                verdictCache.compute(key) { _, currentEntry ->
+                    if (project.isDisposed) currentEntry else entry
+                }
+            if (cachedEntry !== entry) {
+                LOG.debug("Scan for $key reached cache write after project disposal; kept existing verdict")
+                return CachedDetection(ProjectLanguageVerdict.Unavailable, cacheEntry = null)
+            }
+            // Disposal can still happen after the atomic compute window. Remove
+            // only this exact entry so a reopened project's fresh verdict stays.
             if (project.isDisposed) {
                 verdictCache.remove(key, entry)
                 LOG.debug("Scan for $key cached during project disposal; removed stale verdict")

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageScanAsync.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageScanAsync.kt
@@ -1,6 +1,13 @@
 package dev.ayuislands.accent
 
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.progress.EmptyProgressIndicator
+import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
 import com.intellij.util.concurrency.AppExecutorUtil
 import org.jetbrains.annotations.TestOnly
 import java.util.concurrent.ConcurrentHashMap
@@ -23,25 +30,36 @@ internal object ProjectLanguageScanAsync {
     private val LOG = logger<ProjectLanguageScanAsync>()
     private val inFlight: MutableSet<String> = ConcurrentHashMap.newKeySet()
 
+    internal enum class ScanResult {
+        Completed,
+        Unavailable,
+    }
+
     /** True when a scan for [key] is currently scheduled or running. */
     fun isInFlight(key: String): Boolean = key in inFlight
 
     /**
      * Schedule [task] on the IDE's shared application-pool executor, gated on
-     * [key] so duplicate schedulings for the same project become no-ops.
+     * [key] so duplicate schedulings for the same canonical project path become no-ops.
      *
      * Returns true when the task was actually scheduled, false when a prior scan
      * for the same key is still in flight — callers can use the return value to
      * decide whether to fall through to a synchronous path or simply bail out.
      */
     fun schedule(
+        project: Project,
         key: String,
-        task: () -> Unit,
+        task: () -> ScanResult,
     ): Boolean {
         if (!inFlight.add(key)) return false
         AppExecutorUtil.getAppExecutorService().execute {
             try {
-                task()
+                val result = runWithProjectProgress(project, key, task)
+                if (result == ScanResult.Unavailable) {
+                    LOG.debug("Background language scan for '$key' finished unavailable; cache unchanged")
+                }
+            } catch (exception: ProcessCanceledException) {
+                LOG.debug("Background language scan for '$key' canceled; cache unchanged", exception)
             } catch (exception: kotlin.coroutines.cancellation.CancellationException) {
                 // Pool-level cancellation: IDE is shutting down. Let it propagate.
                 throw exception
@@ -54,6 +72,89 @@ internal object ProjectLanguageScanAsync {
             }
         }
         return true
+    }
+
+    private fun runWithProjectProgress(
+        project: Project,
+        key: String,
+        task: () -> ScanResult,
+    ): ScanResult {
+        if (project.isDisposed) {
+            LOG.debug("Background language scan for '$key' skipped: project disposed before scan body ran")
+            return ScanResult.Unavailable
+        }
+        val indicator = EmptyProgressIndicator(ModalityState.nonModal())
+        val disposalCancellation = ProjectDisposalCancellation(indicator)
+        if (!registerDisposalCancellation(project, key, disposalCancellation)) {
+            return ScanResult.Unavailable
+        }
+        return try {
+            var result = ScanResult.Unavailable
+            ProgressManager.getInstance().runProcess(
+                Runnable {
+                    if (project.isDisposed) {
+                        indicator.cancel()
+                        return@Runnable
+                    }
+                    result = task()
+                },
+                indicator,
+            )
+            result
+        } catch (exception: ProcessCanceledException) {
+            LOG.debug("Background language scan for '$key' canceled; cache unchanged", exception)
+            ScanResult.Unavailable
+        } finally {
+            disposeCancellation(disposalCancellation)
+        }
+    }
+
+    private fun registerDisposalCancellation(
+        project: Project,
+        key: String,
+        disposalCancellation: Disposable,
+    ): Boolean =
+        try {
+            Disposer.register(project, disposalCancellation)
+            true
+        } catch (exception: ProcessCanceledException) {
+            LOG.debug("Background language scan for '$key' canceled while registering disposal hook", exception)
+            false
+        } catch (exception: kotlin.coroutines.cancellation.CancellationException) {
+            throw exception
+        } catch (exception: RuntimeException) {
+            LOG.debug("Background language scan for '$key' skipped: project disposal hook unavailable", exception)
+            false
+        }
+
+    private fun disposeCancellation(disposalCancellation: ProjectDisposalCancellation) {
+        try {
+            disposalCancellation.disposeWithoutCancel()
+        } catch (exception: ProcessCanceledException) {
+            LOG.debug("Project language scan disposal hook was already canceled", exception)
+        } catch (exception: kotlin.coroutines.cancellation.CancellationException) {
+            throw exception
+        } catch (exception: RuntimeException) {
+            LOG.debug("Project language scan disposal hook cleanup failed", exception)
+        }
+    }
+
+    private class ProjectDisposalCancellation(
+        private val indicator: EmptyProgressIndicator,
+    ) : Disposable {
+        @Volatile
+        private var shouldCancel = true
+
+        override fun dispose() {
+            if (shouldCancel) {
+                indicator.cancel()
+            }
+        }
+
+        fun disposeWithoutCancel() {
+            shouldCancel = false
+            Disposer.dispose(this)
+        }
     }
 
     @TestOnly

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageScanner.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageScanner.kt
@@ -81,7 +81,6 @@ internal object ProjectLanguageScanner {
             ProgressManager.checkCanceled()
             if (project.isDisposed) return@iterateContent false
             val shouldContinue = visit(file, weights, fileCount)
-            ProgressManager.checkCanceled()
             shouldContinue
         }
         return weights
@@ -108,7 +107,6 @@ internal object ProjectLanguageScanner {
         weights: HashMap<String, Long>,
         fileCount: IntArray,
     ): Boolean {
-        ProgressManager.checkCanceled()
         if (fileCount[0] >= LanguageDetectionRules.MAX_FILES_SCANNED) return false
         // Drop vendored / generated / build-output dirs before paying for VFS
         // metadata access. This is the single biggest real-world accuracy win:
@@ -119,11 +117,9 @@ internal object ProjectLanguageScanner {
         // Count every non-directory, non-excluded file toward the cap so binary-
         // heavy repos don't bypass it (see KDoc rationale).
         fileCount[0]++
-        ProgressManager.checkCanceled()
         sampleLanguageWeight(file)?.let { (languageId, weight) ->
             weights.merge(languageId, weight) { a, b -> a + b }
         }
-        ProgressManager.checkCanceled()
         return true
     }
 

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageScanner.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageScanner.kt
@@ -2,10 +2,12 @@ package dev.ayuislands.accent
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectFileIndex
 import com.intellij.openapi.vfs.VirtualFile
+import org.jetbrains.annotations.TestOnly
 
 /**
  * Walks a project's content roots under a read action and tallies per-language
@@ -41,7 +43,8 @@ internal object ProjectLanguageScanner {
      * Returns null (not cacheable) when the IDE cannot give a trustworthy answer
      * right now — disposal race, dumb mode (indexing), or a ReadAction failure.
      * The caller re-attempts on the next invocation so detection catches up once
-     * the IDE stabilizes.
+     * the IDE stabilizes. Platform cancellation is not a scan failure and is
+     * deliberately propagated so coroutine callers keep structured cancellation.
      */
     fun scan(project: Project): Map<String, Long>? {
         if (project.isDisposed) return null
@@ -57,21 +60,29 @@ internal object ProjectLanguageScanner {
                     scanUnderReadAction(project)
                 }
             }
-        if (scanResult.isFailure) {
+        val failure = scanResult.exceptionOrNull()
+        if (failure != null) {
             LOG.warn(
                 "Project content scan failed; caller will fall back to SDK/module heuristic",
-                scanResult.exceptionOrNull(),
+                failure,
             )
             return null
         }
+        if (project.isDisposed) return null
         return scanResult.getOrDefault(emptyMap())
     }
 
     private fun scanUnderReadAction(project: Project): Map<String, Long> {
         val weights = HashMap<String, Long>()
         val fileCount = IntArray(1)
+        ProgressManager.checkCanceled()
+        if (project.isDisposed) return emptyMap()
         ProjectFileIndex.getInstance(project).iterateContent { file ->
-            visit(file, weights, fileCount)
+            ProgressManager.checkCanceled()
+            if (project.isDisposed) return@iterateContent false
+            val shouldContinue = visit(file, weights, fileCount)
+            ProgressManager.checkCanceled()
+            shouldContinue
         }
         return weights
     }
@@ -88,16 +99,16 @@ internal object ProjectLanguageScanner {
      * responsive on monorepos" purpose of the cap.
      *
      * Per-file exceptions (mid-delete race, a language plugin throwing from its
-     * FileType.detect) must NOT abort the scan. [runCatchingPreservingCancellation]
-     * captures them into a Result (logged at DEBUG and skipped) while still
-     * letting [kotlin.coroutines.cancellation.CancellationException] propagate so
-     * structured concurrency in coroutine-driven callers stays intact.
+     * FileType.detect) must NOT abort the scan. Non-cancellation failures are
+     * logged at DEBUG and skipped, while IntelliJ and Kotlin cancellation
+     * signals still propagate so long-running scans can stop promptly.
      */
     private fun visit(
         file: VirtualFile,
         weights: HashMap<String, Long>,
         fileCount: IntArray,
     ): Boolean {
+        ProgressManager.checkCanceled()
         if (fileCount[0] >= LanguageDetectionRules.MAX_FILES_SCANNED) return false
         // Drop vendored / generated / build-output dirs before paying for VFS
         // metadata access. This is the single biggest real-world accuracy win:
@@ -108,7 +119,19 @@ internal object ProjectLanguageScanner {
         // Count every non-directory, non-excluded file toward the cap so binary-
         // heavy repos don't bypass it (see KDoc rationale).
         fileCount[0]++
-        val sampleResult =
+        ProgressManager.checkCanceled()
+        sampleLanguageWeight(file)?.let { (languageId, weight) ->
+            weights.merge(languageId, weight) { a, b -> a + b }
+        }
+        ProgressManager.checkCanceled()
+        return true
+    }
+
+    @TestOnly
+    internal fun sampleLanguageWeightForTest(file: VirtualFile): Pair<String, Long>? = sampleLanguageWeight(file)
+
+    private fun sampleLanguageWeight(file: VirtualFile): Pair<String, Long>? {
+        val sample =
             runCatchingPreservingCancellation {
                 val languageId =
                     LanguageDetectionRules.resolveLanguageId(file.fileType)
@@ -116,15 +139,14 @@ internal object ProjectLanguageScanner {
                 val weight = file.length.coerceIn(0L, LanguageDetectionRules.MAX_FILE_WEIGHT_BYTES)
                 languageId to weight
             }
-        sampleResult.getOrNull()?.let { (languageId, weight) ->
-            weights.merge(languageId, weight) { a, b -> a + b }
-        }
-        if (sampleResult.isFailure) {
+        val failure = sample.exceptionOrNull()
+        if (failure != null) {
             // AlreadyDisposedException, mid-VFS-change IOException, third-party
             // plugin exceptions from custom FileType.detect implementations all
             // land here. Individual files are not worth failing a whole scan.
-            LOG.debug("Skipping file during language scan: ${file.path}", sampleResult.exceptionOrNull())
+            LOG.debug("Skipping file during language scan: ${file.path}", failure)
+            return null
         }
-        return true
+        return sample.getOrNull()
     }
 }

--- a/src/main/kotlin/dev/ayuislands/font/FontCatalog.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontCatalog.kt
@@ -32,6 +32,8 @@ object FontCatalog {
         val useDirectUrl: Boolean = false,
     )
 
+    // scripts/verify-font-fallback-urls.py parses fallbackUrl values as
+    // references to these simple string const vals; keep them as literal URLs.
     // Last-known-good 2026-04-09 (verified via live HTTP, see RESEARCH.md §1).
     private const val VICTOR_MONO_DIRECT_URL = "https://rubjo.github.io/victor-mono/VictorMonoAll.zip"
 

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/AddProjectMappingDialog.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/AddProjectMappingDialog.kt
@@ -14,6 +14,7 @@ import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.TopGap
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.util.ui.JBUI
+import org.jetbrains.annotations.TestOnly
 import java.awt.Component
 import java.io.File
 import javax.swing.DefaultListCellRenderer
@@ -135,6 +136,26 @@ class AddProjectMappingDialog(
                 ?: File(canonical).name
         resultHex = swatchPicker.selectedHex
         super.doOKAction()
+    }
+
+    @TestOnly
+    internal fun setPathForTest(path: String) {
+        pathField.text = path
+    }
+
+    @TestOnly
+    internal fun selectHexForTest(hex: String?) {
+        swatchPicker.selectedHex = hex
+    }
+
+    @TestOnly
+    internal fun validationMessageForTest(): String? = doValidate()?.message
+
+    @TestOnly
+    internal fun confirmForTest() {
+        val validation = doValidate()
+        check(validation == null) { validation?.message ?: "Dialog validation failed" }
+        doOKAction()
     }
 
     private fun loadRecentProjects(excluded: Set<String>): List<RecentProjectRow> =

--- a/src/test/kotlin/dev/ayuislands/accent/CancellationSafeRunCatchingTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/CancellationSafeRunCatchingTest.kt
@@ -1,5 +1,6 @@
 package dev.ayuislands.accent
 
+import com.intellij.openapi.progress.ProcessCanceledException
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -55,6 +56,19 @@ class CancellationSafeRunCatchingTest {
             }
         assertEquals("coroutine cancelled mid-probe", thrown.message)
         assertSame(boom, thrown, "must rethrow the ORIGINAL instance, not a wrapper")
+    }
+
+    @Test
+    fun `ProcessCanceledException is rethrown instead of being captured`() {
+        // IntelliJ uses ProcessCanceledException for progress and project-disposal
+        // cancellation. Capturing it would let long-running platform scans continue
+        // after cancellation and potentially cache stale results.
+        val boom = ProcessCanceledException()
+        val thrown =
+            assertFailsWith<ProcessCanceledException> {
+                runCatchingPreservingCancellation<String> { throw boom }
+            }
+        assertSame(boom, thrown, "must rethrow the ORIGINAL platform cancellation")
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
@@ -1,5 +1,6 @@
 package dev.ayuislands.accent
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.Project
@@ -643,6 +644,34 @@ class ProjectLanguageDetectorTest {
 
         assertEquals(ProjectLanguageVerdict.Cold, ProjectLanguageDetector.verdict(project))
         verify(exactly = 0) { ProjectLanguageScanner.scan(any()) }
+    }
+
+    @Test
+    fun `dominant on EDT returns fallback immediately and schedules background scan`() {
+        val project = stubProject("/tmp/edt-cold-cache-${System.nanoTime()}")
+        stubDumbServiceSmart(project)
+        every { ProjectLanguageScanner.scan(project) } answers {
+            error("EDT dominant must schedule scan instead of reading project files synchronously")
+        }
+        mockkStatic(ApplicationManager::class)
+        val application = mockk<com.intellij.openapi.application.Application>()
+        every { ApplicationManager.getApplication() } returns application
+        every { application.isDispatchThread } returns true
+        mockkObject(ProjectLanguageScanAsync)
+        val capturedKey = io.mockk.slot<String>()
+        every { ProjectLanguageScanAsync.schedule(project, capture(capturedKey), any()) } returns true
+
+        assertNull(
+            ProjectLanguageDetector.dominant(project),
+            "Cold-cache EDT lookup must return the global fallback immediately",
+        )
+
+        assertEquals(
+            AccentResolver.projectKey(project),
+            capturedKey.captured,
+            "The scheduled scan must use the canonical project key for deduplication",
+        )
+        verify(exactly = 1) { ProjectLanguageScanAsync.schedule(project, any(), any()) }
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
@@ -1027,7 +1027,7 @@ class ProjectLanguageDetectorTest {
 
         stubDumbServiceSmart(project)
         mockkObject(ProjectLanguageScanAsync)
-        every { ProjectLanguageScanAsync.schedule(any(), any()) } returns true
+        every { ProjectLanguageScanAsync.schedule(any(), any(), any()) } returns true
 
         ProjectLanguageDetector.rescan(project)
 
@@ -1051,7 +1051,7 @@ class ProjectLanguageDetectorTest {
         stubDumbServiceSmart(project)
         mockkObject(ProjectLanguageScanAsync)
         val capturedKey = io.mockk.slot<String>()
-        every { ProjectLanguageScanAsync.schedule(capture(capturedKey), any()) } returns true
+        every { ProjectLanguageScanAsync.schedule(any(), capture(capturedKey), any()) } returns true
 
         ProjectLanguageDetector.rescan(project)
 
@@ -1076,7 +1076,7 @@ class ProjectLanguageDetectorTest {
 
         ProjectLanguageDetector.rescan(project)
 
-        verify(exactly = 0) { ProjectLanguageScanAsync.schedule(any(), any()) }
+        verify(exactly = 0) { ProjectLanguageScanAsync.schedule(any(), any(), any()) }
     }
 
     @Test
@@ -1217,9 +1217,9 @@ class ProjectLanguageDetectorTest {
 
         // Custom scheduler: flips disposed right before running the task.
         mockkObject(ProjectLanguageScanAsync)
-        every { ProjectLanguageScanAsync.schedule(any(), any()) } answers {
+        every { ProjectLanguageScanAsync.schedule(any(), any(), any()) } answers {
             every { project.isDisposed } returns true
-            val task = secondArg<() -> Unit>()
+            val task = thirdArg<() -> ProjectLanguageScanAsync.ScanResult>()
             task()
             true
         }
@@ -1227,6 +1227,180 @@ class ProjectLanguageDetectorTest {
         ProjectLanguageDetector.rescan(project)
 
         verify(exactly = 0) { listener.scanCompleted(any()) }
+    }
+
+    @Test
+    fun `rescan skips cache and publish when project disposes after scan before cache write`() {
+        // Dispose-after-scan race: the scanner may return a detected result
+        // just as the project closes. The detector must re-check lifetime
+        // before writing the verdict cache or publishing a stale detected
+        // outcome to subscribers.
+        val project = stubProject("/tmp/rescan-disposed-after-scan-${System.nanoTime()}")
+        every { ProjectLanguageScanner.scan(project) } answers {
+            every { project.isDisposed } returns true
+            mapOf("kotlin" to 1_000L)
+        }
+        wireProjectRootManager(project, sdkName = null)
+        wireModuleManager(project, moduleNames = emptyList())
+
+        stubDumbServiceSmart(project)
+        val listener = mockk<ProjectLanguageDetectionListener>(relaxed = true)
+        wireMessageBus(project, listener)
+        runInvokeLaterInline()
+        runSchedulerInline()
+
+        ProjectLanguageDetector.rescan(project)
+
+        verify(exactly = 0) { listener.scanCompleted(any()) }
+        assertNull(
+            ProjectLanguageDetector.proportions(project),
+            "disposed-after-scan detected weights must not be cached",
+        )
+        assertEquals(
+            ProjectLanguageVerdict.Cold,
+            ProjectLanguageDetector.verdict(project),
+            "disposed-after-scan detected verdict must not be cached",
+        )
+    }
+
+    @Test
+    fun `rescan removes detected cache when project disposes after cache write before publish`() {
+        // Narrower disposal race: the project stays live through the
+        // pre-cache guards, then closes immediately after the cache write.
+        // The scheduler's later publish guard suppresses MessageBus output,
+        // but the detector must also remove the just-written verdict by the
+        // already-known key so a reopened project does not inherit it.
+        val basePath = "/tmp/rescan-disposed-after-cache-${System.nanoTime()}"
+        val closingProject = stubProject(basePath)
+        val reopenedProject = stubProject(basePath)
+        every { closingProject.isDisposed } returnsMany
+            listOf(
+                false, // task entry guard
+                false, // post-scan guard inside detectInternal
+                false, // pre-cache guard inside detectAndCache
+                true, // late disposal immediately after cache write
+                true, // scheduler post-detect guard
+            )
+        every { ProjectLanguageScanner.scan(closingProject) } returns mapOf("kotlin" to 1_000L)
+        wireProjectRootManager(closingProject, sdkName = null)
+        wireModuleManager(closingProject, moduleNames = emptyList())
+
+        stubDumbServiceSmart(closingProject)
+        val listener = mockk<ProjectLanguageDetectionListener>(relaxed = true)
+        wireMessageBus(closingProject, listener)
+        runInvokeLaterInline()
+        runSchedulerInline()
+
+        ProjectLanguageDetector.rescan(closingProject)
+
+        verify(exactly = 0) { listener.scanCompleted(any()) }
+        assertNull(
+            ProjectLanguageDetector.proportions(reopenedProject),
+            "late-disposed detected weights must not survive under the canonical project key",
+        )
+        assertEquals(
+            ProjectLanguageVerdict.Cold,
+            ProjectLanguageDetector.verdict(reopenedProject),
+            "late-disposed detected verdict must be removed by the already-known scheduler key",
+        )
+    }
+
+    @Test
+    fun `rescan removes detected cache when project disposes inside publish delivery`() {
+        // Latest disposal race: cache write and scheduler post-detect guard
+        // both observe a live project. Disposal then happens during the EDT
+        // hop for scanCompleted publish. Dropping that publish must also
+        // remove the just-written verdict by the already-known key.
+        val basePath = "/tmp/rescan-disposed-during-publish-${System.nanoTime()}"
+        val closingProject = stubProject(basePath)
+        val reopenedProject = stubProject(basePath)
+        every { ProjectLanguageScanner.scan(closingProject) } returns mapOf("kotlin" to 1_000L)
+        wireProjectRootManager(closingProject, sdkName = null)
+        wireModuleManager(closingProject, moduleNames = emptyList())
+
+        stubDumbServiceSmart(closingProject)
+        val listener = mockk<ProjectLanguageDetectionListener>(relaxed = true)
+        wireMessageBus(closingProject, listener)
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.resolveFocusedProject() } returns reopenedProject
+        mockkStatic(javax.swing.SwingUtilities::class)
+        var invokeLaterCalls = 0
+        every { javax.swing.SwingUtilities.invokeLater(any()) } answers {
+            invokeLaterCalls++
+            if (invokeLaterCalls == 2) {
+                every { closingProject.isDisposed } returns true
+            }
+            firstArg<Runnable>().run()
+        }
+        runSchedulerInline()
+
+        ProjectLanguageDetector.rescan(closingProject)
+
+        verify(exactly = 0) { listener.scanCompleted(any()) }
+        assertNull(
+            ProjectLanguageDetector.proportions(reopenedProject),
+            "publish-drop detected weights must not survive under the canonical project key",
+        )
+        assertEquals(
+            ProjectLanguageVerdict.Cold,
+            ProjectLanguageDetector.verdict(reopenedProject),
+            "publish-drop detected verdict must be removed by the already-known scheduler key",
+        )
+    }
+
+    @Test
+    fun `stale publish cleanup does not remove reopened equal detected cache`() {
+        // The stale close path and the reopened project can produce
+        // value-equal Detected verdicts for the same canonical path. Cleanup
+        // from the old publish drop must only remove the exact cache generation
+        // it wrote, not a newer equal verdict warmed by the reopened project.
+        val weights = mapOf("kotlin" to 1_000L)
+        val basePath = "/tmp/rescan-reopened-equal-cache-${System.nanoTime()}"
+        val closingProject = stubProject(basePath)
+        val reopenedProject = stubProject(basePath)
+        every { ProjectLanguageScanner.scan(closingProject) } returns weights
+        every { ProjectLanguageScanner.scan(reopenedProject) } returns weights
+        wireProjectRootManager(closingProject, sdkName = null)
+        wireModuleManager(closingProject, moduleNames = emptyList())
+        wireProjectRootManager(reopenedProject, sdkName = null)
+        wireModuleManager(reopenedProject, moduleNames = emptyList())
+
+        stubDumbServiceSmart(closingProject)
+        val listener = mockk<ProjectLanguageDetectionListener>(relaxed = true)
+        wireMessageBus(closingProject, listener)
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.resolveFocusedProject() } returns reopenedProject
+        mockkStatic(javax.swing.SwingUtilities::class)
+        var invokeLaterCalls = 0
+        lateinit var stalePublish: Runnable
+        every { javax.swing.SwingUtilities.invokeLater(any()) } answers {
+            invokeLaterCalls++
+            val runnable = firstArg<Runnable>()
+            if (invokeLaterCalls == 1) {
+                runnable.run()
+            } else {
+                stalePublish = runnable
+            }
+        }
+        runSchedulerInline()
+
+        ProjectLanguageDetector.rescan(closingProject)
+        ProjectLanguageDetector.invalidate(reopenedProject)
+        assertEquals("kotlin", ProjectLanguageDetector.dominant(reopenedProject))
+        assertEquals(weights, ProjectLanguageDetector.proportions(reopenedProject))
+
+        every { closingProject.isDisposed } returns true
+        stalePublish.run()
+
+        verify(exactly = 0) { listener.scanCompleted(any()) }
+        assertEquals(
+            weights,
+            ProjectLanguageDetector.proportions(reopenedProject),
+            "stale publish cleanup must not remove a fresh equal detected cache entry",
+        )
+        val verdict = assertIs<ProjectLanguageVerdict.Detected>(ProjectLanguageDetector.verdict(reopenedProject))
+        assertEquals("kotlin", verdict.languageId)
+        assertEquals(weights, verdict.weights)
     }
 
     @Test
@@ -1254,7 +1428,7 @@ class ProjectLanguageDetectorTest {
         ProjectLanguageDetector.rescan(project)
 
         verify(exactly = 1) { listener.scanCompleted(ScanOutcome.Unavailable) }
-        verify(exactly = 0) { ProjectLanguageScanAsync.schedule(any(), any()) }
+        verify(exactly = 0) { ProjectLanguageScanAsync.schedule(any(), any(), any()) }
     }
 
     @Test
@@ -1314,8 +1488,8 @@ class ProjectLanguageDetectorTest {
 
     private fun runSchedulerInline() {
         mockkObject(ProjectLanguageScanAsync)
-        every { ProjectLanguageScanAsync.schedule(any(), any()) } answers {
-            val task = secondArg<() -> Unit>()
+        every { ProjectLanguageScanAsync.schedule(any(), any(), any()) } answers {
+            val task = thirdArg<() -> ProjectLanguageScanAsync.ScanResult>()
             task()
             true
         }

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
@@ -1404,6 +1404,54 @@ class ProjectLanguageDetectorTest {
     }
 
     @Test
+    fun `disposed cache write does not clobber reopened detected cache`() {
+        // Closing and reopened projects can share the same canonical path. If
+        // the reopened project warms a fresh cache entry while the old scan is
+        // still returning, the old scan must not overwrite that fresh entry
+        // once its project is already disposed at the cache-write boundary.
+        val weights = mapOf("kotlin" to 1_000L)
+        val basePath = "/tmp/rescan-reopened-cache-write-${System.nanoTime()}"
+        val closingProject = stubProject(basePath)
+        val reopenedProject = stubProject(basePath)
+        every { closingProject.isDisposed } returnsMany
+            listOf(
+                false, // task entry guard
+                false, // post-scan guard inside detectInternal
+                false, // pre-cache guard inside detectAndCache
+                true, // atomic cache-write guard
+                true, // scheduler post-detect guard
+            )
+        every { ProjectLanguageScanner.scan(closingProject) } answers {
+            assertEquals("kotlin", ProjectLanguageDetector.dominant(reopenedProject))
+            assertEquals(weights, ProjectLanguageDetector.proportions(reopenedProject))
+            weights
+        }
+        every { ProjectLanguageScanner.scan(reopenedProject) } returns weights
+        wireProjectRootManager(closingProject, sdkName = null)
+        wireModuleManager(closingProject, moduleNames = emptyList())
+        wireProjectRootManager(reopenedProject, sdkName = null)
+        wireModuleManager(reopenedProject, moduleNames = emptyList())
+
+        stubDumbServiceSmart(closingProject)
+        val listener = mockk<ProjectLanguageDetectionListener>(relaxed = true)
+        wireMessageBus(closingProject, listener)
+        runInvokeLaterInline()
+        runSchedulerInline()
+
+        ProjectLanguageDetector.rescan(closingProject)
+
+        verify(exactly = 0) { listener.scanCompleted(any()) }
+        assertEquals(
+            weights,
+            ProjectLanguageDetector.proportions(reopenedProject),
+            "disposed cache write must leave the reopened project's fresh detected weights intact",
+        )
+        val verdict = assertIs<ProjectLanguageVerdict.Detected>(ProjectLanguageDetector.verdict(reopenedProject))
+        assertEquals("kotlin", verdict.languageId)
+        assertEquals(weights, verdict.weights)
+    }
+
+    @Test
     fun `rescan on null project key publishes Unavailable outcome`() {
         // User-facing symptom guard: `AccentResolver.projectKey` can
         // return null for a disposal race or canonicalization failure on

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageScanAsyncTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageScanAsyncTest.kt
@@ -4,9 +4,11 @@ import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.concurrency.AppExecutorUtil
 import io.mockk.every
+import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
@@ -178,6 +180,128 @@ class ProjectLanguageScanAsyncTest {
 
         assertFalse(ranTask, "Disposed project must skip the task body")
         assertFalse(ProjectLanguageScanAsync.isInFlight("alpha"), "Gate must clear after disposal skip")
+    }
+
+    @Test
+    fun `project disposed after progress starts skips task and leaves scan reschedulable`() {
+        var isDisposed = false
+        every { project.isDisposed } answers { isDisposed }
+        every { ProgressManager.getInstance().runProcess(any<Runnable>(), any<ProgressIndicator>()) } answers {
+            isDisposed = true
+            firstArg<Runnable>().run()
+        }
+        var ranTask = false
+        ProjectLanguageScanAsync.schedule(project, "alpha") {
+            ranTask = true
+            ProjectLanguageScanAsync.ScanResult.Completed
+        }
+
+        capturedRunnables[0].run()
+
+        assertFalse(ranTask, "Project-close race must cancel the scan before it touches project files")
+        assertFalse(ProjectLanguageScanAsync.isInFlight("alpha"), "Gate must clear after mid-process disposal")
+        assertTrue(
+            ProjectLanguageScanAsync.schedule(project, "alpha") {
+                ProjectLanguageScanAsync.ScanResult.Completed
+            },
+            "After a project-close race, the next focus or rescan request must be schedulable",
+        )
+    }
+
+    @Test
+    fun `disposal hook registration failure skips task and leaves scan reschedulable`() {
+        mockkStatic(Disposer::class)
+        every { Disposer.register(project, any()) } throws RuntimeException("project is closing")
+        var ranTask = false
+        ProjectLanguageScanAsync.schedule(project, "alpha") {
+            ranTask = true
+            ProjectLanguageScanAsync.ScanResult.Completed
+        }
+
+        capturedRunnables[0].run()
+
+        assertFalse(ranTask, "Scan must not run when it cannot attach project-lifetime cancellation")
+        assertFalse(ProjectLanguageScanAsync.isInFlight("alpha"), "Gate must clear after disposal hook failure")
+        assertTrue(
+            ProjectLanguageScanAsync.schedule(project, "alpha") {
+                ProjectLanguageScanAsync.ScanResult.Completed
+            },
+            "A transient disposal-hook failure must not block future rescans for the project",
+        )
+    }
+
+    @Test
+    fun `disposal hook cancellation skips task and leaves scan reschedulable`() {
+        mockkStatic(Disposer::class)
+        every { Disposer.register(project, any()) } throws ProcessCanceledException()
+        var ranTask = false
+        ProjectLanguageScanAsync.schedule(project, "alpha") {
+            ranTask = true
+            ProjectLanguageScanAsync.ScanResult.Completed
+        }
+
+        capturedRunnables[0].run()
+
+        assertFalse(ranTask, "Canceled disposal-hook registration must not run the scan")
+        assertFalse(
+            ProjectLanguageScanAsync.isInFlight("alpha"),
+            "Gate must clear after hook registration cancellation",
+        )
+        assertTrue(
+            ProjectLanguageScanAsync.schedule(project, "alpha") {
+                ProjectLanguageScanAsync.ScanResult.Completed
+            },
+            "Platform cancellation during hook registration must not block future rescans",
+        )
+    }
+
+    @Test
+    fun `disposal hook cleanup failure still leaves scan reschedulable`() {
+        mockkStatic(Disposer::class)
+        justRun { Disposer.register(project, any()) }
+        every { Disposer.dispose(any()) } throws RuntimeException("hook already disposed")
+        var ranTask = false
+        ProjectLanguageScanAsync.schedule(project, "alpha") {
+            ranTask = true
+            ProjectLanguageScanAsync.ScanResult.Completed
+        }
+
+        capturedRunnables[0].run()
+
+        assertTrue(ranTask, "Cleanup failure happens after the user-visible scan result is produced")
+        assertFalse(
+            ProjectLanguageScanAsync.isInFlight("alpha"),
+            "Gate must clear even when hook cleanup races disposal",
+        )
+        assertTrue(
+            ProjectLanguageScanAsync.schedule(project, "alpha") {
+                ProjectLanguageScanAsync.ScanResult.Completed
+            },
+            "After hook cleanup failure, future rescans must still be available",
+        )
+    }
+
+    @Test
+    fun `disposal hook cleanup cancellation still leaves scan reschedulable`() {
+        mockkStatic(Disposer::class)
+        justRun { Disposer.register(project, any()) }
+        every { Disposer.dispose(any()) } throws ProcessCanceledException()
+        var ranTask = false
+        ProjectLanguageScanAsync.schedule(project, "alpha") {
+            ranTask = true
+            ProjectLanguageScanAsync.ScanResult.Completed
+        }
+
+        capturedRunnables[0].run()
+
+        assertTrue(ranTask, "Cleanup cancellation happens after the scan produced a result")
+        assertFalse(ProjectLanguageScanAsync.isInFlight("alpha"), "Gate must clear after hook cleanup cancellation")
+        assertTrue(
+            ProjectLanguageScanAsync.schedule(project, "alpha") {
+                ProjectLanguageScanAsync.ScanResult.Completed
+            },
+            "Cleanup cancellation must not block future rescans for the same project",
+        )
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageScanAsyncTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageScanAsyncTest.kt
@@ -1,5 +1,10 @@
 package dev.ayuislands.accent
 
+import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.concurrency.AppExecutorUtil
 import io.mockk.every
 import io.mockk.mockk
@@ -10,6 +15,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -20,6 +26,7 @@ import kotlin.test.assertTrue
  */
 class ProjectLanguageScanAsyncTest {
     private val capturedRunnables = mutableListOf<Runnable>()
+    private lateinit var project: Project
 
     @BeforeTest
     fun setUp() {
@@ -31,6 +38,14 @@ class ProjectLanguageScanAsyncTest {
         val executor = mockk<java.util.concurrent.ExecutorService>()
         every { AppExecutorUtil.getAppExecutorService() } returns executor
         every { executor.execute(any()) } answers { capturedRunnables.add(firstArg()) }
+        mockkStatic(ProgressManager::class)
+        val progressManager = mockk<ProgressManager>()
+        every { ProgressManager.getInstance() } returns progressManager
+        every { progressManager.runProcess(any<Runnable>(), any<ProgressIndicator>()) } answers {
+            firstArg<Runnable>().run()
+        }
+        project = mockk(relaxed = true)
+        every { project.isDisposed } returns false
         ProjectLanguageScanAsync.clearForTest()
         capturedRunnables.clear()
     }
@@ -42,8 +57,42 @@ class ProjectLanguageScanAsyncTest {
     }
 
     @Test
+    fun `scanner sampling skips non-cancellation Error from file type lookup`() {
+        val file = mockk<VirtualFile>()
+        every { file.path } returns "/tmp/Broken.kt"
+        every { file.fileType } throws NoClassDefFoundError("language plugin unloaded")
+
+        assertNull(ProjectLanguageScanner.sampleLanguageWeightForTest(file))
+    }
+
+    @Test
+    fun `scanner sampling propagates platform cancellation from file type lookup`() {
+        val file = mockk<VirtualFile>()
+        every { file.path } returns "/tmp/Cancel.kt"
+        every { file.fileType } throws ProcessCanceledException()
+
+        kotlin.test.assertFailsWith<ProcessCanceledException> {
+            ProjectLanguageScanner.sampleLanguageWeightForTest(file)
+        }
+    }
+
+    @Test
+    fun `scanner sampling propagates kotlin cancellation from file type lookup`() {
+        val file = mockk<VirtualFile>()
+        every { file.path } returns "/tmp/Cancel.kt"
+        every { file.fileType } throws kotlin.coroutines.cancellation.CancellationException("cancel")
+
+        kotlin.test.assertFailsWith<kotlin.coroutines.cancellation.CancellationException> {
+            ProjectLanguageScanner.sampleLanguageWeightForTest(file)
+        }
+    }
+
+    @Test
     fun `schedule returns true and dispatches task on first call`() {
-        val scheduled = ProjectLanguageScanAsync.schedule("alpha") { /* no-op */ }
+        val scheduled =
+            ProjectLanguageScanAsync.schedule(project, "alpha") {
+                ProjectLanguageScanAsync.ScanResult.Completed
+            }
         assertTrue(scheduled)
         assertEquals(1, capturedRunnables.size, "Scheduled runnable must be dispatched to the pool")
     }
@@ -51,20 +100,30 @@ class ProjectLanguageScanAsyncTest {
     @Test
     fun `second schedule for the same key while in-flight returns false and does NOT re-dispatch`() {
         // First schedule: task captured but NOT yet run — in-flight gate holds.
-        val first = ProjectLanguageScanAsync.schedule("alpha") { /* no-op */ }
+        val first =
+            ProjectLanguageScanAsync.schedule(project, "alpha") {
+                ProjectLanguageScanAsync.ScanResult.Completed
+            }
         assertTrue(first)
         assertTrue(ProjectLanguageScanAsync.isInFlight("alpha"))
 
         // Second schedule for same key while first is still in-flight: dedup kicks in.
-        val second = ProjectLanguageScanAsync.schedule("alpha") { /* no-op */ }
+        val second =
+            ProjectLanguageScanAsync.schedule(project, "alpha") {
+                ProjectLanguageScanAsync.ScanResult.Completed
+            }
         assertFalse(second)
         assertEquals(1, capturedRunnables.size, "Duplicate schedule must not re-dispatch")
     }
 
     @Test
     fun `schedule for different keys runs both independently`() {
-        ProjectLanguageScanAsync.schedule("alpha") { }
-        ProjectLanguageScanAsync.schedule("beta") { }
+        ProjectLanguageScanAsync.schedule(project, "alpha") {
+            ProjectLanguageScanAsync.ScanResult.Completed
+        }
+        ProjectLanguageScanAsync.schedule(project, "beta") {
+            ProjectLanguageScanAsync.ScanResult.Completed
+        }
         assertTrue(ProjectLanguageScanAsync.isInFlight("alpha"))
         assertTrue(ProjectLanguageScanAsync.isInFlight("beta"))
         assertEquals(2, capturedRunnables.size)
@@ -72,7 +131,9 @@ class ProjectLanguageScanAsyncTest {
 
     @Test
     fun `after task runs the key is no longer in-flight and can be rescheduled`() {
-        ProjectLanguageScanAsync.schedule("alpha") { }
+        ProjectLanguageScanAsync.schedule(project, "alpha") {
+            ProjectLanguageScanAsync.ScanResult.Completed
+        }
         assertTrue(ProjectLanguageScanAsync.isInFlight("alpha"))
 
         // Simulate the pool running the captured task — the schedule's finally
@@ -80,7 +141,10 @@ class ProjectLanguageScanAsyncTest {
         capturedRunnables[0].run()
         assertFalse(ProjectLanguageScanAsync.isInFlight("alpha"))
 
-        val rescheduled = ProjectLanguageScanAsync.schedule("alpha") { }
+        val rescheduled =
+            ProjectLanguageScanAsync.schedule(project, "alpha") {
+                ProjectLanguageScanAsync.ScanResult.Completed
+            }
         assertTrue(rescheduled)
         assertEquals(2, capturedRunnables.size)
     }
@@ -90,17 +154,57 @@ class ProjectLanguageScanAsyncTest {
         // Regression guard: if the finally removed the key BEFORE the try/catch
         // swallowed the exception, a thrown task would leave the gate stuck forever,
         // blocking every subsequent schedule for that key until IDE restart.
-        ProjectLanguageScanAsync.schedule("alpha") { error("simulated task failure") }
+        ProjectLanguageScanAsync.schedule(project, "alpha") { error("simulated task failure") }
         capturedRunnables[0].run() // exception is caught inside the scheduled task
 
         assertFalse(ProjectLanguageScanAsync.isInFlight("alpha"), "Gate must clear after thrown task")
-        val rescheduled = ProjectLanguageScanAsync.schedule("alpha") { }
+        val rescheduled =
+            ProjectLanguageScanAsync.schedule(project, "alpha") {
+                ProjectLanguageScanAsync.ScanResult.Completed
+            }
         assertTrue(rescheduled, "After exception, the key must be reschedulable")
     }
 
     @Test
+    fun `disposed project before task body does not run task and clears the in-flight gate`() {
+        every { project.isDisposed } returns true
+        var ranTask = false
+        ProjectLanguageScanAsync.schedule(project, "alpha") {
+            ranTask = true
+            ProjectLanguageScanAsync.ScanResult.Completed
+        }
+
+        capturedRunnables[0].run()
+
+        assertFalse(ranTask, "Disposed project must skip the task body")
+        assertFalse(ProjectLanguageScanAsync.isInFlight("alpha"), "Gate must clear after disposal skip")
+    }
+
+    @Test
+    fun `unavailable task result does not leak the in-flight gate`() {
+        ProjectLanguageScanAsync.schedule(project, "alpha") {
+            ProjectLanguageScanAsync.ScanResult.Unavailable
+        }
+
+        capturedRunnables[0].run()
+
+        assertFalse(ProjectLanguageScanAsync.isInFlight("alpha"), "Gate must clear after unavailable scan")
+    }
+
+    @Test
+    fun `process cancellation does not leak the in-flight gate`() {
+        ProjectLanguageScanAsync.schedule(project, "alpha") {
+            throw ProcessCanceledException()
+        }
+
+        capturedRunnables[0].run()
+
+        assertFalse(ProjectLanguageScanAsync.isInFlight("alpha"), "Gate must clear after platform cancellation")
+    }
+
+    @Test
     fun `cancellation exception propagates out of the scheduled task`() {
-        ProjectLanguageScanAsync.schedule("alpha") {
+        ProjectLanguageScanAsync.schedule(project, "alpha") {
             throw kotlin.coroutines.cancellation.CancellationException("cancel")
         }
         val runnable = capturedRunnables[0]
@@ -113,8 +217,12 @@ class ProjectLanguageScanAsyncTest {
 
     @Test
     fun `clearForTest resets every in-flight key`() {
-        ProjectLanguageScanAsync.schedule("alpha") { }
-        ProjectLanguageScanAsync.schedule("beta") { }
+        ProjectLanguageScanAsync.schedule(project, "alpha") {
+            ProjectLanguageScanAsync.ScanResult.Completed
+        }
+        ProjectLanguageScanAsync.schedule(project, "beta") {
+            ProjectLanguageScanAsync.ScanResult.Completed
+        }
         ProjectLanguageScanAsync.clearForTest()
         assertFalse(ProjectLanguageScanAsync.isInFlight("alpha"))
         assertFalse(ProjectLanguageScanAsync.isInFlight("beta"))

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageScannerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageScannerTest.kt
@@ -1,0 +1,168 @@
+package dev.ayuislands.accent
+
+import com.intellij.lang.Language
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.fileTypes.LanguageFileType
+import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ContentIterator
+import com.intellij.openapi.roots.ProjectFileIndex
+import com.intellij.openapi.util.Computable
+import com.intellij.openapi.vfs.VirtualFile
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ProjectLanguageScannerTest {
+    private lateinit var application: Application
+    private lateinit var dumbService: DumbService
+    private lateinit var fileIndex: ProjectFileIndex
+    private lateinit var project: Project
+    private var isDisposed = false
+
+    @BeforeTest
+    fun setUp() {
+        mockkStatic(ApplicationManager::class)
+        application = mockk()
+        every { ApplicationManager.getApplication() } returns application
+        every { application.runReadAction<Map<String, Long>>(any()) } answers {
+            firstArg<Computable<Map<String, Long>>>().compute()
+        }
+
+        mockkStatic(ProjectFileIndex::class)
+        fileIndex = mockk()
+        project = mockk(relaxed = true)
+        isDisposed = false
+        every { project.isDisposed } answers { isDisposed }
+        dumbService = mockk()
+        every { dumbService.isDumb } returns false
+        every { project.getService(DumbService::class.java) } returns dumbService
+        every { ProjectFileIndex.getInstance(project) } returns fileIndex
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `scan returns null for disposed project without touching project index`() {
+        isDisposed = true
+
+        assertNull(
+            ProjectLanguageScanner.scan(project),
+            "Closed projects must not produce cacheable language weights",
+        )
+        verify(exactly = 0) { ProjectFileIndex.getInstance(project) }
+    }
+
+    @Test
+    fun `scan returns null during indexing without touching project index`() {
+        every { dumbService.isDumb } returns true
+
+        assertNull(
+            ProjectLanguageScanner.scan(project),
+            "Indexing projects must retry later instead of caching a pre-indexing guess",
+        )
+        verify(exactly = 0) { ProjectFileIndex.getInstance(project) }
+    }
+
+    @Test
+    fun `scan propagates progress cancellation instead of caching fallback`() {
+        mockkStatic(ProgressManager::class)
+        every { ProgressManager.checkCanceled() } throws ProcessCanceledException()
+
+        assertFailsWith<ProcessCanceledException> {
+            ProjectLanguageScanner.scan(project)
+        }
+    }
+
+    @Test
+    fun `scan returns null when read action fails before a stable project answer`() {
+        every { application.runReadAction<Map<String, Long>>(any()) } throws RuntimeException("roots changed")
+
+        assertNull(
+            ProjectLanguageScanner.scan(project),
+            "Read-action failures must leave the detector free to retry on the next lookup",
+        )
+    }
+
+    @Test
+    fun `scan returns language weights when content iteration completes`() {
+        every { fileIndex.iterateContent(any()) } answers {
+            firstArg<ContentIterator>().processFile(sourceFile("/repo/src/Main.kt", "KOTLIN", 1_200L))
+        }
+
+        assertEquals(
+            mapOf("kotlin" to 1_200L),
+            ProjectLanguageScanner.scan(project),
+            "Stable scans should return cacheable language weights for the detector",
+        )
+    }
+
+    @Test
+    fun `scan returns null when project closes after read action completes`() {
+        every { fileIndex.iterateContent(any()) } answers {
+            firstArg<ContentIterator>().processFile(sourceFile("/repo/src/Main.kt", "KOTLIN", 1_200L))
+        }
+        every { application.runReadAction<Map<String, Long>>(any()) } answers {
+            val weights = firstArg<Computable<Map<String, Long>>>().compute()
+            isDisposed = true
+            weights
+        }
+
+        assertNull(
+            ProjectLanguageScanner.scan(project),
+            "A scan that races with project close must not return cacheable language weights",
+        )
+    }
+
+    @Test
+    fun `scan stops visiting files when project closes during content iteration`() {
+        val scannedBeforeClose = sourceFile("/repo/src/Main.kt", "KOTLIN", 1_200L)
+        val skippedAfterClose = sourceFile("/repo/src/Generated.kt", "KOTLIN", 900L)
+        every { fileIndex.iterateContent(any()) } answers {
+            val iterator = firstArg<ContentIterator>()
+            assertTrue(iterator.processFile(scannedBeforeClose))
+            isDisposed = true
+            assertFalse(iterator.processFile(skippedAfterClose))
+            false
+        }
+
+        assertNull(
+            ProjectLanguageScanner.scan(project),
+            "Closing the project mid-scan must make the result non-cacheable",
+        )
+        verify(exactly = 0) { skippedAfterClose.fileType }
+    }
+
+    private fun sourceFile(
+        path: String,
+        languageId: String,
+        length: Long,
+    ): VirtualFile {
+        val language = mockk<Language>()
+        every { language.id } returns languageId
+        val fileType = mockk<LanguageFileType>()
+        every { fileType.language } returns language
+        return mockk<VirtualFile>().also { file ->
+            every { file.path } returns path
+            every { file.isDirectory } returns false
+            every { file.length } returns length
+            every { file.fileType } returns fileType
+        }
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/AddProjectMappingDialogTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/AddProjectMappingDialogTest.kt
@@ -1,0 +1,121 @@
+package dev.ayuislands.settings.mappings
+
+import com.intellij.openapi.ui.DialogWrapper
+import org.junit.jupiter.api.io.TempDir
+import java.lang.reflect.InvocationTargetException
+import java.nio.file.Files
+import java.nio.file.Path
+import javax.swing.SwingUtilities
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class AddProjectMappingDialogTest {
+    @field:TempDir
+    lateinit var tempDir: Path
+
+    @Test
+    fun `validation rejects blank project path`() =
+        onEdt {
+            val dialog =
+                AddProjectMappingDialog(parent = null, excludedPaths = emptySet(), initialHex = "#FFCC66")
+
+            dialog.useDialog {
+                it.setPathForTest("   ")
+
+                assertEquals("Enter a project path.", it.validationMessageForTest())
+            }
+        }
+
+    @Test
+    fun `validation rejects missing project directory`() =
+        onEdt {
+            val missingPath = tempDir.resolve("missing-project")
+            val dialog =
+                AddProjectMappingDialog(parent = null, excludedPaths = emptySet(), initialHex = "#FFCC66")
+
+            dialog.useDialog {
+                it.setPathForTest(missingPath.toString())
+
+                assertEquals("Path is not an existing directory.", it.validationMessageForTest())
+            }
+        }
+
+    @Test
+    fun `validation rejects duplicate project path after canonicalization`() =
+        onEdt {
+            val projectDir = Files.createDirectory(tempDir.resolve("existing-project")).toFile()
+            val dialog =
+                AddProjectMappingDialog(
+                    parent = null,
+                    excludedPaths = setOf(projectDir.canonicalPath.uppercase()),
+                    initialHex = "#FFCC66",
+                )
+
+            dialog.useDialog {
+                it.setPathForTest(projectDir.path)
+
+                assertEquals("This project already has an override.", it.validationMessageForTest())
+            }
+        }
+
+    @Test
+    fun `validation rejects missing accent color`() =
+        onEdt {
+            val projectDir = Files.createDirectory(tempDir.resolve("project-without-color"))
+            val dialog = AddProjectMappingDialog(parent = null, excludedPaths = emptySet())
+
+            dialog.useDialog {
+                it.setPathForTest(projectDir.toString())
+
+                assertEquals("Choose an accent color.", it.validationMessageForTest())
+            }
+        }
+
+    @Test
+    fun `valid project override returns canonical path display name and color`() =
+        onEdt {
+            val projectDir = Files.createDirectory(tempDir.resolve("project-override")).toFile()
+            val dialog = AddProjectMappingDialog(parent = null, excludedPaths = emptySet())
+            var confirmed = false
+
+            try {
+                dialog.setPathForTest(projectDir.path)
+                dialog.selectHexForTest("#FFCC66")
+
+                assertNull(dialog.validationMessageForTest())
+
+                dialog.confirmForTest()
+                confirmed = true
+
+                assertEquals(projectDir.canonicalPath, dialog.resultCanonicalPath)
+                assertEquals(projectDir.name, dialog.resultDisplayName)
+                assertEquals("#FFCC66", dialog.resultHex)
+            } finally {
+                if (!confirmed) {
+                    dialog.close(DialogWrapper.CANCEL_EXIT_CODE)
+                }
+            }
+        }
+
+    private fun onEdt(action: () -> Unit) {
+        if (SwingUtilities.isEventDispatchThread()) {
+            action()
+            return
+        }
+
+        try {
+            SwingUtilities.invokeAndWait(action)
+        } catch (exception: InvocationTargetException) {
+            throw exception.targetException
+        }
+    }
+
+    private inline fun AddProjectMappingDialog.useDialog(block: (AddProjectMappingDialog) -> Unit) {
+        try {
+            block(this)
+        } finally {
+            close(DialogWrapper.CANCEL_EXIT_CODE)
+        }
+    }
+}


### PR DESCRIPTION
── Summary ─────────────────────────────────

Close the verified quality-backlog slices that were still carrying release or runtime risk: font fallback URLs now have CI smoke coverage, project-language scans cancel cleanly on disposal, the IntelliJ Platform Gradle Plugin pin is lifted to the current validated line, and fragile mapping-dialog behavior has focused tests.

The branch intentionally does not add an Atom Material Icons conflict entry because the current production surface evidence is not strong enough: the old `CHECKBOXES` target is gone, and the remaining `MATCHING_TAG` signal is test-only.

── Changes ─────────────────────────────────

- CI: [build.yml](.github/workflows/build.yml) and [verify-font-fallback-urls.py](scripts/verify-font-fallback-urls.py) add a live HEAD smoke for `FontCatalog` fallback URLs, bounded retry handling, and parser/unit coverage.
- Fix: [ProjectLanguageScanAsync.kt](src/main/kotlin/dev/ayuislands/accent/ProjectLanguageScanAsync.kt), [ProjectLanguageDetector.kt](src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt), and [ProjectLanguageScanner.kt](src/main/kotlin/dev/ayuislands/accent/ProjectLanguageScanner.kt) add cancellation/lifetime handling around background scans and preserve reopened-project cache entries during disposal races.
- Build: [build.gradle.kts](build.gradle.kts) updates `org.jetbrains.intellij.platform` from `2.13.1` to `2.17.0`, and [dependabot.yml](.github/dependabot.yml) removes the broad `>= 2.14.0` ignore.
- Test: [AddProjectMappingDialogTest.kt](src/test/kotlin/dev/ayuislands/settings/mappings/AddProjectMappingDialogTest.kt), [ProjectLanguageDetectorTest.kt](src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt), and [ProjectLanguageScanAsyncTest.kt](src/test/kotlin/dev/ayuislands/accent/ProjectLanguageScanAsyncTest.kt) cover mapping validation, disposal races, cancellation, and scanner failure boundaries.
- Docs metadata: [features.yml](docs/features.yml) restamps unchanged screenshots after source-only changes required by the verifier.

── Validation ──────────────────────────────

```bash
scripts/verify-docs.py
# Passed: docs/features.yml in sync with README + plugin.xml + CHANGELOG

python3 scripts/tests/test-verify-font-fallback-urls.py
# Passed: 10 tests

python3 scripts/verify-font-fallback-urls.py
# Passed with network access: 3 URL(s) checked

./gradlew test --tests dev.ayuislands.accent.ProjectLanguageDetectorTest --tests dev.ayuislands.accent.ProjectLanguageScanAsyncTest
# Passed on final HEAD

./gradlew detekt ktlintCheck
# Passed during cleanup and pre-commit hooks

./gradlew buildPlugin
# Passed on final HEAD

./gradlew verifyPlugin
# Passed earlier on this branch after the IJGP 2.17.0 update; not rerun after final cleanup commits
```

── Notes ───────────────────────────────────

- Full `./gradlew test` was not run to completion because a fresh-main baseline run previously hung in `QuickSwitcherRelatedTogglesSectionTest.setUp`; this PR uses focused tests for the touched behavior instead.
- `verifyPlugin` emitted existing deprecated/experimental API warnings during the earlier successful run; no new verifier incompatibility was reported.
- Review focus: language-scan disposal/cache behavior and the CI live-network tradeoff for font fallback URL smoke.

## Summary by Sourcery

Harden language detection and mapping dialog behavior around project disposal and cancellation, introduce CI-backed verification for font fallback URLs, and align build tooling and documentation metadata with the updated IntelliJ Platform plugin line.

New Features:
- Add a Python-based verifier and CI smoke test for FontCatalog fallback URLs with bounded retries.

Bug Fixes:
- Harden project language scan scheduling and caching to respect project disposal, cancellation, and in-flight gate cleanup.
- Prevent stale or disposed project language verdicts from leaking between closed and reopened projects sharing the same path.
- Tighten AddProjectMapping dialog validation for paths, duplicates, and missing accent colors.

Enhancements:
- Improve ProjectLanguageScanner resilience by propagating cancellation, skipping per-file errors, and adding focused unit tests.
- Refine background language detection behavior on the EDT by scheduling scans instead of synchronous file access.

Build:
- Update IntelliJ Platform Gradle Plugin to version 2.17.0 and lift the previous dependabot ignore.
- Extend build and CodeQL workflows to run font fallback URL tests and free disk space, and increase EAP job timeout.

CI:
- Add CI steps to run font fallback URL unit tests and live verifier against FontCatalog.

Documentation:
- Refresh docs/features.yml metadata for screenshots affected by source-only changes.

Tests:
- Add focused tests for ProjectLanguageDetector disposal races and cache behavior, ProjectLanguageScanAsync cancellation and lifetime handling, ProjectLanguageScanner progress and error handling, and AddProjectMappingDialog validation.