### PR TITLE
refactor(onboarding): unify the focus-race tab-open protocol

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -270,8 +270,9 @@ kover {
                     //     paint, JBLabel layout
                     //   - WhatsNewEditor: thin FileEditor contract wrapper
                     //   - WhatsNewLauncher: OnboardingSchedulerService coroutine launch,
-                    //     Dispatchers.EDT hop, IdeFocusManager lookup, FileEditorManager open
-                    //     (the pure isEligible + version normalization paths ARE tested)
+                    //     FileEditorManager open (the pure isEligible + version
+                    //     normalization paths ARE tested; the focus-race protocol lives
+                    //     in the fully tested dev.ayuislands.ui.FocusWinningTabOpener)
                     "dev.ayuislands.whatsnew.WhatsNewPanel",
                     $$"dev.ayuislands.whatsnew.WhatsNewPanel$1",
                     $$"dev.ayuislands.whatsnew.WhatsNewPanel$2",

--- a/scripts/guard-test-source-reads.py
+++ b/scripts/guard-test-source-reads.py
@@ -59,6 +59,18 @@ ALLOWLIST: dict[tuple[str, str], Allowance] = {
         "src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt",
     ): Allowance(1, "documented startup wiring compromise"),
     (
+        "src/test/kotlin/dev/ayuislands/ui/FocusWinningTabOpenerTest.kt",
+        "src/main/kotlin/dev/ayuislands/ui/FocusWinningTabOpener.kt",
+    ): Allowance(1, "documented EDT-hop shape compromise (Dispatchers.EDT undispatchable headless)"),
+    (
+        "src/test/kotlin/dev/ayuislands/ui/FocusWinningTabOpenerTest.kt",
+        "src/main/kotlin/dev/ayuislands/whatsnew/WhatsNewLauncher.kt",
+    ): Allowance(1, "documented opener wiring compromise"),
+    (
+        "src/test/kotlin/dev/ayuislands/ui/FocusWinningTabOpenerTest.kt",
+        "src/main/kotlin/dev/ayuislands/StartupLicenseHandler.kt",
+    ): Allowance(1, "documented opener wiring compromise"),
+    (
         "src/test/kotlin/dev/ayuislands/accent/AccentApplicatorBannedApiGuardTest.kt",
         "src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt",
     ): Allowance(1, "banned platform API guard"),

--- a/src/main/kotlin/dev/ayuislands/StartupLicenseHandler.kt
+++ b/src/main/kotlin/dev/ayuislands/StartupLicenseHandler.kt
@@ -1,13 +1,8 @@
 package dev.ayuislands
 
-import com.intellij.openapi.application.EDT
-import com.intellij.openapi.application.ModalityState
-import com.intellij.openapi.application.asContextElement
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.openapi.wm.IdeFocusManager
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.commitpanel.CommitPanelAutoFitManager
 import dev.ayuislands.editor.EditorScrollbarManager
@@ -22,10 +17,9 @@ import dev.ayuislands.projectview.ProjectViewScrollbarManager
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
 import dev.ayuislands.settings.PanelWidthMode
-import kotlinx.coroutines.Dispatchers
+import dev.ayuislands.ui.FocusWinningTabOpener
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
@@ -114,10 +108,24 @@ internal object StartupLicenseHandler {
     }
 
     /**
+     * Focus-race protocol shared with the What's New launcher: EDT hop,
+     * disposed guard, focus check, [OnboardingOrchestrator.gate] claim, and
+     * release-on-failure so one failed `openFile` can't permanently block the
+     * wizard for the whole JVM session.
+     */
+    private val wizardOpener =
+        FocusWinningTabOpener(
+            gate = OnboardingOrchestrator.gate,
+            log = LOG,
+            logPrefix = "Ayu onboarding",
+            subject = "wizard",
+        )
+
+    /**
      * Schedule a wizard display. Every project running the startup activity schedules
      * its own coroutine. When the coroutines fire after the delay, only the project
-     * whose frame is currently active will actually open the wizard — see
-     * [scheduleFreeWizard] / [scheduleTrialWelcome] for the focus-aware claim logic.
+     * whose frame is currently active will actually open the wizard — the focus-aware
+     * claim logic lives in [FocusWinningTabOpener].
      */
     fun handleWizardAction(
         action: WizardAction,
@@ -143,8 +151,11 @@ internal object StartupLicenseHandler {
         scope.launch {
             delay(delayMs.milliseconds)
             if (project.isDisposed) return@launch
-            openWizardIfThisProjectWins(project, OnboardingVirtualFile()) {
-                settings.state.premiumOnboardingShown = true
+            wizardOpener.open(
+                project = project,
+                onSuccess = { settings.state.premiumOnboardingShown = true },
+            ) { target ->
+                FileEditorManager.getInstance(target).openFile(OnboardingVirtualFile(), true)
             }
         }
     }
@@ -165,47 +176,11 @@ internal object StartupLicenseHandler {
         scope.launch {
             delay(delayMs.milliseconds)
             if (project.isDisposed) return@launch
-            openWizardIfThisProjectWins(project, FreeOnboardingVirtualFile()) {
-                settings.state.freeOnboardingShown = true
-            }
-        }
-    }
-
-    /**
-     * Hop to EDT and open the wizard in the user's active project tab.
-     *
-     * In merged-window mode (project tabs), all projects share one OS frame.
-     * [IdeFocusManager.getGlobalInstance] `.lastFocusedFrame.project` identifies
-     * which project tab the user is currently viewing — even when the IDE itself is in
-     * the background. Only the matching project opens the wizard; the rest bail out.
-     * If no frame is focused (cold start, or IDE minimized), the first project to call
-     * [OnboardingOrchestrator.tryPick] wins as a fallback.
-     */
-    private suspend fun openWizardIfThisProjectWins(
-        project: Project,
-        file: VirtualFile,
-        onSuccess: () -> Unit,
-    ) {
-        withContext(Dispatchers.EDT + ModalityState.nonModal().asContextElement()) {
-            if (project.isDisposed) return@withContext
-
-            val activeProject = IdeFocusManager.getGlobalInstance().lastFocusedFrame?.project
-            if (activeProject != null && activeProject != project) {
-                LOG.info("Ayu onboarding: project ${project.name} is not the active tab — deferring")
-                return@withContext
-            }
-
-            if (!OnboardingOrchestrator.tryPick()) {
-                LOG.info("Ayu onboarding: another project already claimed the wizard slot")
-                return@withContext
-            }
-
-            LOG.info("Ayu onboarding: opening wizard in ${project.name}")
-            try {
-                FileEditorManager.getInstance(project).openFile(file, true)
-                onSuccess()
-            } catch (exception: RuntimeException) {
-                LOG.error("Ayu onboarding: failed to open wizard in ${project.name}", exception)
+            wizardOpener.open(
+                project = project,
+                onSuccess = { settings.state.freeOnboardingShown = true },
+            ) { target ->
+                FileEditorManager.getInstance(target).openFile(FreeOnboardingVirtualFile(), true)
             }
         }
     }

--- a/src/main/kotlin/dev/ayuislands/onboarding/OnboardingOrchestrator.kt
+++ b/src/main/kotlin/dev/ayuislands/onboarding/OnboardingOrchestrator.kt
@@ -1,6 +1,6 @@
 package dev.ayuislands.onboarding
 
-import java.util.concurrent.atomic.AtomicBoolean
+import dev.ayuislands.ui.SessionOneShot
 
 /** Decision result from the onboarding state machine. */
 sealed class WizardAction {
@@ -15,27 +15,15 @@ sealed class WizardAction {
  * Pure-logic state machine that resolves which onboarding wizard to display.
  *
  * No platform dependencies — all inputs are plain booleans, making this trivially testable.
- * The [AtomicBoolean] guard ensures at most one project window actually opens the wizard
- * in a JVM session, even when several project windows race to claim it after their
- * individual coroutine delays elapse. Unlike a simple acquire-on-schedule lock, the
- * pick happens *after* the delay so the currently-focused project window wins, not
- * whichever project happened to start first.
+ * The [gate] ensures at most one project window actually opens the wizard in a JVM session,
+ * even when several project windows race to claim it after their individual coroutine
+ * delays elapse. Unlike a simple acquire-on-schedule lock, the pick happens *after* the
+ * delay so the currently-focused project window wins, not whichever project happened to
+ * start first.
  */
 internal object OnboardingOrchestrator {
-    private val wizardShown = AtomicBoolean(false)
-
-    /**
-     * Atomically claims the right to open the wizard. Returns `true` only to the
-     * first caller; subsequent callers get `false` and must bail without showing.
-     * One-shot for the lifetime of the JVM session.
-     */
-    fun tryPick(): Boolean = wizardShown.compareAndSet(false, true)
-
-    /** Test-only hook: reset the one-shot pick flag between test cases. */
-    @org.jetbrains.annotations.TestOnly
-    fun resetForTesting() {
-        wizardShown.set(false)
-    }
+    /** In-session one-shot claim for the onboarding wizard — see [SessionOneShot]. */
+    val gate: SessionOneShot = SessionOneShot()
 
     /**
      * Resolves which wizard action to take based on license and onboarding state.

--- a/src/main/kotlin/dev/ayuislands/ui/FocusWinningTabOpener.kt
+++ b/src/main/kotlin/dev/ayuislands/ui/FocusWinningTabOpener.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.wm.IdeFocusManager
 import com.intellij.util.concurrency.annotations.RequiresEdt
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * Focus-race protocol for opening a feature tab in exactly one project window.
@@ -75,16 +76,28 @@ internal class FocusWinningTabOpener(
             log.info("$logPrefix: another project already claimed the $subject slot")
             return
         }
-        log.info("$logPrefix: opening $subject in ${project.name}")
+        log.info("$logPrefix: opening $subject in ${project.name} (bypassGate=$bypassGate)")
         try {
             openTab(project)
-            onSuccess()
+        } catch (cancellation: CancellationException) {
+            // PCE (and its IndexNotReadyException subtype thrown by
+            // FileEditorManager.openFile mid-indexing) extends
+            // CancellationException extends RuntimeException on 2024.1+ —
+            // it is control flow, never log.error material. Release the claim
+            // so the cancelled open can retry, then let the signal propagate.
+            if (claimed) gate.release()
+            throw cancellation
         } catch (exception: RuntimeException) {
             log.error("$logPrefix: failed to open $subject in ${project.name}", exception)
             if (claimed && gate.release()) {
                 log.info("$logPrefix: $subject claim released after failed open")
             }
+            return
         }
+        // Outside the try: the tab IS open at this point, so a throwing
+        // success callback must neither release the claim nor log a
+        // misleading "failed open" breadcrumb.
+        onSuccess()
     }
 
     /**

--- a/src/main/kotlin/dev/ayuislands/ui/FocusWinningTabOpener.kt
+++ b/src/main/kotlin/dev/ayuislands/ui/FocusWinningTabOpener.kt
@@ -1,0 +1,103 @@
+package dev.ayuislands.ui
+
+import com.intellij.openapi.application.EDT
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.application.asContextElement
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.IdeFocusManager
+import com.intellij.util.concurrency.annotations.RequiresEdt
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Focus-race protocol for opening a feature tab in exactly one project window.
+ *
+ * Shared by the What's New launcher and the onboarding wizard scheduler
+ * (`WhatsNewLauncher`, `StartupLicenseHandler`), which previously copy-pasted
+ * the same steps:
+ *
+ *  1. Hop to EDT (`Dispatchers.EDT` + [ModalityState.nonModal]).
+ *  2. Bail when the [Project] is already disposed.
+ *  3. Focus check — in merged-window mode (project tabs) all projects share
+ *     one OS frame; `IdeFocusManager.getGlobalInstance().lastFocusedFrame?.project`
+ *     identifies which project tab the user is viewing, even when the IDE is
+ *     in the background. Only the matching project proceeds; the rest defer.
+ *     A `null` frame (cold start, IDE minimized) lets every caller through to
+ *     the CAS fallback.
+ *  4. CAS claim on [gate] — the first project to acquire wins the session slot.
+ *  5. Open via the caller's open action; on success run the success callback,
+ *     on failure release the claim so one failed open can't deadlock the
+ *     whole JVM session.
+ *
+ * Manual triggers (user clicked a menu action) pass `bypassFocus` /
+ * `bypassGate` = true: the click already names the right project, and the
+ * auto-trigger one-shot must not block an explicit request. A bypassed gate
+ * is never claimed, so a failed manual open never releases another window's
+ * claim.
+ */
+internal class FocusWinningTabOpener(
+    private val gate: SessionOneShot,
+    private val log: Logger,
+    private val logPrefix: String,
+    private val subject: String,
+) {
+    /** EDT-hopping entry — see the class KDoc for the protocol steps. */
+    suspend fun open(
+        project: Project,
+        bypassFocus: Boolean = false,
+        bypassGate: Boolean = false,
+        onSuccess: () -> Unit,
+        openTab: (Project) -> Unit,
+    ) {
+        withContext(Dispatchers.EDT + ModalityState.nonModal().asContextElement()) {
+            openOnEdt(project, bypassFocus, bypassGate, onSuccess, openTab)
+        }
+    }
+
+    /**
+     * Protocol body, split from [open] so unit tests can exercise the focus /
+     * claim / release branches directly — `Dispatchers.EDT` needs a live
+     * platform application and cannot dispatch in a headless test.
+     */
+    @RequiresEdt
+    fun openOnEdt(
+        project: Project,
+        bypassFocus: Boolean,
+        bypassGate: Boolean,
+        onSuccess: () -> Unit,
+        openTab: (Project) -> Unit,
+    ) {
+        if (project.isDisposed) return
+        if (!bypassFocus && !isFocusedProject(project)) return
+        val claimed = !bypassGate && gate.tryAcquire()
+        if (!bypassGate && !claimed) {
+            log.info("$logPrefix: another project already claimed the $subject slot")
+            return
+        }
+        log.info("$logPrefix: opening $subject in ${project.name}")
+        try {
+            openTab(project)
+            onSuccess()
+        } catch (exception: RuntimeException) {
+            log.error("$logPrefix: failed to open $subject in ${project.name}", exception)
+            if (claimed && gate.release()) {
+                log.info("$logPrefix: $subject claim released after failed open")
+            }
+        }
+    }
+
+    /**
+     * Returns true iff this project is the right one to open in: either its
+     * frame holds focus, or no frame is focused at all (cold start) and the
+     * CAS fallback decides.
+     */
+    private fun isFocusedProject(project: Project): Boolean {
+        val activeProject = IdeFocusManager.getGlobalInstance().lastFocusedFrame?.project
+        if (activeProject != null && activeProject != project) {
+            log.info("$logPrefix: ${project.name} is not the active tab — deferring")
+            return false
+        }
+        return true
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/ui/SessionOneShot.kt
+++ b/src/main/kotlin/dev/ayuislands/ui/SessionOneShot.kt
@@ -1,0 +1,39 @@
+package dev.ayuislands.ui
+
+import org.jetbrains.annotations.TestOnly
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * JVM-session one-shot claim gate around a single compare-and-set.
+ *
+ * Shared by [FocusWinningTabOpener] callers: each tab-opening feature (the
+ * What's New tab, the onboarding wizard) holds its own instance so claims
+ * never cross-suppress between features. The gate resolves the multi-window
+ * startup race — several project windows schedule the same open in parallel
+ * and only the first to [tryAcquire] proceeds.
+ */
+internal class SessionOneShot {
+    private val claimed = AtomicBoolean(false)
+
+    /**
+     * Atomically claims the one-shot slot for this JVM session. Returns `true`
+     * only to the first caller; subsequent callers get `false` and must bail
+     * without opening.
+     */
+    fun tryAcquire(): Boolean = claimed.compareAndSet(false, true)
+
+    /**
+     * Releases a held claim so a later caller can acquire again. Returns `true`
+     * only when the call actually flipped a held claim — a defensive release
+     * from a caller that never acquired (or ran after another thread already
+     * released) is a no-op returning `false`, letting callers skip a
+     * misleading "released" breadcrumb.
+     */
+    fun release(): Boolean = claimed.compareAndSet(true, false)
+
+    /** Test-only hook: reset the one-shot flag between test cases. */
+    @TestOnly
+    fun resetForTesting() {
+        claimed.set(false)
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/whatsnew/WhatsNewLauncher.kt
+++ b/src/main/kotlin/dev/ayuislands/whatsnew/WhatsNewLauncher.kt
@@ -1,20 +1,15 @@
 package dev.ayuislands.whatsnew
 
-import com.intellij.openapi.application.EDT
-import com.intellij.openapi.application.ModalityState
-import com.intellij.openapi.application.asContextElement
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.wm.IdeFocusManager
 import dev.ayuislands.AyuPlugin
 import dev.ayuislands.onboarding.OnboardingSchedulerService
 import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.ui.FocusWinningTabOpener
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
@@ -25,17 +20,26 @@ import kotlin.time.Duration.Companion.milliseconds
  *  - Persistent: [dev.ayuislands.settings.AyuIslandsState.lastWhatsNewShownVersion]
  *    survives IDE restarts. Once the tab opens for v2.5.0, it never auto-opens
  *    again until v2.6.0 (or whichever version next ships a manifest).
- *  - In-session: [WhatsNewOrchestrator] handles the multi-window startup race.
+ *  - In-session: [WhatsNewOrchestrator] holds the gate for the multi-window
+ *    startup race.
  *
- * Tab open mirrors `StartupLicenseHandler.openWizardIfThisProjectWins` —
- * focus-aware so the user's currently-focused project gets the tab, not just
- * the first one to schedule.
+ * The focus-race protocol itself (EDT hop, disposed guard, focus check, CAS
+ * claim, release-on-failure) lives in [FocusWinningTabOpener], shared with the
+ * onboarding wizard scheduler in `dev.ayuislands.StartupLicenseHandler`.
  */
 internal object WhatsNewLauncher {
     private val LOG = logger<WhatsNewLauncher>()
 
     /** Delay before opening so the IDE frame settles and focus stabilizes. */
     private const val OPEN_DELAY_MS = 500
+
+    private val opener =
+        FocusWinningTabOpener(
+            gate = WhatsNewOrchestrator.gate,
+            log = LOG,
+            logPrefix = "Ayu What's New",
+            subject = "tab",
+        )
 
     /**
      * Auto-trigger entry called from [dev.ayuislands.UpdateNotifier]. Returns
@@ -98,10 +102,19 @@ internal object WhatsNewLauncher {
             try {
                 delay(OPEN_DELAY_MS.milliseconds)
                 if (project.isDisposed) return@launch
-                openIfThisProjectWins(project, isManual) {
-                    settings.state.lastWhatsNewShownVersion = normalizedVersion
-                    LOG.info("Ayu What's New: marked $normalizedVersion as shown")
-                }
+                // Manual triggers bypass both the focus check AND the
+                // orchestrator gate — the user explicitly asked from the
+                // action menu, so this project is the right one and the
+                // auto-trigger one-shot must not block them.
+                opener.open(
+                    project = project,
+                    bypassFocus = isManual,
+                    bypassGate = isManual,
+                    onSuccess = {
+                        settings.state.lastWhatsNewShownVersion = normalizedVersion
+                        LOG.info("Ayu What's New: marked $normalizedVersion as shown")
+                    },
+                ) { target -> openWhatsNewTab(target) }
             } catch (cancellation: CancellationException) {
                 // Catch order matters: CancellationException is a RuntimeException
                 // subtype, so this branch MUST come first to preserve structured
@@ -117,89 +130,25 @@ internal object WhatsNewLauncher {
     }
 
     /**
-     * Hop to EDT and open the tab in the user's active project. Mirrors
-     * [dev.ayuislands.StartupLicenseHandler.openWizardIfThisProjectWins]:
-     *  - In merged-window mode (project tabs), `IdeFocusManager.lastFocusedFrame.project`
-     *    identifies which project tab the user is viewing.
-     *  - Only the matching project opens the tab; others bail.
-     *  - If no frame is focused (cold start), the first project to call
-     *    [WhatsNewOrchestrator.tryPick] wins as a fallback.
+     * What's New-specific open action, run by [FocusWinningTabOpener] on EDT.
      *
-     * For [isManual] = true, both the focus check AND the orchestrator gate
-     * are skipped — the user explicitly asked from the action menu, so this
-     * project is the right one and the orchestrator's auto-trigger one-shot
-     * must not block them. If `openFile` throws, we always release the
-     * orchestrator claim so the JVM session doesn't deadlock.
+     * [WhatsNewVirtualFile] uses identity equality, so a fresh instance would
+     * NOT match an already-open tab and [FileEditorManager] would create a
+     * duplicate. Look up the existing instance first and pass THAT to
+     * `openFile`, which then focuses the existing tab instead. If MULTIPLE
+     * stale instances exist (leaked from an earlier bug or a split-editor
+     * race), focus the first and close the rest so the tab strip doesn't
+     * collect orphans silently.
      */
-    private suspend fun openIfThisProjectWins(
-        project: Project,
-        isManual: Boolean,
-        onSuccess: () -> Unit,
-    ) {
-        withContext(Dispatchers.EDT + ModalityState.nonModal().asContextElement()) {
-            if (project.isDisposed) return@withContext
-            if (!shouldOpenForThisProject(project, isManual)) return@withContext
-            val claimed = !isManual && WhatsNewOrchestrator.tryPick()
-            if (!isManual && !claimed) {
-                LOG.info("Ayu What's New: another project already claimed the tab slot")
-                return@withContext
-            }
-            performOpen(project, isManual, claimed, onSuccess)
+    private fun openWhatsNewTab(project: Project) {
+        val manager = FileEditorManager.getInstance(project)
+        val matches = manager.openFiles.filterIsInstance<WhatsNewVirtualFile>()
+        if (matches.size > 1) {
+            LOG.warn("Ayu What's New: found ${matches.size} stale tabs in ${project.name}; closing extras")
+            matches.drop(1).forEach { manager.closeFile(it) }
         }
-    }
-
-    /**
-     * Returns true iff this project is the right one to open the tab in. For
-     * manual triggers it's always true (user explicitly clicked the menu in
-     * this project). For auto triggers the user's currently-focused project
-     * wins; other windows defer.
-     */
-    private fun shouldOpenForThisProject(
-        project: Project,
-        isManual: Boolean,
-    ): Boolean {
-        if (isManual) return true
-        val activeProject = IdeFocusManager.getGlobalInstance().lastFocusedFrame?.project
-        if (activeProject != null && activeProject != project) {
-            LOG.info("Ayu What's New: ${project.name} is not the active tab — deferring")
-            return false
-        }
-        return true
-    }
-
-    /**
-     * Opens the tab and invokes [onSuccess] on a clean open. On failure releases
-     * the orchestrator claim if it was held — without this, a single failed open
-     * would deadlock the JVM session for both auto and manual triggers.
-     */
-    private fun performOpen(
-        project: Project,
-        isManual: Boolean,
-        claimed: Boolean,
-        onSuccess: () -> Unit,
-    ) {
-        LOG.info("Ayu What's New: opening tab in ${project.name} (manual=$isManual)")
-        try {
-            // WhatsNewVirtualFile uses identity equality, so a fresh instance
-            // would NOT match an already-open tab and FileEditorManager would
-            // create a duplicate. Look up the existing instance first and pass
-            // THAT to openFile, which then focuses the existing tab instead.
-            // If MULTIPLE stale instances exist (leaked from an earlier bug or
-            // a split-editor race), focus the first and close the rest so the
-            // tab strip doesn't collect orphans silently.
-            val manager = FileEditorManager.getInstance(project)
-            val matches = manager.openFiles.filterIsInstance<WhatsNewVirtualFile>()
-            if (matches.size > 1) {
-                LOG.warn("Ayu What's New: found ${matches.size} stale tabs in ${project.name}; closing extras")
-                matches.drop(1).forEach { manager.closeFile(it) }
-            }
-            val target = matches.firstOrNull() ?: WhatsNewVirtualFile()
-            manager.openFile(target, true)
-            onSuccess()
-        } catch (exception: RuntimeException) {
-            LOG.error("Ayu What's New: failed to open tab in ${project.name}", exception)
-            if (claimed) WhatsNewOrchestrator.release()
-        }
+        val target = matches.firstOrNull() ?: WhatsNewVirtualFile()
+        manager.openFile(target, true)
     }
 
     private fun pluginDescriptor() = AyuPlugin.findLoadedPlugin(AyuPlugin.ID)

--- a/src/main/kotlin/dev/ayuislands/whatsnew/WhatsNewOrchestrator.kt
+++ b/src/main/kotlin/dev/ayuislands/whatsnew/WhatsNewOrchestrator.kt
@@ -1,52 +1,21 @@
 package dev.ayuislands.whatsnew
 
-import com.intellij.openapi.diagnostic.logger
-import java.util.concurrent.atomic.AtomicBoolean
+import dev.ayuislands.ui.SessionOneShot
 
 /**
- * JVM-session one-shot pick gate for the What's New tab.
+ * Named holder of the What's New tab's in-session claim gate.
  *
- * No platform dependencies — pure logic, mirror of
- * [dev.ayuislands.onboarding.OnboardingOrchestrator]. Independent atomic so a
- * fresh installer who finishes the onboarding wizard doesn't accidentally
- * suppress the next-version What's New tab in the same session.
+ * Independent instance, mirror of
+ * [dev.ayuislands.onboarding.OnboardingOrchestrator]'s gate, so a fresh
+ * installer who finishes the onboarding wizard doesn't accidentally suppress
+ * the next-version What's New tab in the same session.
  *
- * Two-layer dedup: this in-session atomic handles the multi-window startup
- * race (three project windows opening in parallel before any has written
- * persistent state); `AyuIslandsState.lastWhatsNewShownVersion` handles the
- * cross-restart "already shown" gate.
+ * Two-layer dedup: this in-session gate handles the multi-window startup race
+ * (three project windows opening in parallel before any has written persistent
+ * state); `AyuIslandsState.lastWhatsNewShownVersion` handles the cross-restart
+ * "already shown" gate.
  */
 internal object WhatsNewOrchestrator {
-    private val LOG = logger<WhatsNewOrchestrator>()
-    private val shown = AtomicBoolean(false)
-
-    /**
-     * Atomically claims the right to open the tab in this JVM session.
-     * Returns `true` only to the first caller; subsequent callers get `false`
-     * and must bail without opening.
-     */
-    fun tryPick(): Boolean = shown.compareAndSet(false, true)
-
-    /**
-     * Releases the in-session claim so a later caller can pick again. Called by
-     * the launcher when an open attempt fails after `tryPick` returned true —
-     * without this, a single failed `openFile` call would deadlock the whole
-     * JVM session: no other window's auto-trigger could fire and the manual
-     * "Show What's New…" menu item would also be stuck.
-     */
-    fun release() {
-        // compareAndSet true→false only logs when the call actually flipped a
-        // held claim. A defensive release from a caller that never picked
-        // (or ran after another thread already released) is a no-op and emits
-        // no misleading "released after failed open" breadcrumb.
-        if (shown.compareAndSet(true, false)) {
-            LOG.info("Ayu What's New: orchestrator claim released after failed open")
-        }
-    }
-
-    /** Test-only hook: reset the one-shot flag between test cases. */
-    @org.jetbrains.annotations.TestOnly
-    fun resetForTesting() {
-        shown.set(false)
-    }
+    /** In-session one-shot claim for the What's New tab — see [SessionOneShot]. */
+    val gate: SessionOneShot = SessionOneShot()
 }

--- a/src/test/kotlin/dev/ayuislands/StartupLicenseStateTest.kt
+++ b/src/test/kotlin/dev/ayuislands/StartupLicenseStateTest.kt
@@ -6,7 +6,6 @@ import dev.ayuislands.commitpanel.CommitPanelAutoFitManager
 import dev.ayuislands.editor.EditorScrollbarManager
 import dev.ayuislands.gitpanel.GitPanelAutoFitManager
 import dev.ayuislands.licensing.LicenseChecker
-import dev.ayuislands.onboarding.OnboardingOrchestrator
 import dev.ayuislands.onboarding.WizardAction
 import dev.ayuislands.projectview.ProjectViewScrollbarManager
 import dev.ayuislands.settings.AyuIslandsSettings
@@ -48,9 +47,6 @@ class StartupLicenseStateTest {
         every { LicenseChecker.applyWorkspaceDefaults() } just runs
         every { LicenseChecker.revertToFreeDefaults(any()) } just runs
         every { LicenseChecker.notifyTrialExpired(any()) } just runs
-
-        mockkObject(OnboardingOrchestrator)
-        every { OnboardingOrchestrator.tryPick() } returns true
 
         mockkObject(StartupLicenseHandler)
         every { StartupLicenseHandler.scheduleTrialWelcome(any(), any()) } just runs

--- a/src/test/kotlin/dev/ayuislands/onboarding/OnboardingOrchestratorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/onboarding/OnboardingOrchestratorTest.kt
@@ -1,27 +1,15 @@
 package dev.ayuislands.onboarding
 
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicInteger
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
+/**
+ * The wizard claim gate ([OnboardingOrchestrator.gate]) is a
+ * `dev.ayuislands.ui.SessionOneShot` — its acquire/release/thread-safety
+ * semantics are locked in `SessionOneShotTest`. This file covers the pure
+ * `resolve` state machine.
+ */
 class OnboardingOrchestratorTest {
-    @BeforeTest
-    fun setUp() {
-        OnboardingOrchestrator.resetForTesting()
-    }
-
-    @AfterTest
-    fun tearDown() {
-        OnboardingOrchestrator.resetForTesting()
-    }
-
     // -----------------------------------------------------------------------
     // resolve() - full truth table (all meaningful input combinations)
     // -----------------------------------------------------------------------
@@ -271,69 +259,6 @@ class OnboardingOrchestratorTest {
             WizardAction.NoWizard,
             resolve(licensed = false, freeShown = true, returning = false, premiumShown = true),
         )
-    }
-
-    // -----------------------------------------------------------------------
-    // tryPick - one-shot claim guard
-    // -----------------------------------------------------------------------
-
-    @Test
-    fun `tryPick returns true on first call`() {
-        assertTrue(OnboardingOrchestrator.tryPick())
-    }
-
-    @Test
-    fun `tryPick returns false on subsequent calls`() {
-        OnboardingOrchestrator.tryPick()
-        assertFalse(OnboardingOrchestrator.tryPick())
-    }
-
-    @Test
-    fun `resetForTesting re-enables tryPick`() {
-        OnboardingOrchestrator.tryPick()
-        OnboardingOrchestrator.resetForTesting()
-        assertTrue(OnboardingOrchestrator.tryPick())
-    }
-
-    @Test
-    fun `tryPick is thread-safe under concurrent access from 100 threads`() {
-        OnboardingOrchestrator.resetForTesting()
-        val threadCount = 100
-        val startLatch = CountDownLatch(1)
-        val doneLatch = CountDownLatch(threadCount)
-        val trueCount = AtomicInteger(0)
-        val executor = Executors.newFixedThreadPool(threadCount)
-        try {
-            repeat(threadCount) {
-                executor.submit {
-                    try {
-                        // Block all worker threads until the main thread releases them,
-                        // so they race on tryPick() instead of running serialized.
-                        startLatch.await()
-                        if (OnboardingOrchestrator.tryPick()) {
-                            trueCount.incrementAndGet()
-                        }
-                    } finally {
-                        doneLatch.countDown()
-                    }
-                }
-            }
-            startLatch.countDown()
-            assertTrue(
-                doneLatch.await(5, TimeUnit.SECONDS),
-                "Worker threads did not finish within 5 seconds",
-            )
-        } finally {
-            executor.shutdownNow()
-        }
-
-        assertEquals(
-            1,
-            trueCount.get(),
-            "Exactly one of $threadCount concurrent callers must win tryPick()",
-        )
-        // Subsequent call must still return false - the one-shot is latched.
-        assertFalse(OnboardingOrchestrator.tryPick())
     }
 
     // -----------------------------------------------------------------------

--- a/src/test/kotlin/dev/ayuislands/ui/FocusWinningTabOpenerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/ui/FocusWinningTabOpenerTest.kt
@@ -150,6 +150,61 @@ class FocusWinningTabOpenerTest {
     }
 
     @Test
+    fun `cancellation during open releases the claim and rethrows without error logging`() {
+        // PCE (and IndexNotReadyException, its openFile-thrown subtype) is
+        // control flow: it must propagate — log.error on it trips the
+        // platform's ensureNotControlFlow assertion — and the claim must free
+        // so the cancelled open can retry.
+        val gate = SessionOneShot()
+        val target = project("alpha")
+        focusOn(target)
+        var rethrown = false
+
+        try {
+            opener(gate).openOnEdt(
+                target,
+                bypassFocus = false,
+                bypassGate = false,
+                onSuccess = {},
+            ) {
+                throw com.intellij.openapi.progress
+                    .ProcessCanceledException()
+            }
+        } catch (expected: com.intellij.openapi.progress.ProcessCanceledException) {
+            rethrown = true
+        }
+
+        assertTrue(rethrown, "cancellation must propagate, not convert to a logged failure")
+        assertTrue(gate.tryAcquire(), "cancelled open must release the claim for retry")
+        io.mockk.verify(exactly = 0) { log.error(any<String>(), any<Throwable>()) }
+    }
+
+    @Test
+    fun `success callback throwing does not release the claim — the tab did open`() {
+        // The callback runs outside the open try: the tab is on screen, so a
+        // throwing shown-flag write must not free the gate (a sibling window
+        // would open a duplicate) nor log a misleading "failed open".
+        val gate = SessionOneShot()
+        val target = project("alpha")
+        focusOn(target)
+        var opened = false
+
+        try {
+            opener(gate).openOnEdt(
+                target,
+                bypassFocus = false,
+                bypassGate = false,
+                onSuccess = { error("shown-flag persistence hiccup") },
+            ) { opened = true }
+        } catch (expected: IllegalStateException) {
+            // propagates to the caller's coroutine catch — by design
+        }
+
+        assertTrue(opened)
+        assertFalse(gate.tryAcquire(), "claim must stay held — the tab is genuinely open")
+    }
+
+    @Test
     fun `onboarding wizard claim is released when the wizard open fails`() {
         // Latent-bug regression lock: before the shared opener, the license
         // path's copy of this protocol claimed the onboarding slot via

--- a/src/test/kotlin/dev/ayuislands/ui/FocusWinningTabOpenerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/ui/FocusWinningTabOpenerTest.kt
@@ -1,0 +1,336 @@
+package dev.ayuislands.ui
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.IdeFocusManager
+import com.intellij.openapi.wm.IdeFrame
+import dev.ayuislands.onboarding.OnboardingOrchestrator
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import java.io.File
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Behavioral locks for the focus-race protocol via [FocusWinningTabOpener.openOnEdt]
+ * (the EDT hop itself cannot dispatch headlessly — a source-level guard pins it
+ * instead, mirroring the `AyuIslandsStartupActivityTest` convention).
+ */
+class FocusWinningTabOpenerTest {
+    private val log = mockk<Logger>(relaxed = true)
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    // ------------------------------------------------------------------
+    // Focus check
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `auto trigger defers when a different project frame has focus`() {
+        val gate = SessionOneShot()
+        val target = project("alpha")
+        focusOn(project("beta"))
+        var opened = false
+        var succeeded = false
+
+        opener(gate).openOnEdt(
+            target,
+            bypassFocus = false,
+            bypassGate = false,
+            onSuccess = { succeeded = true },
+        ) { opened = true }
+
+        assertFalse(opened, "non-focused project must not open the tab")
+        assertFalse(succeeded, "deferring must not mark the feature as shown")
+        assertTrue(gate.tryAcquire(), "deferring must not consume the session claim")
+    }
+
+    @Test
+    fun `focused project opens the tab and runs the success callback`() {
+        val gate = SessionOneShot()
+        val target = project("alpha")
+        focusOn(target)
+        var opened = false
+        var succeeded = false
+
+        opener(gate).openOnEdt(
+            target,
+            bypassFocus = false,
+            bypassGate = false,
+            onSuccess = { succeeded = true },
+        ) { opened = true }
+
+        assertTrue(opened, "focused project must open the tab")
+        assertTrue(succeeded, "clean open must run the success callback")
+        assertFalse(gate.tryAcquire(), "successful open must keep the session claim")
+    }
+
+    // ------------------------------------------------------------------
+    // Cold-start CAS fallback
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `cold start with no focused frame lets exactly one project win the claim`() {
+        // Cold start / IDE minimized: `lastFocusedFrame` is null, so every
+        // window passes the focus check and the CAS decides — first caller
+        // wins, the rest bail without opening.
+        val gate = SessionOneShot()
+        focusOn(null)
+        val openedIn = mutableListOf<String>()
+        val sharedOpener = opener(gate)
+
+        sharedOpener.openOnEdt(
+            project("alpha"),
+            bypassFocus = false,
+            bypassGate = false,
+            onSuccess = {},
+        ) { openedIn += it.name }
+        sharedOpener.openOnEdt(
+            project("beta"),
+            bypassFocus = false,
+            bypassGate = false,
+            onSuccess = {},
+        ) { openedIn += it.name }
+
+        assertEquals(listOf("alpha"), openedIn, "first caller wins the CAS; second must bail")
+    }
+
+    @Test
+    fun `auto trigger bails when the session claim is already taken`() {
+        val gate = SessionOneShot()
+        assertTrue(gate.tryAcquire(), "pre-claim the gate to simulate a winning sibling window")
+        val target = project("alpha")
+        focusOn(target)
+        var opened = false
+        var succeeded = false
+
+        opener(gate).openOnEdt(
+            target,
+            bypassFocus = false,
+            bypassGate = false,
+            onSuccess = { succeeded = true },
+        ) { opened = true }
+
+        assertFalse(opened, "claim-lost window must not open a duplicate tab")
+        assertFalse(succeeded)
+    }
+
+    // ------------------------------------------------------------------
+    // Release-on-failure
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `failed open releases the claim so a later trigger can retry`() {
+        val gate = SessionOneShot()
+        val target = project("alpha")
+        focusOn(target)
+        var succeeded = false
+
+        opener(gate).openOnEdt(
+            target,
+            bypassFocus = false,
+            bypassGate = false,
+            onSuccess = { succeeded = true },
+        ) { throw IllegalStateException("editor subsystem not ready") }
+
+        assertFalse(succeeded, "failed open must not mark the feature as shown")
+        assertTrue(
+            gate.tryAcquire(),
+            "failed open must release the claim — otherwise one failure deadlocks the JVM session",
+        )
+    }
+
+    @Test
+    fun `onboarding wizard claim is released when the wizard open fails`() {
+        // Latent-bug regression lock: before the shared opener, the license
+        // path's copy of this protocol claimed the onboarding slot via
+        // `tryPick()` and never released it when `openFile` threw — one failed
+        // open permanently blocked the wizard for the whole JVM session.
+        // This exercises the exact opener configuration wired in
+        // `StartupLicenseHandler` against the real `OnboardingOrchestrator`
+        // gate (global state — reset in finally).
+        try {
+            val target = project("alpha")
+            focusOn(target)
+            val wizardOpener =
+                FocusWinningTabOpener(
+                    gate = OnboardingOrchestrator.gate,
+                    log = log,
+                    logPrefix = "Ayu onboarding",
+                    subject = "wizard",
+                )
+
+            wizardOpener.openOnEdt(
+                target,
+                bypassFocus = false,
+                bypassGate = false,
+                onSuccess = {},
+            ) { throw IllegalStateException("openFile failed") }
+
+            assertTrue(
+                OnboardingOrchestrator.gate.tryAcquire(),
+                "a failed wizard open must release the onboarding claim so a later window can retry",
+            )
+        } finally {
+            OnboardingOrchestrator.gate.resetForTesting()
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Manual bypass
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `manual trigger bypasses both the focus check and the gate`() {
+        val gate = SessionOneShot()
+        assertTrue(gate.tryAcquire(), "pre-claim the gate to prove manual bypasses it")
+        val target = project("alpha")
+        focusOn(project("beta"))
+        var opened = false
+        var succeeded = false
+
+        opener(gate).openOnEdt(
+            target,
+            bypassFocus = true,
+            bypassGate = true,
+            onSuccess = { succeeded = true },
+        ) { opened = true }
+
+        assertTrue(opened, "manual open must proceed even when unfocused and already claimed")
+        assertTrue(succeeded)
+    }
+
+    @Test
+    fun `manual failed open does not release another window's auto-trigger claim`() {
+        // A bypassed gate is never claimed by the manual path, so its failure
+        // handler must not release a claim that belongs to a sibling window.
+        val gate = SessionOneShot()
+        assertTrue(gate.tryAcquire(), "pre-claim the gate on behalf of another window")
+        val target = project("alpha")
+        focusOn(target)
+
+        opener(gate).openOnEdt(
+            target,
+            bypassFocus = true,
+            bypassGate = true,
+            onSuccess = {},
+        ) { throw IllegalStateException("boom") }
+
+        assertFalse(gate.tryAcquire(), "the sibling window's claim must stay held")
+    }
+
+    // ------------------------------------------------------------------
+    // Lifecycle guard
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `disposed project is a no-op and leaves the gate free`() {
+        val gate = SessionOneShot()
+        val target = mockk<Project> { every { isDisposed } returns true }
+        var opened = false
+
+        opener(gate).openOnEdt(
+            target,
+            bypassFocus = false,
+            bypassGate = false,
+            onSuccess = {},
+        ) { opened = true }
+
+        assertFalse(opened, "disposed project must not open anything")
+        assertTrue(gate.tryAcquire(), "disposed bail must not consume the claim")
+    }
+
+    // ------------------------------------------------------------------
+    // Source-level guards (EDT dispatch + launcher wiring)
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `open hops to EDT with nonModal modality around the protocol body`() {
+        // The invariant is source-level: dispatching through `Dispatchers.EDT`
+        // needs a live platform application unavailable in a plain unit test.
+        // Enforce the wrap statically so a future refactor cannot silently
+        // unwrap it (or drop the modality element) without this test failing.
+        val source = readSource("src/main/kotlin/dev/ayuislands/ui/FocusWinningTabOpener.kt")
+        val edtHop =
+            Regex(
+                """withContext\(Dispatchers\.EDT \+ ModalityState\.nonModal\(\)\.asContextElement\(\)\) \{\s*""" +
+                    """openOnEdt\(""",
+            )
+        assertTrue(
+            edtHop.containsMatchIn(source),
+            "open() must run openOnEdt inside " +
+                "withContext(Dispatchers.EDT + ModalityState.nonModal().asContextElement())",
+        )
+    }
+
+    @Test
+    fun `whats new launcher routes tab opens through the shared opener`() {
+        val source = readSource("src/main/kotlin/dev/ayuislands/whatsnew/WhatsNewLauncher.kt")
+        assertTrue(
+            source.contains("FocusWinningTabOpener("),
+            "WhatsNewLauncher must delegate the focus-race protocol to FocusWinningTabOpener",
+        )
+        assertTrue(
+            source.contains("gate = WhatsNewOrchestrator.gate"),
+            "WhatsNewLauncher's opener must claim through the What's New gate",
+        )
+    }
+
+    @Test
+    fun `license handler routes wizard opens through the shared opener with the onboarding gate`() {
+        // Wiring half of the latent-bug lock: the behavioral half above proves
+        // the opener releases on failure; this half proves the license path
+        // actually goes through the opener instead of a local copy without
+        // release-on-failure.
+        val source = readSource("src/main/kotlin/dev/ayuislands/StartupLicenseHandler.kt")
+        assertTrue(
+            source.contains("FocusWinningTabOpener("),
+            "StartupLicenseHandler must delegate the focus-race protocol to FocusWinningTabOpener",
+        )
+        assertTrue(
+            source.contains("gate = OnboardingOrchestrator.gate"),
+            "StartupLicenseHandler's opener must claim through the onboarding gate",
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    private fun opener(gate: SessionOneShot) =
+        FocusWinningTabOpener(
+            gate = gate,
+            log = log,
+            logPrefix = "Ayu test",
+            subject = "tab",
+        )
+
+    private fun project(named: String): Project =
+        mockk {
+            every { isDisposed } returns false
+            every { name } returns named
+        }
+
+    /** Stubs the global focus lookup; `null` simulates a cold start with no focused frame. */
+    private fun focusOn(focused: Project?) {
+        val frame = focused?.let { active -> mockk<IdeFrame> { every { project } returns active } }
+        val focusManager = mockk<IdeFocusManager> { every { lastFocusedFrame } returns frame }
+        mockkStatic(IdeFocusManager::class)
+        every { IdeFocusManager.getGlobalInstance() } returns focusManager
+    }
+
+    private fun readSource(path: String): String {
+        val source = File(path).takeIf { it.exists() }?.readText()
+        assertNotNull(source, "Could not locate $path for source-level guard")
+        return source
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/ui/SessionOneShotTest.kt
+++ b/src/test/kotlin/dev/ayuislands/ui/SessionOneShotTest.kt
@@ -1,0 +1,135 @@
+package dev.ayuislands.ui
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SessionOneShotTest {
+    @Test
+    fun `tryAcquire returns true on first call`() {
+        assertTrue(SessionOneShot().tryAcquire())
+    }
+
+    @Test
+    fun `tryAcquire returns false on subsequent calls`() {
+        val gate = SessionOneShot()
+        gate.tryAcquire()
+        assertFalse(gate.tryAcquire())
+    }
+
+    @Test
+    fun `resetForTesting re-enables tryAcquire`() {
+        val gate = SessionOneShot()
+        gate.tryAcquire()
+        gate.resetForTesting()
+        assertTrue(gate.tryAcquire())
+    }
+
+    @Test
+    fun `release re-enables tryAcquire after a failed open attempt`() {
+        // Production scenario: the opener's `tryAcquire()` succeeded, then the
+        // open action threw, leaving the gate stuck claimed. Without
+        // `release()` the JVM session is dead — no other window's auto-trigger
+        // and no manual menu reopen could ever fire again.
+        val gate = SessionOneShot()
+        assertTrue(gate.tryAcquire(), "first acquire must succeed")
+        assertFalse(gate.tryAcquire(), "second acquire must fail before release")
+        gate.release()
+        assertTrue(gate.tryAcquire(), "post-release acquire must succeed again")
+    }
+
+    @Test
+    fun `release reports whether it flipped a held claim`() {
+        // Callers gate their "released" log breadcrumb on the return value,
+        // so a stray release must report false instead of emitting a
+        // misleading signal.
+        val gate = SessionOneShot()
+        assertFalse(gate.release(), "release before any acquire must report no flip")
+        assertTrue(gate.tryAcquire())
+        assertTrue(gate.release(), "release of a held claim must report the flip")
+        assertFalse(gate.release(), "second release must report a no-op")
+    }
+
+    @Test
+    fun `release on un-claimed gate is a no-op`() {
+        // Idempotent — calling `release()` before any acquire must not flip
+        // state into an unexpected configuration.
+        val gate = SessionOneShot()
+        gate.release()
+        assertTrue(gate.tryAcquire(), "first acquire after stray release must still win")
+        assertFalse(gate.tryAcquire(), "second acquire must lose as usual")
+    }
+
+    @Test
+    fun `double release after single acquire is a no-op on the second call`() {
+        // The conditional `compareAndSet` in `release()` guarantees the second
+        // release from a caller that has already released (or was never
+        // claimed) doesn't re-open the gate. Pin this so a future refactor to
+        // an unconditional `set(false)` regresses in CI.
+        val gate = SessionOneShot()
+        gate.tryAcquire()
+        gate.release() // clears claim
+        assertTrue(gate.tryAcquire(), "acquire after release must succeed")
+        gate.release() // clears second claim
+        // A stray third release must NOT flip state — the next `tryAcquire` owns it.
+        gate.release()
+        assertTrue(gate.tryAcquire(), "gate stays healthy through stray release calls")
+    }
+
+    @Test
+    fun `instances are independent`() {
+        // Each feature (What's New tab, onboarding wizard) holds its own gate;
+        // claiming one must never suppress the other.
+        val first = SessionOneShot()
+        val second = SessionOneShot()
+        assertTrue(first.tryAcquire())
+        assertTrue(second.tryAcquire(), "claiming one gate must not claim another")
+    }
+
+    @Test
+    fun `tryAcquire is thread-safe under concurrent access from 100 threads`() {
+        // Multi-window startup race: 3 IDE windows can all schedule the open
+        // simultaneously after their delays elapse. Exactly one must claim.
+        // 100 threads is overkill for the actual scenario but flushes out any
+        // weak compareAndSet behavior under contention.
+        val gate = SessionOneShot()
+        val threadCount = 100
+        val startLatch = CountDownLatch(1)
+        val doneLatch = CountDownLatch(threadCount)
+        val trueCount = AtomicInteger(0)
+        val executor = Executors.newFixedThreadPool(threadCount)
+        try {
+            repeat(threadCount) {
+                executor.submit {
+                    try {
+                        startLatch.await()
+                        if (gate.tryAcquire()) {
+                            trueCount.incrementAndGet()
+                        }
+                    } finally {
+                        doneLatch.countDown()
+                    }
+                }
+            }
+            startLatch.countDown()
+            assertTrue(
+                doneLatch.await(5, TimeUnit.SECONDS),
+                "Worker threads did not finish within 5 seconds",
+            )
+        } finally {
+            executor.shutdownNow()
+        }
+
+        assertEquals(
+            1,
+            trueCount.get(),
+            "Exactly one of $threadCount concurrent callers must win tryAcquire()",
+        )
+        assertFalse(gate.tryAcquire(), "post-race calls must still return false")
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/whatsnew/WhatsNewOrchestratorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/whatsnew/WhatsNewOrchestratorTest.kt
@@ -1,120 +1,33 @@
 package dev.ayuislands.whatsnew
 
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicInteger
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
+import dev.ayuislands.onboarding.OnboardingOrchestrator
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
+/**
+ * CAS semantics (acquire/release/reset, thread safety) live in
+ * `dev.ayuislands.ui.SessionOneShotTest`. This file locks the
+ * orchestrator-level invariant instead: the What's New gate is a separate
+ * instance from the onboarding gate.
+ */
 class WhatsNewOrchestratorTest {
-    @BeforeTest
-    fun setUp() {
-        WhatsNewOrchestrator.resetForTesting()
-    }
-
-    @AfterTest
-    fun tearDown() {
-        WhatsNewOrchestrator.resetForTesting()
-    }
-
     @Test
-    fun `tryPick returns true on first call`() {
-        assertTrue(WhatsNewOrchestrator.tryPick())
-    }
-
-    @Test
-    fun `tryPick returns false on subsequent calls`() {
-        WhatsNewOrchestrator.tryPick()
-        assertFalse(WhatsNewOrchestrator.tryPick())
-    }
-
-    @Test
-    fun `resetForTesting re-enables tryPick`() {
-        WhatsNewOrchestrator.tryPick()
-        WhatsNewOrchestrator.resetForTesting()
-        assertTrue(WhatsNewOrchestrator.tryPick())
-    }
-
-    @Test
-    fun `release re-enables tryPick after a failed open attempt`() {
-        // Production scenario: launcher's tryPick() succeeded, then openFile
-        // threw, leaving the orchestrator stuck in shown=true. Without release()
-        // the JVM session is dead — no other window's auto-trigger and no
-        // manual menu reopen could ever fire again.
-        assertTrue(WhatsNewOrchestrator.tryPick(), "first pick must succeed")
-        assertFalse(WhatsNewOrchestrator.tryPick(), "second pick must fail before release")
-        WhatsNewOrchestrator.release()
-        assertTrue(WhatsNewOrchestrator.tryPick(), "post-release pick must succeed again")
-    }
-
-    @Test
-    fun `release on un-claimed orchestrator is a no-op`() {
-        // Idempotent — calling release() before any pick must not flip state
-        // into an unexpected configuration.
-        WhatsNewOrchestrator.release()
-        assertTrue(WhatsNewOrchestrator.tryPick(), "first pick after stray release must still win")
-        assertFalse(WhatsNewOrchestrator.tryPick(), "second pick must lose as usual")
-    }
-
-    @Test
-    fun `double release after single pick is a no-op on the second call`() {
-        // The conditional compareAndSet in release() guarantees the second
-        // release from a caller that has already released (or was never
-        // claimed) doesn't re-open the orchestrator gate and doesn't emit
-        // a misleading breadcrumb. Pin this so a future refactor to
-        // unconditional `shown.set(false)` regresses in CI.
-        WhatsNewOrchestrator.tryPick()
-        WhatsNewOrchestrator.release() // clears claim
-        assertTrue(WhatsNewOrchestrator.tryPick(), "pick after release must succeed")
-        WhatsNewOrchestrator.release() // clears second claim
-        // A stray third release must NOT flip state — the next tryPick owns it.
-        WhatsNewOrchestrator.release()
-        assertTrue(WhatsNewOrchestrator.tryPick(), "orchestrator stays healthy through stray release calls")
-    }
-
-    @Test
-    fun `tryPick is thread-safe under concurrent access from 100 threads`() {
-        // Multi-window startup race: 3 IDE windows can all schedule the open
-        // simultaneously after their delays elapse. Exactly one must claim.
-        // 100 threads is overkill for the actual scenario but flushes out any
-        // weak compareAndSet behavior under contention.
-        val threadCount = 100
-        val startLatch = CountDownLatch(1)
-        val doneLatch = CountDownLatch(threadCount)
-        val trueCount = AtomicInteger(0)
-        val executor = Executors.newFixedThreadPool(threadCount)
+    fun `whats new gate is independent from the onboarding wizard gate`() {
+        // A fresh installer who finishes the onboarding wizard must not
+        // accidentally suppress the next-version What's New tab in the same
+        // session — the two features claim through distinct gates. Both gates
+        // are global JVM state, so reset in finally.
         try {
-            repeat(threadCount) {
-                executor.submit {
-                    try {
-                        startLatch.await()
-                        if (WhatsNewOrchestrator.tryPick()) {
-                            trueCount.incrementAndGet()
-                        }
-                    } finally {
-                        doneLatch.countDown()
-                    }
-                }
-            }
-            startLatch.countDown()
+            assertTrue(OnboardingOrchestrator.gate.tryAcquire(), "onboarding claim must start free")
             assertTrue(
-                doneLatch.await(5, TimeUnit.SECONDS),
-                "Worker threads did not finish within 5 seconds",
+                WhatsNewOrchestrator.gate.tryAcquire(),
+                "an onboarding claim must not suppress the What's New tab in the same session",
             )
+            assertFalse(WhatsNewOrchestrator.gate.tryAcquire(), "second What's New pick must lose as usual")
         } finally {
-            executor.shutdownNow()
+            WhatsNewOrchestrator.gate.resetForTesting()
+            OnboardingOrchestrator.gate.resetForTesting()
         }
-
-        assertEquals(
-            1,
-            trueCount.get(),
-            "Exactly one of $threadCount concurrent callers must win tryPick()",
-        )
-        assertFalse(WhatsNewOrchestrator.tryPick(), "post-race calls must still return false")
     }
 }


### PR DESCRIPTION
── Summary ─────────────────────────────────

C6 from the architecture review. The focus-race protocol ("only the project window the user is actually viewing opens the tab; first CAS wins on cold start") was copy-pasted line-for-line between the What's New launcher and the license wizard scheduler, and its session gate was hand-rolled twice as bare AtomicBoolean orchestrators. One `FocusWinningTabOpener` now owns the race, one `SessionOneShot` value type owns the claim — and unification surfaced a real bug: the license path never released its claim after a failed open, so a single `openFile` throw permanently suppressed onboarding for the JVM session.

── Changes ─────────────────────────────────

| Type | Where | What |
|------|-------|------|
| Refactor | `src/main/kotlin/dev/ayuislands/ui/FocusWinningTabOpener.kt:41` | The shared protocol: EDT hop (`Dispatchers.EDT` + `nonModal`, preserved verbatim), disposed guard, focused-frame check, CAS claim, release-on-failure; manual triggers bypass focus + gate |
| Refactor | `src/main/kotlin/dev/ayuislands/ui/SessionOneShot.kt:15` | One CAS gate class; `release()` reports whether it flipped a held claim so defensive releases skip the misleading breadcrumb |
| Refactor | `src/main/kotlin/dev/ayuislands/whatsnew/WhatsNewLauncher.kt` | Delegates to the opener; stale-duplicate-tab cleanup stays launcher-local as the open action; `openIfEligible`/`openManually` signatures untouched |
| Fix | `src/main/kotlin/dev/ayuislands/StartupLicenseHandler.kt` | Wizard opens route through the opener — the failed-open claim leak is gone; wizard virtual files are now built inside the winning open action (losers no longer allocate) |
| Test | `src/test/kotlin/dev/ayuislands/ui/` | `SessionOneShotTest` (9, incl. the ported 100-thread race), `FocusWinningTabOpenerTest` (12: defer/claim/release/manual branches + wiring locks) |

── Validation ──────────────────────────────

```bash
./gradlew test detekt ktlintCheck koverVerify
```
Expected: green; `SessionOneShot` 100% covered, opener 88% (the only uncovered lines are the headless-undispatchable EDT hop, pinned by a source guard with a documented allowlist entry).

Manual: open two project windows, trigger What's New (version bump) — the focused window gets the tab, the other defers; force an open failure — the next activation retries instead of staying suppressed.

── Notes ───────────────────────────────────

- `OnboardingOrchestrator.resolve()` (the pure wizard decision table) intentionally stayed where it was — only the gate internals moved.
- Two log lines unified in wording; feature prefixes ("Ayu What's New:", "Ayu onboarding:") preserved for triage greps.
- Three guard-test-source-reads allowlist entries added, following the existing `AyuIslandsStartupActivityTest` "documented wiring compromise" precedent.

## Summary by Sourcery

Unify the focus-aware, single-window tab-opening protocol for onboarding and the What's New tab around shared utilities, and tighten their session claim behavior.

Bug Fixes:
- Ensure the onboarding wizard session gate releases its claim on failed open attempts so a single openFile failure no longer suppresses onboarding for the entire JVM session.
- Guarantee that the onboarding and What's New features use independent session gates so claiming one cannot accidentally block the other.

Enhancements:
- Introduce a reusable FocusWinningTabOpener to encapsulate the EDT hop, focus check, session gate claim, and release-on-failure logic for feature tabs.
- Introduce a SessionOneShot value type as the shared JVM-session claim gate for tab-opening features, and wire separate instances into the onboarding and What's New orchestrators.
- Simplify WhatsNewLauncher and StartupLicenseHandler by delegating tab/wizard opens to the shared opener while keeping feature-specific open behavior local.
- Update orchestrator tests to focus on decision-table behavior and gate independence rather than low-level CAS semantics, which are now covered by SessionOneShot tests.
- Add source-level guards and build configuration notes documenting the undispatchable EDT hop and opener wiring for test coverage accounting.

Build:
- Extend the Kover configuration comments to account for the refactored focus-race protocol living in FocusWinningTabOpener and the remaining untargeted UI paths.

Tests:
- Add comprehensive SessionOneShotTest coverage for acquire/release semantics, thread safety, and independence between gate instances.
- Add FocusWinningTabOpenerTest to cover focus handling, cold-start CAS behavior, manual bypass paths, failure-release behavior, lifecycle guards, and wiring to the launcher and license handler.
- Adjust WhatsNewOrchestratorTest and OnboardingOrchestratorTest to validate gate independence and the resolve state machine while relying on the shared SessionOneShot tests for CAS behavior.