### PR TITLE
docs(changelog): add post-2.7.7 updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [Unreleased]
+
+- [Fix] **Project-language accent scans** — background detection now cancels
+  when a project closes, checks cancellation during large repository scans, and
+  drops late cache or publish results so reopened projects do not inherit stale
+  language accents.
+- [Fix] **Large project language accents** — language detection now keeps exact
+  scans for projects under the file cap and uses bounded sampling for larger
+  repositories, so accents resolve consistently without walking every file in a
+  monorepo.
+- [Fix] **Font installer fallbacks** — fallback font download URLs are now
+  smoke-checked in CI before release, catching broken upstream links before a
+  bundled font install reaches users.
+
 ## [2.7.7] - 2026-07-01
 
 - [Fix] **Language override diagnostics** — Settings and Quick-Switcher now show


### PR DESCRIPTION
Adds the `[Unreleased]` section covering the user-facing changes since v2.7.7:

- Project-language accent scans now cancel when a project closes and drop late
  cache/publish results, so reopened projects don't inherit stale language accents
- Bounded sampling for language detection in large repositories (exact scans stay
  for projects under the file cap)
- Font fallback download URLs are smoke-checked in CI before release

Not in the changelog, on purpose: the Atom Material Icons conflict UI (#250) was
added and reverted within the same unreleased window (net-zero — users never saw it
in a release), and the ThemeReapplication refactor (#252) is behaviour-preserving
(internal, nothing users observe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CL3RWPcsk5GPd4ig8ND2hp

## Summary by Sourcery

Documentation:
- Add an `[Unreleased]` changelog section describing recent fixes to project-language accent detection and font installer fallback validation.