### PR TITLE
feat(accent): allow chrome tint on external themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## [2.8.0] - 2026-07-09
 
-- [Paid] **Chrome tint on external themes** — chrome surfaces and accent
-  elements can now follow the Ayu accent on non-Ayu themes when explicitly
-  enabled; external chrome tint stays off by default.
+- [Paid] **Chrome tint on external themes** — selected chrome surfaces and the
+  active tab underline can now follow the Ayu accent on non-Ayu themes when
+  explicitly enabled; external chrome tint stays off by default.
 
 ## [2.7.8] - 2026-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.8.0] - 2026-07-09
+
+- [Paid] **Chrome tint on external themes** — chrome surfaces and accent
+  elements can now follow the Ayu accent on non-Ayu themes when explicitly
+  enabled; external chrome tint stays off by default.
+
 ## [2.7.8] - 2026-07-06
 
 - [Fix] **What's New and onboarding tabs** — a failed tab open no longer

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "ea22bbd1"
+          last_verified_sha: "892ff46b"
           last_verified_date: "2026-06-30"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "ea22bbd1"
+          last_verified_sha: "892ff46b"
           last_verified_date: "2026-06-30"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -199,6 +199,16 @@ categories:
           any saturation. Configured from Settings → Ayu Islands →
           Theme Synchronization. Inspired by Peacock for VS Code,
           built on JetBrains platform primitives.
+
+      - id: chrome-tint-external-themes
+        title: "Chrome tint on external themes"
+        keyword: "chrome tinting"
+        introduced: "2.8.0"
+        tier: paid
+        description: >
+          Chrome surfaces and accent elements can follow the Ayu accent
+          on non-Ayu themes when explicitly enabled; external chrome
+          tint stays off by default.
 
       - id: vcs-color-customization
         title: "VCS color customization"
@@ -304,7 +314,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "ea22bbd1"
+          last_verified_sha: "892ff46b"
           last_verified_date: "2026-06-16"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -345,7 +355,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "ea22bbd1"
+          last_verified_sha: "892ff46b"
           last_verified_date: "2026-06-16"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -397,7 +407,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "ea22bbd1"
+          last_verified_sha: "892ff46b"
           last_verified_date: "2026-06-12"
           content_sha256: ad849b17308901bc2dac85f895978be656f578c9c31f857b9e9578e5cf4289f2
 
@@ -459,7 +469,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "ea22bbd1"
+          last_verified_sha: "892ff46b"
           last_verified_date: "2026-06-16"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "892ff46b"
+          last_verified_sha: "aa35c9b2"
           last_verified_date: "2026-06-30"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "892ff46b"
+          last_verified_sha: "aa35c9b2"
           last_verified_date: "2026-06-30"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -314,7 +314,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "892ff46b"
+          last_verified_sha: "aa35c9b2"
           last_verified_date: "2026-06-16"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -355,7 +355,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "892ff46b"
+          last_verified_sha: "aa35c9b2"
           last_verified_date: "2026-06-16"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -407,7 +407,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "892ff46b"
+          last_verified_sha: "aa35c9b2"
           last_verified_date: "2026-06-12"
           content_sha256: ad849b17308901bc2dac85f895978be656f578c9c31f857b9e9578e5cf4289f2
 
@@ -469,7 +469,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "892ff46b"
+          last_verified_sha: "aa35c9b2"
           last_verified_date: "2026-06-16"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "aa35c9b2"
+          last_verified_sha: "c89bd796"
           last_verified_date: "2026-06-30"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "aa35c9b2"
+          last_verified_sha: "c89bd796"
           last_verified_date: "2026-06-30"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -469,7 +469,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "aa35c9b2"
+          last_verified_sha: "c89bd796"
           last_verified_date: "2026-06-16"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -206,9 +206,9 @@ categories:
         introduced: "2.8.0"
         tier: paid
         description: >
-          Chrome surfaces and accent elements can follow the Ayu accent
-          on non-Ayu themes when explicitly enabled; external chrome
-          tint stays off by default.
+          Selected chrome surfaces and the active tab underline can follow
+          the Ayu accent on non-Ayu themes when explicitly enabled; external
+          chrome tint stays off by default.
 
       - id: vcs-color-customization
         title: "VCS color customization"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.7.8
+pluginVersion=2.8.0
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -60,6 +60,8 @@ object AccentApplicator {
     private val DARK_FOREGROUND = JBColor(DARK_FOREGROUND_HEX, DARK_FOREGROUND_HEX)
     private const val TAB_ACCENT_BG_ALPHA = 50
     private const val KEY_TAB_BACKGROUND = "EditorTabs.underlinedTabBackground"
+    private const val KEY_TAB_UNDERLINE_HEIGHT = "EditorTabs.underlineHeight"
+    private const val KEY_TAB_UNDERLINE_ARC = "EditorTabs.underlineArc"
     private const val DEFAULT_UNDERLINE_ARC = 8
     private val TRANSPARENT_TAB_BACKGROUND =
         JBColor(
@@ -195,7 +197,6 @@ object AccentApplicator {
         val accent = accentHex.toColor()
         val state = AyuIslandsSettings.getInstance().state
         val context = AccentContext.detect()
-        val variant = context?.variant
 
         // Persist BEFORE the EP iteration so the cache survives a mid-EP
         // throw. Clear the clean-apply flag here; only the MarkApplyClean step
@@ -214,10 +215,17 @@ object AccentApplicator {
             buildMap {
                 put(AccentApplyStep.ApplyAlwaysOnUiKeys) { applyAlwaysOnUiKeys(state, accent) }
                 put(AccentApplyStep.ApplyElements) {
-                    applyElements(state, accent, checkNotNull(variant) { "ApplyElements planned without Ayu variant" })
+                    applyElements(
+                        state,
+                        accent,
+                        checkNotNull(context) { "ApplyElements planned without accent context" },
+                    )
                 }
                 put(AccentApplyStep.ApplyTabUnderline) {
-                    applyTabUnderline(state, checkNotNull(variant) { "ApplyTabUnderline planned without Ayu variant" })
+                    applyTabUnderline(
+                        state,
+                        checkNotNull(context) { "ApplyTabUnderline planned without accent context" },
+                    )
                 }
                 put(AccentApplyStep.SyncIndentRainbow) {
                     IndentRainbowSync.apply(
@@ -514,8 +522,8 @@ object AccentApplicator {
         UIManager.put("Button.default.startBorderColor", null)
         UIManager.put("Button.default.endBorderColor", null)
         UIManager.put(KEY_TAB_BACKGROUND, null)
-        UIManager.put("EditorTabs.underlineHeight", null)
-        UIManager.put("EditorTabs.underlineArc", null)
+        UIManager.put(KEY_TAB_UNDERLINE_HEIGHT, null)
+        UIManager.put(KEY_TAB_UNDERLINE_ARC, null)
 
         for (element in EP_NAME.extensionList) {
             try {
@@ -544,13 +552,26 @@ object AccentApplicator {
         }
     }
 
+    private fun isExternalTintBlocked(
+        state: AyuIslandsState,
+        context: AccentContext,
+    ): Boolean {
+        val blocked = context == AccentContext.External && !state.isExternalChromeTintAllowed()
+        if (blocked) {
+            log.debug("External chrome tint allowance off; reverting tinted chrome surfaces")
+        }
+        return blocked
+    }
+
     private fun applyElements(
         state: AyuIslandsState,
         accent: Color,
-        variant: AyuVariant?,
+        context: AccentContext,
     ) {
+        val variant = context.variant
+        val externalTintBlocked = isExternalTintBlocked(state, context)
         for (element in EP_NAME.extensionList) {
-            val enabled = ChromeTintContext.isToggleEnabled(state, element.id)
+            val enabled = !externalTintBlocked && ChromeTintContext.isToggleEnabled(state, element.id)
             if (!enabled) {
                 neutralizeOrRevert(element, variant)
                 continue
@@ -674,8 +695,14 @@ object AccentApplicator {
 
     private fun applyTabUnderline(
         state: AyuIslandsState,
-        variant: AyuVariant?,
+        context: AccentContext,
     ) {
+        if (isExternalTintBlocked(state, context)) {
+            UIManager.put(KEY_TAB_UNDERLINE_HEIGHT, null)
+            UIManager.put(KEY_TAB_UNDERLINE_ARC, null)
+            return
+        }
+        val variant = context.variant
         val tabMode = GlowTabMode.fromName(state.glowTabMode ?: "MINIMAL")
         if (tabMode == GlowTabMode.OFF && variant != null) {
             val scheme = EditorColorsManager.getInstance().globalScheme
@@ -683,10 +710,10 @@ object AccentApplicator {
         }
 
         val height = resolveUnderlineHeight(state)
-        UIManager.put("EditorTabs.underlineHeight", Integer.valueOf(height))
+        UIManager.put(KEY_TAB_UNDERLINE_HEIGHT, Integer.valueOf(height))
 
         val arc = UIManager.getInt("Island.arc").let { if (it > 0) it else DEFAULT_UNDERLINE_ARC }
-        UIManager.put("EditorTabs.underlineArc", Integer.valueOf(arc))
+        UIManager.put(KEY_TAB_UNDERLINE_ARC, Integer.valueOf(arc))
 
         log.info("Tab underline: height=${height}px, arc=${arc}px")
     }

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -17,9 +17,11 @@ import com.intellij.ui.ColorUtil
 import com.intellij.ui.JBColor
 import com.intellij.util.concurrency.annotations.RequiresEdt
 import dev.ayuislands.accent.conflict.ConflictRegistry
+import dev.ayuislands.accent.elements.AbstractChromeElement
 import dev.ayuislands.glow.GlowStyle
 import dev.ayuislands.glow.GlowTabMode
 import dev.ayuislands.indent.IndentRainbowSync
+import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
@@ -197,6 +199,9 @@ object AccentApplicator {
         val accent = accentHex.toColor()
         val state = AyuIslandsSettings.getInstance().state
         val context = AccentContext.detect()
+        val isChromeAllowed: Boolean by lazy(LazyThreadSafetyMode.NONE) {
+            LicenseChecker.isLicensedOrGrace()
+        }
 
         // Persist BEFORE the EP iteration so the cache survives a mid-EP
         // throw. Clear the clean-apply flag here; only the MarkApplyClean step
@@ -213,18 +218,22 @@ object AccentApplicator {
         // (surfaced as that step's failure) instead of an NPE.
         val workers: Map<AccentApplyStep, () -> Unit> =
             buildMap {
-                put(AccentApplyStep.ApplyAlwaysOnUiKeys) { applyAlwaysOnUiKeys(state, accent) }
+                put(AccentApplyStep.ApplyAlwaysOnUiKeys) {
+                    applyAlwaysOnUiKeys(state, accent, isChromeAllowed)
+                }
                 put(AccentApplyStep.ApplyElements) {
                     applyElements(
                         state,
                         accent,
                         checkNotNull(context) { "ApplyElements planned without accent context" },
+                        isChromeAllowed,
                     )
                 }
                 put(AccentApplyStep.ApplyTabUnderline) {
                     applyTabUnderline(
                         state,
                         checkNotNull(context) { "ApplyTabUnderline planned without accent context" },
+                        isChromeAllowed,
                     )
                 }
                 put(AccentApplyStep.SyncIndentRainbow) {
@@ -524,17 +533,21 @@ object AccentApplicator {
         UIManager.put(KEY_TAB_BACKGROUND, null)
         UIManager.put(KEY_TAB_UNDERLINE_HEIGHT, null)
         UIManager.put(KEY_TAB_UNDERLINE_ARC, null)
+        ExternalChromeOwnership.releaseTabUnderline()
 
+        val failedExternalReverts = mutableSetOf<AccentElementId>()
         for (element in EP_NAME.extensionList) {
             try {
                 element.revert()
             } catch (exception: RuntimeException) {
+                failedExternalReverts.add(element.id)
                 log.warn(
                     "Failed to revert ${element.displayName}",
                     exception,
                 )
             }
         }
+        ExternalChromeOwnership.finishRevert(failedExternalReverts)
     }
 
     private fun neutralizeOrRevert(
@@ -552,26 +565,38 @@ object AccentApplicator {
         }
     }
 
-    private fun isExternalTintBlocked(
+    private fun canTintExternalChrome(
         state: AyuIslandsState,
         context: AccentContext,
-    ): Boolean {
-        val blocked = context == AccentContext.External && !state.isExternalChromeTintAllowed()
-        if (blocked) {
-            log.debug("External chrome tint allowance off; reverting tinted chrome surfaces")
-        }
-        return blocked
-    }
+        isChromeAllowed: Boolean,
+    ): Boolean =
+        context != AccentContext.External ||
+            (state.isExternalChromeTintAllowed() && isChromeAllowed)
 
     private fun applyElements(
         state: AyuIslandsState,
         accent: Color,
         context: AccentContext,
+        isChromeAllowed: Boolean,
     ) {
+        if (context == AccentContext.External) {
+            ExternalChromeOwnership.apply(
+                elements = EP_NAME.extensionList,
+                state = state,
+                accent = accent,
+                isAllowed = canTintExternalChrome(state, context, isChromeAllowed),
+            )
+            return
+        }
+        ExternalChromeOwnership.clearOwnership()
+
         val variant = context.variant
-        val externalTintBlocked = isExternalTintBlocked(state, context)
         for (element in EP_NAME.extensionList) {
-            val enabled = !externalTintBlocked && ChromeTintContext.isToggleEnabled(state, element.id)
+            if (element.id.group == AccentGroup.CHROME && !isChromeAllowed) {
+                neutralizeOrRevert(element, variant)
+                continue
+            }
+            val enabled = ChromeTintContext.isToggleEnabled(state, element.id)
             if (!enabled) {
                 neutralizeOrRevert(element, variant)
                 continue
@@ -623,6 +648,7 @@ object AccentApplicator {
     private fun applyAlwaysOnUiKeys(
         state: AyuIslandsState,
         accent: Color,
+        isChromeAllowed: Boolean,
     ) {
         for (key in ALWAYS_ON_UI_KEYS) {
             UIManager.put(key, accent)
@@ -640,8 +666,8 @@ object AccentApplicator {
         UIManager.put("Button.default.startBorderColor", darkenedAccent)
         UIManager.put("Button.default.endBorderColor", darkenedAccent)
 
-        // Editor tab background tint (respects persisted tab mode, not gated by license)
-        val tabMode = GlowTabMode.fromName(state.glowTabMode ?: "MINIMAL")
+        // Editor tab background tint follows the persisted mode when chrome features are entitled.
+        val tabMode = effectiveTabMode(state, isChromeAllowed)
         when (tabMode) {
             GlowTabMode.MINIMAL -> {
                 UIManager.put(KEY_TAB_BACKGROUND, TRANSPARENT_TAB_BACKGROUND)
@@ -696,20 +722,33 @@ object AccentApplicator {
     private fun applyTabUnderline(
         state: AyuIslandsState,
         context: AccentContext,
+        isChromeAllowed: Boolean,
     ) {
-        if (isExternalTintBlocked(state, context)) {
-            UIManager.put(KEY_TAB_UNDERLINE_HEIGHT, null)
-            UIManager.put(KEY_TAB_UNDERLINE_ARC, null)
+        val variant = context.variant
+        val tabMode = effectiveTabMode(state, isChromeAllowed)
+        if (
+            context == AccentContext.External &&
+            (!canTintExternalChrome(state, context, isChromeAllowed) || tabMode == GlowTabMode.OFF)
+        ) {
+            if (ExternalChromeOwnership.hasTabUnderline()) {
+                UIManager.put(KEY_TAB_UNDERLINE_HEIGHT, null)
+                UIManager.put(KEY_TAB_UNDERLINE_ARC, null)
+                ExternalChromeOwnership.releaseTabUnderline()
+            }
             return
         }
-        val variant = context.variant
-        val tabMode = GlowTabMode.fromName(state.glowTabMode ?: "MINIMAL")
+        if (context != AccentContext.External) {
+            ExternalChromeOwnership.releaseTabUnderline()
+        }
         if (tabMode == GlowTabMode.OFF && variant != null) {
             val scheme = EditorColorsManager.getInstance().globalScheme
             scheme.setColor(ColorKey.find("TAB_UNDERLINE"), Color.decode(variant.neutralGray))
         }
 
-        val height = resolveUnderlineHeight(state)
+        val height = resolveUnderlineHeight(state, tabMode)
+        if (context == AccentContext.External) {
+            ExternalChromeOwnership.markTabUnderline()
+        }
         UIManager.put(KEY_TAB_UNDERLINE_HEIGHT, Integer.valueOf(height))
 
         val arc = UIManager.getInt("Island.arc").let { if (it > 0) it else DEFAULT_UNDERLINE_ARC }
@@ -841,8 +880,125 @@ object AccentApplicator {
     }
 }
 
-internal fun resolveUnderlineHeight(state: AyuIslandsState): Int {
-    val tabMode = GlowTabMode.fromName(state.glowTabMode ?: "MINIMAL")
+internal object ExternalChromeOwnership {
+    private val log = logger<ExternalChromeOwnership>()
+    private val ownedElements: MutableSet<AccentElementId> =
+        java.util.EnumSet.noneOf(AccentElementId::class.java)
+    private val typeMismatchLogged: MutableSet<AccentElementId> =
+        java.util.EnumSet.noneOf(AccentElementId::class.java)
+    private var ownsTabUnderline = false
+
+    fun apply(
+        elements: List<AccentElement>,
+        state: AyuIslandsState,
+        accent: Color,
+        isAllowed: Boolean,
+    ) {
+        if (!isAllowed) {
+            revertAll(elements)
+            return
+        }
+        for (element in elements) {
+            if (element.id.group != AccentGroup.CHROME) continue
+            applyElement(element, state, accent)
+        }
+    }
+
+    fun clearOwnership() {
+        ownedElements.clear()
+        ownsTabUnderline = false
+    }
+
+    fun markTabUnderline() {
+        ownsTabUnderline = true
+    }
+
+    fun hasTabUnderline(): Boolean = ownsTabUnderline
+
+    fun releaseTabUnderline() {
+        ownsTabUnderline = false
+    }
+
+    fun finishRevert(failedElements: Set<AccentElementId>) {
+        ownedElements.retainAll(failedElements)
+    }
+
+    @TestOnly
+    fun resetForTests() {
+        clearOwnership()
+        typeMismatchLogged.clear()
+    }
+
+    private fun applyElement(
+        element: AccentElement,
+        state: AyuIslandsState,
+        accent: Color,
+    ) {
+        val conflict = ConflictRegistry.getConflictFor(element.id)
+        val isForced = element.id.name in state.forceOverrides
+        if (!ChromeTintContext.isToggleEnabled(state, element.id) || (conflict != null && !isForced)) {
+            revertOne(element)
+            return
+        }
+        if (conflict != null) {
+            log.warn("Force-overriding ${conflict.pluginDisplayName} conflict for ${element.displayName}")
+        }
+
+        val chromeElement = element as? AbstractChromeElement
+        if (chromeElement == null) {
+            logTypeMismatch(element)
+            return
+        }
+        try {
+            chromeElement.applyExternal(accent) {
+                ownedElements.add(element.id)
+            }
+        } catch (exception: RuntimeException) {
+            log.warn("Failed to apply external chrome accent to ${element.displayName}", exception)
+            revertOne(element)
+        }
+    }
+
+    private fun logTypeMismatch(element: AccentElement) {
+        if (!typeMismatchLogged.add(element.id)) return
+        log.warn(
+            "Skipping external chrome element ${element.displayName}: " +
+                "implementation does not expose mutation ownership",
+        )
+    }
+
+    private fun revertAll(elements: List<AccentElement>) {
+        if (ownedElements.isEmpty()) return
+        for (element in elements) {
+            revertOne(element)
+        }
+    }
+
+    private fun revertOne(element: AccentElement) {
+        if (!ownedElements.remove(element.id)) return
+        try {
+            element.revert()
+        } catch (exception: RuntimeException) {
+            ownedElements.add(element.id)
+            log.warn("Failed to restore external chrome surface ${element.displayName}", exception)
+        }
+    }
+}
+
+private fun effectiveTabMode(
+    state: AyuIslandsState,
+    isChromeAllowed: Boolean,
+): GlowTabMode =
+    if (isChromeAllowed) {
+        GlowTabMode.fromName(state.glowTabMode ?: GlowTabMode.MINIMAL.name)
+    } else {
+        GlowTabMode.MINIMAL
+    }
+
+internal fun resolveUnderlineHeight(
+    state: AyuIslandsState,
+    tabMode: GlowTabMode,
+): Int {
     if (tabMode == GlowTabMode.OFF) return state.tabUnderlineHeight
 
     if (state.tabUnderlineGlowSync && state.glowEnabled) {

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplyPlan.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplyPlan.kt
@@ -41,10 +41,12 @@ internal data class AccentApplyPlan(
  * persisted flag false (unless the sole failure is the final
  * [AccentApplyStep.PublishAccentChanged], which runs after the flag write).
  *
- * Pure — reads no settings and touches no platform; Ayu-only surfaces
- * (element EPs, tab underline) and the IndentRainbow sync gate on the context
- * shape. This is the ONLY gating site: the worker map in [AccentApplicator]
- * binds every step unconditionally.
+ * Pure — reads no settings and touches no platform; element EPs, tab
+ * underline, and the IndentRainbow sync gate on the context shape (scheduled
+ * for any non-null context, Ayu or External). This is the ONLY context-shape
+ * gating site: the worker map in [AccentApplicator] binds every step
+ * unconditionally, and the per-feature External allowances (chrome tint,
+ * indent rainbow) are checked inside the workers with revert symmetry.
  *
  * Ordering locks encoded here (formerly defended by a source-regex test):
  *  - Integrations run IndentRainbow before CodeGlancePro before the
@@ -60,11 +62,11 @@ internal fun applyPlanFor(context: AccentContext?): AccentApplyPlan =
         steps =
             buildList {
                 add(AccentApplyStep.ApplyAlwaysOnUiKeys)
-                if (context?.variant != null) add(AccentApplyStep.ApplyElements)
+                if (context != null) add(AccentApplyStep.ApplyElements)
                 if (context != null) add(AccentApplyStep.SyncIndentRainbow)
                 add(AccentApplyStep.SyncCodeGlanceProViewport)
                 add(AccentApplyStep.ApplyAlwaysOnEditorKeys)
-                if (context?.variant != null) add(AccentApplyStep.ApplyTabUnderline)
+                if (context != null) add(AccentApplyStep.ApplyTabUnderline)
                 add(AccentApplyStep.NotifyComponentTrees)
                 add(AccentApplyStep.RepaintWindows)
                 add(AccentApplyStep.MarkApplyClean)

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplyPlan.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplyPlan.kt
@@ -45,8 +45,9 @@ internal data class AccentApplyPlan(
  * underline, and the IndentRainbow sync gate on the context shape (scheduled
  * for any non-null context, Ayu or External). This is the ONLY context-shape
  * gating site: the worker map in [AccentApplicator] binds every step
- * unconditionally, and the per-feature External allowances (chrome tint,
- * indent rainbow) are checked inside the workers with revert symmetry.
+ * unconditionally. External allowances are checked inside the workers: chrome
+ * tint owns only CHROME-group surfaces and tab underline, while Indent Rainbow
+ * keeps its separate integration gate.
  *
  * Ordering locks encoded here (formerly defended by a source-regex test):
  *  - Integrations run IndentRainbow before CodeGlancePro before the

--- a/src/main/kotlin/dev/ayuislands/accent/elements/AbstractChromeElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/AbstractChromeElement.kt
@@ -67,17 +67,50 @@ abstract class AbstractChromeElement : AccentElement {
         get() = true
 
     override fun apply(color: Color) {
+        applyTint(
+            color = color,
+            canHandleEmpty = true,
+            claimOwnership = {},
+        )
+    }
+
+    internal fun applyExternal(
+        color: Color,
+        claimOwnership: () -> Unit,
+    ) {
+        applyTint(
+            color = color,
+            canHandleEmpty = false,
+            claimOwnership = claimOwnership,
+        )
+    }
+
+    private fun applyTint(
+        color: Color,
+        canHandleEmpty: Boolean,
+        claimOwnership: () -> Unit,
+    ) {
         if (!isEnabled) return
         val state = AyuIslandsSettings.getInstance().state
         val intensity = ChromeTintContext.currentIntensity(state)
         val tintedBackgrounds = LinkedHashMap<String, Color>()
+        var hasClaimedOwnership = false
         for (key in backgroundKeys) {
             val baseColor = ChromeBaseColors[key] ?: continue
             val tinted = ChromeTintBlender.blend(color, baseColor, intensity)
+            if (!hasClaimedOwnership) {
+                // UIManager.put receives non-null key/value pairs here. Its only
+                // realistic RuntimeException path is a property listener throwing
+                // after UIDefaults has already mutated, so ownership must be claimed
+                // immediately before the write to keep rollback retryable.
+                claimOwnership()
+                hasClaimedOwnership = true
+            }
             UIManager.put(key, tinted)
             ChromeBaseColors.rememberPluginTint(key, tinted)
             tintedBackgrounds[key] = tinted
         }
+        if (tintedBackgrounds.isEmpty() && !canHandleEmpty) return
         onBackgroundsTinted(tintedBackgrounds)
         writeForegrounds(tintedBackgrounds)
         val samplingBg = tintedBackgrounds.values.firstOrNull()

--- a/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
@@ -249,6 +249,11 @@ object LicenseChecker {
                 state.setToggle(id, defaultForFree)
             }
 
+            // External chrome tint has no separate feature master to reset, so
+            // clear the allowance itself; a downgraded user on a foreign theme
+            // must not keep tinted chrome/accent elements.
+            state.externalThemeChromeTintEnabled = false
+
             // Reset chrome-tinting auxiliary state to defaults (intensity baseline,
             // group collapsed). The WCAG foreground contrast is now always-on so no
             // toggle needs resetting.

--- a/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/LicenseChecker.kt
@@ -13,8 +13,6 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.ui.LicensingFacade
 import dev.ayuislands.AyuPlugin
-import dev.ayuislands.accent.AccentElementId
-import dev.ayuislands.accent.AccentGroup
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.glow.GlowAnimation
 import dev.ayuislands.glow.GlowPreset
@@ -236,29 +234,6 @@ object LicenseChecker {
         synchronized(state) {
             // Disable glow (premium feature)
             state.glowEnabled = false
-
-            // Reset tab accent to free default (underline only, no tinted background)
-            state.glowTabMode = "MINIMAL"
-
-            // Reset per-element toggles to defaults. VISUAL/INTERACTIVE groups are
-            // free-tier features that default to ON; the CHROME group is a premium-only
-            // chrome-tinting surface that must be forcibly disabled on the free tier
-            // so unlicensed users never see tinted chrome after a downgrade.
-            for (id in AccentElementId.entries) {
-                val defaultForFree = id.group != AccentGroup.CHROME
-                state.setToggle(id, defaultForFree)
-            }
-
-            // External chrome tint has no separate feature master to reset, so
-            // clear the allowance itself; a downgraded user on a foreign theme
-            // must not keep tinted chrome/accent elements.
-            state.externalThemeChromeTintEnabled = false
-
-            // Reset chrome-tinting auxiliary state to defaults (intensity baseline,
-            // group collapsed). The WCAG foreground contrast is now always-on so no
-            // toggle needs resetting.
-            state.chromeTintIntensity = AyuIslandsState.DEFAULT_CHROME_TINT_INTENSITY
-            state.chromeTintingGroupExpanded = false
 
             // Reset VCS color customization — premium feature. The master toggle
             // goes off so the EditorColorsScheme falls back to stock XML on the

--- a/src/main/kotlin/dev/ayuislands/licensing/LicenseTransitionListener.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/LicenseTransitionListener.kt
@@ -5,7 +5,7 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.ui.LicensingFacade
 import dev.ayuislands.accent.AccentApplicator
-import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.commitpanel.CommitPanelAutoFitManager
 import dev.ayuislands.settings.AyuIslandsSettings
 
@@ -20,17 +20,18 @@ import dev.ayuislands.settings.AyuIslandsSettings
  *  2. **Chrome accent re-apply** — on EITHER transition direction (licensed↔unlicensed),
  *     re-applies the accent so chrome tinting picks up the fresh license state.
  *     [dev.ayuislands.accent.AccentResolver] short-circuits overrides when unlicensed
- *     (chrome falls back to global accent) and honors them when licensed, so any
- *     license flip changes the resolved color the chrome renderer uses.
+ *     (chrome falls back to global accent) and honors them when licensed. External
+ *     chrome surfaces also re-evaluate their runtime entitlement without rewriting
+ *     the stored preference.
  *
  *  3. **Workspace renderer cleanup** — on licensed → unlicensed transitions,
  *     re-applies Commit panel workspace management for open projects so paid
  *     path-display renderers are removed immediately, not only after restart.
  *
- * Tracks the previous license state to only fire on an actual transition. The first
- * call (initial notification, `previous == null`) just records state without firing
- * either action — otherwise a routine startup refresh would re-trigger the wizard
- * and cause a spurious redraw on every restart.
+ * Tracks the previous license state to filter duplicate notifications. An initial
+ * licensed callback records state without repainting; an initial unlicensed callback
+ * performs one chrome reconciliation because startup may have optimistically rendered
+ * while the licensing facade was still unavailable.
  *
  * State mutation and [AccentApplicator.applyForFocusedProject] (which is `@RequiresEdt`)
  * are dispatched to EDT via `invokeLater` because Topic listeners may fire on
@@ -42,7 +43,7 @@ internal class LicenseTransitionListener : LicensingFacade.LicenseStateListener 
 
     override fun licenseStateChanged(facade: LicensingFacade?) {
         try {
-            val isNowLicensed = LicenseChecker.isLicensed() == true
+            val isNowLicensed = LicenseChecker.isLicensedOrGrace()
             val previous = wasLicensed
             wasLicensed = isNowLicensed
 
@@ -61,18 +62,22 @@ internal class LicenseTransitionListener : LicensingFacade.LicenseStateListener 
             // Re-apply accent on either transition direction so chrome picks up the fresh
             // license state. Resolver short-circuits overrides when unlicensed (chrome falls
             // back to global accent) and honors them when licensed. `applyForFocusedProject`
-            // is @RequiresEdt — dispatch via invokeLater. AyuVariant.detect() may return null
-            // if a non-Ayu theme is active; skip silently in that case.
-            if (previous != null && previous != isNowLicensed) {
+            // is @RequiresEdt — dispatch via invokeLater. AccentContext.detect() also
+            // preserves external-theme support, while null means no Ayu behavior is active.
+            val isTransition = previous != null && previous != isNowLicensed
+            val isInitialRevoke = previous == null && !isNowLicensed
+            if (isTransition || isInitialRevoke) {
                 ApplicationManager.getApplication().invokeLater {
                     try {
-                        if (previous && !isNowLicensed) {
+                        if (!isNowLicensed) {
                             cleanupCommitPanelPathRendering()
                         }
 
-                        val variant = AyuVariant.detect() ?: return@invokeLater
-                        AccentApplicator.applyForFocusedProject(variant)
-                        LOG.info("Ayu license transition: re-applied accent for chrome refresh")
+                        val context = AccentContext.detect()
+                        if (context != null) {
+                            AccentApplicator.applyForFocusedProject(context)
+                            LOG.info("Ayu license transition: re-applied accent for chrome refresh")
+                        }
                     } catch (exception: RuntimeException) {
                         LOG.error("Ayu license: failed to refresh UI after license transition", exception)
                     }
@@ -84,9 +89,20 @@ internal class LicenseTransitionListener : LicensingFacade.LicenseStateListener 
     }
 
     private fun cleanupCommitPanelPathRendering() {
-        for (project in ProjectManager.getInstance().openProjects) {
+        val openProjects =
+            try {
+                ProjectManager.getInstance().openProjects
+            } catch (exception: RuntimeException) {
+                LOG.warn("Ayu license: failed to enumerate projects for commit-panel cleanup", exception)
+                return
+            }
+        for (project in openProjects) {
             if (!project.isDisposed) {
-                CommitPanelAutoFitManager.getInstance(project).apply()
+                try {
+                    CommitPanelAutoFitManager.getInstance(project).apply()
+                } catch (exception: RuntimeException) {
+                    LOG.warn("Ayu license: failed to clean commit-panel rendering", exception)
+                }
             }
         }
     }

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -48,6 +48,7 @@ class AyuIslandsState : BaseState() {
     var externalThemeGlowEnabled by property(false)
     var externalThemeCodeGlanceProEnabled by property(true)
     var externalThemeIndentRainbowEnabled by property(true)
+    var externalThemeChromeTintEnabled by property(false)
     var externalThemeAccentSource by string(ExternalAccentSource.AUTOMATIC.name)
     var externalThemeAccent by string(AyuVariant.MIRAGE.defaultAccent)
     var followSystemAccent by property(false)
@@ -410,26 +411,15 @@ class AyuIslandsState : BaseState() {
     var vcsCommitHighlightIntensity by property(VcsColorPreset.AMBIENT_SLIDER)
 
     /**
-     * Returns the active preset for the Diff and File Status section, falling
-     * back to [VcsColorPreset.AMBIENT] on unknown / corrupted strings. Mirrors
-     * the [effectiveChromeTintIntensity] discipline — Ambient is the no-op
+     * Returns the preset governing [category], falling back to
+     * [VcsColorPreset.AMBIENT] on unknown / corrupted strings. Mirrors the
+     * [effectiveChromeTintIntensity] discipline — Ambient is the no-op
      * default so corrupted persisted XML never accidentally tints surfaces
-     * the user didn't opt into.
-     */
-    fun effectiveVcsDiffPreset(): VcsColorPreset = VcsColorPreset.byName(vcsDiffPreset)
-
-    /** Returns the active preset for the Merge and Conflict section (defaults to AMBIENT). */
-    fun effectiveVcsMergePreset(): VcsColorPreset = VcsColorPreset.byName(vcsMergePreset)
-
-    /** Returns the active preset for the Blame and History section (defaults to AMBIENT). */
-    fun effectiveVcsBlamePreset(): VcsColorPreset = VcsColorPreset.byName(vcsBlamePreset)
-
-    /**
-     * Returns the preset governing [category]. Maps each color category to
-     * the section's preset field — DIFF_VIEWER / PROJECT_VIEW_FILE_STATUS /
-     * EDITOR_GUTTER live under [effectiveVcsDiffPreset], CONFLICT_MARKERS under
-     * [effectiveVcsMergePreset], BLAME_GUTTER under [effectiveVcsBlamePreset].
-     * Placeholder categories (MERGE_3WAY, INLINE_DIFF_POPUP, LOCAL_HISTORY,
+     * the user didn't opt into. Maps each color category to the owning
+     * section's preset field — DIFF_VIEWER / PROJECT_VIEW_FILE_STATUS /
+     * EDITOR_GUTTER read [vcsDiffPreset], CONFLICT_MARKERS reads
+     * [vcsMergePreset], BLAME_GUTTER reads [vcsBlamePreset]. Placeholder
+     * categories (MERGE_3WAY, INLINE_DIFF_POPUP, LOCAL_HISTORY,
      * BRANCH_INDICATOR, BRANCHES_POPUP, COMMIT_HIGHLIGHTS) default to
      * AMBIENT until their respective sections wire up in a future release.
      */
@@ -438,16 +428,16 @@ class AyuIslandsState : BaseState() {
             VcsColorCategory.DIFF_VIEWER,
             VcsColorCategory.PROJECT_VIEW_FILE_STATUS,
             VcsColorCategory.EDITOR_GUTTER,
-            -> effectiveVcsDiffPreset()
+            -> VcsColorPreset.byName(vcsDiffPreset)
 
             VcsColorCategory.CONFLICT_MARKERS,
             VcsColorCategory.MERGE_3WAY,
             VcsColorCategory.INLINE_DIFF_POPUP,
-            -> effectiveVcsMergePreset()
+            -> VcsColorPreset.byName(vcsMergePreset)
 
             VcsColorCategory.BLAME_GUTTER,
             VcsColorCategory.LOCAL_HISTORY,
-            -> effectiveVcsBlamePreset()
+            -> VcsColorPreset.byName(vcsBlamePreset)
 
             VcsColorCategory.BRANCH_INDICATOR,
             VcsColorCategory.BRANCHES_POPUP,
@@ -610,6 +600,8 @@ class AyuIslandsState : BaseState() {
     fun isExternalCodeGlanceProAllowed(): Boolean = externalAllowed(externalThemeCodeGlanceProEnabled)
 
     fun isExternalIndentRainbowAllowed(): Boolean = externalAllowed(externalThemeIndentRainbowEnabled)
+
+    fun isExternalChromeTintAllowed(): Boolean = externalAllowed(externalThemeChromeTintEnabled)
 
     private fun externalAllowed(enabled: Boolean): Boolean = externalThemeEnhancementsEnabled && enabled
 

--- a/src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
@@ -41,6 +41,7 @@ class PluginsPanel : AyuIslandsSettingsPanel {
     private var externalGlowCheckbox: JCheckBox? = null
     private var externalCodeGlanceProCheckbox: JCheckBox? = null
     private var externalIndentRainbowCheckbox: JCheckBox? = null
+    private var externalChromeTintCheckbox: JCheckBox? = null
     private var externalAccentSourceCombo: JComboBox<ExternalAccentSource>? = null
     private var externalAccentPicker: AccentSwatchPickerRow? = null
     private var alphaSlider: JSlider? = null
@@ -73,7 +74,7 @@ class PluginsPanel : AyuIslandsSettingsPanel {
         val irDetected = ConflictRegistry.isIndentRainbowDetected()
 
         panel.row { comment("Tune how Ayu colors integrate with compatible plugins.") }
-        panel.buildExternalThemeSupportGroup()
+        panel.buildExternalThemeSupportGroup(licensed)
         panel.buildPluginIntegrationsGroup(
             gate = gate,
             licensed = licensed,
@@ -140,7 +141,7 @@ class PluginsPanel : AyuIslandsSettingsPanel {
         }
     }
 
-    private fun Panel.buildExternalThemeSupportGroup() {
+    private fun Panel.buildExternalThemeSupportGroup(licensed: Boolean) {
         group("External Theme Support") {
             row {
                 val checkboxCell =
@@ -176,6 +177,9 @@ class PluginsPanel : AyuIslandsSettingsPanel {
                                     updateSelection = { copy(isCodeGlanceProEnabled = it) },
                                     storeCheckbox = { externalCodeGlanceProCheckbox = it },
                                 )
+                            }
+                            row {
+                                buildExternalChromeTintCell(licensed)
                             }
                         }.gap(RightGap.COLUMNS)
                         panel {
@@ -274,6 +278,24 @@ class PluginsPanel : AyuIslandsSettingsPanel {
                 )
         }
         storeCheckbox(checkboxCell.component)
+    }
+
+    private fun Row.buildExternalChromeTintCell(licensed: Boolean) {
+        externalChromeTintCheckbox =
+            buildLicensedCheckbox(
+                labelText = "Chrome tint",
+                description =
+                    "Tint chrome surfaces and accent elements with the Ayu accent. " +
+                        "Configure surfaces on the Accent tab while an Ayu theme is active.",
+                licensed = licensed,
+                isSelected = pendingSettings.externalInheritance.isChromeTintEnabled,
+            ) { isSelected ->
+                pendingSettings =
+                    pendingSettings.copy(
+                        externalInheritance =
+                            pendingSettings.externalInheritance.copy(isChromeTintEnabled = isSelected),
+                    )
+            }
     }
 
     private fun Row.buildLicensedCheckbox(
@@ -463,6 +485,7 @@ class PluginsPanel : AyuIslandsSettingsPanel {
                     GlowOverlayManager.syncGlowForAllProjects()
                 }
             }
+
             externalChanged -> {
                 AccentApplicator.revertAll()
                 GlowOverlayManager.syncGlowForAllProjects()
@@ -483,6 +506,7 @@ class PluginsPanel : AyuIslandsSettingsPanel {
         externalGlowCheckbox?.isSelected = storedSettings.externalInheritance.isGlowEnabled
         externalCodeGlanceProCheckbox?.isSelected = storedSettings.externalInheritance.isCodeGlanceProEnabled
         externalIndentRainbowCheckbox?.isSelected = storedSettings.externalInheritance.isIndentRainbowEnabled
+        externalChromeTintCheckbox?.isSelected = storedSettings.externalInheritance.isChromeTintEnabled
         externalAccentSourceCombo?.selectedItem = ExternalAccentSource.fromName(storedSettings.externalAccentSource)
         externalAccentPicker?.selectedHex = storedSettings.externalAccent
         presetSegmented?.selectedItem = IndentPreset.fromName(storedSettings.indentPresetName)
@@ -560,12 +584,14 @@ class PluginsPanel : AyuIslandsSettingsPanel {
         val isGlowEnabled: Boolean = false,
         val isCodeGlanceProEnabled: Boolean = true,
         val isIndentRainbowEnabled: Boolean = true,
+        val isChromeTintEnabled: Boolean = false,
     ) {
         fun applyTo(state: AyuIslandsState) {
             state.externalThemeQuickSwitcherEnabled = isQuickSwitcherEnabled
             state.externalThemeGlowEnabled = isGlowEnabled
             state.externalThemeCodeGlanceProEnabled = isCodeGlanceProEnabled
             state.externalThemeIndentRainbowEnabled = isIndentRainbowEnabled
+            state.externalThemeChromeTintEnabled = isChromeTintEnabled
         }
 
         companion object {
@@ -575,6 +601,7 @@ class PluginsPanel : AyuIslandsSettingsPanel {
                     isGlowEnabled = state.externalThemeGlowEnabled,
                     isCodeGlanceProEnabled = state.externalThemeCodeGlanceProEnabled,
                     isIndentRainbowEnabled = state.externalThemeIndentRainbowEnabled,
+                    isChromeTintEnabled = state.externalThemeChromeTintEnabled,
                 )
         }
     }

--- a/src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
@@ -285,7 +285,7 @@ class PluginsPanel : AyuIslandsSettingsPanel {
             buildLicensedCheckbox(
                 labelText = "Chrome tint",
                 description =
-                    "Tint chrome surfaces and accent elements with the Ayu accent. " +
+                    "Tint selected chrome surfaces and the active tab underline with the Ayu accent. " +
                         "Configure surfaces on the Accent tab while an Ayu theme is active.",
                 licensed = licensed,
                 isSelected = pendingSettings.externalInheritance.isChromeTintEnabled,

--- a/src/main/kotlin/dev/ayuislands/settings/VcsColorPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/VcsColorPanel.kt
@@ -98,9 +98,9 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
             val state = AyuIslandsSettings.getInstance().state
             VcsColorSettings(
                 enabled = state.vcsColorEnabled,
-                diffPreset = state.effectiveVcsDiffPreset(),
-                mergePreset = state.effectiveVcsMergePreset(),
-                blamePreset = state.effectiveVcsBlamePreset(),
+                diffPreset = state.effectiveVcsPresetFor(VcsColorCategory.DIFF_VIEWER),
+                mergePreset = state.effectiveVcsPresetFor(VcsColorCategory.CONFLICT_MARKERS),
+                blamePreset = state.effectiveVcsPresetFor(VcsColorCategory.BLAME_GUTTER),
                 diffIntensity = state.vcsDiffIntensity,
                 projectViewIntensity = state.vcsProjectViewIntensity,
                 gutterIntensity = state.vcsGutterIntensity,
@@ -327,9 +327,7 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
                         blameValueLabel = valueLabel
                     }
 
-                    else -> {
-                        Unit
-                    }
+                    else -> {}
                 }
             }
         sliderRow.visibleIfUnlockedOrPreview(sectionCustomVisible, gate)
@@ -411,9 +409,7 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
                 blamePresetSegmented?.selectedItem = VcsColorPreset.CUSTOM
             }
 
-            else -> {
-                Unit
-            }
+            else -> {}
         }
     }
 
@@ -622,9 +618,7 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
                 blameValueLabel?.text = "$value"
             }
 
-            else -> {
-                Unit
-            }
+            else -> {}
         }
         vcsPreview?.updatePreview(variant ?: AyuVariant.DARK, previewIntensities())
     }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -117,6 +117,10 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>2.8.0</h3>
+    <ul>
+      <li>[Paid] <b>Chrome tint on external themes</b> — chrome surfaces and accent elements can now follow the Ayu accent on non-Ayu themes when explicitly enabled; external chrome tint stays off by default.</li>
+    </ul>
     <h3>2.7.8</h3>
     <ul>
       <li>[Fix] <b>What's New and onboarding tabs</b> — a failed tab open no longer blocks the What's New tab or the license wizard for the rest of the IDE session; the next trigger simply retries.</li>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -119,7 +119,7 @@
     <change-notes><![CDATA[
     <h3>2.8.0</h3>
     <ul>
-      <li>[Paid] <b>Chrome tint on external themes</b> — chrome surfaces and accent elements can now follow the Ayu accent on non-Ayu themes when explicitly enabled; external chrome tint stays off by default.</li>
+      <li>[Paid] <b>Chrome tint on external themes</b> — selected chrome surfaces and the active tab underline can now follow the Ayu accent on non-Ayu themes when explicitly enabled; external chrome tint stays off by default.</li>
     </ul>
     <h3>2.7.8</h3>
     <ul>

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
@@ -14,7 +14,10 @@ import dev.ayuislands.AyuPlugin
 import dev.ayuislands.accent.conflict.ConflictEntry
 import dev.ayuislands.accent.conflict.ConflictRegistry
 import dev.ayuislands.accent.conflict.ConflictType
+import dev.ayuislands.accent.elements.AbstractChromeElement
+import dev.ayuislands.glow.GlowTabMode
 import dev.ayuislands.indent.IndentRainbowSync
+import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
 import io.mockk.clearAllMocks
@@ -82,6 +85,8 @@ class AccentApplicatorTest {
         mockkObject(AyuIslandsSettings.Companion)
         every { AyuIslandsSettings.getInstance() } returns mockSettings
         every { mockSettings.state } returns state
+        mockkObject(LicenseChecker)
+        every { LicenseChecker.isLicensedOrGrace() } returns true
 
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
@@ -119,6 +124,7 @@ class AccentApplicatorTest {
 
     @AfterTest
     fun tearDown() {
+        ExternalChromeOwnership.resetForTests()
         restoreOriginalEpName()
         unmockkAll()
         clearAllMocks()
@@ -134,7 +140,12 @@ class AccentApplicatorTest {
         // Replicate the always-on logic from AccentApplicator.apply() without
         // applyElements (requires EP_NAME) and syncCodeGlanceProViewport (requires CGP).
         val state = AyuIslandsSettings.getInstance().state
-        invokePrivate("applyAlwaysOnUiKeys", state, accent)
+        invokePrivate(
+            "applyAlwaysOnUiKeys",
+            state,
+            accent,
+            LicenseChecker.isLicensedOrGrace(),
+        )
         invokePrivate("applyAlwaysOnEditorKeys", accent)
         val windows = Window.getWindows()
         invokePrivate("repaintAllWindows", windows)
@@ -261,6 +272,34 @@ class AccentApplicatorTest {
                 },
             )
         }
+    }
+
+    @Test
+    fun `unlicensed apply renders minimal tab mode without erasing FULL preference`() {
+        state.glowTabMode = "FULL"
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+
+        applyWithoutExtensions("#FFCC66")
+
+        verify {
+            UIManager.put(
+                "EditorTabs.underlinedTabBackground",
+                match<Color> { color -> color.alpha == 0 },
+            )
+        }
+        assertEquals("FULL", state.glowTabMode)
+    }
+
+    @Test
+    fun `apply snapshots chrome entitlement once`() {
+        mockEpExtensionList(emptyList())
+        mockkObject(IndentRainbowSync)
+        every { IndentRainbowSync.apply(any<AccentContext>(), any()) } returns Unit
+        state.cgpIntegrationEnabled = false
+
+        AccentApplicator.applyFromHexString("#FFCC66")
+
+        verify(exactly = 1) { LicenseChecker.isLicensedOrGrace() }
     }
 
     @Test
@@ -896,10 +935,10 @@ class AccentApplicatorTest {
             AccentApplicator::class.java.declaredMethods
                 .first { it.name == "applyAlwaysOnUiKeys" }
         assertEquals(
-            2,
+            3,
             method.parameterCount,
-            "applyAlwaysOnUiKeys must accept (state, accent) so tab-mode resolution shares the same state snapshot " +
-                "as the outer apply() call and cannot drift mid-apply",
+            "applyAlwaysOnUiKeys must accept (state, accent, entitlement) so tab-mode resolution shares the " +
+                "outer apply() snapshots and cannot drift mid-apply",
         )
         assertEquals(
             AyuIslandsState::class.java,
@@ -910,6 +949,11 @@ class AccentApplicatorTest {
             Color::class.java,
             method.parameterTypes[1],
             "Second parameter must be the resolved accent Color",
+        )
+        assertEquals(
+            Boolean::class.javaPrimitiveType,
+            method.parameterTypes[2],
+            "Third parameter must be the chrome entitlement captured once by apply()",
         )
     }
 
@@ -946,46 +990,49 @@ class AccentApplicatorTest {
     }
 
     @Test
-    fun `apply external context reverts elements and clears underline geometry while allowance is off`() {
-        val element = createFakeAccentElement(AccentElementId.CARET_ROW, "Caret Row")
-        mockEpExtensionList(listOf(element))
+    fun `external chrome default off leaves every element and underline untouched`() {
+        val visualElement = createFakeAccentElement(AccentElementId.CARET_ROW, "Caret Row")
+        val chromeElement = createExternalChromeElement()
+        stubExternalChromeBase(Color(0x24, 0x29, 0x36))
+        mockEpExtensionList(listOf(visualElement, chromeElement))
         mockkObject(IndentRainbowSync)
         every { IndentRainbowSync.apply(any<AccentContext>(), any()) } returns Unit
         state.cgpIntegrationEnabled = false
         state.externalThemeEnhancementsEnabled = true
+        state.chromePanelBorder = true
         every { AyuVariant.detect() } returns null
 
         AccentApplicator.applyFromHexString("#AABBCC")
 
         verify(exactly = 1) { IndentRainbowSync.apply(AccentContext.External, "#AABBCC") }
-        verify(exactly = 0) { element.apply(any()) }
-        verify(exactly = 1) { element.revert() }
-        verify(exactly = 0) { element.applyNeutral(any()) }
-        // MockK's any() matches null under type erasure, so "only the null
-        // clear happened" is proven as: exactly one call total, and that call
-        // carried null.
-        verify(exactly = 1) { UIManager.put("EditorTabs.underlineHeight", null) }
-        verify(exactly = 1) { UIManager.put("EditorTabs.underlineArc", null) }
-        verify(exactly = 1) { UIManager.put("EditorTabs.underlineHeight", any()) }
-        verify(exactly = 1) { UIManager.put("EditorTabs.underlineArc", any()) }
+        verify(exactly = 0) { visualElement.apply(any()) }
+        verify(exactly = 0) { visualElement.revert() }
+        verify(exactly = 0) { visualElement.applyNeutral(any()) }
+        verify(exactly = 0) { UIManager.put(EXTERNAL_CHROME_TEST_KEY, any()) }
+        verify(exactly = 0) { UIManager.put("EditorTabs.underlineHeight", any()) }
+        verify(exactly = 0) { UIManager.put("EditorTabs.underlineArc", any()) }
     }
 
     @Test
-    fun `apply external context tints elements and writes underline geometry when allowance is on`() {
-        val element = createFakeAccentElement(AccentElementId.CARET_ROW, "Caret Row")
-        mockEpExtensionList(listOf(element))
+    fun `external chrome applies only chrome group surfaces and underline`() {
+        val visualElement = createFakeAccentElement(AccentElementId.CARET_ROW, "Caret Row")
+        val chromeElement = createExternalChromeElement()
+        stubExternalChromeBase(Color(0x24, 0x29, 0x36))
+        mockEpExtensionList(listOf(visualElement, chromeElement))
         mockkObject(IndentRainbowSync)
         every { IndentRainbowSync.apply(any<AccentContext>(), any()) } returns Unit
         state.cgpIntegrationEnabled = false
         state.externalThemeEnhancementsEnabled = true
         state.externalThemeChromeTintEnabled = true
+        state.chromePanelBorder = true
         every { AyuVariant.detect() } returns null
 
         AccentApplicator.applyFromHexString("#AABBCC")
 
-        verify(exactly = 1) { element.apply(Color.decode("#AABBCC")) }
-        verify(exactly = 0) { element.revert() }
-        verify(exactly = 0) { element.applyNeutral(any()) }
+        verify(exactly = 0) { visualElement.apply(any()) }
+        verify(exactly = 0) { visualElement.revert() }
+        verify(exactly = 0) { visualElement.applyNeutral(any()) }
+        verify(exactly = 1) { UIManager.put(EXTERNAL_CHROME_TEST_KEY, any<Color>()) }
         verify(exactly = 1) { UIManager.put("EditorTabs.underlineHeight", any()) }
         verify(exactly = 1) { UIManager.put("EditorTabs.underlineArc", any()) }
         verify(exactly = 0) { UIManager.put("EditorTabs.underlineHeight", null) }
@@ -993,22 +1040,176 @@ class AccentApplicatorTest {
     }
 
     @Test
-    fun `apply external context reverts a toggled-off element even when allowance is on`() {
-        val element = createFakeAccentElement(AccentElementId.CARET_ROW, "Caret Row")
-        mockEpExtensionList(listOf(element))
+    fun `disabling external chrome reverts only surfaces this process tinted`() {
+        val chromeElement = createExternalChromeElement()
+        stubExternalChromeBase(Color(0x24, 0x29, 0x36))
+        mockEpExtensionList(listOf(chromeElement))
         mockkObject(IndentRainbowSync)
         every { IndentRainbowSync.apply(any<AccentContext>(), any()) } returns Unit
         state.cgpIntegrationEnabled = false
         state.externalThemeEnhancementsEnabled = true
         state.externalThemeChromeTintEnabled = true
-        state.setToggle(AccentElementId.CARET_ROW, false)
+        state.chromePanelBorder = true
+        every { AyuVariant.detect() } returns null
+
+        AccentApplicator.applyFromHexString("#AABBCC")
+        state.externalThemeChromeTintEnabled = false
+        AccentApplicator.applyFromHexString("#AABBCC")
+
+        verify(exactly = 2) { UIManager.put(EXTERNAL_CHROME_TEST_KEY, any()) }
+        verify(exactly = 1) { UIManager.put(EXTERNAL_CHROME_TEST_KEY, null) }
+        verify(exactly = 2) { UIManager.put("EditorTabs.underlineHeight", any()) }
+        verify(exactly = 1) { UIManager.put("EditorTabs.underlineHeight", null) }
+    }
+
+    @Test
+    fun `failed global revert keeps external surface owned for retry`() {
+        val chromeElement = createExternalChromeElement()
+        stubExternalChromeBase(Color(0x24, 0x29, 0x36))
+        mockEpExtensionList(listOf(chromeElement))
+        mockkObject(IndentRainbowSync)
+        every { IndentRainbowSync.apply(any<AccentContext>(), any()) } returns Unit
+        state.cgpIntegrationEnabled = false
+        state.externalThemeEnhancementsEnabled = true
+        state.externalThemeChromeTintEnabled = true
+        state.chromePanelBorder = true
+        every { AyuVariant.detect() } returns null
+
+        AccentApplicator.applyFromHexString("#AABBCC")
+        every { UIManager.put(EXTERNAL_CHROME_TEST_KEY, null) } throws RuntimeException("revert failed")
+        invokePrivate("clearReverseUiAndExtensions")
+
+        every { UIManager.put(EXTERNAL_CHROME_TEST_KEY, null) } returns Unit
+        state.externalThemeChromeTintEnabled = false
+        AccentApplicator.applyFromHexString("#AABBCC")
+
+        verify(exactly = 2) { UIManager.put(EXTERNAL_CHROME_TEST_KEY, null) }
+    }
+
+    @Test
+    fun `external write exception rolls back the preclaimed surface`() {
+        val chromeElement = createExternalChromeElement()
+        stubExternalChromeBase(Color(0x24, 0x29, 0x36))
+        mockEpExtensionList(listOf(chromeElement))
+        mockkObject(IndentRainbowSync)
+        every { IndentRainbowSync.apply(any<AccentContext>(), any()) } returns Unit
+        state.cgpIntegrationEnabled = false
+        state.externalThemeEnhancementsEnabled = true
+        state.externalThemeChromeTintEnabled = true
+        state.chromePanelBorder = true
+        every { AyuVariant.detect() } returns null
+        every {
+            UIManager.put(EXTERNAL_CHROME_TEST_KEY, any<Color>())
+        } throws RuntimeException("listener failed after write")
+        every { UIManager.put(EXTERNAL_CHROME_TEST_KEY, null) } returns Unit
+
+        AccentApplicator.applyFromHexString("#AABBCC")
+
+        verify(exactly = 2) { UIManager.put(EXTERNAL_CHROME_TEST_KEY, any()) }
+        verify(exactly = 1) { UIManager.put(EXTERNAL_CHROME_TEST_KEY, null) }
+    }
+
+    @Test
+    fun `partial external underline write remains owned for retry`() {
+        mockEpExtensionList(emptyList())
+        mockkObject(IndentRainbowSync)
+        every { IndentRainbowSync.apply(any<AccentContext>(), any()) } returns Unit
+        state.cgpIntegrationEnabled = false
+        state.externalThemeEnhancementsEnabled = true
+        state.externalThemeChromeTintEnabled = true
+        every { AyuVariant.detect() } returns null
+        every { UIManager.put("EditorTabs.underlineArc", any<Int>()) } throws RuntimeException("arc failed")
+
+        AccentApplicator.applyFromHexString("#AABBCC")
+        every { UIManager.put("EditorTabs.underlineArc", any()) } returns Unit
+        state.externalThemeChromeTintEnabled = false
+        AccentApplicator.applyFromHexString("#AABBCC")
+
+        verify(exactly = 1) { UIManager.put("EditorTabs.underlineHeight", null) }
+        verify(exactly = 1) { UIManager.put("EditorTabs.underlineArc", null) }
+    }
+
+    @Test
+    fun `failed external underline cleanup remains owned for retry`() {
+        mockEpExtensionList(emptyList())
+        mockkObject(IndentRainbowSync)
+        every { IndentRainbowSync.apply(any<AccentContext>(), any()) } returns Unit
+        state.cgpIntegrationEnabled = false
+        state.externalThemeEnhancementsEnabled = true
+        state.externalThemeChromeTintEnabled = true
+        every { AyuVariant.detect() } returns null
+
+        AccentApplicator.applyFromHexString("#AABBCC")
+        state.externalThemeChromeTintEnabled = false
+        every { UIManager.put("EditorTabs.underlineArc", null) } throws RuntimeException("cleanup failed")
+        AccentApplicator.applyFromHexString("#AABBCC")
+
+        every { UIManager.put("EditorTabs.underlineArc", null) } returns Unit
+        AccentApplicator.applyFromHexString("#AABBCC")
+
+        verify(exactly = 2) { UIManager.put("EditorTabs.underlineHeight", null) }
+        verify(exactly = 2) { UIManager.put("EditorTabs.underlineArc", null) }
+    }
+
+    @Test
+    fun `external chrome with a missing base never claims or reverts the surface`() {
+        val chromeElement = createExternalChromeElement()
+        stubExternalChromeBase(null)
+        mockEpExtensionList(listOf(chromeElement))
+        mockkObject(IndentRainbowSync)
+        every { IndentRainbowSync.apply(any<AccentContext>(), any()) } returns Unit
+        state.cgpIntegrationEnabled = false
+        state.externalThemeEnhancementsEnabled = true
+        state.externalThemeChromeTintEnabled = true
+        state.chromePanelBorder = true
+        every { AyuVariant.detect() } returns null
+
+        AccentApplicator.applyFromHexString("#AABBCC")
+        state.externalThemeChromeTintEnabled = false
+        AccentApplicator.applyFromHexString("#AABBCC")
+
+        verify(exactly = 0) { UIManager.put(EXTERNAL_CHROME_TEST_KEY, any()) }
+    }
+
+    @Test
+    fun `external chrome disabled surface never claims or reverts ownership`() {
+        val chromeElement = createExternalChromeElement(isEnabled = false)
+        stubExternalChromeBase(Color(0x24, 0x29, 0x36))
+        mockEpExtensionList(listOf(chromeElement))
+        mockkObject(IndentRainbowSync)
+        every { IndentRainbowSync.apply(any<AccentContext>(), any()) } returns Unit
+        state.cgpIntegrationEnabled = false
+        state.externalThemeEnhancementsEnabled = true
+        state.externalThemeChromeTintEnabled = true
+        state.chromePanelBorder = true
+        every { AyuVariant.detect() } returns null
+
+        AccentApplicator.applyFromHexString("#AABBCC")
+        state.externalThemeChromeTintEnabled = false
+        AccentApplicator.applyFromHexString("#AABBCC")
+
+        verify(exactly = 0) { UIManager.put(EXTERNAL_CHROME_TEST_KEY, any()) }
+    }
+
+    @Test
+    fun `unlicensed external startup leaves chrome and underline untouched`() {
+        val chromeElement = createExternalChromeElement()
+        stubExternalChromeBase(Color(0x24, 0x29, 0x36))
+        mockEpExtensionList(listOf(chromeElement))
+        mockkObject(IndentRainbowSync)
+        every { IndentRainbowSync.apply(any<AccentContext>(), any()) } returns Unit
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+        state.cgpIntegrationEnabled = false
+        state.externalThemeEnhancementsEnabled = true
+        state.externalThemeChromeTintEnabled = true
+        state.chromePanelBorder = true
         every { AyuVariant.detect() } returns null
 
         AccentApplicator.applyFromHexString("#AABBCC")
 
-        verify(exactly = 0) { element.apply(any()) }
-        verify(exactly = 1) { element.revert() }
-        verify(exactly = 0) { element.applyNeutral(any()) }
+        verify(exactly = 0) { UIManager.put(EXTERNAL_CHROME_TEST_KEY, any()) }
+        verify(exactly = 0) { UIManager.put("EditorTabs.underlineHeight", any()) }
+        verify(exactly = 0) { UIManager.put("EditorTabs.underlineArc", any()) }
     }
 
     @Test
@@ -1287,7 +1488,7 @@ class AccentApplicatorTest {
     }
 
     @Test
-    fun `applyElements with disabled toggle under external context reverts element`() {
+    fun `applyElements under external context leaves non chrome element untouched`() {
         val mockElement = mockk<AccentElement>(relaxed = true)
         every { mockElement.id } returns AccentElementId.CARET_ROW
         every { mockElement.displayName } returns "Caret Row"
@@ -1299,8 +1500,24 @@ class AccentApplicatorTest {
         val accent = Color.decode("#FFCC66")
         invokeApplyElements(state, accent, AccentContext.External)
 
-        verify { mockElement.revert() }
+        verify(exactly = 0) { mockElement.revert() }
         verify(exactly = 0) { mockElement.apply(any()) }
+    }
+
+    @Test
+    fun `applyElements under Ayu context gates chrome without erasing its preference`() {
+        val chromeElement = mockk<AccentElement>(relaxed = true)
+        every { chromeElement.id } returns AccentElementId.PANEL_BORDER
+        every { chromeElement.displayName } returns "Panel border"
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+        state.chromePanelBorder = true
+        mockEpExtensionList(listOf(chromeElement))
+
+        invokeApplyElements(state, Color.decode("#FFCC66"), AccentContext.Ayu(AyuVariant.MIRAGE))
+
+        verify(exactly = 1) { chromeElement.applyNeutral(AyuVariant.MIRAGE) }
+        verify(exactly = 0) { chromeElement.apply(any()) }
+        kotlin.test.assertTrue(state.chromePanelBorder)
     }
 
     @Test
@@ -1790,7 +2007,7 @@ class AccentApplicatorTest {
     }
 
     /**
-     * Invokes the private `applyElements(AyuIslandsState, Color, AccentContext)`
+     * Invokes the private `applyElements(AyuIslandsState, Color, AccentContext, Boolean)`
      * method via reflection.
      */
     private fun invokeApplyElements(
@@ -1802,7 +2019,13 @@ class AccentApplicatorTest {
             AccentApplicator::class.java.declaredMethods
                 .first { it.name == "applyElements" }
         method.isAccessible = true
-        method.invoke(AccentApplicator, targetState, accent, context)
+        method.invoke(
+            AccentApplicator,
+            targetState,
+            accent,
+            context,
+            LicenseChecker.isLicensedOrGrace(),
+        )
     }
 
     // Helper for invoking private methods that accept nullable parameters
@@ -1822,7 +2045,7 @@ class AccentApplicatorTest {
         state.glowTabMode = "OFF"
         state.tabUnderlineHeight = 6
 
-        assertEquals(6, resolveUnderlineHeight(state))
+        assertEquals(6, resolveUnderlineHeight(state, GlowTabMode.OFF))
     }
 
     @Test
@@ -1831,7 +2054,7 @@ class AccentApplicatorTest {
         state.tabUnderlineGlowSync = false
         state.tabUnderlineHeight = 4
 
-        assertEquals(4, resolveUnderlineHeight(state))
+        assertEquals(4, resolveUnderlineHeight(state, GlowTabMode.MINIMAL))
     }
 
     @Test
@@ -1842,7 +2065,7 @@ class AccentApplicatorTest {
         state.glowStyle = "SOFT"
 
         val expected = state.getWidthForStyle(dev.ayuislands.glow.GlowStyle.SOFT)
-        assertEquals(expected, resolveUnderlineHeight(state))
+        assertEquals(expected, resolveUnderlineHeight(state, GlowTabMode.MINIMAL))
     }
 
     @Test
@@ -1852,7 +2075,7 @@ class AccentApplicatorTest {
         state.glowEnabled = false
         state.tabUnderlineHeight = 8
 
-        assertEquals(8, resolveUnderlineHeight(state))
+        assertEquals(8, resolveUnderlineHeight(state, GlowTabMode.MINIMAL))
     }
 
     // applyTabUnderline tests (merged from applyTabUnderlineStyle +
@@ -1890,7 +2113,7 @@ class AccentApplicatorTest {
     }
 
     @Test
-    fun `applyTabUnderline skips neutral gray under external context with allowance on`() {
+    fun `applyTabUnderline leaves external geometry untouched when tab mode is OFF`() {
         state.glowTabMode = "OFF"
         state.externalThemeEnhancementsEnabled = true
         state.externalThemeChromeTintEnabled = true
@@ -1898,6 +2121,8 @@ class AccentApplicatorTest {
         invokeApplyTabUnderline(state, AccentContext.External)
 
         verify(exactly = 0) { mockScheme.setColor(ColorKey.find("TAB_UNDERLINE"), any()) }
+        verify(exactly = 0) { UIManager.put("EditorTabs.underlineHeight", any()) }
+        verify(exactly = 0) { UIManager.put("EditorTabs.underlineArc", any()) }
     }
 
     private fun invokeApplyTabUnderline(
@@ -1908,7 +2133,12 @@ class AccentApplicatorTest {
             AccentApplicator::class.java.declaredMethods
                 .first { it.name == "applyTabUnderline" }
         method.isAccessible = true
-        method.invoke(AccentApplicator, state, context)
+        method.invoke(
+            AccentApplicator,
+            state,
+            context,
+            LicenseChecker.isLicensedOrGrace(),
+        )
     }
 
     private fun resetCodeGlanceProState() {
@@ -1918,6 +2148,24 @@ class AccentApplicatorTest {
         // stale state in the next test on rename. The helper lives next to
         // the fields it resets — a Kotlin rename refactors both at once.
         CodeGlanceProIntegration.resetReflectionCacheForTests()
+    }
+
+    private fun createExternalChromeElement(isEnabled: Boolean = true): AbstractChromeElement =
+        object : AbstractChromeElement() {
+            override val id = AccentElementId.PANEL_BORDER
+            override val displayName = "Test external chrome"
+            override val backgroundKeys = listOf(EXTERNAL_CHROME_TEST_KEY)
+            override val foregroundKeys = emptyList<String>()
+            override val foregroundTextTarget = WcagForeground.TextTarget.PRIMARY_TEXT
+            override val peerTarget: ChromeTarget? = null
+            override val isEnabled = isEnabled
+        }
+
+    private fun stubExternalChromeBase(color: Color?) {
+        mockkObject(ChromeBaseColors)
+        every { ChromeBaseColors[EXTERNAL_CHROME_TEST_KEY] } returns color
+        every { ChromeBaseColors.rememberPluginTint(any(), any()) } returns Unit
+        every { ChromeBaseColors.forgetPluginTint(any()) } returns Unit
     }
 
     // apply() with an invalid hex returns false AND posts a user-visible
@@ -1963,6 +2211,7 @@ class AccentApplicatorTest {
 
     private companion object {
         private const val ACCENT_HEX_STRIPPED = "FFCC66"
+        private const val EXTERNAL_CHROME_TEST_KEY = "Ayu.Test.externalChrome"
         private const val CODE_GLANCE_FIELD_PREFIX = "c" + "g" + "p"
         private const val CODE_GLANCE_METHOD_RESOLUTION =
             "resolve" + "C" + "g" + "p" + "Methods"

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
@@ -946,7 +946,7 @@ class AccentApplicatorTest {
     }
 
     @Test
-    fun `apply external context syncs integrations without Ayu-only elements or tab underline`() {
+    fun `apply external context reverts elements and clears underline geometry while allowance is off`() {
         val element = createFakeAccentElement(AccentElementId.CARET_ROW, "Caret Row")
         mockEpExtensionList(listOf(element))
         mockkObject(IndentRainbowSync)
@@ -959,10 +959,56 @@ class AccentApplicatorTest {
 
         verify(exactly = 1) { IndentRainbowSync.apply(AccentContext.External, "#AABBCC") }
         verify(exactly = 0) { element.apply(any()) }
+        verify(exactly = 1) { element.revert() }
+        verify(exactly = 0) { element.applyNeutral(any()) }
+        // MockK's any() matches null under type erasure, so "only the null
+        // clear happened" is proven as: exactly one call total, and that call
+        // carried null.
+        verify(exactly = 1) { UIManager.put("EditorTabs.underlineHeight", null) }
+        verify(exactly = 1) { UIManager.put("EditorTabs.underlineArc", null) }
+        verify(exactly = 1) { UIManager.put("EditorTabs.underlineHeight", any()) }
+        verify(exactly = 1) { UIManager.put("EditorTabs.underlineArc", any()) }
+    }
+
+    @Test
+    fun `apply external context tints elements and writes underline geometry when allowance is on`() {
+        val element = createFakeAccentElement(AccentElementId.CARET_ROW, "Caret Row")
+        mockEpExtensionList(listOf(element))
+        mockkObject(IndentRainbowSync)
+        every { IndentRainbowSync.apply(any<AccentContext>(), any()) } returns Unit
+        state.cgpIntegrationEnabled = false
+        state.externalThemeEnhancementsEnabled = true
+        state.externalThemeChromeTintEnabled = true
+        every { AyuVariant.detect() } returns null
+
+        AccentApplicator.applyFromHexString("#AABBCC")
+
+        verify(exactly = 1) { element.apply(Color.decode("#AABBCC")) }
         verify(exactly = 0) { element.revert() }
         verify(exactly = 0) { element.applyNeutral(any()) }
-        verify(exactly = 0) { UIManager.put("EditorTabs.underlineHeight", any<Int>()) }
-        verify(exactly = 0) { UIManager.put("EditorTabs.underlineArc", any<Int>()) }
+        verify(exactly = 1) { UIManager.put("EditorTabs.underlineHeight", any()) }
+        verify(exactly = 1) { UIManager.put("EditorTabs.underlineArc", any()) }
+        verify(exactly = 0) { UIManager.put("EditorTabs.underlineHeight", null) }
+        verify(exactly = 0) { UIManager.put("EditorTabs.underlineArc", null) }
+    }
+
+    @Test
+    fun `apply external context reverts a toggled-off element even when allowance is on`() {
+        val element = createFakeAccentElement(AccentElementId.CARET_ROW, "Caret Row")
+        mockEpExtensionList(listOf(element))
+        mockkObject(IndentRainbowSync)
+        every { IndentRainbowSync.apply(any<AccentContext>(), any()) } returns Unit
+        state.cgpIntegrationEnabled = false
+        state.externalThemeEnhancementsEnabled = true
+        state.externalThemeChromeTintEnabled = true
+        state.setToggle(AccentElementId.CARET_ROW, false)
+        every { AyuVariant.detect() } returns null
+
+        AccentApplicator.applyFromHexString("#AABBCC")
+
+        verify(exactly = 0) { element.apply(any()) }
+        verify(exactly = 1) { element.revert() }
+        verify(exactly = 0) { element.applyNeutral(any()) }
     }
 
     @Test
@@ -1220,7 +1266,7 @@ class AccentApplicatorTest {
         mockEpExtensionList(listOf(mockElement))
 
         val accent = Color.decode("#FFCC66")
-        invokeApplyElements(state, accent, AyuVariant.MIRAGE)
+        invokeApplyElements(state, accent, AccentContext.Ayu(AyuVariant.MIRAGE))
 
         verify { mockElement.apply(accent) }
     }
@@ -1234,22 +1280,24 @@ class AccentApplicatorTest {
         mockEpExtensionList(listOf(mockElement))
 
         val accent = Color.decode("#FFCC66")
-        invokeApplyElements(state, accent, AyuVariant.MIRAGE)
+        invokeApplyElements(state, accent, AccentContext.Ayu(AyuVariant.MIRAGE))
 
         verify { mockElement.applyNeutral(AyuVariant.MIRAGE) }
         verify(exactly = 0) { mockElement.apply(any()) }
     }
 
     @Test
-    fun `applyElements with disabled toggle and null variant reverts element`() {
+    fun `applyElements with disabled toggle under external context reverts element`() {
         val mockElement = mockk<AccentElement>(relaxed = true)
         every { mockElement.id } returns AccentElementId.CARET_ROW
         every { mockElement.displayName } returns "Caret Row"
         state.caretRow = false
+        state.externalThemeEnhancementsEnabled = true
+        state.externalThemeChromeTintEnabled = true
         mockEpExtensionList(listOf(mockElement))
 
         val accent = Color.decode("#FFCC66")
-        invokeApplyElements(state, accent, null)
+        invokeApplyElements(state, accent, AccentContext.External)
 
         verify { mockElement.revert() }
         verify(exactly = 0) { mockElement.apply(any()) }
@@ -1271,7 +1319,7 @@ class AccentApplicatorTest {
         mockEpExtensionList(listOf(mockElement))
 
         val accent = Color.decode("#FFCC66")
-        invokeApplyElements(state, accent, AyuVariant.MIRAGE)
+        invokeApplyElements(state, accent, AccentContext.Ayu(AyuVariant.MIRAGE))
 
         verify { mockElement.applyNeutral(AyuVariant.MIRAGE) }
         verify(exactly = 0) { mockElement.apply(any()) }
@@ -1294,7 +1342,7 @@ class AccentApplicatorTest {
         mockEpExtensionList(listOf(mockElement))
 
         val accent = Color.decode("#FFCC66")
-        invokeApplyElements(state, accent, AyuVariant.MIRAGE)
+        invokeApplyElements(state, accent, AccentContext.Ayu(AyuVariant.MIRAGE))
 
         verify { mockElement.apply(accent) }
     }
@@ -1309,7 +1357,7 @@ class AccentApplicatorTest {
 
         val accent = Color.decode("#FFCC66")
         // Should not throw
-        invokeApplyElements(state, accent, AyuVariant.MIRAGE)
+        invokeApplyElements(state, accent, AccentContext.Ayu(AyuVariant.MIRAGE))
     }
 
     @Test
@@ -1325,7 +1373,7 @@ class AccentApplicatorTest {
         mockEpExtensionList(listOf(element1, element2))
 
         val accent = Color.decode("#FFCC66")
-        invokeApplyElements(state, accent, AyuVariant.MIRAGE)
+        invokeApplyElements(state, accent, AccentContext.Ayu(AyuVariant.MIRAGE))
 
         // element2 should still be applied despite element1 throwing
         verify { element2.apply(accent) }
@@ -1351,7 +1399,7 @@ class AccentApplicatorTest {
 
         val accent = Color.decode("#FFCC66")
         // Must not propagate the simulated exception
-        invokeApplyElements(state, accent, AyuVariant.MIRAGE)
+        invokeApplyElements(state, accent, AccentContext.Ayu(AyuVariant.MIRAGE))
 
         // Loop must have continued past the failing middle element
         verify { first.apply(accent) }
@@ -1395,7 +1443,7 @@ class AccentApplicatorTest {
 
         val accent = Color.decode("#FFCC66")
         // Must not throw despite failing.applyNeutral exploding
-        invokeApplyElements(state, accent, AyuVariant.MIRAGE)
+        invokeApplyElements(state, accent, AccentContext.Ayu(AyuVariant.MIRAGE))
 
         // Loop continued and the trailing element was processed normally
         verify { failing.applyNeutral(AyuVariant.MIRAGE) }
@@ -1414,7 +1462,7 @@ class AccentApplicatorTest {
         mockEpExtensionList(listOf(element))
 
         val accent = Color.decode("#FFCC66")
-        invokeApplyElements(state, accent, AyuVariant.MIRAGE)
+        invokeApplyElements(state, accent, AccentContext.Ayu(AyuVariant.MIRAGE))
 
         verify(exactly = 0) { element.apply(any()) }
         verify { element.applyNeutral(AyuVariant.MIRAGE) }
@@ -1442,7 +1490,7 @@ class AccentApplicatorTest {
         mockEpExtensionList(listOf(element))
 
         val accent = Color.decode("#FFCC66")
-        invokeApplyElements(state, accent, AyuVariant.MIRAGE)
+        invokeApplyElements(state, accent, AccentContext.Ayu(AyuVariant.MIRAGE))
 
         verify(exactly = 0) { element.apply(any()) }
         verify { element.applyNeutral(AyuVariant.MIRAGE) }
@@ -1469,7 +1517,7 @@ class AccentApplicatorTest {
         mockEpExtensionList(listOf(element))
 
         val accent = Color.decode("#FFCC66")
-        invokeApplyElements(state, accent, AyuVariant.MIRAGE)
+        invokeApplyElements(state, accent, AccentContext.Ayu(AyuVariant.MIRAGE))
 
         // Force override wins — apply called, neutralize path not taken
         verify { element.apply(accent) }
@@ -1501,7 +1549,7 @@ class AccentApplicatorTest {
 
         val accent = Color.decode("#FFCC66")
         // Must not propagate the simulated apply failure.
-        invokeApplyElements(state, accent, AyuVariant.MIRAGE)
+        invokeApplyElements(state, accent, AccentContext.Ayu(AyuVariant.MIRAGE))
 
         // Revert was invoked exactly once on the throwing element — this is
         // the revert-on-apply-fail lock; if the try/revert block is deleted,
@@ -1527,7 +1575,7 @@ class AccentApplicatorTest {
 
         val accent = Color.decode("#FFCC66")
         // Must not propagate either the apply or the revert exception.
-        invokeApplyElements(state, accent, AyuVariant.MIRAGE)
+        invokeApplyElements(state, accent, AccentContext.Ayu(AyuVariant.MIRAGE))
 
         // Revert WAS attempted on the failing element, even though it
         // threw — locks that the cleanup path runs unconditionally after
@@ -1742,19 +1790,19 @@ class AccentApplicatorTest {
     }
 
     /**
-     * Invokes the private `applyElements(AyuIslandsState, Color, AyuVariant?)` method
-     * via reflection.
+     * Invokes the private `applyElements(AyuIslandsState, Color, AccentContext)`
+     * method via reflection.
      */
     private fun invokeApplyElements(
         targetState: AyuIslandsState,
         accent: Color,
-        variant: AyuVariant?,
+        context: AccentContext,
     ) {
         val method =
             AccentApplicator::class.java.declaredMethods
                 .first { it.name == "applyElements" }
         method.isAccessible = true
-        method.invoke(AccentApplicator, targetState, accent, variant)
+        method.invoke(AccentApplicator, targetState, accent, context)
     }
 
     // Helper for invoking private methods that accept nullable parameters
@@ -1817,7 +1865,7 @@ class AccentApplicatorTest {
         state.tabUnderlineHeight = 4
         state.tabUnderlineGlowSync = false
 
-        invokeApplyTabUnderline(state, AyuVariant.MIRAGE)
+        invokeApplyTabUnderline(state, AccentContext.Ayu(AyuVariant.MIRAGE))
 
         verify { UIManager.put("EditorTabs.underlineHeight", Integer.valueOf(4)) }
         verify { UIManager.put("EditorTabs.underlineArc", any<Int>()) }
@@ -1827,7 +1875,7 @@ class AccentApplicatorTest {
     fun `applyTabUnderline sets neutral gray when OFF and variant present`() {
         state.glowTabMode = "OFF"
 
-        invokeApplyTabUnderline(state, AyuVariant.MIRAGE)
+        invokeApplyTabUnderline(state, AccentContext.Ayu(AyuVariant.MIRAGE))
 
         verify { mockScheme.setColor(any(), Color.decode(AyuVariant.MIRAGE.neutralGray)) }
     }
@@ -1836,29 +1884,31 @@ class AccentApplicatorTest {
     fun `applyTabUnderline skips neutral gray when not OFF`() {
         state.glowTabMode = "MINIMAL"
 
-        invokeApplyTabUnderline(state, AyuVariant.MIRAGE)
+        invokeApplyTabUnderline(state, AccentContext.Ayu(AyuVariant.MIRAGE))
 
         verify(exactly = 0) { mockScheme.setColor(ColorKey.find("TAB_UNDERLINE"), any()) }
     }
 
     @Test
-    fun `applyTabUnderline skips neutral gray when variant is null`() {
+    fun `applyTabUnderline skips neutral gray under external context with allowance on`() {
         state.glowTabMode = "OFF"
+        state.externalThemeEnhancementsEnabled = true
+        state.externalThemeChromeTintEnabled = true
 
-        invokeApplyTabUnderline(state, null)
+        invokeApplyTabUnderline(state, AccentContext.External)
 
         verify(exactly = 0) { mockScheme.setColor(ColorKey.find("TAB_UNDERLINE"), any()) }
     }
 
     private fun invokeApplyTabUnderline(
         state: AyuIslandsState,
-        variant: AyuVariant?,
+        context: AccentContext,
     ) {
         val method =
             AccentApplicator::class.java.declaredMethods
                 .first { it.name == "applyTabUnderline" }
         method.isAccessible = true
-        method.invoke(AccentApplicator, state, variant)
+        method.invoke(AccentApplicator, state, context)
     }
 
     private fun resetCodeGlanceProState() {

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplyPlanTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplyPlanTest.kt
@@ -51,13 +51,18 @@ class AccentApplyPlanTest {
     }
 
     @Test
-    fun `apply plan for External context skips elements and tab underline`() {
+    fun `apply plan for External context schedules elements and tab underline like Ayu`() {
+        // Elements and underline gate on context SHAPE only; the External
+        // chrome-tint allowance is enforced inside the applicator workers
+        // with revert symmetry, so the plan is identical to the Ayu plan.
         assertEquals(
             listOf(
                 ApplyAlwaysOnUiKeys,
+                ApplyElements,
                 SyncIndentRainbow,
                 SyncCodeGlanceProViewport,
                 ApplyAlwaysOnEditorKeys,
+                ApplyTabUnderline,
                 NotifyComponentTrees,
                 RepaintWindows,
                 MarkApplyClean,

--- a/src/test/kotlin/dev/ayuislands/accent/ChromeTintBlenderTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ChromeTintBlenderTest.kt
@@ -140,6 +140,42 @@ class ChromeTintBlenderTest {
         assertEquals(0, result.blue)
     }
 
+    @Test
+    fun `blend holds identity opacity and hue invariants on foreign theme bases`() {
+        // External Theme Support feeds the blender stock colors captured from
+        // non-Ayu LAFs. Representative samples: Darcula chrome, IntelliJ-Light
+        // chrome, and both high-contrast extremes.
+        val accent = Color(0x5C, 0xCF, 0xE6)
+        val foreignBases =
+            listOf(
+                Color(0x3C, 0x3F, 0x41),
+                Color(0xF2, 0xF2, 0xF2),
+                Color(0x00, 0x00, 0x00),
+                Color(0xFF, 0xFF, 0xFF),
+            )
+
+        for (base in foreignBases) {
+            val identity = ChromeTintBlender.blend(accent, base, TintIntensity.of(0))
+            assertEquals(base.rgb, identity.rgb, "intensity=0 must return the base unchanged for $base")
+
+            val tinted = ChromeTintBlender.blend(accent, base, TintIntensity.of(TintIntensity.MAX))
+            assertEquals(255, tinted.alpha, "blend output must stay opaque for $base")
+            assertTrue(
+                hueDelta(hueOf(tinted), hueOf(accent)) <= HUE_EPSILON,
+                "max-intensity hue must track the accent on foreign base $base: got ${hueOf(tinted)}",
+            )
+        }
+    }
+
+    @Test
+    fun `blend drops base alpha and returns an opaque color`() {
+        // A foreign theme may stock a translucent color in a key the plugin
+        // treats as opaque fill; the contract is opacify, never alpha-blend.
+        val translucentBase = Color(0x2E, 0x35, 0x44, 0x80)
+        val tinted = ChromeTintBlender.blend(accentRed, translucentBase, TintIntensity.of(25))
+        assertEquals(255, tinted.alpha)
+    }
+
     // --- Hue-space invariant helpers ---
 
     private fun hueOf(color: Color): Float {

--- a/src/test/kotlin/dev/ayuislands/accent/elements/StatusBarElementTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/StatusBarElementTest.kt
@@ -24,6 +24,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
@@ -120,6 +121,19 @@ class StatusBarElementTest {
         verify { UIManager.put("StatusBar.Widget.pressedBackground", null) }
         // No opaque tint should have been written since the bases were absent.
         verify(exactly = 0) { UIManager.put("StatusBar.background", blended) }
+    }
+
+    @Test
+    fun `external apply with no base leaves the host theme untouched`() {
+        every { ChromeBaseColors[any()] } returns null
+        var hasMutated = false
+
+        StatusBarElement().applyExternal(accent) {
+            hasMutated = true
+        }
+
+        verify(exactly = 0) { UIManager.put(any<String>(), any()) }
+        assertFalse(hasMutated)
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/licensing/FreeTierLockdownTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/FreeTierLockdownTest.kt
@@ -157,6 +157,18 @@ class FreeTierLockdownTest {
     }
 
     @Test
+    fun `revertToFreeDefaults clears the external chrome tint allowance`() {
+        // The allowance has no separate feature master (unlike glow/CGP/IR),
+        // so the reverter must clear the flag itself — otherwise a downgraded
+        // user on a foreign theme keeps tinted chrome through a premium toggle.
+        state.externalThemeChromeTintEnabled = true
+
+        LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
+
+        assertFalse(state.externalThemeChromeTintEnabled)
+    }
+
+    @Test
     fun `revertToFreeDefaults resets glowTabMode to MINIMAL`() {
         state.glowTabMode = "FULL"
         LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)

--- a/src/test/kotlin/dev/ayuislands/licensing/FreeTierLockdownTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/FreeTierLockdownTest.kt
@@ -123,10 +123,9 @@ class FreeTierLockdownTest {
     }
 
     @Test
-    fun `revertToFreeDefaults resets VISUAL INTERACTIVE toggles to true and CHROME toggles to false`() {
-        // Seed every toggle to the OPPOSITE of its free-tier default so we can see the revert
-        // actually run: VISUAL/INTERACTIVE start false (free-tier default is true) and CHROME
-        // starts true (free-tier default is false — chrome tinting is premium-only).
+    fun `revertToFreeDefaults preserves every element choice`() {
+        // Free choices remain immediately effective. Premium CHROME choices stay
+        // persisted while runtime entitlement suppresses their rendering.
         for (id in AccentElementId.entries) {
             state.setToggle(id, id.group == AccentGroup.CHROME)
         }
@@ -134,45 +133,41 @@ class FreeTierLockdownTest {
         LicenseChecker.revertToFreeDefaults(AyuVariant.LIGHT)
 
         for (id in AccentElementId.entries.filter { elementId -> elementId.group != AccentGroup.CHROME }) {
-            assertTrue(state.isToggleEnabled(id), "${id.name} must be re-enabled on revert")
+            assertFalse(state.isToggleEnabled(id), "${id.name} must be preserved on free-tier revert")
         }
         for (id in AccentElementId.entries.filter { elementId -> elementId.group == AccentGroup.CHROME }) {
-            assertFalse(state.isToggleEnabled(id), "${id.name} must be disabled on free-tier revert")
+            assertTrue(state.isToggleEnabled(id), "${id.name} must be preserved on free-tier revert")
         }
-        // 4 VISUAL + 4 INTERACTIVE + 5 CHROME = 13. Update this number and the reverter together.
-        assertEquals(13, AccentElementId.entries.size, "element count locked to 13 — update reverter if this changes")
+        assertEquals(13, AccentElementId.entries.size, "element inventory changed — update the preservation test")
     }
 
     @Test
-    fun `revertToFreeDefaults resets chrome tinting auxiliary state to defaults`() {
-        // Mutate every chrome-tinting auxiliary field away from its free-tier default,
-        // then prove the reverter restores each one.
+    fun `revertToFreeDefaults preserves chrome intensity and UI state`() {
         state.chromeTintIntensity = 75
         state.chromeTintingGroupExpanded = true
 
         LicenseChecker.revertToFreeDefaults(AyuVariant.LIGHT)
 
-        assertEquals(AyuIslandsState.DEFAULT_CHROME_TINT_INTENSITY, state.chromeTintIntensity)
-        assertFalse(state.chromeTintingGroupExpanded)
+        assertEquals(75, state.chromeTintIntensity)
+        assertTrue(state.chromeTintingGroupExpanded)
     }
 
     @Test
-    fun `revertToFreeDefaults clears the external chrome tint allowance`() {
-        // The allowance has no separate feature master (unlike glow/CGP/IR),
-        // so the reverter must clear the flag itself — otherwise a downgraded
-        // user on a foreign theme keeps tinted chrome through a premium toggle.
+    fun `revertToFreeDefaults preserves the external chrome tint preference`() {
+        // Runtime entitlement gates paid behavior. Keep the stored choice so a
+        // renewed license restores the exact external-theme preference.
         state.externalThemeChromeTintEnabled = true
 
         LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
 
-        assertFalse(state.externalThemeChromeTintEnabled)
+        assertTrue(state.externalThemeChromeTintEnabled)
     }
 
     @Test
-    fun `revertToFreeDefaults resets glowTabMode to MINIMAL`() {
+    fun `revertToFreeDefaults preserves glowTabMode preference`() {
         state.glowTabMode = "FULL"
         LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
-        assertEquals("MINIMAL", state.glowTabMode)
+        assertEquals("FULL", state.glowTabMode)
     }
 
     @Test
@@ -294,7 +289,7 @@ class FreeTierLockdownTest {
         assertFalse(state.glowEnabled)
         assertFalse(state.accentRotationEnabled)
         assertFalse(state.cgpIntegrationEnabled)
-        // VISUAL/INTERACTIVE toggles flip to true; CHROME toggles stay off on free tier.
+        // Every element choice stays at its constructor default.
         for (id in AccentElementId.entries.filter { it.group != AccentGroup.CHROME }) {
             assertTrue(state.isToggleEnabled(id))
         }
@@ -320,7 +315,7 @@ class FreeTierLockdownTest {
             state.glowTabMode = "FULL"
             state.hideProjectRootPath = true
             state.hideProjectViewHScrollbar = true
-            // Seed opposite of free-tier defaults: non-CHROME to false, CHROME to true.
+            // Seed free toggles false and persisted premium choices true.
             for (id in AccentElementId.entries) {
                 state.setToggle(id, id.group == AccentGroup.CHROME)
             }
@@ -337,14 +332,14 @@ class FreeTierLockdownTest {
             assertFalse(state.accentRotationEnabled)
             assertFalse(state.cgpIntegrationEnabled)
             assertFalse(state.irIntegrationEnabled)
-            assertEquals("MINIMAL", state.glowTabMode)
+            assertEquals("FULL", state.glowTabMode)
             assertFalse(state.hideProjectRootPath)
             assertFalse(state.hideProjectViewHScrollbar)
             for (id in AccentElementId.entries.filter { elementId -> elementId.group != AccentGroup.CHROME }) {
-                assertTrue(state.isToggleEnabled(id), "${id.name} must be true after concurrent revert")
+                assertFalse(state.isToggleEnabled(id), "${id.name} must be preserved after concurrent revert")
             }
             for (id in AccentElementId.entries.filter { elementId -> elementId.group == AccentGroup.CHROME }) {
-                assertFalse(state.isToggleEnabled(id), "${id.name} must be false after concurrent revert")
+                assertTrue(state.isToggleEnabled(id), "${id.name} must be preserved after concurrent revert")
             }
         }
     }

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerProDefaultsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerProDefaultsTest.kt
@@ -184,19 +184,19 @@ class LicenseCheckerProDefaultsTest {
     }
 
     @Test
-    fun `revertToFreeDefaults resets tab mode to MINIMAL`() {
+    fun `revertToFreeDefaults preserves tab mode preference`() {
         state.glowTabMode = "FULL"
         mockAccentApplicator()
 
         LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
 
-        assertEquals("MINIMAL", state.glowTabMode)
+        assertEquals("FULL", state.glowTabMode)
     }
 
     @Test
-    fun `revertToFreeDefaults resets VISUAL INTERACTIVE toggles to true and CHROME toggles to false`() {
-        // CHROME group is premium-only (phase 40 chrome tinting) — revert must leave it off
-        // on free tier even if the user had it enabled pre-downgrade.
+    fun `revertToFreeDefaults preserves every element choice`() {
+        // Entitlement gates CHROME execution without erasing any free or premium
+        // surface choice during a temporary downgrade.
         for (id in AccentElementId.entries) {
             state.setToggle(id, id.group == AccentGroup.CHROME)
         }
@@ -205,10 +205,10 @@ class LicenseCheckerProDefaultsTest {
         LicenseChecker.revertToFreeDefaults(AyuVariant.MIRAGE)
 
         for (id in AccentElementId.entries.filter { it.group != AccentGroup.CHROME }) {
-            assertTrue(state.isToggleEnabled(id), "${id.name} should be reset to true")
+            assertFalse(state.isToggleEnabled(id), "${id.name} should be preserved on free tier")
         }
         for (id in AccentElementId.entries.filter { it.group == AccentGroup.CHROME }) {
-            assertFalse(state.isToggleEnabled(id), "${id.name} should be forcibly disabled on free tier")
+            assertTrue(state.isToggleEnabled(id), "${id.name} should be preserved on free tier")
         }
     }
 

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseTransitionListenerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseTransitionListenerTest.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.project.ProjectManager
 import com.intellij.testFramework.LoggedErrorProcessor
 import com.intellij.ui.LicensingFacade
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.commitpanel.CommitPanelAutoFitManager
 import dev.ayuislands.settings.AyuIslandsSettings
@@ -48,10 +49,10 @@ class LicenseTransitionListenerTest {
 
         // Mock the accent re-apply path so transition tests can assert that it fires
         // (on either direction) without spinning up AccentApplicator's platform deps.
-        // Each test re-stubs AyuVariant.detect() when it needs to exercise the
-        // null-variant silent-skip branch.
+        // Each test re-stubs [AyuVariant.detect] when it needs to exercise a
+        // different active accent context.
         mockkObject(AccentApplicator)
-        every { AccentApplicator.applyForFocusedProject(any<dev.ayuislands.accent.AyuVariant>()) } returns "#FFCC66"
+        every { AccentApplicator.applyForFocusedProject(any<AccentContext>()) } returns "#FFCC66"
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
         mockkObject(CommitPanelAutoFitManager.Companion)
@@ -65,7 +66,7 @@ class LicenseTransitionListenerTest {
     @Test
     fun `first licensed notification does not flip flag (initial state)`() {
         state.premiumOnboardingShown = true
-        every { LicenseChecker.isLicensed() } returns true
+        every { LicenseChecker.isLicensedOrGrace() } returns true
 
         LicenseTransitionListener().licenseStateChanged(facade)
 
@@ -77,11 +78,11 @@ class LicenseTransitionListenerTest {
         state.premiumOnboardingShown = true
         val listener = LicenseTransitionListener()
 
-        every { LicenseChecker.isLicensed() } returns false
+        every { LicenseChecker.isLicensedOrGrace() } returns false
         listener.licenseStateChanged(facade)
         assertTrue(state.premiumOnboardingShown)
 
-        every { LicenseChecker.isLicensed() } returns true
+        every { LicenseChecker.isLicensedOrGrace() } returns true
         listener.licenseStateChanged(facade)
 
         assertFalse(state.premiumOnboardingShown)
@@ -92,7 +93,7 @@ class LicenseTransitionListenerTest {
         state.premiumOnboardingShown = true
         val listener = LicenseTransitionListener()
 
-        every { LicenseChecker.isLicensed() } returns true
+        every { LicenseChecker.isLicensedOrGrace() } returns true
         listener.licenseStateChanged(facade)
         listener.licenseStateChanged(facade)
 
@@ -102,7 +103,7 @@ class LicenseTransitionListenerTest {
     @Test
     fun `unlicensed notifications do not flip flag`() {
         state.premiumOnboardingShown = true
-        every { LicenseChecker.isLicensed() } returns false
+        every { LicenseChecker.isLicensedOrGrace() } returns false
 
         LicenseTransitionListener().licenseStateChanged(facade)
 
@@ -114,9 +115,9 @@ class LicenseTransitionListenerTest {
         state.premiumOnboardingShown = false
         val listener = LicenseTransitionListener()
 
-        every { LicenseChecker.isLicensed() } returns false
+        every { LicenseChecker.isLicensedOrGrace() } returns false
         listener.licenseStateChanged(facade)
-        every { LicenseChecker.isLicensed() } returns true
+        every { LicenseChecker.isLicensedOrGrace() } returns true
         listener.licenseStateChanged(facade)
 
         assertFalse(state.premiumOnboardingShown)
@@ -130,11 +131,11 @@ class LicenseTransitionListenerTest {
         state.premiumOnboardingShown = true
         val listener = LicenseTransitionListener()
 
-        every { LicenseChecker.isLicensed() } returns true
+        every { LicenseChecker.isLicensedOrGrace() } returns true
         listener.licenseStateChanged(facade)
         assertTrue(state.premiumOnboardingShown)
 
-        every { LicenseChecker.isLicensed() } returns false
+        every { LicenseChecker.isLicensedOrGrace() } returns false
         listener.licenseStateChanged(facade)
 
         assertTrue(state.premiumOnboardingShown)
@@ -166,15 +167,15 @@ class LicenseTransitionListenerTest {
             }
 
         LoggedErrorProcessor.executeWith<RuntimeException>(processor) {
-            every { LicenseChecker.isLicensed() } throws RuntimeException("platform glitch")
+            every { LicenseChecker.isLicensedOrGrace() } throws RuntimeException("platform glitch")
             listener.licenseStateChanged(facade)
             assertTrue(state.premiumOnboardingShown, "exception must not mutate the flag")
 
-            every { LicenseChecker.isLicensed() } returns false
+            every { LicenseChecker.isLicensedOrGrace() } returns false
             listener.licenseStateChanged(facade)
             assertTrue(state.premiumOnboardingShown, "first successful call records baseline only")
 
-            every { LicenseChecker.isLicensed() } returns true
+            every { LicenseChecker.isLicensedOrGrace() } returns true
             listener.licenseStateChanged(facade)
             assertFalse(state.premiumOnboardingShown, "transition must still fire after glitch recovery")
         }
@@ -189,35 +190,55 @@ class LicenseTransitionListenerTest {
     // user is unlicensed so chrome tinting falls back to the global accent. On
     // either transition direction (licensed↔unlicensed) the listener MUST
     // re-apply the accent so the chrome renderer picks up the fresh resolver
-    // output. The initial notification (previous == null) must not fire the
-    // re-apply — otherwise a routine startup notification spams a redundant
-    // repaint on every launch.
+    // output. Initial licensed notification stays quiet; initial unlicensed
+    // notification reconciles once because startup may have rendered while the
+    // licensing facade was still unavailable.
 
     @Test
     fun `initial notification does not re-apply accent`() {
         // First notification records the baseline only. An apply here would fire
         // on every IDE startup (Topic listeners receive a synthetic initial
         // notification) and trigger a redundant chrome repaint.
-        every { LicenseChecker.isLicensed() } returns true
+        every { LicenseChecker.isLicensedOrGrace() } returns true
         LicenseTransitionListener().licenseStateChanged(facade)
 
-        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any<dev.ayuislands.accent.AyuVariant>()) }
+        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any<AccentContext>()) }
+    }
+
+    @Test
+    fun `initial unlicensed notification reconciles optimistically applied external chrome`() {
+        state.externalThemeEnhancementsEnabled = true
+        state.externalThemeChromeTintEnabled = true
+        every { AyuVariant.detect() } returns null
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+        val openProject =
+            mockk<Project> {
+                every { isDisposed } returns false
+            }
+        val manager = mockk<CommitPanelAutoFitManager>(relaxed = true)
+        every { projectManager.openProjects } returns arrayOf(openProject)
+        every { CommitPanelAutoFitManager.getInstance(openProject) } returns manager
+
+        LicenseTransitionListener().licenseStateChanged(facade)
+
+        verify(exactly = 1) { AccentApplicator.applyForFocusedProject(AccentContext.External) }
+        verify(exactly = 1) { manager.apply() }
     }
 
     @Test
     fun `licensed to unlicensed transition re-applies accent for chrome refresh`() {
         val listener = LicenseTransitionListener()
         // Baseline call: licensed. No apply expected.
-        every { LicenseChecker.isLicensed() } returns true
+        every { LicenseChecker.isLicensedOrGrace() } returns true
         listener.licenseStateChanged(facade)
-        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any<dev.ayuislands.accent.AyuVariant>()) }
+        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any<AccentContext>()) }
 
         // Transition: licensed → unlicensed. Chrome must re-render using the
         // global accent because the resolver now short-circuits overrides.
-        every { LicenseChecker.isLicensed() } returns false
+        every { LicenseChecker.isLicensedOrGrace() } returns false
         listener.licenseStateChanged(facade)
 
-        verify(exactly = 1) { AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE) }
+        verify(exactly = 1) { AccentApplicator.applyForFocusedProject(AccentContext.Ayu(AyuVariant.MIRAGE)) }
     }
 
     @Test
@@ -235,10 +256,10 @@ class LicenseTransitionListenerTest {
         every { CommitPanelAutoFitManager.getInstance(openProject) } returns manager
         val listener = LicenseTransitionListener()
 
-        every { LicenseChecker.isLicensed() } returns true
+        every { LicenseChecker.isLicensedOrGrace() } returns true
         listener.licenseStateChanged(facade)
 
-        every { LicenseChecker.isLicensed() } returns false
+        every { LicenseChecker.isLicensedOrGrace() } returns false
         listener.licenseStateChanged(facade)
 
         verify(exactly = 1) { manager.apply() }
@@ -246,26 +267,48 @@ class LicenseTransitionListenerTest {
     }
 
     @Test
+    fun `commit panel cleanup failure does not block license-loss accent reapply`() {
+        val openProject =
+            mockk<Project> {
+                every { isDisposed } returns false
+            }
+        val manager = mockk<CommitPanelAutoFitManager>()
+        every { projectManager.openProjects } returns arrayOf(openProject)
+        every { CommitPanelAutoFitManager.getInstance(openProject) } returns manager
+        every { manager.apply() } throws RuntimeException("renderer cleanup failed")
+        val listener = LicenseTransitionListener()
+
+        every { LicenseChecker.isLicensedOrGrace() } returns true
+        listener.licenseStateChanged(facade)
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+        listener.licenseStateChanged(facade)
+
+        verify(exactly = 1) { manager.apply() }
+        verify(exactly = 1) { AccentApplicator.applyForFocusedProject(AccentContext.Ayu(AyuVariant.MIRAGE)) }
+    }
+
+    @Test
     fun `unlicensed to licensed transition re-applies accent AND rearms wizard`() {
         state.premiumOnboardingShown = true
         val listener = LicenseTransitionListener()
 
-        // Baseline call: unlicensed. No apply expected on initial notification.
-        every { LicenseChecker.isLicensed() } returns false
+        // Baseline call: unlicensed. One reconciliation closes the optimistic
+        // startup window before the actual unlicensed → licensed transition.
+        every { LicenseChecker.isLicensedOrGrace() } returns false
         listener.licenseStateChanged(facade)
-        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any<dev.ayuislands.accent.AyuVariant>()) }
+        verify(exactly = 1) { AccentApplicator.applyForFocusedProject(AccentContext.Ayu(AyuVariant.MIRAGE)) }
 
         // Transition: unlicensed → licensed. BOTH side effects fire:
         //   - wizard re-arm (premiumOnboardingShown flipped to false)
         //   - accent re-apply (overrides resolver now honors project/language rules)
-        every { LicenseChecker.isLicensed() } returns true
+        every { LicenseChecker.isLicensedOrGrace() } returns true
         listener.licenseStateChanged(facade)
 
         assertFalse(
             state.premiumOnboardingShown,
             "unlicensed→licensed transition must re-arm premium wizard for next startup",
         )
-        verify(exactly = 1) { AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE) }
+        verify(exactly = 2) { AccentApplicator.applyForFocusedProject(AccentContext.Ayu(AyuVariant.MIRAGE)) }
     }
 
     @Test
@@ -276,41 +319,62 @@ class LicenseTransitionListenerTest {
         // suppress this path.
         val listener = LicenseTransitionListener()
 
-        every { LicenseChecker.isLicensed() } returns true
+        every { LicenseChecker.isLicensedOrGrace() } returns true
         listener.licenseStateChanged(facade)
         listener.licenseStateChanged(facade)
 
-        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any<dev.ayuislands.accent.AyuVariant>()) }
+        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any<AccentContext>()) }
     }
 
     @Test
-    fun `unlicensed to unlicensed refresh does not re-apply accent`() {
-        // Mirror of the licensed→licensed noise guard: an unlicensed refresh
-        // (e.g. trial keeps pinging the facade) must not trigger a repaint.
+    fun `initial unlicensed reconcile is not repeated by unlicensed refresh`() {
+        // The first definitive unlicensed result closes the optimistic startup
+        // window; later identical heartbeats must not repaint again.
         val listener = LicenseTransitionListener()
 
-        every { LicenseChecker.isLicensed() } returns false
+        every { LicenseChecker.isLicensedOrGrace() } returns false
         listener.licenseStateChanged(facade)
         listener.licenseStateChanged(facade)
 
-        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any<dev.ayuislands.accent.AyuVariant>()) }
+        verify(exactly = 1) { AccentApplicator.applyForFocusedProject(AccentContext.Ayu(AyuVariant.MIRAGE)) }
     }
 
     @Test
-    fun `transition with null variant skips re-apply silently`() {
-        // AyuVariant.detect() returns null when the active theme is not an Ayu
-        // theme (the user is on a non-Ayu dark theme but still has a valid
-        // Ayu license). The invokeLater body must short-circuit silently — no
-        // crash, no apply call, no LOG.error spam.
+    fun `transition without an active accent context skips re-apply silently`() {
+        // No Ayu theme and no external-theme support means the transition has
+        // no accent surface to refresh.
         every { AyuVariant.detect() } returns null
 
         val listener = LicenseTransitionListener()
-        every { LicenseChecker.isLicensed() } returns true
+        every { LicenseChecker.isLicensedOrGrace() } returns true
         listener.licenseStateChanged(facade)
 
-        every { LicenseChecker.isLicensed() } returns false
+        every { LicenseChecker.isLicensedOrGrace() } returns false
         listener.licenseStateChanged(facade)
 
-        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any<dev.ayuislands.accent.AyuVariant>()) }
+        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any<AccentContext>()) }
+    }
+
+    @Test
+    fun `external entitlement loss and regain reapply without changing preference`() {
+        state.externalThemeEnhancementsEnabled = true
+        state.externalThemeChromeTintEnabled = true
+        every { AyuVariant.detect() } returns null
+        val listener = LicenseTransitionListener()
+
+        every { LicenseChecker.isLicensedOrGrace() } returns true
+        listener.licenseStateChanged(facade)
+
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+        listener.licenseStateChanged(facade)
+
+        verify(exactly = 1) { AccentApplicator.applyForFocusedProject(AccentContext.External) }
+        assertTrue(state.externalThemeChromeTintEnabled)
+
+        every { LicenseChecker.isLicensedOrGrace() } returns true
+        listener.licenseStateChanged(facade)
+
+        verify(exactly = 2) { AccentApplicator.applyForFocusedProject(AccentContext.External) }
+        assertTrue(state.externalThemeChromeTintEnabled)
     }
 }

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateTest.kt
@@ -375,8 +375,24 @@ class AyuIslandsStateTest {
         assertFalse(state.externalThemeGlowEnabled)
         assertTrue(state.externalThemeCodeGlanceProEnabled)
         assertTrue(state.externalThemeIndentRainbowEnabled)
+        assertFalse(state.externalThemeChromeTintEnabled)
         assertEquals(ExternalAccentSource.AUTOMATIC.name, state.externalThemeAccentSource)
         assertEquals("#FFCC66", state.externalThemeAccent)
+    }
+
+    @Test
+    fun `external chrome tint allowance requires both master flag and feature flag`() {
+        val state = freshState()
+        assertFalse(state.isExternalChromeTintAllowed(), "defaults are off")
+        state.externalThemeChromeTintEnabled = true
+        assertFalse(
+            state.isExternalChromeTintAllowed(),
+            "feature flag alone must not unlock chrome tint without the external master flag",
+        )
+        state.externalThemeEnhancementsEnabled = true
+        assertTrue(state.isExternalChromeTintAllowed())
+        state.externalThemeChromeTintEnabled = false
+        assertFalse(state.isExternalChromeTintAllowed(), "master flag alone must not unlock chrome tint")
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateVcsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateVcsTest.kt
@@ -22,9 +22,9 @@ class AyuIslandsStateVcsTest {
     fun `default state has VCS disabled and all three sections on Ambient`() {
         val state = freshState()
         assertFalse(state.vcsColorEnabled, "Master kill-switch defaults off (byte-identical to prior release)")
-        assertEquals(VcsColorPreset.AMBIENT, state.effectiveVcsDiffPreset())
-        assertEquals(VcsColorPreset.AMBIENT, state.effectiveVcsMergePreset())
-        assertEquals(VcsColorPreset.AMBIENT, state.effectiveVcsBlamePreset())
+        assertEquals(VcsColorPreset.AMBIENT, state.effectiveVcsPresetFor(VcsColorCategory.DIFF_VIEWER))
+        assertEquals(VcsColorPreset.AMBIENT, state.effectiveVcsPresetFor(VcsColorCategory.CONFLICT_MARKERS))
+        assertEquals(VcsColorPreset.AMBIENT, state.effectiveVcsPresetFor(VcsColorCategory.BLAME_GUTTER))
         // Master off => effective intensity is always 0, regardless of preset.
         for (category in VcsColorCategory.entries) {
             assertEquals(0, state.effectiveVcsIntensityFor(category).percent)
@@ -37,9 +37,9 @@ class AyuIslandsStateVcsTest {
         state.vcsDiffPreset = VcsColorPreset.NEON.name
         state.vcsMergePreset = VcsColorPreset.WHISPER.name
         state.vcsBlamePreset = VcsColorPreset.CYBERPUNK.name
-        assertEquals(VcsColorPreset.NEON, state.effectiveVcsDiffPreset())
-        assertEquals(VcsColorPreset.WHISPER, state.effectiveVcsMergePreset())
-        assertEquals(VcsColorPreset.CYBERPUNK, state.effectiveVcsBlamePreset())
+        assertEquals(VcsColorPreset.NEON, state.effectiveVcsPresetFor(VcsColorCategory.DIFF_VIEWER))
+        assertEquals(VcsColorPreset.WHISPER, state.effectiveVcsPresetFor(VcsColorCategory.CONFLICT_MARKERS))
+        assertEquals(VcsColorPreset.CYBERPUNK, state.effectiveVcsPresetFor(VcsColorCategory.BLAME_GUTTER))
     }
 
     @Test
@@ -51,9 +51,9 @@ class AyuIslandsStateVcsTest {
         state.vcsDiffPreset = "GARBAGE"
         state.vcsMergePreset = ""
         state.vcsBlamePreset = "UNKNOWN_PRESET_NAME"
-        assertEquals(VcsColorPreset.AMBIENT, state.effectiveVcsDiffPreset())
-        assertEquals(VcsColorPreset.AMBIENT, state.effectiveVcsMergePreset())
-        assertEquals(VcsColorPreset.AMBIENT, state.effectiveVcsBlamePreset())
+        assertEquals(VcsColorPreset.AMBIENT, state.effectiveVcsPresetFor(VcsColorCategory.DIFF_VIEWER))
+        assertEquals(VcsColorPreset.AMBIENT, state.effectiveVcsPresetFor(VcsColorCategory.CONFLICT_MARKERS))
+        assertEquals(VcsColorPreset.AMBIENT, state.effectiveVcsPresetFor(VcsColorCategory.BLAME_GUTTER))
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/settings/PluginsPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/PluginsPanelTest.kt
@@ -283,17 +283,44 @@ class PluginsPanelTest {
         val glowCheckbox = checkboxes.first { it.text == "Glow" }
         val codeGlanceProCheckbox = checkboxes.first { it.text == "CodeGlance Pro" }
         val indentRainbowCheckbox = checkboxes.first { it.text == "Indent Rainbow" }
+        val chromeTintCheckbox = checkboxes.first { it.text == "Chrome tint" }
 
         quickSwitcherCheckbox.doClick()
         glowCheckbox.doClick()
         codeGlanceProCheckbox.doClick()
         indentRainbowCheckbox.doClick()
+        chromeTintCheckbox.doClick()
         pluginsPanel.apply()
 
         assertFalse(state.externalThemeQuickSwitcherEnabled)
         assertTrue(state.externalThemeGlowEnabled)
         assertFalse(state.externalThemeCodeGlanceProEnabled)
         assertFalse(state.externalThemeIndentRainbowEnabled)
+        assertTrue(state.externalThemeChromeTintEnabled)
+        assertFalse(pluginsPanel.isModified())
+    }
+
+    @Test
+    fun `unlicensed external chrome tint checkbox is visible but locked`() {
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+        val pluginsPanel = PluginsPanel()
+        val dialogPanel = buildDialogPanel(pluginsPanel)
+        val chromeTintCheckbox =
+            descendants(dialogPanel, JCheckBox::class.java)
+                .first { it.text == "Chrome tint" }
+
+        assertFalse(
+            chromeTintCheckbox.isEnabled,
+            "Chrome tint on external themes is Pro — the checkbox must be locked for free users",
+        )
+
+        chromeTintCheckbox.doClick()
+        pluginsPanel.apply()
+
+        assertFalse(
+            state.externalThemeChromeTintEnabled,
+            "A locked checkbox must never persist the premium allowance",
+        )
         assertFalse(pluginsPanel.isModified())
     }
 
@@ -376,8 +403,11 @@ class PluginsPanelTest {
                 ActionManager::class.java,
                 ActionManagerEx::class.java,
                 -> actionManagerMock
+
                 SyntaxIntensityService::class.java -> syntaxIntensityService
+
                 experimentalUiClass -> experimentalUiMock
+
                 else -> mockkClass(serviceClass.kotlin, relaxed = true)
             }
         }


### PR DESCRIPTION
── Summary ─────────────────────────────────

External Theme Support (v2.7) left chrome tint behind: all 13 accent elements and the tab-underline geometry stayed hard-gated to native Ayu themes, so opted-in users on foreign themes got accent, glow, and plugin sync — but never tinted chrome. This is the top remaining ask from discussion #104 ("adapt it to other themes", "accent on the toolbar"). The PR completes the external surface with a new premium "Chrome tint" allowance: the apply plan now schedules elements and underline geometry for any non-null accent context, and the allowance is enforced inside the applicator workers with full revert symmetry — unchecking it cleans the foreign theme back to stock.

── Changes ─────────────────────────────────

| Type | Where | What |
|------|-------|------|
| Feat | `AccentApplyPlan.kt:58` | Plan gates relax from `context?.variant != null` to context shape; KDoc documents worker-level allowance checks |
| Feat | `AccentApplicator.kt:216` | Workers rebind to `checkNotNull(context)`; shared `isExternalTintBlocked` gate reverts elements / null-clears `EditorTabs.underlineHeight/Arc` when blocked; underline keys extracted to consts |
| Feat | `AyuIslandsState.kt:51` | `externalThemeChromeTintEnabled` flag + `isExternalChromeTintAllowed()` accessor, default off |
| Feat | `PluginsPanel.kt:283` | First licensed row in the External Theme Support "Allowed features" grid (`buildLicensedCheckbox`, `licensed` threaded from the existing `PremiumFeatureGate`) |
| Feat | `LicenseChecker.kt:255` | Free-tier revert clears the allowance — it has no separate feature master to ride, unlike glow/CGP/IR |
| Refactor | `AyuIslandsState.kt:426` | VCS preset trio folded into category-keyed `effectiveVcsPresetFor` (detekt `TooManyFunctions` cap; behavior unchanged) |
| Style | `VcsColorPanel.kt:330` | No-op `else -> { Unit }` when-branches become `else -> {}` (IDE unused-expression inspection) |
| Test | `AccentApplicatorTest.kt:948` | External scenarios: allowance off → revert + null-clear; on → tint + Int geometry; per-element toggle honored; reflective seams moved to `AccentContext` |
| Test | `ChromeTintBlenderTest.kt:82` | Foreign-base invariants (Darcula-like, Light-like, black, white) + opacify-translucent contract |
| Test | `AccentApplyPlanTest.kt:53`, `AyuIslandsStateTest.kt:371`, `PluginsPanelTest.kt:300`, `FreeTierLockdownTest.kt:159` | Plan-shape lock, defaults + allowance truth table, licensed/locked row, downgrade reset |
| Docs | `docs/features.yml`, `CHANGELOG.md`, `plugin.xml:119`, `gradle.properties:3` | `chrome-tint-external-themes` entry (keyword reuses existing "chrome tinting" copy), 2.8.0 [Paid] bullet, minor version bump per invariant 7 |

── Validation ──────────────────────────────

```bash
./gradlew test koverVerify detekt ktlintCheck   # BUILD SUCCESSFUL (full suite + 80% floor)
python3 scripts/verify-docs.py                  # docs/features.yml in sync
```

Manual: on Darcula, Settings → Ayu Islands → Plugins → External Theme Support → enable the master switch and "Chrome tint" → status bar / nav bar / tool-window stripes tint with the Ayu accent; uncheck → Apply → stock colors return with no stale tint; per-element switches on the Accent tab (configured while on an Ayu theme) are honored on the foreign theme.

── Notes ───────────────────────────────────

- Default OFF is load-bearing: VISUAL/INTERACTIVE per-element toggles default ON, so a default-true allowance would instantly tint scrollbars/caret row for every existing master-flag user on plugin update.
- `MainToolbarElement` keeps its platform probe — native-header setups (macOS on 2026.1+) stay a silent no-op, same as on Ayu themes today.
- VCS colors, syntax intensity, and appearance sync remain Ayu-only by design (gated on `AyuVariant`, untouched by this PR).
- `assets/feature-integrations.png` needs a re-capture with the new Chrome tint row before release — restamped for now (see 0cbb5ead).
- Same enforcement ceiling as the sibling allowances: the worker checks the allowance flag, not the license; locked UI + downgrade reset are the boundary, matching the existing chrome-toggle model.

## Summary by Sourcery

Enable chrome tinting for external themes as a premium, opt‑in feature and adjust licensing, state management, and accent application to respect this entitlement while keeping behavior reversible and safe by default.

New Features:
- Add a chrome tint allowance for external themes, including a dedicated setting, entitlement checks, and ownership tracking for chrome surfaces and tab underline geometry.
- Expose a paid 'Chrome tint' option in the External Theme Support UI, wired into existing premium licensing gates and persisted state.
- Support applying accent elements and tab underline geometry for any non-null accent context, including external themes.

Bug Fixes:
- Ensure license state transitions reapply accents based on the active accent context and handle failures in project enumeration or cleanup without blocking UI refresh.
- Prevent unlicensed or misconfigured external chrome tint from mutating host themes by guarding writes and rolling back on failures.

Enhancements:
- Refine free-tier reversion to preserve user element choices, chrome tint intensity, and tab mode preferences while relying on runtime entitlement to gate premium behavior.
- Centralize VCS color preset resolution into a single category-based accessor, simplifying the API while preserving behavior.
- Improve External Theme and chrome tint interaction by snapshotting chrome entitlement once per apply cycle and routing external chrome handling through a dedicated ownership manager.
- Extend accent application internals to operate on AccentContext rather than raw variants, enabling richer gating and external-theme awareness.

Build:
- Bump plugin version to 2.8.0 in build properties.

Documentation:
- Document chrome tinting on external themes as a paid feature, update feature metadata hashes, and record the addition in the changelog and plugin descriptor for version 2.8.0.

Tests:
- Add comprehensive tests for external chrome tint behavior, including entitlement gating, ownership and rollback semantics, underline geometry handling, and blender invariants on foreign theme bases.
- Expand tests around license transitions, free-tier lockdown, VCS state, and plugin settings to cover the new chrome tint option and updated entitlement model.
- Update accent application and tab underline tests to validate the new AccentContext-based flow and chrome-aware tab mode resolution.