### PR TITLE
fix(reapply): escalate torn accent applies back into ReapplyResult

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "0bfa7bec"
+          last_verified_sha: "5ba4f37c"
           last_verified_date: "2026-06-30"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "0bfa7bec"
+          last_verified_sha: "5ba4f37c"
           last_verified_date: "2026-06-30"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -304,7 +304,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "0bfa7bec"
+          last_verified_sha: "5ba4f37c"
           last_verified_date: "2026-06-16"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -345,7 +345,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "0bfa7bec"
+          last_verified_sha: "5ba4f37c"
           last_verified_date: "2026-06-16"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -397,7 +397,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "0bfa7bec"
+          last_verified_sha: "5ba4f37c"
           last_verified_date: "2026-06-12"
           content_sha256: ad849b17308901bc2dac85f895978be656f578c9c31f857b9e9578e5cf4289f2
 
@@ -459,7 +459,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "0bfa7bec"
+          last_verified_sha: "5ba4f37c"
           last_verified_date: "2026-06-16"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplyPlanRunner.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplyPlanRunner.kt
@@ -47,17 +47,11 @@ internal object AccentApplyPlanRunner {
     ): List<AccentApplyStepFailure> {
         val failures = mutableListOf<AccentApplyStepFailure>()
         for (step in plan.steps) {
+            // Cancellation and VirtualMachineError rethrow inside the helper;
+            // only genuine step failures reach the Result.
             runCatchingPreservingCancellation { executeStep(step) }
                 .exceptionOrNull()
-                ?.let { error ->
-                    // A JVM-level error (heap exhaustion, stack overflow) must not
-                    // degrade into a per-step WARN — the process is compromised and
-                    // the old pre-plan code let it propagate. LinkageError stays
-                    // contained: plugin-unload races produce NoClassDefFoundError
-                    // in integration steps by design (ThemeReapplication precedent).
-                    if (error is VirtualMachineError) throw error
-                    failures += AccentApplyStepFailure(step, error)
-                }
+                ?.let { failures += AccentApplyStepFailure(step, it) }
             if (failures.isNotEmpty() && plan.policy == AccentApplyFailurePolicy.AbortOnFirstFailure) break
         }
         return failures

--- a/src/main/kotlin/dev/ayuislands/accent/CancellationSafeRunCatching.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/CancellationSafeRunCatching.kt
@@ -27,7 +27,14 @@ import kotlin.coroutines.cancellation.CancellationException
 internal inline fun <T> runCatchingPreservingCancellation(block: () -> T): Result<T> {
     val result = runCatching(block)
     val cause = result.exceptionOrNull()
-    if (cause is ProcessCanceledException) throw cause
-    if (cause is CancellationException) throw cause
+    // VirtualMachineError joins the cancellation rethrows: JVM-level errors
+    // (heap exhaustion, stack overflow) must not degrade into a
+    // fallback-to-failure Result anywhere in the plugin — the process is
+    // compromised and containment would mask it. LinkageError subtypes stay
+    // contained: plugin-unload races produce NoClassDefFoundError in
+    // integration paths by design.
+    if (cause is ProcessCanceledException || cause is CancellationException || cause is VirtualMachineError) {
+        throw cause
+    }
     return result
 }

--- a/src/main/kotlin/dev/ayuislands/reapply/ThemeReapplication.kt
+++ b/src/main/kotlin/dev/ayuislands/reapply/ThemeReapplication.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.project.ProjectManager
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentContext
+import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.runCatchingPreservingCancellation
 import dev.ayuislands.font.FontPresetApplicator
@@ -119,7 +120,15 @@ object ThemeReapplication {
 
             ApplyResolvedAccent -> {
                 val context = accentContextOf(reason) ?: return
-                AccentApplicator.applyForFocusedProject(context)
+                val hex = AccentApplicator.applyForFocusedProject(context)
+                // A shape-invalid hex is the ONE case where the applicator skips
+                // apply() entirely (leaving lastApplyOk stale from the previous
+                // apply), so the clean-flag check below cannot see it. The hex
+                // itself carries the signal: mirror ApplyExplicitHex's rejection
+                // failure by validating the returned value.
+                check(AccentHex.of(hex) != null) {
+                    "resolver produced a shape-invalid hex '$hex'; apply was skipped"
+                }
                 ensureAccentApplyClean(step)
             }
 
@@ -187,6 +196,14 @@ object ThemeReapplication {
      * reflects THAT apply. Throwing here restores what consumers relied on
      * before the containment refactor: the rotation circuit breaker counts the
      * failure and the license revert surfaces its "restart to complete" notice.
+     *
+     * Synchronicity coupling: this contract holds only while [reapply]'s EDT
+     * check (`Application.isDispatchThread`) and the runner's
+     * (`SwingUtilities.isEventDispatchThread`) agree — they delegate to the same
+     * EDT in production. A runner dispatch refactor must preserve that.
+     *
+     * Does NOT cover the rejected-hex skip (apply never ran, flag stale) — the
+     * callers validate the hex shape separately before consulting this.
      */
     private fun ensureAccentApplyClean(step: ReapplyStep) {
         check(AyuIslandsSettings.getInstance().state.lastApplyOk) {

--- a/src/main/kotlin/dev/ayuislands/reapply/ThemeReapplication.kt
+++ b/src/main/kotlin/dev/ayuislands/reapply/ThemeReapplication.kt
@@ -120,18 +120,25 @@ object ThemeReapplication {
             ApplyResolvedAccent -> {
                 val context = accentContextOf(reason) ?: return
                 AccentApplicator.applyForFocusedProject(context)
+                ensureAccentApplyClean(step)
             }
 
             ApplyExplicitHex -> {
                 val hex = (reason as? ReapplyReason.LicenseRevert)?.freeHex ?: return
-                AccentApplicator.applyFromHexString(hex)
+                check(AccentApplicator.applyFromHexString(hex)) {
+                    "free-default hex rejected by the applicator: '$hex'"
+                }
+                ensureAccentApplyClean(step)
             }
 
             RevertAccent -> {
                 AccentApplicator.revertAll()
             }
 
-            Font, RevertFont, Notify, Glow, Syntax, VcsRevert -> {}
+            // Surface steps are dispatched by runStep; unreachable here.
+            Font, RevertFont, Notify, Glow, Syntax, VcsRevert -> {
+                return
+            }
         }
     }
 
@@ -164,7 +171,26 @@ object ThemeReapplication {
                 VcsColorApplier.revertAll()
             }
 
-            BindScheme, ApplyResolvedAccent, ApplyExplicitHex, RevertAccent -> {}
+            // Accent steps are dispatched by runStep; unreachable here.
+            BindScheme, ApplyResolvedAccent, ApplyExplicitHex, RevertAccent -> {
+                return
+            }
+        }
+    }
+
+    /**
+     * Escalate a torn accent apply into this step's [StepFailure]. The applicator
+     * contains mid-step throws internally (WARN + skipped tail — see
+     * `AccentApplyPlanRunner`), so the only in-process tear signal available to
+     * plan consumers is the persisted clean flag: [reapply] runs on the EDT and
+     * the apply is EDT-synchronous, so after the apply call returns the flag
+     * reflects THAT apply. Throwing here restores what consumers relied on
+     * before the containment refactor: the rotation circuit breaker counts the
+     * failure and the license revert surfaces its "restart to complete" notice.
+     */
+    private fun ensureAccentApplyClean(step: ReapplyStep) {
+        check(AyuIslandsSettings.getInstance().state.lastApplyOk) {
+            "accent apply torn during $step — see the 'Accent apply torn at' warning above"
         }
     }
 

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsLafListenerSyntaxReapplyTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsLafListenerSyntaxReapplyTest.kt
@@ -49,6 +49,9 @@ class AyuIslandsLafListenerSyntaxReapplyTest {
     @BeforeTest
     fun setUp() {
         state = AyuIslandsState()
+        // Stubbed applies report success, so the persisted clean flag must read
+        // clean too — ThemeReapplication's tear-escalation check consults it.
+        state.lastApplyOk = true
         every { mockSettings.state } returns state
         mockkObject(AyuIslandsSettings.Companion)
         every { AyuIslandsSettings.getInstance() } returns mockSettings

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsLafListenerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsLafListenerTest.kt
@@ -49,6 +49,9 @@ class AyuIslandsLafListenerTest {
     @BeforeTest
     fun setUp() {
         state = AyuIslandsState()
+        // Stubbed applies report success, so the persisted clean flag must read
+        // clean too — ThemeReapplication's tear-escalation check consults it.
+        state.lastApplyOk = true
         every { mockSettings.state } returns state
         mockkObject(AyuIslandsSettings.Companion)
         every { AyuIslandsSettings.getInstance() } returns mockSettings

--- a/src/test/kotlin/dev/ayuislands/licensing/FreeTierLockdownTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/FreeTierLockdownTest.kt
@@ -52,6 +52,9 @@ class FreeTierLockdownTest {
     @BeforeTest
     fun setUp() {
         state = AyuIslandsState()
+        // Stubbed applies report success, so the persisted clean flag must read
+        // clean too — ThemeReapplication's tear-escalation check consults it.
+        state.lastApplyOk = true
         settings = mockk()
         every { settings.state } returns state
         every { settings.getAccentForVariant(any()) } returns "#FFCC66"

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerProDefaultsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerProDefaultsTest.kt
@@ -38,6 +38,9 @@ class LicenseCheckerProDefaultsTest {
     @BeforeTest
     fun setUp() {
         state = AyuIslandsState()
+        // Stubbed applies report success, so the persisted clean flag must read
+        // clean too — ThemeReapplication's tear-escalation check consults it.
+        state.lastApplyOk = true
         val settingsMock = mockk<AyuIslandsSettings>()
         mockkObject(AyuIslandsSettings.Companion)
         every { AyuIslandsSettings.getInstance() } returns settingsMock

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerQuickSwitcherRevertTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerQuickSwitcherRevertTest.kt
@@ -44,6 +44,9 @@ class LicenseCheckerQuickSwitcherRevertTest {
     @BeforeEach
     fun setUp() {
         state = AyuIslandsState()
+        // Stubbed applies report success, so the persisted clean flag must read
+        // clean too — ThemeReapplication's tear-escalation check consults it.
+        state.lastApplyOk = true
         settings = mockk()
         every { settings.state } returns state
         every { settings.getAccentForVariant(any()) } returns "#FFCC66"

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerVcsRevokeTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerVcsRevokeTest.kt
@@ -58,6 +58,9 @@ class LicenseCheckerVcsRevokeTest {
     @BeforeTest
     fun setUp() {
         state = AyuIslandsState()
+        // Stubbed applies report success, so the persisted clean flag must read
+        // clean too — ThemeReapplication's tear-escalation check consults it.
+        state.lastApplyOk = true
         settings = mockk()
         every { settings.state } returns state
         every { settings.getAccentForVariant(any()) } returns "#FFCC66"

--- a/src/test/kotlin/dev/ayuislands/licensing/TrialLifecycleIntegrationTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/TrialLifecycleIntegrationTest.kt
@@ -67,6 +67,9 @@ class TrialLifecycleIntegrationTest {
     @BeforeTest
     fun setUp() {
         state = AyuIslandsState()
+        // Stubbed applies report success, so the persisted clean flag must read
+        // clean too — ThemeReapplication's tear-escalation check consults it.
+        state.lastApplyOk = true
         settings = mockk()
         every { settings.state } returns state
         every { settings.getAccentForVariant(any()) } returns "#FFCC66"

--- a/src/test/kotlin/dev/ayuislands/reapply/ThemeReapplicationTearEscalationTest.kt
+++ b/src/test/kotlin/dev/ayuislands/reapply/ThemeReapplicationTearEscalationTest.kt
@@ -92,6 +92,22 @@ class ThemeReapplicationTearEscalationTest {
     }
 
     @Test
+    fun `rotation tick reports the apply step failed when the resolver hex is shape-invalid`() {
+        // The one case the clean-flag check cannot see: a shape-invalid hex makes
+        // the applicator skip apply() entirely, leaving lastApplyOk stale (true
+        // here). The returned hex carries the signal instead.
+        state.lastApplyOk = true
+        every {
+            AccentApplicator.applyForFocusedProject(any<dev.ayuislands.accent.AccentContext>())
+        } returns "not-a-hex"
+
+        var result: ReapplyResult? = null
+        ThemeReapplication.reapply(ReapplyReason.RotationTick(AyuVariant.DARK)) { result = it }
+
+        assertTrue(requireNotNull(result).failed(ReapplyStep.ApplyResolvedAccent))
+    }
+
+    @Test
     fun `license revert reports the explicit-hex step failed when the hex is rejected`() {
         state.lastApplyOk = true
         every { AccentApplicator.applyFromHexString(any()) } returns false

--- a/src/test/kotlin/dev/ayuislands/reapply/ThemeReapplicationTearEscalationTest.kt
+++ b/src/test/kotlin/dev/ayuislands/reapply/ThemeReapplicationTearEscalationTest.kt
@@ -1,0 +1,104 @@
+package dev.ayuislands.reapply
+
+import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.settings.AyuIslandsState
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import javax.swing.SwingUtilities
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Locks the tear-escalation contract: the applicator contains mid-step throws
+ * internally (WARN, `lastApplyOk` stays false), and the accent steps translate
+ * that persisted signal back into a [StepFailure] so [ReapplyResult] consumers
+ * — the rotation circuit breaker (`result.isClean`) and the license revert
+ * notice (`result.failed(ApplyExplicitHex)`) — observe the tear again.
+ */
+class ThemeReapplicationTearEscalationTest {
+    private val mockSettings = mockk<AyuIslandsSettings>(relaxed = true)
+    private val state = AyuIslandsState()
+
+    @BeforeTest
+    fun setUp() {
+        mockkStatic(SwingUtilities::class)
+        every { SwingUtilities.isEventDispatchThread() } returns true
+
+        // reapply() dispatches via Application.isDispatchThread, not SwingUtilities.
+        val mockApplication = mockk<com.intellij.openapi.application.Application>(relaxed = true)
+        mockkStatic(com.intellij.openapi.application.ApplicationManager::class)
+        every {
+            com.intellij.openapi.application.ApplicationManager
+                .getApplication()
+        } returns mockApplication
+        every { mockApplication.isDispatchThread } returns true
+
+        mockkObject(AyuIslandsSettings.Companion)
+        every { AyuIslandsSettings.getInstance() } returns mockSettings
+        every { mockSettings.state } returns state
+
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.applyForFocusedProject(any<dev.ayuislands.accent.AccentContext>()) } returns "#FFCC66"
+        every { AccentApplicator.applyFromHexString(any()) } returns true
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `rotation tick reports the apply step failed when the apply tore`() {
+        state.lastApplyOk = false
+
+        var result: ReapplyResult? = null
+        ThemeReapplication.reapply(ReapplyReason.RotationTick(AyuVariant.DARK)) { result = it }
+
+        assertTrue(
+            requireNotNull(result).failed(ReapplyStep.ApplyResolvedAccent),
+            "a torn apply must surface as the accent step's failure so the rotation circuit breaker counts it",
+        )
+    }
+
+    @Test
+    fun `rotation tick is clean when the apply completed cleanly`() {
+        state.lastApplyOk = true
+
+        var result: ReapplyResult? = null
+        ThemeReapplication.reapply(ReapplyReason.RotationTick(AyuVariant.DARK)) { result = it }
+
+        assertFalse(requireNotNull(result).failed(ReapplyStep.ApplyResolvedAccent))
+    }
+
+    @Test
+    fun `license revert reports the explicit-hex step failed when the apply tore`() {
+        state.lastApplyOk = false
+
+        var result: ReapplyResult? = null
+        ThemeReapplication.reapply(ReapplyReason.LicenseRevert("#E6B450")) { result = it }
+
+        assertTrue(
+            requireNotNull(result).failed(ReapplyStep.ApplyExplicitHex),
+            "a torn apply must surface as the explicit-hex step's failure so the revert-incomplete notice fires",
+        )
+    }
+
+    @Test
+    fun `license revert reports the explicit-hex step failed when the hex is rejected`() {
+        state.lastApplyOk = true
+        every { AccentApplicator.applyFromHexString(any()) } returns false
+
+        var result: ReapplyResult? = null
+        ThemeReapplication.reapply(ReapplyReason.LicenseRevert("#E6B450")) { result = it }
+
+        assertTrue(requireNotNull(result).failed(ReapplyStep.ApplyExplicitHex))
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
@@ -104,6 +104,9 @@ class AccentRotationServiceTest {
 
     private fun mockRotationEnvironment() {
         state = AyuIslandsState()
+        // Stubbed applies report success, so the persisted clean flag must read
+        // clean too — ThemeReapplication's tear-escalation check consults it.
+        state.lastApplyOk = true
         settingsMock = mockk(relaxed = true)
 
         mockkStatic(ApplicationManager::class)


### PR DESCRIPTION
── Summary ─────────────────────────────────

Stacked on #254 (retarget to `main` after it merges). The plan-runner containment in #254 deliberately deferred one loss: `ReapplyResult` consumers went blind to apply-internal tears — the rotation circuit breaker reset its failure count on every tick (rotation would tick forever against a torn applicator with no escalation), and the license revert's "restart to complete the reset" notice became unreachable. This PR restores that escalation through the persisted clean flag, and moves the `VirtualMachineError` rethrow into the repo-wide cancellation-safe helper.

── Changes ─────────────────────────────────

| Type | Where | What |
|------|-------|------|
| Fix | `src/main/kotlin/dev/ayuislands/reapply/ThemeReapplication.kt:120` | Accent steps consult `lastApplyOk` right after their EDT-synchronous apply (`ensureAccentApplyClean`) and convert a tear into that step's `StepFailure`; `ApplyExplicitHex` also fails on a rejected hex instead of ignoring the Boolean |
| Fix | `src/main/kotlin/dev/ayuislands/accent/CancellationSafeRunCatching.kt:27` | `VirtualMachineError` rethrows alongside cancellation repo-wide; `LinkageError` stays contained (plugin-unload races) |
| Refactor | `src/main/kotlin/dev/ayuislands/accent/AccentApplyPlanRunner.kt:47` | Local VME check removed — redundant once the helper owns it (runner test still locks the behavior) |
| Test | `src/test/kotlin/dev/ayuislands/reapply/ThemeReapplicationTearEscalationTest.kt:26` | Torn/rejected/clean cases for `failed(ApplyResolvedAccent)` / `failed(ApplyExplicitHex)` |
| Test | 8 fixtures (license, rotation, LAF-listener, trial-lifecycle) | Stubbed clean applies now present a clean flag (`state.lastApplyOk = true`) |

── Validation ──────────────────────────────

```bash
./gradlew test koverVerify detekt ktlintCheck
```
Expected: full suite green (2953 tests), Kover ≥80%, zero lint findings.

Manual: with a deliberately torn apply, rotation stops after the failure threshold with the "accent rotation stopped" notification; license revert surfaces "restart to complete the reset".

── Notes ───────────────────────────────────

- The tear signal is the persisted `lastApplyOk` read on the EDT immediately after the EDT-synchronous apply — the same trust primitive `trustedCachedAccent()` formalized in #254; no signature changes anywhere.
- A rejected free-default hex now also fails `ApplyExplicitHex` (previously silently ignored); the hex is a compile-time constant, so this is defense-in-depth.
- IDE-inspection cleanups: unreachable `when` branches use explicit `return` instead of empty blocks.

## Summary by Sourcery

Restore accent apply tear escalation to ReapplyResult and centralize JVM error rethrow behavior.

Bug Fixes:
- Ensure accent reapplication steps fail when the persisted clean flag indicates a torn apply, so rotation and license revert logic can observe failures.
- Treat explicit hex accent application as failed when the applicator rejects the hex instead of silently succeeding.
- Propagate VirtualMachineError alongside cancellation from the shared run-catching helper so JVM-level failures are never downgraded to step failures.

Enhancements:
- Remove redundant VirtualMachineError handling from the accent apply plan runner now that the shared helper owns this behavior.

Tests:
- Add ThemeReapplication tear-escalation tests covering torn, clean, and rejected-hex scenarios for accent steps.
- Initialize the persisted clean flag in existing accent-related tests so stubbed applies reflect a successful state.