### PR TITLE
fix(deps): restore verifier-compatible platform plugin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,11 @@ updates:
       default-days: 3
       semver-major-days: 7
     open-pull-requests-limit: 5
+    ignore:
+      # 2.18.1 breaks the verifyPlugin compatibility matrix; allow later fixes.
+      - dependency-name: "org.jetbrains.intellij.platform"
+        versions:
+          - "2.18.1"
     labels:
       - "dependencies"
       - "gradle"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,8 @@ buildscript {
 }
 
 plugins {
-    id("org.jetbrains.intellij.platform") version "2.18.1"
+    // 2.18.1 breaks the verifyPlugin compatibility matrix; keep in sync with Dependabot.
+    id("org.jetbrains.intellij.platform") version "2.17.0"
     kotlin("jvm") version "2.4.0"
     id("org.jetbrains.kotlinx.kover") version "0.9.8"
     id("org.jlleitschuh.gradle.ktlint") version "14.2.0"


### PR DESCRIPTION
── Summary ─────────────────────────────────

Restore the compatibility verifier after IntelliJ Platform Gradle Plugin 2.18.1 broke the existing B/C matrix. Roll back to the immediately preceding known-good 2.17.0 release and prevent Dependabot from reopening only that broken version.

This unblocks the stacked glow PRs without removing IDE targets or weakening verification.

── Changes ─────────────────────────────────

| Type | File | Description |
|------|------|-------------|
| Fix | [build.gradle.kts:13](build.gradle.kts#L13) | Pin the platform Gradle plugin back to verifier-compatible 2.17.0. |
| Chore | [dependabot.yml:32](.github/dependabot.yml#L32) | Ignore exactly 2.18.1 while allowing later fixes such as 2.18.2+. |

── Validation ────────────────────────────────

- `./gradlew --no-daemon help --console=plain` - passed; 2.17.0 resolves.
- `./gradlew --no-daemon compileKotlin --console=plain` - passed.
- `./gradlew --no-daemon detekt ktlintCheck --console=plain` - passed.
- `./gradlew --no-daemon verifyPlugin -DverifyGroup=C` - passed against IU-262.6653.22 on 2.17.0.
- `.github/dependabot.yml` parsed successfully with Ruby Psych; pre-commit YAML, zizmor, ktlint, and detekt hooks passed.

── Notes ───────────────────────────────────

- Regression introduced by #272.
- [Current 2.18.1 failure](https://github.com/barad1tos/ayu-jetbrains/actions/runs/29454342350): Verify B/C fail while A1/A2 pass.
- [Known-good 2.17.0 run](https://github.com/barad1tos/ayu-jetbrains/actions/runs/29047051621): B, C, and Gate pass.
- The ignore is deliberately version-specific so the next platform-plugin fix is still tested automatically.

## Summary by Sourcery

Restore IntelliJ platform Gradle plugin compatibility verification by reverting to a known-good plugin version and preventing automatic re-upgrades to the broken release.

Build:
- Pin the org.jetbrains.intellij.platform Gradle plugin to version 2.17.0 to maintain a working verification compatibility matrix.

CI:
- Configure Dependabot to ignore the broken org.jetbrains.intellij.platform 2.18.1 release while allowing future plugin updates.