### PR TITLE
refactor(accent): walk the resolution ladder once through one engine

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "7669ae5f"
+          last_verified_sha: "37059633"
           last_verified_date: "2026-06-30"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "7669ae5f"
+          last_verified_sha: "37059633"
           last_verified_date: "2026-06-30"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -304,7 +304,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "7669ae5f"
+          last_verified_sha: "37059633"
           last_verified_date: "2026-06-16"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -345,7 +345,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "7669ae5f"
+          last_verified_sha: "37059633"
           last_verified_date: "2026-06-16"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -397,7 +397,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "7669ae5f"
+          last_verified_sha: "37059633"
           last_verified_date: "2026-06-12"
           content_sha256: ad849b17308901bc2dac85f895978be656f578c9c31f857b9e9578e5cf4289f2
 
@@ -459,7 +459,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "7669ae5f"
+          last_verified_sha: "37059633"
           last_verified_date: "2026-06-16"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "37059633"
+          last_verified_sha: "55c741ec"
           last_verified_date: "2026-06-30"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "37059633"
+          last_verified_sha: "55c741ec"
           last_verified_date: "2026-06-30"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -304,7 +304,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "37059633"
+          last_verified_sha: "55c741ec"
           last_verified_date: "2026-06-16"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -345,7 +345,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "37059633"
+          last_verified_sha: "55c741ec"
           last_verified_date: "2026-06-16"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -397,7 +397,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "37059633"
+          last_verified_sha: "55c741ec"
           last_verified_date: "2026-06-12"
           content_sha256: ad849b17308901bc2dac85f895978be656f578c9c31f857b9e9578e5cf4289f2
 
@@ -459,7 +459,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "37059633"
+          last_verified_sha: "55c741ec"
           last_verified_date: "2026-06-16"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "e32e31e6"
+          last_verified_sha: "7669ae5f"
           last_verified_date: "2026-06-30"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "e32e31e6"
+          last_verified_sha: "7669ae5f"
           last_verified_date: "2026-06-30"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -304,7 +304,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "e32e31e6"
+          last_verified_sha: "7669ae5f"
           last_verified_date: "2026-06-16"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -345,7 +345,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "e32e31e6"
+          last_verified_sha: "7669ae5f"
           last_verified_date: "2026-06-16"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -397,7 +397,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "e32e31e6"
+          last_verified_sha: "7669ae5f"
           last_verified_date: "2026-06-12"
           content_sha256: ad849b17308901bc2dac85f895978be656f578c9c31f857b9e9578e5cf4289f2
 
@@ -459,7 +459,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "e32e31e6"
+          last_verified_sha: "7669ae5f"
           last_verified_date: "2026-06-16"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "7cfa00e9"
+          last_verified_sha: "e32e31e6"
           last_verified_date: "2026-06-30"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "7cfa00e9"
+          last_verified_sha: "e32e31e6"
           last_verified_date: "2026-06-30"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -304,7 +304,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "7cfa00e9"
+          last_verified_sha: "e32e31e6"
           last_verified_date: "2026-06-16"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -345,7 +345,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "7cfa00e9"
+          last_verified_sha: "e32e31e6"
           last_verified_date: "2026-06-16"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -397,7 +397,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "7cfa00e9"
+          last_verified_sha: "e32e31e6"
           last_verified_date: "2026-06-12"
           content_sha256: ad849b17308901bc2dac85f895978be656f578c9c31f857b9e9578e5cf4289f2
 
@@ -459,7 +459,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "7cfa00e9"
+          last_verified_sha: "e32e31e6"
           last_verified_date: "2026-06-16"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/scripts/guard-test-source-reads.py
+++ b/scripts/guard-test-source-reads.py
@@ -75,6 +75,10 @@ ALLOWLIST: dict[tuple[str, str], Allowance] = {
         "src/main/kotlin/dev/ayuislands/accent/AccentApplyPlanRunner.kt",
     ): Allowance(1, "banned platform API guard"),
     (
+        "src/test/kotlin/dev/ayuislands/accent/AccentResolutionChainBuilderGuardTest.kt",
+        "src/main/kotlin/dev/ayuislands/accent/AccentResolutionChainBuilder.kt",
+    ): Allowance(1, "documented unreachable-guard shape compromise (Pattern L)"),
+    (
         "src/test/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanelTest.kt",
         "src/main/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanel.kt",
     ): Allowance(1, "documented syntax panel static compromise"),

--- a/src/main/kotlin/dev/ayuislands/accent/AccentDetectorLookup.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentDetectorLookup.kt
@@ -1,0 +1,87 @@
+package dev.ayuislands.accent
+
+import com.intellij.openapi.project.Project
+
+/**
+ * How the resolution engine consults [ProjectLanguageDetector] per rung.
+ *
+ * The live resolver and the diagnostics chain intentionally diverge here: the
+ * live path may warm the detector cache (kick a scan) because its answer is
+ * applied to the UI, while diagnostics must stay read-only so opening Settings
+ * never schedules background work. On a cold cache the two can therefore
+ * disagree — live resolve may already serve a language override while the
+ * chain trace still shows "Detection pending". That asymmetry is a feature;
+ * this seam pins each caller's exact detector calls.
+ */
+internal sealed interface AccentDetectorLookup {
+    /**
+     * Verdict backing the language-override rung, or `null` when this lookup
+     * does not consult the detector for the given candidate set. A `null`
+     * marks the rung as "skipped" — the engine renders a skip step and the
+     * fallback rung later receives `null` as its consulted-verdict input.
+     */
+    fun languageRungVerdict(
+        project: Project,
+        hasLanguageCandidate: Boolean,
+        hasFallbackCandidate: Boolean,
+    ): ProjectLanguageVerdict?
+
+    /**
+     * Verdict backing the project-fallback rung's no-winner check.
+     * [languageRungVerdict] is the value the language rung consulted, or
+     * `null` when that rung was skipped (forced-language entry present, or a
+     * warming lookup with no language candidates).
+     */
+    fun fallbackRungVerdict(
+        project: Project,
+        languageRungVerdict: ProjectLanguageVerdict?,
+    ): ProjectLanguageVerdict
+
+    /**
+     * Read-only lookup for diagnostics surfaces: cache reads only, except the
+     * forced-language + fallback-candidate corner, which warms the cache
+     * (`warmCache = true`) so the fallback answer is not permanently stuck on
+     * "Detection pending".
+     */
+    data object CacheOnlyLookup : AccentDetectorLookup {
+        override fun languageRungVerdict(
+            project: Project,
+            hasLanguageCandidate: Boolean,
+            hasFallbackCandidate: Boolean,
+        ): ProjectLanguageVerdict? =
+            if (hasLanguageCandidate || hasFallbackCandidate) {
+                ProjectLanguageDetector.verdict(project)
+            } else {
+                null
+            }
+
+        override fun fallbackRungVerdict(
+            project: Project,
+            languageRungVerdict: ProjectLanguageVerdict?,
+        ): ProjectLanguageVerdict = languageRungVerdict ?: ProjectLanguageDetector.verdict(project, warmCache = true)
+    }
+
+    /**
+     * Live-resolve lookup: the language rung rides [ProjectLanguageDetector.dominant]
+     * (which warms the cache off the EDT and schedules a background scan on it),
+     * and the fallback rung warms only when the language rung was not consulted.
+     * `AccentResolverTest` pins this call pattern with interaction assertions —
+     * an extra warm call would schedule scans on projects with no override work.
+     */
+    data object WarmingLookup : AccentDetectorLookup {
+        override fun languageRungVerdict(
+            project: Project,
+            hasLanguageCandidate: Boolean,
+            hasFallbackCandidate: Boolean,
+        ): ProjectLanguageVerdict? {
+            if (!hasLanguageCandidate) return null
+            val dominantLanguageId = ProjectLanguageDetector.dominant(project) ?: return ProjectLanguageVerdict.Cold
+            return ProjectLanguageVerdict.Detected(dominantLanguageId, weights = null)
+        }
+
+        override fun fallbackRungVerdict(
+            project: Project,
+            languageRungVerdict: ProjectLanguageVerdict?,
+        ): ProjectLanguageVerdict = ProjectLanguageDetector.verdict(project, warmCache = languageRungVerdict == null)
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/accent/AccentDetectorLookup.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentDetectorLookup.kt
@@ -62,6 +62,33 @@ internal sealed interface AccentDetectorLookup {
     }
 
     /**
+     * Strictly read-only lookup for the pending cache-only preview: NO rung
+     * ever warms the cache, so merely opening or refreshing the read-only
+     * Settings resolution panel cannot enqueue a background scan. This
+     * reproduces the pre-engine pending walker exactly
+     * (`warmCache = !detectorConsulted && warmDetector` — always false when
+     * cacheOnly). Diagnostics chains use [CacheOnlyLookup] instead, whose
+     * fallback-corner warm-up is pre-existing pinned behavior.
+     */
+    data object StrictCacheOnlyLookup : AccentDetectorLookup {
+        override fun languageRungVerdict(
+            project: Project,
+            hasLanguageCandidate: Boolean,
+            hasFallbackCandidate: Boolean,
+        ): ProjectLanguageVerdict? =
+            if (hasLanguageCandidate || hasFallbackCandidate) {
+                ProjectLanguageDetector.verdict(project)
+            } else {
+                null
+            }
+
+        override fun fallbackRungVerdict(
+            project: Project,
+            languageRungVerdict: ProjectLanguageVerdict?,
+        ): ProjectLanguageVerdict = languageRungVerdict ?: ProjectLanguageDetector.verdict(project)
+    }
+
+    /**
      * Live-resolve lookup: the language rung rides [ProjectLanguageDetector.dominant]
      * (which warms the cache off the EDT and schedules a background scan on it),
      * and the fallback rung warms only when the language rung was not consulted.

--- a/src/main/kotlin/dev/ayuislands/accent/AccentHexPolicy.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentHexPolicy.kt
@@ -1,0 +1,49 @@
+package dev.ayuislands.accent
+
+/**
+ * How the resolution engine judges a stored hex before letting a rung win.
+ * The engine's consumers agree on ladder order but not on this judgment, so
+ * the policy is the seam that lets one engine serve all of them:
+ *
+ * - [STRICT] — only a valid `#RRGGBB` wins; invalid values fall through to the
+ *   next rung. Used by the diagnostics chain ([AccentResolver.resolveChain])
+ *   and the external-theme resolve, which must never propagate a raw invalid
+ *   hex into the applicator.
+ * - [LENIENT] — valid hex wins normalized (trimmed); an invalid value still
+ *   wins verbatim EXCEPT on the language-fallback rung, which always validates.
+ *   Used by the native-variant [AccentResolver.resolve] / [AccentResolver.source]
+ *   pair, where an invalid stored override must still report its source instead
+ *   of silently claiming the global accent is active.
+ * - [RAW] — everything wins verbatim. Used by the Settings pending preview,
+ *   whose model values are already normalized at entry; validating again here
+ *   would hide a broken entry path instead of surfacing it.
+ */
+internal enum class AccentHexPolicy {
+    STRICT,
+    LENIENT,
+    RAW,
+    ;
+
+    /**
+     * Returns the hex that [source]'s rung may win with, or `null` when the
+     * rung must fall through to the next one.
+     */
+    fun accept(
+        source: AccentResolver.Source,
+        rawHex: String,
+    ): String? =
+        when (this) {
+            STRICT -> {
+                AccentHex.of(rawHex)?.value
+            }
+
+            LENIENT -> {
+                AccentHex.of(rawHex)?.value
+                    ?: rawHex.takeUnless { source == AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE }
+            }
+
+            RAW -> {
+                rawHex
+            }
+        }
+}

--- a/src/main/kotlin/dev/ayuislands/accent/AccentMappingsView.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentMappingsView.kt
@@ -1,0 +1,88 @@
+package dev.ayuislands.accent
+
+import dev.ayuislands.settings.mappings.AccentMappingsSettings
+import dev.ayuislands.settings.mappings.AccentMappingsState
+
+/**
+ * Read-side contract over one accent-override mapping set, walked by
+ * [AccentResolutionChainBuilder] — the single resolution engine behind
+ * [AccentResolver.resolve], [AccentResolver.source], [AccentResolver.resolveChain],
+ * and the Settings pending preview. Abstracting the mapping reads is what lets the
+ * persisted state and the not-yet-applied Settings models share one priority-ladder
+ * walk instead of three hand-kept copies.
+ *
+ * All hex-valued reads return the stored value verbatim: whether an invalid or
+ * padded hex wins, loses, or passes through raw is the [AccentHexPolicy]'s decision,
+ * not the view's.
+ *
+ * [hasForcedLanguageEntry] is deliberately separate from [forcedLanguageId]:
+ * a forced entry whose id normalizes to `null` (blank after trim) must still
+ * suppress language detection — presence of the entry, not validity of the id,
+ * gates the detection rung.
+ */
+internal interface AccentMappingsView {
+    /** Raw project-override hex pinned to [projectKey], or `null` when none is stored. */
+    fun projectAccent(projectKey: String): String?
+
+    /** Normalized forced-language id for [projectKey]: trimmed, `null` when absent or blank. */
+    fun forcedLanguageId(projectKey: String): String?
+
+    /** Whether ANY forced-language entry exists for [projectKey], even a blank one. */
+    fun hasForcedLanguageEntry(projectKey: String): Boolean
+
+    /** Raw language-accent hex mapped to [languageId], or `null` when unmapped. */
+    fun languageAccent(languageId: String): String?
+
+    /** Whether at least one language-accent mapping exists. */
+    val hasLanguageAccents: Boolean
+
+    /** Normalized language-fallback hex: trimmed, `null` when absent or blank. */
+    val languageFallbackAccent: String?
+
+    /** Raw project-fallback hex for [projectKey], or `null` when none is stored. */
+    fun projectFallbackAccent(projectKey: String): String?
+
+    /** Whether a project-fallback entry exists for [projectKey]. */
+    fun hasProjectFallbackCandidate(projectKey: String): Boolean
+}
+
+/**
+ * [AccentMappingsView] over the persisted [AccentMappingsState].
+ *
+ * The state is read lazily so constructing a view (e.g. as a default argument)
+ * never touches the [AccentMappingsSettings] service before the engine's license
+ * and project gates have passed — unlicensed and no-project resolutions must stay
+ * zero-cost.
+ *
+ * Normalization note: [forcedLanguageId] and [languageFallbackAccent] are
+ * trim-and-blank-filtered here, once, for every consumer. Blank or padded
+ * hand-edited XML entries therefore resolve identically for the live accent and
+ * the diagnostics trace — the live resolver's semantics, which treat such
+ * entries as absent rather than as unmatchable lookup keys.
+ */
+internal class PersistedAccentMappingsView(
+    stateSupplier: () -> AccentMappingsState = { AccentMappingsSettings.getInstance().state },
+) : AccentMappingsView {
+    private val state: AccentMappingsState by lazy(LazyThreadSafetyMode.NONE, stateSupplier)
+
+    override fun projectAccent(projectKey: String): String? = state.projectAccents[projectKey]
+
+    override fun forcedLanguageId(projectKey: String): String? =
+        state.forcedProjectLanguages[projectKey]?.trim()?.takeIf { it.isNotEmpty() }
+
+    override fun hasForcedLanguageEntry(projectKey: String): Boolean =
+        state.forcedProjectLanguages.containsKey(projectKey)
+
+    override fun languageAccent(languageId: String): String? = state.languageAccents[languageId]
+
+    override val hasLanguageAccents: Boolean
+        get() = state.languageAccents.isNotEmpty()
+
+    override val languageFallbackAccent: String?
+        get() = state.languageFallbackAccent?.trim()?.takeIf { it.isNotEmpty() }
+
+    override fun projectFallbackAccent(projectKey: String): String? = state.projectFallbackAccents[projectKey]
+
+    override fun hasProjectFallbackCandidate(projectKey: String): Boolean =
+        state.projectFallbackAccents.containsKey(projectKey)
+}

--- a/src/main/kotlin/dev/ayuislands/accent/AccentResolutionChainBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentResolutionChainBuilder.kt
@@ -48,7 +48,7 @@ internal object AccentResolutionChainBuilder {
     ): AccentResolutionChain {
         val globalAccent = AyuIslandsSettings.getInstance().getAccentForVariant(variant)
         val steps = mutableListOf<AccentResolutionStep>()
-        val verdict = collectOverrideChainSteps(project, steps)
+        val verdict = collectOverrideChainSteps(project, steps, AccentResolutionRequest.diagnostics())
         val winner =
             steps.firstOrNull { it.outcome == StepOutcome.WON }
                 ?: AccentResolutionStep(
@@ -81,7 +81,7 @@ internal object AccentResolutionChainBuilder {
             return AccentResolutionChain(listOf(step), step, null)
         }
 
-        val verdict = collectOverrideChainSteps(project, steps)
+        val verdict = collectOverrideChainSteps(project, steps, AccentResolutionRequest.diagnostics())
         collectUiColorStep(
             steps,
             Source.MATERIAL_THEME,
@@ -139,7 +139,7 @@ internal object AccentResolutionChainBuilder {
     private fun collectOverrideChainSteps(
         project: Project?,
         steps: MutableList<AccentResolutionStep>,
-        request: AccentResolutionRequest = AccentResolutionRequest.diagnostics(),
+        request: AccentResolutionRequest,
     ): ProjectLanguageVerdict? {
         if (!LicenseChecker.isLicensedOrGrace()) {
             collectPremiumUnavailableSteps(steps, StepOutcome.LICENSE_BLOCKED, DETAIL_LICENSE_BLOCKED)

--- a/src/main/kotlin/dev/ayuislands/accent/AccentResolutionChainBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentResolutionChainBuilder.kt
@@ -1,17 +1,36 @@
 package dev.ayuislands.accent
 
 import com.intellij.lang.Language
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
-import dev.ayuislands.settings.mappings.AccentMappingsSettings
-import dev.ayuislands.settings.mappings.AccentMappingsState
 import java.awt.Color
 import java.util.Locale
 
 private typealias Source = AccentResolver.Source
 
+/**
+ * The single accent-resolution engine: one walk of the override priority
+ * ladder (project override → forced language → language override / fallback →
+ * project fallback), parameterized by an [AccentResolutionRequest].
+ *
+ * Every consumer is a projection of the same walk:
+ * - [resolveAyu] / [resolveExternal] build the full diagnostics trace
+ *   (steps + winner + verdict) for the status-bar widget and Settings.
+ * - [overrideWinner] reduces the walk to its winning `(source, hex)` pair —
+ *   the projection behind [AccentResolver.resolve], [AccentResolver.source],
+ *   and the Settings pending preview in
+ *   `dev.ayuislands.settings.mappings.OverridesGroupBuilder`.
+ *
+ * Parity between hex, source label, and the rendered chain therefore holds by
+ * construction: they cannot disagree on ladder order, license gating, or
+ * short-circuit points, only on the seams a request explicitly selects
+ * (mapping source, detector consultation, hex validation).
+ */
 internal object AccentResolutionChainBuilder {
+    private val LOG = logger<AccentResolutionChainBuilder>()
+
     private const val PROPORTIONS_TOP_N = 3
     private const val NO_WINNER_TOP_N = 2
     private const val PERCENTAGE_SCALE = 100
@@ -90,9 +109,37 @@ internal object AccentResolutionChainBuilder {
         return AccentResolutionChain(steps, winner, verdict)
     }
 
+    /**
+     * Runs one ladder walk for [request] and reduces it to the winning
+     * override, or `null` when no override rung won (the caller then serves
+     * its own global / external fallback). This is the ONLY reduction from
+     * chain to accent — [AccentResolver.resolve] and [AccentResolver.source]
+     * both go through here, so their answers agree by construction.
+     */
+    fun overrideWinner(
+        project: Project?,
+        request: AccentResolutionRequest,
+    ): ResolvedAccent? {
+        val steps = mutableListOf<AccentResolutionStep>()
+        collectOverrideChainSteps(project, steps, request)
+        val winner = steps.firstOrNull { it.outcome == StepOutcome.WON } ?: return null
+        val hex = winner.hex
+        if (hex == null) {
+            // Unreachable today: every WON step built by collectOverrideChainSteps carries a
+            // non-null hex. Lock kept against future step-construction refactors — degrading a
+            // hex-less winner to "no override" keeps callers on their global fallback instead
+            // of pushing a null hex toward the applicator. Source-locked in
+            // `AccentResolutionChainBuilderGuardTest`.
+            LOG.warn("Override winner ${winner.source} carried no hex; treating as no override")
+            return null
+        }
+        return ResolvedAccent(winner.source, hex)
+    }
+
     private fun collectOverrideChainSteps(
         project: Project?,
         steps: MutableList<AccentResolutionStep>,
+        request: AccentResolutionRequest = AccentResolutionRequest.diagnostics(),
     ): ProjectLanguageVerdict? {
         if (!LicenseChecker.isLicensedOrGrace()) {
             collectPremiumUnavailableSteps(steps, StepOutcome.LICENSE_BLOCKED, DETAIL_LICENSE_BLOCKED)
@@ -108,38 +155,32 @@ internal object AccentResolutionChainBuilder {
             return null
         }
 
-        val mappings = AccentMappingsSettings.getInstance().state
         val projectKey = AccentResolver.projectKey(activeProject)
         if (projectKey == null) {
             collectPremiumUnavailableSteps(steps, StepOutcome.NOT_APPLICABLE, DETAIL_NO_PROJECT_KEY)
             return null
         }
 
-        if (collectProjectOverrideStep(projectKey, mappings, steps)) {
+        if (collectProjectOverrideStep(projectKey, request, steps)) {
+            return null
+        }
+        if (collectForcedLanguageStep(request.view.forcedLanguageId(projectKey), request, steps)) {
             return null
         }
 
-        val forcedLanguageId = mappings.forcedProjectLanguages[projectKey]
-        if (collectForcedLanguageStep(forcedLanguageId, mappings, steps)) {
-            return null
-        }
-        val hasProjectFallbackCandidate = mappings.projectFallbackAccents.containsKey(projectKey)
-
-        val verdict =
-            collectLanguageOverrideStep(
-                forcedLanguageId = forcedLanguageId,
-                mappings = mappings,
-                activeProject = activeProject,
-                steps = steps,
-                shouldConsultForProjectFallback = hasProjectFallbackCandidate,
-            )
-                ?: return null
+        val hasForcedLanguageEntry = request.view.hasForcedLanguageEntry(projectKey)
+        val hasFallbackCandidate = request.view.hasProjectFallbackCandidate(projectKey)
+        val languageVerdict =
+            collectLanguageOverrideStep(activeProject, hasForcedLanguageEntry, hasFallbackCandidate, request, steps)
         if (steps.lastOrNull()?.outcome == StepOutcome.WON) {
-            return verdict
+            return languageVerdict
+        }
+        if (languageVerdict == null && !hasFallbackCandidate) {
+            return null
         }
 
-        collectProjectFallbackStep(projectKey, verdict, mappings, steps)
-        return verdict
+        val fallbackVerdict = collectProjectFallbackStep(projectKey, activeProject, languageVerdict, request, steps)
+        return languageVerdict ?: fallbackVerdict
     }
 
     private fun collectPremiumUnavailableSteps(
@@ -161,10 +202,10 @@ internal object AccentResolutionChainBuilder {
 
     private fun collectProjectOverrideStep(
         projectKey: String,
-        mappings: AccentMappingsState,
+        request: AccentResolutionRequest,
         steps: MutableList<AccentResolutionStep>,
     ): Boolean {
-        val projectAccent = mappings.projectAccents[projectKey]
+        val projectAccent = request.view.projectAccent(projectKey)
         if (projectAccent == null) {
             steps.add(
                 AccentResolutionStep(Source.PROJECT_OVERRIDE, null, StepOutcome.NOT_SET, "No project override set"),
@@ -172,7 +213,7 @@ internal object AccentResolutionChainBuilder {
             return false
         }
 
-        val hex = AccentHex.of(projectAccent)?.value
+        val hex = request.policy.accept(Source.PROJECT_OVERRIDE, projectAccent)
         if (hex != null) {
             steps.add(
                 AccentResolutionStep(Source.PROJECT_OVERRIDE, hex, StepOutcome.WON, "Pinned accent for this project"),
@@ -188,7 +229,7 @@ internal object AccentResolutionChainBuilder {
 
     private fun collectForcedLanguageStep(
         forcedLanguageId: String?,
-        mappings: AccentMappingsState,
+        request: AccentResolutionRequest,
         steps: MutableList<AccentResolutionStep>,
     ): Boolean {
         if (forcedLanguageId == null) {
@@ -203,7 +244,7 @@ internal object AccentResolutionChainBuilder {
             return false
         }
 
-        val forcedAccent = mappings.languageAccents[forcedLanguageId]
+        val forcedAccent = request.view.languageAccent(forcedLanguageId)
         if (forcedAccent == null) {
             steps.add(
                 AccentResolutionStep(
@@ -214,13 +255,13 @@ internal object AccentResolutionChainBuilder {
                 ),
             )
             return collectLanguageFallbackStep(
-                mappings.languageFallbackAccent,
+                request,
                 "Language fallback for forced ${displayNameFor(forcedLanguageId)}",
                 steps,
             )
         }
 
-        val hex = AccentHex.of(forcedAccent)?.value
+        val hex = request.policy.accept(Source.FORCED_LANGUAGE_OVERRIDE, forcedAccent)
         if (hex != null) {
             steps.add(
                 AccentResolutionStep(
@@ -242,44 +283,51 @@ internal object AccentResolutionChainBuilder {
             ),
         )
         return collectLanguageFallbackStep(
-            mappings.languageFallbackAccent,
+            request,
             "Language fallback for forced ${displayNameFor(forcedLanguageId)}",
             steps,
         )
     }
 
+    /**
+     * Language-override rung. Returns the verdict the detector produced, or
+     * `null` when the rung was skipped — either because a forced-language
+     * entry suppresses detection (any entry, even a blank-id one) or because
+     * the [AccentDetectorLookup] declined to consult for the candidate set.
+     */
     private fun collectLanguageOverrideStep(
-        forcedLanguageId: String?,
-        mappings: AccentMappingsState,
         activeProject: Project,
+        hasForcedLanguageEntry: Boolean,
+        hasFallbackCandidate: Boolean,
+        request: AccentResolutionRequest,
         steps: MutableList<AccentResolutionStep>,
-        shouldConsultForProjectFallback: Boolean,
     ): ProjectLanguageVerdict? {
-        val hasLanguageCandidate =
-            mappings.languageAccents.isNotEmpty() ||
-                mappings.languageFallbackAccent != null
-        if (forcedLanguageId != null) {
-            collectSkippedLanguageOverrideStep(forcedLanguageId, steps)
-            return if (shouldConsultForProjectFallback) {
-                ProjectLanguageDetector.verdict(activeProject, warmCache = true)
-            } else {
-                null
-            }
-        }
-        if (!hasLanguageCandidate && !shouldConsultForProjectFallback) {
-            collectSkippedLanguageOverrideStep(forcedLanguageId, steps)
+        if (hasForcedLanguageEntry) {
+            collectSkippedLanguageOverrideStep(hasForcedLanguageEntry = true, steps)
             return null
         }
-
-        val verdict = ProjectLanguageDetector.verdict(activeProject)
+        val hasLanguageCandidate = request.view.hasLanguageAccents || request.view.languageFallbackAccent != null
+        val verdict = request.lookup.languageRungVerdict(activeProject, hasLanguageCandidate, hasFallbackCandidate)
+        if (verdict == null) {
+            collectSkippedLanguageOverrideStep(hasForcedLanguageEntry = false, steps)
+            return null
+        }
         when (verdict) {
-            is ProjectLanguageVerdict.Detected -> collectDetectedLanguageStep(verdict, mappings, steps)
-            is ProjectLanguageVerdict.NoWinner -> collectNoWinnerLanguageStep(verdict, steps)
-            ProjectLanguageVerdict.Cold ->
+            is ProjectLanguageVerdict.Detected -> {
+                collectDetectedLanguageStep(verdict, request, steps)
+            }
+
+            is ProjectLanguageVerdict.NoWinner -> {
+                collectNoWinnerLanguageStep(verdict, steps)
+            }
+
+            ProjectLanguageVerdict.Cold -> {
                 steps.add(
                     AccentResolutionStep(Source.LANGUAGE_OVERRIDE, null, StepOutcome.NOT_SET, "Detection pending"),
                 )
-            ProjectLanguageVerdict.Empty ->
+            }
+
+            ProjectLanguageVerdict.Empty -> {
                 steps.add(
                     AccentResolutionStep(
                         Source.LANGUAGE_OVERRIDE,
@@ -288,7 +336,9 @@ internal object AccentResolutionChainBuilder {
                         "No project languages detected",
                     ),
                 )
-            ProjectLanguageVerdict.Unavailable ->
+            }
+
+            ProjectLanguageVerdict.Unavailable -> {
                 steps.add(
                     AccentResolutionStep(
                         Source.LANGUAGE_OVERRIDE,
@@ -297,21 +347,22 @@ internal object AccentResolutionChainBuilder {
                         "Language detection unavailable",
                     ),
                 )
+            }
         }
         return verdict
     }
 
     private fun collectSkippedLanguageOverrideStep(
-        forcedLanguageId: String?,
+        hasForcedLanguageEntry: Boolean,
         steps: MutableList<AccentResolutionStep>,
     ) {
         val detail =
-            if (forcedLanguageId != null) {
+            if (hasForcedLanguageEntry) {
                 "Skipped — forced language takes priority"
             } else {
                 "No language accent mappings configured"
             }
-        val outcome = if (forcedLanguageId != null) StepOutcome.NOT_APPLICABLE else StepOutcome.NOT_SET
+        val outcome = if (hasForcedLanguageEntry) StepOutcome.NOT_APPLICABLE else StepOutcome.NOT_SET
         steps.add(AccentResolutionStep(Source.LANGUAGE_OVERRIDE, null, outcome, detail))
     }
 
@@ -339,11 +390,11 @@ internal object AccentResolutionChainBuilder {
 
     private fun collectDetectedLanguageStep(
         verdict: ProjectLanguageVerdict.Detected,
-        mappings: AccentMappingsState,
+        request: AccentResolutionRequest,
         steps: MutableList<AccentResolutionStep>,
     ) {
-        val langAccent = mappings.languageAccents[verdict.languageId]
-        val hex = langAccent?.let { AccentHex.of(it)?.value }
+        val languageAccent = request.view.languageAccent(verdict.languageId)
+        val hex = languageAccent?.let { request.policy.accept(Source.LANGUAGE_OVERRIDE, it) }
         if (hex != null) {
             steps.add(
                 AccentResolutionStep(
@@ -365,26 +416,33 @@ internal object AccentResolutionChainBuilder {
             ),
         )
         collectLanguageFallbackStep(
-            mappings.languageFallbackAccent,
+            request,
             "Language fallback for ${displayNameFor(verdict.languageId)}",
             steps,
         )
     }
 
+    /**
+     * Project-fallback rung. Returns the verdict it consulted, or `null`
+     * when no fallback accent is stored — in that case the detector is not
+     * consulted at all — the zero-work guarantee live resolution relies on.
+     */
     private fun collectProjectFallbackStep(
         projectKey: String,
-        verdict: ProjectLanguageVerdict,
-        mappings: AccentMappingsState,
+        activeProject: Project,
+        languageVerdict: ProjectLanguageVerdict?,
+        request: AccentResolutionRequest,
         steps: MutableList<AccentResolutionStep>,
-    ) {
-        val fallbackHex = mappings.projectFallbackAccents[projectKey]
-        if (fallbackHex == null) {
+    ): ProjectLanguageVerdict? {
+        val fallbackAccent = request.view.projectFallbackAccent(projectKey)
+        if (fallbackAccent == null) {
             steps.add(
                 AccentResolutionStep(Source.PROJECT_FALLBACK, null, StepOutcome.NOT_SET, "No project fallback set"),
             )
-            return
+            return null
         }
 
+        val verdict = request.lookup.fallbackRungVerdict(activeProject, languageVerdict)
         if (verdict !is ProjectLanguageVerdict.NoWinner) {
             steps.add(
                 AccentResolutionStep(
@@ -394,10 +452,10 @@ internal object AccentResolutionChainBuilder {
                     "Fallback only applies when no dominant language",
                 ),
             )
-            return
+            return verdict
         }
 
-        val hex = AccentHex.of(fallbackHex)?.value
+        val hex = request.policy.accept(Source.PROJECT_FALLBACK, fallbackAccent)
         if (hex != null) {
             steps.add(
                 AccentResolutionStep(
@@ -417,15 +475,16 @@ internal object AccentResolutionChainBuilder {
                 ),
             )
         }
+        return verdict
     }
 
     private fun collectLanguageFallbackStep(
-        rawHex: String?,
+        request: AccentResolutionRequest,
         detail: String,
         steps: MutableList<AccentResolutionStep>,
     ): Boolean {
-        val fallbackHex = rawHex ?: return false
-        val hex = AccentHex.of(fallbackHex)?.value
+        val fallbackHex = request.view.languageFallbackAccent ?: return false
+        val hex = request.policy.accept(Source.LANGUAGE_FALLBACK_OVERRIDE, fallbackHex)
         if (hex != null) {
             steps.add(
                 AccentResolutionStep(

--- a/src/main/kotlin/dev/ayuislands/accent/AccentResolutionRequest.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentResolutionRequest.kt
@@ -1,0 +1,43 @@
+package dev.ayuislands.accent
+
+/**
+ * Bundle of the three seams that distinguish the accent-ladder consumers:
+ * where mappings are read from ([AccentMappingsView]), how the language
+ * detector is consulted ([AccentDetectorLookup]), and how stored hex values
+ * are judged ([AccentHexPolicy]). Ladder ORDER is fixed inside
+ * [AccentResolutionChainBuilder]; a request only selects the projection.
+ */
+internal class AccentResolutionRequest(
+    val view: AccentMappingsView,
+    val lookup: AccentDetectorLookup,
+    val policy: AccentHexPolicy,
+) {
+    companion object {
+        /**
+         * Read-only diagnostics walk over persisted state, backing
+         * [AccentResolver.resolveChain]: cache-only detector reads and strict
+         * hex validation, so the rendered trace never claims a win for a value
+         * the applicator would reject.
+         */
+        fun diagnostics(): AccentResolutionRequest =
+            AccentResolutionRequest(
+                view = PersistedAccentMappingsView(),
+                lookup = AccentDetectorLookup.CacheOnlyLookup,
+                policy = AccentHexPolicy.STRICT,
+            )
+
+        /**
+         * Live walk over persisted state, backing [AccentResolver.resolve] and
+         * [AccentResolver.source]: the detector cache may be warmed because the
+         * answer is applied to the UI. [policy] stays a parameter because the
+         * native and external resolve paths judge invalid hex differently
+         * ([AccentHexPolicy.LENIENT] vs [AccentHexPolicy.STRICT]).
+         */
+        fun liveResolve(policy: AccentHexPolicy): AccentResolutionRequest =
+            AccentResolutionRequest(
+                view = PersistedAccentMappingsView(),
+                lookup = AccentDetectorLookup.WarmingLookup,
+                policy = policy,
+            )
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt
@@ -2,10 +2,8 @@ package dev.ayuislands.accent
 
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
-import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
-import dev.ayuislands.settings.mappings.AccentMappingsSettings
 import org.jetbrains.annotations.TestOnly
 import java.awt.Color
 import java.io.File
@@ -30,8 +28,16 @@ import javax.swing.UIManager
  *  6. **Global** — [AyuIslandsSettings.getAccentForVariant] (which itself honors
  *     follow-system-accent and per-variant stored hex).
  *
+ * The ladder itself lives in ONE place — [AccentResolutionChainBuilder]. [resolve] and
+ * [source] are projections of that engine's winning step, and [resolveChain] renders the
+ * same walk as a diagnostics trace, so hex, source label, and chain cannot drift apart.
+ * The projections differ from diagnostics only in their [AccentResolutionRequest] seams:
+ * live resolution warms the detector cache ([AccentDetectorLookup.WarmingLookup]) and
+ * judges hex leniently ([AccentHexPolicy.LENIENT]) for native variants, while the
+ * external path validates strictly.
+ *
  * Per-project and per-language overrides are premium features: when the license check
- * fails, the resolver short-circuits to the global accent regardless of stored mappings.
+ * fails, the engine short-circuits to the global accent regardless of stored mappings.
  * The UI disables override add/edit for unlicensed users, but this guard protects against
  * trial expiry with previously-stored mappings and against manually imported settings XML.
  *
@@ -69,8 +75,8 @@ object AccentResolver {
     internal fun uiColorForDiagnostics(key: String): Color? = uiColor(key)
 
     /**
-     * Resolves the effective accent hex. Delegates to the shared override-traversal helper,
-     * falling back to the global per-variant accent when no override applies.
+     * Resolves the effective accent hex: the engine's override winner, falling back
+     * to the global per-variant accent when no override rung wins.
      */
     fun resolve(
         project: Project?,
@@ -86,11 +92,15 @@ object AccentResolver {
      * Returns which layer of the resolution chain produced the accent for [project].
      * Used by the settings UI to surface "Currently active: ... (project override)" context.
      *
-     * Mirrors the license gate in [resolve]: unlicensed callers always see [Source.GLOBAL],
-     * so the UI label does not claim a project/language override is "active" when the
-     * resolver is actually returning the global accent.
+     * Runs the same engine walk as [resolve] (same request seams), so the label and the
+     * applied hex agree by construction — unlicensed callers always see [Source.GLOBAL]
+     * because the engine's license gate fires before any mapping is read.
      */
-    fun source(project: Project?): Source = findOverride(project, validateHex = false)?.source ?: Source.GLOBAL
+    fun source(project: Project?): Source =
+        AccentResolutionChainBuilder
+            .overrideWinner(project, AccentResolutionRequest.liveResolve(AccentHexPolicy.LENIENT))
+            ?.source
+            ?: Source.GLOBAL
 
     fun source(
         project: Project?,
@@ -159,7 +169,9 @@ object AccentResolver {
             return storedExternalAccent(state)
         }
 
-        findOverride(project, validateHex = true)?.let { return it }
+        AccentResolutionChainBuilder
+            .overrideWinner(project, AccentResolutionRequest.liveResolve(AccentHexPolicy.STRICT))
+            ?.let { return it }
         uiColorAccent(MATERIAL_ACCENT_KEY, Source.MATERIAL_THEME)?.let { return it }
         uiColorAccent(COMPONENT_ACCENT_KEY, Source.IDE_ACCENT)?.let { return it }
         uiColorAccent(ACTIONS_BLUE_KEY, Source.IDE_ACCENT)?.let { return it }
@@ -176,7 +188,9 @@ object AccentResolver {
         variant: AyuVariant,
     ): ResolvedAccent {
         val globalAccent = AyuIslandsSettings.getInstance().getAccentForVariant(variant)
-        return findOverride(project, validateHex = false) ?: ResolvedAccent(Source.GLOBAL, globalAccent)
+        return AccentResolutionChainBuilder
+            .overrideWinner(project, AccentResolutionRequest.liveResolve(AccentHexPolicy.LENIENT))
+            ?: ResolvedAccent(Source.GLOBAL, globalAccent)
     }
 
     private fun resolveContext(
@@ -187,77 +201,6 @@ object AccentResolver {
             is AccentContext.Ayu -> resolveAyu(project, context.ayuVariant)
             AccentContext.External -> resolveExternal(project)
         }
-
-    private fun findOverride(
-        project: Project?,
-        validateHex: Boolean,
-    ): ResolvedAccent? {
-        if (!LicenseChecker.isLicensedOrGrace()) return null
-        val activeProject =
-            project
-                ?.takeUnless { it.isDefault }
-                ?.takeUnless { it.isDisposed }
-                ?: return null
-
-        val mappings = AccentMappingsSettings.getInstance().state
-        val projectKey = projectKey(activeProject) ?: return null
-        mappings.projectAccents[projectKey]
-            ?.let { rawHex -> overrideAccent(Source.PROJECT_OVERRIDE, rawHex, validateHex)?.let { return it } }
-
-        val languageRequest =
-            LanguageOverrideRequest(
-                languageAccents = mappings.languageAccents,
-                hasForcedLanguageEntry = mappings.forcedProjectLanguages.containsKey(projectKey),
-                forcedLanguageId = mappings.forcedProjectLanguages[projectKey]?.trim()?.takeIf { it.isNotEmpty() },
-                languageFallbackAccent = mappings.languageFallbackAccent?.trim()?.takeIf { it.isNotEmpty() },
-                validateHex = validateHex,
-            )
-        val hasProjectFallbackCandidate = mappings.projectFallbackAccents.containsKey(projectKey)
-        if (!languageRequest.hasResolutionWork && !hasProjectFallbackCandidate) return null
-
-        val (languageOverride, detectorConsulted) =
-            resolveLanguageOverride(
-                project = activeProject,
-                request = languageRequest,
-            )
-        languageOverride?.let { return it }
-        val fallbackAccent = mappings.projectFallbackAccents[projectKey] ?: return null
-        val fallbackVerdict = ProjectLanguageDetector.verdict(activeProject, warmCache = !detectorConsulted)
-        if (fallbackVerdict is ProjectLanguageVerdict.NoWinner) {
-            overrideAccent(Source.PROJECT_FALLBACK, fallbackAccent, validateHex)?.let { return it }
-        }
-        return null
-    }
-
-    private fun resolveLanguageOverride(
-        project: Project,
-        request: LanguageOverrideRequest,
-    ): Pair<ResolvedAccent?, Boolean> {
-        request.forcedLanguageId
-            ?.let { languageId ->
-                overrideAccentForLanguage(
-                    languageAccents = request.languageAccents,
-                    languageFallbackAccent = request.languageFallbackAccent,
-                    languageId = languageId,
-                    exactSource = Source.FORCED_LANGUAGE_OVERRIDE,
-                    validateHex = request.validateHex,
-                )?.let { return it to false }
-            }
-        if (!request.shouldDetectLanguage) return null to false
-        val resolvedAccent =
-            ProjectLanguageDetector
-                .dominant(project)
-                ?.let { languageId ->
-                    overrideAccentForLanguage(
-                        languageAccents = request.languageAccents,
-                        languageFallbackAccent = request.languageFallbackAccent,
-                        languageId = languageId,
-                        exactSource = Source.LANGUAGE_OVERRIDE,
-                        validateHex = request.validateHex,
-                    )
-                }
-        return resolvedAccent to true
-    }
 
     /**
      * Stable key for a [project]: the canonicalized absolute path of `basePath`.
@@ -381,55 +324,16 @@ object AccentResolver {
 
 private fun Color.toHex(): String = "#%02X%02X%02X".format(Locale.ROOT, red, green, blue)
 
-private data class LanguageOverrideRequest(
-    val languageAccents: Map<String, String>,
-    val hasForcedLanguageEntry: Boolean,
-    val forcedLanguageId: String?,
-    val languageFallbackAccent: String?,
-    val validateHex: Boolean,
-) {
-    private val hasLanguageCandidate = languageAccents.isNotEmpty() || languageFallbackAccent != null
-
-    val hasResolutionWork: Boolean =
-        hasLanguageCandidate && (forcedLanguageId != null || !hasForcedLanguageEntry)
-
-    val shouldDetectLanguage: Boolean =
-        hasLanguageCandidate && !hasForcedLanguageEntry
-}
-
-private data class ResolvedAccent(
+/**
+ * Winning `(source, hex)` pair of one override-ladder walk. Produced by
+ * [AccentResolutionChainBuilder.overrideWinner] and by the global / external
+ * fallbacks in [AccentResolver]; the `hex` is non-null by construction so no
+ * consumer needs a defensive null check before handing it to the applicator.
+ */
+internal data class ResolvedAccent(
     val source: AccentResolver.Source,
     val hex: String,
 )
-
-private fun overrideAccentForLanguage(
-    languageAccents: Map<String, String>,
-    languageFallbackAccent: String?,
-    languageId: String,
-    exactSource: AccentResolver.Source,
-    validateHex: Boolean,
-): ResolvedAccent? {
-    languageAccents[languageId]
-        ?.let { rawHex -> overrideAccent(exactSource, rawHex, validateHex) }
-        ?.let { return it }
-    return languageFallbackAccent
-        ?.let { rawHex -> overrideAccent(AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE, rawHex, validateHex) }
-}
-
-private fun overrideAccent(
-    source: AccentResolver.Source,
-    rawHex: String,
-    validateHex: Boolean,
-): ResolvedAccent? {
-    val accent = AccentHex.of(rawHex)
-    if (accent != null) {
-        return ResolvedAccent(source, accent.value)
-    }
-    if (!validateHex && source != AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE) {
-        return ResolvedAccent(source, rawHex)
-    }
-    return null
-}
 
 private fun storedExternalAccent(state: AyuIslandsState): ResolvedAccent {
     val hex = AccentHex.of(state.externalThemeAccent)?.value ?: AyuVariant.MIRAGE.defaultAccent

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
@@ -105,6 +105,7 @@ object ProjectLanguageDetector {
     fun proportions(project: Project): Map<String, Long>? =
         when (val cached = verdict(project)) {
             is ProjectLanguageVerdict.Detected -> cached.weights
+
             is ProjectLanguageVerdict.NoWinner,
             ProjectLanguageVerdict.Cold,
             ProjectLanguageVerdict.Empty,
@@ -308,9 +309,11 @@ object ProjectLanguageDetector {
             val outcome: ScanOutcome =
                 when (verdict) {
                     is ProjectLanguageVerdict.Detected -> ScanOutcome.Detected(verdict.languageId)
+
                     is ProjectLanguageVerdict.NoWinner,
                     ProjectLanguageVerdict.Empty,
                     -> ScanOutcome.Polyglot
+
                     ProjectLanguageVerdict.Cold,
                     ProjectLanguageVerdict.Unavailable,
                     -> ScanOutcome.Unavailable
@@ -330,6 +333,7 @@ object ProjectLanguageDetector {
                 is ScanOutcome.Detected,
                 ScanOutcome.Polyglot,
                 -> ProjectLanguageScanAsync.ScanResult.Completed
+
                 ScanOutcome.Unavailable -> ProjectLanguageScanAsync.ScanResult.Unavailable
             }
         }
@@ -510,8 +514,9 @@ object ProjectLanguageDetector {
     private fun legacySdkModuleDetection(project: Project): DetectionResult {
         // Both platform lookups wrap via runCatchingPreservingCancellation — `dominant`
         // is reachable from AyuIslandsStartupActivity.execute's coroutine body via
-        // AccentResolver.findOverride, and plain `runCatching` would swallow
-        // CancellationException and keep a cancelled coroutine alive.
+        // the resolution engine in [AccentResolutionChainBuilder], and plain
+        // `runCatching` would swallow CancellationException and keep a cancelled
+        // coroutine alive.
         val sdkResult =
             runCatchingPreservingCancellation {
                 ProjectRootManager
@@ -581,15 +586,20 @@ object ProjectLanguageDetector {
     private fun sdkNameLookupSecondary(lowered: String): String? =
         when {
             lowered.contains("ruby") -> "ruby"
+
             lowered.contains("php") -> "php"
+
             lowered.contains("dart") -> "dart"
+
             lowered.contains("scala") -> "scala"
+
             // "jdk" covers "OpenJDK", "AdoptOpenJDK", "Amazon Corretto JDK"; the
             // conjunction handles "Java SDK" / "JavaSDK" SDK type names where
             // lowercasing drops the word boundary and the letters never form
             // a "jdk" substring (j-a-v-a-s-d-k).
             lowered.contains("jdk") ||
                 (lowered.contains("java") && lowered.contains("sdk")) -> "java"
+
             else -> null
         }
 

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -452,9 +452,10 @@ class OverridesGroupBuilder(
 
     /**
      * Winning pending override for [project], or `null` when the global accent
-     * applies. Cache-only mode keeps the read-only detector contract of the
-     * Settings preview ([AccentDetectorLookup.CacheOnlyLookup]); the default
-     * warming mode mirrors live resolution. [AccentHexPolicy.RAW] because the
+     * applies. Cache-only mode keeps the strictly read-only detector contract
+     * of the Settings preview ([AccentDetectorLookup.StrictCacheOnlyLookup] —
+     * never schedules a scan); the default warming mode mirrors live
+     * resolution. [AccentHexPolicy.RAW] because the
      * pending models normalize values at entry — see [PendingAccentMappingsView].
      */
     private fun pendingOverrideWinner(
@@ -467,7 +468,7 @@ class OverridesGroupBuilder(
                 view = pendingMappingsView(),
                 lookup =
                     if (cacheOnly) {
-                        AccentDetectorLookup.CacheOnlyLookup
+                        AccentDetectorLookup.StrictCacheOnlyLookup
                     } else {
                         AccentDetectorLookup.WarmingLookup
                     },

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -10,13 +10,19 @@ import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.table.JBTable
 import com.intellij.util.messages.MessageBusConnection
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentDetectorLookup
 import dev.ayuislands.accent.AccentHex
+import dev.ayuislands.accent.AccentHexPolicy
+import dev.ayuislands.accent.AccentMappingsView
+import dev.ayuislands.accent.AccentResolutionChainBuilder
+import dev.ayuislands.accent.AccentResolutionRequest
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.LanguageDetectionRules
 import dev.ayuislands.accent.ProjectLanguageDetectionListener
 import dev.ayuislands.accent.ProjectLanguageDetector
 import dev.ayuislands.accent.ProjectLanguageVerdict
+import dev.ayuislands.accent.ResolvedAccent
 import dev.ayuislands.accent.runCatchingPreservingCancellation
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
@@ -393,21 +399,25 @@ class OverridesGroupBuilder(
     /**
      * Resolve the accent hex using the **pending** (not yet applied) overrides model.
      * Falls back to [fallbackGlobalHex] when no override matches.
+     *
+     * Projection of the shared [AccentResolutionChainBuilder] engine over
+     * [PendingAccentMappingsView] — the same ladder walk that serves the persisted
+     * [AccentResolver.resolve], so the preview cannot drift from post-Apply behavior.
      */
     fun resolvePending(
         project: Project?,
         fallbackGlobalHex: String,
         cacheOnly: Boolean = false,
-    ): String = findPendingOverride(project, warmDetector = !cacheOnly)?.hex ?: fallbackGlobalHex
+    ): String = pendingOverrideWinner(project, cacheOnly)?.hex ?: fallbackGlobalHex
 
     /**
      * Matching [AccentResolver.Source] for [project] under the **pending** overrides model.
+     * Same engine walk as [resolvePending], so hex and source label agree by construction.
      */
     fun sourcePending(
         project: Project?,
         cacheOnly: Boolean = false,
-    ): AccentResolver.Source =
-        findPendingOverride(project, warmDetector = !cacheOnly)?.source ?: AccentResolver.Source.GLOBAL
+    ): AccentResolver.Source = pendingOverrideWinner(project, cacheOnly)?.source ?: AccentResolver.Source.GLOBAL
 
     internal fun activeSourceDetailPending(
         project: Project?,
@@ -440,116 +450,39 @@ class OverridesGroupBuilder(
         return (verdict as? ProjectLanguageVerdict.Detected)?.let(::detectedLanguageDetail)
     }
 
-    private fun findPendingOverride(
+    /**
+     * Winning pending override for [project], or `null` when the global accent
+     * applies. Cache-only mode keeps the read-only detector contract of the
+     * Settings preview ([AccentDetectorLookup.CacheOnlyLookup]); the default
+     * warming mode mirrors live resolution. [AccentHexPolicy.RAW] because the
+     * pending models normalize values at entry — see [PendingAccentMappingsView].
+     */
+    private fun pendingOverrideWinner(
         project: Project?,
-        warmDetector: Boolean,
-    ): PendingResolvedAccent? {
-        if (!LicenseChecker.isLicensedOrGrace()) return null
-        val activeProject =
-            project
-                ?.takeUnless { it.isDefault }
-                ?.takeUnless { it.isDisposed }
-                ?: return null
-        val projectKey = AccentResolver.projectKey(activeProject) ?: return null
-        projectModel
-            .snapshot()
-            .firstOrNull { it.canonicalPath == projectKey }
-            ?.let { return PendingResolvedAccent(AccentResolver.Source.PROJECT_OVERRIDE, it.hex) }
-
-        val languageAccents = languageModel.snapshot().associate { it.languageId to it.hex }
-        val hasProjectFallbackCandidate = pendingFallbackAccents.containsKey(projectKey)
-
-        val cachedVerdict =
-            if (warmDetector) {
-                null
-            } else {
-                ProjectLanguageDetector.verdict(activeProject)
-            }
-        val languageOverride =
-            findPendingLanguageOverride(
-                activeProject = activeProject,
-                projectKey = projectKey,
-                languageAccents = languageAccents,
-                cachedVerdict = cachedVerdict,
-                warmDetector = warmDetector,
-            )
-        languageOverride.accent?.let { return it }
-        if (!languageOverride.hasResolutionWork && !hasProjectFallbackCandidate) return null
-
-        return findPendingFallbackOverride(
-            activeProject = activeProject,
-            projectKey = projectKey,
-            detectorConsulted = languageOverride.detectorConsulted,
-            cachedVerdict = cachedVerdict,
-            warmDetector = warmDetector,
+        cacheOnly: Boolean,
+    ): ResolvedAccent? =
+        AccentResolutionChainBuilder.overrideWinner(
+            project,
+            AccentResolutionRequest(
+                view = pendingMappingsView(),
+                lookup =
+                    if (cacheOnly) {
+                        AccentDetectorLookup.CacheOnlyLookup
+                    } else {
+                        AccentDetectorLookup.WarmingLookup
+                    },
+                policy = AccentHexPolicy.RAW,
+            ),
         )
-    }
 
-    private fun findPendingLanguageOverride(
-        activeProject: Project,
-        projectKey: String,
-        languageAccents: Map<String, String>,
-        cachedVerdict: ProjectLanguageVerdict?,
-        warmDetector: Boolean,
-    ): PendingLanguageOverrideResult {
-        val hasForcedLanguageEntry = pendingForcedLanguages.containsKey(projectKey)
-        val hasLanguageCandidate = languageAccents.isNotEmpty() || pendingLanguageFallbackAccent != null
-        pendingForcedLanguages[projectKey]
-            ?.let { languageId ->
-                pendingAccentForLanguage(
-                    languageAccents = languageAccents,
-                    languageId = languageId,
-                    exactSource = AccentResolver.Source.FORCED_LANGUAGE_OVERRIDE,
-                )
-            }?.let { return PendingLanguageOverrideResult(it, hasResolutionWork = true, detectorConsulted = false) }
-
-        val shouldDetectLanguage = !hasForcedLanguageEntry && hasLanguageCandidate
-        if (!shouldDetectLanguage) {
-            return PendingLanguageOverrideResult(
-                accent = null,
-                hasResolutionWork = hasLanguageCandidate && !hasForcedLanguageEntry,
-                detectorConsulted = false,
-            )
-        }
-
-        val accent =
-            pendingDetectedLanguageId(activeProject, cachedVerdict, warmDetector)
-                ?.let { languageId ->
-                    pendingAccentForLanguage(
-                        languageAccents = languageAccents,
-                        languageId = languageId,
-                        exactSource = AccentResolver.Source.LANGUAGE_OVERRIDE,
-                    )
-                }
-        return PendingLanguageOverrideResult(accent, hasResolutionWork = true, detectorConsulted = true)
-    }
-
-    private fun pendingDetectedLanguageId(
-        activeProject: Project,
-        cachedVerdict: ProjectLanguageVerdict?,
-        warmDetector: Boolean,
-    ): String? =
-        if (warmDetector) {
-            ProjectLanguageDetector.dominant(activeProject)
-        } else {
-            (cachedVerdict as? ProjectLanguageVerdict.Detected)?.languageId
-        }
-
-    private fun findPendingFallbackOverride(
-        activeProject: Project,
-        projectKey: String,
-        detectorConsulted: Boolean,
-        cachedVerdict: ProjectLanguageVerdict?,
-        warmDetector: Boolean,
-    ): PendingResolvedAccent? {
-        val fallbackAccent = pendingFallbackAccents[projectKey] ?: return null
-        val verdict =
-            cachedVerdict
-                ?: ProjectLanguageDetector.verdict(activeProject, warmCache = !detectorConsulted && warmDetector)
-        return fallbackAccent
-            .takeIf { verdict is ProjectLanguageVerdict.NoWinner }
-            ?.let { PendingResolvedAccent(AccentResolver.Source.PROJECT_FALLBACK, it) }
-    }
+    private fun pendingMappingsView(): AccentMappingsView =
+        PendingAccentMappingsView(
+            projectAccents = projectModel.snapshot().associate { it.canonicalPath to it.hex },
+            languageAccents = languageModel.snapshot().associate { it.languageId to it.hex },
+            forcedLanguages = pendingForcedLanguages,
+            projectFallbackAccents = pendingFallbackAccents,
+            languageFallbackAccent = pendingLanguageFallbackAccent,
+        )
 
     // Internals: pending-model resolver + UI wiring helpers
 
@@ -590,56 +523,14 @@ class OverridesGroupBuilder(
             verdict = verdict,
             forcedLanguageId = projectKey?.let(pendingForcedLanguages::get),
             fallbackHex = projectKey?.let(pendingFallbackAccents::get),
-            activeSource = diagnosticsSource(projectKey, verdict, licensed),
+            // Same cache-only engine walk as the "Currently active" label — the
+            // diagnostics row and the label can never disagree on the source.
+            activeSource = sourcePending(parentProject, cacheOnly = true),
             canMutate = licensed && projectKey != null,
             canRescan = licensed && projectKey != null,
             canSetFallbackToCurrentAccent = licensed && currentPendingAccentHex() != null,
         )
     }
-
-    private fun diagnosticsSource(
-        projectKey: String?,
-        verdict: ProjectLanguageVerdict,
-        isLicensed: Boolean,
-    ): AccentResolver.Source {
-        if (!isLicensed || projectKey == null) return AccentResolver.Source.GLOBAL
-        projectModel
-            .snapshot()
-            .firstOrNull { it.canonicalPath == projectKey }
-            ?.let { return AccentResolver.Source.PROJECT_OVERRIDE }
-
-        val languageIds = languageModel.snapshot().map { it.languageId }.toSet()
-        val forcedLanguageId = pendingForcedLanguages[projectKey]
-        if (forcedLanguageId != null && forcedLanguageId in languageIds) {
-            return AccentResolver.Source.FORCED_LANGUAGE_OVERRIDE
-        }
-        if (forcedLanguageId != null && pendingLanguageFallbackAccent != null) {
-            return AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE
-        }
-        if (forcedLanguageId == null &&
-            verdict is ProjectLanguageVerdict.Detected &&
-            verdict.languageId in languageIds
-        ) {
-            return AccentResolver.Source.LANGUAGE_OVERRIDE
-        }
-        if (forcedLanguageId == null &&
-            verdict is ProjectLanguageVerdict.Detected &&
-            pendingLanguageFallbackAccent != null
-        ) {
-            return AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE
-        }
-        return fallbackDiagnosticsSource(projectKey, verdict)
-    }
-
-    private fun fallbackDiagnosticsSource(
-        projectKey: String,
-        verdict: ProjectLanguageVerdict,
-    ): AccentResolver.Source =
-        if (pendingFallbackAccents.containsKey(projectKey) && verdict is ProjectLanguageVerdict.NoWinner) {
-            AccentResolver.Source.PROJECT_FALLBACK
-        } else {
-            AccentResolver.Source.GLOBAL
-        }
 
     private fun currentPendingAccentHex(): String? {
         val candidate = currentProjectOverrideHex() ?: currentGlobalAccentHex()
@@ -960,27 +851,6 @@ class OverridesGroupBuilder(
         }
     }
 
-    private data class PendingResolvedAccent(
-        val source: AccentResolver.Source,
-        val hex: String,
-    )
-
-    private data class PendingLanguageOverrideResult(
-        val accent: PendingResolvedAccent?,
-        val hasResolutionWork: Boolean,
-        val detectorConsulted: Boolean,
-    )
-
-    private fun pendingAccentForLanguage(
-        languageAccents: Map<String, String>,
-        languageId: String,
-        exactSource: AccentResolver.Source,
-    ): PendingResolvedAccent? =
-        languageAccents[languageId]
-            ?.let { PendingResolvedAccent(exactSource, it) }
-            ?: pendingLanguageFallbackAccent
-                ?.let { PendingResolvedAccent(AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE, it) }
-
     private class DimOrphanRenderer(
         private val orphanProbe: (Int) -> Boolean,
     ) : DefaultTableCellRenderer() {
@@ -1020,6 +890,45 @@ class OverridesGroupBuilder(
             return this
         }
     }
+}
+
+/**
+ * [AccentMappingsView] over the not-yet-applied Settings models, so the pending
+ * preview ("Currently active: ...") walks the exact same
+ * [dev.ayuislands.accent.AccentResolutionChainBuilder] ladder as the persisted
+ * resolver — parity by construction instead of by paired tests.
+ *
+ * Values arrive pre-normalized by [OverridesGroupBuilder]: table rows enforce
+ * `#RRGGBB` hex at construction, forced-language ids are trimmed/lowercased on
+ * entry, and fallback accents are dropped when malformed. The view therefore
+ * returns everything verbatim — re-normalizing here would mask a broken
+ * model-entry path instead of surfacing it.
+ *
+ * Construct with named arguments only: four of the five parameters share the
+ * `Map<String, String>` shape, so positional calls are a silent swap hazard.
+ */
+internal class PendingAccentMappingsView(
+    private val projectAccents: Map<String, String>,
+    private val languageAccents: Map<String, String>,
+    private val forcedLanguages: Map<String, String>,
+    private val projectFallbackAccents: Map<String, String>,
+    override val languageFallbackAccent: String?,
+) : AccentMappingsView {
+    override fun projectAccent(projectKey: String): String? = projectAccents[projectKey]
+
+    override fun forcedLanguageId(projectKey: String): String? = forcedLanguages[projectKey]
+
+    override fun hasForcedLanguageEntry(projectKey: String): Boolean = forcedLanguages.containsKey(projectKey)
+
+    override fun languageAccent(languageId: String): String? = languageAccents[languageId]
+
+    override val hasLanguageAccents: Boolean
+        get() = languageAccents.isNotEmpty()
+
+    override fun projectFallbackAccent(projectKey: String): String? = projectFallbackAccents[projectKey]
+
+    override fun hasProjectFallbackCandidate(projectKey: String): Boolean =
+        projectFallbackAccents.containsKey(projectKey)
 }
 
 /**

--- a/src/test/kotlin/dev/ayuislands/accent/AccentDetectorLookupTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentDetectorLookupTest.kt
@@ -94,6 +94,8 @@ class AccentDetectorLookupTest {
 
     @Test
     fun `cache-only fallback rung warms the cache when the language rung was skipped`() {
+        // Pre-existing diagnostics-chain behavior (pinned by AccentResolverChainTest):
+        // without the warm-up the fallback answer would stay "Detection pending" forever.
         val noWinner = ProjectLanguageVerdict.NoWinner(mapOf("kotlin" to 500L, "java" to 500L))
         every { ProjectLanguageDetector.verdict(project, warmCache = true) } returns noWinner
 
@@ -101,6 +103,40 @@ class AccentDetectorLookupTest {
 
         assertEquals(noWinner, verdict)
         verify(atLeast = 1) { ProjectLanguageDetector.verdict(project, warmCache = true) }
+    }
+
+    // StrictCacheOnlyLookup
+
+    @Test
+    fun `strict cache-only fallback rung never warms even when the language rung was skipped`() {
+        // The pending Settings preview is read-only: opening or refreshing the
+        // resolution panel must not enqueue a background scan (pre-engine
+        // pending-walker behavior, re-flagged by two independent reviews).
+        val cold = ProjectLanguageVerdict.Cold
+        every { ProjectLanguageDetector.verdict(project) } returns cold
+
+        val verdict =
+            AccentDetectorLookup.StrictCacheOnlyLookup.fallbackRungVerdict(project, languageRungVerdict = null)
+
+        assertEquals(cold, verdict)
+        verify(exactly = 0) { ProjectLanguageDetector.verdict(project, warmCache = true) }
+    }
+
+    @Test
+    fun `strict cache-only language rung reads the cached verdict without warming`() {
+        val detected = ProjectLanguageVerdict.Detected("kotlin", weights = null)
+        every { ProjectLanguageDetector.verdict(project) } returns detected
+
+        val verdict =
+            AccentDetectorLookup.StrictCacheOnlyLookup.languageRungVerdict(
+                project,
+                hasLanguageCandidate = true,
+                hasFallbackCandidate = false,
+            )
+
+        assertEquals(detected, verdict)
+        verify(exactly = 0) { ProjectLanguageDetector.verdict(project, warmCache = true) }
+        verify(exactly = 0) { ProjectLanguageDetector.dominant(project) }
     }
 
     // WarmingLookup

--- a/src/test/kotlin/dev/ayuislands/accent/AccentDetectorLookupTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentDetectorLookupTest.kt
@@ -1,0 +1,174 @@
+package dev.ayuislands.accent
+
+import com.intellij.openapi.project.Project
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Locks the exact [ProjectLanguageDetector] call pattern per lookup strategy.
+ * These interactions are contractual: resolver and pending tests pin them with
+ * `verify(exactly = 0)` / `verify(atLeast = 1)` assertions, so a drift here
+ * (e.g. the diagnostics path starting to warm the cache from Settings) would
+ * either schedule background scans from a read-only UI or leave the live
+ * resolver permanently cold.
+ */
+class AccentDetectorLookupTest {
+    private val project = mockk<Project>()
+
+    @BeforeTest
+    fun setUp() {
+        mockkObject(ProjectLanguageDetector)
+        every { ProjectLanguageDetector.dominant(any()) } returns null
+        every { ProjectLanguageDetector.verdict(any(), any<Boolean>()) } returns ProjectLanguageVerdict.Cold
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    // CacheOnlyLookup
+
+    @Test
+    fun `cache-only language rung reads the cached verdict when language candidates exist`() {
+        val detected = ProjectLanguageVerdict.Detected("kotlin", mapOf("kotlin" to 1_000L))
+        every { ProjectLanguageDetector.verdict(project) } returns detected
+
+        val verdict =
+            AccentDetectorLookup.CacheOnlyLookup.languageRungVerdict(
+                project,
+                hasLanguageCandidate = true,
+                hasFallbackCandidate = false,
+            )
+
+        assertEquals(detected, verdict)
+        verify(exactly = 0) { ProjectLanguageDetector.dominant(any()) }
+        verify(exactly = 0) { ProjectLanguageDetector.verdict(project, warmCache = true) }
+    }
+
+    @Test
+    fun `cache-only language rung consults for a fallback candidate even without language candidates`() {
+        val noWinner = ProjectLanguageVerdict.NoWinner(mapOf("kotlin" to 500L, "java" to 500L))
+        every { ProjectLanguageDetector.verdict(project) } returns noWinner
+
+        val verdict =
+            AccentDetectorLookup.CacheOnlyLookup.languageRungVerdict(
+                project,
+                hasLanguageCandidate = false,
+                hasFallbackCandidate = true,
+            )
+
+        assertEquals(noWinner, verdict)
+    }
+
+    @Test
+    fun `cache-only language rung skips the detector when nothing can use its answer`() {
+        assertNull(
+            AccentDetectorLookup.CacheOnlyLookup.languageRungVerdict(
+                project,
+                hasLanguageCandidate = false,
+                hasFallbackCandidate = false,
+            ),
+        )
+        verify(exactly = 0) { ProjectLanguageDetector.verdict(project) }
+    }
+
+    @Test
+    fun `cache-only fallback rung reuses the language rung verdict without a second read`() {
+        val noWinner = ProjectLanguageVerdict.NoWinner(mapOf("kotlin" to 500L, "java" to 500L))
+
+        val verdict = AccentDetectorLookup.CacheOnlyLookup.fallbackRungVerdict(project, noWinner)
+
+        assertEquals(noWinner, verdict)
+        verify(exactly = 0) { ProjectLanguageDetector.verdict(project, warmCache = true) }
+        verify(exactly = 0) { ProjectLanguageDetector.verdict(project) }
+    }
+
+    @Test
+    fun `cache-only fallback rung warms the cache when the language rung was skipped`() {
+        val noWinner = ProjectLanguageVerdict.NoWinner(mapOf("kotlin" to 500L, "java" to 500L))
+        every { ProjectLanguageDetector.verdict(project, warmCache = true) } returns noWinner
+
+        val verdict = AccentDetectorLookup.CacheOnlyLookup.fallbackRungVerdict(project, languageRungVerdict = null)
+
+        assertEquals(noWinner, verdict)
+        verify(atLeast = 1) { ProjectLanguageDetector.verdict(project, warmCache = true) }
+    }
+
+    // WarmingLookup
+
+    @Test
+    fun `warming language rung rides dominant and synthesizes a detected verdict`() {
+        every { ProjectLanguageDetector.dominant(project) } returns "kotlin"
+
+        val verdict =
+            AccentDetectorLookup.WarmingLookup.languageRungVerdict(
+                project,
+                hasLanguageCandidate = true,
+                hasFallbackCandidate = true,
+            )
+
+        assertEquals(ProjectLanguageVerdict.Detected("kotlin", weights = null), verdict)
+        verify(exactly = 0) { ProjectLanguageDetector.verdict(project) }
+    }
+
+    @Test
+    fun `warming language rung reports a cold verdict when dominant has no answer`() {
+        every { ProjectLanguageDetector.dominant(project) } returns null
+
+        val verdict =
+            AccentDetectorLookup.WarmingLookup.languageRungVerdict(
+                project,
+                hasLanguageCandidate = true,
+                hasFallbackCandidate = false,
+            )
+
+        assertEquals(ProjectLanguageVerdict.Cold, verdict)
+    }
+
+    @Test
+    fun `warming language rung never consults dominant without language candidates`() {
+        assertNull(
+            AccentDetectorLookup.WarmingLookup.languageRungVerdict(
+                project,
+                hasLanguageCandidate = false,
+                hasFallbackCandidate = true,
+            ),
+        )
+        verify(exactly = 0) { ProjectLanguageDetector.dominant(any()) }
+    }
+
+    @Test
+    fun `warming fallback rung reads cache-only when the language rung already consulted`() {
+        val noWinner = ProjectLanguageVerdict.NoWinner(mapOf("kotlin" to 500L, "java" to 500L))
+        every { ProjectLanguageDetector.verdict(project) } returns noWinner
+
+        val verdict =
+            AccentDetectorLookup.WarmingLookup.fallbackRungVerdict(
+                project,
+                languageRungVerdict = ProjectLanguageVerdict.Cold,
+            )
+
+        assertEquals(noWinner, verdict)
+        verify(exactly = 0) { ProjectLanguageDetector.verdict(project, warmCache = true) }
+    }
+
+    @Test
+    fun `warming fallback rung warms the cache when the language rung was skipped`() {
+        val noWinner = ProjectLanguageVerdict.NoWinner(mapOf("kotlin" to 500L, "java" to 500L))
+        every { ProjectLanguageDetector.verdict(project, warmCache = true) } returns noWinner
+
+        val verdict = AccentDetectorLookup.WarmingLookup.fallbackRungVerdict(project, languageRungVerdict = null)
+
+        assertEquals(noWinner, verdict)
+        verify(atLeast = 1) { ProjectLanguageDetector.verdict(project, warmCache = true) }
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/accent/AccentHexPolicyTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentHexPolicyTest.kt
@@ -1,0 +1,63 @@
+package dev.ayuislands.accent
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Locks the per-rung hex judgment that historically distinguished the three
+ * accent-ladder walkers. [AccentHexPolicy.LENIENT]'s language-fallback carve-out
+ * is the load-bearing branch: the live resolver has always rejected an invalid
+ * language fallback while letting every other rung pass invalid values through
+ * raw — flattening the policies would silently change which rung wins.
+ */
+class AccentHexPolicyTest {
+    @Test
+    fun `STRICT accepts only valid hex and normalizes padding`() {
+        assertEquals("#112233", AccentHexPolicy.STRICT.accept(AccentResolver.Source.PROJECT_OVERRIDE, "  #112233  "))
+        assertNull(AccentHexPolicy.STRICT.accept(AccentResolver.Source.PROJECT_OVERRIDE, "not-a-hex"))
+        assertNull(AccentHexPolicy.STRICT.accept(AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE, "not-a-hex"))
+    }
+
+    @Test
+    fun `LENIENT passes invalid hex through raw for non-fallback rungs`() {
+        assertEquals(
+            "not-a-hex",
+            AccentHexPolicy.LENIENT.accept(AccentResolver.Source.PROJECT_OVERRIDE, "not-a-hex"),
+        )
+        assertEquals(
+            "not-a-hex",
+            AccentHexPolicy.LENIENT.accept(AccentResolver.Source.FORCED_LANGUAGE_OVERRIDE, "not-a-hex"),
+        )
+        assertEquals(
+            "not-a-hex",
+            AccentHexPolicy.LENIENT.accept(AccentResolver.Source.LANGUAGE_OVERRIDE, "not-a-hex"),
+        )
+    }
+
+    @Test
+    fun `LENIENT rejects invalid hex on the language fallback rung`() {
+        assertNull(AccentHexPolicy.LENIENT.accept(AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE, "not-a-hex"))
+    }
+
+    @Test
+    fun `LENIENT normalizes valid hex on every rung including language fallback`() {
+        assertEquals(
+            "#73D0FF",
+            AccentHexPolicy.LENIENT.accept(AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE, " #73D0FF "),
+        )
+        assertEquals(
+            "#112233",
+            AccentHexPolicy.LENIENT.accept(AccentResolver.Source.PROJECT_FALLBACK, "#112233"),
+        )
+    }
+
+    @Test
+    fun `RAW passes every value through verbatim`() {
+        assertEquals("#112233", AccentHexPolicy.RAW.accept(AccentResolver.Source.PROJECT_OVERRIDE, "#112233"))
+        assertEquals(
+            "not-a-hex",
+            AccentHexPolicy.RAW.accept(AccentResolver.Source.LANGUAGE_FALLBACK_OVERRIDE, "not-a-hex"),
+        )
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/accent/AccentMappingsViewTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentMappingsViewTest.kt
@@ -1,0 +1,115 @@
+package dev.ayuislands.accent
+
+import dev.ayuislands.settings.mappings.AccentMappingsState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Behavioral contract of [PersistedAccentMappingsView]: given a persisted
+ * [AccentMappingsState], the view answers exactly what the resolution engine
+ * asks per rung. Locks the normalization split — forced-language ids and the
+ * language fallback are trimmed/blank-filtered (live-resolver semantics), while
+ * every hex value passes through verbatim so [AccentHexPolicy] stays the only
+ * place that judges validity.
+ */
+class AccentMappingsViewTest {
+    private fun viewOf(configure: AccentMappingsState.() -> Unit = {}): PersistedAccentMappingsView {
+        val state = AccentMappingsState().apply(configure)
+        return PersistedAccentMappingsView { state }
+    }
+
+    @Test
+    fun `projectAccent returns stored hex verbatim and null when absent`() {
+        val view =
+            viewOf {
+                projectAccents["/tmp/alpha"] = "not-a-hex"
+            }
+
+        assertEquals("not-a-hex", view.projectAccent("/tmp/alpha"))
+        assertNull(view.projectAccent("/tmp/other"))
+    }
+
+    @Test
+    fun `forcedLanguageId trims stored id and keeps case`() {
+        val view =
+            viewOf {
+                forcedProjectLanguages["/tmp/alpha"] = "  TypeScript  "
+            }
+
+        assertEquals("TypeScript", view.forcedLanguageId("/tmp/alpha"))
+        assertNull(view.forcedLanguageId("/tmp/other"))
+    }
+
+    @Test
+    fun `blank forced entry yields null id but still reports entry presence`() {
+        // The blank-entry split is load-bearing: the engine must suppress the
+        // language-detection rung for ANY forced entry, valid id or not.
+        val view =
+            viewOf {
+                forcedProjectLanguages["/tmp/alpha"] = "   "
+            }
+
+        assertNull(view.forcedLanguageId("/tmp/alpha"))
+        assertTrue(view.hasForcedLanguageEntry("/tmp/alpha"))
+        assertFalse(view.hasForcedLanguageEntry("/tmp/other"))
+    }
+
+    @Test
+    fun `languageAccent is an exact lookup without case folding`() {
+        val view =
+            viewOf {
+                languageAccents["kotlin"] = "#ABCDEF"
+            }
+
+        assertEquals("#ABCDEF", view.languageAccent("kotlin"))
+        assertNull(view.languageAccent("Kotlin"))
+    }
+
+    @Test
+    fun `hasLanguageAccents reflects mapping presence`() {
+        assertFalse(viewOf().hasLanguageAccents)
+        assertTrue(viewOf { languageAccents["go"] = "#5CCFE6" }.hasLanguageAccents)
+    }
+
+    @Test
+    fun `languageFallbackAccent trims stored value and filters blank to null`() {
+        assertEquals(
+            "#73D0FF",
+            viewOf { languageFallbackAccent = "  #73D0FF  " }.languageFallbackAccent,
+        )
+        assertNull(viewOf { languageFallbackAccent = "   " }.languageFallbackAccent)
+        assertNull(viewOf().languageFallbackAccent)
+    }
+
+    @Test
+    fun `projectFallbackAccent returns stored hex verbatim with matching candidate flag`() {
+        val view =
+            viewOf {
+                projectFallbackAccents["/tmp/alpha"] = "bad-hex"
+            }
+
+        assertEquals("bad-hex", view.projectFallbackAccent("/tmp/alpha"))
+        assertTrue(view.hasProjectFallbackCandidate("/tmp/alpha"))
+        assertNull(view.projectFallbackAccent("/tmp/other"))
+        assertFalse(view.hasProjectFallbackCandidate("/tmp/other"))
+    }
+
+    @Test
+    fun `state supplier is consulted lazily so gated resolutions stay zero-cost`() {
+        var reads = 0
+        val state = AccentMappingsState().apply { projectAccents["/tmp/alpha"] = "#112233" }
+        val view =
+            PersistedAccentMappingsView {
+                reads += 1
+                state
+            }
+
+        assertEquals(0, reads, "Construction must not read the persisted state")
+        assertEquals("#112233", view.projectAccent("/tmp/alpha"))
+        view.hasProjectFallbackCandidate("/tmp/alpha")
+        assertEquals(1, reads, "State must be materialized once per view instance")
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/accent/AccentResolutionChainBuilderGuardTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentResolutionChainBuilderGuardTest.kt
@@ -1,0 +1,42 @@
+package dev.ayuislands.accent
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Source-level regression locks for [AccentResolutionChainBuilder] branches
+ * that are structurally unreachable through the public surface and therefore
+ * have no behavioral test (same technique as `LiveChromeRefresherTest`'s
+ * broken-container cap lock).
+ */
+class AccentResolutionChainBuilderGuardTest {
+    @Test
+    fun `overrideWinner keeps the defensive null-hex winner guard`() {
+        // Every WON step the engine builds today carries a non-null hex, so the
+        // guard cannot be exercised behaviorally. It must survive refactors
+        // anyway: without it, a future step-construction change that produces a
+        // hex-less winner would push a null hex toward the applicator instead
+        // of degrading to the caller's global fallback.
+        val source = readChainBuilderSource()
+        assertTrue(
+            source.contains("val hex = winner.hex"),
+            "overrideWinner must read the winner hex into a local for the null guard",
+        )
+        val nullHexGuard =
+            Regex(
+                """if\s*\(hex\s*==\s*null\)\s*\{.*?LOG\.warn\(.*?return null""",
+                RegexOption.DOT_MATCHES_ALL,
+            )
+        assertTrue(
+            nullHexGuard.containsMatchIn(source),
+            "overrideWinner must warn and degrade to 'no override' when a WON step carries no hex",
+        )
+    }
+
+    private fun readChainBuilderSource(): String {
+        val file = File("src/main/kotlin/dev/ayuislands/accent/AccentResolutionChainBuilder.kt")
+        return file.takeIf { it.exists() }?.readText()
+            ?: error("Could not locate AccentResolutionChainBuilder.kt for source-level guard")
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/PendingAccentMappingsViewTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/PendingAccentMappingsViewTest.kt
@@ -1,0 +1,79 @@
+package dev.ayuislands.settings.mappings
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Behavioral contract of [PendingAccentMappingsView]: given the in-memory
+ * Settings model snapshots, the view answers exactly what the resolution
+ * engine asks per rung. Everything passes through verbatim — normalization is
+ * [OverridesGroupBuilder]'s job at model-entry time, so the view re-applying it
+ * would mask a broken entry path instead of surfacing it.
+ */
+class PendingAccentMappingsViewTest {
+    private fun viewOf(
+        projectAccents: Map<String, String> = emptyMap(),
+        languageAccents: Map<String, String> = emptyMap(),
+        forcedLanguages: Map<String, String> = emptyMap(),
+        projectFallbackAccents: Map<String, String> = emptyMap(),
+        languageFallbackAccent: String? = null,
+    ): PendingAccentMappingsView =
+        PendingAccentMappingsView(
+            projectAccents = projectAccents,
+            languageAccents = languageAccents,
+            forcedLanguages = forcedLanguages,
+            projectFallbackAccents = projectFallbackAccents,
+            languageFallbackAccent = languageFallbackAccent,
+        )
+
+    @Test
+    fun `projectAccent answers from the pending project snapshot`() {
+        val view = viewOf(projectAccents = mapOf("/tmp/alpha" to "#112233"))
+
+        assertEquals("#112233", view.projectAccent("/tmp/alpha"))
+        assertNull(view.projectAccent("/tmp/other"))
+    }
+
+    @Test
+    fun `forcedLanguageId returns pending entry verbatim with matching presence flag`() {
+        val view = viewOf(forcedLanguages = mapOf("/tmp/alpha" to "typescript"))
+
+        assertEquals("typescript", view.forcedLanguageId("/tmp/alpha"))
+        assertTrue(view.hasForcedLanguageEntry("/tmp/alpha"))
+        assertNull(view.forcedLanguageId("/tmp/other"))
+        assertFalse(view.hasForcedLanguageEntry("/tmp/other"))
+    }
+
+    @Test
+    fun `languageAccent is an exact lookup without case folding`() {
+        val view = viewOf(languageAccents = mapOf("kotlin" to "#CAFE00"))
+
+        assertEquals("#CAFE00", view.languageAccent("kotlin"))
+        assertNull(view.languageAccent("Kotlin"))
+    }
+
+    @Test
+    fun `hasLanguageAccents reflects pending language rows`() {
+        assertFalse(viewOf().hasLanguageAccents)
+        assertTrue(viewOf(languageAccents = mapOf("go" to "#5CCFE6")).hasLanguageAccents)
+    }
+
+    @Test
+    fun `languageFallbackAccent passes through the pending value`() {
+        assertEquals("#73D0FF", viewOf(languageFallbackAccent = "#73D0FF").languageFallbackAccent)
+        assertNull(viewOf().languageFallbackAccent)
+    }
+
+    @Test
+    fun `projectFallbackAccent answers with matching candidate flag`() {
+        val view = viewOf(projectFallbackAccents = mapOf("/tmp/alpha" to "#FFB454"))
+
+        assertEquals("#FFB454", view.projectFallbackAccent("/tmp/alpha"))
+        assertTrue(view.hasProjectFallbackCandidate("/tmp/alpha"))
+        assertNull(view.projectFallbackAccent("/tmp/other"))
+        assertFalse(view.hasProjectFallbackCandidate("/tmp/other"))
+    }
+}


### PR DESCRIPTION
── Summary ─────────────────────────────────

C3 from the architecture review — the cleanest standalone. The accent priority ladder (project override → forced language → language override/fallback → project fallback → global) was re-implemented four times: `AccentResolver.findOverride` (live hex+source), `AccentResolutionChainBuilder` (diagnostics trace), `OverridesGroupBuilder.findPendingOverride` (settings pending preview), and a `diagnosticsSource` copy. A case without a paired test literal could drift silently between them. The chain builder is now the single engine; hex, source, trace, and pending preview are projections of its winner — parity holds by construction.

**Proof of equivalence:** every pinned suite passes byte-unchanged (`git diff origin/main -- src/test/` touches no existing file): AccentResolverChainTest 29 (incl. the explicit hex==winner parity asserts), AccentResolverTest 35, AccentResolverExternalTest 14, OverridesGroupBuilderPendingTest 17 (incl. the `verify(exactly=0){dominant}` cache-only locks and `verify(atLeast=1){verdict(warm)}` warming locks), OverridesGroupBuilderProportionsTest 27.

── Changes ─────────────────────────────────

| Type | Where | What |
|------|-------|------|
| Refactor | `src/main/kotlin/dev/ayuislands/accent/AccentResolutionRequest.kt:10` | The three seams that actually differed, bundled: `AccentMappingsView` (persisted vs pending), `AccentDetectorLookup` (warming vs cache-only), `AccentHexPolicy` (strict/lenient/raw); ladder ORDER stays fixed in the engine |
| Refactor | `src/main/kotlin/dev/ayuislands/accent/AccentMappingsView.kt:1` | View interface + `PersistedAccentMappingsView` (lazy state read; normalizes blank/untrimmed hand-edited XML once for every consumer) |
| Refactor | `src/main/kotlin/dev/ayuislands/accent/AccentResolutionChainBuilder.kt` | +59 lines: the engine + `overrideWinner` projection (19/20 detekt function budget) |
| Refactor | `src/main/kotlin/dev/ayuislands/accent/AccentResolver.kt` | 437→341: `resolve`/`source` project the winner; `findOverride`, `resolveLanguageOverride`, `LanguageOverrideRequest`, `overrideAccent*` deleted |
| Refactor | `src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt` | 1109→1018: `PendingAccentMappingsView` + projections; `findPending*` ×3, `pendingAccentForLanguage`, and the fourth `diagnosticsSource` ladder deleted; the diagnostics row now provably agrees with the "Currently active" label |
| Test | `src/test/kotlin/dev/ayuislands/accent/`, `settings/mappings/` | 30 new behavioral tests over the seam types + a documented Pattern L source guard |

── Validation ──────────────────────────────

```bash
./gradlew test detekt ktlintCheck koverVerify
```
Expected: green, 2954 tests; chain builder 89% line coverage, all new seam files 100%.

Manual: Settings → Accent → Overrides — pin a project override and a language override; the "Currently active" label, the diagnostics proportions row, and the actually painted accent must name the same source; status-bar widget chain unchanged.

── Notes ───────────────────────────────────

- Detector-consultation semantics preserved per caller (this was the subtle part): live resolve warms via `dominant()`, diagnostics stay cache-only, pending honors `cacheOnly` — all pinned by the unchanged `verify(exactly=0/atLeast=1)` tests.
- Two convergence fixes fall out of one engine (blank forced-id normalization; the removed unconditional cache read in the pending zero-work case) — both documented in KDoc, neither test-visible.
- `PendingAccentMappingsView` takes four same-typed maps — named-arguments-only note in KDoc; wrapper types are a possible follow-up.
- The now-shrunk `OverridesGroupBuilder` keeps its pre-existing `@Suppress("LargeClass","TooManyFunctions")` — removing it is a separate cleanup.

## Summary by Sourcery

Unify accent override resolution behind a single ladder engine and reuse it for live resolution, diagnostics, and settings previews to keep hex, source labels, and diagnostics chains in sync by construction.

Enhancements:
- Introduce AccentResolutionRequest, AccentMappingsView, AccentDetectorLookup, and AccentHexPolicy seams so persisted and pending mappings share one resolution ladder with configurable detector and hex-validation behavior.
- Refactor AccentResolver to delegate all override decisions to AccentResolutionChainBuilder, removing bespoke language/override resolution logic.
- Refactor OverridesGroupBuilder to use a PendingAccentMappingsView and the shared resolution engine for pending previews and diagnostics, eliminating its local ladder implementation.

Tests:
- Add focused unit tests for AccentDetectorLookup, AccentMappingsView, PendingAccentMappingsView, AccentHexPolicy, and source-level guards on AccentResolutionChainBuilder to lock detector-call patterns, normalization behavior, and unreachable defensive branches.

Chores:
- Update the test source-read guard script to allow the new AccentResolutionChainBuilder guard test to inspect engine source.