### PR TITLE
chore(release): prepare v2.7.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog
 
-## [Unreleased]
-
 ## [2.7.8] - 2026-07-06
 
 - [Fix] **What's New and onboarding tabs** — a failed tab open no longer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## [Unreleased]
 
+## [2.7.8] - 2026-07-06
+
+- [Fix] **What's New and onboarding tabs** — a failed tab open no longer
+  blocks the What's New tab or the license wizard for the rest of the IDE
+  session; the next trigger simply retries.
+- [Fix] **Accent apply recovery** — when applying an accent fails midway, the
+  color now recovers on the next window focus instead of freezing until
+  restart, and startup only trusts cached accents from a cleanly finished
+  apply.
+- [Fix] **Accent rotation reliability** — rotation now counts failed applies
+  and stops with the "accent rotation stopped" notification instead of
+  silently ticking forever against a broken apply.
+- [Fix] **License downgrade revert** — the "restart to complete the reset"
+  notice now appears when the free-tier revert could not finish cleanly.
+- [Fix] **Settings overrides preview** — opening the Accent → Overrides
+  resolution preview is now strictly read-only and never schedules background
+  language scans.
+- [Fix] **Resolution diagnostics consistency** — the "Currently active" label,
+  the diagnostics row, and the accent actually applied now always name the
+  same resolution source.
 - [Fix] **Project-language accent scans** — background detection now cancels
   when a project closes, checks cancellation during large repository scans, and
   drops late cache or publish results so reopened projects do not inherit stale

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.7.7
+pluginVersion=2.7.8
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
@@ -55,6 +55,14 @@ internal object UpdateNotifier {
 
     private val RELEASE_NOTES =
         mapOf(
+            "2.7.8" to
+                releaseNotes(
+                    "[Fix] Failed What's New or onboarding opens retry instead of blocking the session",
+                    "[Fix] Interrupted accent applies recover on the next window focus",
+                    "[Fix] Accent rotation stops with a notification when applies keep failing",
+                    "[Fix] Settings overrides preview no longer schedules background language scans",
+                    "[Fix] Language scans cancel on project close and skip stale results",
+                ),
             "2.7.7" to
                 releaseNotes(
                     "[Fix] Language diagnostics show detected breakdowns, manual state, and the winning accent source",

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -117,6 +117,18 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>2.7.8</h3>
+    <ul>
+      <li>[Fix] <b>What's New and onboarding tabs</b> — a failed tab open no longer blocks the What's New tab or the license wizard for the rest of the IDE session; the next trigger simply retries.</li>
+      <li>[Fix] <b>Accent apply recovery</b> — when applying an accent fails midway, the color now recovers on the next window focus instead of freezing until restart, and startup only trusts cached accents from a cleanly finished apply.</li>
+      <li>[Fix] <b>Accent rotation reliability</b> — rotation now counts failed applies and stops with the "accent rotation stopped" notification instead of silently ticking forever against a broken apply.</li>
+      <li>[Fix] <b>License downgrade revert</b> — the "restart to complete the reset" notice now appears when the free-tier revert could not finish cleanly.</li>
+      <li>[Fix] <b>Settings overrides preview</b> — opening the Accent → Overrides resolution preview is now strictly read-only and never schedules background language scans.</li>
+      <li>[Fix] <b>Resolution diagnostics consistency</b> — the "Currently active" label, the diagnostics row, and the accent actually applied now always name the same resolution source.</li>
+      <li>[Fix] <b>Project-language accent scans</b> — background detection now cancels when a project closes, checks cancellation during large repository scans, and drops late cache or publish results so reopened projects do not inherit stale language accents.</li>
+      <li>[Fix] <b>Large project language accents</b> — language detection now keeps exact scans for projects under the file cap and uses bounded sampling for larger repositories, so accents resolve consistently without walking every file in a monorepo.</li>
+      <li>[Fix] <b>Font installer fallbacks</b> — fallback font download URLs are now smoke-checked in CI before release, catching broken upstream links before a bundled font install reaches users.</li>
+    </ul>
     <h3>2.7.7</h3>
     <ul>
       <li>[Fix] <b>Language override diagnostics</b> — Settings and Quick-Switcher now show the detected project-language breakdown, manual forced-language state, polyglot fallback detail, and the language that actually won accent resolution.</li>


### PR DESCRIPTION
── Summary ─────────────────────────────────

Release metadata for v2.7.8 — the patch carrying the six user-facing fixes from the architecture-review cycle (PRs #254, #256–#260) plus the three fixes that were sitting in Unreleased (#248/#249). No code changes; `release-version`/`release-date` stay locked per the 2.7.x Marketplace rules.

── Changes ─────────────────────────────────

| Type | Where | What |
|------|-------|------|
| Chore | `CHANGELOG.md` | New `[2.7.8] - 2026-07-06` section: 9 user-facing entries, Unreleased emptied |
| Chore | `src/main/resources/META-INF/plugin.xml` | Matching `<h3>2.7.8</h3>` change-notes block |
| Chore | `src/main/kotlin/dev/ayuislands/UpdateNotifier.kt` | 5-line update-notification copy for 2.7.8 |
| Chore | `gradle.properties` | `pluginVersion=2.7.8` |

── Validation ──────────────────────────────

```bash
./gradlew test detekt ktlintCheck koverVerify && python3 scripts/verify-docs.py
```
Expected: green (docs sync passes; the two orphaned-stamp warnings are the usual post-squash-merge state, warn-only).

Before Marketplace publish: `./gradlew verifyPlugin` + review `build/reports/pluginVerifier/`.

## Summary by Sourcery

Prepare release metadata for plugin version 2.7.8 with updated notes and versioning.

Bug Fixes:
- Document nine user-facing fixes in the changelog and plugin change-notes for issues addressed since the previous release.

Enhancements:
- Add 2.7.8 entry to the in-IDE update notifier so users see a concise summary of the latest fixes.

Build:
- Bump pluginVersion in gradle.properties from 2.7.7 to 2.7.8 for the new release.