### PR TITLE
feat(glow): add placement variants under tabs and side edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - [Paid] **Chrome tint on external themes** — selected chrome surfaces and the
   active tab underline can now follow the Ayu accent on non-Ayu themes when
   explicitly enabled; external chrome tint stays off by default.
+- [Paid] **Glow placement** — choose where glow renders: the full island, a
+  strip under the editor tabs, or tool-window side edges only.
 
 ## [2.7.8] - 2026-07-06
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -314,7 +314,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "aa35c9b2"
+          last_verified_sha: "14c864d2"
           last_verified_date: "2026-06-16"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -314,7 +314,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "42d23350"
+          last_verified_sha: "5cccc809"
           last_verified_date: "2026-06-16"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -327,6 +327,16 @@ categories:
           Glow can follow Ayu accents on non-Ayu themes when explicitly
           enabled; external Glow stays off by default.
 
+      - id: glow-placement
+        title: "Glow placement variants"
+        keyword: "Glow"
+        introduced: "2.8.0"
+        tier: paid
+        description: >
+          Choose where glow renders per surface: the full island frame, a
+          strip under the editor tabs, or tool-window side edges only.
+          Existing setups keep the full-island default.
+
   fonts:
     title: "Font presets"
     features:

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -314,7 +314,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "14c864d2"
+          last_verified_sha: "42d23350"
           last_verified_date: "2026-06-16"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 

--- a/proguard-rules.pro
+++ b/proguard-rules.pro
@@ -50,6 +50,7 @@
 -keep enum dev.ayuislands.glow.GlowAnimation { *; }
 -keep enum dev.ayuislands.glow.GlowTabMode { *; }
 -keep enum dev.ayuislands.glow.GlowPreset { *; }
+-keep enum dev.ayuislands.glow.GlowPlacement { *; }
 -keep enum dev.ayuislands.font.FontWeight { *; }
 -keep enum dev.ayuislands.font.FontPreset { *; }
 -keep enum dev.ayuislands.vcs.VcsColorPreset { *; }

--- a/src/main/kotlin/dev/ayuislands/glow/GlowGlassPane.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/GlowGlassPane.kt
@@ -7,6 +7,7 @@ import java.awt.Graphics
 import java.awt.Graphics2D
 import java.awt.Rectangle
 import java.awt.RenderingHints
+import java.awt.geom.Area
 import javax.swing.JPanel
 import javax.swing.Timer
 import javax.swing.UIManager
@@ -23,6 +24,7 @@ class GlowGlassPane(
     var glowIntensity: Int,
     var glowWidth: Int,
     var isEditorOverlay: Boolean = false,
+    var glowPlacement: GlowPlacement = GlowPlacement.ISLAND,
 ) : JPanel(null) {
     private val renderer = GlowRenderer()
     private var fadeAlpha: Float = 0.0f
@@ -73,6 +75,15 @@ class GlowGlassPane(
 
             val arcWidth = UIManager.getInt("Island.arc").let { if (it > 0) it else DEFAULT_ARC_FALLBACK }
             val bounds = Rectangle(0, 0, width, height)
+
+            val clipRegions = GlowPlacementGeometry.clipRegions(glowPlacement, width, height, glowWidth, arcWidth)
+            if (clipRegions.isNotEmpty()) {
+                val clipArea = Area()
+                for (region in clipRegions) {
+                    clipArea.add(Area(region))
+                }
+                g2.clip(clipArea)
+            }
 
             renderer.ensureCache(glowColor, glowStyle, glowIntensity, glowWidth)
             renderer.paintGlow(g2, bounds, glowWidth, arcWidth)

--- a/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
@@ -476,12 +476,13 @@ class GlowOverlayManager(
         accent: Color,
         style: GlowStyle,
     ) {
-        for ((id, entry) in overlays) {
+        for (entry in overlays.values) {
             entry.glassPane.glowColor = accent
             entry.glassPane.glowStyle = style
             entry.glassPane.glowIntensity = state.getIntensityForStyle(style)
             entry.glassPane.glowWidth = state.getWidthForStyle(style)
-            entry.glassPane.glowPlacement = resolveGlowPlacement(isEditorOverlay = id == EDITOR_ID, state = state)
+            entry.glassPane.glowPlacement =
+                resolveGlowPlacement(isEditorOverlay = entry.glassPane.isEditorOverlay, state = state)
             entry.glassPane.invalidateRendererCache()
             entry.glassPane.repaint()
         }

--- a/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
@@ -304,6 +304,7 @@ class GlowOverlayManager(
                 glowIntensity = state.getIntensityForStyle(style),
                 glowWidth = state.getWidthForStyle(style),
                 isEditorOverlay = isEditorOverlay,
+                glowPlacement = resolveGlowPlacement(isEditorOverlay, state),
             )
 
         layeredPane.setLayer(glassPane, JLayeredPane.PALETTE_LAYER)
@@ -475,11 +476,12 @@ class GlowOverlayManager(
         accent: Color,
         style: GlowStyle,
     ) {
-        for ((_, entry) in overlays) {
+        for ((id, entry) in overlays) {
             entry.glassPane.glowColor = accent
             entry.glassPane.glowStyle = style
             entry.glassPane.glowIntensity = state.getIntensityForStyle(style)
             entry.glassPane.glowWidth = state.getWidthForStyle(style)
+            entry.glassPane.glowPlacement = resolveGlowPlacement(isEditorOverlay = id == EDITOR_ID, state = state)
             entry.glassPane.invalidateRendererCache()
             entry.glassPane.repaint()
         }
@@ -549,3 +551,13 @@ private fun resolveCurrentGlowAccentHex(
     state: AyuIslandsState,
     context: AccentContext,
 ): String = state.trustedCachedAccent()?.value ?: AccentResolver.resolve(project, context)
+
+private fun resolveGlowPlacement(
+    isEditorOverlay: Boolean,
+    state: AyuIslandsState,
+): GlowPlacement =
+    if (isEditorOverlay) {
+        GlowPlacement.forEditor(state.glowEditorPlacement)
+    } else {
+        GlowPlacement.forToolWindow(state.glowToolWindowPlacement)
+    }

--- a/src/main/kotlin/dev/ayuislands/glow/GlowPlacement.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/GlowPlacement.kt
@@ -1,0 +1,27 @@
+package dev.ayuislands.glow
+
+/**
+ * Where a glow overlay renders: the full island frame or a partial strip
+ * clipped out of it. Editor surfaces support [ISLAND] and [TAB_BAR]; tool
+ * windows support [ISLAND] and [SIDE_EDGES] — the per-surface companion
+ * factories normalize persisted values that name the wrong surface's
+ * placement (hand-edited XML) back to [ISLAND].
+ */
+enum class GlowPlacement(
+    val displayName: String,
+) {
+    ISLAND("Island"),
+    TAB_BAR("Under tabs"),
+    SIDE_EDGES("Side edges"),
+    ;
+
+    companion object {
+        fun fromName(name: String?): GlowPlacement = entries.firstOrNull { it.name == name } ?: ISLAND
+
+        /** Editor placement: [SIDE_EDGES] has no editor meaning and normalizes to [ISLAND]. */
+        fun forEditor(name: String?): GlowPlacement = fromName(name).takeIf { it != SIDE_EDGES } ?: ISLAND
+
+        /** Tool-window placement: [TAB_BAR] has no tool-window meaning and normalizes to [ISLAND]. */
+        fun forToolWindow(name: String?): GlowPlacement = fromName(name).takeIf { it != TAB_BAR } ?: ISLAND
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/glow/GlowPlacementGeometry.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/GlowPlacementGeometry.kt
@@ -1,0 +1,54 @@
+package dev.ayuislands.glow
+
+import java.awt.Rectangle
+
+/**
+ * Pure clip-region math for [GlowPlacement] variants. The glass pane paints a
+ * cached full-perimeter glow frame; partial placements clip that frame to
+ * strips instead of re-rendering, so style, intensity, width, animation, and
+ * fade semantics carry over unchanged.
+ */
+object GlowPlacementGeometry {
+    /**
+     * Rectangles the paint pass clips to for [placement] over a
+     * `width x height` overlay. An empty list means paint unclipped —
+     * returned for [GlowPlacement.ISLAND] and for degenerate sizes, where
+     * nothing paints anyway.
+     *
+     * The strip extends past [glowWidth] by half of [arcWidth] so the island
+     * corner falloff is not chopped mid-curve; tune the reach in
+     * [stripThickness] only.
+     */
+    fun clipRegions(
+        placement: GlowPlacement,
+        width: Int,
+        height: Int,
+        glowWidth: Int,
+        arcWidth: Int,
+    ): List<Rectangle> {
+        if (width <= 0 || height <= 0) return emptyList()
+        return when (placement) {
+            GlowPlacement.ISLAND -> {
+                emptyList()
+            }
+
+            GlowPlacement.TAB_BAR -> {
+                val strip = stripThickness(glowWidth, arcWidth).coerceAtMost(height)
+                listOf(Rectangle(0, 0, width, strip))
+            }
+
+            GlowPlacement.SIDE_EDGES -> {
+                val strip = stripThickness(glowWidth, arcWidth).coerceAtMost(width)
+                listOf(
+                    Rectangle(0, 0, strip, height),
+                    Rectangle(width - strip, 0, strip, height),
+                )
+            }
+        }
+    }
+
+    private fun stripThickness(
+        glowWidth: Int,
+        arcWidth: Int,
+    ): Int = (glowWidth + arcWidth / 2).coerceAtLeast(1)
+}

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
@@ -101,8 +101,8 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
     private val islandCheckboxes = mutableMapOf<String, JCheckBox>()
     private var animationDescriptionLabel: javax.swing.JEditorPane? = null
     private var presetSegmentedButton: SegmentedButton<GlowPreset>? = null
-    private var editorPlacementSegmented: SegmentedButton<GlowPlacement>? = null
-    private var toolWindowPlacementSegmented: SegmentedButton<GlowPlacement>? = null
+    private var editorPlacement: SegmentedButton<GlowPlacement>? = null
+    private var toolWindowPlacement: SegmentedButton<GlowPlacement>? = null
     private var glowGroupPanel: GlowGroupPanel? = null
 
     // Suppress listener events during programmatic updates
@@ -229,6 +229,7 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
                     )
                     buildAnimationRows(this, gate)
                 }
+                buildPlacementGroup(this, gate)
                 buildTargetsGroup(this, gate, customModeVisible)
             }
 
@@ -381,23 +382,6 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
                         refreshIslandCheckboxes()
                     }.enabled(licensed && section.pending.enabled)
                 }
-                editorPlacementSegmented =
-                    buildPlacementRow(
-                        labelText = "Editor placement",
-                        items = listOf(GlowPlacement.ISLAND, GlowPlacement.TAB_BAR),
-                        licensed = licensed,
-                    ) { placement -> section.update { it.copy(editorPlacement = placement) } }
-                editorPlacementSegmented?.selectedItem = section.pending.editorPlacement
-                toolWindowPlacementSegmented =
-                    buildPlacementRow(
-                        labelText = "Tool window placement",
-                        items = listOf(GlowPlacement.ISLAND, GlowPlacement.SIDE_EDGES),
-                        licensed = licensed,
-                    ) { placement -> section.update { it.copy(toolWindowPlacement = placement) } }
-                toolWindowPlacementSegmented?.selectedItem = section.pending.toolWindowPlacement
-                row {
-                    comment("Island glows the full frame; Under tabs and Side edges glow only that strip.")
-                }
                 // Headers row
                 threeColumnsRow(
                     { label("Workspace").bold() },
@@ -425,9 +409,36 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
             }.visibleIfUnlockedOrPreview(customVisible, gate)
     }
 
+    private fun buildPlacementGroup(
+        panel: Panel,
+        gate: PremiumFeatureGate,
+    ) {
+        val licensed = gate.isUnlocked
+        panel.group("Placement") {
+            editorPlacement =
+                buildPlacementRow(
+                    labelText = "Editor placement",
+                    items = listOf(GlowPlacement.ISLAND, GlowPlacement.TAB_BAR),
+                    selected = section.pending.editorPlacement,
+                    licensed = licensed,
+                ) { placement -> section.update { it.copy(editorPlacement = placement) } }
+            toolWindowPlacement =
+                buildPlacementRow(
+                    labelText = "Tool window placement",
+                    items = listOf(GlowPlacement.ISLAND, GlowPlacement.SIDE_EDGES),
+                    selected = section.pending.toolWindowPlacement,
+                    licensed = licensed,
+                ) { placement -> section.update { it.copy(toolWindowPlacement = placement) } }
+            row {
+                comment("Island glows the full frame; Under tabs and Side edges glow only that strip.")
+            }
+        }
+    }
+
     private fun Panel.buildPlacementRow(
         labelText: String,
         items: List<GlowPlacement>,
+        selected: GlowPlacement,
         licensed: Boolean,
         onSelected: (GlowPlacement) -> Unit,
     ): SegmentedButton<GlowPlacement> {
@@ -439,6 +450,7 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
                     text = placement.displayName
                 }
             segmented.maxButtonsCount(items.size)
+            segmented.selectedItem = selected
             segmented.enabled(licensed && section.pending.enabled)
             @Suppress("UnstableApiUsage")
             segmented.whenItemSelected { placement ->
@@ -557,8 +569,8 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
         styleCombo?.isEnabled = enabled
         animationCombo?.isEnabled = enabled
         presetSegmentedButton?.enabled(enabled)
-        editorPlacementSegmented?.enabled(enabled)
-        toolWindowPlacementSegmented?.enabled(enabled)
+        editorPlacement?.enabled(enabled)
+        toolWindowPlacement?.enabled(enabled)
 
         for ((_, cb) in islandCheckboxes) {
             cb.isEnabled = enabled
@@ -568,8 +580,8 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
     private fun refreshAllControls() {
         suppressListeners = true
         presetSegmentedButton?.selectedItem = section.pending.preset
-        editorPlacementSegmented?.selectedItem = section.pending.editorPlacement
-        toolWindowPlacementSegmented?.selectedItem = section.pending.toolWindowPlacement
+        editorPlacement?.selectedItem = section.pending.editorPlacement
+        toolWindowPlacement?.selectedItem = section.pending.toolWindowPlacement
         customModeVisible.set(section.pending.preset == GlowPreset.CUSTOM)
         styleCombo?.selectedItem = section.pending.style.displayName
         animationCombo?.selectedItem = section.pending.animation.displayName

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
@@ -8,6 +8,7 @@ import com.intellij.ui.dsl.builder.Row
 import com.intellij.ui.dsl.builder.SegmentedButton
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.glow.GlowAnimation
+import dev.ayuislands.glow.GlowPlacement
 import dev.ayuislands.glow.GlowPreset
 import dev.ayuislands.glow.GlowStyle
 import dev.ayuislands.licensing.LicenseChecker
@@ -48,6 +49,8 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
         val width: Map<GlowStyle, Int> = emptyMap(),
         val animation: GlowAnimation = GlowAnimation.NONE,
         val islandToggles: Map<String, Boolean> = emptyMap(),
+        val editorPlacement: GlowPlacement = GlowPlacement.ISLAND,
+        val toolWindowPlacement: GlowPlacement = GlowPlacement.ISLAND,
     ) {
         /**
          * Folds [preset]'s canonical style/intensity/width/animation into the
@@ -79,6 +82,8 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
                 width = GlowStyle.entries.associateWith { state.getWidthForStyle(it) },
                 animation = GlowAnimation.fromName(state.glowAnimation ?: GlowAnimation.NONE.name),
                 islandToggles = ISLAND_IDS.associateWith { state.isIslandEnabled(it) },
+                editorPlacement = GlowPlacement.forEditor(state.glowEditorPlacement),
+                toolWindowPlacement = GlowPlacement.forToolWindow(state.glowToolWindowPlacement),
             )
         }
 
@@ -96,6 +101,8 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
     private val islandCheckboxes = mutableMapOf<String, JCheckBox>()
     private var animationDescriptionLabel: javax.swing.JEditorPane? = null
     private var presetSegmentedButton: SegmentedButton<GlowPreset>? = null
+    private var editorPlacementSegmented: SegmentedButton<GlowPlacement>? = null
+    private var toolWindowPlacementSegmented: SegmentedButton<GlowPlacement>? = null
     private var glowGroupPanel: GlowGroupPanel? = null
 
     // Suppress listener events during programmatic updates
@@ -374,6 +381,23 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
                         refreshIslandCheckboxes()
                     }.enabled(licensed && section.pending.enabled)
                 }
+                editorPlacementSegmented =
+                    buildPlacementRow(
+                        labelText = "Editor placement",
+                        items = listOf(GlowPlacement.ISLAND, GlowPlacement.TAB_BAR),
+                        licensed = licensed,
+                    ) { placement -> section.update { it.copy(editorPlacement = placement) } }
+                editorPlacementSegmented?.selectedItem = section.pending.editorPlacement
+                toolWindowPlacementSegmented =
+                    buildPlacementRow(
+                        labelText = "Tool window placement",
+                        items = listOf(GlowPlacement.ISLAND, GlowPlacement.SIDE_EDGES),
+                        licensed = licensed,
+                    ) { placement -> section.update { it.copy(toolWindowPlacement = placement) } }
+                toolWindowPlacementSegmented?.selectedItem = section.pending.toolWindowPlacement
+                row {
+                    comment("Island glows the full frame; Under tabs and Side edges glow only that strip.")
+                }
                 // Headers row
                 threeColumnsRow(
                     { label("Workspace").bold() },
@@ -399,6 +423,31 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
                     { },
                 )
             }.visibleIfUnlockedOrPreview(customVisible, gate)
+    }
+
+    private fun Panel.buildPlacementRow(
+        labelText: String,
+        items: List<GlowPlacement>,
+        licensed: Boolean,
+        onSelected: (GlowPlacement) -> Unit,
+    ): SegmentedButton<GlowPlacement> {
+        lateinit var segmented: SegmentedButton<GlowPlacement>
+        row {
+            label(labelText)
+            segmented =
+                segmentedButton(items) { placement ->
+                    text = placement.displayName
+                }
+            segmented.maxButtonsCount(items.size)
+            segmented.enabled(licensed && section.pending.enabled)
+            @Suppress("UnstableApiUsage")
+            segmented.whenItemSelected { placement ->
+                if (!suppressListeners && LicenseChecker.isLicensedOrGrace()) {
+                    onSelected(placement)
+                }
+            }
+        }
+        return segmented
     }
 
     private fun Row.islandCheckbox(
@@ -508,6 +557,8 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
         styleCombo?.isEnabled = enabled
         animationCombo?.isEnabled = enabled
         presetSegmentedButton?.enabled(enabled)
+        editorPlacementSegmented?.enabled(enabled)
+        toolWindowPlacementSegmented?.enabled(enabled)
 
         for ((_, cb) in islandCheckboxes) {
             cb.isEnabled = enabled
@@ -517,6 +568,8 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
     private fun refreshAllControls() {
         suppressListeners = true
         presetSegmentedButton?.selectedItem = section.pending.preset
+        editorPlacementSegmented?.selectedItem = section.pending.editorPlacement
+        toolWindowPlacementSegmented?.selectedItem = section.pending.toolWindowPlacement
         customModeVisible.set(section.pending.preset == GlowPreset.CUSTOM)
         styleCombo?.selectedItem = section.pending.style.displayName
         animationCombo?.selectedItem = section.pending.animation.displayName
@@ -557,6 +610,9 @@ class AyuIslandsEffectsPanel : AyuIslandsSettingsPanel {
             for (id in ISLAND_IDS) {
                 state.setIslandEnabled(id, pending.islandToggles[id] ?: false)
             }
+
+            state.glowEditorPlacement = pending.editorPlacement.name
+            state.glowToolWindowPlacement = pending.toolWindowPlacement.name
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsState.kt
@@ -8,6 +8,7 @@ import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.ExternalAccentSource
 import dev.ayuislands.accent.TintIntensity
 import dev.ayuislands.glow.GlowAnimation
+import dev.ayuislands.glow.GlowPlacement
 import dev.ayuislands.glow.GlowPreset
 import dev.ayuislands.glow.GlowStyle
 import dev.ayuislands.indent.IndentPreset
@@ -149,6 +150,11 @@ class AyuIslandsState : BaseState() {
 
     // Focused input focus-ring glow (subtle, less intense than an island glow)
     var glowFocusRing by property(true)
+
+    // Glow placement per surface family; normalized through
+    // GlowPlacement.forEditor / forToolWindow at read sites.
+    var glowEditorPlacement by string(GlowPlacement.ISLAND.name)
+    var glowToolWindowPlacement by string(GlowPlacement.ISLAND.name)
 
     // CodeGlancePro integration (opt-in, default OFF)
     var cgpIntegrationEnabled by property(false)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -120,6 +120,7 @@
     <h3>2.8.0</h3>
     <ul>
       <li>[Paid] <b>Chrome tint on external themes</b> — selected chrome surfaces and the active tab underline can now follow the Ayu accent on non-Ayu themes when explicitly enabled; external chrome tint stays off by default.</li>
+      <li>[Paid] <b>Glow placement</b> — choose where glow renders: the full island, a strip under the editor tabs, or tool-window side edges only.</li>
     </ul>
     <h3>2.7.8</h3>
     <ul>

--- a/src/test/kotlin/dev/ayuislands/glow/GlowEnumsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/GlowEnumsTest.kt
@@ -94,5 +94,45 @@ class GlowEnumsTest {
         assertEquals(3, GlowStyle.entries.size)
         assertEquals(3, GlowTabMode.entries.size)
         assertEquals(4, GlowAnimation.entries.size)
+        assertEquals(3, GlowPlacement.entries.size)
+    }
+
+    // GlowPlacement
+
+    @Test
+    fun `GlowPlacement fromName returns correct entry for valid names`() {
+        assertEquals(GlowPlacement.ISLAND, GlowPlacement.fromName("ISLAND"))
+        assertEquals(GlowPlacement.TAB_BAR, GlowPlacement.fromName("TAB_BAR"))
+        assertEquals(GlowPlacement.SIDE_EDGES, GlowPlacement.fromName("SIDE_EDGES"))
+    }
+
+    @Test
+    fun `GlowPlacement fromName falls back to ISLAND for invalid name`() {
+        assertEquals(GlowPlacement.ISLAND, GlowPlacement.fromName("NONEXISTENT"))
+        assertEquals(GlowPlacement.ISLAND, GlowPlacement.fromName(""))
+        assertEquals(GlowPlacement.ISLAND, GlowPlacement.fromName(null))
+    }
+
+    @Test
+    fun `GlowPlacement forEditor normalizes the tool-window-only placement to ISLAND`() {
+        assertEquals(GlowPlacement.TAB_BAR, GlowPlacement.forEditor("TAB_BAR"))
+        assertEquals(GlowPlacement.ISLAND, GlowPlacement.forEditor("ISLAND"))
+        assertEquals(GlowPlacement.ISLAND, GlowPlacement.forEditor("SIDE_EDGES"))
+        assertEquals(GlowPlacement.ISLAND, GlowPlacement.forEditor("GARBAGE"))
+    }
+
+    @Test
+    fun `GlowPlacement forToolWindow normalizes the editor-only placement to ISLAND`() {
+        assertEquals(GlowPlacement.SIDE_EDGES, GlowPlacement.forToolWindow("SIDE_EDGES"))
+        assertEquals(GlowPlacement.ISLAND, GlowPlacement.forToolWindow("ISLAND"))
+        assertEquals(GlowPlacement.ISLAND, GlowPlacement.forToolWindow("TAB_BAR"))
+        assertEquals(GlowPlacement.ISLAND, GlowPlacement.forToolWindow(null))
+    }
+
+    @Test
+    fun `GlowPlacement entries have correct display names`() {
+        assertEquals("Island", GlowPlacement.ISLAND.displayName)
+        assertEquals("Under tabs", GlowPlacement.TAB_BAR.displayName)
+        assertEquals("Side edges", GlowPlacement.SIDE_EDGES.displayName)
     }
 }

--- a/src/test/kotlin/dev/ayuislands/glow/GlowOverlayManagerLifecycleTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/GlowOverlayManagerLifecycleTest.kt
@@ -209,6 +209,42 @@ class GlowOverlayManagerLifecycleTest {
     }
 
     @Test
+    fun `updateGlow pushes per-surface placement onto live overlays`() {
+        // Changing placement in Settings must restyle live overlays through the
+        // normal updateGlow path: the editor overlay picks the editor placement,
+        // every other overlay picks the tool-window placement.
+        every { AyuVariant.isAyuActive() } returns true
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        state.glowEditorPlacement = GlowPlacement.TAB_BAR.name
+        state.glowToolWindowPlacement = GlowPlacement.SIDE_EDGES.name
+
+        val project = stubProject("placement-project")
+        val manager = GlowOverlayManager(project)
+        val editorPane = mockk<GlowGlassPane>(relaxed = true)
+        val toolWindowPane = mockk<GlowGlassPane>(relaxed = true)
+        seedOverlaysMapWithMocks(
+            manager,
+            editorPane,
+            host = mockk(relaxed = true),
+            layeredPane = mockk(relaxed = true),
+            key = "Editor",
+        )
+        seedOverlaysMapWithMocks(
+            manager,
+            toolWindowPane,
+            host = mockk(relaxed = true),
+            layeredPane = mockk(relaxed = true),
+        )
+
+        manager.updateGlow()
+
+        verify(exactly = 1) { editorPane.glowPlacement = GlowPlacement.TAB_BAR }
+        verify(exactly = 1) { toolWindowPane.glowPlacement = GlowPlacement.SIDE_EDGES }
+        verify(exactly = 0) { editorPane.glowPlacement = GlowPlacement.SIDE_EDGES }
+        verify(exactly = 0) { toolWindowPane.glowPlacement = GlowPlacement.TAB_BAR }
+    }
+
+    @Test
     fun `updateGlow paints clean last applied accent instead of project resolver`() {
         // Glow follows the app-global chrome color that was actually painted.
         // A background project may resolve to a different override, but its
@@ -599,14 +635,16 @@ class GlowOverlayManagerLifecycleTest {
      * passed in. The non-disposal-path `updateOverlayStyles` iteration just
      * assigns properties on the glassPane mock, which relaxed-mock no-ops.
      *
-     * Always seeds under the [DISPOSAL_TARGET_KEY] sentinel — the only
-     * caller is the disposal-path test, which doesn't need to vary the key.
+     * Seeds under [DISPOSAL_TARGET_KEY] by default (the disposal-path tests
+     * don't vary the key); the placement-push test overrides [key] with the
+     * editor overlay id to hit the editor branch of the placement resolver.
      */
     private fun seedOverlaysMapWithMocks(
         manager: GlowOverlayManager,
         glassPane: GlowGlassPane,
         host: javax.swing.JComponent,
         layeredPane: javax.swing.JLayeredPane,
+        key: String = DISPOSAL_TARGET_KEY,
     ) {
         val field = GlowOverlayManager::class.java.getDeclaredField("overlays")
         field.isAccessible = true
@@ -620,7 +658,7 @@ class GlowOverlayManagerLifecycleTest {
                 Any::class.java,
                 Any::class.java,
             )
-        putMethod.invoke(map, DISPOSAL_TARGET_KEY, makeOverlayEntryWith(glassPane, host, layeredPane))
+        putMethod.invoke(map, key, makeOverlayEntryWith(glassPane, host, layeredPane))
     }
 
     private fun makeOverlayEntryWith(

--- a/src/test/kotlin/dev/ayuislands/glow/GlowOverlayManagerLifecycleTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/GlowOverlayManagerLifecycleTest.kt
@@ -222,6 +222,8 @@ class GlowOverlayManagerLifecycleTest {
         val manager = GlowOverlayManager(project)
         val editorPane = mockk<GlowGlassPane>(relaxed = true)
         val toolWindowPane = mockk<GlowGlassPane>(relaxed = true)
+        every { editorPane.isEditorOverlay } returns true
+        every { toolWindowPane.isEditorOverlay } returns false
         seedOverlaysMapWithMocks(
             manager,
             editorPane,
@@ -636,8 +638,8 @@ class GlowOverlayManagerLifecycleTest {
      * assigns properties on the glassPane mock, which relaxed-mock no-ops.
      *
      * Seeds under [DISPOSAL_TARGET_KEY] by default (the disposal-path tests
-     * don't vary the key); the placement-push test overrides [key] with the
-     * editor overlay id to hit the editor branch of the placement resolver.
+     * don't vary the key); the placement-push test varies [key] only to seed
+     * two entries, while each pane's `isEditorOverlay` flag selects placement.
      */
     private fun seedOverlaysMapWithMocks(
         manager: GlowOverlayManager,

--- a/src/test/kotlin/dev/ayuislands/glow/GlowPlacementGeometryTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/GlowPlacementGeometryTest.kt
@@ -1,0 +1,78 @@
+package dev.ayuislands.glow
+
+import java.awt.Rectangle
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Pure-math locks for [GlowPlacementGeometry.clipRegions] — the strips the
+ * glass pane clips the cached glow frame to. The user-visible contract:
+ * ISLAND paints the full frame, TAB_BAR only a band under the editor tab
+ * strip, SIDE_EDGES only the left/right tool-window edges.
+ */
+class GlowPlacementGeometryTest {
+    @Test
+    fun `island placement paints unclipped`() {
+        assertEquals(
+            emptyList(),
+            GlowPlacementGeometry.clipRegions(GlowPlacement.ISLAND, 800, 600, 10, 8),
+        )
+    }
+
+    @Test
+    fun `tab bar placement clips to a single top strip spanning the full width`() {
+        val regions = GlowPlacementGeometry.clipRegions(GlowPlacement.TAB_BAR, 800, 600, 10, 8)
+
+        assertEquals(listOf(Rectangle(0, 0, 800, 14)), regions, "strip = glowWidth + arc/2 = 10 + 4")
+    }
+
+    @Test
+    fun `side edges placement clips to left and right strips spanning the full height`() {
+        val regions = GlowPlacementGeometry.clipRegions(GlowPlacement.SIDE_EDGES, 800, 600, 10, 8)
+
+        assertEquals(
+            listOf(
+                Rectangle(0, 0, 14, 600),
+                Rectangle(786, 0, 14, 600),
+            ),
+            regions,
+            "left strip flush to x=0, right strip flush to width - strip",
+        )
+    }
+
+    @Test
+    fun `strips never exceed the overlay bounds`() {
+        val tabBar = GlowPlacementGeometry.clipRegions(GlowPlacement.TAB_BAR, 800, 6, 10, 8)
+        assertEquals(listOf(Rectangle(0, 0, 800, 6)), tabBar, "tab strip clamps to a short overlay")
+
+        val edges = GlowPlacementGeometry.clipRegions(GlowPlacement.SIDE_EDGES, 10, 600, 10, 8)
+        assertTrue(
+            edges.all { it.x >= 0 && it.x + it.width <= 10 },
+            "edge strips clamp to a narrow overlay: $edges",
+        )
+    }
+
+    @Test
+    fun `degenerate sizes return no clip regions for every placement`() {
+        for (placement in GlowPlacement.entries) {
+            assertEquals(
+                emptyList(),
+                GlowPlacementGeometry.clipRegions(placement, 0, 600, 10, 8),
+                "zero width must not produce clip regions for $placement",
+            )
+            assertEquals(
+                emptyList(),
+                GlowPlacementGeometry.clipRegions(placement, 800, -1, 10, 8),
+                "negative height must not produce clip regions for $placement",
+            )
+        }
+    }
+
+    @Test
+    fun `strip thickness never collapses below one pixel`() {
+        val regions = GlowPlacementGeometry.clipRegions(GlowPlacement.TAB_BAR, 800, 600, 0, 0)
+
+        assertEquals(listOf(Rectangle(0, 0, 800, 1)), regions)
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanelTest.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.ui.dsl.builder.SegmentedButton
+import com.intellij.ui.dsl.builder.components.SegmentedButtonComponent
 import dev.ayuislands.glow.GlowPlacement
 import dev.ayuislands.glow.GlowPreset
 import dev.ayuislands.licensing.LicenseChecker
@@ -136,18 +137,63 @@ class AyuIslandsEffectsPanelTest {
     }
 
     @Test
+    fun `licensed default preset keeps placement visible while targets stay hidden`() {
+        val effectsPanel = AyuIslandsEffectsPanel()
+        val dialogPanel = buildDialogPanel(effectsPanel)
+        val labels = descendants(dialogPanel, JLabel::class.java)
+
+        assertTrue(
+            labels.first { it.text == "Editor placement" }.isEffectivelyVisibleWithin(dialogPanel),
+            "Editor placement must remain reachable outside the Custom preset",
+        )
+        assertTrue(
+            labels.first { it.text == "Tool window placement" }.isEffectivelyVisibleWithin(dialogPanel),
+            "Tool window placement must remain reachable outside the Custom preset",
+        )
+        assertFalse(
+            labels.first { it.text == "Targets" }.isEffectivelyVisibleWithin(dialogPanel),
+            "Licensed default presets must keep fine-grained Targets hidden until Custom is selected",
+        )
+    }
+
+    @Test
+    fun `licensed disabled glow keeps placement visible but locked`() {
+        state.glowEnabled = false
+        val effectsPanel = AyuIslandsEffectsPanel()
+        val dialogPanel = buildDialogPanel(effectsPanel)
+        val placementLabel = descendants(dialogPanel, JLabel::class.java).first { it.text == "Editor placement" }
+        val placementControl =
+            descendants(dialogPanel, SegmentedButtonComponent::class.java)
+                .first { GlowPlacement.TAB_BAR in it.items }
+
+        assertTrue(
+            placementLabel.isEffectivelyVisibleWithin(dialogPanel),
+            "disabled Glow must keep placement visible",
+        )
+        assertFalse(
+            placementControl.isEnabled,
+            "disabled Glow must lock placement options",
+        )
+    }
+
+    @Test
     fun `licensed placement selection persists through apply into state`() {
         val effectsPanel = AyuIslandsEffectsPanel()
         buildDialogPanel(effectsPanel)
 
-        placementSegmented(effectsPanel, "editorPlacementSegmented").selectedItem = GlowPlacement.TAB_BAR
-        placementSegmented(effectsPanel, "toolWindowPlacementSegmented").selectedItem = GlowPlacement.SIDE_EDGES
+        placementSegmented(effectsPanel, "editorPlacement").selectedItem = GlowPlacement.TAB_BAR
+        placementSegmented(effectsPanel, "toolWindowPlacement").selectedItem = GlowPlacement.SIDE_EDGES
 
         assertTrue(effectsPanel.isModified(), "placement change must dirty the panel")
         effectsPanel.apply()
 
         assertEquals(GlowPlacement.TAB_BAR.name, state.glowEditorPlacement)
         assertEquals(GlowPlacement.SIDE_EDGES.name, state.glowToolWindowPlacement)
+        assertEquals(
+            GlowPreset.WHISPER.name,
+            state.glowPreset,
+            "placement is independent from the selected visual preset",
+        )
         assertFalse(effectsPanel.isModified(), "apply must converge stored onto pending")
     }
 
@@ -155,9 +201,15 @@ class AyuIslandsEffectsPanelTest {
     fun `unlicensed glow placement preview cannot mutate pending state`() {
         every { LicenseChecker.isLicensedOrGrace() } returns false
         val effectsPanel = AyuIslandsEffectsPanel()
-        buildDialogPanel(effectsPanel)
+        val dialogPanel = buildDialogPanel(effectsPanel)
+        val placementLabel = descendants(dialogPanel, JLabel::class.java).first { it.text == "Editor placement" }
 
-        placementSegmented(effectsPanel, "editorPlacementSegmented").selectedItem = GlowPlacement.TAB_BAR
+        assertTrue(
+            placementLabel.isEffectivelyVisibleWithin(dialogPanel),
+            "locked placement preview must remain visible outside the Custom preset",
+        )
+
+        placementSegmented(effectsPanel, "editorPlacement").selectedItem = GlowPlacement.TAB_BAR
 
         assertFalse(
             effectsPanel.isModified(),
@@ -170,7 +222,7 @@ class AyuIslandsEffectsPanelTest {
         val effectsPanel = AyuIslandsEffectsPanel()
         buildDialogPanel(effectsPanel)
 
-        placementSegmented(effectsPanel, "editorPlacementSegmented").selectedItem = GlowPlacement.TAB_BAR
+        placementSegmented(effectsPanel, "editorPlacement").selectedItem = GlowPlacement.TAB_BAR
         assertTrue(effectsPanel.isModified(), "precondition: selection dirtied the panel")
 
         effectsPanel.reset()
@@ -178,7 +230,7 @@ class AyuIslandsEffectsPanelTest {
         assertFalse(effectsPanel.isModified(), "reset must drop the pending placement change")
         assertEquals(
             GlowPlacement.ISLAND,
-            placementSegmented(effectsPanel, "editorPlacementSegmented").selectedItem,
+            placementSegmented(effectsPanel, "editorPlacement").selectedItem,
             "reset must restore the stored placement selection",
         )
     }

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanelTest.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.ui.dsl.builder.SegmentedButton
+import dev.ayuislands.glow.GlowPlacement
 import dev.ayuislands.glow.GlowPreset
 import dev.ayuislands.licensing.LicenseChecker
 import io.mockk.every
@@ -22,6 +23,7 @@ import javax.swing.JSlider
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -133,6 +135,54 @@ class AyuIslandsEffectsPanelTest {
         )
     }
 
+    @Test
+    fun `licensed placement selection persists through apply into state`() {
+        val effectsPanel = AyuIslandsEffectsPanel()
+        buildDialogPanel(effectsPanel)
+
+        placementSegmented(effectsPanel, "editorPlacementSegmented").selectedItem = GlowPlacement.TAB_BAR
+        placementSegmented(effectsPanel, "toolWindowPlacementSegmented").selectedItem = GlowPlacement.SIDE_EDGES
+
+        assertTrue(effectsPanel.isModified(), "placement change must dirty the panel")
+        effectsPanel.apply()
+
+        assertEquals(GlowPlacement.TAB_BAR.name, state.glowEditorPlacement)
+        assertEquals(GlowPlacement.SIDE_EDGES.name, state.glowToolWindowPlacement)
+        assertFalse(effectsPanel.isModified(), "apply must converge stored onto pending")
+    }
+
+    @Test
+    fun `unlicensed glow placement preview cannot mutate pending state`() {
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+        val effectsPanel = AyuIslandsEffectsPanel()
+        buildDialogPanel(effectsPanel)
+
+        placementSegmented(effectsPanel, "editorPlacementSegmented").selectedItem = GlowPlacement.TAB_BAR
+
+        assertFalse(
+            effectsPanel.isModified(),
+            "locked placement preview must ignore selection changes instead of dirtying Settings",
+        )
+    }
+
+    @Test
+    fun `reset restores placement selection from stored state`() {
+        val effectsPanel = AyuIslandsEffectsPanel()
+        buildDialogPanel(effectsPanel)
+
+        placementSegmented(effectsPanel, "editorPlacementSegmented").selectedItem = GlowPlacement.TAB_BAR
+        assertTrue(effectsPanel.isModified(), "precondition: selection dirtied the panel")
+
+        effectsPanel.reset()
+
+        assertFalse(effectsPanel.isModified(), "reset must drop the pending placement change")
+        assertEquals(
+            GlowPlacement.ISLAND,
+            placementSegmented(effectsPanel, "editorPlacementSegmented").selectedItem,
+            "reset must restore the stored placement selection",
+        )
+    }
+
     private fun buildDialogPanel(panel: AyuIslandsEffectsPanel) =
         com.intellij.ui.dsl.builder
             .panel {
@@ -145,6 +195,17 @@ class AyuIslandsEffectsPanelTest {
         field.isAccessible = true
         return field.get(panel) as? SegmentedButton<GlowPreset>
             ?: error("Glow preset segmented button must be created")
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun placementSegmented(
+        panel: AyuIslandsEffectsPanel,
+        fieldName: String,
+    ): SegmentedButton<GlowPlacement> {
+        val field = AyuIslandsEffectsPanel::class.java.getDeclaredField(fieldName)
+        field.isAccessible = true
+        return field.get(panel) as? SegmentedButton<GlowPlacement>
+            ?: error("Glow placement segmented button '$fieldName' must be created")
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateTest.kt
@@ -4,6 +4,7 @@ import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.AccentGroup
 import dev.ayuislands.accent.ExternalAccentSource
 import dev.ayuislands.glow.GlowAnimation
+import dev.ayuislands.glow.GlowPlacement
 import dev.ayuislands.glow.GlowPreset
 import dev.ayuislands.glow.GlowStyle
 import kotlin.test.Test
@@ -418,6 +419,13 @@ class AyuIslandsStateTest {
     fun `glow preset defaults to WHISPER`() {
         val state = freshState()
         assertEquals(GlowPreset.WHISPER.name, state.glowPreset)
+    }
+
+    @Test
+    fun `glow placement defaults to full island for both surfaces`() {
+        val state = freshState()
+        assertEquals(GlowPlacement.ISLAND.name, state.glowEditorPlacement)
+        assertEquals(GlowPlacement.ISLAND.name, state.glowToolWindowPlacement)
     }
 
     @Test


### PR DESCRIPTION
## Why

Full-island glow is not the right fit for every workspace. Discussion #104 asked for focused alternatives under editor tabs and along tool-window edges without changing the selected glow preset or the defaults of existing users.

## What changed

- Add per-surface placement: `Island` or `Under tabs` for editors, and `Island` or `Side edges` for tool windows.
- Keep `Island` as the persisted default and normalize invalid cross-surface values back to it.
- Clip the existing cached glow frame with pure placement geometry, preserving style, intensity, animation, fade, and repaint semantics.
- Expose placement in an always-visible Settings group independent of the visual preset; controls remain visible but locked when Glow is off or the feature is unavailable.
- Push placement changes to live overlays using each pane's authoritative editor/tool-window identity.
- Cover geometry, persistence, Settings visibility and locking, live updates, invalid values, and ProGuard enum preservation.

## Validation

- `./gradlew build`
- `./gradlew test --tests dev.ayuislands.glow.GlowOverlayManagerLifecycleTest --tests dev.ayuislands.settings.AyuIslandsEffectsPanelTest detekt ktlintCheck`
- `scripts/verify-docs.py`
- Read-only Claude branch review: approved; the single maintainability finding was fixed and regression-tested.

## Notes

- The existing tab-accent UIManager mechanism is intentionally unchanged; `Under tabs` is the glow overlay clipped to a focused strip.
- The settings screenshot is verifier-restamped for this branch and should be recaptured before release if the Marketplace image is refreshed.
