### PR TITLE
fix(accent): bound project language scan sampling

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "e8063e35"
+          last_verified_sha: "83681b28"
           last_verified_date: "2026-06-30"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "e8063e35"
+          last_verified_sha: "83681b28"
           last_verified_date: "2026-06-30"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
@@ -148,7 +148,7 @@ internal object LanguageDetectionRules {
     const val MAX_FILES_SCANNED: Int = 10_000
 
     /**
-     * Initial eligible files sampled without gaps before stride sampling starts.
+     * Initial eligible files sampled without gaps before bounded sampling starts.
      * Keeps small projects exact and preserves early-root signal in large repos.
      */
     const val PROJECT_LANGUAGE_WARMUP_SAMPLE_FILES: Int = 128
@@ -159,13 +159,6 @@ internal object LanguageDetectionRules {
      * expensive language/file-type work stops at this bound.
      */
     const val PROJECT_LANGUAGE_MAX_SAMPLED_FILES: Int = 1_000
-
-    /**
-     * Stable stride for eligible files after [PROJECT_LANGUAGE_WARMUP_SAMPLE_FILES].
-     * A value of 10 samples the 10th, 20th, 30th, ... post-warmup file until
-     * [PROJECT_LANGUAGE_MAX_SAMPLED_FILES] is reached.
-     */
-    const val PROJECT_LANGUAGE_SAMPLE_STRIDE: Int = 10
 
     @Suppress("unused")
     private val projectLanguageSamplingInvariants: Unit =
@@ -181,9 +174,6 @@ internal object LanguageDetectionRules {
             require(PROJECT_LANGUAGE_MAX_SAMPLED_FILES <= MAX_FILES_SCANNED) {
                 "PROJECT_LANGUAGE_MAX_SAMPLED_FILES ($PROJECT_LANGUAGE_MAX_SAMPLED_FILES) " +
                     "must not exceed MAX_FILES_SCANNED ($MAX_FILES_SCANNED)."
-            }
-            require(PROJECT_LANGUAGE_SAMPLE_STRIDE > 0) {
-                "PROJECT_LANGUAGE_SAMPLE_STRIDE ($PROJECT_LANGUAGE_SAMPLE_STRIDE) must be greater than 0."
             }
         }
 

--- a/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
@@ -167,6 +167,26 @@ internal object LanguageDetectionRules {
      */
     const val PROJECT_LANGUAGE_SAMPLE_STRIDE: Int = 10
 
+    @Suppress("unused")
+    private val projectLanguageSamplingInvariants: Unit =
+        run {
+            require(PROJECT_LANGUAGE_WARMUP_SAMPLE_FILES <= MAX_FILES_SCANNED) {
+                "PROJECT_LANGUAGE_WARMUP_SAMPLE_FILES ($PROJECT_LANGUAGE_WARMUP_SAMPLE_FILES) " +
+                    "must not exceed MAX_FILES_SCANNED ($MAX_FILES_SCANNED)."
+            }
+            require(PROJECT_LANGUAGE_WARMUP_SAMPLE_FILES <= PROJECT_LANGUAGE_MAX_SAMPLED_FILES) {
+                "PROJECT_LANGUAGE_WARMUP_SAMPLE_FILES ($PROJECT_LANGUAGE_WARMUP_SAMPLE_FILES) " +
+                    "must not exceed PROJECT_LANGUAGE_MAX_SAMPLED_FILES ($PROJECT_LANGUAGE_MAX_SAMPLED_FILES)."
+            }
+            require(PROJECT_LANGUAGE_MAX_SAMPLED_FILES <= MAX_FILES_SCANNED) {
+                "PROJECT_LANGUAGE_MAX_SAMPLED_FILES ($PROJECT_LANGUAGE_MAX_SAMPLED_FILES) " +
+                    "must not exceed MAX_FILES_SCANNED ($MAX_FILES_SCANNED)."
+            }
+            require(PROJECT_LANGUAGE_SAMPLE_STRIDE > 0) {
+                "PROJECT_LANGUAGE_SAMPLE_STRIDE ($PROJECT_LANGUAGE_SAMPLE_STRIDE) must be greater than 0."
+            }
+        }
+
     /**
      * "Leading plurality" ratio: when no language clears [DEFAULT_DOMINANCE_THRESHOLD],
      * the top can still win if it's this many times larger than #2. Handles the

--- a/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/LanguageDetectionRules.kt
@@ -148,6 +148,26 @@ internal object LanguageDetectionRules {
     const val MAX_FILES_SCANNED: Int = 10_000
 
     /**
+     * Initial eligible files sampled without gaps before stride sampling starts.
+     * Keeps small projects exact and preserves early-root signal in large repos.
+     */
+    const val PROJECT_LANGUAGE_WARMUP_SAMPLE_FILES: Int = 128
+
+    /**
+     * Hard cap on files whose [FileType] and length are sampled during one
+     * project-language scan. Traversal still obeys [MAX_FILES_SCANNED], but
+     * expensive language/file-type work stops at this bound.
+     */
+    const val PROJECT_LANGUAGE_MAX_SAMPLED_FILES: Int = 1_000
+
+    /**
+     * Stable stride for eligible files after [PROJECT_LANGUAGE_WARMUP_SAMPLE_FILES].
+     * A value of 10 samples the 10th, 20th, 30th, ... post-warmup file until
+     * [PROJECT_LANGUAGE_MAX_SAMPLED_FILES] is reached.
+     */
+    const val PROJECT_LANGUAGE_SAMPLE_STRIDE: Int = 10
+
+    /**
      * "Leading plurality" ratio: when no language clears [DEFAULT_DOMINANCE_THRESHOLD],
      * the top can still win if it's this many times larger than #2. Handles the
      * React-style 55 / 30 / 15 TypeScript / JavaScript / other case where no

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageScanner.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageScanner.kt
@@ -73,18 +73,16 @@ internal object ProjectLanguageScanner {
     }
 
     private fun scanUnderReadAction(project: Project): Map<String, Long> {
-        val weights = HashMap<String, Long>()
-        val fileCount = IntArray(1)
-        val sampledFileCount = IntArray(1)
+        val candidates = ArrayList<VirtualFile>(LanguageDetectionRules.PROJECT_LANGUAGE_MAX_SAMPLED_FILES)
+        val counters = ScanCounters()
         ProgressManager.checkCanceled()
         if (project.isDisposed) return emptyMap()
         ProjectFileIndex.getInstance(project).iterateContent { file ->
             ProgressManager.checkCanceled()
             if (project.isDisposed) return@iterateContent false
-            val shouldContinue = visit(file, weights, fileCount, sampledFileCount)
-            shouldContinue
+            collectCandidate(file, candidates, counters)
         }
-        return weights
+        return sampleCandidates(project, candidates)
     }
 
     /**
@@ -98,18 +96,15 @@ internal object ProjectLanguageScanner {
      * 50 200 entries before stopping, defeating the whole "keep the EDT
      * responsive on monorepos" purpose of the cap.
      *
-     * Per-file exceptions (mid-delete race, a language plugin throwing from its
-     * FileType.detect) must NOT abort the scan. Non-cancellation failures are
-     * logged at DEBUG and skipped, while IntelliJ and Kotlin cancellation
-     * signals still propagate so long-running scans can stop promptly.
+     * Expensive FileType/length reads happen later in [sampleCandidates], after
+     * this pass knows whether the scan is below the sampling cap and can stay exact.
      */
-    private fun visit(
+    private fun collectCandidate(
         file: VirtualFile,
-        weights: HashMap<String, Long>,
-        fileCount: IntArray,
-        sampledFileCount: IntArray,
+        candidates: MutableList<VirtualFile>,
+        counters: ScanCounters,
     ): Boolean {
-        if (fileCount[0] >= LanguageDetectionRules.MAX_FILES_SCANNED) return false
+        if (counters.traversedFileCount >= LanguageDetectionRules.MAX_FILES_SCANNED) return false
         // Drop vendored / generated / build-output dirs before paying for VFS
         // metadata access. This is the single biggest real-world accuracy win:
         // a Python project with a committed .venv otherwise mis-reports as
@@ -118,20 +113,37 @@ internal object ProjectLanguageScanner {
         if (file.isDirectory) return true
         // Count every non-directory, non-excluded file toward the cap so binary-
         // heavy repos don't bypass it (see KDoc rationale).
-        fileCount[0]++
-        if (!shouldSampleFile(fileCount[0], sampledFileCount[0])) return true
-        sampledFileCount[0]++
-        sampleLanguageWeight(file)?.let { (languageId, weight) ->
-            weights.merge(languageId, weight) { a, b -> a + b }
-        }
+        counters.traversedFileCount++
+        candidates.add(file)
         return true
+    }
+
+    private fun sampleCandidates(
+        project: Project,
+        candidates: List<VirtualFile>,
+    ): Map<String, Long> {
+        val weights = HashMap<String, Long>()
+        val counters = ScanCounters()
+        val isSubCapScan = candidates.size <= LanguageDetectionRules.PROJECT_LANGUAGE_MAX_SAMPLED_FILES
+        candidates.forEachIndexed { index, file ->
+            ProgressManager.checkCanceled()
+            if (project.isDisposed) return emptyMap()
+            if (!shouldSampleFile(index + 1, counters.sampledFileCount, isSubCapScan)) return@forEachIndexed
+            counters.sampledFileCount++
+            sampleLanguageWeight(file)?.let { (languageId, weight) ->
+                weights.merge(languageId, weight) { a, b -> a + b }
+            }
+        }
+        return weights
     }
 
     private fun shouldSampleFile(
         traversedFileCount: Int,
         sampledFileCount: Int,
+        isSubCapScan: Boolean,
     ): Boolean {
         if (sampledFileCount >= LanguageDetectionRules.PROJECT_LANGUAGE_MAX_SAMPLED_FILES) return false
+        if (isSubCapScan) return true
         if (traversedFileCount <= LanguageDetectionRules.PROJECT_LANGUAGE_WARMUP_SAMPLE_FILES) return true
         val postWarmupOffset = traversedFileCount - LanguageDetectionRules.PROJECT_LANGUAGE_WARMUP_SAMPLE_FILES
         return postWarmupOffset % LanguageDetectionRules.PROJECT_LANGUAGE_SAMPLE_STRIDE == 0
@@ -159,4 +171,9 @@ internal object ProjectLanguageScanner {
         }
         return sample.getOrNull()
     }
+
+    private data class ScanCounters(
+        var traversedFileCount: Int = 0,
+        var sampledFileCount: Int = 0,
+    )
 }

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageScanner.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageScanner.kt
@@ -11,9 +11,9 @@ import org.jetbrains.annotations.TestOnly
 
 /**
  * Walks a project's content roots under a read action and tallies per-language
- * bytes, cap-limited per file so generated monsters can't skew proportions and
- * cap-limited by total file count so the scan doesn't block the EDT on
- * linux-kernel-sized repos.
+ * bytes, cap-limited per file so generated monsters can't skew proportions,
+ * cap-limited by total file count so traversal stays bounded, and sample-limited
+ * so language/file-type work stays cheap on linux-kernel-sized repos.
  *
  * Separate object (not a private fun inside [ProjectLanguageDetector]) so the
  * detector's caching / threshold logic can be unit-tested via
@@ -75,12 +75,13 @@ internal object ProjectLanguageScanner {
     private fun scanUnderReadAction(project: Project): Map<String, Long> {
         val weights = HashMap<String, Long>()
         val fileCount = IntArray(1)
+        val sampledFileCount = IntArray(1)
         ProgressManager.checkCanceled()
         if (project.isDisposed) return emptyMap()
         ProjectFileIndex.getInstance(project).iterateContent { file ->
             ProgressManager.checkCanceled()
             if (project.isDisposed) return@iterateContent false
-            val shouldContinue = visit(file, weights, fileCount)
+            val shouldContinue = visit(file, weights, fileCount, sampledFileCount)
             shouldContinue
         }
         return weights
@@ -106,6 +107,7 @@ internal object ProjectLanguageScanner {
         file: VirtualFile,
         weights: HashMap<String, Long>,
         fileCount: IntArray,
+        sampledFileCount: IntArray,
     ): Boolean {
         if (fileCount[0] >= LanguageDetectionRules.MAX_FILES_SCANNED) return false
         // Drop vendored / generated / build-output dirs before paying for VFS
@@ -117,10 +119,22 @@ internal object ProjectLanguageScanner {
         // Count every non-directory, non-excluded file toward the cap so binary-
         // heavy repos don't bypass it (see KDoc rationale).
         fileCount[0]++
+        if (!shouldSampleFile(fileCount[0], sampledFileCount[0])) return true
+        sampledFileCount[0]++
         sampleLanguageWeight(file)?.let { (languageId, weight) ->
             weights.merge(languageId, weight) { a, b -> a + b }
         }
         return true
+    }
+
+    private fun shouldSampleFile(
+        traversedFileCount: Int,
+        sampledFileCount: Int,
+    ): Boolean {
+        if (sampledFileCount >= LanguageDetectionRules.PROJECT_LANGUAGE_MAX_SAMPLED_FILES) return false
+        if (traversedFileCount <= LanguageDetectionRules.PROJECT_LANGUAGE_WARMUP_SAMPLE_FILES) return true
+        val postWarmupOffset = traversedFileCount - LanguageDetectionRules.PROJECT_LANGUAGE_WARMUP_SAMPLE_FILES
+        return postWarmupOffset % LanguageDetectionRules.PROJECT_LANGUAGE_SAMPLE_STRIDE == 0
     }
 
     @TestOnly

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageScanner.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageScanner.kt
@@ -124,11 +124,11 @@ internal object ProjectLanguageScanner {
     ): Map<String, Long> {
         val weights = HashMap<String, Long>()
         val counters = ScanCounters()
-        val isSubCapScan = candidates.size <= LanguageDetectionRules.PROJECT_LANGUAGE_MAX_SAMPLED_FILES
+        val totalCandidateCount = candidates.size
         candidates.forEachIndexed { index, file ->
             ProgressManager.checkCanceled()
             if (project.isDisposed) return emptyMap()
-            if (!shouldSampleFile(index + 1, counters.sampledFileCount, isSubCapScan)) return@forEachIndexed
+            if (!shouldSampleFile(index + 1, counters.sampledFileCount, totalCandidateCount)) return@forEachIndexed
             counters.sampledFileCount++
             sampleLanguageWeight(file)?.let { (languageId, weight) ->
                 weights.merge(languageId, weight) { a, b -> a + b }
@@ -140,13 +140,28 @@ internal object ProjectLanguageScanner {
     private fun shouldSampleFile(
         traversedFileCount: Int,
         sampledFileCount: Int,
-        isSubCapScan: Boolean,
+        totalCandidateCount: Int,
     ): Boolean {
         if (sampledFileCount >= LanguageDetectionRules.PROJECT_LANGUAGE_MAX_SAMPLED_FILES) return false
-        if (isSubCapScan) return true
+        if (totalCandidateCount <= LanguageDetectionRules.PROJECT_LANGUAGE_MAX_SAMPLED_FILES) return true
         if (traversedFileCount <= LanguageDetectionRules.PROJECT_LANGUAGE_WARMUP_SAMPLE_FILES) return true
-        val postWarmupOffset = traversedFileCount - LanguageDetectionRules.PROJECT_LANGUAGE_WARMUP_SAMPLE_FILES
-        return postWarmupOffset % LanguageDetectionRules.PROJECT_LANGUAGE_SAMPLE_STRIDE == 0
+        return shouldSamplePostWarmupFile(traversedFileCount, totalCandidateCount)
+    }
+
+    private fun shouldSamplePostWarmupFile(
+        traversedFileCount: Int,
+        totalCandidateCount: Int,
+    ): Boolean {
+        val remainingCandidates = totalCandidateCount - LanguageDetectionRules.PROJECT_LANGUAGE_WARMUP_SAMPLE_FILES
+        val remainingSampleBudget =
+            LanguageDetectionRules.PROJECT_LANGUAGE_MAX_SAMPLED_FILES -
+                LanguageDetectionRules.PROJECT_LANGUAGE_WARMUP_SAMPLE_FILES
+        if (remainingCandidates <= 0 || remainingSampleBudget <= 0) return false
+
+        val postWarmupPosition = traversedFileCount - LanguageDetectionRules.PROJECT_LANGUAGE_WARMUP_SAMPLE_FILES
+        val previousBucket = (postWarmupPosition - 1).toLong() * remainingSampleBudget / remainingCandidates
+        val currentBucket = postWarmupPosition.toLong() * remainingSampleBudget / remainingCandidates
+        return currentBucket > previousBucket
     }
 
     @TestOnly

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageScannerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageScannerTest.kt
@@ -102,15 +102,114 @@ class ProjectLanguageScannerTest {
 
     @Test
     fun `scan returns language weights when content iteration completes`() {
+        val kotlinFile = sourceFile("/repo/src/Main.kt", "KOTLIN", 1_200L)
+        val javaFile = sourceFile("/repo/src/App.java", "JAVA", 300L)
+        val secondKotlinFile = sourceFile("/repo/src/Feature.kt", "KOTLIN", 800L)
         every { fileIndex.iterateContent(any()) } answers {
-            firstArg<ContentIterator>().processFile(sourceFile("/repo/src/Main.kt", "KOTLIN", 1_200L))
+            val iterator = firstArg<ContentIterator>()
+            assertTrue(iterator.processFile(kotlinFile))
+            assertTrue(iterator.processFile(javaFile))
+            iterator.processFile(secondKotlinFile)
         }
 
         assertEquals(
-            mapOf("kotlin" to 1_200L),
+            mapOf("kotlin" to 2_000L, "java" to 300L),
             ProjectLanguageScanner.scan(project),
-            "Stable scans should return cacheable language weights for the detector",
+            "Small stable scans should sample every eligible file exactly",
         )
+        verify(exactly = 1) { kotlinFile.fileType }
+        verify(exactly = 1) { javaFile.fileType }
+        verify(exactly = 1) { secondKotlinFile.fileType }
+    }
+
+    @Test
+    fun `large scan stops sampling at sample cap while traversal continues to hard ceiling`() {
+        var currentFileIndex = 0
+        val sourceFile = sourceFile("/repo/src/File0.kt", "KOTLIN", 1L)
+        every { sourceFile.path } answers { "/repo/src/File$currentFileIndex.kt" }
+        var attemptedFiles = 0
+        every { fileIndex.iterateContent(any()) } answers {
+            val iterator = firstArg<ContentIterator>()
+            for (index in 0..LanguageDetectionRules.MAX_FILES_SCANNED) {
+                currentFileIndex = index
+                attemptedFiles++
+                if (!iterator.processFile(sourceFile)) return@answers false
+            }
+            true
+        }
+
+        assertEquals(
+            mapOf("kotlin" to LanguageDetectionRules.PROJECT_LANGUAGE_MAX_SAMPLED_FILES.toLong()),
+            ProjectLanguageScanner.scan(project),
+            "Large scans should cap expensive language sampling independently from traversal",
+        )
+        assertEquals(
+            LanguageDetectionRules.MAX_FILES_SCANNED + 1,
+            attemptedFiles,
+            "Traversal should continue until the existing hard file ceiling stops iteration",
+        )
+        verify(exactly = LanguageDetectionRules.PROJECT_LANGUAGE_MAX_SAMPLED_FILES) { sourceFile.fileType }
+        verify(exactly = LanguageDetectionRules.PROJECT_LANGUAGE_MAX_SAMPLED_FILES) { sourceFile.length }
+    }
+
+    @Test
+    fun `large scan sampling is deterministic and keeps warmup signal`() {
+        val sourceFile = sourceFile("/repo/src/File0.kt", "KOTLIN", 1L)
+        var currentFileIndex = 0
+        every { sourceFile.path } answers { "/repo/src/File$currentFileIndex.kt" }
+        every { sourceFile.fileType } answers {
+            if (currentFileIndex == 0) {
+                languageFileType("KOTLIN")
+            } else {
+                languageFileType("JAVA")
+            }
+        }
+        every { fileIndex.iterateContent(any()) } answers {
+            val iterator = firstArg<ContentIterator>()
+            for (index in 0 until LanguageDetectionRules.MAX_FILES_SCANNED) {
+                currentFileIndex = index
+                assertTrue(iterator.processFile(sourceFile))
+            }
+            true
+        }
+
+        val firstScan = ProjectLanguageScanner.scan(project)
+        val secondScan = ProjectLanguageScanner.scan(project)
+
+        val expectedJavaSamples = LanguageDetectionRules.PROJECT_LANGUAGE_MAX_SAMPLED_FILES.toLong() - 1L
+        assertEquals(
+            mapOf("kotlin" to 1L, "java" to expectedJavaSamples),
+            firstScan,
+            "Warmup sampling should include the first eligible source file before stride sampling",
+        )
+        assertEquals(firstScan, secondScan, "Sampling must be deterministic for the same traversal order")
+    }
+
+    @Test
+    fun `large scan sampling skips first post-warmup files until stride boundary`() {
+        val warmupBoundaryFile = sourceFile("/repo/src/File128.kt", "KOTLIN", 1L)
+        val firstPostWarmupFile = sourceFile("/repo/src/File129.java", "JAVA", 100L)
+        val firstStrideFile = sourceFile("/repo/src/File138.py", "Python", 10L)
+        val fillerFile = sourceFile("/repo/src/Filler.txt", "TEXT", 1L)
+        every { fileIndex.iterateContent(any()) } answers {
+            val iterator = firstArg<ContentIterator>()
+            repeat(LanguageDetectionRules.PROJECT_LANGUAGE_WARMUP_SAMPLE_FILES - 1) {
+                assertTrue(iterator.processFile(fillerFile))
+            }
+            assertTrue(iterator.processFile(warmupBoundaryFile))
+            assertTrue(iterator.processFile(firstPostWarmupFile))
+            repeat(LanguageDetectionRules.PROJECT_LANGUAGE_SAMPLE_STRIDE - 2) {
+                assertTrue(iterator.processFile(fillerFile))
+            }
+            iterator.processFile(firstStrideFile)
+        }
+
+        assertEquals(
+            mapOf("text" to 127L, "kotlin" to 1L, "python" to 10L),
+            ProjectLanguageScanner.scan(project),
+            "Sampling must include the warmup boundary, skip file 129, and sample the first stride boundary",
+        )
+        verify(exactly = 0) { firstPostWarmupFile.fileType }
     }
 
     @Test
@@ -154,15 +253,20 @@ class ProjectLanguageScannerTest {
         languageId: String,
         length: Long,
     ): VirtualFile {
-        val language = mockk<Language>()
-        every { language.id } returns languageId
-        val fileType = mockk<LanguageFileType>()
-        every { fileType.language } returns language
+        val fileType = languageFileType(languageId)
         return mockk<VirtualFile>().also { file ->
             every { file.path } returns path
             every { file.isDirectory } returns false
             every { file.length } returns length
             every { file.fileType } returns fileType
         }
+    }
+
+    private fun languageFileType(languageId: String): LanguageFileType {
+        val language = mockk<Language>()
+        every { language.id } returns languageId
+        val fileType = mockk<LanguageFileType>()
+        every { fileType.language } returns language
+        return fileType
     }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageScannerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageScannerTest.kt
@@ -183,46 +183,42 @@ class ProjectLanguageScannerTest {
         assertEquals(
             mapOf("kotlin" to 1L, "java" to expectedJavaSamples),
             firstScan,
-            "Warmup sampling should include the first eligible source file before stride sampling",
+            "Warmup sampling should include the first eligible source file before bounded sampling",
         )
         assertEquals(firstScan, secondScan, "Sampling must be deterministic for the same traversal order")
     }
 
     @Test
-    fun `large scan sampling skips first post-warmup files until stride boundary`() {
+    fun `large scan sampling spans full candidate range while staying capped`() {
         val warmupBoundaryFile = sourceFile("/repo/src/File128.kt", "KOTLIN", 1L)
-        val firstPostWarmupFile = sourceFile("/repo/src/File129.java", "JAVA", 100L)
-        val firstStrideFile = sourceFile("/repo/src/File138.py", "Python", 10L)
         val fillerFile = sourceFile("/repo/src/Filler.txt", "TEXT", 1L)
-        val tailFile = sourceFile("/repo/src/Tail.txt", "TEXT", 1L)
+        val finalFile = sourceFile("/repo/src/Final.py", "Python", 10L)
+        val postWarmupFillerCount =
+            LanguageDetectionRules.MAX_FILES_SCANNED -
+                LanguageDetectionRules.PROJECT_LANGUAGE_WARMUP_SAMPLE_FILES - 1
         every { fileIndex.iterateContent(any()) } answers {
             val iterator = firstArg<ContentIterator>()
             repeat(LanguageDetectionRules.PROJECT_LANGUAGE_WARMUP_SAMPLE_FILES - 1) {
                 assertTrue(iterator.processFile(fillerFile))
             }
             assertTrue(iterator.processFile(warmupBoundaryFile))
-            assertTrue(iterator.processFile(firstPostWarmupFile))
-            repeat(LanguageDetectionRules.PROJECT_LANGUAGE_SAMPLE_STRIDE - 2) {
+            repeat(postWarmupFillerCount) {
                 assertTrue(iterator.processFile(fillerFile))
             }
-            assertTrue(iterator.processFile(firstStrideFile))
-            repeat(LanguageDetectionRules.PROJECT_LANGUAGE_MAX_SAMPLED_FILES) {
-                assertTrue(iterator.processFile(tailFile))
-            }
+            assertTrue(iterator.processFile(finalFile))
             true
         }
 
         assertEquals(
-            mapOf("text" to 227L, "kotlin" to 1L, "python" to 10L),
+            mapOf("text" to 998L, "kotlin" to 1L, "python" to 10L),
             ProjectLanguageScanner.scan(project),
-            "Over-cap scans must include warmup, skip file 129, and sample the first stride boundary",
+            "Over-cap scans should fill the sample budget across the whole candidate range",
         )
-        verify(exactly = 0) { firstPostWarmupFile.fileType }
-        verify(exactly = 1) { firstStrideFile.fileType }
+        verify(exactly = 1) { finalFile.fileType }
     }
 
     @Test
-    fun `sub-cap scan remains exact instead of striding after warmup`() {
+    fun `sub-cap scan remains exact after warmup`() {
         val javaFiles =
             List(LanguageDetectionRules.PROJECT_LANGUAGE_WARMUP_SAMPLE_FILES) { index ->
                 sourceFile("/repo/src/Java$index.java", "JAVA", 1L)
@@ -243,6 +239,34 @@ class ProjectLanguageScannerTest {
             mapOf("java" to 128L, "kotlin" to 200L),
             ProjectLanguageScanner.scan(project),
             "Scans below the sampling cap should stay exact so late-majority languages are preserved",
+        )
+    }
+
+    @Test
+    fun `barely over-cap scan preserves late majority within sample budget`() {
+        val javaFiles =
+            List(LanguageDetectionRules.PROJECT_LANGUAGE_WARMUP_SAMPLE_FILES) { index ->
+                sourceFile("/repo/src/Java$index.java", "JAVA", 1L)
+            }
+        val kotlinFiles =
+            List(
+                LanguageDetectionRules.PROJECT_LANGUAGE_MAX_SAMPLED_FILES -
+                    LanguageDetectionRules.PROJECT_LANGUAGE_WARMUP_SAMPLE_FILES + 1,
+            ) { index ->
+                sourceFile("/repo/src/Kotlin$index.kt", "KOTLIN", 1L)
+            }
+        every { fileIndex.iterateContent(any()) } answers {
+            val iterator = firstArg<ContentIterator>()
+            (javaFiles + kotlinFiles).forEach { file ->
+                assertTrue(iterator.processFile(file))
+            }
+            true
+        }
+
+        assertEquals(
+            mapOf("java" to 128L, "kotlin" to 872L),
+            ProjectLanguageScanner.scan(project),
+            "Scans just over the sampling cap should not discard most late-majority files",
         )
     }
 

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageScannerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageScannerTest.kt
@@ -157,8 +157,11 @@ class ProjectLanguageScannerTest {
         val sourceFile = sourceFile("/repo/src/File0.kt", "KOTLIN", 1L)
         var currentFileIndex = 0
         every { sourceFile.path } answers { "/repo/src/File$currentFileIndex.kt" }
+        var sampledFileTypeCalls = 0
         every { sourceFile.fileType } answers {
-            if (currentFileIndex == 0) {
+            val sampleIndex = sampledFileTypeCalls % LanguageDetectionRules.PROJECT_LANGUAGE_MAX_SAMPLED_FILES
+            sampledFileTypeCalls++
+            if (sampleIndex == 0) {
                 languageFileType("KOTLIN")
             } else {
                 languageFileType("JAVA")
@@ -191,6 +194,7 @@ class ProjectLanguageScannerTest {
         val firstPostWarmupFile = sourceFile("/repo/src/File129.java", "JAVA", 100L)
         val firstStrideFile = sourceFile("/repo/src/File138.py", "Python", 10L)
         val fillerFile = sourceFile("/repo/src/Filler.txt", "TEXT", 1L)
+        val tailFile = sourceFile("/repo/src/Tail.txt", "TEXT", 1L)
         every { fileIndex.iterateContent(any()) } answers {
             val iterator = firstArg<ContentIterator>()
             repeat(LanguageDetectionRules.PROJECT_LANGUAGE_WARMUP_SAMPLE_FILES - 1) {
@@ -201,15 +205,45 @@ class ProjectLanguageScannerTest {
             repeat(LanguageDetectionRules.PROJECT_LANGUAGE_SAMPLE_STRIDE - 2) {
                 assertTrue(iterator.processFile(fillerFile))
             }
-            iterator.processFile(firstStrideFile)
+            assertTrue(iterator.processFile(firstStrideFile))
+            repeat(LanguageDetectionRules.PROJECT_LANGUAGE_MAX_SAMPLED_FILES) {
+                assertTrue(iterator.processFile(tailFile))
+            }
+            true
         }
 
         assertEquals(
-            mapOf("text" to 127L, "kotlin" to 1L, "python" to 10L),
+            mapOf("text" to 227L, "kotlin" to 1L, "python" to 10L),
             ProjectLanguageScanner.scan(project),
-            "Sampling must include the warmup boundary, skip file 129, and sample the first stride boundary",
+            "Over-cap scans must include warmup, skip file 129, and sample the first stride boundary",
         )
         verify(exactly = 0) { firstPostWarmupFile.fileType }
+        verify(exactly = 1) { firstStrideFile.fileType }
+    }
+
+    @Test
+    fun `sub-cap scan remains exact instead of striding after warmup`() {
+        val javaFiles =
+            List(LanguageDetectionRules.PROJECT_LANGUAGE_WARMUP_SAMPLE_FILES) { index ->
+                sourceFile("/repo/src/Java$index.java", "JAVA", 1L)
+            }
+        val kotlinFiles =
+            List(200) { index ->
+                sourceFile("/repo/src/Kotlin$index.kt", "KOTLIN", 1L)
+            }
+        every { fileIndex.iterateContent(any()) } answers {
+            val iterator = firstArg<ContentIterator>()
+            (javaFiles + kotlinFiles).forEach { file ->
+                assertTrue(iterator.processFile(file))
+            }
+            true
+        }
+
+        assertEquals(
+            mapOf("java" to 128L, "kotlin" to 200L),
+            ProjectLanguageScanner.scan(project),
+            "Scans below the sampling cap should stay exact so late-majority languages are preserved",
+        )
     }
 
     @Test


### PR DESCRIPTION
-- Summary ------------------------------------------------

Large project-language scans still walked a bounded number of files, but they paid the file-type/length sampling cost for every eligible file up to that traversal ceiling. This bounds the expensive sampling work separately while preserving cancellation, disposal, and small-repo behavior.

-- Changes ------------------------------------------------

- Fix: `LanguageDetectionRules.kt` adds explicit warmup, sampled-file cap, and stride constants for project-language scans.
- Fix: `ProjectLanguageScanner.kt` separates traversal count from sampled count, samples early files exactly, then uses deterministic stride sampling until the sample cap.
- Test: `ProjectLanguageScannerTest.kt` covers small exact scans, sample-cap traversal continuation, deterministic warmup, stride boundary, and disposal behavior.

-- Validation ---------------------------------------------

- `./gradlew test --rerun-tasks --tests dev.ayuislands.accent.ProjectLanguageScannerTest --tests dev.ayuislands.accent.ProjectLanguageScanAsyncTest --tests dev.ayuislands.accent.ProjectLanguageDetectorTest` - passed, `BUILD SUCCESSFUL`
- `./gradlew detekt ktlintCheck` - passed, `BUILD SUCCESSFUL`
- `scripts/verify-docs.py` - passed; emitted existing orphan-SHA warnings only

-- Notes --------------------------------------------------

- Weighted totals intentionally remain based only on sampled files; no normalization or async scheduler redesign is included here.

## Summary by Sourcery

Bound project-language scan sampling so file-type and length work remains limited while traversal stays capped for large repositories.

Bug Fixes:
- Separate traversal count from sampled file count to prevent large scans from performing expensive sampling on every eligible file.
- Introduce deterministic warmup and stride-based sampling so project-language scans remain stable and efficient across repository sizes.

Enhancements:
- Add configurable warmup, maximum sampled file count, and sampling stride constants for project-language scans.
- Extend project language scanner tests to cover small exact scans, sampling caps, deterministic warmup behavior, stride boundaries, and disposal behavior.

Documentation:
- Update verified documentation metadata for accent-related feature entries.