### PR TITLE
test: protect merged settings and glow flows

### DIFF
--- a/src/test/kotlin/dev/ayuislands/glow/GlowOverlayManagerLifecycleTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/GlowOverlayManagerLifecycleTest.kt
@@ -363,6 +363,18 @@ class GlowOverlayManagerLifecycleTest {
     }
 
     @Test
+    fun `Power Save reaches the active waveform through the real input sink`() {
+        val manager = GlowOverlayManager(stubProject("power-save-input-project"))
+        val active = mockk<GlowGlassPane>(relaxed = true)
+        seedOverlaysMapWithMocks(manager, active, mockk(relaxed = true), mockk(relaxed = true), key = "active")
+        setActiveGlow(manager, "active")
+
+        manager.input.onPowerSaveChanged(enabled = true)
+
+        verify(exactly = 1) { active.changeWaveformPowerSave(true) }
+    }
+
+    @Test
     fun `focus handoff deactivates old waveform and activates only the new overlay`() {
         state.glowShape = GlowShape.WAVEFORM.name
         val project = stubProject("focus-project")

--- a/src/test/kotlin/dev/ayuislands/glow/KeystrokeHubTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/KeystrokeHubTest.kt
@@ -144,7 +144,7 @@ class KeystrokeHubTest {
     }
 
     @Test
-    fun `Power Save topic broadcasts the current mode`() {
+    fun `initialization is idempotent and Power Save changes broadcast the current mode`() {
         val application = mockk<Application>()
         val messageBus = mockk<MessageBus>()
         val connection = mockk<MessageBusConnection>(relaxed = true)
@@ -161,8 +161,10 @@ class KeystrokeHubTest {
         every { GlowOverlayManager.broadcastPowerSave(any()) } returns Unit
 
         hub.initialize()
+        hub.initialize()
         listener.captured.powerSaveStateChanged()
 
+        verify(exactly = 1) { messageBus.connect(hub) }
         verify(exactly = 1) { GlowOverlayManager.broadcastPowerSave(true) }
     }
 

--- a/src/test/kotlin/dev/ayuislands/glow/waveform/WaveformEngineTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/waveform/WaveformEngineTest.kt
@@ -254,6 +254,25 @@ class WaveformEngineTest {
     }
 
     @Test
+    fun `refresh activation preserves the configured moving trace`() {
+        val engine = WaveformEngine(WaveformConfig(), Random(84))
+        engine.handle(WaveformEvent.Activate(powerSaveEnabled = false))
+        engine.handle(WaveformEvent.Tick(0L, 1_000f))
+        engine.handle(WaveformEvent.Keystroke(100L))
+        engine.handle(WaveformEvent.Tick(140L, 1_000f))
+        engine.handle(WaveformEvent.Configure(WaveformConfig(amplitude = 24)))
+        val configured = assertIs<WaveformState.Looping>(engine.state)
+        assertTrue(configured.travelPhase > 0f)
+        assertNotNull(configured.energyEnvelope)
+
+        val update = engine.handle(WaveformEvent.Activate(powerSaveEnabled = false))
+
+        assertEquals(configured, engine.state, "refresh activation must not restart the live trace")
+        assertEquals(TimerDirective.KEEP, update.timerDirective)
+        assertFalse(update.needsRepaint)
+    }
+
+    @Test
     fun `identical configuration preserves running animation`() {
         val config = WaveformConfig()
         val engine = WaveformEngine(config, Random(83))

--- a/src/test/kotlin/dev/ayuislands/settings/ProjectIconAccentSectionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/ProjectIconAccentSectionTest.kt
@@ -1,20 +1,29 @@
 package dev.ayuislands.settings
 
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.dsl.builder.panel
 import dev.ayuislands.licensing.LicenseChecker
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkClass
 import io.mockk.mockkObject
-import io.mockk.unmockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import java.awt.Component
+import java.awt.Container
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 /**
- * Pattern U locks for [ProjectIconAccentSection]'s pending/stored logic —
- * the UI row itself is IDE glue exercised via the Accent tab; the license
- * boundary and persistence live here.
+ * Pattern U locks for [ProjectIconAccentSection]'s checkbox, pending/stored
+ * state, license boundary, and persistence.
  */
 class ProjectIconAccentSectionTest {
     private lateinit var state: AyuIslandsState
@@ -33,15 +42,18 @@ class ProjectIconAccentSectionTest {
 
     @AfterTest
     fun tearDown() {
-        unmockkObject(AyuIslandsSettings.Companion)
-        unmockkObject(LicenseChecker)
+        unmockkAll()
     }
 
     @Test
-    fun `licensed enable persists through apply and converges stored`() {
+    fun `licensed checkbox click persists through apply and converges stored`() {
         val section = ProjectIconAccentSection()
         section.load()
-        section.setPendingForTest(true)
+        mockUiDslApplication()
+        val form = panel { section.buildRow(this) }
+        val checkbox = assertNotNull(findCheckBox(form))
+
+        checkbox.doClick()
 
         assertTrue(section.isModified(), "pending change must dirty the section")
         section.apply()
@@ -79,12 +91,43 @@ class ProjectIconAccentSectionTest {
     fun `reset drops the pending change`() {
         val section = ProjectIconAccentSection()
         section.load()
-        section.setPendingForTest(true)
+        mockUiDslApplication()
+        val form = panel { section.buildRow(this) }
+        val checkbox = assertNotNull(findCheckBox(form))
+
+        checkbox.doClick()
 
         section.reset()
 
+        assertFalse(checkbox.isSelected, "reset must restore the visible checkbox")
         assertFalse(section.isModified())
         section.apply()
         assertFalse(state.projectIconAccentEnabled, "reset pending must not leak into apply")
+    }
+
+    private fun mockUiDslApplication() {
+        mockkStatic(ApplicationManager::class)
+        val application = mockk<Application>(relaxed = true)
+        val actionManager = mockk<ActionManager>(relaxed = true)
+        every { ApplicationManager.getApplication() } returns application
+        every { application.invokeLater(any()) } answers { firstArg<Runnable>().run() }
+        every { application.getService(ActionManager::class.java) } returns actionManager
+        every { actionManager.getAction(any()) } returns null
+
+        @Suppress("UNCHECKED_CAST")
+        val experimentalUiClass = Class.forName("com.intellij.ui.ExperimentalUI") as Class<Any>
+        val experimentalUi = mockkClass(experimentalUiClass.kotlin, relaxed = true)
+        every { application.getService(experimentalUiClass) } returns experimentalUi
+    }
+
+    private fun findCheckBox(root: Container): JBCheckBox? {
+        val queue = ArrayDeque<Component>()
+        queue.add(root)
+        while (queue.isNotEmpty()) {
+            val current = queue.removeFirst()
+            if (current is JBCheckBox) return current
+            if (current is Container) queue.addAll(current.components)
+        }
+        return null
     }
 }

--- a/src/test/kotlin/dev/ayuislands/settings/SettingsBadgesTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/SettingsBadgesTest.kt
@@ -298,6 +298,28 @@ class SettingsBadgesTest {
     }
 
     @Test
+    fun `review action opens and acknowledges the first pending tab`() {
+        val state = updatedState()
+        val settings = mockk<AyuIslandsSettings>()
+        every { settings.state } returns state
+        mockkObject(AyuIslandsSettings.Companion)
+        every { AyuIslandsSettings.getInstance() } returns settings
+        SettingsBadges.registerGroupExpanded("accent-from-project-icon") { false }
+
+        val titles = listOf("Plugins", "Glow", "Accent")
+        val tabs = JBTabbedPane()
+        for (title in titles) tabs.addTab(title, JPanel())
+        val controller = assertNotNull(installSettingsBadges(tabs, titles, Color.ORANGE))
+
+        controller.jumpToFirstPending()
+
+        assertEquals(1, tabs.selectedIndex, "Review must open the first tab that still carries a badge")
+        assertFalse(SettingsBadges.isPending(state, "glow-waveform"))
+        assertFalse(SettingsBadges.isPending(state, "glow-placement"))
+        assertTrue(SettingsBadges.isPending(state, "accent-from-project-icon"))
+    }
+
+    @Test
     fun `group title carries an accent dot while its anchor pends and restores after`() {
         val state = updatedState()
         val settings = mockk<AyuIslandsSettings>()

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectIconAccentAssignerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectIconAccentAssignerTest.kt
@@ -172,6 +172,43 @@ class ProjectIconAccentAssignerTest {
         assertEquals("pinned-by-hand", mappingsState.projectDisplayNames[key])
     }
 
+    @Test
+    fun `disabling auto assignment during extraction preserves the empty mapping`() {
+        state.projectIconAccentEnabled = true
+        writeIcon(Color(0x5C, 0xCF, 0xE6))
+        val project = stubProject()
+        val extractionStarted = CompletableDeferred<Unit>()
+        val allowExtraction = CountDownLatch(1)
+        mockkObject(ProjectIconAccentExtractor)
+        every { ProjectIconAccentExtractor.extract(any<File>()) } answers {
+            extractionStarted.complete(Unit)
+            check(allowExtraction.await(5, TimeUnit.SECONDS)) { "Timed out waiting for the toggle change" }
+            AccentHex.of("#5CCFE6")
+        }
+
+        try {
+            runBlocking {
+                val assignment =
+                    async {
+                        ProjectIconAccentAssigner.assignIfAbsent(project, EmptyCoroutineContext)
+                    }
+                try {
+                    withTimeout(5_000) { extractionStarted.await() }
+                    state.projectIconAccentEnabled = false
+                } finally {
+                    allowExtraction.countDown()
+                }
+
+                assertFalse(withTimeout(5_000) { assignment.await() })
+            }
+        } finally {
+            unmockkObject(ProjectIconAccentExtractor)
+        }
+
+        assertTrue(mappingsState.projectAccents.isEmpty(), "a disabled feature must reject the late result")
+        assertTrue(mappingsState.projectDisplayNames.isEmpty())
+    }
+
     private fun assign(project: Project): Boolean =
         runBlocking { ProjectIconAccentAssigner.assignIfAbsent(project, EmptyCoroutineContext) }
 


### PR DESCRIPTION
── Summary ─────────────────────────────────

The merged settings and ECG work exposed a few behavior boundaries that could regress while broad coverage remained healthy. This adds focused regression locks for those user-visible paths without padding defensive, paint-only, or framework-controlled branches.

── Changes ─────────────────────────────────

- Test: [SettingsBadgesTest.kt](src/test/kotlin/dev/ayuislands/settings/SettingsBadgesTest.kt) — Verify the Review action opens and acknowledges the first pending settings tab.
- Test: [ProjectIconAccentSectionTest.kt](src/test/kotlin/dev/ayuislands/settings/ProjectIconAccentSectionTest.kt) — Drive the real UI checkbox and verify Apply and Reset keep visible and stored state aligned.
- Test: [WaveformEngineTest.kt](src/test/kotlin/dev/ayuislands/glow/waveform/WaveformEngineTest.kt) — Preserve live trace phase and typing energy when an active waveform is refreshed.
- Test: [GlowOverlayManagerLifecycleTest.kt](src/test/kotlin/dev/ayuislands/glow/GlowOverlayManagerLifecycleTest.kt) and [KeystrokeHubTest.kt](src/test/kotlin/dev/ayuislands/glow/KeystrokeHubTest.kt) — Keep input initialization idempotent and route Power Save through the real active-waveform sink.
- Test: [ProjectIconAccentAssignerTest.kt](src/test/kotlin/dev/ayuislands/settings/mappings/ProjectIconAccentAssignerTest.kt) — Reject a late extraction result after automatic assignment is disabled.

── Validation ──────────────────────────────

- `./gradlew test --tests dev.ayuislands.settings.SettingsBadgesTest --tests dev.ayuislands.settings.ProjectIconAccentSectionTest --tests dev.ayuislands.glow.waveform.WaveformEngineTest --tests dev.ayuislands.settings.mappings.ProjectIconAccentAssignerTest --tests dev.ayuislands.glow.KeystrokeHubTest` — passed.
- `./gradlew test --tests dev.ayuislands.glow.GlowOverlayManagerLifecycleTest` — passed.
- `./gradlew detekt ktlintCheck` — passed.
- `./gradlew build koverXmlReport` — passed, including unit tests, integration tests, and the protected Kover gate.
- `scripts/verify-docs.py` — passed; feature metadata remains in sync.

── Notes ───────────────────────────────────

This is test-only. The remaining uncovered lines are intentionally left alone where no concrete user or caller failure exists.

## Summary by Sourcery

Add focused regression tests to protect user-facing settings flows and glow waveform behavior after recent configuration and lifecycle changes.

Enhancements:
- Extend settings tests to cover real UI checkbox interactions, apply/reset alignment, and badge review navigation across tabs.
- Strengthen glow waveform and overlay lifecycle tests to ensure refresh activations preserve live traces and power-save signals reach the active waveform via the input sink.
- Add mapping tests to ensure project icon accent auto-assignment rejects late extraction results when the feature is disabled.
- Tighten KeystrokeHub initialization tests to enforce idempotent setup and correct Power Save broadcasting behavior.

Tests:
- Introduce new unit tests around settings badges, project icon accent section UI, and accent assignment edge cases.
- Add additional tests for waveform engine activation/configuration, glow overlay manager power-save routing, and keystroke hub initialization semantics.