### PR TITLE
refactor(reapply): centralize theme reapplication behind one seam

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "83681b28"
+          last_verified_sha: "6bdb8c24"
           last_verified_date: "2026-06-30"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "83681b28"
+          last_verified_sha: "6bdb8c24"
           last_verified_date: "2026-06-30"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -345,7 +345,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "94d81354"
+          last_verified_sha: "6bdb8c24"
           last_verified_date: "2026-06-16"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -459,7 +459,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "e8063e35"
+          last_verified_sha: "6bdb8c24"
           last_verified_date: "2026-06-16"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsLafListener.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsLafListener.kt
@@ -3,112 +3,41 @@ package dev.ayuislands
 import com.intellij.ide.ui.LafManager
 import com.intellij.ide.ui.LafManagerListener
 import com.intellij.openapi.diagnostic.logger
-import com.intellij.openapi.project.ProjectManager
-import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentContext
-import dev.ayuislands.accent.AyuVariant
-import dev.ayuislands.font.FontPresetApplicator
-import dev.ayuislands.glow.GlowOverlayManager
+import dev.ayuislands.reapply.ReapplyReason
+import dev.ayuislands.reapply.ThemeReapplication
 import dev.ayuislands.settings.AyuIslandsSettings
-import dev.ayuislands.syntax.SyntaxIntensityService
-import dev.ayuislands.theme.AyuEditorSchemeBinder
-import dev.ayuislands.ui.ComponentTreeRefresher
 
 /** Re-applies accent, font, glow, and scrollbar settings on theme change. */
 class AyuIslandsLafListener : LafManagerListener {
     override fun lookAndFeelChanged(source: LafManager) {
         val context = AccentContext.detect()
-        if (context == null) {
-            // Switched away from an active Ayu Islands context -- clean up managed overrides.
-            AccentApplicator.revertAll()
-            FontPresetApplicator.revert()
-            GlowOverlayManager.syncGlowForAllProjects()
-            return
+
+        // Appearance-sync bookkeeping needs the LafManager source and is UI-order-independent,
+        // so it stays here (not a reapply step). Only runs for a live Ayu context.
+        if (context is AccentContext.Ayu) {
+            recordAppearanceChoice(source)
         }
 
-        when (context) {
-            is AccentContext.Ayu -> applyAyuThemeChange(source, context)
-            AccentContext.External -> applyExternalThemeChange()
+        ThemeReapplication.reapply(ReapplyReason.ThemeSwitched(context)) { result ->
+            if (!result.isClean) {
+                LOG.warn(
+                    "Theme reapplication had ${result.failures.size} failed step(s): " +
+                        result.failures.joinToString { it.step.name },
+                )
+            } else {
+                LOG.info("Ayu Islands theme reapplied (${context ?: "switched-away"})")
+            }
         }
     }
 
-    private fun applyAyuThemeChange(
-        source: LafManager,
-        context: AccentContext.Ayu,
-    ) {
-        val variant = context.ayuVariant
+    private fun recordAppearanceChoice(source: LafManager) {
         val settings = AyuIslandsSettings.getInstance()
-
-        // Bind matching editor color scheme BEFORE `AccentApplicator` mutates
-        // the global scheme. `AccentApplicator.applyAlwaysOnEditorKeys` writes
-        // to `EditorColorsManager.globalScheme` in-place; if the bind happened
-        // AFTER, the prior scheme (`Default` / `Darcula` / another Ayu) would
-        // be silently polluted with accent overrides on `TAB_UNDERLINE` /
-        // `BUTTON_BACKGROUND` / `BOOKMARKS_ATTRIBUTES`, while the
-        // freshly-swapped Ayu scheme would lack the user's accent. Pattern G
-        // — apply path symmetry: `revertAll` on LAF-back operates on the
-        // same scheme this mutation lands on. Boolean return ignored: all
-        // three return-false branches (already-matched, user-custom skip,
-        // target-missing) are safe to fall through; binder logs internally.
-        if (settings.state.syncEditorScheme) {
-            AyuEditorSchemeBinder.bindForVariant(variant)
-        }
-
-        val accentHex = AccentApplicator.applyForFocusedProject(context)
-        LOG.info("Ayu Islands accent re-applied on theme change: $accentHex")
-
-        // Re-apply font preset if enabled
-        FontPresetApplicator.applyFromState()
-
-        // Track manual sub-variant choices for appearance sync
         val syncService = AppearanceSyncService.getInstance()
         if (settings.state.followSystemAppearance && !syncService.programmaticSwitch) {
-            val themeName = AyuLaf.currentThemeName(source)
-            syncService.recordManualChoice(themeName)
+            syncService.recordManualChoice(AyuLaf.currentThemeName(source))
         }
         syncService.clearProgrammaticSwitch()
-
-        notifyOpenProjects()
-
-        // Update glow overlays with new accent color
-        GlowOverlayManager.syncGlowForAllProjects()
-
-        // Re-apply syntax intensity preset after LAF switch back to Ayu (Pattern J).
-        // The [AyuVariant.isAyuActive] gate is structurally redundant with the early-return
-        // above (this block only executes when variant != null) but is preserved as the
-        // Pattern J source-grep anchor for future audits. The listener owns lifecycle;
-        // `SyntaxIntensityService.reapplyForActiveLaf` itself stays lifecycle-agnostic.
-        if (AyuVariant.isAyuActive()) {
-            SyntaxIntensityService.getInstance().reapplyForActiveLaf()
-        }
-    }
-
-    private fun applyExternalThemeChange() {
-        AccentApplicator.revertAll()
-        FontPresetApplicator.revert()
-
-        val accentHex = AccentApplicator.applyForFocusedProject(AccentContext.External)
-        LOG.info("Ayu Islands external accent applied on theme change: $accentHex")
-
-        // External themes only receive integration surfaces that can resolve against
-        // a generic accent; editor scheme binding, font preset, and syntax intensity
-        // remain Ayu-theme lifecycle features.
-        GlowOverlayManager.syncGlowForAllProjects()
-    }
-
-    private fun notifyOpenProjects() {
-        // Platform already walked the component tree during the LAF change, resetting component-level
-        // overrides (scrollbar preferredSize, horizontal policy, rendering wrappers). Publish the
-        // refresh event per open project so subscribed managers reapply. No tree walk needed here.
-        //
-        // Load-bearing platform-behavior assumption — verified against IntelliJ Platform 2025.1
-        // (`LafManagerImpl.updateLafNoSave` walks frames before firing `lookAndFeelChanged`).
-        // If a future platform bump changes the order, scrollbar hides will regress after theme
-        // switches and we'll need to switch this back to `ComponentTreeRefresher.walkAndNotify`.
-        for (openProject in ProjectManager.getInstance().openProjects) {
-            if (openProject.isDefault || openProject.isDisposed) continue
-            ComponentTreeRefresher.notifyOnly(openProject)
-        }
     }
 
     companion object {

--- a/src/main/kotlin/dev/ayuislands/accent/CancellationSafeRunCatching.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/CancellationSafeRunCatching.kt
@@ -20,8 +20,9 @@ import kotlin.coroutines.cancellation.CancellationException
  * cancellation signal is lost. No current caller sits behind such a rewrap, but if a
  * future call site does, walk the `cause` chain before returning the Result.
  *
- * Package-internal because every caller today sits in `dev.ayuislands.accent`; lift
- * further if a caller from another package ever needs the same contract.
+ * Internal (module-wide) rather than private: callers include both `dev.ayuislands.accent`
+ * and `dev.ayuislands.reapply.ThemeReapplication.runPlan`. Lift to `public` only if a caller
+ * outside this module ever needs the same contract.
  */
 internal inline fun <T> runCatchingPreservingCancellation(block: () -> T): Result<T> {
     val result = runCatching(block)

--- a/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
@@ -13,14 +13,15 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.ui.LicensingFacade
 import dev.ayuislands.AyuPlugin
-import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.AccentGroup
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.glow.GlowAnimation
-import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.glow.GlowPreset
 import dev.ayuislands.glow.GlowStyle
+import dev.ayuislands.reapply.ReapplyReason
+import dev.ayuislands.reapply.ReapplyStep
+import dev.ayuislands.reapply.ThemeReapplication
 import dev.ayuislands.rotation.AccentRotationService
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
@@ -30,7 +31,6 @@ import dev.ayuislands.syntax.SyntaxIntensityService
 import dev.ayuislands.syntax.SyntaxIntensityState
 import dev.ayuislands.syntax.SyntaxPreset
 import dev.ayuislands.syntax.SyntaxReadabilityOptions
-import dev.ayuislands.vcs.VcsColorApplier
 import dev.ayuislands.vcs.VcsColorPreset
 import org.jetbrains.annotations.VisibleForTesting
 import java.time.LocalDate
@@ -225,10 +225,10 @@ object LicenseChecker {
      * transition listener, and any future direct callers). `BaseState` itself
      * is not thread-safe for parallel writes, and the writes here are idempotent
      * resets — a lost update would produce the same terminal state, but the lock
-     * prevents a half-committed toggle map from leaking. Downstream calls
-     * (`AccentApplicator.apply`, `GlowOverlayManager.syncGlowForAllProjects`)
-     * intentionally stay *outside* the lock: both hop to EDT and can take other
-     * platform locks, so holding `state` across them would risk deadlock.
+     * prevents a half-committed toggle map from leaking. The downstream
+     * [ThemeReapplication.reapply] call (accent, glow, VCS colors) intentionally
+     * stays *outside* the lock: it hops to EDT and can take other platform
+     * locks, so holding `state` across it would risk deadlock.
      */
     fun revertToFreeDefaults(variant: AyuVariant) {
         val state = AyuIslandsSettings.getInstance().state
@@ -317,52 +317,42 @@ object LicenseChecker {
 
         ApplicationManager.getApplication().getService(AccentRotationService::class.java)?.stopRotation()
 
-        // Re-apply accent with reset toggles (accent color itself stays — it's free)
-        try {
-            val accentHex = AyuIslandsSettings.getInstance().getAccentForVariant(variant)
-            val applied = AccentApplicator.applyFromHexString(accentHex)
-            if (!applied) {
-                LOG.warn(
-                    "Revert-to-free accent apply rejected (hex='$accentHex', variant=$variant); " +
-                        "visible accent left unchanged",
-                )
+        // Re-apply accent (free-tier feature stays), sync glow, and revert VCS colors
+        // through the shared reapplication seam so this caller matches the LAF-listener
+        // and rotation-tick paths. `LicenseRevert`'s plan is [ApplyExplicitHex, Glow,
+        // VcsRevert] (see `ThemeReapplication.planFor`) — same order as before this migration.
+        val freeHex = AyuIslandsSettings.getInstance().getAccentForVariant(variant)
+        ThemeReapplication.reapply(ReapplyReason.LicenseRevert(freeHex)) { result ->
+            for (failure in result.failures) {
+                LOG.warn("License revert step=${failure.step} failed", failure.error)
             }
-        } catch (exception: RuntimeException) {
-            LOG.warn("Revert to free defaults failed", exception)
-            NotificationGroupManager
-                .getInstance()
-                .getNotificationGroup(NOTIFICATION_GROUP)
-                .createNotification(
+            if (result.failed(ReapplyStep.ApplyExplicitHex)) {
+                notifyRevertIncomplete(
                     "Accent revert incomplete",
                     "Some accent colors could not be reverted. " +
                         "Restart your IDE to complete the reset.",
-                    NotificationType.WARNING,
-                ).notify(null)
-        }
-
-        try {
-            GlowOverlayManager.syncGlowForAllProjects()
-        } catch (exception: RuntimeException) {
-            LOG.warn("Glow sync after license revert failed", exception)
-            NotificationGroupManager
-                .getInstance()
-                .getNotificationGroup(NOTIFICATION_GROUP)
-                .createNotification(
+                )
+            }
+            if (result.failed(ReapplyStep.Glow)) {
+                notifyRevertIncomplete(
                     "Glow sync incomplete",
                     "Glow overlays could not be updated after license change. " +
                         "Restart your IDE to complete the reset.",
-                    NotificationType.WARNING,
-                ).notify(null)
+                )
+            }
+            // VcsRevert failures stay LOG.warn-only (above), matching pre-migration behavior.
         }
+    }
 
-        // Write nulls into the editor scheme for every VCS color key the plugin
-        // owns so the user sees stock colors restore immediately, without
-        // waiting for a theme switch or restart.
-        try {
-            VcsColorApplier.revertAll()
-        } catch (exception: RuntimeException) {
-            LOG.warn("VCS color revert after license revert failed", exception)
-        }
+    private fun notifyRevertIncomplete(
+        title: String,
+        body: String,
+    ) {
+        NotificationGroupManager
+            .getInstance()
+            .getNotificationGroup(NOTIFICATION_GROUP)
+            .createNotification(title, body, NotificationType.WARNING)
+            .notify(null)
     }
 
     private fun resetSyntaxIntensityToFreeDefaults() {

--- a/src/main/kotlin/dev/ayuislands/reapply/ReapplyReason.kt
+++ b/src/main/kotlin/dev/ayuislands/reapply/ReapplyReason.kt
@@ -1,0 +1,54 @@
+package dev.ayuislands.reapply
+
+import dev.ayuislands.accent.AccentContext
+import dev.ayuislands.accent.AyuVariant
+
+/**
+ * Why a [theme reapplication][ThemeReapplication] is happening. Selects the
+ * ordered [ReapplyStep] sequence via [ThemeReapplication.planFor].
+ */
+sealed interface ReapplyReason {
+    /** IDE LAF changed. [context] = Ayu(variant) | External | null (switched away from Ayu). */
+    data class ThemeSwitched(
+        val context: AccentContext?,
+    ) : ReapplyReason
+
+    /** License downgrade: re-apply the free-default accent [freeHex] and reset premium surfaces. */
+    data class LicenseRevert(
+        val freeHex: String,
+    ) : ReapplyReason
+
+    /** Accent-rotation scheduler fired for [variant]. */
+    data class RotationTick(
+        val variant: AyuVariant,
+    ) : ReapplyReason
+}
+
+/** One atomic re-application unit. Each step self-gates on its own toggle and no-ops when off. */
+enum class ReapplyStep {
+    BindScheme,
+    ApplyResolvedAccent,
+    ApplyExplicitHex,
+    Font,
+    Notify,
+    Glow,
+    Syntax,
+    RevertAccent,
+    RevertFont,
+    VcsRevert,
+}
+
+/** A step that threw while running, paired with its cause. */
+data class StepFailure(
+    val step: ReapplyStep,
+    val error: Throwable,
+)
+
+/** Outcome of running a plan: the steps that failed (empty = clean). Steps isolate, never abort. */
+data class ReapplyResult(
+    val failures: List<StepFailure>,
+) {
+    val isClean: Boolean get() = failures.isEmpty()
+
+    fun failed(step: ReapplyStep): Boolean = failures.any { it.step == step }
+}

--- a/src/main/kotlin/dev/ayuislands/reapply/ThemeReapplication.kt
+++ b/src/main/kotlin/dev/ayuislands/reapply/ThemeReapplication.kt
@@ -1,0 +1,55 @@
+package dev.ayuislands.reapply
+
+import dev.ayuislands.accent.AccentContext
+import dev.ayuislands.reapply.ReapplyStep.ApplyExplicitHex
+import dev.ayuislands.reapply.ReapplyStep.ApplyResolvedAccent
+import dev.ayuislands.reapply.ReapplyStep.BindScheme
+import dev.ayuislands.reapply.ReapplyStep.Font
+import dev.ayuislands.reapply.ReapplyStep.Glow
+import dev.ayuislands.reapply.ReapplyStep.Notify
+import dev.ayuislands.reapply.ReapplyStep.RevertAccent
+import dev.ayuislands.reapply.ReapplyStep.RevertFont
+import dev.ayuislands.reapply.ReapplyStep.Syntax
+import dev.ayuislands.reapply.ReapplyStep.VcsRevert
+import org.jetbrains.annotations.VisibleForTesting
+
+/**
+ * Theme reapplication — re-applies every plugin-owned visual surface (accent,
+ * editor scheme, font, glow, syntax, VCS colors) in a defined order after a
+ * [ReapplyReason]. This object owns the reason-to-step ordering table via the
+ * pure [planFor]; each surface manager is invoked in that order by the runner.
+ */
+object ThemeReapplication {
+    /**
+     * The single source of the ordering invariant: a pure map from reason to an
+     * ordered step sequence. Reads no settings — self-gating happens in the runner,
+     * so this stays fixture-free and is the unit-tested surface.
+     */
+    @VisibleForTesting
+    internal fun planFor(reason: ReapplyReason): List<ReapplyStep> =
+        when (reason) {
+            is ReapplyReason.ThemeSwitched -> {
+                when (reason.context) {
+                    is AccentContext.Ayu -> {
+                        listOf(BindScheme, ApplyResolvedAccent, Font, Notify, Glow, Syntax)
+                    }
+
+                    AccentContext.External -> {
+                        listOf(RevertAccent, RevertFont, ApplyResolvedAccent, Glow)
+                    }
+
+                    null -> {
+                        listOf(RevertAccent, RevertFont, Glow)
+                    }
+                }
+            }
+
+            is ReapplyReason.LicenseRevert -> {
+                listOf(ApplyExplicitHex, Glow, VcsRevert)
+            }
+
+            is ReapplyReason.RotationTick -> {
+                listOf(ApplyResolvedAccent, Glow)
+            }
+        }
+}

--- a/src/main/kotlin/dev/ayuislands/reapply/ThemeReapplication.kt
+++ b/src/main/kotlin/dev/ayuislands/reapply/ThemeReapplication.kt
@@ -1,6 +1,14 @@
 package dev.ayuislands.reapply
 
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.project.ProjectManager
+import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentContext
+import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.accent.runCatchingPreservingCancellation
+import dev.ayuislands.font.FontPresetApplicator
+import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.reapply.ReapplyStep.ApplyExplicitHex
 import dev.ayuislands.reapply.ReapplyStep.ApplyResolvedAccent
 import dev.ayuislands.reapply.ReapplyStep.BindScheme
@@ -11,6 +19,11 @@ import dev.ayuislands.reapply.ReapplyStep.RevertAccent
 import dev.ayuislands.reapply.ReapplyStep.RevertFont
 import dev.ayuislands.reapply.ReapplyStep.Syntax
 import dev.ayuislands.reapply.ReapplyStep.VcsRevert
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.syntax.SyntaxIntensityService
+import dev.ayuislands.theme.AyuEditorSchemeBinder
+import dev.ayuislands.ui.ComponentTreeRefresher
+import dev.ayuislands.vcs.VcsColorApplier
 import org.jetbrains.annotations.VisibleForTesting
 
 /**
@@ -52,4 +65,129 @@ object ThemeReapplication {
                 listOf(ApplyResolvedAccent, Glow)
             }
         }
+
+    /**
+     * Run [reason]'s plan on a single EDT turn: directly when already on the EDT,
+     * otherwise `invokeLater(nonModal)`. Each step is isolated — a throwing step is
+     * recorded in [ReapplyResult] and the sequence continues. The result is delivered
+     * to [onComplete] on the EDT (see the signature note in the plan).
+     */
+    fun reapply(
+        reason: ReapplyReason,
+        onComplete: (ReapplyResult) -> Unit = {},
+    ) {
+        val app = ApplicationManager.getApplication()
+        val task = Runnable { onComplete(runPlan(reason)) }
+        if (app.isDispatchThread) {
+            task.run()
+        } else {
+            app.invokeLater(task, ModalityState.nonModal())
+        }
+    }
+
+    private fun runPlan(reason: ReapplyReason): ReapplyResult {
+        val failures =
+            planFor(reason).mapNotNull { step ->
+                runCatchingPreservingCancellation { runStep(step, reason) }
+                    .exceptionOrNull()
+                    ?.let { StepFailure(step, it) }
+            }
+        return ReapplyResult(failures)
+    }
+
+    private fun runStep(
+        step: ReapplyStep,
+        reason: ReapplyReason,
+    ) {
+        when (step) {
+            BindScheme, ApplyResolvedAccent, ApplyExplicitHex, RevertAccent -> runAccentStep(step, reason)
+            Font, RevertFont, Notify, Glow, Syntax, VcsRevert -> runSurfaceStep(step)
+        }
+    }
+
+    /** Runs the accent-facing steps: scheme binding and accent apply/revert. */
+    private fun runAccentStep(
+        step: ReapplyStep,
+        reason: ReapplyReason,
+    ) {
+        when (step) {
+            BindScheme -> {
+                if (!AyuIslandsSettings.getInstance().state.syncEditorScheme) return
+                val variant = ayuVariantOf(reason) ?: return
+                AyuEditorSchemeBinder.bindForVariant(variant)
+            }
+
+            ApplyResolvedAccent -> {
+                val context = accentContextOf(reason) ?: return
+                AccentApplicator.applyForFocusedProject(context)
+            }
+
+            ApplyExplicitHex -> {
+                val hex = (reason as? ReapplyReason.LicenseRevert)?.freeHex ?: return
+                AccentApplicator.applyFromHexString(hex)
+            }
+
+            RevertAccent -> {
+                AccentApplicator.revertAll()
+            }
+
+            Font, RevertFont, Notify, Glow, Syntax, VcsRevert -> {}
+        }
+    }
+
+    /** Runs the non-accent surfaces: font, notify, glow, syntax, VCS colors. */
+    private fun runSurfaceStep(step: ReapplyStep) {
+        when (step) {
+            Font -> {
+                FontPresetApplicator.applyFromState()
+            }
+
+            RevertFont -> {
+                FontPresetApplicator.revert()
+            }
+
+            Notify -> {
+                notifyOpenProjects()
+            }
+
+            Glow -> {
+                GlowOverlayManager.syncGlowForAllProjects()
+            }
+
+            Syntax -> {
+                if (AyuVariant.isAyuActive()) {
+                    SyntaxIntensityService.getInstance().reapplyForActiveLaf()
+                }
+            }
+
+            VcsRevert -> {
+                VcsColorApplier.revertAll()
+            }
+
+            BindScheme, ApplyResolvedAccent, ApplyExplicitHex, RevertAccent -> {}
+        }
+    }
+
+    /** The [AccentContext] the accent steps resolve against, or null when the reason carries none. */
+    private fun accentContextOf(reason: ReapplyReason): AccentContext? =
+        when (reason) {
+            is ReapplyReason.ThemeSwitched -> reason.context
+            is ReapplyReason.RotationTick -> AccentContext.Ayu(reason.variant)
+            is ReapplyReason.LicenseRevert -> null
+        }
+
+    private fun ayuVariantOf(reason: ReapplyReason): AyuVariant? =
+        (accentContextOf(reason) as? AccentContext.Ayu)?.ayuVariant
+
+    /**
+     * Publish the component-tree refresh per open project so subscribed managers reapply.
+     * No tree walk — the platform's own LAF refresh already walked it (mirrors the old
+     * `AyuIslandsLafListener.notifyOpenProjects`).
+     */
+    private fun notifyOpenProjects() {
+        for (openProject in ProjectManager.getInstance().openProjects) {
+            if (openProject.isDefault || openProject.isDisposed) continue
+            ComponentTreeRefresher.notifyOnly(openProject)
+        }
+    }
 }

--- a/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
+++ b/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
@@ -241,7 +241,12 @@ class AccentRotationService : Disposable {
      * Map a failed [ReapplyResult] to the circuit breaker's [RotationFailure], logging every
      * failed step for idea.log forensics. When both the accent apply and the glow sync fail,
      * apply wins priority — mirrors the pre-seam behaviour where the apply-stage catch block
-     * ran (and reported) before the glow-stage catch block.
+     * ran (and reported) before the glow-stage catch block. Falls back to the first recorded
+     * failure (defaulting to [Stage.APPLY]) if neither of those two steps is the one that
+     * failed — this runs inside an EDT `invokeLater` callback, so it must never throw: a
+     * `RotationTick` plan gaining a new step must degrade gracefully here, not crash the EDT.
+     * [result.failures] is guaranteed non-empty by [ReapplyResult.isClean]'s contract, so
+     * `first()` is safe.
      */
     private fun rotationFailureFrom(result: ReapplyResult): RotationFailure {
         result.failures.forEach { failure ->
@@ -249,10 +254,13 @@ class AccentRotationService : Disposable {
         }
         val applyError = result.failures.firstOrNull { it.step == ReapplyStep.ApplyResolvedAccent }?.error
         val glowError = result.failures.firstOrNull { it.step == ReapplyStep.Glow }?.error
-        val exception =
-            applyError ?: glowError
-                ?: error("rotationFailureFrom called with a clean ReapplyResult")
-        val stage = if (applyError != null) Stage.APPLY else Stage.GLOW_SYNC
+        val exception = applyError ?: glowError ?: result.failures.first().error
+        val stage =
+            when {
+                applyError != null -> Stage.APPLY
+                glowError != null -> Stage.GLOW_SYNC
+                else -> Stage.APPLY
+            }
         return RotationFailure(stage = stage, exception = exception)
     }
 

--- a/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
+++ b/src/main/kotlin/dev/ayuislands/rotation/AccentRotationService.kt
@@ -7,17 +7,18 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.logger
-import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.util.CheckedDisposable
 import com.intellij.openapi.util.Condition
 import com.intellij.openapi.util.Disposer
 import com.intellij.util.concurrency.AppExecutorUtil
 import dev.ayuislands.accent.AYU_ACCENT_PRESETS
-import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentColor
 import dev.ayuislands.accent.AyuVariant
-import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.licensing.LicenseChecker
+import dev.ayuislands.reapply.ReapplyReason
+import dev.ayuislands.reapply.ReapplyResult
+import dev.ayuislands.reapply.ReapplyStep
+import dev.ayuislands.reapply.ThemeReapplication
 import dev.ayuislands.settings.AyuIslandsSettings
 import org.jetbrains.annotations.TestOnly
 import java.util.concurrent.ScheduledFuture
@@ -184,10 +185,12 @@ class AccentRotationService : Disposable {
                         )
                     nextIndex to hex
                 }
-                AccentRotationMode.RANDOM ->
+
+                AccentRotationMode.RANDOM -> {
                     -1 to
                         ContrastAwareColorGenerator
                             .generate(variant)
+                }
             }
 
         val app =
@@ -200,13 +203,13 @@ class AccentRotationService : Disposable {
                 }
         app.invokeLater(
             {
-                val applyFailure = runApplyStage(mode, newHex, variant, state, settings)
-                val glowFailure = runGlowStage()
-
-                if (applyFailure != null || glowFailure != null) {
-                    onRotationFailure(applyFailure ?: glowFailure!!)
-                } else {
-                    consecutiveFailures = 0
+                commitRotationState(mode, newHex, variant, state, settings)
+                ThemeReapplication.reapply(ReapplyReason.RotationTick(variant)) { result ->
+                    if (result.isClean) {
+                        consecutiveFailures = 0
+                    } else {
+                        onRotationFailure(rotationFailureFrom(result))
+                    }
                 }
             },
             ModalityState.nonModal(),
@@ -215,64 +218,42 @@ class AccentRotationService : Disposable {
     }
 
     /**
-     * Commit the new preset index + global accent hex, then re-apply the resolver output for
-     * the focused project so overrides stay sticky. Returns a failure descriptor on exception.
+     * Commit the new preset index + global accent hex, plus the last-switch timestamp. State
+     * only — [ThemeReapplication.reapply] performs the actual apply (and glow sync) against the
+     * resolver output, so per-project and per-language overrides keep winning during rotation.
      */
-    private fun runApplyStage(
+    private fun commitRotationState(
         mode: AccentRotationMode,
         newHex: Pair<Int, String>,
         variant: AyuVariant,
         state: dev.ayuislands.settings.AyuIslandsState,
         settings: AyuIslandsSettings,
-    ): RotationFailure? {
-        val stage = Stage.APPLY
-        return try {
-            if (mode == AccentRotationMode.PRESET) {
-                state.accentRotationPresetIndex = newHex.first
-            }
-            settings.setAccentForVariant(variant, newHex.second)
-            state.accentRotationLastSwitchMs = System.currentTimeMillis()
-            // Rotation updates the GLOBAL accent layer only. For the currently focused project we
-            // must apply the RESOLVED color so per-project and per-language overrides keep winning
-            // during rotation ticks.
-            val resolvedHex = AccentApplicator.applyForFocusedProject(variant)
-            LOG.info("Accent rotated: mode=$mode, global=${newHex.second}, applied=$resolvedHex")
-            null
-        } catch (exception: RuntimeException) {
-            // Include focused-project identity so post-mortems can tell which project's
-            // override (if any) the apply stage was wrestling with when it failed.
-            val focusedName =
-                runCatching { focusedProjectName() }.getOrDefault("<unknown>")
-            LOG.error(
-                "Accent rotation stage=$stage failed (mode=$mode, color=${newHex.second}, " +
-                    "focusedProject=$focusedName)",
-                exception,
-            )
-            RotationFailure(stage = stage, exception = exception)
+    ) {
+        if (mode == AccentRotationMode.PRESET) {
+            state.accentRotationPresetIndex = newHex.first
         }
+        settings.setAccentForVariant(variant, newHex.second)
+        state.accentRotationLastSwitchMs = System.currentTimeMillis()
+        LOG.info("Accent rotated: mode=$mode, global=${newHex.second}")
     }
 
-    private fun focusedProjectName(): String =
-        ProjectManager
-            .getInstance()
-            .openProjects
-            .firstOrNull { !it.isDefault && !it.isDisposed }
-            ?.name
-            ?: "<none>"
-
     /**
-     * Sync glow overlays with the new accent. Returns a [RotationFailure] so the circuit
-     * breaker upstream can count glow-sync failures alongside apply failures.
+     * Map a failed [ReapplyResult] to the circuit breaker's [RotationFailure], logging every
+     * failed step for idea.log forensics. When both the accent apply and the glow sync fail,
+     * apply wins priority — mirrors the pre-seam behaviour where the apply-stage catch block
+     * ran (and reported) before the glow-stage catch block.
      */
-    private fun runGlowStage(): RotationFailure? {
-        val stage = Stage.GLOW_SYNC
-        return try {
-            GlowOverlayManager.syncGlowForAllProjects()
-            null
-        } catch (exception: RuntimeException) {
-            LOG.error("Accent rotation stage=$stage failed", exception)
-            RotationFailure(stage = stage, exception = exception)
+    private fun rotationFailureFrom(result: ReapplyResult): RotationFailure {
+        result.failures.forEach { failure ->
+            LOG.error("Accent rotation step=${failure.step} failed", failure.error)
         }
+        val applyError = result.failures.firstOrNull { it.step == ReapplyStep.ApplyResolvedAccent }?.error
+        val glowError = result.failures.firstOrNull { it.step == ReapplyStep.Glow }?.error
+        val exception =
+            applyError ?: glowError
+                ?: error("rotationFailureFrom called with a clean ReapplyResult")
+        val stage = if (applyError != null) Stage.APPLY else Stage.GLOW_SYNC
+        return RotationFailure(stage = stage, exception = exception)
     }
 
     /**

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsLafListenerSyntaxReapplyTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsLafListenerSyntaxReapplyTest.kt
@@ -1,6 +1,8 @@
 package dev.ayuislands
 
 import com.intellij.ide.ui.LafManager
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.util.io.FileUtil
 import dev.ayuislands.accent.AccentApplicator
@@ -42,6 +44,7 @@ class AyuIslandsLafListenerSyntaxReapplyTest {
     private val mockSettings = mockk<AyuIslandsSettings>(relaxed = true)
     private val mockProjectManager = mockk<ProjectManager>(relaxed = true)
     private val mockSyntaxService = mockk<SyntaxIntensityService>(relaxed = true)
+    private val mockApplication = mockk<Application>(relaxed = true)
 
     @BeforeTest
     fun setUp() {
@@ -49,6 +52,14 @@ class AyuIslandsLafListenerSyntaxReapplyTest {
         every { mockSettings.state } returns state
         mockkObject(AyuIslandsSettings.Companion)
         every { AyuIslandsSettings.getInstance() } returns mockSettings
+
+        // `lookAndFeelChanged` now delegates to `ThemeReapplication.reapply`, which reads
+        // `ApplicationManager.getApplication().isDispatchThread` to decide whether to run
+        // its plan inline or hop through `invokeLater`. Stub it to run inline so the plan's
+        // effects (and this file's `verify` assertions) happen synchronously.
+        mockkStatic(ApplicationManager::class)
+        every { ApplicationManager.getApplication() } returns mockApplication
+        every { mockApplication.isDispatchThread } returns true
 
         mockkStatic(ProjectManager::class)
         every { ProjectManager.getInstance() } returns mockProjectManager
@@ -84,8 +95,9 @@ class AyuIslandsLafListenerSyntaxReapplyTest {
     @Test
     fun `lookAndFeelChanged when AyuVariant isAyuActive true calls reapplyForActiveLaf`() {
         // Pattern J — reapply must fire whenever the LAF lands on an Ayu variant.
-        // `detect` returns non-null (passes the early-return guard) and
-        // `isAyuActive` returns true (passes the source-grep gate at the call site).
+        // `detect` returns non-null, so `ThemeReapplication.planFor` includes the
+        // `Syntax` step, and `isAyuActive` returns true, so the step's own gate
+        // (inside `ThemeReapplication.runStep`) lets the call through.
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
         every { AyuVariant.isAyuActive() } returns true
         val mockLafManager = mockk<LafManager>(relaxed = true)
@@ -99,9 +111,10 @@ class AyuIslandsLafListenerSyntaxReapplyTest {
     @Test
     fun `lookAndFeelChanged when AyuVariant isAyuActive false does NOT call reapplyForActiveLaf`() {
         // Pattern J — non-Ayu LAF must skip the reapply path entirely.
-        // `detect` returns null which triggers the listener's early-return
-        // BEFORE the syntax reapply block; `isAyuActive` returns false to
-        // double-lock the gate at the call site for future audits.
+        // `detect` returns null, so `ThemeReapplication.planFor` omits the `Syntax`
+        // step outright; `isAyuActive` returns false to double-lock the seam's own
+        // gate for future audits, in case a step-ordering change ever reintroduces
+        // `Syntax` for a null context.
         state.externalThemeEnhancementsEnabled = false
         every { AyuVariant.detect() } returns null
         every { AyuVariant.isAyuActive() } returns false

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsLafListenerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsLafListenerTest.kt
@@ -1,6 +1,8 @@
 package dev.ayuislands
 
 import com.intellij.ide.ui.LafManager
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.ProjectManager
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentContext
@@ -30,8 +32,9 @@ import kotlin.test.Test
  *      `AccentApplicator.applyAlwaysOnEditorKeys` mutates `globalScheme`
  *      in-place and a swap-after-mutate would strand the prior scheme with
  *      accent overrides forever.
- *   3. The `variant == null` early-return path (theme switched AWAY from
- *      Ayu) does NOT call `bindForVariant` — the binder has no revert path.
+ *   3. The null-context path (theme switched AWAY from Ayu — `ThemeReapplication.planFor`
+ *      omits `BindScheme` from its plan) does NOT call `bindForVariant` — the binder has
+ *      no revert path.
  *
  * Pattern G — symmetry between the bind/apply order and the revert path.
  */
@@ -41,6 +44,7 @@ class AyuIslandsLafListenerTest {
     private val mockSettings = mockk<AyuIslandsSettings>(relaxed = true)
     private val mockProjectManager = mockk<ProjectManager>(relaxed = true)
     private val mockSyntaxService = mockk<SyntaxIntensityService>(relaxed = true)
+    private val mockApplication = mockk<Application>(relaxed = true)
 
     @BeforeTest
     fun setUp() {
@@ -48,6 +52,14 @@ class AyuIslandsLafListenerTest {
         every { mockSettings.state } returns state
         mockkObject(AyuIslandsSettings.Companion)
         every { AyuIslandsSettings.getInstance() } returns mockSettings
+
+        // `lookAndFeelChanged` now delegates to `ThemeReapplication.reapply`, which reads
+        // `ApplicationManager.getApplication().isDispatchThread` to decide whether to run
+        // its plan inline or hop through `invokeLater`. Stub it to run inline so the plan's
+        // effects (and this file's `verify` assertions) happen synchronously.
+        mockkStatic(ApplicationManager::class)
+        every { ApplicationManager.getApplication() } returns mockApplication
+        every { mockApplication.isDispatchThread } returns true
 
         mockkStatic(ProjectManager::class)
         every { ProjectManager.getInstance() } returns mockProjectManager
@@ -132,9 +144,10 @@ class AyuIslandsLafListenerTest {
 
     @Test
     fun `lookAndFeelChanged on non-Ayu LAF reverts and does NOT bind`() {
-        // Pattern J — the listener's `variant == null` early-return must NOT
-        // call the binder. The binder has no revert path (Ayu→non-Ayu would
-        // require persisting the user's prior scheme — separate feature).
+        // Pattern J — a null context (theme switched AWAY from Ayu) must NOT
+        // call the binder: `ThemeReapplication.planFor` omits `BindScheme` from
+        // its plan for a null context. The binder has no revert path (Ayu→non-Ayu
+        // would require persisting the user's prior scheme — separate feature).
         state.syncEditorScheme = true
         state.externalThemeEnhancementsEnabled = false
         every { AyuVariant.detect() } returns null

--- a/src/test/kotlin/dev/ayuislands/licensing/FreeTierLockdownTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/FreeTierLockdownTest.kt
@@ -68,6 +68,7 @@ class FreeTierLockdownTest {
         mockkStatic(ApplicationManager::class)
         val app = mockk<Application>()
         every { ApplicationManager.getApplication() } returns app
+        every { app.isDispatchThread } returns true
         rotationService = mockk(relaxed = true)
         every { app.getService(AccentRotationService::class.java) } returns rotationService
 

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerProDefaultsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerProDefaultsTest.kt
@@ -279,6 +279,7 @@ class LicenseCheckerProDefaultsTest {
         val rotationService = mockk<AccentRotationService>(relaxed = true)
         val app = mockk<Application>()
         every { ApplicationManager.getApplication() } returns app
+        every { app.isDispatchThread } returns true
         every { app.getService(AccentRotationService::class.java) } returns rotationService
 
         LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
@@ -304,6 +305,7 @@ class LicenseCheckerProDefaultsTest {
         mockkStatic(ApplicationManager::class)
         val app = mockk<Application>()
         every { ApplicationManager.getApplication() } returns app
+        every { app.isDispatchThread } returns true
         every { app.getService(AccentRotationService::class.java) } returns null
 
         // Mock GlowOverlayManager.syncGlowForAllProjects()
@@ -345,6 +347,7 @@ class LicenseCheckerProDefaultsTest {
         mockkStatic(ApplicationManager::class)
         val app = mockk<Application>()
         every { ApplicationManager.getApplication() } returns app
+        every { app.isDispatchThread } returns true
         every { app.getService(AccentRotationService::class.java) } returns null
 
         // Mock GlowOverlayManager.syncGlowForAllProjects()

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerQuickSwitcherRevertTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerQuickSwitcherRevertTest.kt
@@ -63,6 +63,7 @@ class LicenseCheckerQuickSwitcherRevertTest {
         mockkStatic(ApplicationManager::class)
         val app = mockk<Application>()
         every { ApplicationManager.getApplication() } returns app
+        every { app.isDispatchThread } returns true
         val rotationService = mockk<AccentRotationService>(relaxed = true)
         every { app.getService(AccentRotationService::class.java) } returns rotationService
 

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerVcsRevokeTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerVcsRevokeTest.kt
@@ -86,6 +86,7 @@ class LicenseCheckerVcsRevokeTest {
         mockkStatic(ApplicationManager::class)
         val app = mockk<Application>()
         every { ApplicationManager.getApplication() } returns app
+        every { app.isDispatchThread } returns true
         val rotationService = mockk<AccentRotationService>(relaxed = true)
         every { app.getService(AccentRotationService::class.java) } returns rotationService
 

--- a/src/test/kotlin/dev/ayuislands/licensing/TrialLifecycleIntegrationTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/TrialLifecycleIntegrationTest.kt
@@ -103,6 +103,7 @@ class TrialLifecycleIntegrationTest {
         mockkStatic(ApplicationManager::class)
         val app = mockk<Application>()
         every { ApplicationManager.getApplication() } returns app
+        every { app.isDispatchThread } returns true
         val rotationService = mockk<AccentRotationService>(relaxed = true)
         every { app.getService(AccentRotationService::class.java) } returns rotationService
 

--- a/src/test/kotlin/dev/ayuislands/reapply/ThemeReapplicationPlanTest.kt
+++ b/src/test/kotlin/dev/ayuislands/reapply/ThemeReapplicationPlanTest.kt
@@ -1,0 +1,51 @@
+package dev.ayuislands.reapply
+
+import dev.ayuislands.accent.AccentContext
+import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.reapply.ReapplyStep.ApplyExplicitHex
+import dev.ayuislands.reapply.ReapplyStep.ApplyResolvedAccent
+import dev.ayuislands.reapply.ReapplyStep.BindScheme
+import dev.ayuislands.reapply.ReapplyStep.Font
+import dev.ayuislands.reapply.ReapplyStep.Glow
+import dev.ayuislands.reapply.ReapplyStep.Notify
+import dev.ayuislands.reapply.ReapplyStep.RevertAccent
+import dev.ayuislands.reapply.ReapplyStep.RevertFont
+import dev.ayuislands.reapply.ReapplyStep.Syntax
+import dev.ayuislands.reapply.ReapplyStep.VcsRevert
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ThemeReapplicationPlanTest {
+    @Test
+    fun `theme switch to Ayu binds scheme first then accent, font, notify, glow, syntax`() {
+        val plan =
+            ThemeReapplication.planFor(
+                ReapplyReason.ThemeSwitched(AccentContext.Ayu(AyuVariant.DARK)),
+            )
+        assertEquals(listOf(BindScheme, ApplyResolvedAccent, Font, Notify, Glow, Syntax), plan)
+    }
+
+    @Test
+    fun `theme switch to External reverts accent and font, then applies external accent and glow`() {
+        val plan = ThemeReapplication.planFor(ReapplyReason.ThemeSwitched(AccentContext.External))
+        assertEquals(listOf(RevertAccent, RevertFont, ApplyResolvedAccent, Glow), plan)
+    }
+
+    @Test
+    fun `theme switch away reverts accent and font, then syncs glow`() {
+        val plan = ThemeReapplication.planFor(ReapplyReason.ThemeSwitched(null))
+        assertEquals(listOf(RevertAccent, RevertFont, Glow), plan)
+    }
+
+    @Test
+    fun `license revert applies explicit hex, syncs glow, reverts vcs`() {
+        val plan = ThemeReapplication.planFor(ReapplyReason.LicenseRevert("#E6B450"))
+        assertEquals(listOf(ApplyExplicitHex, Glow, VcsRevert), plan)
+    }
+
+    @Test
+    fun `rotation tick applies resolved accent then syncs glow`() {
+        val plan = ThemeReapplication.planFor(ReapplyReason.RotationTick(AyuVariant.DARK))
+        assertEquals(listOf(ApplyResolvedAccent, Glow), plan)
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
@@ -358,8 +358,9 @@ class AccentRotationServiceTest {
     @Test
     fun `successful tick between failures resets the circuit-breaker budget`() {
         // Regression guard for the reset-on-success path (consecutiveFailures = 0 after a
-        // clean runApplyStage). Two fail + one success + two fail must NOT trip the breaker
-        // because consecutive-failures counts go 1, 2, 0, 1, 2 — never reaches 3.
+        // clean ReapplyResult, i.e. ThemeReapplication.reapply reports isClean == true). Two
+        // fail + one success + two fail must NOT trip the breaker because consecutive-failures
+        // counts go 1, 2, 0, 1, 2 — never reaches 3.
         mockRotationEnvironment()
         val (notificationGroup, _) = captureNotifications()
         state.accentRotationEnabled = true
@@ -457,12 +458,15 @@ class AccentRotationServiceTest {
 
         val service = AccentRotationService()
         LoggedErrorProcessor.executeWith<RuntimeException>(processor) {
-            // Must not propagate — rotateAccent catches RuntimeException inside invokeLater.
+            // Must not propagate — ThemeReapplication.runPlan isolates each step via
+            // mapNotNull { runCatchingPreservingCancellation { runStep(...) } }, so the
+            // ApplyResolvedAccent failure is captured as a StepFailure instead of throwing.
             service.rotateAccent()
         }
 
         verify(exactly = 1) { AccentApplicator.applyFromHexString(any()) }
-        // Glow sync runs in a separate try/catch and should still fire after apply() fails.
+        // Glow is isolated as its own step in runPlan's mapNotNull chain and should still
+        // fire after the ApplyResolvedAccent step fails.
         verify(exactly = 1) { GlowOverlayManager.syncGlowForAllProjects() }
         assertEquals(1, loggedErrors.size, "Expected exactly one LOG.error for the failed apply()")
         assertEquals("boom", loggedErrors.single()?.message)

--- a/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
@@ -114,6 +114,11 @@ class AccentRotationServiceTest {
         } answers {
             firstArg<Runnable>().run()
         }
+        // rotateAccent() now delegates the apply+glow work to `ThemeReapplication.reapply`,
+        // which reads `isDispatchThread` to decide whether to run its plan inline or hop
+        // through the (unstubbed) 2-arg invokeLater overload. Stub it `true` so the plan runs
+        // synchronously and this file's `verify`/state assertions observe its effects.
+        every { appMock.isDispatchThread } returns true
 
         mockkObject(AyuIslandsSettings.Companion)
         every { AyuIslandsSettings.getInstance() } returns settingsMock


### PR DESCRIPTION
## Why

"Make the UI reflect the new color" had no single home. The behaviour was smeared
across 8–9 mechanisms and ~25 trigger sites, `globalSchemeChange` fired three times
per theme switch, and the re-application *order* was re-encoded in three entry points
(LAF listener, startup, app listener) — defended only by prose comments and a
source-regex test. Changing the sequence meant editing every caller and hoping they
stayed in sync.

## What

A deep `ThemeReapplication` seam that owns the ordering:

- `reapply(reason)` where `reason` is `ThemeSwitched(context) | LicenseRevert | RotationTick`
- a pure `planFor(reason): List<ReapplyStep>` — the single source of the ordering
  invariant, unit-tested without mocks or fixtures (it replaces the source-regex guard
  for these sequences)
- a thin, EDT-self-dispatching runner that executes each step against the existing
  managers and isolates per-step failures into a `ReapplyResult`

Three callers moved off their hand-rolled sequences onto `reapply(reason)`:

- `AyuIslandsLafListener` — three branches (Ayu / external / switched-away) collapse to one call
- `AccentRotationService` — the rotation tick
- `LicenseChecker` — the license revert

This is **coordinator-only**: `AccentApplicator.apply` is still called as-is; pulling the
refresh out of it is deliberately left for later.

## Notes

- Behaviour-preserving — each migrated sequence maps step-for-step onto its old body
  (verified in the whole-branch review).
- Small correctness win folded in: the license revert path is reachable off the EDT and
  used to call glow/vcs directly on the calling thread; the seam now routes them through
  the EDT.
- The runner is genuinely exercised by the caller tests (they stub `isDispatchThread` and
  run the real `runPlan`/`runStep` against mocked managers), not mock theater.

## Before merge

⚠️ Please `/deploy-to-ide` and exercise the **trial-expiry license revert** once — that
path's off-EDT dispatch changed here, and the earlier in-IDE check predated it. Theme
switch and rotation are already verified in the running IDE.

Deferred, non-blocking follow-ups: seam accent-step outcome logging (natural to revisit
alongside the future refresh-extraction), one stale docstring, and a couple of
diagnostic-log wording changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CL3RWPcsk5GPd4ig8ND2hp

## Summary by Sourcery

Centralize theme-related visual reapplication (accent, fonts, glow, syntax, VCS colors) behind a new ThemeReapplication seam and migrate key callers to it.

Enhancements:
- Replace scattered theme reapply logic in LAF listener, accent rotation, and license revert paths with a single ordered ThemeReapplication planner and runner.
- Ensure theme reapplication steps run on the EDT with failure isolation and structured logging for rotation and license revert flows.
- Refine accent rotation to commit state separately and derive circuit-breaker failures from the shared reapply result.
- Adjust cancellation-safe utility visibility and refactor tests to accommodate the new centralized reapply mechanism and EDT dispatch behavior.

Tests:
- Add unit tests for ThemeReapplication planning to lock in step ordering per reapply reason.
- Update existing LAF listener, rotation, and licensing tests to exercise the new reapply seam and verify behavior and error-handling remain correct.