### PR TITLE
fix(commitpanel): contain lock-prohibited crashes in the path renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - [Paid] **Accent from project icon** — projects without an override can take
   their accent from `.idea/icon.png` automatically when they open, and the
   Add Override dialog offers the icon's dominant color as a one-click pick.
+- [Fix] **Commit panel accessibility crash** — screen-reader and macOS
+  accessibility walks over the commit changes tree no longer flood idea.log
+  with "Attempt to take read lock was prevented" errors; the path renderer
+  now serves plain text when the platform forbids model access mid-walk.
 
 ## [2.7.8] - 2026-07-06
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "39103ba9"
+          last_verified_sha: "e4cf2cbf"
           last_verified_date: "2026-06-30"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "39103ba9"
+          last_verified_sha: "e4cf2cbf"
           last_verified_date: "2026-06-30"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -324,7 +324,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "39103ba9"
+          last_verified_sha: "e4cf2cbf"
           last_verified_date: "2026-06-16"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -375,7 +375,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "39103ba9"
+          last_verified_sha: "e4cf2cbf"
           last_verified_date: "2026-06-16"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -427,7 +427,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "39103ba9"
+          last_verified_sha: "e4cf2cbf"
           last_verified_date: "2026-06-12"
           content_sha256: ad849b17308901bc2dac85f895978be656f578c9c31f857b9e9578e5cf4289f2
 
@@ -489,7 +489,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "39103ba9"
+          last_verified_sha: "e4cf2cbf"
           last_verified_date: "2026-06-16"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/src/main/kotlin/dev/ayuislands/commitpanel/CommitPathShorteningRenderer.kt
+++ b/src/main/kotlin/dev/ayuislands/commitpanel/CommitPathShorteningRenderer.kt
@@ -1,5 +1,6 @@
 package dev.ayuislands.commitpanel
 
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.ui.SimpleColoredComponent
 import com.intellij.ui.SimpleTextAttributes
 import dev.ayuislands.settings.AyuIslandsSettings
@@ -9,6 +10,7 @@ import dev.ayuislands.settings.PanelWidthMode
 import java.awt.Component
 import java.awt.Container
 import java.awt.Font
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.swing.JComponent
 import javax.swing.JTree
 import javax.swing.ToolTipManager
@@ -27,16 +29,36 @@ internal class CommitPathShorteningRenderer(
         row: Int,
         hasFocus: Boolean,
     ): Component {
+        // The macOS accessibility bridge walks tree nodes from EDT dispatches
+        // that PROHIBIT taking the platform RW lock (Dispatchers.UI /
+        // prohibitTakingLocksInsideAndRun), but the platform changes-tree
+        // renderers this delegates to still take read actions while rendering
+        // (ChangesBrowserChangeNode.render, git hover icons). Without this
+        // guard every such walk throws LockAccessDisallowed with this class as
+        // the entry frame. Serve a minimal text component instead — the a11y
+        // walk only needs something to derive role/state/bounds from.
         val component =
-            delegate.getTreeCellRendererComponent(
-                tree,
-                value,
-                selected,
-                expanded,
-                leaf,
-                row,
-                hasFocus,
-            )
+            try {
+                delegate.getTreeCellRendererComponent(
+                    tree,
+                    value,
+                    selected,
+                    expanded,
+                    leaf,
+                    row,
+                    hasFocus,
+                )
+            } catch (exception: RuntimeException) {
+                if (!exception.isLockAccessDisallowed()) throw exception
+                if (lockDisallowedLogged.compareAndSet(false, true)) {
+                    log.warn(
+                        "Commit path renderer: platform delegate required a read action in a " +
+                            "lock-prohibited context (accessibility walk); serving fallback text",
+                        exception,
+                    )
+                }
+                return fallbackComponent(value)
+            }
         component.clearRendererTooltips()
         val textComponent = component.findPathTextComponent() ?: return component
         shortenPathFragment(
@@ -265,7 +287,36 @@ internal class CommitPathShorteningRenderer(
         return result
     }
 
+    private fun Throwable.isLockAccessDisallowed(): Boolean {
+        var current: Throwable? = this
+        while (current != null) {
+            if (current.javaClass.name.endsWith(LOCK_DISALLOWED_CLASS_SUFFIX)) return true
+            current = current.cause.takeIf { it !== current }
+        }
+        return false
+    }
+
+    private fun fallbackComponent(value: Any?): Component =
+        SimpleColoredComponent().apply {
+            append(value?.toString().orEmpty(), SimpleTextAttributes.REGULAR_ATTRIBUTES)
+        }
+
     companion object {
+        private val log = logger<CommitPathShorteningRenderer>()
+
+        /**
+         * One WARN per IDE session, not per walked node — the accessibility
+         * bridge re-renders every visible row on each walk, so an unlatched
+         * warning floods idea.log within seconds.
+         */
+        private val lockDisallowedLogged = AtomicBoolean(false)
+
+        /**
+         * Matched by name: `ThreadingSupport.LockAccessDisallowed` is not part
+         * of the 2025.1 compile-time API surface this plugin builds against.
+         */
+        private const val LOCK_DISALLOWED_CLASS_SUFFIX = "LockAccessDisallowed"
+
         private const val DEFAULT_FONT_SIZE = 12
         private const val UNIX_SEPARATOR = "/"
         private const val WINDOWS_SEPARATOR = "\\"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -126,6 +126,7 @@
       <li>[Paid] <b>Chrome tint on external themes</b> — chrome surfaces and accent elements can now follow the Ayu accent on non-Ayu themes when explicitly enabled; external chrome tint stays off by default.</li>
       <li>[Paid] <b>Glow placement</b> — choose where glow renders: the full island, a strip under the editor tabs, or tool-window side edges only.</li>
       <li>[Paid] <b>Accent from project icon</b> — projects without an override can take their accent from .idea/icon.png automatically when they open; the Add Override dialog offers the icon's dominant color as a one-click pick.</li>
+      <li>[Fix] <b>Commit panel accessibility crash</b> — screen-reader and macOS accessibility walks over the commit changes tree no longer flood idea.log with "Attempt to take read lock was prevented" errors; the path renderer serves plain text when the platform forbids model access mid-walk.</li>
     </ul>
     <h3>2.7.8</h3>
     <ul>

--- a/src/test/kotlin/dev/ayuislands/commitpanel/CommitPathShorteningRendererTest.kt
+++ b/src/test/kotlin/dev/ayuislands/commitpanel/CommitPathShorteningRendererTest.kt
@@ -17,6 +17,7 @@ import javax.swing.tree.DefaultMutableTreeNode
 import javax.swing.tree.TreeCellRenderer
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertSame
@@ -451,6 +452,61 @@ class CommitPathShorteningRendererTest {
             assertTrue(fragments.last().contains("..."))
         }
     }
+
+    @Test
+    fun `renderer serves fallback text when the delegate hits a lock-prohibited context`() {
+        SwingUtilities.invokeAndWait {
+            val renderer =
+                CommitPathShorteningRenderer(
+                    delegate = TreeCellRenderer { _, _, _, _, _, _, _ -> throw FakeLockAccessDisallowed() },
+                    stateProvider = { AyuIslandsState() },
+                )
+
+            val component = render(renderer, treeWithVisibleWidth(260), value = "ChangeNode.txt")
+
+            assertEquals(listOf("ChangeNode.txt"), component.fragmentsForTest())
+        }
+    }
+
+    @Test
+    fun `renderer serves fallback text when the lock error is wrapped as a cause`() {
+        SwingUtilities.invokeAndWait {
+            val renderer =
+                CommitPathShorteningRenderer(
+                    delegate =
+                        TreeCellRenderer { _, _, _, _, _, _, _ ->
+                            throw IllegalStateException("render failed", FakeLockAccessDisallowed())
+                        },
+                    stateProvider = { AyuIslandsState() },
+                )
+
+            val component = render(renderer, treeWithVisibleWidth(260), value = "WrappedNode.txt")
+
+            assertEquals(listOf("WrappedNode.txt"), component.fragmentsForTest())
+        }
+    }
+
+    @Test
+    fun `renderer rethrows unrelated delegate failures`() {
+        SwingUtilities.invokeAndWait {
+            val renderer =
+                CommitPathShorteningRenderer(
+                    delegate = TreeCellRenderer { _, _, _, _, _, _, _ -> throw IllegalStateException("boom") },
+                    stateProvider = { AyuIslandsState() },
+                )
+
+            assertFailsWith<IllegalStateException> {
+                renderComponent(renderer, treeWithVisibleWidth(260))
+            }
+        }
+    }
+
+    /**
+     * Stand-in for the platform's `ThreadingSupport$LockAccessDisallowed`,
+     * which is not on the 2025.1 compile classpath — the production guard
+     * matches by class-name suffix, which this fake's name satisfies too.
+     */
+    private class FakeLockAccessDisallowed : IllegalStateException("lock guard test double")
 
     private fun render(
         renderer: TreeCellRenderer,


### PR DESCRIPTION
> Stacked on #267 (`feat/project-icon-accent`) — retarget after the base merges; do not delete base branches before retargeting.

── Summary ─────────────────────────────────

macOS accessibility (and any screen-reader) walks over the commit changes tree dispatch on an EDT context where the platform RW lock is prohibited (`Dispatchers.UI` / `prohibitTakingLocksInsideAndRun`), but the platform renderers our `CommitPathShorteningRenderer` delegates to still take read actions mid-render — `ChangesBrowserChangeNode.render` and the git hover-icon path both call `ReadAction`. Every walk threw `ThreadingSupport$LockAccessDisallowed` with our renderer as the entry frame, flooding idea.log (five distinct traces reported from a live 2.7.8 install). The renderer now detects that failure and serves a plain-text fallback — the a11y walk only needs a component to derive role/state/bounds from.

── Changes ─────────────────────────────────

| Type | Where | What |
|------|-------|------|
| Fix | `CommitPathShorteningRenderer.kt:33` | Delegate call guarded: `LockAccessDisallowed` (matched by class-name suffix through the cause chain — the class is absent from the 2025.1 compile classpath) → plain `SimpleColoredComponent` fallback; anything else rethrows |
| Fix | `CommitPathShorteningRenderer.kt:290` | One WARN per IDE session (`AtomicBoolean` latch) — the a11y bridge re-renders every visible row per walk, so an unlatched warning floods the log in seconds |
| Test | `CommitPathShorteningRendererTest.kt:455` | Direct and wrapped-cause lock errors fall back to the node text; unrelated `IllegalStateException` rethrows |
| Docs | `CHANGELOG.md`, `plugin.xml` | User-facing [Fix] bullet in the 2.8.0 section |

── Validation ──────────────────────────────

```bash
./gradlew test --tests 'dev.ayuislands.commitpanel.CommitPathShorteningRendererTest' detekt detektTest ktlintCheck
# BUILD SUCCESSFUL
```

Manual: on macOS with VoiceOver (or any tool that triggers `CAccessibility` walks) focus a window with the Commit tool window open — idea.log stays free of "Attempt to take read lock was prevented"; one WARN with the original stack appears at most once per session; the commit tree renders identically.

── Notes ───────────────────────────────────

- Root cause is a platform-side contract gap (renderers that take read actions vs. lock-prohibited a11y dispatches) — worth a YouTrack report; this guard keeps user logs clean regardless of when the platform fixes it.
- Rendering behavior for normal paints is byte-identical: the guard only engages when the platform itself refuses the read lock.

## Summary by Sourcery

Contain commit panel accessibility crashes caused by platform read-lock restrictions by guarding the path renderer, providing a plain-text fallback, and updating documentation and tests.

Bug Fixes:
- Handle lock-prohibited accessibility contexts in the commit path renderer by falling back to plain text instead of propagating platform read-lock errors.

Enhancements:
- Log the accessibility-related lock error at most once per IDE session to avoid flooding idea.log.

Documentation:
- Document the commit panel accessibility crash fix in the changelog and plugin description.

Tests:
- Add tests covering fallback rendering when lock errors occur (including wrapped causes) and rethrowing unrelated delegate failures.

Chores:
- Refresh feature verification metadata in docs/features.yml to point to the latest commit.