### PR TITLE
refactor(accent): make language detection publish-only

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "886cbbdc"
+          last_verified_sha: "d8514db2"
           last_verified_date: "2026-06-30"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "886cbbdc"
+          last_verified_sha: "d8514db2"
           last_verified_date: "2026-06-30"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -304,7 +304,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "886cbbdc"
+          last_verified_sha: "d8514db2"
           last_verified_date: "2026-06-16"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -345,7 +345,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "886cbbdc"
+          last_verified_sha: "d8514db2"
           last_verified_date: "2026-06-16"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -397,7 +397,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "886cbbdc"
+          last_verified_sha: "d8514db2"
           last_verified_date: "2026-06-12"
           content_sha256: ad849b17308901bc2dac85f895978be656f578c9c31f857b9e9578e5cf4289f2
 
@@ -459,7 +459,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "886cbbdc"
+          last_verified_sha: "d8514db2"
           last_verified_date: "2026-06-16"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "bfc77829"
+          last_verified_sha: "a44b472f"
           last_verified_date: "2026-06-30"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "bfc77829"
+          last_verified_sha: "a44b472f"
           last_verified_date: "2026-06-30"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -304,7 +304,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "bfc77829"
+          last_verified_sha: "a44b472f"
           last_verified_date: "2026-06-16"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -345,7 +345,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "bfc77829"
+          last_verified_sha: "a44b472f"
           last_verified_date: "2026-06-16"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -397,7 +397,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "bfc77829"
+          last_verified_sha: "a44b472f"
           last_verified_date: "2026-06-12"
           content_sha256: ad849b17308901bc2dac85f895978be656f578c9c31f857b9e9578e5cf4289f2
 
@@ -459,7 +459,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "bfc77829"
+          last_verified_sha: "a44b472f"
           last_verified_date: "2026-06-16"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "a44b472f"
+          last_verified_sha: "886cbbdc"
           last_verified_date: "2026-06-30"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "a44b472f"
+          last_verified_sha: "886cbbdc"
           last_verified_date: "2026-06-30"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -304,7 +304,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "a44b472f"
+          last_verified_sha: "886cbbdc"
           last_verified_date: "2026-06-16"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -345,7 +345,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "a44b472f"
+          last_verified_sha: "886cbbdc"
           last_verified_date: "2026-06-16"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -397,7 +397,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "a44b472f"
+          last_verified_sha: "886cbbdc"
           last_verified_date: "2026-06-12"
           content_sha256: ad849b17308901bc2dac85f895978be656f578c9c31f857b9e9578e5cf4289f2
 
@@ -459,7 +459,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "a44b472f"
+          last_verified_sha: "886cbbdc"
           last_verified_date: "2026-06-16"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "55c741ec"
+          last_verified_sha: "bfc77829"
           last_verified_date: "2026-06-30"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "55c741ec"
+          last_verified_sha: "bfc77829"
           last_verified_date: "2026-06-30"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -304,7 +304,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "55c741ec"
+          last_verified_sha: "bfc77829"
           last_verified_date: "2026-06-16"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -345,7 +345,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "55c741ec"
+          last_verified_sha: "bfc77829"
           last_verified_date: "2026-06-16"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -397,7 +397,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "55c741ec"
+          last_verified_sha: "bfc77829"
           last_verified_date: "2026-06-12"
           content_sha256: ad849b17308901bc2dac85f895978be656f578c9c31f857b9e9578e5cf4289f2
 
@@ -459,7 +459,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "55c741ec"
+          last_verified_sha: "bfc77829"
           last_verified_date: "2026-06-16"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -12,6 +12,7 @@ import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.ProjectLanguageDetector
 import dev.ayuislands.accent.ProjectLanguageRootChangeListener
+import dev.ayuislands.accent.ScanCompletionAccentRefresher
 import dev.ayuislands.accent.conflict.ConflictRegistry
 import dev.ayuislands.accent.runCatchingPreservingCancellation
 import dev.ayuislands.editor.EditorScrollbarManager
@@ -39,6 +40,18 @@ internal class AyuIslandsStartupActivity : ProjectActivity {
         LOG.info("Ayu Islands loaded — active theme: $themeName, project: ${project.name}")
 
         val settings = AyuIslandsSettings.getInstance()
+
+        // Language detection is a one-way event: the detector only publishes
+        // scanCompleted, and this project service is the single subscriber that
+        // owns the post-scan re-resolve + accent apply. Instantiate it BEFORE
+        // the first accent resolve below — runStartupAccentOnEdt can schedule
+        // the first background scan (EDT resolve on a cold cache), and the
+        // scan's completion must not fire into an empty subscriber list.
+        // Installed before the external-theme early return on purpose: the
+        // refresher self-gates on AyuVariant.detect(), mirroring the reaction
+        // that previously lived unconditionally inside the detector.
+        ScanCompletionAccentRefresher.getInstance(project)
+
         val variant =
             AyuVariant.fromThemeName(themeName) ?: return initializeExternalThemeIfEnabled(project, settings)
 

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetectionListener.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetectionListener.kt
@@ -8,10 +8,13 @@ import com.intellij.util.messages.Topic
  * definitive no-winner verdict, or hit a transient failure path.
  *
  * Subscribers refresh UI projections over the detector cache (the Settings
- * proportions status row, the Tools-menu Rescan balloon). Listener runs on
- * the EDT so handlers can touch Swing directly without their own
- * `invokeLater` wrap; [ProjectLanguageDetector.publishScanCompleted] is the
- * sole producer and already dispatches the publish onto EDT.
+ * proportions status row, the Tools-menu Rescan balloon); the one
+ * non-projection subscriber is [ScanCompletionAccentRefresher], which owns
+ * the post-scan re-resolve + accent apply so the detector stays a one-way
+ * event source. Listener runs on the EDT so handlers can touch Swing
+ * directly without their own `invokeLater` wrap;
+ * [ProjectLanguageDetector.publishScanCompleted] is the sole producer and
+ * already dispatches the publish onto EDT.
  *
  * Project-scoped (not application-scoped) so the subscription list is
  * automatically cleared when the project closes and the `Project`-keyed

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
@@ -7,7 +7,6 @@ import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
 import dev.ayuislands.settings.mappings.AccentMappingsSettings
-import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
 import javax.swing.SwingUtilities
@@ -37,9 +36,12 @@ import javax.swing.SwingUtilities
  * On EDT, first-call detection on a large monorepo is a ~300–500 ms freeze. To avoid
  * that, an EDT invocation with an empty cache kicks off a deduplicated background scan
  * via [ProjectLanguageScanAsync] and returns null immediately; the caller falls through
- * to the global accent. When the BG scan completes with a cacheable verdict, the
- * detector re-applies the resolver result on EDT so the UI picks up either the new
- * winner or the fallback without waiting for the next focus swap.
+ * to the global accent. When the BG scan completes, the detector only publishes
+ * [ProjectLanguageDetectionListener.scanCompleted]; [ScanCompletionAccentRefresher] —
+ * the sole accent-owning subscriber — re-applies the resolver result on EDT for
+ * cacheable outcomes so the UI picks up either the new winner or the fallback
+ * without waiting for the next focus swap. Detection stays a one-way event: this
+ * detector never re-enters the resolve+apply pipeline itself.
  *
  * Cache correctness: a detection whose scan threw is NOT cached — the next call
  * retries. A scan that ran cleanly but produced no winner (after both the proportional
@@ -159,8 +161,9 @@ object ProjectLanguageDetector {
      *    the next `ModuleRootListener.rootsChanged` to re-trigger detection
      *    on a Gradle sync / module change).
      *  - On scan completion, [ProjectLanguageDetectionListener.scanCompleted]
-     *    fires on EDT via [publishScanCompleted], so UI subscribers (the
-     *    Settings proportions row, the action's balloon) receive the new
+     *    fires on EDT via [publishScanCompleted], so subscribers (the
+     *    Settings proportions row, the action's balloon, the
+     *    [ScanCompletionAccentRefresher] accent re-apply) receive the new
      *    state without polling.
      *  - When [project] has no canonical path (disposal race, default
      *    project), publishes [ScanOutcome.Unavailable] immediately so one-shot
@@ -318,16 +321,6 @@ object ProjectLanguageDetector {
                     ProjectLanguageVerdict.Unavailable,
                     -> ScanOutcome.Unavailable
                 }
-            when (verdict) {
-                is ProjectLanguageVerdict.Detected,
-                is ProjectLanguageVerdict.NoWinner,
-                ProjectLanguageVerdict.Empty,
-                -> tryRefreshAccentAfterCacheableScan(project)
-
-                ProjectLanguageVerdict.Cold,
-                ProjectLanguageVerdict.Unavailable,
-                -> Unit
-            }
             publishScanCompleted(project, outcome, key, cachedDetection.cacheEntry)
             when (outcome) {
                 is ScanOutcome.Detected,
@@ -380,56 +373,6 @@ object ProjectLanguageDetector {
             }.onFailure { exception ->
                 LOG.warn("scanCompleted publish failed; subscribers will not refresh for this scan", exception)
             }
-        }
-    }
-
-    /**
-     * After a background scan reaches a cacheable verdict, re-apply the current
-     * resolver result. Both positive hits and definitive polyglot/no-match
-     * outcomes can change the visible accent: a hit may enable a language
-     * override, while a fallback verdict may remove one.
-     */
-    private fun tryRefreshAccentAfterCacheableScan(project: Project) {
-        SwingUtilities.invokeLater { refreshAccentOnEdt(project) }
-    }
-
-    /**
-     * EDT body extracted from [tryRefreshAccentAfterCacheableScan] so the
-     * resolver + apply chain can be red/green tested synchronously without
-     * having to pump a Swing event loop. The caller is expected to already be
-     * on the EDT (production: wrapped in `SwingUtilities.invokeLater`; tests:
-     * called directly on the test thread). Returns early on disposal, logs and
-     * swallows any downstream apply failure.
-     *
-     * `internal` (no `@TestOnly`) because [tryRefreshAccentAfterCacheableScan]
-     * — the production caller — reaches this helper through the
-     * `SwingUtilities.invokeLater` boundary; marking it test-only would
-     * misrepresent the call graph and any `@TestOnly` inspection would either
-     * miss real misuse or flag this legitimate production path.
-     */
-    internal fun refreshAccentOnEdt(project: Project) {
-        if (project.isDisposed) return
-        runCatchingPreservingCancellation {
-            // Best-effort refresh: the cache already has the cacheable scan
-            // verdict, so `dominant()` behavior is unaffected by failures here.
-            // Containing exceptions keeps a regression in any of the
-            // downstream apply paths (variant detection, UIManager writes,
-            // focus-swap notification) from surfacing as an uncaught EDT
-            // exception and risking the UI.
-            if (AccentApplicator.resolveFocusedProject() !== project) {
-                LOG.debug("Post-scan accent refresh skipped because focused project changed")
-                return@runCatchingPreservingCancellation
-            }
-            val variant = AyuVariant.detect() ?: return@runCatchingPreservingCancellation
-            val hex = AccentResolver.resolve(project, variant)
-            val applied = AccentApplicator.applyFromHexString(hex)
-            if (applied) {
-                ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
-            } else {
-                LOG.warn("Skipping swap publish: applyFromHexString rejected '$hex'")
-            }
-        }.onFailure { exception ->
-            LOG.warn("Post-scan accent refresh failed; cache is still warm", exception)
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/accent/ScanCompletionAccentRefresher.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ScanCompletionAccentRefresher.kt
@@ -58,7 +58,10 @@ internal class ScanCompletionAccentRefresher(
 
     /**
      * EDT body of the post-scan refresh. Returns early on disposal, logs and
-     * swallows any downstream apply failure.
+     * swallows any downstream apply failure. The EDT contract is enforced only
+     * transitively by `publishScanCompleted`'s dispatch choice — a future
+     * producer publishing off-EDT would race the UIManager writes downstream,
+     * so keep that dispatch the sole publish path.
      */
     private fun refreshAccent() {
         if (project.isDisposed) return

--- a/src/main/kotlin/dev/ayuislands/accent/ScanCompletionAccentRefresher.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ScanCompletionAccentRefresher.kt
@@ -1,0 +1,98 @@
+package dev.ayuislands.accent
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import dev.ayuislands.settings.mappings.ProjectAccentSwapService
+
+/**
+ * Sole accent-owning subscriber of [ProjectLanguageDetectionListener.TOPIC].
+ *
+ * Keeps language detection a one-way event: [ProjectLanguageDetector] only
+ * publishes `scanCompleted`, and this project service reacts by re-applying
+ * the current resolver result. Before this class existed the detector
+ * re-entered the resolve+apply pipeline from inside its own scan-completion
+ * body, which coupled the scanner to the applicator and duplicated the
+ * disposal-race defenses on both sides.
+ *
+ * After a background scan reaches a cacheable verdict ([ScanOutcome.Detected]
+ * or [ScanOutcome.Polyglot]) the current resolver result must be re-applied:
+ * a hit may enable a language override, while a fallback verdict may remove
+ * one. [ScanOutcome.Unavailable] is transient — the cache was not populated,
+ * so there is nothing new to apply and the previous accent stays put.
+ *
+ * Threading: [ProjectLanguageDetectionListener] handlers run on the EDT
+ * (`publishScanCompleted` dispatches the publish via `invokeLater`), so the
+ * resolver + apply chain here needs no additional dispatch. The subscription
+ * is anchored to this service's own [Disposable], so it is torn down with
+ * the project (the service container disposes project services on close).
+ */
+@Service(Service.Level.PROJECT)
+internal class ScanCompletionAccentRefresher(
+    private val project: Project,
+) : Disposable {
+    init {
+        project.messageBus.connect(this).subscribe(
+            ProjectLanguageDetectionListener.TOPIC,
+            ProjectLanguageDetectionListener { outcome -> onScanCompleted(outcome) },
+        )
+    }
+
+    /**
+     * Mirrors the cacheable-verdict gate the detector used before the refresh
+     * reaction moved here: `Detected` / `NoWinner` / `Empty` verdicts (which
+     * publish as [ScanOutcome.Detected] / [ScanOutcome.Polyglot]) refreshed
+     * the accent; `Cold` / `Unavailable` (publishing as
+     * [ScanOutcome.Unavailable]) did not.
+     */
+    internal fun onScanCompleted(outcome: ScanOutcome) {
+        when (outcome) {
+            is ScanOutcome.Detected,
+            ScanOutcome.Polyglot,
+            -> refreshAccent()
+
+            ScanOutcome.Unavailable -> Unit
+        }
+    }
+
+    /**
+     * EDT body of the post-scan refresh. Returns early on disposal, logs and
+     * swallows any downstream apply failure.
+     */
+    private fun refreshAccent() {
+        if (project.isDisposed) return
+        runCatchingPreservingCancellation {
+            // Best-effort refresh: the cache already has the cacheable scan
+            // verdict (the detector publishes only after `detectAndCache`), so
+            // `dominant()` behavior is unaffected by failures here. Containing
+            // exceptions keeps a regression in any of the downstream apply
+            // paths (variant detection, UIManager writes, focus-swap
+            // notification) from surfacing as an uncaught EDT exception and
+            // risking the UI.
+            if (AccentApplicator.resolveFocusedProject() !== project) {
+                LOG.debug("Post-scan accent refresh skipped because focused project changed")
+                return@runCatchingPreservingCancellation
+            }
+            val variant = AyuVariant.detect() ?: return@runCatchingPreservingCancellation
+            val hex = AccentResolver.resolve(project, variant)
+            val applied = AccentApplicator.applyFromHexString(hex)
+            if (applied) {
+                ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
+            } else {
+                LOG.warn("Skipping swap publish: applyFromHexString rejected '$hex'")
+            }
+        }.onFailure { exception ->
+            LOG.warn("Post-scan accent refresh failed; cache is still warm", exception)
+        }
+    }
+
+    override fun dispose() = Unit
+
+    companion object {
+        private val LOG = logger<ScanCompletionAccentRefresher>()
+
+        fun getInstance(project: Project): ScanCompletionAccentRefresher =
+            project.getService(ScanCompletionAccentRefresher::class.java)
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/actions/RescanLanguageAction.kt
+++ b/src/main/kotlin/dev/ayuislands/actions/RescanLanguageAction.kt
@@ -27,6 +27,12 @@ import dev.ayuislands.licensing.LicenseChecker
  * is a one-shot — it disconnects inside the callback so rapid-fire clicks don't
  * pile subscriptions on the bus. The scheduler's dedup gate coalesces concurrent
  * scans, so one balloon fires per *completed* scan regardless of click spam.
+ *
+ * Triage note: on a pathologically slow startup this action can complete a scan
+ * before [dev.ayuislands.accent.ScanCompletionAccentRefresher] is installed by
+ * the project activity — the balloon then reports the detected language while
+ * the accent visibly changes only moments later, once the activity's own apply
+ * reads the (already warm) cache. Expected convergence, not a lost refresh.
  */
 internal class RescanLanguageAction : DumbAwareAction() {
     override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
@@ -614,6 +614,31 @@ class AyuIslandsStartupActivityTest {
         )
     }
 
+    @Test
+    fun `startup installs the scan-completion accent refresher before the first accent resolve`() {
+        // Regression guard: `runStartupAccentOnEdt` can schedule the first
+        // background language scan (EDT resolve on a cold detector cache).
+        // `ScanCompletionAccentRefresher` owns the post-scan accent re-apply,
+        // so it must subscribe BEFORE that first resolve — otherwise the
+        // startup scan's completion fires into an empty subscriber list and
+        // the accent stays on the global fallback until the next focus swap.
+        // Like the EDT-wrap guards above, the invariant is source-level:
+        // dynamically invoking execute() needs a full project fixture.
+        val source = readStartupActivitySource()
+        val installCall = "ScanCompletionAccentRefresher.getInstance(project)"
+        val firstResolveCall = "runStartupAccentOnEdt(project, variant)"
+        val installIndex = source.indexOf(installCall)
+        val resolveIndex = source.indexOf(firstResolveCall)
+
+        assertTrue(installIndex >= 0, "startup must install ScanCompletionAccentRefresher")
+        assertTrue(resolveIndex >= 0, "startup must still run the initial accent resolve")
+        assertTrue(
+            installIndex < resolveIndex,
+            "ScanCompletionAccentRefresher must be installed before runStartupAccentOnEdt " +
+                "schedules the first background language scan",
+        )
+    }
+
     private fun readStartupActivitySource(): String {
         val source =
             java.io

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
@@ -883,159 +883,6 @@ class ProjectLanguageDetectorTest {
         )
     }
 
-    // ── refreshAccentOnEdt (extracted from cacheable scan refresh) ────────────
-
-    @Test
-    fun `refreshAccentOnEdt reapplies resolver fallback when language override no longer matches`() {
-        // A cacheable scan can remove the active language override as well as
-        // add one. The resolver owns that fallback decision; this helper must
-        // apply whatever it resolves so chrome/glow do not stay on the old
-        // language accent until the next focus swap.
-        mockkObject(AyuVariant.Companion)
-        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
-        mockkObject(AccentResolver)
-        every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#FFCC66"
-        mockkObject(AccentApplicator)
-        justRun { AccentApplicator.apply(any()) }
-        val swapService = mockk<dev.ayuislands.settings.mappings.ProjectAccentSwapService>(relaxed = true)
-        mockkObject(dev.ayuislands.settings.mappings.ProjectAccentSwapService.Companion)
-        every {
-            dev.ayuislands.settings.mappings.ProjectAccentSwapService
-                .getInstance()
-        } returns swapService
-
-        val project = stubProject("/tmp/refresh-fallback-${System.nanoTime()}")
-        every { AccentApplicator.resolveFocusedProject() } returns project
-        ProjectLanguageDetector.refreshAccentOnEdt(project)
-
-        verify(exactly = 1) { AccentApplicator.applyFromHexString("#FFCC66") }
-        verify(exactly = 1) { swapService.notifyExternalApply("#FFCC66") }
-    }
-
-    @Test
-    fun `refreshAccentOnEdt runs the full apply chain when override is present`() {
-        // Happy-path lock: given a resolved language override on a live
-        // project, the helper must call the full resolver → applicator →
-        // swap-cache chain. Dropping any of the three downstream calls would
-        // leave users stuck on the previous accent until the next focus swap.
-        mockkObject(AyuVariant.Companion)
-        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
-        mockkObject(AccentResolver)
-        every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#FFCC66"
-        mockkObject(AccentApplicator)
-        justRun { AccentApplicator.apply(any()) }
-        val swapService = mockk<dev.ayuislands.settings.mappings.ProjectAccentSwapService>(relaxed = true)
-        mockkObject(dev.ayuislands.settings.mappings.ProjectAccentSwapService.Companion)
-        every {
-            dev.ayuislands.settings.mappings.ProjectAccentSwapService
-                .getInstance()
-        } returns swapService
-
-        val project = stubProject("/tmp/refresh-hit-${System.nanoTime()}")
-        every { AccentApplicator.resolveFocusedProject() } returns project
-        ProjectLanguageDetector.refreshAccentOnEdt(project)
-
-        verify(exactly = 1) { AccentApplicator.applyFromHexString("#FFCC66") }
-        verify(exactly = 1) { swapService.notifyExternalApply("#FFCC66") }
-    }
-
-    @Test
-    fun `refreshAccentOnEdt swallows a throwing apply chain without rethrowing`() {
-        // Contract lock on the runCatchingPreservingCancellation wrapper:
-        // AccentApplicator.apply can throw on a LafManager race / UIManager
-        // shutdown; if that propagates out of the invokeLater callback it
-        // becomes an uncaught EDT exception. This test asserts the helper
-        // returns normally (WARN-logged internally) instead of rethrowing.
-        mockkObject(AyuVariant.Companion)
-        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
-        mockkObject(AccentResolver)
-        every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#FFCC66"
-        mockkObject(AccentApplicator)
-        every { AccentApplicator.apply(any()) } throws RuntimeException("LafManager boom")
-
-        val project = stubProject("/tmp/refresh-throw-${System.nanoTime()}")
-        every { AccentApplicator.resolveFocusedProject() } returns project
-        // Must not throw — load-bearing assertion is simply that the call
-        // completes. A regression dropping the runCatching would propagate
-        // the RuntimeException and fail this test.
-        ProjectLanguageDetector.refreshAccentOnEdt(project)
-    }
-
-    @Test
-    fun `refreshAccentOnEdt swallows a throwing resolver without rethrowing`() {
-        // The resolver now owns both hit and fallback decisions. A corrupt
-        // override, plugin-unload race, or resolver regression must not escape
-        // the invokeLater callback as an uncaught EDT exception.
-        mockkObject(AyuVariant.Companion)
-        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
-        mockkObject(AccentResolver)
-        every { AccentResolver.resolve(any(), any<AyuVariant>()) } throws RuntimeException("resolver boom")
-
-        mockkObject(AccentApplicator)
-        justRun { AccentApplicator.apply(any()) }
-
-        val project = stubProject("/tmp/refresh-settings-boom-${System.nanoTime()}")
-        every { AccentApplicator.resolveFocusedProject() } returns project
-
-        // Must not throw — the runCatching contains the resolver.
-        ProjectLanguageDetector.refreshAccentOnEdt(project)
-
-        // And because the resolver failed, the apply chain must not be reached.
-        verify(exactly = 0) { AccentApplicator.apply(any()) }
-    }
-
-    @Test
-    fun `refreshAccentOnEdt skips apply chain when variant detection returns null`() {
-        // Null variant = no Ayu theme active. The early `?: return@…` keeps
-        // the applicator from touching UIManager when there's no Ayu theme to
-        // drive. Locking the guard so a future author doesn't delete it as
-        // "dead code" — it's the fallback path for users on a non-Ayu theme.
-        mockkObject(AyuVariant.Companion)
-        every { AyuVariant.detect() } returns null
-
-        mockkObject(AccentApplicator)
-        justRun { AccentApplicator.apply(any()) }
-
-        val project = stubProject("/tmp/refresh-null-variant-${System.nanoTime()}")
-        every { AccentApplicator.resolveFocusedProject() } returns project
-        ProjectLanguageDetector.refreshAccentOnEdt(project)
-
-        verify(exactly = 0) { AccentApplicator.apply(any()) }
-    }
-
-    @Test
-    fun `refreshAccentOnEdt skips apply chain when focused project changed after scan`() {
-        // The apply path writes app-global UIManager state. A background scan
-        // from an old project must not repaint over the project that gained
-        // focus while the scan was running.
-        val scannedProject = stubProject("/tmp/refresh-old-focus-${System.nanoTime()}")
-        val focusedProject = stubProject("/tmp/refresh-new-focus-${System.nanoTime()}")
-        mockkObject(AccentApplicator)
-        every { AccentApplicator.resolveFocusedProject() } returns focusedProject
-        justRun { AccentApplicator.apply(any()) }
-
-        ProjectLanguageDetector.refreshAccentOnEdt(scannedProject)
-
-        verify(exactly = 0) { AccentApplicator.apply(any()) }
-    }
-
-    @Test
-    fun `refreshAccentOnEdt skips apply chain when project is disposed`() {
-        // Round-2 disposal guard: scheduling delay between background scan
-        // and EDT dispatch can close the project. The early return here
-        // keeps the applicator from writing UIManager entries for a dead
-        // project's swap-cache.
-        mockkObject(AccentApplicator)
-        justRun { AccentApplicator.apply(any()) }
-
-        val project = stubProject("/tmp/refresh-disposed-${System.nanoTime()}")
-        every { project.isDisposed } returns true
-
-        ProjectLanguageDetector.refreshAccentOnEdt(project)
-
-        verify(exactly = 0) { AccentApplicator.apply(any()) }
-    }
-
     // ── rescan (Phase 29) ─────────────────────────────────────────────────────
 
     @Test
@@ -1350,15 +1197,13 @@ class ProjectLanguageDetectorTest {
         stubDumbServiceSmart(closingProject)
         val listener = mockk<ProjectLanguageDetectionListener>(relaxed = true)
         wireMessageBus(closingProject, listener)
-        mockkObject(AccentApplicator)
-        every { AccentApplicator.resolveFocusedProject() } returns reopenedProject
         mockkStatic(javax.swing.SwingUtilities::class)
-        var invokeLaterCalls = 0
         every { javax.swing.SwingUtilities.invokeLater(any()) } answers {
-            invokeLaterCalls++
-            if (invokeLaterCalls == 2) {
-                every { closingProject.isDisposed } returns true
-            }
+            // With the accent refresh behind the scanCompleted subscriber, the
+            // scan body queues exactly ONE EDT hop — the publish. Flip
+            // disposal before the queued runnable runs to simulate the
+            // project closing during that hop.
+            every { closingProject.isDisposed } returns true
             firstArg<Runnable>().run()
         }
         runSchedulerInline()
@@ -1397,19 +1242,14 @@ class ProjectLanguageDetectorTest {
         stubDumbServiceSmart(closingProject)
         val listener = mockk<ProjectLanguageDetectionListener>(relaxed = true)
         wireMessageBus(closingProject, listener)
-        mockkObject(AccentApplicator)
-        every { AccentApplicator.resolveFocusedProject() } returns reopenedProject
         mockkStatic(javax.swing.SwingUtilities::class)
-        var invokeLaterCalls = 0
         lateinit var stalePublish: Runnable
         every { javax.swing.SwingUtilities.invokeLater(any()) } answers {
-            invokeLaterCalls++
-            val runnable = firstArg<Runnable>()
-            if (invokeLaterCalls == 1) {
-                runnable.run()
-            } else {
-                stalePublish = runnable
-            }
+            // The scan body queues exactly one EDT hop (the scanCompleted
+            // publish); capture it without running so the test can replay it
+            // as a stale publish after the reopened project warms a fresh
+            // cache entry.
+            stalePublish = firstArg<Runnable>()
         }
         runSchedulerInline()
 
@@ -1547,13 +1387,29 @@ class ProjectLanguageDetectorTest {
         every { project.getService(com.intellij.openapi.project.DumbService::class.java) } returns dumbService
     }
 
+    /**
+     * Wires a mocked `MessageBus` whose `syncPublisher` fans each publish out
+     * to BOTH the test's [listener] (assertion surface) AND a real
+     * [ScanCompletionAccentRefresher] subscribed through the mocked
+     * connection — so detector specs exercise the production accent-refresh
+     * reaction end-to-end through the one-way `scanCompleted` event.
+     */
     private fun wireMessageBus(
         project: Project,
         listener: ProjectLanguageDetectionListener,
     ) {
         val bus = mockk<com.intellij.util.messages.MessageBus>()
         every { project.messageBus } returns bus
-        every { bus.syncPublisher(ProjectLanguageDetectionListener.TOPIC) } returns listener
+        val connection = mockk<com.intellij.util.messages.MessageBusConnection>()
+        every { bus.connect(any<com.intellij.openapi.Disposable>()) } returns connection
+        val subscribed = mutableListOf<ProjectLanguageDetectionListener>()
+        every { connection.subscribe(ProjectLanguageDetectionListener.TOPIC, capture(subscribed)) } returns Unit
+        ScanCompletionAccentRefresher(project)
+        every { bus.syncPublisher(ProjectLanguageDetectionListener.TOPIC) } returns
+            ProjectLanguageDetectionListener { outcome ->
+                listener.scanCompleted(outcome)
+                subscribed.forEach { it.scanCompleted(outcome) }
+            }
     }
 
     private fun runInvokeLaterInline() {

--- a/src/test/kotlin/dev/ayuislands/accent/ScanCompletionAccentRefresherTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ScanCompletionAccentRefresherTest.kt
@@ -1,0 +1,274 @@
+package dev.ayuislands.accent
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.project.Project
+import com.intellij.util.messages.MessageBus
+import com.intellij.util.messages.MessageBusConnection
+import dev.ayuislands.settings.mappings.ProjectAccentSwapService
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertSame
+
+/**
+ * Behavioral suite for [ScanCompletionAccentRefresher] — the sole
+ * accent-owning subscriber of [ProjectLanguageDetectionListener.TOPIC].
+ *
+ * Every spec drives the refresher through the listener it actually
+ * subscribes in its `init` block (captured from the mocked
+ * `MessageBusConnection`), not through direct method calls, so the
+ * subscription wiring and the reaction body are locked together. The
+ * resolver + apply chain specs were relocated from
+ * `ProjectLanguageDetectorTest` when the refresh reaction moved out of the
+ * detector; each keeps its original behavioral assertions.
+ */
+class ScanCompletionAccentRefresherTest {
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `detected outcome runs the full resolver to apply chain when focus is unchanged`() {
+        // Happy-path lock: given a cacheable detected verdict on a live,
+        // still-focused project, the subscriber must call the full resolver →
+        // applicator → swap-cache chain. Dropping any of the three downstream
+        // calls would leave users stuck on the previous accent until the next
+        // focus swap.
+        val project = stubProject()
+        val swapService = wireHappyApplyChain(project)
+        val subscriber = installRefresher(project)
+
+        subscriber.scanCompleted(ScanOutcome.Detected("kotlin"))
+
+        verify(exactly = 1) { AccentApplicator.applyFromHexString("#FFCC66") }
+        verify(exactly = 1) { swapService.notifyExternalApply("#FFCC66") }
+    }
+
+    @Test
+    fun `polyglot outcome reapplies the resolver fallback`() {
+        // A cacheable scan can remove the active language override as well as
+        // add one (polyglot / no-winner verdicts publish as Polyglot). The
+        // resolver owns that fallback decision; the subscriber must apply
+        // whatever it resolves so chrome/glow do not stay on the old language
+        // accent until the next focus swap.
+        val project = stubProject()
+        val swapService = wireHappyApplyChain(project)
+        val subscriber = installRefresher(project)
+
+        subscriber.scanCompleted(ScanOutcome.Polyglot)
+
+        verify(exactly = 1) { AccentApplicator.applyFromHexString("#FFCC66") }
+        verify(exactly = 1) { swapService.notifyExternalApply("#FFCC66") }
+    }
+
+    @Test
+    fun `unavailable outcome never touches the applicator`() {
+        // Unavailable means the scan produced no cacheable verdict — the
+        // detector cache was not repopulated, so there is nothing new to
+        // apply and the previous accent must stay put. Mirrors the
+        // Cold/Unavailable arm of the verdict gate that lived in the detector
+        // before the reaction moved here.
+        val project = stubProject()
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.resolveFocusedProject() } returns project
+        justRun { AccentApplicator.apply(any()) }
+        val subscriber = installRefresher(project)
+
+        subscriber.scanCompleted(ScanOutcome.Unavailable)
+
+        verify(exactly = 0) { AccentApplicator.resolveFocusedProject() }
+        verify(exactly = 0) { AccentApplicator.apply(any()) }
+    }
+
+    @Test
+    fun `refresh skips apply chain when focused project changed after scan`() {
+        // The apply path writes app-global UIManager state. A background scan
+        // from an old project must not repaint over the project that gained
+        // focus while the scan was running.
+        val scannedProject = stubProject()
+        val focusedProject = stubProject()
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.resolveFocusedProject() } returns focusedProject
+        justRun { AccentApplicator.apply(any()) }
+        val subscriber = installRefresher(scannedProject)
+
+        subscriber.scanCompleted(ScanOutcome.Detected("kotlin"))
+
+        verify(exactly = 0) { AccentApplicator.apply(any()) }
+    }
+
+    @Test
+    fun `refresh skips apply chain when variant detection returns null`() {
+        // Null variant = no Ayu theme active. The early `?: return@…` keeps
+        // the applicator from touching UIManager when there's no Ayu theme to
+        // drive. Locking the guard so a future author doesn't delete it as
+        // "dead code" — it's the fallback path for users on a non-Ayu theme.
+        val project = stubProject()
+        mockkObject(AyuVariant.Companion)
+        every { AyuVariant.detect() } returns null
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.resolveFocusedProject() } returns project
+        justRun { AccentApplicator.apply(any()) }
+        val subscriber = installRefresher(project)
+
+        subscriber.scanCompleted(ScanOutcome.Detected("kotlin"))
+
+        verify(exactly = 0) { AccentApplicator.apply(any()) }
+    }
+
+    @Test
+    fun `refresh skips apply chain when project is disposed`() {
+        // Scheduling delay between the background scan and the EDT publish
+        // can close the project. The early return keeps the applicator from
+        // writing UIManager entries for a dead project's swap-cache.
+        val project = stubProject()
+        mockkObject(AccentApplicator)
+        justRun { AccentApplicator.apply(any()) }
+        val subscriber = installRefresher(project)
+        every { project.isDisposed } returns true
+
+        subscriber.scanCompleted(ScanOutcome.Detected("kotlin"))
+
+        verify(exactly = 0) { AccentApplicator.apply(any()) }
+    }
+
+    @Test
+    fun `refresh swallows a throwing apply chain without rethrowing`() {
+        // Contract lock on the runCatchingPreservingCancellation wrapper:
+        // AccentApplicator.apply can throw on a LafManager race / UIManager
+        // shutdown; the listener runs inside the EDT publish turn, so a
+        // propagated throw becomes an uncaught EDT exception. This test
+        // asserts the handler returns normally (WARN-logged internally)
+        // instead of rethrowing.
+        val project = stubProject()
+        mockkObject(AyuVariant.Companion)
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        mockkObject(AccentResolver)
+        every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#FFCC66"
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.resolveFocusedProject() } returns project
+        every { AccentApplicator.apply(any()) } throws RuntimeException("LafManager boom")
+        val subscriber = installRefresher(project)
+
+        // Must not throw — the load-bearing assertion is simply that the call
+        // completes. A regression dropping the runCatching would propagate
+        // the RuntimeException and fail this test.
+        subscriber.scanCompleted(ScanOutcome.Detected("kotlin"))
+    }
+
+    @Test
+    fun `refresh swallows a throwing resolver without rethrowing`() {
+        // The resolver owns both hit and fallback decisions. A corrupt
+        // override, plugin-unload race, or resolver regression must not
+        // escape the EDT publish turn as an uncaught EDT exception.
+        val project = stubProject()
+        mockkObject(AyuVariant.Companion)
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        mockkObject(AccentResolver)
+        every { AccentResolver.resolve(any(), any<AyuVariant>()) } throws RuntimeException("resolver boom")
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.resolveFocusedProject() } returns project
+        justRun { AccentApplicator.apply(any()) }
+        val subscriber = installRefresher(project)
+
+        // Must not throw — the runCatching contains the resolver.
+        subscriber.scanCompleted(ScanOutcome.Detected("kotlin"))
+
+        // And because the resolver failed, the apply chain must not be reached.
+        verify(exactly = 0) { AccentApplicator.apply(any()) }
+    }
+
+    @Test
+    fun `rejected hex suppresses the swap-cache publish`() {
+        // applyFromHexString returns false for a rejected hex (user-facing
+        // notification already fired inside the applicator). Publishing the
+        // rejected value to the swap cache would make the next
+        // WINDOW_ACTIVATED treat an unapplied color as current — the Boolean
+        // gate must suppress notifyExternalApply.
+        val project = stubProject()
+        val swapService = wireHappyApplyChain(project)
+        every { AccentApplicator.applyFromHexString(any()) } returns false
+        val subscriber = installRefresher(project)
+
+        subscriber.scanCompleted(ScanOutcome.Detected("kotlin"))
+
+        verify(exactly = 1) { AccentApplicator.applyFromHexString("#FFCC66") }
+        verify(exactly = 0) { swapService.notifyExternalApply(any()) }
+    }
+
+    @Test
+    fun `subscription is anchored to the refresher's own disposable`() {
+        // Lifetime lock: the MessageBus connection's parent must be the
+        // service's own Disposable so the platform tears the subscription
+        // down with the project (project services are disposed on close). A
+        // connection without this parent would leak the subscriber across
+        // plugin reloads.
+        val project = stubProject()
+        val bus = mockk<MessageBus>()
+        every { project.messageBus } returns bus
+        val connection = mockk<MessageBusConnection>()
+        val parent = slot<Disposable>()
+        every { bus.connect(capture(parent)) } returns connection
+        every { connection.subscribe(ProjectLanguageDetectionListener.TOPIC, any()) } returns Unit
+
+        val refresher = ScanCompletionAccentRefresher(project)
+
+        assertSame(
+            refresher,
+            parent.captured,
+            "messageBus.connect parent must be the refresher itself so disposal ends the subscription",
+        )
+        // Platform teardown entry point on project close — must complete cleanly.
+        refresher.dispose()
+    }
+
+    // ── fixtures ───────────────────────────────────────────────────────────────
+
+    private fun stubProject(): Project {
+        val project = mockk<Project>()
+        every { project.isDisposed } returns false
+        return project
+    }
+
+    /**
+     * Stubs the mocked bus + connection, constructs the refresher through its
+     * real `init` subscription, and returns the listener it registered — the
+     * exact handler production publishes will hit.
+     */
+    private fun installRefresher(project: Project): ProjectLanguageDetectionListener {
+        val bus = mockk<MessageBus>()
+        every { project.messageBus } returns bus
+        val connection = mockk<MessageBusConnection>()
+        every { bus.connect(any<Disposable>()) } returns connection
+        val subscribed = slot<ProjectLanguageDetectionListener>()
+        every { connection.subscribe(ProjectLanguageDetectionListener.TOPIC, capture(subscribed)) } returns Unit
+        ScanCompletionAccentRefresher(project)
+        return subscribed.captured
+    }
+
+    /**
+     * Mocks the happy resolver → applicator → swap-service chain: MIRAGE
+     * variant, `#FFCC66` resolution, focus on [project], stubbed apply.
+     * Returns the swap-service mock for publish assertions.
+     */
+    private fun wireHappyApplyChain(project: Project): ProjectAccentSwapService {
+        mockkObject(AyuVariant.Companion)
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        mockkObject(AccentResolver)
+        every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#FFCC66"
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.resolveFocusedProject() } returns project
+        justRun { AccentApplicator.apply(any()) }
+        val swapService = mockk<ProjectAccentSwapService>(relaxed = true)
+        mockkObject(ProjectAccentSwapService.Companion)
+        every { ProjectAccentSwapService.getInstance() } returns swapService
+        return swapService
+    }
+}


### PR DESCRIPTION
── Summary ─────────────────────────────────

C7 from the architecture review (its "speculative / higher risk" candidate — landed with the minimal restructuring). A cold-cache resolve scheduled a background scan whose completion **re-entered the resolve+apply pipeline from inside `ProjectLanguageDetector`** — the reason disposal-race defenses dominated its 607 lines. The detector now only publishes the existing `scanCompleted` Topic; one project-scoped subscriber (`ScanCompletionAccentRefresher`) owns the re-resolve+apply reaction with the verbatim body, gates, and log messages.

── Changes ─────────────────────────────────

| Type | Where | What |
|------|-------|------|
| Refactor | `src/main/kotlin/dev/ayuislands/accent/ScanCompletionAccentRefresher.kt:1` | Project-scoped light service; subscribes in `init` with its own Disposable as parent (Pattern E); outcome gate mirrors the deleted verdict gate exactly (Detected/Polyglot → refresh, Unavailable → skip) |
| Refactor | `src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt` | −84 lines: scan body is detectAndCache → classify → publish only; `tryRefreshAccentAfterCacheableScan`/`refreshAccentOnEdt` deleted (KDoc reasoning relocated with the code) |
| Refactor | `src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt` | Refresher installs as the FIRST project-scoped statement — before the cold-cache resolve that schedules the first scan (closes a subscriber-not-yet-installed race the baked-in version never had), and before the external-theme early return (mid-session theme-switch behavior preserved 1:1); locked by a source-order test |
| Test | `src/test/kotlin/dev/ayuislands/accent/ScanCompletionAccentRefresherTest.kt:1` | 10 tests, all driven through the real `init` subscription; +3 new locks that fell out: rejected-hex swap suppression (previously untested), Unavailable gate, disposable anchoring |

── Validation ──────────────────────────────

```bash
./gradlew test detekt ktlintCheck koverVerify
```
Expected: green, 2928 tests; refresher 100% line/branch, detector 95.7%.

Manual: open a polyglot project cold (no forced language, language override configured) — after indexing settles, the accent must flip to the detected language's override without touching Settings; `grep "Post-scan accent refresh" idea.log` shows the subscriber path.

── Notes ───────────────────────────────────

- One deliberate, strictly-safer delta: a disposal-dropped publish now means no refresh for a dying project (previously the refresh could still run). No test pinned the old apply-before-publish order — verified before reworking the two tests that pinned the internal two-EDT-hop structure (wiring-only changes, every behavioral assertion intact).
- Declarative `plugin.xml` `projectListeners` was considered and rejected: no precedent in this plugin and more platform-API risk on the 2025.1 pin than a light service with an init-block subscription.

## Summary by Sourcery

Refactor language detection so ProjectLanguageDetector becomes a publish-only event source and move the post-scan accent refresh logic into a dedicated project service subscribed to scanCompleted, with tests and documentation updated to lock in the new one-way flow and startup ordering.

Enhancements:
- Decouple accent refresh from language detection by introducing a project-scoped ScanCompletionAccentRefresher service subscribed to scanCompleted events.
- Restrict ProjectLanguageDetector to publishing scan outcomes without re-entering the accent resolve+apply pipeline.
- Ensure startup installs the scan-completion accent refresher before the first accent resolve to avoid missing the initial background scan.
- Strengthen the ProjectLanguageDetectionListener contract to document the new accent refresher subscriber and one-way event flow.

Documentation:
- Update feature verification metadata in docs/features.yml to reflect the new accent-detection behavior and verified commit.

Tests:
- Move and expand accent refresh behavior tests into ScanCompletionAccentRefresherTest, exercising subscription wiring and edge cases end-to-end.
- Adapt ProjectLanguageDetectorTest and AyuIslandsStartupActivityTest to the publish-only detector model, including source-order guards for refresher installation.