### PR TITLE
refactor(settings): one SettingsSection machine behind five panels

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "d8514db2"
+          last_verified_sha: "760bfbd3"
           last_verified_date: "2026-06-30"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "d8514db2"
+          last_verified_sha: "760bfbd3"
           last_verified_date: "2026-06-30"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -304,7 +304,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "d8514db2"
+          last_verified_sha: "760bfbd3"
           last_verified_date: "2026-06-16"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -345,7 +345,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "d8514db2"
+          last_verified_sha: "760bfbd3"
           last_verified_date: "2026-06-16"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -397,7 +397,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "d8514db2"
+          last_verified_sha: "760bfbd3"
           last_verified_date: "2026-06-12"
           content_sha256: ad849b17308901bc2dac85f895978be656f578c9c31f857b9e9578e5cf4289f2
 
@@ -459,7 +459,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "d8514db2"
+          last_verified_sha: "760bfbd3"
           last_verified_date: "2026-06-16"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "760bfbd3"
+          last_verified_sha: "ea22bbd1"
           last_verified_date: "2026-06-30"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "760bfbd3"
+          last_verified_sha: "ea22bbd1"
           last_verified_date: "2026-06-30"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -304,7 +304,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "760bfbd3"
+          last_verified_sha: "ea22bbd1"
           last_verified_date: "2026-06-16"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -345,7 +345,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "760bfbd3"
+          last_verified_sha: "ea22bbd1"
           last_verified_date: "2026-06-16"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -397,7 +397,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "760bfbd3"
+          last_verified_sha: "ea22bbd1"
           last_verified_date: "2026-06-12"
           content_sha256: ad849b17308901bc2dac85f895978be656f578c9c31f857b9e9578e5cf4289f2
 
@@ -459,7 +459,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "760bfbd3"
+          last_verified_sha: "ea22bbd1"
           last_verified_date: "2026-06-16"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAppearancePanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAppearancePanel.kt
@@ -28,14 +28,30 @@ typealias SystemAccentRowInstaller = (Panel) -> Unit
  * The scheme-bind row is rendered FIRST so it surfaces above the macOS-only
  * group when both apply. On non-macOS platforms only the scheme-bind row is
  * rendered.
+ *
+ * Pending/stored bookkeeping is delegated to a [SettingsSection] over
+ * [AppearanceSettings] — except `syncEditorScheme`, whose pending/stored
+ * Boolean fields are a reflection contract with
+ * `AyuIslandsAppearancePanelSyncEditorSchemeTest` (the test writes the fields
+ * via `getDeclaredField`), so they deliberately stay hand-rolled.
  */
 class AyuIslandsAppearancePanel : AyuIslandsSettingsPanel {
-    private var pendingFollowAppearance: Boolean = false
-    private var storedFollowAppearance: Boolean = false
-    private var followAppearanceCheckbox: JBCheckBox? = null
+    private data class AppearanceSettings(
+        val followSystemAppearance: Boolean = false,
+        val nightTheme: String = "Mirage",
+    )
 
-    private var pendingNightTheme: String = "Mirage"
-    private var storedNightTheme: String = "Mirage"
+    private val section =
+        SettingsSection(initial = AppearanceSettings()) {
+            val state = AyuIslandsSettings.getInstance().state
+            val currentDarkTheme = state.lastDarkAppearanceTheme ?: "Ayu Mirage (Islands UI)"
+            AppearanceSettings(
+                followSystemAppearance = state.followSystemAppearance,
+                nightTheme = if (currentDarkTheme.contains("Dark")) "Dark" else "Mirage",
+            )
+        }
+
+    private var followAppearanceCheckbox: JBCheckBox? = null
     private var nightThemeCombo: JComboBox<String>? = null
 
     private var pendingSyncEditorScheme: Boolean = true
@@ -49,13 +65,7 @@ class AyuIslandsAppearancePanel : AyuIslandsSettingsPanel {
         variant: AyuVariant,
     ) {
         val settings = AyuIslandsSettings.getInstance()
-        storedFollowAppearance = settings.state.followSystemAppearance
-        pendingFollowAppearance = storedFollowAppearance
-
-        val currentDarkTheme = settings.state.lastDarkAppearanceTheme ?: "Ayu Mirage (Islands UI)"
-        val currentNight = if (currentDarkTheme.contains("Dark")) "Dark" else "Mirage"
-        storedNightTheme = currentNight
-        pendingNightTheme = currentNight
+        section.load()
 
         storedSyncEditorScheme = settings.state.syncEditorScheme
         pendingSyncEditorScheme = storedSyncEditorScheme
@@ -88,9 +98,9 @@ class AyuIslandsAppearancePanel : AyuIslandsSettingsPanel {
                     checkboxCell =
                         checkBox("Follow system appearance (Light / Dark)")
                     val checkbox = checkboxCell.component
-                    checkbox.isSelected = pendingFollowAppearance
+                    checkbox.isSelected = section.pending.followSystemAppearance
                     checkbox.addActionListener {
-                        pendingFollowAppearance = checkbox.isSelected
+                        section.update { it.copy(followSystemAppearance = checkbox.isSelected) }
                     }
                     followAppearanceCheckbox = checkbox
                 }
@@ -98,15 +108,15 @@ class AyuIslandsAppearancePanel : AyuIslandsSettingsPanel {
                     label("Night theme:")
                     val nightOptions = listOf("Mirage", "Dark")
                     val combo = comboBox(nightOptions).component
-                    combo.selectedItem = currentNight
+                    combo.selectedItem = section.pending.nightTheme
                     combo.addActionListener {
-                        pendingNightTheme = combo.selectedItem as? String ?: "Mirage"
+                        section.update { it.copy(nightTheme = combo.selectedItem as? String ?: "Mirage") }
                     }
                     nightThemeCombo = combo
                 }.visibleIf(checkboxCell.selected)
 
                 // Accent-color system checkbox lives in AyuIslandsAccentPanel (owns the
-                // pendingFollowSystem state and swatch-panel disable logic). We inject
+                // pending follow-system state and swatch-panel disable logic). We inject
                 // its row here so the UI groups both macOS integrations together.
                 systemAccentRowInstaller?.invoke(this)
             }
@@ -117,32 +127,31 @@ class AyuIslandsAppearancePanel : AyuIslandsSettingsPanel {
     }
 
     override fun isModified(): Boolean =
-        pendingFollowAppearance != storedFollowAppearance ||
-            pendingNightTheme != storedNightTheme ||
+        section.isModified() ||
             pendingSyncEditorScheme != storedSyncEditorScheme
 
     override fun apply() {
         if (!isModified()) return
         val settings = AyuIslandsSettings.getInstance()
 
-        if (pendingFollowAppearance != storedFollowAppearance) {
-            settings.state.followSystemAppearance = pendingFollowAppearance
-            storedFollowAppearance = pendingFollowAppearance
-            if (pendingFollowAppearance) {
-                AppearanceSyncService.getInstance().syncIfNeeded()
-            }
-        }
-
-        if (pendingNightTheme != storedNightTheme) {
-            val currentDarkTheme = settings.state.lastDarkAppearanceTheme ?: ""
-            val isIslands = currentDarkTheme.contains("Islands UI")
-            val newDarkTheme =
-                when (pendingNightTheme) {
-                    "Dark" -> if (isIslands) "Ayu Dark (Islands UI)" else "Ayu Dark"
-                    else -> if (isIslands) "Ayu Mirage (Islands UI)" else "Ayu Mirage"
+        section.commit { pending, stored ->
+            if (pending.followSystemAppearance != stored.followSystemAppearance) {
+                settings.state.followSystemAppearance = pending.followSystemAppearance
+                if (pending.followSystemAppearance) {
+                    AppearanceSyncService.getInstance().syncIfNeeded()
                 }
-            settings.state.lastDarkAppearanceTheme = newDarkTheme
-            storedNightTheme = pendingNightTheme
+            }
+
+            if (pending.nightTheme != stored.nightTheme) {
+                val currentDarkTheme = settings.state.lastDarkAppearanceTheme ?: ""
+                val isIslands = currentDarkTheme.contains("Islands UI")
+                val newDarkTheme =
+                    when (pending.nightTheme) {
+                        "Dark" -> if (isIslands) "Ayu Dark (Islands UI)" else "Ayu Dark"
+                        else -> if (isIslands) "Ayu Mirage (Islands UI)" else "Ayu Mirage"
+                    }
+                settings.state.lastDarkAppearanceTheme = newDarkTheme
+            }
         }
 
         if (pendingSyncEditorScheme != storedSyncEditorScheme) {
@@ -152,10 +161,9 @@ class AyuIslandsAppearancePanel : AyuIslandsSettingsPanel {
     }
 
     override fun reset() {
-        pendingFollowAppearance = storedFollowAppearance
-        followAppearanceCheckbox?.isSelected = storedFollowAppearance
-        pendingNightTheme = storedNightTheme
-        nightThemeCombo?.selectedItem = storedNightTheme
+        val restored = section.resetToStored()
+        followAppearanceCheckbox?.isSelected = restored.followSystemAppearance
+        nightThemeCombo?.selectedItem = restored.nightTheme
         pendingSyncEditorScheme = storedSyncEditorScheme
         syncEditorSchemeCheckbox?.isSelected = storedSyncEditorScheme
     }

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsChromePanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsChromePanel.kt
@@ -24,8 +24,9 @@ import javax.swing.JSlider
  * Settings panel rendering the "Chrome Tinting" collapsible group inside the Accent
  * tab. Follows the same shape as [AyuIslandsElementsPanel]:
  *
- *  - Pending/stored pairs for each state field so [isModified] can diff without touching
- *    the live [AyuIslandsState] until [apply] is called.
+ *  - Pending/stored bookkeeping delegated to a [SettingsSection] over the immutable
+ *    [ChromeTintSettings] snapshot so [isModified] can diff without touching the live
+ *    [AyuIslandsState] until [apply] is called.
  *  - Premium gate: unlicensed users see the full settings surface, but controls
  *    are locked. The underlying apply path re-checks [LicenseChecker] so a
  *    mid-session license revoke cannot persist premium state.
@@ -45,23 +46,38 @@ import javax.swing.JSlider
 class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
     // ── Pending / stored state ────────────────────────────────────────────────
 
-    private var pendingChromeStatusBar: Boolean = false
-    private var storedChromeStatusBar: Boolean = false
-    private var pendingChromeMainToolbar: Boolean = false
-    private var storedChromeMainToolbar: Boolean = false
-    private var pendingChromeToolWindowStripe: Boolean = false
-    private var storedChromeToolWindowStripe: Boolean = false
-    private var pendingChromeNavBar: Boolean = false
-    private var storedChromeNavBar: Boolean = false
-    private var pendingChromePanelBorder: Boolean = false
-    private var storedChromePanelBorder: Boolean = false
-    private var pendingChromeTintIntensity: Int = AyuIslandsState.DEFAULT_CHROME_TINT_INTENSITY
-    private var storedChromeTintIntensity: Int = AyuIslandsState.DEFAULT_CHROME_TINT_INTENSITY
-
-    // ── Swing references (kept for reset-time refresh + test seams) ───────────
+    private data class ChromeTintSettings(
+        val statusBar: Boolean = false,
+        val mainToolbar: Boolean = false,
+        val toolWindowStripe: Boolean = false,
+        val navBar: Boolean = false,
+        val panelBorder: Boolean = false,
+        val intensity: Int = AyuIslandsState.DEFAULT_CHROME_TINT_INTENSITY,
+    )
 
     private var variant: AyuVariant? = null
     private var licensed: Boolean = false
+
+    private val section =
+        SettingsSection(initial = ChromeTintSettings()) {
+            val state = AyuIslandsSettings.getInstance().state
+            // Stored intensity mirrors whatever AyuIslandsState holds (including legacy
+            // out-of-range values 51-100 from sessions predating the cap) while the
+            // user is licensed; unlicensed users get the clamped value so the locked
+            // preview never opens dirty (free users cannot apply the clamp anyway).
+            val clamped = state.chromeTintIntensity.coerceIn(MIN_INTENSITY, MAX_INTENSITY)
+            ChromeTintSettings(
+                statusBar = state.chromeStatusBar,
+                mainToolbar = state.chromeMainToolbar,
+                toolWindowStripe = state.chromeToolWindowStripe,
+                navBar = state.chromeNavBar,
+                panelBorder = state.chromePanelBorder,
+                intensity = if (licensed) state.chromeTintIntensity else clamped,
+            )
+        }
+
+    // ── Swing references (kept for reset-time refresh + test seams) ───────────
+
     private var statusBarCheckbox: JBCheckBox? = null
     private var mainToolbarCheckbox: JBCheckBox? = null
     private var toolWindowStripeCheckbox: JBCheckBox? = null
@@ -91,7 +107,7 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
                 isUnlocked = licensed,
             )
         val state = AyuIslandsSettings.getInstance().state
-        loadStored(state)
+        loadStored()
         val probeAllowsMainToolbar = ChromeDecorationsProbe.isCustomHeaderActive()
 
         val collapsible =
@@ -99,22 +115,22 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
                 premiumFeatureNotice(gate)
                 buildChromeSurfaceRows(gate, probeAllowsMainToolbar)
                 row("Intensity (%):") {
-                    val valueLabel = JLabel("$pendingChromeTintIntensity")
+                    val valueLabel = JLabel("${section.pending.intensity}")
                     val sliderCell =
                         slider(MIN_INTENSITY, MAX_INTENSITY, INTENSITY_MAJOR_TICK, INTENSITY_MINOR_TICK)
                             .bindValue(
-                                { pendingChromeTintIntensity },
-                                {
-                                    pendingChromeTintIntensity = it
-                                    valueLabel.text = "$it"
+                                { section.pending.intensity },
+                                { newValue ->
+                                    section.update { it.copy(intensity = newValue) }
+                                    valueLabel.text = "$newValue"
                                 },
                             ).applyToComponent {
-                                value = pendingChromeTintIntensity
+                                value = section.pending.intensity
                                 paintTicks = true
                                 applyPremiumLock(gate)
                                 addChangeListener {
                                     if (!gate.isUnlocked) return@addChangeListener
-                                    pendingChromeTintIntensity = value
+                                    section.update { it.copy(intensity = value) }
                                     valueLabel.text = "$value"
                                 }
                             }
@@ -123,12 +139,13 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
                         .resizableColumn()
                         .align(Align.FILL)
                         .onReset {
-                            pendingChromeTintIntensity =
-                                storedChromeTintIntensity.coerceIn(MIN_INTENSITY, MAX_INTENSITY)
-                            slider.value = pendingChromeTintIntensity
-                            valueLabel.text = "$pendingChromeTintIntensity"
+                            section.update {
+                                it.copy(intensity = section.stored.intensity.coerceIn(MIN_INTENSITY, MAX_INTENSITY))
+                            }
+                            slider.value = section.pending.intensity
+                            valueLabel.text = "${section.pending.intensity}"
                         }.onIsModified {
-                            pendingChromeTintIntensity != storedChromeTintIntensity
+                            section.pending.intensity != section.stored.intensity
                         }
                     cell(valueLabel)
                     intensitySlider = slider
@@ -161,39 +178,39 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
         listOf(
             ChromeSurfaceRow(
                 label = "Status bar",
-                currentValue = { pendingChromeStatusBar },
-                storedValue = { storedChromeStatusBar },
-                updatePending = { pendingChromeStatusBar = it },
+                currentValue = { section.pending.statusBar },
+                storedValue = { section.stored.statusBar },
+                updatePending = { checked -> section.update { it.copy(statusBar = checked) } },
                 rememberComponent = { statusBarCheckbox = it },
             ),
             ChromeSurfaceRow(
                 label = "Main toolbar",
-                currentValue = { pendingChromeMainToolbar },
-                storedValue = { storedChromeMainToolbar },
-                updatePending = { pendingChromeMainToolbar = it },
+                currentValue = { section.pending.mainToolbar },
+                storedValue = { section.stored.mainToolbar },
+                updatePending = { checked -> section.update { it.copy(mainToolbar = checked) } },
                 rememberComponent = { mainToolbarCheckbox = it },
                 enabledWhenUnlocked = probeAllowsMainToolbar,
                 disabledComment = disabledToolbarComment,
             ),
             ChromeSurfaceRow(
                 label = "Tool window stripe",
-                currentValue = { pendingChromeToolWindowStripe },
-                storedValue = { storedChromeToolWindowStripe },
-                updatePending = { pendingChromeToolWindowStripe = it },
+                currentValue = { section.pending.toolWindowStripe },
+                storedValue = { section.stored.toolWindowStripe },
+                updatePending = { checked -> section.update { it.copy(toolWindowStripe = checked) } },
                 rememberComponent = { toolWindowStripeCheckbox = it },
             ),
             ChromeSurfaceRow(
                 label = "Navigation bar",
-                currentValue = { pendingChromeNavBar },
-                storedValue = { storedChromeNavBar },
-                updatePending = { pendingChromeNavBar = it },
+                currentValue = { section.pending.navBar },
+                storedValue = { section.stored.navBar },
+                updatePending = { checked -> section.update { it.copy(navBar = checked) } },
                 rememberComponent = { navBarCheckbox = it },
             ),
             ChromeSurfaceRow(
                 label = "Panel borders",
-                currentValue = { pendingChromePanelBorder },
-                storedValue = { storedChromePanelBorder },
-                updatePending = { pendingChromePanelBorder = it },
+                currentValue = { section.pending.panelBorder },
+                storedValue = { section.stored.panelBorder },
+                updatePending = { checked -> section.update { it.copy(panelBorder = checked) } },
                 rememberComponent = { panelBorderCheckbox = it },
             ),
         ).forEach { surfaceRow ->
@@ -233,13 +250,7 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
         val disabledComment: String? = null,
     )
 
-    override fun isModified(): Boolean =
-        pendingChromeStatusBar != storedChromeStatusBar ||
-            pendingChromeMainToolbar != storedChromeMainToolbar ||
-            pendingChromeToolWindowStripe != storedChromeToolWindowStripe ||
-            pendingChromeNavBar != storedChromeNavBar ||
-            pendingChromePanelBorder != storedChromePanelBorder ||
-            pendingChromeTintIntensity != storedChromeTintIntensity
+    override fun isModified(): Boolean = section.isModified()
 
     override fun apply() {
         if (!isModified()) return
@@ -268,30 +279,40 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
             return
         }
 
-        val chromeTintingEnabled =
-            pendingChromeStatusBar ||
-                pendingChromeMainToolbar ||
-                pendingChromeToolWindowStripe ||
-                pendingChromeNavBar ||
-                pendingChromePanelBorder
-        val chromeSnapshot =
-            ChromeTintSnapshot(
-                chromeStatusBar = pendingChromeStatusBar,
-                chromeMainToolbar = pendingChromeMainToolbar,
-                chromeToolWindowStripe = pendingChromeToolWindowStripe,
-                chromeNavBar = pendingChromeNavBar,
-                chromePanelBorder = pendingChromePanelBorder,
-                intensity = TintIntensity.of(pendingChromeTintIntensity),
-                chromeTintingEnabled = chromeTintingEnabled,
-            )
-
-        // Run the EP chain FIRST so a throw from applyForFocusedProject leaves
-        // persisted state untouched and the user can retry after fixing the cause.
-        // The applicator consumes the pending chrome snapshot above, so this ordering
-        // no longer makes the visible tint one Apply behind the slider.
         try {
-            ChromeTintContext.withSnapshot(chromeSnapshot) {
-                AccentApplicator.applyForFocusedProject(resolvedVariant)
+            section.commit { pending, _ ->
+                val chromeTintingEnabled =
+                    pending.statusBar ||
+                        pending.mainToolbar ||
+                        pending.toolWindowStripe ||
+                        pending.navBar ||
+                        pending.panelBorder
+                val chromeSnapshot =
+                    ChromeTintSnapshot(
+                        chromeStatusBar = pending.statusBar,
+                        chromeMainToolbar = pending.mainToolbar,
+                        chromeToolWindowStripe = pending.toolWindowStripe,
+                        chromeNavBar = pending.navBar,
+                        chromePanelBorder = pending.panelBorder,
+                        intensity = TintIntensity.of(pending.intensity),
+                        chromeTintingEnabled = chromeTintingEnabled,
+                    )
+
+                // Run the EP chain FIRST so a throw from applyForFocusedProject leaves
+                // persisted state untouched and the user can retry after fixing the cause.
+                // The applicator consumes the pending chrome snapshot above, so this ordering
+                // no longer makes the visible tint one Apply behind the slider.
+                ChromeTintContext.withSnapshot(chromeSnapshot) {
+                    AccentApplicator.applyForFocusedProject(resolvedVariant)
+                }
+                val state = AyuIslandsSettings.getInstance().state
+                state.chromeTintingEnabled = chromeTintingEnabled
+                state.chromeStatusBar = pending.statusBar
+                state.chromeMainToolbar = pending.mainToolbar
+                state.chromeToolWindowStripe = pending.toolWindowStripe
+                state.chromeNavBar = pending.navBar
+                state.chromePanelBorder = pending.panelBorder
+                state.chromeTintIntensity = chromeSnapshot.intensity.percent
             }
         } catch (exception: RuntimeException) {
             LOG.warn(
@@ -302,15 +323,7 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
             notifyApplyFailed()
             return
         }
-        val state = AyuIslandsSettings.getInstance().state
-        state.chromeTintingEnabled = chromeTintingEnabled
-        state.chromeStatusBar = pendingChromeStatusBar
-        state.chromeMainToolbar = pendingChromeMainToolbar
-        state.chromeToolWindowStripe = pendingChromeToolWindowStripe
-        state.chromeNavBar = pendingChromeNavBar
-        state.chromePanelBorder = pendingChromePanelBorder
-        state.chromeTintIntensity = chromeSnapshot.intensity.percent
-        loadStored(state)
+        loadStored()
     }
 
     /**
@@ -343,32 +356,22 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
     }
 
     override fun reset() {
-        val state = AyuIslandsSettings.getInstance().state
-        loadStored(state)
-        statusBarCheckbox?.isSelected = pendingChromeStatusBar
-        mainToolbarCheckbox?.isSelected = pendingChromeMainToolbar
-        toolWindowStripeCheckbox?.isSelected = pendingChromeToolWindowStripe
-        navBarCheckbox?.isSelected = pendingChromeNavBar
-        panelBorderCheckbox?.isSelected = pendingChromePanelBorder
-        intensitySlider?.value = pendingChromeTintIntensity
-        intensityValueLabel?.text = "$pendingChromeTintIntensity"
+        loadStored()
+        val pending = section.pending
+        statusBarCheckbox?.isSelected = pending.statusBar
+        mainToolbarCheckbox?.isSelected = pending.mainToolbar
+        toolWindowStripeCheckbox?.isSelected = pending.toolWindowStripe
+        navBarCheckbox?.isSelected = pending.navBar
+        panelBorderCheckbox?.isSelected = pending.panelBorder
+        intensitySlider?.value = pending.intensity
+        intensityValueLabel?.text = "${pending.intensity}"
     }
 
-    private fun loadStored(state: AyuIslandsState) {
-        storedChromeStatusBar = state.chromeStatusBar
-        pendingChromeStatusBar = storedChromeStatusBar
-        storedChromeMainToolbar = state.chromeMainToolbar
-        pendingChromeMainToolbar = storedChromeMainToolbar
-        storedChromeToolWindowStripe = state.chromeToolWindowStripe
-        pendingChromeToolWindowStripe = storedChromeToolWindowStripe
-        storedChromeNavBar = state.chromeNavBar
-        pendingChromeNavBar = storedChromeNavBar
-        storedChromePanelBorder = state.chromePanelBorder
-        pendingChromePanelBorder = storedChromePanelBorder
-        // Stored intensity mirrors whatever AyuIslandsState holds (including legacy
-        // out-of-range values 51-100 from sessions predating the cap); the pending
-        // value is clamped into [MIN_INTENSITY, MAX_INTENSITY] so the slider can
-        // always display it. A legacy value outside that range leaves
+    private fun loadStored() {
+        section.load()
+        // Stored intensity keeps the raw persisted value (see the snapshot lambda);
+        // the pending value is clamped into [MIN_INTENSITY, MAX_INTENSITY] so the
+        // slider can always display it. A legacy value outside that range leaves
         // stored != pending on purpose — isModified() reports true and the user sees
         // a one-time Apply button that persists the capped value back into state.
         //
@@ -376,9 +379,7 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
         // (corrupted XML, older schema, third-party migration) would otherwise slip
         // through the cap and reach the JSlider constructor, which throws when
         // value < min. The lower bound keeps the slider construction total.
-        val clampedIntensity = state.chromeTintIntensity.coerceIn(MIN_INTENSITY, MAX_INTENSITY)
-        storedChromeTintIntensity = if (licensed) state.chromeTintIntensity else clampedIntensity
-        pendingChromeTintIntensity = clampedIntensity
+        section.update { it.copy(intensity = it.intensity.coerceIn(MIN_INTENSITY, MAX_INTENSITY)) }
     }
 
     /**
@@ -398,14 +399,21 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
     private fun disabledMainToolbarComment(): String {
         val unsupported = ChromeDecorationsProbe.probe() as? ChromeSupport.Unsupported ?: return ""
         return when (unsupported) {
-            ChromeSupport.Unsupported.NativeMacTitleBar ->
+            ChromeSupport.Unsupported.NativeMacTitleBar -> {
                 "Disabled: macOS paints the native title bar (IDE 2026.1+ no longer exposes a toggle)."
-            ChromeSupport.Unsupported.WindowsNoCustomHeader ->
+            }
+
+            ChromeSupport.Unsupported.WindowsNoCustomHeader -> {
                 "Disabled: your IDE is not using custom window decorations."
-            ChromeSupport.Unsupported.GnomeSsd ->
+            }
+
+            ChromeSupport.Unsupported.GnomeSsd -> {
                 "Disabled: your window manager paints the native title bar."
-            ChromeSupport.Unsupported.UnknownOs ->
+            }
+
+            ChromeSupport.Unsupported.UnknownOs -> {
                 "Disabled: your OS paints the native title bar."
+            }
         }
     }
 
@@ -459,39 +467,39 @@ class AyuIslandsChromePanel : AyuIslandsSettingsPanel {
 
     @TestOnly
     internal fun setPendingChromeStatusBarForTest(value: Boolean) {
-        pendingChromeStatusBar = value
+        section.update { it.copy(statusBar = value) }
     }
 
     @TestOnly
     internal fun setPendingChromeMainToolbarForTest(value: Boolean) {
-        pendingChromeMainToolbar = value
+        section.update { it.copy(mainToolbar = value) }
     }
 
     @TestOnly
     internal fun setPendingChromeToolWindowStripeForTest(value: Boolean) {
-        pendingChromeToolWindowStripe = value
+        section.update { it.copy(toolWindowStripe = value) }
     }
 
     @TestOnly
     internal fun setPendingChromeNavBarForTest(value: Boolean) {
-        pendingChromeNavBar = value
+        section.update { it.copy(navBar = value) }
     }
 
     @TestOnly
     internal fun setPendingChromePanelBorderForTest(value: Boolean) {
-        pendingChromePanelBorder = value
+        section.update { it.copy(panelBorder = value) }
     }
 
     @TestOnly
     internal fun setPendingChromeTintIntensityForTest(value: Int) {
-        pendingChromeTintIntensity = value
+        section.update { it.copy(intensity = value) }
     }
 
     @TestOnly
-    internal fun getPendingChromeStatusBarForTest(): Boolean = pendingChromeStatusBar
+    internal fun getPendingChromeStatusBarForTest(): Boolean = section.pending.statusBar
 
     @TestOnly
-    internal fun getPendingChromeTintIntensityForTest(): Int = pendingChromeTintIntensity
+    internal fun getPendingChromeTintIntensityForTest(): Int = section.pending.intensity
 
     companion object {
         private val LOG = logger<AyuIslandsChromePanel>()

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
@@ -34,26 +34,53 @@ private data class SliderConfig(
  * [buildGlowPanel] renders the master toggle, preset selection, style/animation controls,
  * sliders, and glow targets.
  * Called from [AyuIslandsConfigurable] into a single tab pane.
+ *
+ * Pending/stored bookkeeping is delegated to a [SettingsSection] over the
+ * immutable [GlowSettings] snapshot.
  */
 @Suppress("TooManyFunctions") // Settings panel with grouped UI builders
 class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
-    // Pending state (applied on OK/Apply, not live)
-    private var pendingGlowEnabled: Boolean = false
-    private var pendingPreset: GlowPreset = GlowPreset.WHISPER
-    private var pendingStyle: GlowStyle = GlowStyle.SOFT
-    private var pendingIntensity: MutableMap<GlowStyle, Int> = mutableMapOf()
-    private var pendingWidth: MutableMap<GlowStyle, Int> = mutableMapOf()
-    private var pendingAnimation: GlowAnimation = GlowAnimation.NONE
-    private var pendingIslandToggles: MutableMap<String, Boolean> = mutableMapOf()
+    private data class GlowSettings(
+        val enabled: Boolean = false,
+        val preset: GlowPreset = GlowPreset.WHISPER,
+        val style: GlowStyle = GlowStyle.SOFT,
+        val intensity: Map<GlowStyle, Int> = emptyMap(),
+        val width: Map<GlowStyle, Int> = emptyMap(),
+        val animation: GlowAnimation = GlowAnimation.NONE,
+        val islandToggles: Map<String, Boolean> = emptyMap(),
+    ) {
+        /**
+         * Folds [preset]'s canonical style/intensity/width/animation into the
+         * snapshot. Returns `this` unchanged for presets without canonical
+         * values (i.e. [GlowPreset.CUSTOM]).
+         */
+        fun withPresetValues(preset: GlowPreset): GlowSettings {
+            val presetStyle = preset.style ?: return this
+            val presetIntensity = preset.intensity ?: return this
+            val presetWidth = preset.width ?: return this
+            val presetAnimation = preset.animation ?: return this
+            return copy(
+                style = presetStyle,
+                intensity = intensity + (presetStyle to presetIntensity),
+                width = width + (presetStyle to presetWidth),
+                animation = presetAnimation,
+            )
+        }
+    }
 
-    // Stored state (for isModified comparison)
-    private var storedGlowEnabled: Boolean = false
-    private var storedPreset: GlowPreset = GlowPreset.WHISPER
-    private var storedStyle: GlowStyle = GlowStyle.SOFT
-    private var storedIntensity: Map<GlowStyle, Int> = emptyMap()
-    private var storedWidth: Map<GlowStyle, Int> = emptyMap()
-    private var storedAnimation: GlowAnimation = GlowAnimation.NONE
-    private var storedIslandToggles: Map<String, Boolean> = emptyMap()
+    private val section =
+        SettingsSection(initial = GlowSettings()) {
+            val state = AyuIslandsSettings.getInstance().state
+            GlowSettings(
+                enabled = state.glowEnabled,
+                preset = GlowPreset.fromName(migratePresetIfNeeded(state)),
+                style = GlowStyle.fromName(state.glowStyle ?: GlowStyle.SOFT.name),
+                intensity = GlowStyle.entries.associateWith { state.getIntensityForStyle(it) },
+                width = GlowStyle.entries.associateWith { state.getWidthForStyle(it) },
+                animation = GlowAnimation.fromName(state.glowAnimation ?: GlowAnimation.NONE.name),
+                islandToggles = ISLAND_IDS.associateWith { state.isIslandEnabled(it) },
+            )
+        }
 
     // Observable property for Custom mode visibility
     private val customModeVisible = AtomicBooleanProperty(false)
@@ -83,10 +110,8 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
 
     private fun ensureStateLoaded() {
         if (stateLoaded) return
-        val state = AyuIslandsSettings.getInstance().state
-        val migratedPreset = migratePresetIfNeeded(state)
-        loadStateIntoPending(state, migratedPreset)
-        copyPendingToStored()
+        section.load()
+        customModeVisible.set(section.pending.preset == GlowPreset.CUSTOM)
         stateLoaded = true
     }
 
@@ -114,10 +139,10 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
     ) {
         panel.row {
             val cb = checkBox("Enable glow")
-            cb.component.isSelected = pendingGlowEnabled
+            cb.component.isSelected = section.pending.enabled
             cb.component.isEnabled = licensed
             cb.component.addActionListener {
-                pendingGlowEnabled = cb.component.isSelected
+                section.update { it.copy(enabled = cb.component.isSelected) }
                 updateControlStates()
                 updateGlowGroupPanel()
             }
@@ -125,8 +150,9 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
 
             if (licensed) {
                 link("Reset defaults") {
-                    applyPresetValues(GlowPreset.WHISPER)
-                    pendingPreset = GlowPreset.WHISPER
+                    section.update {
+                        it.withPresetValues(GlowPreset.WHISPER).copy(preset = GlowPreset.WHISPER)
+                    }
                     refreshAllControls()
                 }
             }
@@ -161,12 +187,12 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
                                 label = "Intensity",
                                 min = 0,
                                 max = MAX_INTENSITY,
-                                initialValue = pendingIntensity[pendingStyle] ?: DEFAULT_INTENSITY,
+                                initialValue = section.pending.intensity[section.pending.style] ?: DEFAULT_INTENSITY,
                                 majorTick = INTENSITY_MAJOR_TICK,
                                 minorTick = INTENSITY_MINOR_TICK,
                             ),
-                        onValueChanged = {
-                            pendingIntensity[pendingStyle] = it
+                        onValueChanged = { value ->
+                            section.update { it.copy(intensity = it.intensity + (it.style to value)) }
                             updateGlowGroupPanel()
                         },
                         onCreated = { slider, label ->
@@ -182,11 +208,11 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
                                 label = "Width (px)",
                                 min = MIN_WIDTH,
                                 max = MAX_WIDTH,
-                                initialValue = pendingWidth[pendingStyle] ?: DEFAULT_WIDTH,
+                                initialValue = section.pending.width[section.pending.style] ?: DEFAULT_WIDTH,
                                 majorTick = WIDTH_MAJOR_TICK,
                             ),
-                        onValueChanged = {
-                            pendingWidth[pendingStyle] = it
+                        onValueChanged = { value ->
+                            section.update { it.copy(width = it.width + (it.style to value)) }
                             updateGlowGroupPanel()
                         },
                         onCreated = { slider, label ->
@@ -215,13 +241,18 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
                     text = preset.displayName
                 }
             segmented.maxButtonsCount(GlowPreset.entries.size)
-            segmented.selectedItem = pendingPreset
+            segmented.selectedItem = section.pending.preset
             @Suppress("UnstableApiUsage")
             segmented.whenItemSelected { preset ->
                 if (!suppressListeners && LicenseChecker.isLicensedOrGrace()) {
-                    pendingPreset = preset
+                    section.update { current ->
+                        if (preset == GlowPreset.CUSTOM) {
+                            current.copy(preset = preset)
+                        } else {
+                            current.withPresetValues(preset).copy(preset = preset)
+                        }
+                    }
                     if (preset != GlowPreset.CUSTOM) {
-                        applyPresetValues(preset)
                         refreshSliders()
                         refreshStyleAndAnimation()
                     }
@@ -244,13 +275,13 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
                 label("Style")
                 val model = DefaultComboBoxModel(GlowStyle.entries.map { it.displayName }.toTypedArray())
                 val combo = ComboBox(model)
-                combo.selectedItem = pendingStyle.displayName
-                combo.isEnabled = licensed && pendingGlowEnabled
+                combo.selectedItem = section.pending.style.displayName
+                combo.isEnabled = licensed && section.pending.enabled
                 combo.addActionListener {
                     if (!suppressListeners) {
                         val selectedName = combo.selectedItem as? String ?: return@addActionListener
                         val style = GlowStyle.entries.first { it.displayName == selectedName }
-                        pendingStyle = style
+                        section.update { it.copy(style = style) }
                         switchToCustom()
                         refreshSliders()
                     }
@@ -274,7 +305,7 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
                 slider.paintTicks = true
                 slider.majorTickSpacing = config.majorTick
                 if (config.minorTick > 0) slider.minorTickSpacing = config.minorTick
-                slider.applyPremiumLock(gate, pendingGlowEnabled)
+                slider.applyPremiumLock(gate, section.pending.enabled)
                 val valueLabel = JLabel("${slider.value}")
                 slider.addChangeListener {
                     if (!suppressListeners && gate.isUnlocked) {
@@ -299,12 +330,13 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
                 label("Animation")
                 val model = DefaultComboBoxModel(GlowAnimation.entries.map { it.displayName }.toTypedArray())
                 val combo = ComboBox(model)
-                combo.selectedItem = pendingAnimation.displayName
-                combo.isEnabled = licensed && pendingGlowEnabled
+                combo.selectedItem = section.pending.animation.displayName
+                combo.isEnabled = licensed && section.pending.enabled
                 combo.addActionListener {
                     if (!suppressListeners) {
                         val selectedName = combo.selectedItem as? String ?: return@addActionListener
-                        pendingAnimation = GlowAnimation.entries.first { it.displayName == selectedName }
+                        val animation = GlowAnimation.entries.first { it.displayName == selectedName }
+                        section.update { it.copy(animation = animation) }
                         switchToCustom()
                         updateAnimationDescription()
                     }
@@ -314,7 +346,7 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
             }.visibleIfUnlockedOrPreview(customModeVisible, gate)
         group
             .row {
-                val descCell = comment(animationDescription(pendingAnimation))
+                val descCell = comment(animationDescription(section.pending.animation))
                 animationDescriptionLabel = descCell.component
             }.visibleIfUnlockedOrPreview(customModeVisible, gate)
     }
@@ -334,17 +366,13 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
                 }
                 row {
                     link("Enable all") {
-                        for (key in pendingIslandToggles.keys) {
-                            pendingIslandToggles[key] = true
-                        }
+                        section.update { s -> s.copy(islandToggles = s.islandToggles.mapValues { true }) }
                         refreshIslandCheckboxes()
-                    }.enabled(licensed && pendingGlowEnabled)
+                    }.enabled(licensed && section.pending.enabled)
                     link("Disable all") {
-                        for (key in pendingIslandToggles.keys) {
-                            pendingIslandToggles[key] = false
-                        }
+                        section.update { s -> s.copy(islandToggles = s.islandToggles.mapValues { false }) }
                         refreshIslandCheckboxes()
-                    }.enabled(licensed && pendingGlowEnabled)
+                    }.enabled(licensed && section.pending.enabled)
                 }
                 // Headers row
                 threeColumnsRow(
@@ -378,31 +406,19 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
         licensed: Boolean,
     ) {
         val cb = checkBox(islandId)
-        cb.component.isSelected = pendingIslandToggles[islandId] ?: false
-        cb.component.isEnabled = licensed && pendingGlowEnabled
+        cb.component.isSelected = section.pending.islandToggles[islandId] ?: false
+        cb.component.isEnabled = licensed && section.pending.enabled
         cb.component.addActionListener {
-            pendingIslandToggles[islandId] = cb.component.isSelected
+            section.update { it.copy(islandToggles = it.islandToggles + (islandId to cb.component.isSelected)) }
         }
         islandCheckboxes[islandId] = cb.component
     }
 
     // Preset helpers
 
-    private fun applyPresetValues(preset: GlowPreset) {
-        val style = preset.style ?: return
-        val intensity = preset.intensity ?: return
-        val width = preset.width ?: return
-        val animation = preset.animation ?: return
-
-        pendingStyle = style
-        pendingIntensity[style] = intensity
-        pendingWidth[style] = width
-        pendingAnimation = animation
-    }
-
     private fun switchToCustom() {
-        if (pendingPreset != GlowPreset.CUSTOM) {
-            pendingPreset = GlowPreset.CUSTOM
+        if (section.pending.preset != GlowPreset.CUSTOM) {
+            section.update { it.copy(preset = GlowPreset.CUSTOM) }
             customModeVisible.set(true)
             suppressListeners = true
             presetSegmentedButton?.selectedItem = GlowPreset.CUSTOM
@@ -413,8 +429,9 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
 
     private fun refreshSliders() {
         suppressListeners = true
-        val intensity = pendingIntensity[pendingStyle] ?: pendingStyle.defaultIntensity
-        val width = pendingWidth[pendingStyle] ?: pendingStyle.defaultWidth
+        val pending = section.pending
+        val intensity = pending.intensity[pending.style] ?: pending.style.defaultIntensity
+        val width = pending.width[pending.style] ?: pending.style.defaultWidth
         intensitySlider?.value = intensity
         widthSlider?.value = width
         intensityValueLabel?.text = "$intensity"
@@ -424,15 +441,15 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
 
     private fun refreshStyleAndAnimation() {
         suppressListeners = true
-        styleCombo?.selectedItem = pendingStyle.displayName
-        animationCombo?.selectedItem = pendingAnimation.displayName
+        styleCombo?.selectedItem = section.pending.style.displayName
+        animationCombo?.selectedItem = section.pending.animation.displayName
         updateAnimationDescription()
         suppressListeners = false
     }
 
     private fun refreshIslandCheckboxes() {
         for ((id, cb) in islandCheckboxes) {
-            cb.isSelected = pendingIslandToggles[id] ?: false
+            cb.isSelected = section.pending.islandToggles[id] ?: false
         }
     }
 
@@ -447,7 +464,7 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
         }
 
     private fun updateAnimationDescription() {
-        animationDescriptionLabel?.text = animationDescription(pendingAnimation)
+        animationDescriptionLabel?.text = animationDescription(section.pending.animation)
     }
 
     // State management
@@ -459,40 +476,6 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
         val width = state.getWidthForStyle(style)
         val animation = GlowAnimation.fromName(state.glowAnimation ?: GlowAnimation.NONE.name)
         return GlowPreset.detect(style, intensity, width, animation).name
-    }
-
-    private fun loadStateIntoPending(
-        state: AyuIslandsState,
-        presetName: String = state.glowPreset ?: GlowPreset.WHISPER.name,
-    ) {
-        pendingGlowEnabled = state.glowEnabled
-        pendingPreset = GlowPreset.fromName(presetName)
-        pendingStyle = GlowStyle.fromName(state.glowStyle ?: GlowStyle.SOFT.name)
-        pendingAnimation = GlowAnimation.fromName(state.glowAnimation ?: GlowAnimation.NONE.name)
-
-        pendingIntensity.clear()
-        pendingWidth.clear()
-        for (style in GlowStyle.entries) {
-            pendingIntensity[style] = state.getIntensityForStyle(style)
-            pendingWidth[style] = state.getWidthForStyle(style)
-        }
-
-        pendingIslandToggles.clear()
-        for (id in ISLAND_IDS) {
-            pendingIslandToggles[id] = state.isIslandEnabled(id)
-        }
-
-        customModeVisible.set(pendingPreset == GlowPreset.CUSTOM)
-    }
-
-    private fun copyPendingToStored() {
-        storedGlowEnabled = pendingGlowEnabled
-        storedPreset = pendingPreset
-        storedStyle = pendingStyle
-        storedIntensity = pendingIntensity.toMap()
-        storedWidth = pendingWidth.toMap()
-        storedAnimation = pendingAnimation
-        storedIslandToggles = pendingIslandToggles.toMap()
     }
 
     private fun resolveAccentColor(): Color {
@@ -508,16 +491,17 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
 
     private fun updateGlowGroupPanel() {
         val panel = glowGroupPanel ?: return
-        val style = pendingStyle
-        val intensity = pendingIntensity[style] ?: style.defaultIntensity
-        val width = pendingWidth[style] ?: style.defaultWidth
+        val pending = section.pending
+        val style = pending.style
+        val intensity = pending.intensity[style] ?: style.defaultIntensity
+        val width = pending.width[style] ?: style.defaultWidth
         val color = resolveAccentColor()
-        val visible = pendingGlowEnabled || !LicenseChecker.isLicensedOrGrace()
+        val visible = pending.enabled || !LicenseChecker.isLicensedOrGrace()
         panel.updateFromPreset(style, intensity, width, color, visible)
     }
 
     private fun updateControlStates() {
-        val enabled = pendingGlowEnabled && LicenseChecker.isLicensedOrGrace()
+        val enabled = section.pending.enabled && LicenseChecker.isLicensedOrGrace()
 
         intensitySlider?.isEnabled = enabled
         widthSlider?.isEnabled = enabled
@@ -532,13 +516,13 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
 
     private fun refreshAllControls() {
         suppressListeners = true
-        presetSegmentedButton?.selectedItem = pendingPreset
-        customModeVisible.set(pendingPreset == GlowPreset.CUSTOM)
-        styleCombo?.selectedItem = pendingStyle.displayName
-        animationCombo?.selectedItem = pendingAnimation.displayName
+        presetSegmentedButton?.selectedItem = section.pending.preset
+        customModeVisible.set(section.pending.preset == GlowPreset.CUSTOM)
+        styleCombo?.selectedItem = section.pending.style.displayName
+        animationCombo?.selectedItem = section.pending.animation.displayName
         refreshSliders()
         refreshIslandCheckboxes()
-        masterToggle?.isSelected = pendingGlowEnabled
+        masterToggle?.isSelected = section.pending.enabled
         updateAnimationDescription()
         suppressListeners = false
         updateControlStates()
@@ -547,52 +531,37 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
 
     // AyuIslandsSettingsPanel contract
 
-    override fun isModified(): Boolean =
-        pendingGlowEnabled != storedGlowEnabled ||
-            pendingPreset != storedPreset ||
-            pendingStyle != storedStyle ||
-            pendingIntensity != storedIntensity ||
-            pendingWidth != storedWidth ||
-            pendingAnimation != storedAnimation ||
-            pendingIslandToggles != storedIslandToggles
+    override fun isModified(): Boolean = section.isModified()
 
     override fun apply() {
         if (!isModified()) return
         if (!LicenseChecker.isLicensedOrGrace()) return
-        val state = AyuIslandsSettings.getInstance().state
 
-        state.glowEnabled = pendingGlowEnabled
-        state.glowPreset = pendingPreset.name
+        // Write-through: preset values → raw state fields (GlowOverlayManager reads
+        // raw fields). Folding before commit lets stored converge onto the folded
+        // pending values, exactly like the previous copy-pending-to-stored did.
+        section.update { if (it.preset == GlowPreset.CUSTOM) it else it.withPresetValues(it.preset) }
 
-        // Write-through: preset values → raw state fields (GlowOverlayManager reads raw fields)
-        if (pendingPreset != GlowPreset.CUSTOM) {
-            applyPresetValues(pendingPreset)
+        section.commit { pending, _ ->
+            val state = AyuIslandsSettings.getInstance().state
+            state.glowEnabled = pending.enabled
+            state.glowPreset = pending.preset.name
+            state.glowStyle = pending.style.name
+            state.glowAnimation = pending.animation.name
+
+            for (style in GlowStyle.entries) {
+                state.setIntensityForStyle(style, pending.intensity[style] ?: style.defaultIntensity)
+                state.setWidthForStyle(style, pending.width[style] ?: style.defaultWidth)
+            }
+
+            for (id in ISLAND_IDS) {
+                state.setIslandEnabled(id, pending.islandToggles[id] ?: false)
+            }
         }
-
-        state.glowStyle = pendingStyle.name
-        state.glowAnimation = pendingAnimation.name
-
-        for (style in GlowStyle.entries) {
-            state.setIntensityForStyle(style, pendingIntensity[style] ?: style.defaultIntensity)
-            state.setWidthForStyle(style, pendingWidth[style] ?: style.defaultWidth)
-        }
-
-        for (id in ISLAND_IDS) {
-            state.setIslandEnabled(id, pendingIslandToggles[id] ?: false)
-        }
-
-        copyPendingToStored()
     }
 
     override fun reset() {
-        pendingGlowEnabled = storedGlowEnabled
-        pendingPreset = storedPreset
-        pendingStyle = storedStyle
-        pendingIntensity = storedIntensity.toMutableMap()
-        pendingWidth = storedWidth.toMutableMap()
-        pendingAnimation = storedAnimation
-        pendingIslandToggles = storedIslandToggles.toMutableMap()
-
+        section.resetToStored()
         refreshAllControls()
     }
 

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsElementsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsElementsPanel.kt
@@ -19,18 +19,34 @@ import javax.swing.JCheckBox
 
 /** Per-element accent toggle checkboxes with conflict detection and license-aware dimming. */
 class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
-    private val pendingToggles: MutableMap<AccentElementId, Boolean> = mutableMapOf()
-    private var storedToggles: Map<AccentElementId, Boolean> = emptyMap()
-    private var pendingForceOverrides: MutableSet<String> = mutableSetOf()
-    private var storedForceOverrides: Set<String> = emptySet()
-    private var pendingTabMode: String = "MINIMAL"
-    private var storedTabMode: String = "MINIMAL"
-    private var pendingTabUnderlineHeight: Int = AyuIslandsState.DEFAULT_TAB_UNDERLINE_HEIGHT
-    private var storedTabUnderlineHeight: Int = AyuIslandsState.DEFAULT_TAB_UNDERLINE_HEIGHT
-    private var pendingTabUnderlineGlowSync: Boolean = false
-    private var storedTabUnderlineGlowSync: Boolean = false
-    private var pendingBracketScope: Boolean = true
-    private var storedBracketScope: Boolean = true
+    private data class ElementSettings(
+        val toggles: Map<AccentElementId, Boolean> = emptyMap(),
+        val forceOverrides: Set<String> = emptySet(),
+        val tabMode: String = "MINIMAL",
+        val tabUnderlineHeight: Int = AyuIslandsState.DEFAULT_TAB_UNDERLINE_HEIGHT,
+        val tabUnderlineGlowSync: Boolean = false,
+        val bracketScope: Boolean = true,
+    )
+
+    // CHROME-group ids are owned by the Chrome tinting panel and must NOT surface
+    // in this panel's checkbox list — the snapshot filters them out; blockedIds
+    // and enable/disable-all filter likewise.
+    private val section =
+        SettingsSection(initial = ElementSettings()) {
+            val state = AyuIslandsSettings.getInstance().state
+            ElementSettings(
+                toggles =
+                    AccentElementId.entries
+                        .filter { it.group != AccentGroup.CHROME }
+                        .associateWith { state.isToggleEnabled(it) },
+                forceOverrides = state.forceOverrides.toSet(),
+                tabMode = state.glowTabMode ?: "MINIMAL",
+                tabUnderlineHeight = state.tabUnderlineHeight,
+                tabUnderlineGlowSync = state.tabUnderlineGlowSync,
+                bracketScope = state.bracketScopeEnabled,
+            )
+        }
+
     private val checkboxes: MutableMap<AccentElementId, JCheckBox> = mutableMapOf()
     private var tabModeSegmented: SegmentedButton<GlowTabMode>? = null
     private var tabModeCommentRow: Row? = null
@@ -56,7 +72,6 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
         variant: AyuVariant,
     ) {
         this.variant = variant
-        val state = AyuIslandsSettings.getInstance().state
         val gate =
             PremiumFeatureGate(
                 featureName = "Accent elements",
@@ -67,27 +82,7 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
             )
         licensed = gate.isUnlocked
 
-        // Initialize toggle state from persisted settings. CHROME-group ids are owned
-        // by the Chrome tinting panel (phase 40) and must NOT surface in this panel's
-        // checkbox list — filter them out here, at blockedIds, and at enable/disable-all.
-        for (id in AccentElementId.entries.filter { it.group != AccentGroup.CHROME }) {
-            val enabled = state.isToggleEnabled(id)
-            pendingToggles[id] = enabled
-        }
-        storedToggles = pendingToggles.toMap()
-
-        storedForceOverrides = state.forceOverrides.toSet()
-        pendingForceOverrides = storedForceOverrides.toMutableSet()
-
-        storedTabMode = state.glowTabMode ?: "MINIMAL"
-        pendingTabMode = storedTabMode
-
-        storedTabUnderlineHeight = state.tabUnderlineHeight
-        pendingTabUnderlineHeight = storedTabUnderlineHeight
-        storedTabUnderlineGlowSync = state.tabUnderlineGlowSync
-        pendingTabUnderlineGlowSync = storedTabUnderlineGlowSync
-        storedBracketScope = state.bracketScopeEnabled
-        pendingBracketScope = storedBracketScope
+        section.load()
 
         // Detect conflicts on panel open and clean stale overrides for blocked elements
         ConflictRegistry.detectConflicts()
@@ -97,12 +92,12 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
                 .filter { ConflictRegistry.getConflictFor(it)?.type == ConflictType.BLOCK }
                 .map { it.name }
                 .toSet()
-        pendingForceOverrides.removeAll(blockedIds)
+        section.update { it.copy(forceOverrides = it.forceOverrides - blockedIds) }
 
         // Create a preview component (used inside the row below)
         val preview = AyuIslandsPreviewPanel()
         preview.previewAccentHex = AyuIslandsSettings.getInstance().getAccentForVariant(variant)
-        preview.previewToggles = pendingToggles.toMap()
+        preview.previewToggles = section.pending.toggles
         preview.previewGlowEnabled = false
         val previewComponent = preview.createComponent()
         elementPreview = preview
@@ -136,20 +131,10 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
                         )
                         row {
                             link("Enable all") {
-                                AccentElementId.entries
-                                    .filter { it.group != AccentGroup.CHROME }
-                                    .forEach { pendingToggles[it] = true }
-                                refreshCheckboxes()
-                                syncPreviewToggles()
-                                onToggleChanged?.invoke()
+                                setAllToggles(enabled = true)
                             }.enabled(licensed)
                             link("Disable all") {
-                                AccentElementId.entries
-                                    .filter { it.group != AccentGroup.CHROME }
-                                    .forEach { pendingToggles[it] = false }
-                                refreshCheckboxes()
-                                syncPreviewToggles()
-                                onToggleChanged?.invoke()
+                                setAllToggles(enabled = false)
                             }.enabled(licensed)
                         }
                     }
@@ -169,11 +154,11 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
                     val scopeCb =
                         checkBox("Highlight bracket scope on gutter")
                             .comment("Show accent-colored scope stripe when caret is on a bracket")
-                    scopeCb.component.isSelected = pendingBracketScope
+                    scopeCb.component.isSelected = section.pending.bracketScope
                     scopeCb.component.isEnabled = licensed
                     scopeCb.component.addActionListener {
                         if (!licensed) return@addActionListener
-                        pendingBracketScope = scopeCb.component.isSelected
+                        section.update { it.copy(bracketScope = scopeCb.component.isSelected) }
                     }
                     bracketScopeCheckbox = scopeCb.component
                 }
@@ -182,6 +167,20 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
         collapsible.addExpandedListener { expanded ->
             settings.state.accentElementsGroupExpanded = expanded
         }
+    }
+
+    private fun setAllToggles(enabled: Boolean) {
+        section.update { settings ->
+            settings.copy(
+                toggles =
+                    AccentElementId.entries
+                        .filter { it.group != AccentGroup.CHROME }
+                        .associateWith { enabled },
+            )
+        }
+        refreshCheckboxes()
+        syncPreviewToggles()
+        onToggleChanged?.invoke()
     }
 
     /**
@@ -206,30 +205,30 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
                 label("Tab accent style")
                 val segmented =
                     segmentedButton(GlowTabMode.entries) { mode -> text = mode.displayName }
-                segmented.selectedItem = GlowTabMode.fromName(pendingTabMode)
+                segmented.selectedItem = GlowTabMode.fromName(section.pending.tabMode)
                 segmented.enabled(licensed)
                 @Suppress("UnstableApiUsage")
                 segmented.whenItemSelected { mode ->
                     if (!licensed) return@whenItemSelected
-                    pendingTabMode = mode.name
+                    section.update { it.copy(tabMode = mode.name) }
                     updateThicknessRowVisibility()
                 }
                 tabModeSegmented = segmented
             }.visible(islandsUi)
 
         // Underline thickness presets (non-Islands only)
-        val tabModeIsOff = GlowTabMode.fromName(pendingTabMode) == GlowTabMode.OFF
+        val tabModeIsOff = GlowTabMode.fromName(section.pending.tabMode) == GlowTabMode.OFF
         thicknessRow =
             row {
                 label("Underline thickness")
                 val thickSegmented =
                     segmentedButton(UNDERLINE_THICKNESS_PRESETS) { value -> text = "${value}px" }
-                thickSegmented.selectedItem = pendingTabUnderlineHeight
-                thickSegmented.enabled(licensed && !pendingTabUnderlineGlowSync)
+                thickSegmented.selectedItem = section.pending.tabUnderlineHeight
+                thickSegmented.enabled(licensed && !section.pending.tabUnderlineGlowSync)
                 @Suppress("UnstableApiUsage")
                 thickSegmented.whenItemSelected { value ->
                     if (licensed) {
-                        pendingTabUnderlineHeight = value
+                        section.update { it.copy(tabUnderlineHeight = value) }
                     }
                 }
                 thicknessSegmented = thickSegmented
@@ -239,16 +238,16 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
         syncRow =
             row {
                 val cb = checkBox("Sync with glow width")
-                cb.component.isSelected = pendingTabUnderlineGlowSync
+                cb.component.isSelected = section.pending.tabUnderlineGlowSync
                 cb.component.isEnabled = licensed && glowEnabled
                 if (!glowEnabled) {
                     cb.component.toolTipText = "Enable glow to sync"
                 }
                 cb.component.addActionListener {
                     if (!licensed) return@addActionListener
-                    pendingTabUnderlineGlowSync = cb.component.isSelected
+                    section.update { it.copy(tabUnderlineGlowSync = cb.component.isSelected) }
                     updateThicknessEnabledState()
-                    if (pendingTabUnderlineGlowSync && glowEnabled) {
+                    if (section.pending.tabUnderlineGlowSync && glowEnabled) {
                         val style = GlowStyle.fromName(state.glowStyle ?: GlowStyle.SOFT.name)
                         val syncedWidth = state.getWidthForStyle(style)
                         thicknessSegmented?.selectedItem = syncedWidth
@@ -259,7 +258,7 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
     }
 
     private fun updateThicknessRowVisibility() {
-        val isOff = GlowTabMode.fromName(pendingTabMode) == GlowTabMode.OFF
+        val isOff = GlowTabMode.fromName(section.pending.tabMode) == GlowTabMode.OFF
         val visible = if (licensed) !isOff && !AyuVariant.isIslandsUi() else !AyuVariant.isIslandsUi()
         thicknessRow?.visible(visible)
         syncRow?.visible(visible)
@@ -269,7 +268,7 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
     }
 
     private fun updateThicknessEnabledState() {
-        thicknessSegmented?.enabled(licensed && !pendingTabUnderlineGlowSync)
+        thicknessSegmented?.enabled(licensed && !section.pending.tabUnderlineGlowSync)
         syncCheckbox?.isEnabled = licensed && AyuIslandsSettings.getInstance().state.glowEnabled
     }
 
@@ -283,11 +282,11 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
 
         panel.row {
             val cb = checkBox(id.displayName)
-            cb.component.isSelected = pendingToggles[id] ?: true
+            cb.component.isSelected = section.pending.toggles[id] ?: true
             cb.component.isEnabled = licensed && !isBlocking
             cb.component.addActionListener {
                 if (!licensed || isBlocking) return@addActionListener
-                pendingToggles[id] = cb.component.isSelected
+                section.update { it.copy(toggles = it.toggles + (id to cb.component.isSelected)) }
                 syncPreviewToggles()
                 onToggleChanged?.invoke()
             }
@@ -316,45 +315,32 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
 
     private fun refreshCheckboxes() {
         for ((id, cb) in checkboxes) {
-            cb.isSelected = pendingToggles[id] ?: true
+            cb.isSelected = section.pending.toggles[id] ?: true
         }
     }
 
     private fun syncPreviewToggles() {
-        elementPreview?.previewToggles = pendingToggles.toMap()
+        elementPreview?.previewToggles = section.pending.toggles
         elementPreview?.updatePreview()
     }
 
-    override fun isModified(): Boolean {
-        if (pendingToggles != storedToggles) return true
-        if (pendingForceOverrides != storedForceOverrides) return true
-        if (pendingTabMode != storedTabMode) return true
-        if (pendingTabUnderlineHeight != storedTabUnderlineHeight) return true
-        if (pendingTabUnderlineGlowSync != storedTabUnderlineGlowSync) return true
-        if (pendingBracketScope != storedBracketScope) return true
-        return false
-    }
+    override fun isModified(): Boolean = section.isModified()
 
     override fun apply() {
         if (!isModified()) return
         if (!LicenseChecker.isLicensedOrGrace()) return
-        val state = AyuIslandsSettings.getInstance().state
 
-        for ((id, enabled) in pendingToggles) {
-            state.setToggle(id, enabled)
+        section.commit { pending, _ ->
+            val state = AyuIslandsSettings.getInstance().state
+            for ((id, enabled) in pending.toggles) {
+                state.setToggle(id, enabled)
+            }
+            state.forceOverrides = pending.forceOverrides.toMutableSet()
+            state.glowTabMode = pending.tabMode
+            state.tabUnderlineHeight = pending.tabUnderlineHeight
+            state.tabUnderlineGlowSync = pending.tabUnderlineGlowSync
+            state.bracketScopeEnabled = pending.bracketScope
         }
-        state.forceOverrides = pendingForceOverrides.toMutableSet()
-        state.glowTabMode = pendingTabMode
-        state.tabUnderlineHeight = pendingTabUnderlineHeight
-        state.tabUnderlineGlowSync = pendingTabUnderlineGlowSync
-        state.bracketScopeEnabled = pendingBracketScope
-
-        storedToggles = pendingToggles.toMap()
-        storedForceOverrides = pendingForceOverrides.toSet()
-        storedTabMode = pendingTabMode
-        storedTabUnderlineHeight = pendingTabUnderlineHeight
-        storedTabUnderlineGlowSync = pendingTabUnderlineGlowSync
-        storedBracketScope = pendingBracketScope
 
         // Re-apply accent with new toggle states via applyForFocusedProject so per-project/
         // per-language overrides aren't stomped by the accent applied by AyuIslandsAccentPanel
@@ -364,19 +350,13 @@ class AyuIslandsElementsPanel : AyuIslandsSettingsPanel {
     }
 
     override fun reset() {
-        pendingToggles.clear()
-        pendingToggles.putAll(storedToggles)
-        pendingForceOverrides = storedForceOverrides.toMutableSet()
-        pendingTabMode = storedTabMode
-        pendingTabUnderlineHeight = storedTabUnderlineHeight
-        pendingTabUnderlineGlowSync = storedTabUnderlineGlowSync
-        pendingBracketScope = storedBracketScope
+        val restored = section.resetToStored()
         refreshCheckboxes()
-        bracketScopeCheckbox?.isSelected = storedBracketScope
+        bracketScopeCheckbox?.isSelected = restored.bracketScope
         syncPreviewToggles()
-        tabModeSegmented?.selectedItem = GlowTabMode.fromName(pendingTabMode)
-        thicknessSegmented?.selectedItem = pendingTabUnderlineHeight
-        syncCheckbox?.isSelected = pendingTabUnderlineGlowSync
+        tabModeSegmented?.selectedItem = GlowTabMode.fromName(restored.tabMode)
+        thicknessSegmented?.selectedItem = restored.tabUnderlineHeight
+        syncCheckbox?.isSelected = restored.tabUnderlineGlowSync
         updateThicknessRowVisibility()
     }
 

--- a/src/main/kotlin/dev/ayuislands/settings/SettingsSection.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/SettingsSection.kt
@@ -24,10 +24,13 @@ package dev.ayuislands.settings
  *  - [commit] runs the panel's whole apply step — side-effects and
  *    persistence in whatever order that panel requires — and only converges
  *    [stored] onto [pending] afterwards. A throw from [commit]'s action
- *    leaves both values untouched, so [isModified] keeps reporting `true`
- *    and the user can retry. The action may normalize [pending] via [update]
- *    (e.g. folding preset values before persisting); [stored] converges onto
- *    the value of [pending] as observed AFTER the action returns.
+ *    aborts the commit: [stored] is guaranteed unchanged, so [isModified]
+ *    keeps reporting `true` and the user can retry. [pending], however, keeps
+ *    any [update] mutations the action made before throwing — actions that
+ *    normalize [pending] mid-commit should do so before their first throwing
+ *    operation. The action may normalize [pending] via [update] (e.g. folding
+ *    preset values before persisting); [stored] converges onto the value of
+ *    [pending] as observed AFTER the action returns.
  *
  * Named `commit` rather than `apply` on purpose: a zero-parameter trailing
  * lambda on an `apply(action: (T, T) -> Unit)` member would silently resolve
@@ -71,7 +74,8 @@ internal class SettingsSection<T>(
     /**
      * Runs [action] with the current ([pending], [stored]) pair, then
      * converges [stored] onto [pending]. No-op when nothing diverged; a
-     * throw from [action] propagates with both values untouched.
+     * throw from [action] propagates with [stored] unchanged — [pending]
+     * keeps any [update] mutations made before the throw (see class KDoc).
      */
     fun commit(action: (pending: T, stored: T) -> Unit) {
         if (!isModified()) return

--- a/src/main/kotlin/dev/ayuislands/settings/SettingsSection.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/SettingsSection.kt
@@ -1,0 +1,81 @@
+package dev.ayuislands.settings
+
+/**
+ * Pending/stored bookkeeping for a settings panel section over an immutable
+ * snapshot [T].
+ *
+ * Every [AyuIslandsSettingsPanel] used to hand-roll the same machine: a
+ * `pending*`/`stored*` field pair per setting, an OR-chain `isModified`, an
+ * apply that copies pending into stored, and a reset that copies stored back
+ * into pending. This class owns that machine once, over a whole-object
+ * snapshot compared with `!=` (the `PluginSettingsSnapshot` shape).
+ *
+ * Contract:
+ *  - [pending] is what the UI edits (via [update]); [stored] is the baseline
+ *    the panel last loaded or committed. Both are read-only outside so every
+ *    mutation goes through a named seam.
+ *  - [load] re-reads the persisted baseline through [snapshot] and aligns
+ *    [pending] with it — the "reset from persisted state" semantics used by
+ *    `AyuIslandsChromePanel`/`VcsColorPanel`. Panels that clamp legacy
+ *    persisted values follow [load] with an [update] so [stored] keeps the
+ *    raw value while [pending] holds the normalized one (a deliberate diff
+ *    that surfaces the Apply button).
+ *  - [resetToStored] is the in-memory reset used by the remaining panels.
+ *  - [commit] runs the panel's whole apply step — side-effects and
+ *    persistence in whatever order that panel requires — and only converges
+ *    [stored] onto [pending] afterwards. A throw from [commit]'s action
+ *    leaves both values untouched, so [isModified] keeps reporting `true`
+ *    and the user can retry. The action may normalize [pending] via [update]
+ *    (e.g. folding preset values before persisting); [stored] converges onto
+ *    the value of [pending] as observed AFTER the action returns.
+ *
+ * Named `commit` rather than `apply` on purpose: a zero-parameter trailing
+ * lambda on an `apply(action: (T, T) -> Unit)` member would silently resolve
+ * to the stdlib `apply` scope function instead of failing to compile.
+ *
+ * @param initial default snapshot used before the first [load] — panels are
+ *   constructed before `buildPanel` runs, and the settings service must not
+ *   be touched at construction time.
+ * @param snapshot reads the persisted state into a fresh [T]; invoked by
+ *   every [load].
+ */
+internal class SettingsSection<T>(
+    initial: T,
+    private val snapshot: () -> T,
+) {
+    var pending: T = initial
+        private set
+
+    var stored: T = initial
+        private set
+
+    fun isModified(): Boolean = pending != stored
+
+    /** Rewrites [pending] through [transform]; [stored] is untouched. */
+    fun update(transform: (T) -> T) {
+        pending = transform(pending)
+    }
+
+    /** Re-reads the persisted baseline; [pending] and [stored] both take it. */
+    fun load() {
+        stored = snapshot()
+        pending = stored
+    }
+
+    /** In-memory reset: [pending] returns to [stored]. Returns the restored value. */
+    fun resetToStored(): T {
+        pending = stored
+        return pending
+    }
+
+    /**
+     * Runs [action] with the current ([pending], [stored]) pair, then
+     * converges [stored] onto [pending]. No-op when nothing diverged; a
+     * throw from [action] propagates with both values untouched.
+     */
+    fun commit(action: (pending: T, stored: T) -> Unit) {
+        if (!isModified()) return
+        action(pending, stored)
+        stored = pending
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/settings/VcsColorPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/VcsColorPanel.kt
@@ -28,7 +28,8 @@ import javax.swing.JSlider
  * that section's surfaces.
  *
  * Mirrors the [AyuIslandsChromePanel] discipline:
- *  - Pending / stored pairs per field so [isModified] can diff without
+ *  - Pending/stored bookkeeping delegated to a [SettingsSection] over the
+ *    immutable [VcsColorSettings] snapshot so [isModified] can diff without
  *    touching the live [AyuIslandsState] until [apply] is called.
  *  - Premium gate: unlicensed users see the full settings surface and preview,
  *    but controls are locked. Runtime apply still re-checks the license so a
@@ -40,24 +41,73 @@ import javax.swing.JSlider
 class VcsColorPanel : AyuIslandsSettingsPanel {
     // ── Pending / stored state ────────────────────────────────────────────────
 
-    private var pendingEnabled: Boolean = false
-    private var storedEnabled: Boolean = false
-    private var pendingDiffPreset: VcsColorPreset = VcsColorPreset.AMBIENT
-    private var storedDiffPreset: VcsColorPreset = VcsColorPreset.AMBIENT
-    private var pendingMergePreset: VcsColorPreset = VcsColorPreset.AMBIENT
-    private var storedMergePreset: VcsColorPreset = VcsColorPreset.AMBIENT
-    private var pendingBlamePreset: VcsColorPreset = VcsColorPreset.AMBIENT
-    private var storedBlamePreset: VcsColorPreset = VcsColorPreset.AMBIENT
-    private var pendingDiffIntensity: Int = VcsColorPreset.AMBIENT_SLIDER
-    private var storedDiffIntensity: Int = VcsColorPreset.AMBIENT_SLIDER
-    private var pendingProjectViewIntensity: Int = VcsColorPreset.AMBIENT_SLIDER
-    private var storedProjectViewIntensity: Int = VcsColorPreset.AMBIENT_SLIDER
-    private var pendingGutterIntensity: Int = VcsColorPreset.AMBIENT_SLIDER
-    private var storedGutterIntensity: Int = VcsColorPreset.AMBIENT_SLIDER
-    private var pendingConflictMarkerIntensity: Int = VcsColorPreset.AMBIENT_SLIDER
-    private var storedConflictMarkerIntensity: Int = VcsColorPreset.AMBIENT_SLIDER
-    private var pendingBlameIntensity: Int = VcsColorPreset.AMBIENT_SLIDER
-    private var storedBlameIntensity: Int = VcsColorPreset.AMBIENT_SLIDER
+    private data class VcsColorSettings(
+        val enabled: Boolean = false,
+        val diffPreset: VcsColorPreset = VcsColorPreset.AMBIENT,
+        val mergePreset: VcsColorPreset = VcsColorPreset.AMBIENT,
+        val blamePreset: VcsColorPreset = VcsColorPreset.AMBIENT,
+        val diffIntensity: Int = VcsColorPreset.AMBIENT_SLIDER,
+        val projectViewIntensity: Int = VcsColorPreset.AMBIENT_SLIDER,
+        val gutterIntensity: Int = VcsColorPreset.AMBIENT_SLIDER,
+        val conflictMarkerIntensity: Int = VcsColorPreset.AMBIENT_SLIDER,
+        val blameIntensity: Int = VcsColorPreset.AMBIENT_SLIDER,
+    ) {
+        fun presetFor(vcsSection: VcsSection): VcsColorPreset =
+            when (vcsSection) {
+                VcsSection.DIFF -> diffPreset
+                VcsSection.MERGE -> mergePreset
+                VcsSection.BLAME -> blamePreset
+            }
+
+        fun withPreset(
+            vcsSection: VcsSection,
+            preset: VcsColorPreset,
+        ): VcsColorSettings =
+            when (vcsSection) {
+                VcsSection.DIFF -> copy(diffPreset = preset)
+                VcsSection.MERGE -> copy(mergePreset = preset)
+                VcsSection.BLAME -> copy(blamePreset = preset)
+            }
+
+        fun intensityFor(category: VcsColorCategory): Int =
+            when (category) {
+                VcsColorCategory.DIFF_VIEWER -> diffIntensity
+                VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> projectViewIntensity
+                VcsColorCategory.EDITOR_GUTTER -> gutterIntensity
+                VcsColorCategory.CONFLICT_MARKERS -> conflictMarkerIntensity
+                VcsColorCategory.BLAME_GUTTER -> blameIntensity
+                else -> VcsColorPreset.AMBIENT_SLIDER
+            }
+
+        fun withIntensity(
+            category: VcsColorCategory,
+            value: Int,
+        ): VcsColorSettings =
+            when (category) {
+                VcsColorCategory.DIFF_VIEWER -> copy(diffIntensity = value)
+                VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> copy(projectViewIntensity = value)
+                VcsColorCategory.EDITOR_GUTTER -> copy(gutterIntensity = value)
+                VcsColorCategory.CONFLICT_MARKERS -> copy(conflictMarkerIntensity = value)
+                VcsColorCategory.BLAME_GUTTER -> copy(blameIntensity = value)
+                else -> this
+            }
+    }
+
+    private val section =
+        SettingsSection(initial = VcsColorSettings()) {
+            val state = AyuIslandsSettings.getInstance().state
+            VcsColorSettings(
+                enabled = state.vcsColorEnabled,
+                diffPreset = state.effectiveVcsDiffPreset(),
+                mergePreset = state.effectiveVcsMergePreset(),
+                blamePreset = state.effectiveVcsBlamePreset(),
+                diffIntensity = state.vcsDiffIntensity,
+                projectViewIntensity = state.vcsProjectViewIntensity,
+                gutterIntensity = state.vcsGutterIntensity,
+                conflictMarkerIntensity = state.vcsConflictMarkerIntensity,
+                blameIntensity = state.vcsBlameIntensity,
+            )
+        }
 
     // ── Swing references (kept for reset-time refresh + test seams) ───────────
 
@@ -80,12 +130,12 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
     private var vcsPreview: VcsColorPreviewComponent? = null
 
     /** Drives `visibleIf` on each section's Custom-mode slider rows. */
-    private val diffCustomSelected = AtomicBooleanProperty(pendingDiffPreset == VcsColorPreset.CUSTOM)
-    private val mergeCustomSelected = AtomicBooleanProperty(pendingMergePreset == VcsColorPreset.CUSTOM)
-    private val blameCustomSelected = AtomicBooleanProperty(pendingBlamePreset == VcsColorPreset.CUSTOM)
+    private val diffCustomSelected = AtomicBooleanProperty(section.pending.diffPreset == VcsColorPreset.CUSTOM)
+    private val mergeCustomSelected = AtomicBooleanProperty(section.pending.mergePreset == VcsColorPreset.CUSTOM)
+    private val blameCustomSelected = AtomicBooleanProperty(section.pending.blamePreset == VcsColorPreset.CUSTOM)
 
     /** Drives `visibleIf(masterEnabled)` so all sections collapse when master is off. */
-    private val masterEnabled = AtomicBooleanProperty(pendingEnabled)
+    private val masterEnabled = AtomicBooleanProperty(section.pending.enabled)
 
     /**
      * Tracks whether the panel is mid-listener-suppress (preset switch or
@@ -112,8 +162,8 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
                 isUnlocked = licensed,
             )
         val state = AyuIslandsSettings.getInstance().state
-        loadStored(state)
-        masterEnabled.set(pendingEnabled || !gate.isUnlocked)
+        loadStored()
+        masterEnabled.set(section.pending.enabled || !gate.isUnlocked)
         panel.buildContent(state, gate)
     }
 
@@ -138,39 +188,39 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
     private fun Panel.buildMasterToggleRow(gate: PremiumFeatureGate) {
         row {
             val cb = checkBox("Enable VCS color customization")
-            cb.component.isSelected = pendingEnabled
+            cb.component.isSelected = section.pending.enabled
             cb.component.applyPremiumLock(gate)
             cb.component.addActionListener {
                 if (!gate.isUnlocked) return@addActionListener
-                pendingEnabled = cb.component.isSelected
-                masterEnabled.set(pendingEnabled)
+                section.update { it.copy(enabled = cb.component.isSelected) }
+                masterEnabled.set(section.pending.enabled)
             }
             enabledCheckbox = cb.component
         }
     }
 
     private fun Panel.buildSection(
-        section: VcsSection,
+        vcsSection: VcsSection,
         state: AyuIslandsState,
         gate: PremiumFeatureGate,
     ) {
-        val ctx = sectionContext(section)
+        val ctx = sectionContext(vcsSection)
         val collapsible =
-            collapsibleGroup(section.title) {
-                buildSectionPresetRow(section, ctx, gate)
-                for ((category, label) in section.sliders) {
+            collapsibleGroup(vcsSection.title) {
+                buildSectionPresetRow(vcsSection, ctx, gate)
+                for ((category, label) in vcsSection.sliders) {
                     buildSliderRow(category, label, ctx.customVisible, gate)
                 }
             }
         collapsible.expanded =
-            when (section) {
+            when (vcsSection) {
                 VcsSection.DIFF -> state.vcsDiffSectionExpanded
                 VcsSection.MERGE -> state.vcsMergeSectionExpanded
                 VcsSection.BLAME -> state.vcsBlameSectionExpanded
             }
         collapsible.addExpandedListener { expanded ->
             val live = AyuIslandsSettings.getInstance().state
-            when (section) {
+            when (vcsSection) {
                 VcsSection.DIFF -> live.vcsDiffSectionExpanded = expanded
                 VcsSection.MERGE -> live.vcsMergeSectionExpanded = expanded
                 VcsSection.BLAME -> live.vcsBlameSectionExpanded = expanded
@@ -188,19 +238,24 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
         val storeSegmented: (SegmentedButton<VcsColorPreset>) -> Unit,
     )
 
-    private fun sectionContext(section: VcsSection): SectionContext =
-        when (section) {
-            VcsSection.DIFF ->
-                SectionContext(pendingDiffPreset, diffCustomSelected) { diffPresetSegmented = it }
-            VcsSection.MERGE ->
-                SectionContext(pendingMergePreset, mergeCustomSelected) { mergePresetSegmented = it }
-            VcsSection.BLAME ->
-                SectionContext(pendingBlamePreset, blameCustomSelected) { blamePresetSegmented = it }
+    private fun sectionContext(vcsSection: VcsSection): SectionContext =
+        when (vcsSection) {
+            VcsSection.DIFF -> {
+                SectionContext(section.pending.diffPreset, diffCustomSelected) { diffPresetSegmented = it }
+            }
+
+            VcsSection.MERGE -> {
+                SectionContext(section.pending.mergePreset, mergeCustomSelected) { mergePresetSegmented = it }
+            }
+
+            VcsSection.BLAME -> {
+                SectionContext(section.pending.blamePreset, blameCustomSelected) { blamePresetSegmented = it }
+            }
         }
 
     @Suppress("UnstableApiUsage")
     private fun Panel.buildSectionPresetRow(
-        section: VcsSection,
+        vcsSection: VcsSection,
         ctx: SectionContext,
         gate: PremiumFeatureGate,
     ) {
@@ -211,7 +266,7 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
             segmented.enabled(gate.isUnlocked)
             segmented.whenItemSelected { preset ->
                 if (!gate.isUnlocked) return@whenItemSelected
-                onSectionPresetChosen(section, preset)
+                onSectionPresetChosen(vcsSection, preset)
                 ctx.customVisible.set(preset == VcsColorPreset.CUSTOM)
             }
             ctx.storeSegmented(segmented)
@@ -224,15 +279,7 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
         sectionCustomVisible: AtomicBooleanProperty,
         gate: PremiumFeatureGate,
     ) {
-        val initialValue =
-            when (category) {
-                VcsColorCategory.DIFF_VIEWER -> pendingDiffIntensity
-                VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> pendingProjectViewIntensity
-                VcsColorCategory.EDITOR_GUTTER -> pendingGutterIntensity
-                VcsColorCategory.CONFLICT_MARKERS -> pendingConflictMarkerIntensity
-                VcsColorCategory.BLAME_GUTTER -> pendingBlameIntensity
-                else -> VcsColorPreset.AMBIENT_SLIDER
-            }
+        val initialValue = section.pending.intensityFor(category)
         val sliderRow =
             row(label) {
                 val slider =
@@ -259,23 +306,30 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
                         diffSlider = slider
                         diffValueLabel = valueLabel
                     }
+
                     VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> {
                         projectViewSlider = slider
                         projectViewValueLabel = valueLabel
                     }
+
                     VcsColorCategory.EDITOR_GUTTER -> {
                         gutterSlider = slider
                         gutterValueLabel = valueLabel
                     }
+
                     VcsColorCategory.CONFLICT_MARKERS -> {
                         conflictMarkerSlider = slider
                         conflictMarkerValueLabel = valueLabel
                     }
+
                     VcsColorCategory.BLAME_GUTTER -> {
                         blameSlider = slider
                         blameValueLabel = valueLabel
                     }
-                    else -> Unit
+
+                    else -> {
+                        Unit
+                    }
                 }
             }
         sliderRow.visibleIfUnlockedOrPreview(sectionCustomVisible, gate)
@@ -283,51 +337,53 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
 
     private fun previewIntensities(): VcsPreviewIntensities =
         VcsPreviewIntensities(
-            diffViewer = pendingDiffIntensity,
-            projectView = pendingProjectViewIntensity,
-            editorGutter = pendingGutterIntensity,
-            conflictMarkers = pendingConflictMarkerIntensity,
-            blameGutter = pendingBlameIntensity,
+            diffViewer = section.pending.diffIntensity,
+            projectView = section.pending.projectViewIntensity,
+            editorGutter = section.pending.gutterIntensity,
+            conflictMarkers = section.pending.conflictMarkerIntensity,
+            blameGutter = section.pending.blameIntensity,
         )
 
     /**
      * Handles a slider value change for [category]. Writes the new value into
-     * the matching `pending*` field, refreshes the value label, and (if the
-     * change is a user gesture rather than programmatic) promotes the
-     * governing section's preset to [VcsColorPreset.CUSTOM] so the manual
-     * slider position actually takes effect on apply.
+     * the pending snapshot, refreshes the value label, and (if the change is
+     * a user gesture rather than programmatic) promotes the governing
+     * section's preset to [VcsColorPreset.CUSTOM] so the manual slider
+     * position actually takes effect on apply.
      */
     private fun onSliderChanged(
         category: VcsColorCategory,
         value: Int,
     ) {
         when (category) {
-            VcsColorCategory.DIFF_VIEWER -> {
-                pendingDiffIntensity = value
-                diffValueLabel?.text = "$value"
+            VcsColorCategory.DIFF_VIEWER,
+            VcsColorCategory.PROJECT_VIEW_FILE_STATUS,
+            VcsColorCategory.EDITOR_GUTTER,
+            VcsColorCategory.CONFLICT_MARKERS,
+            VcsColorCategory.BLAME_GUTTER,
+            -> {
+                section.update { it.withIntensity(category, value) }
+                valueLabelFor(category)?.text = "$value"
             }
-            VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> {
-                pendingProjectViewIntensity = value
-                projectViewValueLabel?.text = "$value"
+
+            else -> {
+                return
             }
-            VcsColorCategory.EDITOR_GUTTER -> {
-                pendingGutterIntensity = value
-                gutterValueLabel?.text = "$value"
-            }
-            VcsColorCategory.CONFLICT_MARKERS -> {
-                pendingConflictMarkerIntensity = value
-                conflictMarkerValueLabel?.text = "$value"
-            }
-            VcsColorCategory.BLAME_GUTTER -> {
-                pendingBlameIntensity = value
-                blameValueLabel?.text = "$value"
-            }
-            else -> return
         }
         vcsPreview?.updatePreview(variant ?: AyuVariant.DARK, previewIntensities())
         if (suppressSliderListeners) return
         promoteSectionToCustom(category)
     }
+
+    private fun valueLabelFor(category: VcsColorCategory): JLabel? =
+        when (category) {
+            VcsColorCategory.DIFF_VIEWER -> diffValueLabel
+            VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> projectViewValueLabel
+            VcsColorCategory.EDITOR_GUTTER -> gutterValueLabel
+            VcsColorCategory.CONFLICT_MARKERS -> conflictMarkerValueLabel
+            VcsColorCategory.BLAME_GUTTER -> blameValueLabel
+            else -> null
+        }
 
     private fun promoteSectionToCustom(category: VcsColorCategory) {
         when (category) {
@@ -335,37 +391,33 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
             VcsColorCategory.PROJECT_VIEW_FILE_STATUS,
             VcsColorCategory.EDITOR_GUTTER,
             -> {
-                if (pendingDiffPreset == VcsColorPreset.CUSTOM) return
-                pendingDiffPreset = VcsColorPreset.CUSTOM
+                if (section.pending.diffPreset == VcsColorPreset.CUSTOM) return
+                section.update { it.copy(diffPreset = VcsColorPreset.CUSTOM) }
                 diffCustomSelected.set(true)
                 diffPresetSegmented?.selectedItem = VcsColorPreset.CUSTOM
             }
+
             VcsColorCategory.CONFLICT_MARKERS -> {
-                if (pendingMergePreset == VcsColorPreset.CUSTOM) return
-                pendingMergePreset = VcsColorPreset.CUSTOM
+                if (section.pending.mergePreset == VcsColorPreset.CUSTOM) return
+                section.update { it.copy(mergePreset = VcsColorPreset.CUSTOM) }
                 mergeCustomSelected.set(true)
                 mergePresetSegmented?.selectedItem = VcsColorPreset.CUSTOM
             }
+
             VcsColorCategory.BLAME_GUTTER -> {
-                if (pendingBlamePreset == VcsColorPreset.CUSTOM) return
-                pendingBlamePreset = VcsColorPreset.CUSTOM
+                if (section.pending.blamePreset == VcsColorPreset.CUSTOM) return
+                section.update { it.copy(blamePreset = VcsColorPreset.CUSTOM) }
                 blameCustomSelected.set(true)
                 blamePresetSegmented?.selectedItem = VcsColorPreset.CUSTOM
             }
-            else -> Unit
+
+            else -> {
+                Unit
+            }
         }
     }
 
-    override fun isModified(): Boolean =
-        pendingEnabled != storedEnabled ||
-            pendingDiffPreset != storedDiffPreset ||
-            pendingMergePreset != storedMergePreset ||
-            pendingBlamePreset != storedBlamePreset ||
-            pendingDiffIntensity != storedDiffIntensity ||
-            pendingProjectViewIntensity != storedProjectViewIntensity ||
-            pendingGutterIntensity != storedGutterIntensity ||
-            pendingConflictMarkerIntensity != storedConflictMarkerIntensity ||
-            pendingBlameIntensity != storedBlameIntensity
+    override fun isModified(): Boolean = section.isModified()
 
     override fun apply() {
         if (!isModified()) return
@@ -377,45 +429,63 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
             return
         }
 
-        // Resolve per-section preset choices into per-category intensities,
-        // then materialise the snapshot. The applier reads only per-category
-        // intensities — preset/Custom branching is fully resolved here.
-        // Non-Custom presets defer to VcsColorPreset.intensityFor per
-        // category (so future preset variants that differentiate intensity
-        // across categories work correctly); Custom mode pulls the slider
-        // value for that specific category.
-        fun resolveCategory(
-            preset: VcsColorPreset,
-            category: VcsColorCategory,
-            customValue: Int,
-        ): Int = if (preset == VcsColorPreset.CUSTOM) customValue else preset.intensityFor(category)
-
-        val resolved =
-            mapOf(
-                VcsColorCategory.DIFF_VIEWER to
-                    resolveCategory(pendingDiffPreset, VcsColorCategory.DIFF_VIEWER, pendingDiffIntensity),
-                VcsColorCategory.PROJECT_VIEW_FILE_STATUS to
-                    resolveCategory(
-                        pendingDiffPreset,
-                        VcsColorCategory.PROJECT_VIEW_FILE_STATUS,
-                        pendingProjectViewIntensity,
-                    ),
-                VcsColorCategory.EDITOR_GUTTER to
-                    resolveCategory(pendingDiffPreset, VcsColorCategory.EDITOR_GUTTER, pendingGutterIntensity),
-                VcsColorCategory.CONFLICT_MARKERS to
-                    resolveCategory(
-                        pendingMergePreset,
-                        VcsColorCategory.CONFLICT_MARKERS,
-                        pendingConflictMarkerIntensity,
-                    ),
-                VcsColorCategory.BLAME_GUTTER to
-                    resolveCategory(pendingBlamePreset, VcsColorCategory.BLAME_GUTTER, pendingBlameIntensity),
-            )
-        val snapshot = VcsColorSnapshot(enabled = pendingEnabled, perCategoryIntensities = resolved)
-
         try {
-            VcsColorContext.withSnapshot(snapshot) {
-                VcsColorApplier.applyAll()
+            section.commit { pending, _ ->
+                // Resolve per-section preset choices into per-category intensities,
+                // then materialise the snapshot. The applier reads only per-category
+                // intensities — preset/Custom branching is fully resolved here.
+                // Non-Custom presets defer to VcsColorPreset.intensityFor per
+                // category (so future preset variants that differentiate intensity
+                // across categories work correctly); Custom mode pulls the slider
+                // value for that specific category.
+                fun resolveCategory(
+                    preset: VcsColorPreset,
+                    category: VcsColorCategory,
+                    customValue: Int,
+                ): Int = if (preset == VcsColorPreset.CUSTOM) customValue else preset.intensityFor(category)
+
+                val resolved =
+                    mapOf(
+                        VcsColorCategory.DIFF_VIEWER to
+                            resolveCategory(pending.diffPreset, VcsColorCategory.DIFF_VIEWER, pending.diffIntensity),
+                        VcsColorCategory.PROJECT_VIEW_FILE_STATUS to
+                            resolveCategory(
+                                pending.diffPreset,
+                                VcsColorCategory.PROJECT_VIEW_FILE_STATUS,
+                                pending.projectViewIntensity,
+                            ),
+                        VcsColorCategory.EDITOR_GUTTER to
+                            resolveCategory(
+                                pending.diffPreset,
+                                VcsColorCategory.EDITOR_GUTTER,
+                                pending.gutterIntensity,
+                            ),
+                        VcsColorCategory.CONFLICT_MARKERS to
+                            resolveCategory(
+                                pending.mergePreset,
+                                VcsColorCategory.CONFLICT_MARKERS,
+                                pending.conflictMarkerIntensity,
+                            ),
+                        VcsColorCategory.BLAME_GUTTER to
+                            resolveCategory(pending.blamePreset, VcsColorCategory.BLAME_GUTTER, pending.blameIntensity),
+                    )
+                val snapshot = VcsColorSnapshot(enabled = pending.enabled, perCategoryIntensities = resolved)
+
+                // Run the applier FIRST so a throw leaves persisted state untouched
+                // and the user can retry after fixing the cause.
+                VcsColorContext.withSnapshot(snapshot) {
+                    VcsColorApplier.applyAll()
+                }
+                val state = AyuIslandsSettings.getInstance().state
+                state.vcsColorEnabled = pending.enabled
+                state.vcsDiffPreset = pending.diffPreset.name
+                state.vcsMergePreset = pending.mergePreset.name
+                state.vcsBlamePreset = pending.blamePreset.name
+                state.vcsDiffIntensity = pending.diffIntensity
+                state.vcsProjectViewIntensity = pending.projectViewIntensity
+                state.vcsGutterIntensity = pending.gutterIntensity
+                state.vcsConflictMarkerIntensity = pending.conflictMarkerIntensity
+                state.vcsBlameIntensity = pending.blameIntensity
             }
         } catch (exception: RuntimeException) {
             LOG.warn(
@@ -441,92 +511,74 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
             }
             return
         }
-        val state = AyuIslandsSettings.getInstance().state
-        state.vcsColorEnabled = pendingEnabled
-        state.vcsDiffPreset = pendingDiffPreset.name
-        state.vcsMergePreset = pendingMergePreset.name
-        state.vcsBlamePreset = pendingBlamePreset.name
-        state.vcsDiffIntensity = pendingDiffIntensity
-        state.vcsProjectViewIntensity = pendingProjectViewIntensity
-        state.vcsGutterIntensity = pendingGutterIntensity
-        state.vcsConflictMarkerIntensity = pendingConflictMarkerIntensity
-        state.vcsBlameIntensity = pendingBlameIntensity
-        loadStored(state)
+        loadStored()
     }
 
     override fun reset() {
-        val state = AyuIslandsSettings.getInstance().state
-        loadStored(state)
+        loadStored()
         suppressSliderListeners = true
         try {
-            enabledCheckbox?.isSelected = pendingEnabled
-            diffPresetSegmented?.selectedItem = pendingDiffPreset
-            mergePresetSegmented?.selectedItem = pendingMergePreset
-            blamePresetSegmented?.selectedItem = pendingBlamePreset
-            masterEnabled.set(pendingEnabled || !licensed)
-            diffCustomSelected.set(pendingDiffPreset == VcsColorPreset.CUSTOM)
-            mergeCustomSelected.set(pendingMergePreset == VcsColorPreset.CUSTOM)
-            blameCustomSelected.set(pendingBlamePreset == VcsColorPreset.CUSTOM)
-            diffSlider?.value = pendingDiffIntensity
-            diffValueLabel?.text = "$pendingDiffIntensity"
-            projectViewSlider?.value = pendingProjectViewIntensity
-            projectViewValueLabel?.text = "$pendingProjectViewIntensity"
-            gutterSlider?.value = pendingGutterIntensity
-            gutterValueLabel?.text = "$pendingGutterIntensity"
-            conflictMarkerSlider?.value = pendingConflictMarkerIntensity
-            conflictMarkerValueLabel?.text = "$pendingConflictMarkerIntensity"
-            blameSlider?.value = pendingBlameIntensity
-            blameValueLabel?.text = "$pendingBlameIntensity"
+            val pending = section.pending
+            enabledCheckbox?.isSelected = pending.enabled
+            diffPresetSegmented?.selectedItem = pending.diffPreset
+            mergePresetSegmented?.selectedItem = pending.mergePreset
+            blamePresetSegmented?.selectedItem = pending.blamePreset
+            masterEnabled.set(pending.enabled || !licensed)
+            diffCustomSelected.set(pending.diffPreset == VcsColorPreset.CUSTOM)
+            mergeCustomSelected.set(pending.mergePreset == VcsColorPreset.CUSTOM)
+            blameCustomSelected.set(pending.blamePreset == VcsColorPreset.CUSTOM)
+            diffSlider?.value = pending.diffIntensity
+            diffValueLabel?.text = "${pending.diffIntensity}"
+            projectViewSlider?.value = pending.projectViewIntensity
+            projectViewValueLabel?.text = "${pending.projectViewIntensity}"
+            gutterSlider?.value = pending.gutterIntensity
+            gutterValueLabel?.text = "${pending.gutterIntensity}"
+            conflictMarkerSlider?.value = pending.conflictMarkerIntensity
+            conflictMarkerValueLabel?.text = "${pending.conflictMarkerIntensity}"
+            blameSlider?.value = pending.blameIntensity
+            blameValueLabel?.text = "${pending.blameIntensity}"
             vcsPreview?.updatePreview(variant ?: AyuVariant.DARK, previewIntensities())
         } finally {
             suppressSliderListeners = false
         }
     }
 
-    private fun loadStored(state: AyuIslandsState) {
-        storedEnabled = state.vcsColorEnabled
-        pendingEnabled = storedEnabled
-        storedDiffPreset = state.effectiveVcsDiffPreset()
-        pendingDiffPreset = storedDiffPreset
-        storedMergePreset = state.effectiveVcsMergePreset()
-        pendingMergePreset = storedMergePreset
-        storedBlamePreset = state.effectiveVcsBlamePreset()
-        pendingBlamePreset = storedBlamePreset
-        storedDiffIntensity = state.vcsDiffIntensity
-        pendingDiffIntensity = state.vcsDiffIntensity.coerceIn(MIN_INTENSITY, MAX_INTENSITY)
-        storedProjectViewIntensity = state.vcsProjectViewIntensity
-        pendingProjectViewIntensity = state.vcsProjectViewIntensity.coerceIn(MIN_INTENSITY, MAX_INTENSITY)
-        storedGutterIntensity = state.vcsGutterIntensity
-        pendingGutterIntensity = state.vcsGutterIntensity.coerceIn(MIN_INTENSITY, MAX_INTENSITY)
-        storedConflictMarkerIntensity = state.vcsConflictMarkerIntensity
-        pendingConflictMarkerIntensity = state.vcsConflictMarkerIntensity.coerceIn(MIN_INTENSITY, MAX_INTENSITY)
-        storedBlameIntensity = state.vcsBlameIntensity
-        pendingBlameIntensity = state.vcsBlameIntensity.coerceIn(MIN_INTENSITY, MAX_INTENSITY)
-        masterEnabled.set(pendingEnabled || !licensed)
-        diffCustomSelected.set(pendingDiffPreset == VcsColorPreset.CUSTOM)
-        mergeCustomSelected.set(pendingMergePreset == VcsColorPreset.CUSTOM)
-        blameCustomSelected.set(pendingBlamePreset == VcsColorPreset.CUSTOM)
+    private fun loadStored() {
+        section.load()
+        // Stored intensities mirror the raw persisted values; pending is clamped
+        // into the slider-safe range so JSlider construction stays total even for
+        // corrupted out-of-range XML. An out-of-range legacy value leaves
+        // stored != pending on purpose — the panel opens with a visible Apply.
+        section.update {
+            it.copy(
+                diffIntensity = it.diffIntensity.coerceIn(MIN_INTENSITY, MAX_INTENSITY),
+                projectViewIntensity = it.projectViewIntensity.coerceIn(MIN_INTENSITY, MAX_INTENSITY),
+                gutterIntensity = it.gutterIntensity.coerceIn(MIN_INTENSITY, MAX_INTENSITY),
+                conflictMarkerIntensity = it.conflictMarkerIntensity.coerceIn(MIN_INTENSITY, MAX_INTENSITY),
+                blameIntensity = it.blameIntensity.coerceIn(MIN_INTENSITY, MAX_INTENSITY),
+            )
+        }
+        masterEnabled.set(section.pending.enabled || !licensed)
+        diffCustomSelected.set(section.pending.diffPreset == VcsColorPreset.CUSTOM)
+        mergeCustomSelected.set(section.pending.mergePreset == VcsColorPreset.CUSTOM)
+        blameCustomSelected.set(section.pending.blamePreset == VcsColorPreset.CUSTOM)
     }
 
     /**
      * Switching a section's preset writes the new preset into that section's
-     * pending field, then (for non-Custom presets) snaps every slider owned by
-     * the section to the preset's canonical position. Custom mode leaves
+     * pending snapshot, then (for non-Custom presets) snaps every slider owned
+     * by the section to the preset's canonical position. Custom mode leaves
      * sliders alone so the user can fine-tune from the last preset.
      */
     private fun onSectionPresetChosen(
-        section: VcsSection,
+        vcsSection: VcsSection,
         preset: VcsColorPreset,
     ) {
-        when (section) {
-            VcsSection.DIFF -> pendingDiffPreset = preset
-            VcsSection.MERGE -> pendingMergePreset = preset
-            VcsSection.BLAME -> pendingBlamePreset = preset
-        }
+        section.update { it.withPreset(vcsSection, preset) }
         if (preset == VcsColorPreset.CUSTOM) return
         suppressSliderListeners = true
         try {
-            for ((category, _) in section.sliders) {
+            for ((category, _) in vcsSection.sliders) {
                 val snap = preset.intensityFor(category)
                 writeSliderValue(category, snap)
             }
@@ -541,90 +593,79 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
     ) {
         when (category) {
             VcsColorCategory.DIFF_VIEWER -> {
-                pendingDiffIntensity = value
+                section.update { it.copy(diffIntensity = value) }
                 diffSlider?.value = value
                 diffValueLabel?.text = "$value"
             }
+
             VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> {
-                pendingProjectViewIntensity = value
+                section.update { it.copy(projectViewIntensity = value) }
                 projectViewSlider?.value = value
                 projectViewValueLabel?.text = "$value"
             }
+
             VcsColorCategory.EDITOR_GUTTER -> {
-                pendingGutterIntensity = value
+                section.update { it.copy(gutterIntensity = value) }
                 gutterSlider?.value = value
                 gutterValueLabel?.text = "$value"
             }
+
             VcsColorCategory.CONFLICT_MARKERS -> {
-                pendingConflictMarkerIntensity = value
+                section.update { it.copy(conflictMarkerIntensity = value) }
                 conflictMarkerSlider?.value = value
                 conflictMarkerValueLabel?.text = "$value"
             }
+
             VcsColorCategory.BLAME_GUTTER -> {
-                pendingBlameIntensity = value
+                section.update { it.copy(blameIntensity = value) }
                 blameSlider?.value = value
                 blameValueLabel?.text = "$value"
             }
-            else -> Unit
+
+            else -> {
+                Unit
+            }
         }
         vcsPreview?.updatePreview(variant ?: AyuVariant.DARK, previewIntensities())
     }
 
     // ── @TestOnly seams ───────────────────────────────────────────────────────
 
-    @TestOnly internal fun getPendingEnabledForTest(): Boolean = pendingEnabled
+    @TestOnly internal fun getPendingEnabledForTest(): Boolean = section.pending.enabled
 
     @TestOnly internal fun setPendingEnabledForTest(value: Boolean) {
-        pendingEnabled = value
+        section.update { it.copy(enabled = value) }
     }
 
-    @TestOnly internal fun getPendingPresetForTest(section: VcsSection): VcsColorPreset =
-        when (section) {
-            VcsSection.DIFF -> pendingDiffPreset
-            VcsSection.MERGE -> pendingMergePreset
-            VcsSection.BLAME -> pendingBlamePreset
-        }
+    @TestOnly internal fun getPendingPresetForTest(vcsSection: VcsSection): VcsColorPreset =
+        section.pending.presetFor(
+            vcsSection,
+        )
 
     @TestOnly internal fun setPendingPresetForTest(
-        section: VcsSection,
+        vcsSection: VcsSection,
         preset: VcsColorPreset,
     ) {
-        when (section) {
-            VcsSection.DIFF -> pendingDiffPreset = preset
-            VcsSection.MERGE -> pendingMergePreset = preset
-            VcsSection.BLAME -> pendingBlamePreset = preset
-        }
+        section.update { it.withPreset(vcsSection, preset) }
     }
 
     @TestOnly internal fun getPendingIntensityForTest(category: VcsColorCategory): Int =
-        when (category) {
-            VcsColorCategory.DIFF_VIEWER -> pendingDiffIntensity
-            VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> pendingProjectViewIntensity
-            VcsColorCategory.EDITOR_GUTTER -> pendingGutterIntensity
-            VcsColorCategory.CONFLICT_MARKERS -> pendingConflictMarkerIntensity
-            VcsColorCategory.BLAME_GUTTER -> pendingBlameIntensity
-            else -> VcsColorPreset.AMBIENT_SLIDER
-        }
+        section.pending.intensityFor(
+            category,
+        )
 
     @TestOnly internal fun setPendingIntensityForTest(
         category: VcsColorCategory,
         value: Int,
     ) {
-        when (category) {
-            VcsColorCategory.DIFF_VIEWER -> pendingDiffIntensity = value
-            VcsColorCategory.PROJECT_VIEW_FILE_STATUS -> pendingProjectViewIntensity = value
-            VcsColorCategory.EDITOR_GUTTER -> pendingGutterIntensity = value
-            VcsColorCategory.CONFLICT_MARKERS -> pendingConflictMarkerIntensity = value
-            VcsColorCategory.BLAME_GUTTER -> pendingBlameIntensity = value
-            else -> Unit
-        }
+        section.update { it.withIntensity(category, value) }
     }
 
     @TestOnly internal fun triggerSectionPresetChosenForTest(
-        section: VcsSection,
+        vcsSection: VcsSection,
         preset: VcsColorPreset,
     ) {
-        onSectionPresetChosen(section, preset)
+        onSectionPresetChosen(vcsSection, preset)
     }
 
     companion object {

--- a/src/test/kotlin/dev/ayuislands/settings/SettingsSectionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/SettingsSectionTest.kt
@@ -1,0 +1,173 @@
+package dev.ayuislands.settings
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Behavioral coverage for [SettingsSection] — the pending/stored machine every
+ * settings panel delegates to. Zero mocks: the snapshot source is a plain
+ * `var` the tests mutate to simulate persisted-state changes.
+ *
+ * Branches locked:
+ *  - fresh section is clean; [SettingsSection.update] diverges pending only
+ *  - [SettingsSection.load] pulls the persisted baseline into both values
+ *  - [SettingsSection.resetToStored] is the in-memory reset (ignores newer
+ *    persisted state, unlike [SettingsSection.load])
+ *  - [SettingsSection.commit] no-ops when clean, converges stored when dirty,
+ *    leaves both values untouched when the action throws (retry contract),
+ *    and honors mid-action normalization via [SettingsSection.update]
+ */
+class SettingsSectionTest {
+    private data class Draft(
+        val name: String = "default",
+        val level: Int = 0,
+    )
+
+    private var persisted = Draft(name = "persisted", level = 7)
+
+    private fun newSection(): SettingsSection<Draft> = SettingsSection(initial = Draft()) { persisted }
+
+    @Test
+    fun `fresh section starts clean at the initial snapshot`() {
+        val section = newSection()
+
+        assertEquals(Draft(), section.pending, "pending must start at the initial snapshot")
+        assertEquals(Draft(), section.stored, "stored must start at the initial snapshot")
+        assertFalse(section.isModified(), "fresh section must not report modified")
+    }
+
+    @Test
+    fun `update diverges pending and leaves stored at the baseline`() {
+        val section = newSection()
+
+        section.update { it.copy(level = 42) }
+
+        assertEquals(42, section.pending.level, "update must rewrite pending")
+        assertEquals(Draft(), section.stored, "update must never touch stored")
+        assertTrue(section.isModified(), "pending != stored must report modified")
+    }
+
+    @Test
+    fun `load pulls the persisted snapshot into both pending and stored`() {
+        val section = newSection()
+        section.update { it.copy(level = 42) }
+
+        section.load()
+
+        assertEquals(persisted, section.pending, "load must align pending with persisted state")
+        assertEquals(persisted, section.stored, "load must align stored with persisted state")
+        assertFalse(section.isModified(), "section must be clean right after load")
+    }
+
+    @Test
+    fun `load followed by a normalizing update leaves a deliberate diff`() {
+        // The clamp-legacy-values pattern: stored keeps the raw persisted value,
+        // pending holds the normalized one, so the Apply button surfaces.
+        persisted = Draft(name = "legacy", level = 90)
+        val section = newSection()
+
+        section.load()
+        section.update { it.copy(level = it.level.coerceAtMost(50)) }
+
+        assertEquals(90, section.stored.level, "stored must keep the raw persisted value")
+        assertEquals(50, section.pending.level, "pending must hold the normalized value")
+        assertTrue(section.isModified(), "normalization diff must mark the section modified")
+    }
+
+    @Test
+    fun `resetToStored reverts pending in-memory and returns the restored value`() {
+        val section = newSection()
+        section.load()
+        section.update { it.copy(name = "edited") }
+
+        val restored = section.resetToStored()
+
+        assertEquals(persisted, restored, "resetToStored must return the restored snapshot")
+        assertEquals(persisted, section.pending, "pending must return to stored")
+        assertFalse(section.isModified(), "section must be clean after resetToStored")
+    }
+
+    @Test
+    fun `resetToStored ignores newer persisted state while load re-reads it`() {
+        val section = newSection()
+        section.load()
+        val baseline = section.stored
+        persisted = Draft(name = "changed-behind-the-panel", level = 99)
+
+        section.update { it.copy(level = 1) }
+        section.resetToStored()
+        assertEquals(baseline, section.pending, "resetToStored must revert to the in-memory baseline")
+
+        section.load()
+        assertEquals(persisted, section.pending, "load must re-read the newer persisted state")
+        assertEquals(persisted, section.stored, "load must rebase stored on the newer persisted state")
+    }
+
+    @Test
+    fun `commit is a no-op when nothing diverged`() {
+        val section = newSection()
+        section.load()
+        var invoked = false
+
+        section.commit { _, _ -> invoked = true }
+
+        assertFalse(invoked, "commit must not run its action on a clean section")
+    }
+
+    @Test
+    fun `commit hands the action the diverged pending and the pre-commit stored`() {
+        val section = newSection()
+        section.load()
+        section.update { it.copy(level = 42) }
+        var observedPending: Draft? = null
+        var observedStored: Draft? = null
+
+        section.commit { pending, stored ->
+            observedPending = pending
+            observedStored = stored
+        }
+
+        assertEquals(persisted.copy(level = 42), observedPending, "action must see the edited pending")
+        assertEquals(persisted, observedStored, "action must see the pre-commit stored baseline")
+        assertEquals(section.pending, section.stored, "stored must converge onto pending after commit")
+        assertFalse(section.isModified(), "section must be clean after a successful commit")
+    }
+
+    @Test
+    fun `commit leaves both values untouched when the action throws`() {
+        val section = newSection()
+        section.load()
+        section.update { it.copy(level = 42) }
+
+        assertFailsWith<IllegalStateException> {
+            section.commit { _, _ -> error("simulated apply failure") }
+        }
+
+        assertEquals(42, section.pending.level, "pending must survive a failed commit for retry")
+        assertEquals(persisted, section.stored, "stored must stay at the baseline when the action throws")
+        assertTrue(section.isModified(), "section must stay modified so the user can retry")
+    }
+
+    @Test
+    fun `commit converges stored onto pending as normalized by the action`() {
+        // The Effects-panel pattern: the action folds preset values into pending
+        // before persisting; stored must pick up the normalized value.
+        val section = newSection()
+        section.load()
+        section.update { it.copy(level = 42) }
+
+        section.commit { _, _ ->
+            section.update { it.copy(level = 40, name = "normalized") }
+        }
+
+        assertEquals(
+            persisted.copy(level = 40, name = "normalized"),
+            section.stored,
+            "stored must converge onto the pending value observed after the action",
+        )
+        assertFalse(section.isModified(), "section must be clean after a normalizing commit")
+    }
+}


### PR DESCRIPTION
── Summary ─────────────────────────────────

C4 (phase 1) from the architecture review. Every settings panel re-implements the same pending/stored/isModified lifecycle machine by hand against flat field pairs. `SettingsSection<T>` now owns that machine generically over an immutable per-panel snapshot; five panels (Appearance, Elements, Effects, Chrome, VCS) migrated with **zero edits to existing tests** — including the two heaviest seam consumers (`AyuIslandsChromePanelTest`: 50 `@TestOnly` call sites, `VcsColorPanelTest`: 80), whose seams became thin delegates over the section.

── Changes ─────────────────────────────────

| Type | Where | What |
|------|-------|------|
| Refactor | `src/main/kotlin/dev/ayuislands/settings/SettingsSection.kt:1` | The machine: `pending`/`stored`, `update {}`, `isModified`, `load()` (reset-from-persisted) vs `resetToStored()`, `commit(action)` with throw-aborts-commit |
| Refactor | 5 × `settings/*Panel.kt` | Field pairs → one section + private data-class snapshot each; `VcsColorSettings` category helpers delete six duplicated `when(category)` dispatches; Chrome's license-clamp + "legacy value opens dirty" semantics reproduced exactly |
| Test | `src/test/kotlin/dev/ayuislands/settings/SettingsSectionTest.kt:1` | 10 zero-mock tests: no-op gate, throw-aborts, mid-commit normalization convergence, load-vs-reset semantics |

── Validation ──────────────────────────────

```bash
./gradlew test detekt ktlintCheck koverVerify
```
Expected: green; `SettingsSection` 100% covered, `AyuIslandsChromePanel` 92.8%, `VcsColorPanel` 90.3%; no threshold or exclusion changes.

Manual: Settings → each migrated tab — edit, Apply, Cancel, Reset; Chrome/VCS failure balloons still gate persistence (effect-first ordering preserved).

── Notes ───────────────────────────────────

- `commit(action: (pending, stored) -> Unit)` deliberately does NOT fix an effect/persist order: the census showed three legitimate orderings (Chrome/Vcs effect-first-transactional; Elements/Appearance persist-first because side-effects read fresh state; Effects persist-only). The panel-defined action keeps each byte-compatible.
- Named `commit`, not `apply` — a trailing lambda on `apply` silently resolves to stdlib `T.apply`.
- Deliberately not folded in: Appearance's `syncEditorScheme` pair (its test reaches the fields via `getDeclaredField` reflection — migrate that test first), and the remaining panels (Accent/Overrides/Font/Workspace/Plugins/Syntax) — follow-up phase.

## Summary by Sourcery

Introduce a reusable SettingsSection abstraction to centralize pending/stored state management for settings panels and migrate multiple existing panels to use it while preserving behavior.

Enhancements:
- Refactor VCS color, effects, chrome tinting, elements, and appearance panels to delegate their pending/stored lifecycle and isModified logic to the shared SettingsSection snapshot-based machine.
- Maintain existing edge-case semantics such as legacy value clamping, effect-vs-persist ordering, and license gating while simplifying panel state handling.
- Streamline VCS and elements panels by introducing per-panel immutable settings snapshots with helpers that replace duplicated category and toggle handling logic.

Tests:
- Add focused unit tests for SettingsSection covering load, reset, commit, and normalization behaviors without mocks to lock in its lifecycle semantics.