### PR TITLE
docs(glow): rebind ECG verification after squash merge

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -324,7 +324,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "a572f75"
+          last_verified_sha: "201670f8"
           last_verified_date: "2026-07-18"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 


### PR DESCRIPTION
-- Summary ------------------------------------------------

Squash-merging #282 made the previous glow screenshot verification SHA no longer an ancestor of main. This rebinds the ECG verification metadata to the squash commit without changing screenshots or content hashes.

-- Changes ------------------------------------------------

- Docs: [features.yml](docs/features.yml) - Point the glow waveform verification stamp at `201670f8`.

-- Validation ---------------------------------------------

- `scripts/verify-docs.py` - passed
- Pre-commit hooks - passed

-- Notes --------------------------------------------------

Metadata-only follow-up required by the post-squash verification workflow.

## Summary by Sourcery

Documentation:
- Rebind the glow waveform verification stamp in docs/features.yml to the latest squash-merge SHA.