### PR TITLE
Refactor accent override traversal

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "7abedbb5"
+          last_verified_sha: "5642cf3"
           last_verified_date: "2026-06-30"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "7abedbb5"
+          last_verified_sha: "5642cf3"
           last_verified_date: "2026-06-30"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "83681b28"
+          last_verified_sha: "73142d28"
           last_verified_date: "2026-06-30"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "83681b28"
+          last_verified_sha: "73142d28"
           last_verified_date: "2026-06-30"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -345,7 +345,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "94d81354"
+          last_verified_sha: "73142d28"
           last_verified_date: "2026-06-16"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -459,7 +459,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "e8063e35"
+          last_verified_sha: "73142d28"
           last_verified_date: "2026-06-16"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "5642cf3"
+          last_verified_sha: "8a4770ce"
           last_verified_date: "2026-06-30"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "5642cf3"
+          last_verified_sha: "8a4770ce"
           last_verified_date: "2026-06-30"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "73142d28"
+          last_verified_sha: "7abedbb5"
           last_verified_date: "2026-06-30"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "73142d28"
+          last_verified_sha: "7abedbb5"
           last_verified_date: "2026-06-30"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/src/main/kotlin/dev/ayuislands/accent/AccentOverrideResolver.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentOverrideResolver.kt
@@ -14,8 +14,20 @@ internal object AccentOverrideResolver {
         val snapshot: AccentOverrideSnapshot,
         val overridesEnabled: Boolean,
         val validateHex: Boolean,
-        val warmDetector: Boolean = true,
-        val detectedLanguage: () -> String?,
+        val warmLanguageDetection: Boolean = true,
+        val languageDetection: LanguageDetection,
+    )
+
+    /**
+     * Project-language read adapter for resolver callers.
+     *
+     * [detectedLanguage] and [verdict] must honor `warmCache`: `false` is a
+     * cache-only read with no scan scheduling. The resolver passes `true` at
+     * most once per resolution path, then uses cache-only verdict reads for
+     * fallback checks after detection was already consulted.
+     */
+    data class LanguageDetection(
+        val detectedLanguage: (warmCache: Boolean) -> String?,
         val verdict: (warmCache: Boolean) -> ProjectLanguageVerdict,
     )
 
@@ -46,7 +58,10 @@ internal object AccentOverrideResolver {
         languageResult.accent?.let { return it }
 
         val fallbackAccent = request.snapshot.projectFallbackAccents[projectKey] ?: return null
-        val fallbackVerdict = request.verdict(!languageResult.detectorConsulted && request.warmDetector)
+        val fallbackVerdict =
+            request
+                .languageDetection
+                .verdict(!languageResult.detectionConsulted && request.warmLanguageDetection)
         return fallbackAccent
             .takeIf { fallbackVerdict is ProjectLanguageVerdict.NoWinner }
             ?.let { rawHex -> overrideAccent(AccentResolver.Source.PROJECT_FALLBACK, rawHex, request.validateHex) }
@@ -64,14 +79,15 @@ internal object AccentOverrideResolver {
                     languageId = languageId,
                     exactSource = AccentResolver.Source.FORCED_LANGUAGE_OVERRIDE,
                     validateHex = request.validateHex,
-                )?.let { return LanguageResult(it, detectorConsulted = false) }
+                )?.let { return LanguageResult(it, detectionConsulted = false) }
             }
         if (!languageRequest.shouldDetectLanguage) {
-            return LanguageResult(accent = null, detectorConsulted = false)
+            return LanguageResult(accent = null, detectionConsulted = false)
         }
         val resolvedAccent =
             request
-                .detectedLanguage()
+                .languageDetection
+                .detectedLanguage(request.warmLanguageDetection)
                 ?.let { languageId ->
                     overrideAccentForLanguage(
                         languageAccents = request.snapshot.languageAccents,
@@ -81,7 +97,7 @@ internal object AccentOverrideResolver {
                         validateHex = request.validateHex,
                     )
                 }
-        return LanguageResult(resolvedAccent, detectorConsulted = true)
+        return LanguageResult(resolvedAccent, detectionConsulted = true)
     }
 
     private data class LanguageRequest(
@@ -108,7 +124,7 @@ internal object AccentOverrideResolver {
 
     private data class LanguageResult(
         val accent: Result?,
-        val detectorConsulted: Boolean,
+        val detectionConsulted: Boolean,
     )
 
     private fun overrideAccentForLanguage(

--- a/src/main/kotlin/dev/ayuislands/accent/AccentOverrideResolver.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentOverrideResolver.kt
@@ -24,6 +24,8 @@ internal object AccentOverrideResolver {
         val hex: String,
     )
 
+    fun source(request: Request): AccentResolver.Source = resolve(request)?.source ?: AccentResolver.Source.GLOBAL
+
     fun resolve(request: Request): Result? {
         if (!request.overridesEnabled) return null
         val projectKey = request.projectKey?.takeIf { it.isNotBlank() } ?: return null

--- a/src/main/kotlin/dev/ayuislands/accent/AccentOverrideResolver.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentOverrideResolver.kt
@@ -1,0 +1,140 @@
+package dev.ayuislands.accent
+
+internal data class AccentOverrideSnapshot(
+    val projectAccents: Map<String, String> = emptyMap(),
+    val languageAccents: Map<String, String> = emptyMap(),
+    val projectFallbackAccents: Map<String, String> = emptyMap(),
+    val forcedProjectLanguages: Map<String, String> = emptyMap(),
+    val languageFallbackAccent: String? = null,
+)
+
+internal object AccentOverrideResolver {
+    data class Request(
+        val projectKey: String?,
+        val snapshot: AccentOverrideSnapshot,
+        val overridesEnabled: Boolean,
+        val validateHex: Boolean,
+        val warmDetector: Boolean = true,
+        val detectedLanguage: () -> String?,
+        val verdict: (warmCache: Boolean) -> ProjectLanguageVerdict,
+    )
+
+    data class Result(
+        val source: AccentResolver.Source,
+        val hex: String,
+    )
+
+    fun resolve(request: Request): Result? {
+        if (!request.overridesEnabled) return null
+        val projectKey = request.projectKey?.takeIf { it.isNotBlank() } ?: return null
+
+        request.snapshot.projectAccents[projectKey]
+            ?.let { rawHex -> overrideAccent(AccentResolver.Source.PROJECT_OVERRIDE, rawHex, request.validateHex) }
+            ?.let { return it }
+
+        val languageRequest =
+            LanguageRequest(
+                snapshot = request.snapshot,
+                projectKey = projectKey,
+            )
+        val hasProjectFallbackCandidate = request.snapshot.projectFallbackAccents.containsKey(projectKey)
+        if (!languageRequest.hasResolutionWork && !hasProjectFallbackCandidate) return null
+
+        val languageResult = resolveLanguageOverride(request, languageRequest)
+        languageResult.accent?.let { return it }
+
+        val fallbackAccent = request.snapshot.projectFallbackAccents[projectKey] ?: return null
+        val fallbackVerdict = request.verdict(!languageResult.detectorConsulted && request.warmDetector)
+        return fallbackAccent
+            .takeIf { fallbackVerdict is ProjectLanguageVerdict.NoWinner }
+            ?.let { rawHex -> overrideAccent(AccentResolver.Source.PROJECT_FALLBACK, rawHex, request.validateHex) }
+    }
+
+    private fun resolveLanguageOverride(
+        request: Request,
+        languageRequest: LanguageRequest,
+    ): LanguageResult {
+        languageRequest.forcedLanguageId
+            ?.let { languageId ->
+                overrideAccentForLanguage(
+                    languageAccents = request.snapshot.languageAccents,
+                    languageFallbackAccent = languageRequest.languageFallbackAccent,
+                    languageId = languageId,
+                    exactSource = AccentResolver.Source.FORCED_LANGUAGE_OVERRIDE,
+                    validateHex = request.validateHex,
+                )?.let { return LanguageResult(it, detectorConsulted = false) }
+            }
+        if (!languageRequest.shouldDetectLanguage) {
+            return LanguageResult(accent = null, detectorConsulted = false)
+        }
+        val resolvedAccent =
+            request
+                .detectedLanguage()
+                ?.let { languageId ->
+                    overrideAccentForLanguage(
+                        languageAccents = request.snapshot.languageAccents,
+                        languageFallbackAccent = languageRequest.languageFallbackAccent,
+                        languageId = languageId,
+                        exactSource = AccentResolver.Source.LANGUAGE_OVERRIDE,
+                        validateHex = request.validateHex,
+                    )
+                }
+        return LanguageResult(resolvedAccent, detectorConsulted = true)
+    }
+
+    private data class LanguageRequest(
+        val snapshot: AccentOverrideSnapshot,
+        val projectKey: String,
+    ) {
+        val hasForcedLanguageEntry: Boolean = snapshot.forcedProjectLanguages.containsKey(projectKey)
+        val forcedLanguageId: String? =
+            snapshot.forcedProjectLanguages[projectKey]
+                ?.trim()
+                ?.takeIf { it.isNotEmpty() }
+        val languageFallbackAccent: String? =
+            snapshot.languageFallbackAccent
+                ?.trim()
+                ?.takeIf { it.isNotEmpty() }
+        private val hasLanguageCandidate = snapshot.languageAccents.isNotEmpty() || languageFallbackAccent != null
+
+        val hasResolutionWork: Boolean =
+            hasLanguageCandidate && (forcedLanguageId != null || !hasForcedLanguageEntry)
+
+        val shouldDetectLanguage: Boolean =
+            hasLanguageCandidate && !hasForcedLanguageEntry
+    }
+
+    private data class LanguageResult(
+        val accent: Result?,
+        val detectorConsulted: Boolean,
+    )
+
+    private fun overrideAccentForLanguage(
+        languageAccents: Map<String, String>,
+        languageFallbackAccent: String?,
+        languageId: String,
+        exactSource: AccentResolver.Source,
+        validateHex: Boolean,
+    ): Result? {
+        languageAccents[languageId]
+            ?.let { rawHex -> overrideAccent(exactSource, rawHex, validateHex) }
+            ?.let { return it }
+        return languageFallbackAccent
+            ?.let { rawHex -> overrideAccent(AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE, rawHex, validateHex) }
+    }
+
+    private fun overrideAccent(
+        source: AccentResolver.Source,
+        rawHex: String,
+        validateHex: Boolean,
+    ): Result? {
+        val accent = AccentHex.of(rawHex)
+        if (accent != null) {
+            return Result(source, accent.value)
+        }
+        if (!validateHex && source != AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE) {
+            return Result(source, rawHex)
+        }
+        return null
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
@@ -201,62 +201,24 @@ object AccentResolver {
 
         val mappings = AccentMappingsSettings.getInstance().state
         val projectKey = projectKey(activeProject) ?: return null
-        mappings.projectAccents[projectKey]
-            ?.let { rawHex -> overrideAccent(Source.PROJECT_OVERRIDE, rawHex, validateHex)?.let { return it } }
-
-        val languageRequest =
-            LanguageOverrideRequest(
-                languageAccents = mappings.languageAccents,
-                hasForcedLanguageEntry = mappings.forcedProjectLanguages.containsKey(projectKey),
-                forcedLanguageId = mappings.forcedProjectLanguages[projectKey]?.trim()?.takeIf { it.isNotEmpty() },
-                languageFallbackAccent = mappings.languageFallbackAccent?.trim()?.takeIf { it.isNotEmpty() },
-                validateHex = validateHex,
-            )
-        val hasProjectFallbackCandidate = mappings.projectFallbackAccents.containsKey(projectKey)
-        if (!languageRequest.hasResolutionWork && !hasProjectFallbackCandidate) return null
-
-        val (languageOverride, detectorConsulted) =
-            resolveLanguageOverride(
-                project = activeProject,
-                request = languageRequest,
-            )
-        languageOverride?.let { return it }
-        val fallbackAccent = mappings.projectFallbackAccents[projectKey] ?: return null
-        val fallbackVerdict = ProjectLanguageDetector.verdict(activeProject, warmCache = !detectorConsulted)
-        if (fallbackVerdict is ProjectLanguageVerdict.NoWinner) {
-            overrideAccent(Source.PROJECT_FALLBACK, fallbackAccent, validateHex)?.let { return it }
-        }
-        return null
-    }
-
-    private fun resolveLanguageOverride(
-        project: Project,
-        request: LanguageOverrideRequest,
-    ): Pair<ResolvedAccent?, Boolean> {
-        request.forcedLanguageId
-            ?.let { languageId ->
-                overrideAccentForLanguage(
-                    languageAccents = request.languageAccents,
-                    languageFallbackAccent = request.languageFallbackAccent,
-                    languageId = languageId,
-                    exactSource = Source.FORCED_LANGUAGE_OVERRIDE,
-                    validateHex = request.validateHex,
-                )?.let { return it to false }
-            }
-        if (!request.shouldDetectLanguage) return null to false
-        val resolvedAccent =
-            ProjectLanguageDetector
-                .dominant(project)
-                ?.let { languageId ->
-                    overrideAccentForLanguage(
-                        languageAccents = request.languageAccents,
-                        languageFallbackAccent = request.languageFallbackAccent,
-                        languageId = languageId,
-                        exactSource = Source.LANGUAGE_OVERRIDE,
-                        validateHex = request.validateHex,
-                    )
-                }
-        return resolvedAccent to true
+        return AccentOverrideResolver
+            .resolve(
+                AccentOverrideResolver.Request(
+                    projectKey = projectKey,
+                    snapshot =
+                        AccentOverrideSnapshot(
+                            projectAccents = mappings.projectAccents,
+                            languageAccents = mappings.languageAccents,
+                            projectFallbackAccents = mappings.projectFallbackAccents,
+                            forcedProjectLanguages = mappings.forcedProjectLanguages,
+                            languageFallbackAccent = mappings.languageFallbackAccent,
+                        ),
+                    overridesEnabled = true,
+                    validateHex = validateHex,
+                    detectedLanguage = { ProjectLanguageDetector.dominant(activeProject) },
+                    verdict = { warmCache -> ProjectLanguageDetector.verdict(activeProject, warmCache = warmCache) },
+                ),
+            )?.toResolvedAccent()
     }
 
     /**
@@ -381,55 +343,12 @@ object AccentResolver {
 
 private fun Color.toHex(): String = "#%02X%02X%02X".format(Locale.ROOT, red, green, blue)
 
-private data class LanguageOverrideRequest(
-    val languageAccents: Map<String, String>,
-    val hasForcedLanguageEntry: Boolean,
-    val forcedLanguageId: String?,
-    val languageFallbackAccent: String?,
-    val validateHex: Boolean,
-) {
-    private val hasLanguageCandidate = languageAccents.isNotEmpty() || languageFallbackAccent != null
-
-    val hasResolutionWork: Boolean =
-        hasLanguageCandidate && (forcedLanguageId != null || !hasForcedLanguageEntry)
-
-    val shouldDetectLanguage: Boolean =
-        hasLanguageCandidate && !hasForcedLanguageEntry
-}
-
 private data class ResolvedAccent(
     val source: AccentResolver.Source,
     val hex: String,
 )
 
-private fun overrideAccentForLanguage(
-    languageAccents: Map<String, String>,
-    languageFallbackAccent: String?,
-    languageId: String,
-    exactSource: AccentResolver.Source,
-    validateHex: Boolean,
-): ResolvedAccent? {
-    languageAccents[languageId]
-        ?.let { rawHex -> overrideAccent(exactSource, rawHex, validateHex) }
-        ?.let { return it }
-    return languageFallbackAccent
-        ?.let { rawHex -> overrideAccent(AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE, rawHex, validateHex) }
-}
-
-private fun overrideAccent(
-    source: AccentResolver.Source,
-    rawHex: String,
-    validateHex: Boolean,
-): ResolvedAccent? {
-    val accent = AccentHex.of(rawHex)
-    if (accent != null) {
-        return ResolvedAccent(source, accent.value)
-    }
-    if (!validateHex && source != AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE) {
-        return ResolvedAccent(source, rawHex)
-    }
-    return null
-}
+private fun AccentOverrideResolver.Result.toResolvedAccent(): ResolvedAccent = ResolvedAccent(source, hex)
 
 private fun storedExternalAccent(state: AyuIslandsState): ResolvedAccent {
     val hex = AccentHex.of(state.externalThemeAccent)?.value ?: AyuVariant.MIRAGE.defaultAccent

--- a/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
@@ -205,18 +205,19 @@ object AccentResolver {
             .resolve(
                 AccentOverrideResolver.Request(
                     projectKey = projectKey,
-                    snapshot =
-                        AccentOverrideSnapshot(
-                            projectAccents = mappings.projectAccents,
-                            languageAccents = mappings.languageAccents,
-                            projectFallbackAccents = mappings.projectFallbackAccents,
-                            forcedProjectLanguages = mappings.forcedProjectLanguages,
-                            languageFallbackAccent = mappings.languageFallbackAccent,
-                        ),
+                    snapshot = mappings.toAccentOverrideSnapshot(),
                     overridesEnabled = true,
                     validateHex = validateHex,
-                    detectedLanguage = { ProjectLanguageDetector.dominant(activeProject) },
-                    verdict = { warmCache -> ProjectLanguageDetector.verdict(activeProject, warmCache = warmCache) },
+                    languageDetection =
+                        AccentOverrideResolver.LanguageDetection(
+                            detectedLanguage = { warmCache ->
+                                val verdict = ProjectLanguageDetector.verdict(activeProject, warmCache = warmCache)
+                                (verdict as? ProjectLanguageVerdict.Detected)?.languageId
+                            },
+                            verdict = { warmCache ->
+                                ProjectLanguageDetector.verdict(activeProject, warmCache = warmCache)
+                            },
+                        ),
                 ),
             )?.toResolvedAccent()
     }

--- a/src/main/kotlin/dev/ayuislands/accent/CancellationSafeRunCatching.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/CancellationSafeRunCatching.kt
@@ -7,12 +7,13 @@ import kotlin.coroutines.cancellation.CancellationException
  * [kotlin.runCatching] variant that rethrows platform and coroutine cancellation
  * instead of capturing it in the returned [Result].
  *
- * The resolver chain ([AccentResolver.projectKey], [ProjectLanguageDetector.dominant]) is
- * reachable from `AyuIslandsStartupActivity.execute`'s coroutine body; swallowing
- * cancellation there would let the coroutine continue past its scope's cancellation,
- * breaking structured concurrency. Other `Throwable`s (including `Error` subtypes like
- * `NoClassDefFoundError` from a mid-dispose race on a lazily-loaded service accessor) keep
- * the existing fall-back-to-failure-result behavior.
+ * The startup resolver chain ([AccentResolver.projectKey],
+ * [ProjectLanguageDetector.dominant]) is reachable from
+ * `AyuIslandsStartupActivity.execute`'s coroutine body; swallowing cancellation there
+ * would let the coroutine continue past its scope's cancellation, breaking structured
+ * concurrency. Other `Throwable`s (including `Error` subtypes like `NoClassDefFoundError`
+ * from a mid-dispose race on a lazily-loaded service accessor) keep the existing
+ * fall-back-to-failure-result behavior.
  *
  * Only the top-level exception is inspected. If an IntelliJ platform API catches a
  * `CancellationException` and rewraps it (e.g. `throw IllegalStateException("disposed",

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
@@ -33,13 +33,14 @@ import javax.swing.SwingUtilities
  *     recognized source files: brand-new project, docs-only-after-filtering, or
  *     pre-indexing state.
  *
- * Concurrency: `dominant()` may be called from EDT (settings UI, focus-swap listener).
- * On EDT, first-call detection on a large monorepo is a ~300–500 ms freeze. To avoid
- * that, an EDT invocation with an empty cache kicks off a deduplicated background scan
- * via [ProjectLanguageScanAsync] and returns null immediately; the caller falls through
- * to the global accent. When the BG scan completes with a cacheable verdict, the
- * detector re-applies the resolver result on EDT so the UI picks up either the new
- * winner or the fallback without waiting for the next focus swap.
+ * Concurrency: `verdict(warmCache = true)` and `dominant()` may be called from EDT
+ * settings and focus-swap paths. On EDT, first-call detection on a large monorepo is a
+ * ~300–500 ms freeze. To avoid that, an EDT invocation with an empty cache kicks off a
+ * deduplicated background scan via [ProjectLanguageScanAsync] and returns a cold/null
+ * result immediately; the caller falls through to the global accent. When the BG scan
+ * completes with a cacheable verdict, the detector re-applies the resolver result on EDT
+ * so the UI picks up either the new winner or the fallback without waiting for the next
+ * focus swap.
  *
  * Cache correctness: a detection whose scan threw is NOT cached — the next call
  * retries. A scan that ran cleanly but produced no winner (after both the proportional
@@ -93,9 +94,9 @@ object ProjectLanguageDetector {
      *
      * Never triggers a scan or schedules background work. The caller is responsible
      * for rendering a fallback (polyglot copy) on null. The single [verdictCache]
-     * entry is warmed via [dominant] (called from
-     * [dev.ayuislands.AyuIslandsStartupActivity] and the focus-swap path in
-     * [AccentResolver]) and invalidated via [invalidate].
+     * entry is warmed via [dominant] from
+     * [dev.ayuislands.AyuIslandsStartupActivity] and via `verdict(warmCache = true)`
+     * from resolver and pending-settings paths, then invalidated via [invalidate].
      *
      * Phase 26 contract: this is a read-only projection of existing detector state.
      * Phase 29 supplies a manual rescan trigger; Phase 31 may extend this API with

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/AccentMappingsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/AccentMappingsState.kt
@@ -1,6 +1,7 @@
 package dev.ayuislands.settings.mappings
 
 import com.intellij.openapi.components.BaseState
+import dev.ayuislands.accent.AccentOverrideSnapshot
 import dev.ayuislands.accent.LanguageDetectionRules
 
 /**
@@ -29,6 +30,15 @@ class AccentMappingsState : BaseState() {
             dominanceMarginRatio = dominanceMarginRatio.toStoredDouble(),
             dominanceFloor = dominanceFloor.toStoredDouble(),
             tiebreakMinShare = tiebreakMinShare.toStoredDouble(),
+        )
+
+    internal fun toAccentOverrideSnapshot(): AccentOverrideSnapshot =
+        AccentOverrideSnapshot(
+            projectAccents = projectAccents.toMap(),
+            languageAccents = languageAccents.toMap(),
+            projectFallbackAccents = projectFallbackAccents.toMap(),
+            forcedProjectLanguages = forcedProjectLanguages.toMap(),
+            languageFallbackAccent = languageFallbackAccent,
         )
 }
 

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -532,45 +532,17 @@ class OverridesGroupBuilder(
         projectKey: String?,
         verdict: ProjectLanguageVerdict,
         isLicensed: Boolean,
-    ): AccentResolver.Source {
-        if (!isLicensed || projectKey == null) return AccentResolver.Source.GLOBAL
-        projectModel
-            .snapshot()
-            .firstOrNull { it.canonicalPath == projectKey }
-            ?.let { return AccentResolver.Source.PROJECT_OVERRIDE }
-
-        val languageIds = languageModel.snapshot().map { it.languageId }.toSet()
-        val forcedLanguageId = pendingForcedLanguages[projectKey]
-        if (forcedLanguageId != null && forcedLanguageId in languageIds) {
-            return AccentResolver.Source.FORCED_LANGUAGE_OVERRIDE
-        }
-        if (forcedLanguageId != null && pendingLanguageFallbackAccent != null) {
-            return AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE
-        }
-        if (forcedLanguageId == null &&
-            verdict is ProjectLanguageVerdict.Detected &&
-            verdict.languageId in languageIds
-        ) {
-            return AccentResolver.Source.LANGUAGE_OVERRIDE
-        }
-        if (forcedLanguageId == null &&
-            verdict is ProjectLanguageVerdict.Detected &&
-            pendingLanguageFallbackAccent != null
-        ) {
-            return AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE
-        }
-        return fallbackDiagnosticsSource(projectKey, verdict)
-    }
-
-    private fun fallbackDiagnosticsSource(
-        projectKey: String,
-        verdict: ProjectLanguageVerdict,
     ): AccentResolver.Source =
-        if (pendingFallbackAccents.containsKey(projectKey) && verdict is ProjectLanguageVerdict.NoWinner) {
-            AccentResolver.Source.PROJECT_FALLBACK
-        } else {
-            AccentResolver.Source.GLOBAL
-        }
+        AccentOverrideResolver.source(
+            AccentOverrideResolver.Request(
+                projectKey = projectKey,
+                snapshot = pendingOverrideSnapshot(),
+                overridesEnabled = isLicensed,
+                validateHex = false,
+                detectedLanguage = { (verdict as? ProjectLanguageVerdict.Detected)?.languageId },
+                verdict = { verdict },
+            ),
+        )
 
     private fun currentPendingAccentHex(): String? {
         val candidate = currentProjectOverrideHex() ?: currentGlobalAccentHex()

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -400,7 +400,7 @@ class OverridesGroupBuilder(
         project: Project?,
         fallbackGlobalHex: String,
         cacheOnly: Boolean = false,
-    ): String = resolvePendingOverride(project, warmDetector = !cacheOnly)?.hex ?: fallbackGlobalHex
+    ): String = resolvePendingOverride(project, warmLanguageDetection = !cacheOnly)?.hex ?: fallbackGlobalHex
 
     /**
      * Matching [AccentResolver.Source] for [project] under the **pending** overrides model.
@@ -409,7 +409,7 @@ class OverridesGroupBuilder(
         project: Project?,
         cacheOnly: Boolean = false,
     ): AccentResolver.Source =
-        resolvePendingOverride(project, warmDetector = !cacheOnly)?.source ?: AccentResolver.Source.GLOBAL
+        resolvePendingOverride(project, warmLanguageDetection = !cacheOnly)?.source ?: AccentResolver.Source.GLOBAL
 
     internal fun activeSourceDetailPending(
         project: Project?,
@@ -444,7 +444,7 @@ class OverridesGroupBuilder(
 
     private fun resolvePendingOverride(
         project: Project?,
-        warmDetector: Boolean,
+        warmLanguageDetection: Boolean,
     ): AccentOverrideResolver.Result? {
         val activeProject =
             project
@@ -466,9 +466,14 @@ class OverridesGroupBuilder(
                 snapshot = pendingOverrideSnapshot(),
                 overridesEnabled = LicenseChecker.isLicensedOrGrace(),
                 validateHex = false,
-                warmDetector = warmDetector,
-                detectedLanguage = { (verdict(warmDetector) as? ProjectLanguageVerdict.Detected)?.languageId },
-                verdict = ::verdict,
+                warmLanguageDetection = warmLanguageDetection,
+                languageDetection =
+                    AccentOverrideResolver.LanguageDetection(
+                        detectedLanguage = { warmCache ->
+                            (verdict(warmCache) as? ProjectLanguageVerdict.Detected)?.languageId
+                        },
+                        verdict = ::verdict,
+                    ),
             ),
         )
     }
@@ -539,8 +544,11 @@ class OverridesGroupBuilder(
                 snapshot = pendingOverrideSnapshot(),
                 overridesEnabled = isLicensed,
                 validateHex = false,
-                detectedLanguage = { (verdict as? ProjectLanguageVerdict.Detected)?.languageId },
-                verdict = { verdict },
+                languageDetection =
+                    AccentOverrideResolver.LanguageDetection(
+                        detectedLanguage = { (verdict as? ProjectLanguageVerdict.Detected)?.languageId },
+                        verdict = { verdict },
+                    ),
             ),
         )
 

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -11,6 +11,8 @@ import com.intellij.ui.table.JBTable
 import com.intellij.util.messages.MessageBusConnection
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentHex
+import dev.ayuislands.accent.AccentOverrideResolver
+import dev.ayuislands.accent.AccentOverrideSnapshot
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.LanguageDetectionRules
@@ -398,7 +400,7 @@ class OverridesGroupBuilder(
         project: Project?,
         fallbackGlobalHex: String,
         cacheOnly: Boolean = false,
-    ): String = findPendingOverride(project, warmDetector = !cacheOnly)?.hex ?: fallbackGlobalHex
+    ): String = resolvePendingOverride(project, warmDetector = !cacheOnly)?.hex ?: fallbackGlobalHex
 
     /**
      * Matching [AccentResolver.Source] for [project] under the **pending** overrides model.
@@ -407,7 +409,7 @@ class OverridesGroupBuilder(
         project: Project?,
         cacheOnly: Boolean = false,
     ): AccentResolver.Source =
-        findPendingOverride(project, warmDetector = !cacheOnly)?.source ?: AccentResolver.Source.GLOBAL
+        resolvePendingOverride(project, warmDetector = !cacheOnly)?.source ?: AccentResolver.Source.GLOBAL
 
     internal fun activeSourceDetailPending(
         project: Project?,
@@ -440,116 +442,45 @@ class OverridesGroupBuilder(
         return (verdict as? ProjectLanguageVerdict.Detected)?.let(::detectedLanguageDetail)
     }
 
-    private fun findPendingOverride(
+    private fun resolvePendingOverride(
         project: Project?,
         warmDetector: Boolean,
-    ): PendingResolvedAccent? {
-        if (!LicenseChecker.isLicensedOrGrace()) return null
+    ): AccentOverrideResolver.Result? {
         val activeProject =
             project
                 ?.takeUnless { it.isDefault }
                 ?.takeUnless { it.isDisposed }
                 ?: return null
         val projectKey = AccentResolver.projectKey(activeProject) ?: return null
-        projectModel
-            .snapshot()
-            .firstOrNull { it.canonicalPath == projectKey }
-            ?.let { return PendingResolvedAccent(AccentResolver.Source.PROJECT_OVERRIDE, it.hex) }
+        var cachedVerdict: ProjectLanguageVerdict? = null
 
-        val languageAccents = languageModel.snapshot().associate { it.languageId to it.hex }
-        val hasProjectFallbackCandidate = pendingFallbackAccents.containsKey(projectKey)
+        fun verdict(warmCache: Boolean): ProjectLanguageVerdict =
+            cachedVerdict
+                ?: ProjectLanguageDetector
+                    .verdict(activeProject, warmCache = warmCache)
+                    .also { cachedVerdict = it }
 
-        val cachedVerdict =
-            if (warmDetector) {
-                null
-            } else {
-                ProjectLanguageDetector.verdict(activeProject)
-            }
-        val languageOverride =
-            findPendingLanguageOverride(
-                activeProject = activeProject,
+        return AccentOverrideResolver.resolve(
+            AccentOverrideResolver.Request(
                 projectKey = projectKey,
-                languageAccents = languageAccents,
-                cachedVerdict = cachedVerdict,
+                snapshot = pendingOverrideSnapshot(),
+                overridesEnabled = LicenseChecker.isLicensedOrGrace(),
+                validateHex = false,
                 warmDetector = warmDetector,
-            )
-        languageOverride.accent?.let { return it }
-        if (!languageOverride.hasResolutionWork && !hasProjectFallbackCandidate) return null
-
-        return findPendingFallbackOverride(
-            activeProject = activeProject,
-            projectKey = projectKey,
-            detectorConsulted = languageOverride.detectorConsulted,
-            cachedVerdict = cachedVerdict,
-            warmDetector = warmDetector,
+                detectedLanguage = { (verdict(warmDetector) as? ProjectLanguageVerdict.Detected)?.languageId },
+                verdict = ::verdict,
+            ),
         )
     }
 
-    private fun findPendingLanguageOverride(
-        activeProject: Project,
-        projectKey: String,
-        languageAccents: Map<String, String>,
-        cachedVerdict: ProjectLanguageVerdict?,
-        warmDetector: Boolean,
-    ): PendingLanguageOverrideResult {
-        val hasForcedLanguageEntry = pendingForcedLanguages.containsKey(projectKey)
-        val hasLanguageCandidate = languageAccents.isNotEmpty() || pendingLanguageFallbackAccent != null
-        pendingForcedLanguages[projectKey]
-            ?.let { languageId ->
-                pendingAccentForLanguage(
-                    languageAccents = languageAccents,
-                    languageId = languageId,
-                    exactSource = AccentResolver.Source.FORCED_LANGUAGE_OVERRIDE,
-                )
-            }?.let { return PendingLanguageOverrideResult(it, hasResolutionWork = true, detectorConsulted = false) }
-
-        val shouldDetectLanguage = !hasForcedLanguageEntry && hasLanguageCandidate
-        if (!shouldDetectLanguage) {
-            return PendingLanguageOverrideResult(
-                accent = null,
-                hasResolutionWork = hasLanguageCandidate && !hasForcedLanguageEntry,
-                detectorConsulted = false,
-            )
-        }
-
-        val accent =
-            pendingDetectedLanguageId(activeProject, cachedVerdict, warmDetector)
-                ?.let { languageId ->
-                    pendingAccentForLanguage(
-                        languageAccents = languageAccents,
-                        languageId = languageId,
-                        exactSource = AccentResolver.Source.LANGUAGE_OVERRIDE,
-                    )
-                }
-        return PendingLanguageOverrideResult(accent, hasResolutionWork = true, detectorConsulted = true)
-    }
-
-    private fun pendingDetectedLanguageId(
-        activeProject: Project,
-        cachedVerdict: ProjectLanguageVerdict?,
-        warmDetector: Boolean,
-    ): String? =
-        if (warmDetector) {
-            ProjectLanguageDetector.dominant(activeProject)
-        } else {
-            (cachedVerdict as? ProjectLanguageVerdict.Detected)?.languageId
-        }
-
-    private fun findPendingFallbackOverride(
-        activeProject: Project,
-        projectKey: String,
-        detectorConsulted: Boolean,
-        cachedVerdict: ProjectLanguageVerdict?,
-        warmDetector: Boolean,
-    ): PendingResolvedAccent? {
-        val fallbackAccent = pendingFallbackAccents[projectKey] ?: return null
-        val verdict =
-            cachedVerdict
-                ?: ProjectLanguageDetector.verdict(activeProject, warmCache = !detectorConsulted && warmDetector)
-        return fallbackAccent
-            .takeIf { verdict is ProjectLanguageVerdict.NoWinner }
-            ?.let { PendingResolvedAccent(AccentResolver.Source.PROJECT_FALLBACK, it) }
-    }
+    private fun pendingOverrideSnapshot(): AccentOverrideSnapshot =
+        AccentOverrideSnapshot(
+            projectAccents = projectModel.snapshot().associate { it.canonicalPath to it.hex },
+            languageAccents = languageModel.snapshot().associate { it.languageId to it.hex },
+            projectFallbackAccents = pendingFallbackAccents.toMap(),
+            forcedProjectLanguages = pendingForcedLanguages.toMap(),
+            languageFallbackAccent = pendingLanguageFallbackAccent,
+        )
 
     // Internals: pending-model resolver + UI wiring helpers
 
@@ -959,27 +890,6 @@ class OverridesGroupBuilder(
             private const val MIN_VIEWPORT_WIDTH = 520
         }
     }
-
-    private data class PendingResolvedAccent(
-        val source: AccentResolver.Source,
-        val hex: String,
-    )
-
-    private data class PendingLanguageOverrideResult(
-        val accent: PendingResolvedAccent?,
-        val hasResolutionWork: Boolean,
-        val detectorConsulted: Boolean,
-    )
-
-    private fun pendingAccentForLanguage(
-        languageAccents: Map<String, String>,
-        languageId: String,
-        exactSource: AccentResolver.Source,
-    ): PendingResolvedAccent? =
-        languageAccents[languageId]
-            ?.let { PendingResolvedAccent(exactSource, it) }
-            ?: pendingLanguageFallbackAccent
-                ?.let { PendingResolvedAccent(AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE, it) }
 
     private class DimOrphanRenderer(
         private val orphanProbe: (Int) -> Boolean,

--- a/src/test/kotlin/dev/ayuislands/accent/AccentOverrideResolverTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentOverrideResolverTest.kt
@@ -141,6 +141,34 @@ class AccentOverrideResolverTest {
     }
 
     @Test
+    fun `source reports global when no override resolves`() {
+        val source =
+            AccentOverrideResolver.source(
+                request(
+                    projectKey = PROJECT_KEY,
+                    snapshot = AccentOverrideSnapshot(languageAccents = mapOf("kotlin" to "#A6E22E")),
+                    detectedLanguage = { "typescript" },
+                ),
+            )
+
+        assertEquals(AccentResolver.Source.GLOBAL, source)
+    }
+
+    @Test
+    fun `source reports project fallback for no-winner verdict`() {
+        val source =
+            AccentOverrideResolver.source(
+                request(
+                    projectKey = PROJECT_KEY,
+                    snapshot = AccentOverrideSnapshot(projectFallbackAccents = mapOf(PROJECT_KEY to "#5CCFE6")),
+                    verdict = { ProjectLanguageVerdict.NoWinner(mapOf("kotlin" to 500L, "java" to 500L)) },
+                ),
+            )
+
+        assertEquals(AccentResolver.Source.PROJECT_FALLBACK, source)
+    }
+
+    @Test
     fun `hex validation matches ayu and external traversal parity`() {
         val rawProjectResult =
             AccentOverrideResolver.resolve(

--- a/src/test/kotlin/dev/ayuislands/accent/AccentOverrideResolverTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentOverrideResolverTest.kt
@@ -1,0 +1,198 @@
+package dev.ayuislands.accent
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+
+class AccentOverrideResolverTest {
+    @Test
+    fun `project override wins before language rules`() {
+        var detectorConsulted = false
+        val result =
+            AccentOverrideResolver.resolve(
+                request(
+                    projectKey = PROJECT_KEY,
+                    snapshot =
+                        AccentOverrideSnapshot(
+                            projectAccents = mapOf(PROJECT_KEY to "#111111"),
+                            languageAccents = mapOf("kotlin" to "#222222"),
+                        ),
+                    detectedLanguage = {
+                        detectorConsulted = true
+                        "kotlin"
+                    },
+                ),
+            )
+
+        assertEquals(AccentResolver.Source.PROJECT_OVERRIDE, result?.source)
+        assertEquals("#111111", result?.hex)
+        assertFalse(detectorConsulted)
+    }
+
+    @Test
+    fun `forced language wins without consulting detector`() {
+        var detectorConsulted = false
+        val result =
+            AccentOverrideResolver.resolve(
+                request(
+                    projectKey = PROJECT_KEY,
+                    snapshot =
+                        AccentOverrideSnapshot(
+                            languageAccents = mapOf("typescript" to "#3178C6", "javascript" to "#F7DF1E"),
+                            forcedProjectLanguages = mapOf(PROJECT_KEY to "typescript"),
+                        ),
+                    detectedLanguage = {
+                        detectorConsulted = true
+                        "javascript"
+                    },
+                ),
+            )
+
+        assertEquals(AccentResolver.Source.FORCED_LANGUAGE_OVERRIDE, result?.source)
+        assertEquals("#3178C6", result?.hex)
+        assertFalse(detectorConsulted)
+    }
+
+    @Test
+    fun `detected language uses injected verdict`() {
+        val result =
+            AccentOverrideResolver.resolve(
+                request(
+                    projectKey = PROJECT_KEY,
+                    snapshot = AccentOverrideSnapshot(languageAccents = mapOf("kotlin" to "#A6E22E")),
+                    detectedLanguage = { "kotlin" },
+                ),
+            )
+
+        assertEquals(AccentResolver.Source.LANGUAGE_OVERRIDE, result?.source)
+        assertEquals("#A6E22E", result?.hex)
+    }
+
+    @Test
+    fun `language fallback applies when forced language is unmapped`() {
+        val result =
+            AccentOverrideResolver.resolve(
+                request(
+                    projectKey = PROJECT_KEY,
+                    snapshot =
+                        AccentOverrideSnapshot(
+                            forcedProjectLanguages = mapOf(PROJECT_KEY to "rust"),
+                            languageFallbackAccent = "#73D0FF",
+                        ),
+                    detectedLanguage = { error("detector must not be consulted") },
+                ),
+            )
+
+        assertEquals(AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE, result?.source)
+        assertEquals("#73D0FF", result?.hex)
+    }
+
+    @Test
+    fun `project fallback applies only on no-winner verdict`() {
+        val coldResult =
+            AccentOverrideResolver.resolve(
+                request(
+                    projectKey = PROJECT_KEY,
+                    snapshot = AccentOverrideSnapshot(projectFallbackAccents = mapOf(PROJECT_KEY to "#5CCFE6")),
+                    verdict = { ProjectLanguageVerdict.Cold },
+                ),
+            )
+        val noWinnerResult =
+            AccentOverrideResolver.resolve(
+                request(
+                    projectKey = PROJECT_KEY,
+                    snapshot = AccentOverrideSnapshot(projectFallbackAccents = mapOf(PROJECT_KEY to "#5CCFE6")),
+                    verdict = { ProjectLanguageVerdict.NoWinner(mapOf("kotlin" to 500L, "java" to 500L)) },
+                ),
+            )
+
+        assertNull(coldResult)
+        assertEquals(AccentResolver.Source.PROJECT_FALLBACK, noWinnerResult?.source)
+        assertEquals("#5CCFE6", noWinnerResult?.hex)
+    }
+
+    @Test
+    fun `disabled override gate returns no result without consulting detector`() {
+        var detectorConsulted = false
+        val result =
+            AccentOverrideResolver.resolve(
+                request(
+                    projectKey = PROJECT_KEY,
+                    snapshot =
+                        AccentOverrideSnapshot(
+                            projectAccents = mapOf(PROJECT_KEY to "#111111"),
+                            languageAccents = mapOf("kotlin" to "#222222"),
+                            projectFallbackAccents = mapOf(PROJECT_KEY to "#333333"),
+                        ),
+                    detectedLanguage = {
+                        detectorConsulted = true
+                        "kotlin"
+                    },
+                    verdict = {
+                        detectorConsulted = true
+                        ProjectLanguageVerdict.NoWinner(emptyMap())
+                    },
+                ).copy(overridesEnabled = false),
+            )
+
+        assertNull(result)
+        assertFalse(detectorConsulted)
+    }
+
+    @Test
+    fun `hex validation matches ayu and external traversal parity`() {
+        val rawProjectResult =
+            AccentOverrideResolver.resolve(
+                request(
+                    projectKey = PROJECT_KEY,
+                    validateHex = false,
+                    snapshot = AccentOverrideSnapshot(projectAccents = mapOf(PROJECT_KEY to "not-a-hex")),
+                ),
+            )
+        val validatedProjectResult =
+            AccentOverrideResolver.resolve(
+                request(
+                    projectKey = PROJECT_KEY,
+                    validateHex = true,
+                    snapshot = AccentOverrideSnapshot(projectAccents = mapOf(PROJECT_KEY to "not-a-hex")),
+                ),
+            )
+        val invalidLanguageFallbackResult =
+            AccentOverrideResolver.resolve(
+                request(
+                    projectKey = PROJECT_KEY,
+                    validateHex = false,
+                    snapshot =
+                        AccentOverrideSnapshot(
+                            forcedProjectLanguages = mapOf(PROJECT_KEY to "kotlin"),
+                            languageFallbackAccent = "not-a-hex",
+                        ),
+                ),
+            )
+
+        assertEquals("not-a-hex", rawProjectResult?.hex)
+        assertNull(validatedProjectResult)
+        assertNull(invalidLanguageFallbackResult)
+    }
+
+    private fun request(
+        projectKey: String?,
+        snapshot: AccentOverrideSnapshot,
+        validateHex: Boolean = false,
+        detectedLanguage: () -> String? = { null },
+        verdict: (warmCache: Boolean) -> ProjectLanguageVerdict = { ProjectLanguageVerdict.Cold },
+    ): AccentOverrideResolver.Request =
+        AccentOverrideResolver.Request(
+            projectKey = projectKey,
+            snapshot = snapshot,
+            overridesEnabled = true,
+            validateHex = validateHex,
+            detectedLanguage = detectedLanguage,
+            verdict = verdict,
+        )
+
+    private companion object {
+        const val PROJECT_KEY = "/tmp/ayu-project"
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/accent/AccentOverrideResolverTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentOverrideResolverTest.kt
@@ -18,9 +18,9 @@ class AccentOverrideResolverTest {
                             projectAccents = mapOf(PROJECT_KEY to "#111111"),
                             languageAccents = mapOf("kotlin" to "#222222"),
                         ),
-                    detectedLanguage = {
+                    languageVerdict = {
                         detectorConsulted = true
-                        "kotlin"
+                        ProjectLanguageVerdict.Detected("kotlin", weights = null)
                     },
                 ),
             )
@@ -42,9 +42,9 @@ class AccentOverrideResolverTest {
                             languageAccents = mapOf("typescript" to "#3178C6", "javascript" to "#F7DF1E"),
                             forcedProjectLanguages = mapOf(PROJECT_KEY to "typescript"),
                         ),
-                    detectedLanguage = {
+                    languageVerdict = {
                         detectorConsulted = true
-                        "javascript"
+                        ProjectLanguageVerdict.Detected("javascript", weights = null)
                     },
                 ),
             )
@@ -61,7 +61,7 @@ class AccentOverrideResolverTest {
                 request(
                     projectKey = PROJECT_KEY,
                     snapshot = AccentOverrideSnapshot(languageAccents = mapOf("kotlin" to "#A6E22E")),
-                    detectedLanguage = { "kotlin" },
+                    languageVerdict = { ProjectLanguageVerdict.Detected("kotlin", weights = null) },
                 ),
             )
 
@@ -80,7 +80,7 @@ class AccentOverrideResolverTest {
                             forcedProjectLanguages = mapOf(PROJECT_KEY to "rust"),
                             languageFallbackAccent = "#73D0FF",
                         ),
-                    detectedLanguage = { error("detector must not be consulted") },
+                    languageVerdict = { error("language verdict must not be consulted") },
                 ),
             )
 
@@ -95,7 +95,7 @@ class AccentOverrideResolverTest {
                 request(
                     projectKey = PROJECT_KEY,
                     snapshot = AccentOverrideSnapshot(projectFallbackAccents = mapOf(PROJECT_KEY to "#5CCFE6")),
-                    verdict = { ProjectLanguageVerdict.Cold },
+                    languageVerdict = { ProjectLanguageVerdict.Cold },
                 ),
             )
         val noWinnerResult =
@@ -103,13 +103,40 @@ class AccentOverrideResolverTest {
                 request(
                     projectKey = PROJECT_KEY,
                     snapshot = AccentOverrideSnapshot(projectFallbackAccents = mapOf(PROJECT_KEY to "#5CCFE6")),
-                    verdict = { ProjectLanguageVerdict.NoWinner(mapOf("kotlin" to 500L, "java" to 500L)) },
+                    languageVerdict = { ProjectLanguageVerdict.NoWinner(mapOf("kotlin" to 500L, "java" to 500L)) },
                 ),
             )
 
         assertNull(coldResult)
         assertEquals(AccentResolver.Source.PROJECT_FALLBACK, noWinnerResult?.source)
         assertEquals("#5CCFE6", noWinnerResult?.hex)
+    }
+
+    @Test
+    fun `project fallback verdict is cache-only after language detection was consulted`() {
+        val warmCacheCalls = mutableListOf<Boolean>()
+        val result =
+            AccentOverrideResolver.resolve(
+                request(
+                    projectKey = PROJECT_KEY,
+                    snapshot =
+                        AccentOverrideSnapshot(
+                            languageAccents = mapOf("kotlin" to "#A6E22E"),
+                            projectFallbackAccents = mapOf(PROJECT_KEY to "#5CCFE6"),
+                        ),
+                    languageVerdict = { warmCache ->
+                        warmCacheCalls += warmCache
+                        if (warmCacheCalls.size == 1) {
+                            ProjectLanguageVerdict.Detected("typescript", weights = null)
+                        } else {
+                            ProjectLanguageVerdict.NoWinner(mapOf("kotlin" to 500L, "typescript" to 500L))
+                        }
+                    },
+                ),
+            )
+
+        assertEquals(AccentResolver.Source.PROJECT_FALLBACK, result?.source)
+        assertEquals(listOf(true, false), warmCacheCalls)
     }
 
     @Test
@@ -125,13 +152,9 @@ class AccentOverrideResolverTest {
                             languageAccents = mapOf("kotlin" to "#222222"),
                             projectFallbackAccents = mapOf(PROJECT_KEY to "#333333"),
                         ),
-                    detectedLanguage = {
+                    languageVerdict = {
                         detectorConsulted = true
-                        "kotlin"
-                    },
-                    verdict = {
-                        detectorConsulted = true
-                        ProjectLanguageVerdict.NoWinner(emptyMap())
+                        ProjectLanguageVerdict.Detected("kotlin", weights = null)
                     },
                 ).copy(overridesEnabled = false),
             )
@@ -147,7 +170,7 @@ class AccentOverrideResolverTest {
                 request(
                     projectKey = PROJECT_KEY,
                     snapshot = AccentOverrideSnapshot(languageAccents = mapOf("kotlin" to "#A6E22E")),
-                    detectedLanguage = { "typescript" },
+                    languageVerdict = { ProjectLanguageVerdict.Detected("typescript", weights = null) },
                 ),
             )
 
@@ -161,7 +184,7 @@ class AccentOverrideResolverTest {
                 request(
                     projectKey = PROJECT_KEY,
                     snapshot = AccentOverrideSnapshot(projectFallbackAccents = mapOf(PROJECT_KEY to "#5CCFE6")),
-                    verdict = { ProjectLanguageVerdict.NoWinner(mapOf("kotlin" to 500L, "java" to 500L)) },
+                    languageVerdict = { ProjectLanguageVerdict.NoWinner(mapOf("kotlin" to 500L, "java" to 500L)) },
                 ),
             )
 
@@ -208,16 +231,20 @@ class AccentOverrideResolverTest {
         projectKey: String?,
         snapshot: AccentOverrideSnapshot,
         validateHex: Boolean = false,
-        detectedLanguage: () -> String? = { null },
-        verdict: (warmCache: Boolean) -> ProjectLanguageVerdict = { ProjectLanguageVerdict.Cold },
+        languageVerdict: (warmCache: Boolean) -> ProjectLanguageVerdict = { ProjectLanguageVerdict.Cold },
     ): AccentOverrideResolver.Request =
         AccentOverrideResolver.Request(
             projectKey = projectKey,
             snapshot = snapshot,
             overridesEnabled = true,
             validateHex = validateHex,
-            detectedLanguage = detectedLanguage,
-            verdict = verdict,
+            languageDetection =
+                AccentOverrideResolver.LanguageDetection(
+                    detectedLanguage = { warmCache ->
+                        (languageVerdict(warmCache) as? ProjectLanguageVerdict.Detected)?.languageId
+                    },
+                    verdict = languageVerdict,
+                ),
         )
 
     private companion object {

--- a/src/test/kotlin/dev/ayuislands/accent/AccentResolverChainTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentResolverChainTest.kt
@@ -61,7 +61,6 @@ class AccentResolverChainTest {
         every { AccentMappingsSettings.getInstance() } returns mappingsSettings
 
         mockkObject(ProjectLanguageDetector)
-        every { ProjectLanguageDetector.dominant(any()) } returns null
         every { ProjectLanguageDetector.verdict(any()) } returns ProjectLanguageVerdict.Cold
         every { ProjectLanguageDetector.verdict(any(), any<Boolean>()) } returns ProjectLanguageVerdict.Cold
 
@@ -176,7 +175,6 @@ class AccentResolverChainTest {
         mappingsState.projectAccents[tmp] = "#111111"
         mappingsState.languageAccents["kotlin"] = "#222222"
         val project = stubProject(File(tmp))
-        every { ProjectLanguageDetector.dominant(project) } returns "kotlin"
 
         val chain = AccentResolver.resolveChain(project, AyuVariant.MIRAGE)
 
@@ -329,7 +327,6 @@ class AccentResolverChainTest {
         mappingsState.forcedProjectLanguages[tmp] = "typescript"
         mappingsState.languageAccents["typescript"] = "#3178C6"
         val project = stubProject(File(tmp))
-        every { ProjectLanguageDetector.dominant(any()) } returns "javascript"
 
         val chain = AccentResolver.resolveChain(project, AyuVariant.MIRAGE)
 
@@ -347,7 +344,6 @@ class AccentResolverChainTest {
         mappingsState.languageAccents["kotlin"] = "#ABCDEF"
         val project = stubProject(File(stubsDir, "lang-override"))
 
-        every { ProjectLanguageDetector.dominant(project) } returns "kotlin"
         val verdict =
             ProjectLanguageVerdict.Detected(
                 languageId = "kotlin",
@@ -379,7 +375,6 @@ class AccentResolverChainTest {
     fun `resolveChain language override with NO_MAPPING when language not in accent map falls through to global`() {
         mappingsState.languageAccents["kotlin"] = "#ABCDEF"
         val project = stubProject(File(stubsDir, "lang-no-map"))
-        every { ProjectLanguageDetector.dominant(project) } returns "python"
         every { ProjectLanguageDetector.verdict(project) } returns
             ProjectLanguageVerdict.Detected("python", mapOf("python" to 1_000L))
 
@@ -402,9 +397,9 @@ class AccentResolverChainTest {
     fun `resolveChain language fallback wins when detected language has no exact mapping`() {
         mappingsState.languageFallbackAccent = "#73D0FF"
         val project = stubProject(File(stubsDir, "detected-language-fallback"))
-        every { ProjectLanguageDetector.dominant(project) } returns "python"
         val verdict = ProjectLanguageVerdict.Detected("python", mapOf("python" to 1_000L))
         every { ProjectLanguageDetector.verdict(project) } returns verdict
+        every { ProjectLanguageDetector.verdict(project, warmCache = true) } returns verdict
 
         val chain = AccentResolver.resolveChain(project, AyuVariant.MIRAGE)
 
@@ -426,7 +421,6 @@ class AccentResolverChainTest {
     fun `resolveChain language override shows Cold verdict when detection not yet run`() {
         mappingsState.languageAccents["kotlin"] = "#ABCDEF"
         val project = stubProject(File(stubsDir, "lang-cold"))
-        every { ProjectLanguageDetector.dominant(project) } returns null
         every { ProjectLanguageDetector.verdict(project) } returns ProjectLanguageVerdict.Cold
 
         val chain = AccentResolver.resolveChain(project, AyuVariant.MIRAGE)
@@ -451,7 +445,6 @@ class AccentResolverChainTest {
         mappingsState.projectFallbackAccents[tmp] = "#5CCFE6"
         val project = stubProject(File(tmp))
 
-        every { ProjectLanguageDetector.dominant(project) } returns null
         val noWinnerVerdict =
             ProjectLanguageVerdict.NoWinner(
                 mapOf("typescript" to 500L, "javascript" to 500L),
@@ -485,7 +478,6 @@ class AccentResolverChainTest {
         mappingsState.projectFallbackAccents[tmp] = "#5CCFE6"
         val project = stubProject(File(tmp))
 
-        every { ProjectLanguageDetector.dominant(project) } returns null
         val noWinnerVerdict =
             ProjectLanguageVerdict.NoWinner(
                 mapOf("typescript" to 500L, "javascript" to 500L),
@@ -533,7 +525,6 @@ class AccentResolverChainTest {
         mappingsState.languageAccents["kotlin"] = "#ABCDEF"
         val project = stubProject(File(tmp))
 
-        every { ProjectLanguageDetector.dominant(project) } returns "kotlin"
         every { ProjectLanguageDetector.verdict(project) } returns
             ProjectLanguageVerdict.Detected("kotlin", mapOf("kotlin" to 1_000L))
 
@@ -553,7 +544,6 @@ class AccentResolverChainTest {
         mappingsState.projectFallbackAccents[tmp] = "bad-hex"
         val project = stubProject(File(tmp))
 
-        every { ProjectLanguageDetector.dominant(project) } returns null
         every { ProjectLanguageDetector.verdict(project) } returns
             ProjectLanguageVerdict.NoWinner(mapOf("typescript" to 500L, "javascript" to 500L))
 

--- a/src/test/kotlin/dev/ayuislands/accent/AccentResolverExternalTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentResolverExternalTest.kt
@@ -40,7 +40,7 @@ class AccentResolverExternalTest {
             mappingsState.languageAccents["kotlin"] = "#223344"
             state.externalThemeAccent = "#445566"
             val project = stubProject(File(System.getProperty("java.io.tmpdir"), "external-language"))
-            every { ProjectLanguageDetector.dominant(project) } returns "kotlin"
+            stubDetectedLanguage(project, "kotlin")
 
             withUiColorProvider({ key -> if (key == "material.accent") Color(0xAA, 0xBB, 0xCC) else null }) {
                 assertEquals("#223344", AccentResolver.resolve(project, AccentContext.External))
@@ -58,7 +58,7 @@ class AccentResolverExternalTest {
             mappingsState.languageFallbackAccent = "#73D0FF"
             state.externalThemeAccent = "#445566"
             val project = stubProject(File(System.getProperty("java.io.tmpdir"), "external-language-fallback"))
-            every { ProjectLanguageDetector.dominant(project) } returns "terraform"
+            stubDetectedLanguage(project, "terraform")
 
             withUiColorProvider({ key -> if (key == "material.accent") Color(0xAA, 0xBB, 0xCC) else null }) {
                 assertEquals("#73D0FF", AccentResolver.resolve(project, AccentContext.External))
@@ -76,7 +76,7 @@ class AccentResolverExternalTest {
             mappingsState.languageFallbackAccent = "not-a-hex"
             state.externalThemeAccent = "#445566"
             val project = stubProject(File(System.getProperty("java.io.tmpdir"), "external-invalid-language-fallback"))
-            every { ProjectLanguageDetector.dominant(project) } returns "terraform"
+            stubDetectedLanguage(project, "terraform")
 
             withUiColorProvider({ key -> if (key == "material.accent") Color(0xAA, 0xBB, 0xCC) else null }) {
                 assertEquals("#AABBCC", AccentResolver.resolve(project, AccentContext.External))
@@ -96,7 +96,7 @@ class AccentResolverExternalTest {
             mappingsState.languageAccents["typescript"] = "#3178C6"
             state.externalThemeAccent = "#445566"
             val project = stubProject(File(projectPath))
-            every { ProjectLanguageDetector.dominant(project) } returns "javascript"
+            stubDetectedLanguage(project, "javascript")
 
             withUiColorProvider({ key -> if (key == "material.accent") Color(0xAA, 0xBB, 0xCC) else null }) {
                 assertEquals("#3178C6", AccentResolver.resolve(project, AccentContext.External))
@@ -230,7 +230,7 @@ class AccentResolverExternalTest {
             state.externalThemeAccentSource = ExternalAccentSource.MANUAL.name
             state.externalThemeAccent = "#13579B"
             val project = stubProject(File(projectPath))
-            every { ProjectLanguageDetector.dominant(project) } returns "kotlin"
+            stubDetectedLanguage(project, "kotlin")
 
             withUiColorProvider({ key -> if (key == "material.accent") Color(0xAA, 0xBB, 0xCC) else null }) {
                 assertEquals("#13579B", AccentResolver.resolve(project, AccentContext.External))
@@ -250,7 +250,7 @@ class AccentResolverExternalTest {
             mappingsState.languageAccents["kotlin"] = "#223344"
             state.externalThemeAccent = "#445566"
             val project = stubProject(File(projectPath))
-            every { ProjectLanguageDetector.dominant(project) } returns "kotlin"
+            stubDetectedLanguage(project, "kotlin")
 
             withUiColorProvider({ key -> if (key == "material.accent") Color(0xAA, 0xBB, 0xCC) else null }) {
                 assertEquals("#AABBCC", AccentResolver.resolve(project, AccentContext.External))
@@ -298,7 +298,6 @@ class AccentResolverExternalTest {
             every { mappingsSettings.state } returns mappingsState
             every { AccentMappingsSettings.getInstance() } returns mappingsSettings
 
-            every { ProjectLanguageDetector.dominant(any()) } returns null
             every { ProjectLanguageDetector.verdict(any()) } returns ProjectLanguageVerdict.Cold
             every { ProjectLanguageDetector.verdict(any(), any<Boolean>()) } returns ProjectLanguageVerdict.Cold
             every { LicenseChecker.isLicensedOrGrace() } returns licensed
@@ -321,6 +320,14 @@ class AccentResolverExternalTest {
         block: () -> Unit,
     ) {
         AccentResolver.withUiColorProviderForTest(provider, block)
+    }
+
+    private fun stubDetectedLanguage(
+        project: Project,
+        languageId: String,
+    ) {
+        every { ProjectLanguageDetector.verdict(project, warmCache = true) } returns
+            ProjectLanguageVerdict.Detected(languageId, weights = null)
     }
 
     private data class ResolverStubs(

--- a/src/test/kotlin/dev/ayuislands/accent/AccentResolverTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentResolverTest.kt
@@ -42,7 +42,6 @@ class AccentResolverTest {
         every { AccentMappingsSettings.getInstance() } returns mappingsSettings
 
         mockkObject(ProjectLanguageDetector)
-        every { ProjectLanguageDetector.dominant(any()) } returns null
         every { ProjectLanguageDetector.verdict(any()) } returns ProjectLanguageVerdict.Cold
         every { ProjectLanguageDetector.verdict(any(), any<Boolean>()) } returns ProjectLanguageVerdict.Cold
 
@@ -87,7 +86,7 @@ class AccentResolverTest {
     fun `resolve prefers language override over global when no project override`() {
         mappingsState.languageAccents["kotlin"] = "#ABCDEF"
         val project = stubProject(File(System.getProperty("java.io.tmpdir"), "kotlin-proj"))
-        every { ProjectLanguageDetector.dominant(project) } returns "kotlin"
+        stubDetectedLanguage(project, "kotlin")
 
         assertEquals("#ABCDEF", AccentResolver.resolve(project, AyuVariant.MIRAGE))
     }
@@ -97,7 +96,7 @@ class AccentResolverTest {
         mappingsState.languageAccents["kotlin"] = "#ABCDEF"
         mappingsState.languageFallbackAccent = "#73D0FF"
         val project = stubProject(File(System.getProperty("java.io.tmpdir"), "typescript-fallback"))
-        every { ProjectLanguageDetector.dominant(project) } returns "typescript"
+        stubDetectedLanguage(project, "typescript")
 
         assertEquals("#73D0FF", AccentResolver.resolve(project, AyuVariant.MIRAGE))
         assertEquals(AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE, AccentResolver.source(project))
@@ -108,7 +107,7 @@ class AccentResolverTest {
         mappingsState.languageAccents["kotlin"] = "#ABCDEF"
         mappingsState.languageFallbackAccent = "#73D0FF"
         val project = stubProject(File(System.getProperty("java.io.tmpdir"), "kotlin-exact-fallback"))
-        every { ProjectLanguageDetector.dominant(project) } returns "kotlin"
+        stubDetectedLanguage(project, "kotlin")
 
         assertEquals("#ABCDEF", AccentResolver.resolve(project, AyuVariant.MIRAGE))
         assertEquals(AccentResolver.Source.LANGUAGE_OVERRIDE, AccentResolver.source(project))
@@ -121,7 +120,7 @@ class AccentResolverTest {
         mappingsState.languageAccents["kotlin"] = "#222222"
 
         val project = stubProject(File(tmp))
-        every { ProjectLanguageDetector.dominant(project) } returns "kotlin"
+        stubDetectedLanguage(project, "kotlin")
 
         assertEquals("#111111", AccentResolver.resolve(project, AyuVariant.MIRAGE))
     }
@@ -134,7 +133,7 @@ class AccentResolverTest {
         mappingsState.languageAccents["javascript"] = "#F7DF1E"
 
         val project = stubProject(File(tmp))
-        every { ProjectLanguageDetector.dominant(project) } returns "javascript"
+        stubDetectedLanguage(project, "javascript")
 
         assertEquals("#3178C6", AccentResolver.resolve(project, AyuVariant.MIRAGE))
         assertEquals(AccentResolver.Source.FORCED_LANGUAGE_OVERRIDE, AccentResolver.source(project))
@@ -147,12 +146,11 @@ class AccentResolverTest {
         mappingsState.languageAccents["javascript"] = "#F7DF1E"
 
         val project = stubProject(File(tmp))
-        every { ProjectLanguageDetector.dominant(project) } returns "javascript"
+        stubDetectedLanguage(project, "javascript")
 
         assertEquals(globalMirageAccent, AccentResolver.resolve(project, AyuVariant.MIRAGE))
         assertEquals(AccentResolver.Source.GLOBAL, AccentResolver.source(project))
-        io.mockk.verify(exactly = 0) { ProjectLanguageDetector.dominant(any()) }
-        io.mockk.verify(exactly = 0) { ProjectLanguageDetector.verdict(any()) }
+        io.mockk.verify(exactly = 0) { ProjectLanguageDetector.verdict(any(), any<Boolean>()) }
     }
 
     @Test
@@ -162,11 +160,11 @@ class AccentResolverTest {
         mappingsState.languageFallbackAccent = "#73D0FF"
 
         val project = stubProject(File(tmp))
-        every { ProjectLanguageDetector.dominant(project) } returns "javascript"
+        stubDetectedLanguage(project, "javascript")
 
         assertEquals("#73D0FF", AccentResolver.resolve(project, AyuVariant.MIRAGE))
         assertEquals(AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE, AccentResolver.source(project))
-        io.mockk.verify(exactly = 0) { ProjectLanguageDetector.dominant(any()) }
+        io.mockk.verify(exactly = 0) { ProjectLanguageDetector.verdict(any(), any<Boolean>()) }
     }
 
     @Test
@@ -175,7 +173,7 @@ class AccentResolverTest {
         mappingsState.languageFallbackAccent = "not-a-hex"
 
         val project = stubProject(File(tmp))
-        every { ProjectLanguageDetector.dominant(project) } returns "typescript"
+        stubDetectedLanguage(project, "typescript")
 
         assertEquals(globalMirageAccent, AccentResolver.resolve(project, AyuVariant.MIRAGE))
         assertEquals(AccentResolver.Source.GLOBAL, AccentResolver.source(project))
@@ -187,7 +185,6 @@ class AccentResolverTest {
         mappingsState.projectFallbackAccents[tmp] = "#5CCFE6"
 
         val project = stubProject(File(tmp))
-        every { ProjectLanguageDetector.dominant(project) } returns null
         val noWinnerVerdict = ProjectLanguageVerdict.NoWinner(mapOf("typescript" to 500L, "javascript" to 500L))
         every { ProjectLanguageDetector.verdict(project) } returns noWinnerVerdict
         every { ProjectLanguageDetector.verdict(project, warmCache = true) } returns noWinnerVerdict
@@ -205,7 +202,6 @@ class AccentResolverTest {
         mappingsState.languageAccents["javascript"] = "#F7DF1E"
 
         val project = stubProject(File(tmp))
-        every { ProjectLanguageDetector.dominant(project) } returns null
         val noWinnerVerdict = ProjectLanguageVerdict.NoWinner(mapOf("typescript" to 500L, "javascript" to 500L))
         every { ProjectLanguageDetector.verdict(project) } returns noWinnerVerdict
         every { ProjectLanguageDetector.verdict(project, warmCache = true) } returns noWinnerVerdict
@@ -234,8 +230,7 @@ class AccentResolverTest {
 
         assertEquals(globalMirageAccent, AccentResolver.resolve(project, AyuVariant.MIRAGE))
 
-        io.mockk.verify(exactly = 0) { ProjectLanguageDetector.dominant(any()) }
-        io.mockk.verify(exactly = 0) { ProjectLanguageDetector.verdict(any()) }
+        io.mockk.verify(exactly = 0) { ProjectLanguageDetector.verdict(any(), any<Boolean>()) }
     }
 
     @Test
@@ -247,8 +242,7 @@ class AccentResolverTest {
 
         assertEquals(globalMirageAccent, AccentResolver.resolve(project, AyuVariant.MIRAGE))
 
-        io.mockk.verify(exactly = 0) { ProjectLanguageDetector.dominant(any()) }
-        io.mockk.verify(exactly = 0) { ProjectLanguageDetector.verdict(any()) }
+        io.mockk.verify(exactly = 0) { ProjectLanguageDetector.verdict(any(), any<Boolean>()) }
     }
 
     @Test
@@ -257,7 +251,7 @@ class AccentResolverTest {
         val project = stubProject(File(System.getProperty("java.io.tmpdir"), "skip-detector"))
 
         assertEquals(globalMirageAccent, AccentResolver.resolve(project, AyuVariant.MIRAGE))
-        io.mockk.verify(exactly = 0) { ProjectLanguageDetector.dominant(any()) }
+        io.mockk.verify(exactly = 0) { ProjectLanguageDetector.verdict(any(), any<Boolean>()) }
     }
 
     @Test
@@ -273,7 +267,7 @@ class AccentResolverTest {
     fun `source reports LANGUAGE_OVERRIDE when only language mapped`() {
         mappingsState.languageAccents["python"] = "#222222"
         val project = stubProject(File(System.getProperty("java.io.tmpdir"), "src-lang"))
-        every { ProjectLanguageDetector.dominant(project) } returns "python"
+        stubDetectedLanguage(project, "python")
 
         assertEquals(AccentResolver.Source.LANGUAGE_OVERRIDE, AccentResolver.source(project))
     }
@@ -350,7 +344,7 @@ class AccentResolverTest {
         every { LicenseChecker.isLicensedOrGrace() } returns false
 
         val project = stubProject(File(System.getProperty("java.io.tmpdir"), "unlicensed-lang"))
-        every { ProjectLanguageDetector.dominant(project) } returns "kotlin"
+        stubDetectedLanguage(project, "kotlin")
 
         assertEquals(globalMirageAccent, AccentResolver.resolve(project, AyuVariant.MIRAGE))
     }
@@ -365,7 +359,7 @@ class AccentResolverTest {
         every { LicenseChecker.isLicensedOrGrace() } returns false
 
         val project = stubProject(File(tmp))
-        every { ProjectLanguageDetector.dominant(project) } returns "kotlin"
+        stubDetectedLanguage(project, "kotlin")
 
         assertEquals(AccentResolver.Source.GLOBAL, AccentResolver.source(project))
     }
@@ -375,10 +369,18 @@ class AccentResolverTest {
         // Row 6 of the truth table: LM=Y, D=Y, L=N → global wins.
         mappingsState.languageAccents["kotlin"] = "#ABCDEF"
         val project = stubProject(File(System.getProperty("java.io.tmpdir"), "python-only"))
-        every { ProjectLanguageDetector.dominant(project) } returns "python"
+        stubDetectedLanguage(project, "python")
 
         assertEquals(globalMirageAccent, AccentResolver.resolve(project, AyuVariant.MIRAGE))
         assertEquals(AccentResolver.Source.GLOBAL, AccentResolver.source(project))
+    }
+
+    private fun stubDetectedLanguage(
+        project: Project,
+        languageId: String,
+    ) {
+        every { ProjectLanguageDetector.verdict(project, warmCache = true) } returns
+            ProjectLanguageVerdict.Detected(languageId, weights = null)
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderPendingTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderPendingTest.kt
@@ -66,7 +66,7 @@ class OverridesGroupBuilderPendingTest {
     fun `resolvePending returns language override when project has no pending entry`() {
         mappingsState.languageAccents["kotlin"] = "#112233"
         val project = stubProject(File(System.getProperty("java.io.tmpdir"), "pending-lang"))
-        every { ProjectLanguageDetector.dominant(project) } returns "kotlin"
+        detectLanguage(project, "kotlin")
 
         val builder = OverridesGroupBuilder().apply { loadFromState() }
 
@@ -79,7 +79,7 @@ class OverridesGroupBuilderPendingTest {
         mappingsState.languageAccents["kotlin"] = "#112233"
         mappingsState.languageFallbackAccent = "#73D0FF"
         val project = stubProject(File(System.getProperty("java.io.tmpdir"), "pending-language-fallback"))
-        every { ProjectLanguageDetector.dominant(project) } returns "typescript"
+        detectLanguage(project, "typescript")
 
         val builder = OverridesGroupBuilder().apply { loadFromState() }
 
@@ -219,6 +219,25 @@ class OverridesGroupBuilderPendingTest {
         assertEquals("#3178C6", builder.resolvePending(project, "#FFCC66"))
         assertEquals(AccentResolver.Source.FORCED_LANGUAGE_OVERRIDE, builder.sourcePending(project))
         io.mockk.verify(exactly = 0) { ProjectLanguageDetector.dominant(project) }
+    }
+
+    @Test
+    fun `resolvePending uses pending forced language removal instead of persisted forced language`() {
+        val tmp = File(System.getProperty("java.io.tmpdir"), "pending-forced-removed").canonicalPath
+        mappingsState.forcedProjectLanguages[tmp] = "typescript"
+        mappingsState.languageAccents["typescript"] = "#3178C6"
+        mappingsState.languageAccents["javascript"] = "#F7DF1E"
+        val project = stubProject(File(tmp))
+        every { ProjectLanguageDetector.dominant(project) } returns "typescript"
+        every { ProjectLanguageDetector.verdict(project, warmCache = true) } returns
+            ProjectLanguageVerdict.Detected("javascript", mapOf("javascript" to 1_000L))
+
+        val builder = OverridesGroupBuilder().apply { loadFromState() }
+        builder.setPendingForcedLanguage(tmp, null)
+
+        assertEquals("#F7DF1E", builder.resolvePending(project, "#FFCC66"))
+        assertEquals(AccentResolver.Source.LANGUAGE_OVERRIDE, builder.sourcePending(project))
+        io.mockk.verify(atLeast = 1) { ProjectLanguageDetector.verdict(project, warmCache = true) }
     }
 
     @Test
@@ -362,11 +381,11 @@ class OverridesGroupBuilderPendingTest {
         val builder = OverridesGroupBuilder().apply { loadFromState() }
 
         val lowercaseProject = stubProject(File(System.getProperty("java.io.tmpdir"), "case-lower"))
-        every { ProjectLanguageDetector.dominant(lowercaseProject) } returns "kotlin"
+        detectLanguage(lowercaseProject, "kotlin")
         assertEquals("#CAFE00", builder.resolvePending(lowercaseProject, "#FFCC66"))
 
         val mixedCaseProject = stubProject(File(System.getProperty("java.io.tmpdir"), "case-mixed"))
-        every { ProjectLanguageDetector.dominant(mixedCaseProject) } returns "Kotlin"
+        detectLanguage(mixedCaseProject, "Kotlin")
         assertEquals(
             "#FFCC66",
             builder.resolvePending(mixedCaseProject, "#FFCC66"),
@@ -381,5 +400,13 @@ class OverridesGroupBuilderPendingTest {
         every { project.basePath } returns baseDir.path
         every { project.name } returns baseDir.name
         return project
+    }
+
+    private fun detectLanguage(
+        project: Project,
+        languageId: String,
+    ) {
+        every { ProjectLanguageDetector.verdict(project, warmCache = true) } returns
+            ProjectLanguageVerdict.Detected(languageId, mapOf(languageId to 1_000L))
     }
 }


### PR DESCRIPTION
── Summary ─────────────────────────────────

Accent override resolution was split across runtime resolution, pending Settings preview, and diagnostics, which made precedence easy to drift. This PR moves the shared traversal into `AccentOverrideResolver` and reuses it from persisted resolution, pending preview, and active-source diagnostics while keeping the existing UI copy and layout intact.

── Changes ─────────────────────────────────

| Type | File | Description |
|------|------|-------------|
| Refactor | [AccentOverrideResolver.kt](src/main/kotlin/dev/ayuislands/accent/AccentOverrideResolver.kt) | Centralize project, custom, user, and default accent traversal. |
| Refactor | [AccentResolver.kt](src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt), [OverridesGroupBuilder.kt](src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt) | Route runtime accent resolution, pending Settings preview, and diagnostics source state through the shared resolver. |
| Test | [AccentOverrideResolverTest.kt](src/test/kotlin/dev/ayuislands/accent/AccentOverrideResolverTest.kt), [OverridesGroupBuilderPendingTest.kt](src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderPendingTest.kt) | Cover override precedence and the pending forced-language removal regression. |
| Docs | [features.yml](docs/features.yml) | Restamp accent settings feature metadata for the changed tracked sources. |

── Validation ──────────────────────────────

```bash
./gradlew test --tests dev.ayuislands.accent.AccentOverrideResolverTest --tests dev.ayuislands.settings.mappings.OverridesGroupBuilderPendingTest  # Passed
./gradlew test --tests dev.ayuislands.accent.AccentResolverChainTest --tests dev.ayuislands.accent.AccentResolverExternalTest --tests dev.ayuislands.settings.AyuIslandsAccentPanelTest --tests dev.ayuislands.settings.mappings.ProjectLanguageResolutionPanelTest  # Passed
./gradlew test  # Passed
./gradlew detekt ktlintCheck  # Passed
./gradlew koverVerify  # Passed
scripts/verify-docs.py  # Passed
```

── Notes ───────────────────────────────────

Review focus: `AccentOverrideResolver` owns the precedence order; callers should only adapt their local settings/request inputs into that resolver.

## Summary by Sourcery

Centralize accent override resolution into a shared resolver and reuse it across runtime, pending settings, and diagnostics while keeping existing behavior and UI intact.

Bug Fixes:
- Ensure pending accent resolution honors removal of a forced language override instead of falling back to persisted state.

Enhancements:
- Introduce AccentOverrideResolver and AccentOverrideSnapshot to own project, language, and fallback accent precedence in one place.
- Route AccentResolver and OverridesGroupBuilder pending resolution and diagnostics source computation through the shared override resolver to keep precedence consistent.

Documentation:
- Update accent settings feature metadata in docs to reflect the new tracked sources and verification state.

Tests:
- Add AccentOverrideResolver tests to lock in override precedence, fallback behavior, and hex validation parity.
- Extend OverridesGroupBuilderPending tests to cover pending forced-language removal and detector usage behavior.