### PR TITLE
refactor(accent): cache CodeGlance methods atomically

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "def51113"
+          last_verified_sha: "200e99ac"
           last_verified_date: "2026-07-30"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "def51113"
+          last_verified_sha: "200e99ac"
           last_verified_date: "2026-07-30"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -399,7 +399,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "b95c003a"
+          last_verified_sha: "d0efa5da"
           last_verified_date: "2026-07-29"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -451,7 +451,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "def51113"
+          last_verified_sha: "d0efa5da"
           last_verified_date: "2026-07-30"
           content_sha256: ad849b17308901bc2dac85f895978be656f578c9c31f857b9e9578e5cf4289f2
 
@@ -513,7 +513,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "def51113"
+          last_verified_sha: "d0efa5da"
           last_verified_date: "2026-07-30"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 

--- a/src/main/kotlin/dev/ayuislands/accent/CodeGlanceProIntegration.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/CodeGlanceProIntegration.kt
@@ -9,6 +9,7 @@ import dev.ayuislands.integration.IntegrationOwnership
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
+import org.jetbrains.annotations.TestOnly
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
 
@@ -76,22 +77,23 @@ internal object CodeGlanceProIntegration {
     internal const val CGP_DEFAULT_VIEWPORT_BORDER_COLOR = "A0A0A0"
     internal const val CGP_DEFAULT_VIEWPORT_BORDER_THICKNESS = 0
 
+    internal data class CgpMethods(
+        val service: Any,
+        val getState: Method,
+        val viewport: CgpViewportMethods,
+    )
+
+    internal data class CgpViewportMethods(
+        val getColor: Method,
+        val getBorder: Method,
+        val getThickness: Method,
+        val setColor: Method,
+        val setBorder: Method,
+        val setThickness: Method,
+    )
+
     // Cached CodeGlance Pro reflection objects (resolved once per session)
-    @Volatile private var cgpService: Any? = null
-
-    @Volatile private var cgpGetState: Method? = null
-
-    @Volatile private var cgpGetColor: Method? = null
-
-    @Volatile private var cgpGetBorder: Method? = null
-
-    @Volatile private var cgpGetThickness: Method? = null
-
-    @Volatile private var cgpSetColor: Method? = null
-
-    @Volatile private var cgpSetBorder: Method? = null
-
-    @Volatile private var cgpSetThickness: Method? = null
+    @Volatile private var cgpMethods: CgpMethods? = null
 
     @Volatile private var cgpMethodsResolved = false
 
@@ -118,21 +120,21 @@ internal object CodeGlanceProIntegration {
             val getState = service.javaClass.getMethod("getState")
             val config = getState.invoke(service) ?: return
             val configClass = config.javaClass
-            val getColor = configClass.getMethod("getViewportColor")
-            val getBorder = configClass.getMethod("getViewportBorderColor")
-            val getThickness = configClass.getMethod("getViewportBorderThickness")
-            val setColor = configClass.getMethod("setViewportColor", String::class.java)
-            val setBorder = configClass.getMethod("setViewportBorderColor", String::class.java)
-            val setThickness = configClass.getMethod("setViewportBorderThickness", Int::class.java)
-
-            cgpService = service
-            cgpGetState = getState
-            cgpGetColor = getColor
-            cgpGetBorder = getBorder
-            cgpGetThickness = getThickness
-            cgpSetColor = setColor
-            cgpSetBorder = setBorder
-            cgpSetThickness = setThickness
+            val viewport =
+                CgpViewportMethods(
+                    getColor = configClass.getMethod("getViewportColor"),
+                    getBorder = configClass.getMethod("getViewportBorderColor"),
+                    getThickness = configClass.getMethod("getViewportBorderThickness"),
+                    setColor = configClass.getMethod("setViewportColor", String::class.java),
+                    setBorder = configClass.getMethod("setViewportBorderColor", String::class.java),
+                    setThickness = configClass.getMethod("setViewportBorderThickness", Int::class.java),
+                )
+            cgpMethods =
+                CgpMethods(
+                    service = service,
+                    getState = getState,
+                    viewport = viewport,
+                )
         } catch (exception: ReflectiveOperationException) {
             cgpResolutionFailure = exception
             log.warn(
@@ -322,17 +324,17 @@ internal object CodeGlanceProIntegration {
     }
 
     private fun resolvedAccess(): CgpAccess? {
-        val service = cgpService ?: return null
-        val getState = cgpGetState ?: return null
-        val config = getState.invoke(service) ?: return null
+        val methods = cgpMethods ?: return null
+        val config = methods.getState.invoke(methods.service) ?: return null
+        val viewport = methods.viewport
         return CgpAccess(
             config = config,
-            getColor = cgpGetColor ?: return null,
-            getBorder = cgpGetBorder ?: return null,
-            getThickness = cgpGetThickness ?: return null,
-            setColor = cgpSetColor ?: return null,
-            setBorder = cgpSetBorder ?: return null,
-            setThickness = cgpSetThickness ?: return null,
+            getColor = viewport.getColor,
+            getBorder = viewport.getBorder,
+            getThickness = viewport.getThickness,
+            setColor = viewport.setColor,
+            setBorder = viewport.setBorder,
+            setThickness = viewport.setThickness,
         )
     }
 
@@ -460,16 +462,16 @@ internal object CodeGlanceProIntegration {
         return getService.invoke(application, serviceClass)
     }
 
+    @TestOnly
+    internal fun seedReflectionMethods(methods: CgpMethods) {
+        cgpMethods = methods
+        cgpMethodsResolved = true
+        cgpResolutionFailure = null
+    }
+
     /** Invalidates a failed reflection chain so the next reconciliation resolves it again. */
     internal fun resetReflectionCache() {
-        cgpService = null
-        cgpGetState = null
-        cgpGetColor = null
-        cgpGetBorder = null
-        cgpGetThickness = null
-        cgpSetColor = null
-        cgpSetBorder = null
-        cgpSetThickness = null
+        cgpMethods = null
         cgpMethodsResolved = false
         cgpResolutionFailure = null
     }

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorRevertAllIntegrationTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorRevertAllIntegrationTest.kt
@@ -377,7 +377,7 @@ class AccentApplicatorRevertAllIntegrationTest {
         every { mockSetBorderColor.invoke(mockConfig, any()) } returns null
         every { mockSetBorderThickness.invoke(mockConfig, any()) } returns null
 
-        installCgpReflectionMocks(
+        seedCgpMethods(
             service = mockService,
             getState = mockGetState,
             setColor = mockSetColor,
@@ -698,7 +698,7 @@ class AccentApplicatorRevertAllIntegrationTest {
             null
         }
 
-        installCgpReflectionMocks(
+        seedCgpMethods(
             service = mockService,
             getState = mockGetState,
             setColor = mockSetColor,
@@ -731,7 +731,7 @@ class AccentApplicatorRevertAllIntegrationTest {
         every { mockSetColor.invoke(mockConfig, any()) } throws
             java.lang.reflect.InvocationTargetException(IllegalStateException("CGP setter rejected"))
 
-        installCgpReflectionMocks(
+        seedCgpMethods(
             service = mockService,
             getState = mockGetState,
             setColor = mockSetColor,
@@ -759,7 +759,7 @@ class AccentApplicatorRevertAllIntegrationTest {
         every { mockSetColor.invoke(mockConfig, any()) } throws
             IllegalAccessException("CGP setter inaccessible")
 
-        installCgpReflectionMocks(
+        seedCgpMethods(
             service = mockService,
             getState = mockGetState,
             setColor = mockSetColor,
@@ -795,7 +795,7 @@ class AccentApplicatorRevertAllIntegrationTest {
         }
         every { mockSetBorderThickness.invoke(mockConfig, any()) } returns null
 
-        installCgpReflectionMocks(
+        seedCgpMethods(
             service = mockService,
             getState = mockGetState,
             setColor = mockSetColor,
@@ -821,8 +821,8 @@ class AccentApplicatorRevertAllIntegrationTest {
         // [CodeGlanceProIntegration.revertCodeGlanceProViewport]. Pre-test, the
         // `syncCodeGlanceProViewport` reflection happy path (CodeGlanceProIntegration.kt
         // lines ~152-169) had no behavior-locked test — only the
-        // `cgpService ?: return` short-circuit was hit. This stages the
-        // reflection chain via `installCgpReflectionMocks`, calls sync
+        // `cgpMethods ?: return` short-circuit was hit. This stages the
+        // reflection chain via `seedCgpMethods`, calls sync
         // directly, and verifies all three setters fire with the `#`
         // stripped from the input AND in the documented order: color,
         // border-color, border-thickness=1 (active accent thickness, NOT
@@ -850,7 +850,7 @@ class AccentApplicatorRevertAllIntegrationTest {
             null
         }
 
-        installCgpReflectionMocks(
+        seedCgpMethods(
             service = mockService,
             getState = mockGetState,
             setColor = mockSetColor,
@@ -890,7 +890,7 @@ class AccentApplicatorRevertAllIntegrationTest {
         every { mockSetBorderColor.invoke(mockConfig, any()) } returns null
         every { mockSetBorderThickness.invoke(mockConfig, any()) } returns null
 
-        installCgpReflectionMocks(
+        seedCgpMethods(
             service = mockService,
             getState = mockGetState,
             setColor = mockSetColor,
@@ -921,7 +921,7 @@ class AccentApplicatorRevertAllIntegrationTest {
         val mockSetBorderThickness = mockk<java.lang.reflect.Method>(relaxed = true)
         every { mockGetState.invoke(mockService) } returns null
 
-        installCgpReflectionMocks(
+        seedCgpMethods(
             service = mockService,
             getState = mockGetState,
             setColor = mockSetColor,
@@ -953,7 +953,7 @@ class AccentApplicatorRevertAllIntegrationTest {
         every { mockSetColor.invoke(mockConfig, any()) } throws
             java.lang.reflect.InvocationTargetException(IllegalStateException("CGP setter rejected"))
 
-        installCgpReflectionMocks(
+        seedCgpMethods(
             service = mockService,
             getState = mockGetState,
             setColor = mockSetColor,
@@ -981,7 +981,7 @@ class AccentApplicatorRevertAllIntegrationTest {
         every { mockSetColor.invoke(mockConfig, any()) } throws
             IllegalAccessException("CGP setter inaccessible")
 
-        installCgpReflectionMocks(
+        seedCgpMethods(
             service = mockService,
             getState = mockGetState,
             setColor = mockSetColor,
@@ -1008,7 +1008,7 @@ class AccentApplicatorRevertAllIntegrationTest {
         every { mockSetColor.invoke(mockConfig, any()) } throws
             IllegalStateException("CGP internal NPE")
 
-        installCgpReflectionMocks(
+        seedCgpMethods(
             service = mockService,
             getState = mockGetState,
             setColor = mockSetColor,
@@ -1032,7 +1032,7 @@ class AccentApplicatorRevertAllIntegrationTest {
         val mockSetBorderThickness = mockk<java.lang.reflect.Method>(relaxed = true)
         every { mockGetState.invoke(mockService) } returns null
 
-        installCgpReflectionMocks(
+        seedCgpMethods(
             service = mockService,
             getState = mockGetState,
             setColor = mockSetColor,
@@ -1066,7 +1066,7 @@ class AccentApplicatorRevertAllIntegrationTest {
         every { mockSetColor.invoke(mockConfig, any()) } throws
             IllegalStateException("CGP internal NPE on revert")
 
-        installCgpReflectionMocks(
+        seedCgpMethods(
             service = mockService,
             getState = mockGetState,
             setColor = mockSetColor,
@@ -1115,8 +1115,7 @@ class AccentApplicatorRevertAllIntegrationTest {
 
     @Test
     fun `syncCodeGlanceProViewport resolveCgpMethods catches ReflectiveOperationException when CGP class missing`() {
-        // Pattern B isolation: drives the `ReflectiveOperationException` catch
-        // inside `resolveCgpMethods` (CodeGlanceProIntegration.kt lines 116-121).
+        // Pattern B isolation: drives the `ReflectiveOperationException` catch.
         // When the CGP plugin reports a classloader but `Class.forName` cannot
         // locate `com.nasller.codeglance.config.CodeGlanceConfigService` (the
         // test classpath has no CGP), `Class.forName` throws
@@ -1136,26 +1135,15 @@ class AccentApplicatorRevertAllIntegrationTest {
         // plugin is present, but the service class is absent.
         every { mockPlugin.pluginClassLoader } returns MissingCgpClassLoader
 
-        // No throw expected. The `cgpService` field stays null because the
-        // catch swallows before it can be assigned.
         val outcome = CodeGlanceProIntegration.syncCodeGlanceProViewport("#5CCFE6")
 
-        val serviceField = CodeGlanceProIntegration::class.java.getDeclaredField("cgpService")
-        serviceField.isAccessible = true
         assertTrue(outcome is IntegrationOutcome.Failed)
         assertEquals(IntegrationOwnership.UNOWNED.name, state.cgpOwnership)
-        assertEquals(
-            null,
-            serviceField.get(CodeGlanceProIntegration),
-            "cgpService MUST stay null after `Class.forName` throws — the catch " +
-                "must short-circuit before any field assignment.",
-        )
     }
 
     @Test
     fun `syncCodeGlanceProViewport resolveCgpMethods catches RuntimeException when classloader misbehaves`() {
-        // Pattern B isolation: drives the `RuntimeException` catch inside
-        // `resolveCgpMethods` (CodeGlanceProIntegration.kt lines 122-127).
+        // Pattern B isolation: drives the `RuntimeException` catch.
         // A classloader subclass that throws `IllegalStateException` from
         // `loadClass` exercises the second catch — covers a CGP plugin in a
         // weird state (corrupt jar, security manager rejection) where the
@@ -1173,78 +1161,38 @@ class AccentApplicatorRevertAllIntegrationTest {
         // not a `ReflectiveOperationException` — the second catch handles it.
         val outcome = CodeGlanceProIntegration.syncCodeGlanceProViewport("#5CCFE6")
 
-        val serviceField = CodeGlanceProIntegration::class.java.getDeclaredField("cgpService")
-        serviceField.isAccessible = true
         assertTrue(outcome is IntegrationOutcome.Failed)
         assertEquals(IntegrationOwnership.UNOWNED.name, state.cgpOwnership)
-        assertEquals(
-            null,
-            serviceField.get(CodeGlanceProIntegration),
-            "cgpService MUST stay null after the classloader throws " +
-                "RuntimeException — the broader catch must short-circuit before " +
-                "any field assignment.",
-        )
     }
 
-    // ── Helpers ───────────────────────────────────────────────────────────────
-
-    private fun installCgpReflectionMocks(
+    private fun seedCgpMethods(
         service: Any,
         getState: java.lang.reflect.Method,
         setColor: java.lang.reflect.Method,
         setBorderColor: java.lang.reflect.Method,
         setBorderThickness: java.lang.reflect.Method,
     ) {
-        // Stage non-null reflection chain so [revertCodeGlanceProViewport] /
-        // [syncCodeGlanceProViewport] reach the production reflection branch
-        // instead of short-circuiting on `cgpService ?: return`. Uses raw
-        // field writes routed through the typed
-        // [CodeGlanceProIntegration.resetReflectionCache] helper for cleanup.
-        // Marks `cgpMethodsResolved = true` so `resolveCgpMethods` is a no-op
-        // (we already supplied the cached refs).
-        val ownerClass = CodeGlanceProIntegration::class.java
         val getColor = mockk<java.lang.reflect.Method>(relaxed = true)
         val getBorderColor = mockk<java.lang.reflect.Method>(relaxed = true)
         val getBorderThickness = mockk<java.lang.reflect.Method>(relaxed = true)
         every { getColor.invoke(any()) } returns "00FF00"
         every { getBorderColor.invoke(any()) } returns "A0A0A0"
         every { getBorderThickness.invoke(any()) } returns 0
-        ownerClass.getDeclaredField("cgpService").apply {
-            isAccessible = true
-            set(CodeGlanceProIntegration, service)
-        }
-        ownerClass.getDeclaredField("cgpGetState").apply {
-            isAccessible = true
-            set(CodeGlanceProIntegration, getState)
-        }
-        ownerClass.getDeclaredField("cgpGetColor").apply {
-            isAccessible = true
-            set(CodeGlanceProIntegration, getColor)
-        }
-        ownerClass.getDeclaredField("cgpGetBorder").apply {
-            isAccessible = true
-            set(CodeGlanceProIntegration, getBorderColor)
-        }
-        ownerClass.getDeclaredField("cgpGetThickness").apply {
-            isAccessible = true
-            set(CodeGlanceProIntegration, getBorderThickness)
-        }
-        ownerClass.getDeclaredField("cgpSetColor").apply {
-            isAccessible = true
-            set(CodeGlanceProIntegration, setColor)
-        }
-        ownerClass.getDeclaredField("cgpSetBorder").apply {
-            isAccessible = true
-            set(CodeGlanceProIntegration, setBorderColor)
-        }
-        ownerClass.getDeclaredField("cgpSetThickness").apply {
-            isAccessible = true
-            set(CodeGlanceProIntegration, setBorderThickness)
-        }
-        ownerClass.getDeclaredField("cgpMethodsResolved").apply {
-            isAccessible = true
-            set(CodeGlanceProIntegration, true)
-        }
+        CodeGlanceProIntegration.seedReflectionMethods(
+            CodeGlanceProIntegration.CgpMethods(
+                service = service,
+                getState = getState,
+                viewport =
+                    CodeGlanceProIntegration.CgpViewportMethods(
+                        getColor = getColor,
+                        getBorder = getBorderColor,
+                        getThickness = getBorderThickness,
+                        setColor = setColor,
+                        setBorder = setBorderColor,
+                        setThickness = setBorderThickness,
+                    ),
+            ),
+        )
     }
 
     private fun installCgpService(shouldResetCache: Boolean = true): CodeGlanceConfigService {

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
@@ -178,20 +178,9 @@ class AccentApplicatorTest {
         invokePrivate("repaintAllWindows", windows)
     }
 
-    /**
-     * The CGP reflection chain lives on the peer object [CodeGlanceProIntegration]
-     * to keep [AccentApplicator] under the detekt `TooManyFunctions` cap. The
-     * CodeGlance Pro reflection fields and method-resolution state live on
-     * [CodeGlanceProIntegration]; everything else
-     * stays on [AccentApplicator]. The helpers below dispatch by name so existing
-     * tests can keep their AccentApplicator-flavoured reflection without
-     * re-templating every `setPrivateField(...)` callsite.
-     */
+    /** Routes the one private CodeGlance method to its owning object. */
     private fun ownerForName(name: String): Any =
-        if (name.startsWith(CODE_GLANCE_FIELD_PREFIX) ||
-            name == "syncCodeGlanceProViewport" ||
-            name == CODE_GLANCE_METHOD_RESOLUTION
-        ) {
+        if (name == CODE_GLANCE_METHOD_RESOLUTION) {
             CodeGlanceProIntegration
         } else {
             AccentApplicator
@@ -215,16 +204,6 @@ class AccentApplicatorTest {
         val field = owner.javaClass.getDeclaredField(fieldName)
         field.isAccessible = true
         return field.get(owner) as T
-    }
-
-    private fun setPrivateField(
-        fieldName: String,
-        value: Any?,
-    ) {
-        val owner = ownerForName(fieldName)
-        val field = owner.javaClass.getDeclaredField(fieldName)
-        field.isAccessible = true
-        field.set(owner, value)
     }
 
     @Test
@@ -568,27 +547,20 @@ class AccentApplicatorTest {
     fun `CodeGlance Pro viewport sync returns early when integration is disabled`() {
         state.cgpIntegrationEnabled = false
 
-        invokePrivate("syncCodeGlanceProViewport", "#FFCC66")
+        val outcome = CodeGlanceProIntegration.syncCodeGlanceProViewport("#FFCC66")
 
-        // Should not throw. The method-resolution flag can be true from prior tests
-        // because the peer object owns static state, but this branch exits before
-        // doing any work on the config.
-        val service = getPrivateField<Any?>(CODE_GLANCE_SERVICE_FIELD)
-        // The service should be null because no CodeGlance Pro plugin is
-        // installed in tests.
-        assertEquals(null, service)
+        assertEquals(IntegrationOutcome.Skipped, outcome)
+        verify(exactly = 0) { AyuPlugin.findLoadedPlugin(any()) }
     }
 
     @Test
     fun `CodeGlance Pro viewport sync with enabled flag but no plugin does not throw`() {
         state.cgpIntegrationEnabled = true
 
-        // Method resolution tries to find the CodeGlance Pro plugin, which does not
-        // exist in this test harness, so the service stays null and sync returns early.
-        invokePrivate("syncCodeGlanceProViewport", "#FFCC66")
+        val outcome = CodeGlanceProIntegration.syncCodeGlanceProViewport("#FFCC66")
 
-        val service = getPrivateField<Any?>(CODE_GLANCE_SERVICE_FIELD)
-        assertEquals(null, service)
+        assertEquals(IntegrationOutcome.Skipped, outcome)
+        verify(exactly = 1) { AyuPlugin.findLoadedPlugin(any()) }
     }
 
     // revertAlwaysOnEditorKeys
@@ -780,17 +752,12 @@ class AccentApplicatorTest {
     // CodeGlance Pro method resolution.
 
     @Test
-    fun `CodeGlance Pro method resolution sets flag when plugin is missing`() {
-        // Reset the flag first via reflection
+    fun `CodeGlance Pro method resolution checks plugin when cache is empty`() {
         resetCodeGlanceProState()
 
         invokePrivate(CODE_GLANCE_METHOD_RESOLUTION)
 
-        val resolved = getPrivateField<Boolean>(CODE_GLANCE_METHODS_RESOLVED_FIELD)
-        assertTrue(
-            resolved,
-            "CodeGlance Pro methods should be marked resolved after first call",
-        )
+        verify(exactly = 1) { AyuPlugin.findLoadedPlugin(any()) }
     }
 
     @Test
@@ -800,9 +767,7 @@ class AccentApplicatorTest {
         invokePrivate(CODE_GLANCE_METHOD_RESOLUTION)
         invokePrivate(CODE_GLANCE_METHOD_RESOLUTION)
 
-        // Should not throw — second call exits immediately via the guard
-        val resolved = getPrivateField<Boolean>(CODE_GLANCE_METHODS_RESOLVED_FIELD)
-        assertTrue(resolved)
+        verify(exactly = 1) { AyuPlugin.findLoadedPlugin(any()) }
     }
 
     // AttrOverride data class
@@ -830,49 +795,15 @@ class AccentApplicatorTest {
         }
     }
 
-    // CodeGlance Pro viewport sync: various null method fields.
-
-    @Test
-    fun `CodeGlance Pro viewport sync exits early when service is null`() {
-        state.cgpIntegrationEnabled = true
-        setPrivateField(CODE_GLANCE_METHODS_RESOLVED_FIELD, true)
-        // Service left as null.
-
-        invokePrivate("syncCodeGlanceProViewport", "#FFCC66")
-    }
-
-    @Test
-    fun `CodeGlance Pro viewport sync exits early when get-state method is null`() {
-        state.cgpIntegrationEnabled = true
-        setPrivateField(CODE_GLANCE_METHODS_RESOLVED_FIELD, true)
-        setPrivateField(CODE_GLANCE_SERVICE_FIELD, Any())
-
-        invokePrivate("syncCodeGlanceProViewport", "#FFCC66")
-    }
-
-    @Test
-    fun `CodeGlance Pro viewport sync exits early when color setter is null`() {
-        state.cgpIntegrationEnabled = true
-        setPrivateField(CODE_GLANCE_METHODS_RESOLVED_FIELD, true)
-        setPrivateField(CODE_GLANCE_SERVICE_FIELD, Any())
-        setPrivateField(
-            CODE_GLANCE_GET_STATE_FIELD,
-            Any::class.java.getMethod("toString"),
-        )
-
-        invokePrivate("syncCodeGlanceProViewport", "#FFCC66")
-    }
-
     // CodeGlance Pro method resolution: additional scenarios.
 
     @Test
     fun `CodeGlance Pro method resolution skips when already resolved`() {
-        setPrivateField(CODE_GLANCE_METHODS_RESOLVED_FIELD, true)
+        seedCodeGlanceMethods(Any(), mockk(relaxed = true), Any())
 
         invokePrivate(CODE_GLANCE_METHOD_RESOLUTION)
 
-        val service = getPrivateField<Any?>(CODE_GLANCE_SERVICE_FIELD)
-        assertEquals(null, service)
+        verify(exactly = 0) { AyuPlugin.findLoadedPlugin(any()) }
     }
 
     @Test
@@ -883,9 +814,8 @@ class AccentApplicatorTest {
 
         invokePrivate(CODE_GLANCE_METHOD_RESOLUTION)
 
-        val service = getPrivateField<Any?>(CODE_GLANCE_SERVICE_FIELD)
-        assertEquals(null, service)
-        assertTrue(getPrivateField(CODE_GLANCE_METHODS_RESOLVED_FIELD))
+        verify(exactly = 1) { AyuPlugin.findLoadedPlugin(any()) }
+        verify(exactly = 1) { mockPlugin.pluginClassLoader }
     }
 
     // Field constant verification
@@ -1860,47 +1790,57 @@ class AccentApplicatorTest {
         return element
     }
 
+    private fun seedCodeGlanceMethods(
+        service: Any,
+        getState: Method,
+        config: Any,
+    ): CodeGlanceProIntegration.CgpViewportMethods {
+        val viewport = viewportMethods(config)
+        CodeGlanceProIntegration.seedReflectionMethods(
+            CodeGlanceProIntegration.CgpMethods(
+                service = service,
+                getState = getState,
+                viewport = viewport,
+            ),
+        )
+        return viewport
+    }
+
+    private fun viewportMethods(config: Any): CodeGlanceProIntegration.CgpViewportMethods {
+        val viewport =
+            CodeGlanceProIntegration.CgpViewportMethods(
+                getColor = mockk(relaxed = true),
+                getBorder = mockk(relaxed = true),
+                getThickness = mockk(relaxed = true),
+                setColor = mockk(relaxed = true),
+                setBorder = mockk(relaxed = true),
+                setThickness = mockk(relaxed = true),
+            )
+        every { viewport.getColor.invoke(config) } returns "123456"
+        every { viewport.getBorder.invoke(config) } returns "654321"
+        every { viewport.getThickness.invoke(config) } returns 2
+        return viewport
+    }
+
     // Tests for syncCodeGlanceProViewport full flow
 
     @Test
     fun `syncCodeGlanceProViewport full flow with all methods resolved`() {
         state.cgpIntegrationEnabled = true
 
-        // Set up mock CGP service and methods
         val mockConfig = Any()
         val mockService = Any()
         val mockGetState = mockk<Method>(relaxed = true)
-        val mockGetColor = mockk<Method>(relaxed = true)
-        val mockGetBorderColor = mockk<Method>(relaxed = true)
-        val mockGetBorderThickness = mockk<Method>(relaxed = true)
-        val mockSetColor = mockk<Method>(relaxed = true)
-        val mockSetBorderColor = mockk<Method>(relaxed = true)
-        val mockSetBorderThickness = mockk<Method>(relaxed = true)
+        val viewport = seedCodeGlanceMethods(mockService, mockGetState, mockConfig)
 
         every { mockGetState.invoke(any()) } returns mockConfig
-        every { mockGetColor.invoke(mockConfig) } returns "123456"
-        every { mockGetBorderColor.invoke(mockConfig) } returns "654321"
-        every { mockGetBorderThickness.invoke(mockConfig) } returns 2
-        every { mockSetColor.invoke(any(), any()) } returns null
-        every { mockSetBorderColor.invoke(any(), any()) } returns null
-        every { mockSetBorderThickness.invoke(any(), any()) } returns null
+        val outcome = CodeGlanceProIntegration.syncCodeGlanceProViewport("#FFCC66")
 
-        setPrivateField(CODE_GLANCE_METHODS_RESOLVED_FIELD, true)
-        setPrivateField(CODE_GLANCE_SERVICE_FIELD, mockService)
-        setPrivateField(CODE_GLANCE_GET_STATE_FIELD, mockGetState)
-        setPrivateField(CGP_GET_COLOR_FIELD, mockGetColor)
-        setPrivateField(CGP_GET_BORDER_FIELD, mockGetBorderColor)
-        setPrivateField(CGP_GET_THICKNESS_FIELD, mockGetBorderThickness)
-        setPrivateField(CODE_GLANCE_SET_COLOR_FIELD, mockSetColor)
-        setPrivateField(CODE_GLANCE_SET_BORDER_COLOR_FIELD, mockSetBorderColor)
-        setPrivateField(CODE_GLANCE_SET_BORDER_THICKNESS_FIELD, mockSetBorderThickness)
-
-        invokePrivate("syncCodeGlanceProViewport", "#FFCC66")
-
+        assertEquals(IntegrationOutcome.Applied, outcome)
         verify { mockGetState.invoke(mockService) }
-        verify { mockSetColor.invoke(mockConfig, ACCENT_HEX_STRIPPED) }
-        verify { mockSetBorderColor.invoke(mockConfig, ACCENT_HEX_STRIPPED) }
-        verify { mockSetBorderThickness.invoke(mockConfig, 1) }
+        verify { viewport.setColor.invoke(mockConfig, ACCENT_HEX_STRIPPED) }
+        verify { viewport.setBorder.invoke(mockConfig, ACCENT_HEX_STRIPPED) }
+        verify { viewport.setThickness.invoke(mockConfig, 1) }
     }
 
     @Test
@@ -1918,35 +1858,18 @@ class AccentApplicatorTest {
         val mockConfig = Any()
         val mockService = Any()
         val mockGetState = mockk<Method>(relaxed = true)
-        val mockGetColor = mockk<Method>(relaxed = true)
-        val mockGetBorderColor = mockk<Method>(relaxed = true)
-        val mockGetBorderThickness = mockk<Method>(relaxed = true)
-        val mockSetColor = mockk<Method>(relaxed = true)
-        val mockSetBorderColor = mockk<Method>(relaxed = true)
-        val mockSetBorderThickness = mockk<Method>(relaxed = true)
+        val viewport = seedCodeGlanceMethods(mockService, mockGetState, mockConfig)
         every { mockGetState.invoke(any()) } returns mockConfig
-        every { mockGetColor.invoke(mockConfig) } returns ACCENT_HEX_STRIPPED
-        every { mockGetBorderColor.invoke(mockConfig) } returns ACCENT_HEX_STRIPPED
-        every { mockGetBorderThickness.invoke(mockConfig) } returns 1
-        every { mockSetColor.invoke(any(), any()) } returns null
-        every { mockSetBorderColor.invoke(any(), any()) } returns null
-        every { mockSetBorderThickness.invoke(any(), any()) } returns null
+        every { viewport.getColor.invoke(mockConfig) } returns ACCENT_HEX_STRIPPED
+        every { viewport.getBorder.invoke(mockConfig) } returns ACCENT_HEX_STRIPPED
+        every { viewport.getThickness.invoke(mockConfig) } returns 1
 
-        setPrivateField(CODE_GLANCE_METHODS_RESOLVED_FIELD, true)
-        setPrivateField(CODE_GLANCE_SERVICE_FIELD, mockService)
-        setPrivateField(CODE_GLANCE_GET_STATE_FIELD, mockGetState)
-        setPrivateField(CGP_GET_COLOR_FIELD, mockGetColor)
-        setPrivateField(CGP_GET_BORDER_FIELD, mockGetBorderColor)
-        setPrivateField(CGP_GET_THICKNESS_FIELD, mockGetBorderThickness)
-        setPrivateField(CODE_GLANCE_SET_COLOR_FIELD, mockSetColor)
-        setPrivateField(CODE_GLANCE_SET_BORDER_COLOR_FIELD, mockSetBorderColor)
-        setPrivateField(CODE_GLANCE_SET_BORDER_THICKNESS_FIELD, mockSetBorderThickness)
+        val outcome = CodeGlanceProIntegration.syncCodeGlanceProViewport("#FFCC66")
 
-        invokePrivate("syncCodeGlanceProViewport", "#FFCC66")
-
-        verify { mockSetColor.invoke(mockConfig, "123456") }
-        verify { mockSetBorderColor.invoke(mockConfig, "654321") }
-        verify { mockSetBorderThickness.invoke(mockConfig, 2) }
+        assertEquals(IntegrationOutcome.Restored, outcome)
+        verify { viewport.setColor.invoke(mockConfig, "123456") }
+        verify { viewport.setBorder.invoke(mockConfig, "654321") }
+        verify { viewport.setThickness.invoke(mockConfig, 2) }
         assertTrue(state.cgpIntegrationEnabled)
     }
 
@@ -1957,35 +1880,13 @@ class AccentApplicatorTest {
         val mockConfig = Any()
         val mockService = Any()
         val mockGetState = mockk<Method>(relaxed = true)
-        val mockGetColor = mockk<Method>(relaxed = true)
-        val mockGetBorderColor = mockk<Method>(relaxed = true)
-        val mockGetBorderThickness = mockk<Method>(relaxed = true)
-        val mockSetColor = mockk<Method>(relaxed = true)
-        val mockSetBorderColor = mockk<Method>(relaxed = true)
-        val mockSetBorderThickness = mockk<Method>(relaxed = true)
+        val viewport = seedCodeGlanceMethods(mockService, mockGetState, mockConfig)
 
         every { mockGetState.invoke(any()) } returns mockConfig
-        every { mockGetColor.invoke(mockConfig) } returns "123456"
-        every { mockGetBorderColor.invoke(mockConfig) } returns "654321"
-        every { mockGetBorderThickness.invoke(mockConfig) } returns 2
-        every { mockSetColor.invoke(any(), any()) } returns null
-        every { mockSetBorderColor.invoke(any(), any()) } returns null
-        every { mockSetBorderThickness.invoke(any(), any()) } returns null
+        val outcome = CodeGlanceProIntegration.syncCodeGlanceProViewport("#E6B450")
 
-        setPrivateField(CODE_GLANCE_METHODS_RESOLVED_FIELD, true)
-        setPrivateField(CODE_GLANCE_SERVICE_FIELD, mockService)
-        setPrivateField(CODE_GLANCE_GET_STATE_FIELD, mockGetState)
-        setPrivateField(CGP_GET_COLOR_FIELD, mockGetColor)
-        setPrivateField(CGP_GET_BORDER_FIELD, mockGetBorderColor)
-        setPrivateField(CGP_GET_THICKNESS_FIELD, mockGetBorderThickness)
-        setPrivateField(CODE_GLANCE_SET_COLOR_FIELD, mockSetColor)
-        setPrivateField(CODE_GLANCE_SET_BORDER_COLOR_FIELD, mockSetBorderColor)
-        setPrivateField(CODE_GLANCE_SET_BORDER_THICKNESS_FIELD, mockSetBorderThickness)
-
-        invokePrivate("syncCodeGlanceProViewport", "#E6B450")
-
-        // Verify the hash was stripped
-        verify { mockSetColor.invoke(mockConfig, "E6B450") }
+        assertEquals(IntegrationOutcome.Applied, outcome)
+        verify { viewport.setColor.invoke(mockConfig, "E6B450") }
     }
 
     @Test
@@ -1994,23 +1895,14 @@ class AccentApplicatorTest {
 
         val mockService = Any()
         val mockGetState = mockk<Method>(relaxed = true)
-        val mockSetColor = mockk<Method>(relaxed = true)
-        val mockSetBorderColor = mockk<Method>(relaxed = true)
-        val mockSetBorderThickness = mockk<Method>(relaxed = true)
+        val viewport = seedCodeGlanceMethods(mockService, mockGetState, Any())
 
         every { mockGetState.invoke(any()) } returns null
 
-        setPrivateField(CODE_GLANCE_METHODS_RESOLVED_FIELD, true)
-        setPrivateField(CODE_GLANCE_SERVICE_FIELD, mockService)
-        setPrivateField(CODE_GLANCE_GET_STATE_FIELD, mockGetState)
-        setPrivateField(CODE_GLANCE_SET_COLOR_FIELD, mockSetColor)
-        setPrivateField(CODE_GLANCE_SET_BORDER_COLOR_FIELD, mockSetBorderColor)
-        setPrivateField(CODE_GLANCE_SET_BORDER_THICKNESS_FIELD, mockSetBorderThickness)
+        val outcome = CodeGlanceProIntegration.syncCodeGlanceProViewport("#FFCC66")
 
-        invokePrivate("syncCodeGlanceProViewport", "#FFCC66")
-
-        // setColor should not be called since config is null
-        verify(exactly = 0) { mockSetColor.invoke(any(), any()) }
+        assertEquals(IntegrationOutcome.Skipped, outcome)
+        verify(exactly = 0) { viewport.setColor.invoke(any(), any()) }
     }
 
     @Test
@@ -2020,23 +1912,15 @@ class AccentApplicatorTest {
         val mockConfig = Any()
         val mockService = Any()
         val mockGetState = mockk<Method>(relaxed = true)
-        val mockSetColor = mockk<Method>(relaxed = true)
-        val mockSetBorderColor = mockk<Method>(relaxed = true)
-        val mockSetBorderThickness = mockk<Method>(relaxed = true)
+        val viewport = seedCodeGlanceMethods(mockService, mockGetState, mockConfig)
 
         every { mockGetState.invoke(any()) } returns mockConfig
-        every { mockSetColor.invoke(any(), any()) } throws
+        every { viewport.setColor.invoke(any(), any()) } throws
             java.lang.reflect.InvocationTargetException(RuntimeException("inner"))
 
-        setPrivateField(CODE_GLANCE_METHODS_RESOLVED_FIELD, true)
-        setPrivateField(CODE_GLANCE_SERVICE_FIELD, mockService)
-        setPrivateField(CODE_GLANCE_GET_STATE_FIELD, mockGetState)
-        setPrivateField(CODE_GLANCE_SET_COLOR_FIELD, mockSetColor)
-        setPrivateField(CODE_GLANCE_SET_BORDER_COLOR_FIELD, mockSetBorderColor)
-        setPrivateField(CODE_GLANCE_SET_BORDER_THICKNESS_FIELD, mockSetBorderThickness)
+        val outcome = CodeGlanceProIntegration.syncCodeGlanceProViewport("#FFCC66")
 
-        // Should not throw
-        invokePrivate("syncCodeGlanceProViewport", "#FFCC66")
+        assertTrue(outcome is IntegrationOutcome.Failed)
     }
 
     @Test
@@ -2046,22 +1930,14 @@ class AccentApplicatorTest {
         val mockConfig = Any()
         val mockService = Any()
         val mockGetState = mockk<Method>(relaxed = true)
-        val mockSetColor = mockk<Method>(relaxed = true)
-        val mockSetBorderColor = mockk<Method>(relaxed = true)
-        val mockSetBorderThickness = mockk<Method>(relaxed = true)
+        val viewport = seedCodeGlanceMethods(mockService, mockGetState, mockConfig)
 
         every { mockGetState.invoke(any()) } returns mockConfig
-        every { mockSetColor.invoke(any(), any()) } throws RuntimeException("CGP exploded")
+        every { viewport.setColor.invoke(any(), any()) } throws RuntimeException("CGP exploded")
 
-        setPrivateField(CODE_GLANCE_METHODS_RESOLVED_FIELD, true)
-        setPrivateField(CODE_GLANCE_SERVICE_FIELD, mockService)
-        setPrivateField(CODE_GLANCE_GET_STATE_FIELD, mockGetState)
-        setPrivateField(CODE_GLANCE_SET_COLOR_FIELD, mockSetColor)
-        setPrivateField(CODE_GLANCE_SET_BORDER_COLOR_FIELD, mockSetBorderColor)
-        setPrivateField(CODE_GLANCE_SET_BORDER_THICKNESS_FIELD, mockSetBorderThickness)
+        val outcome = CodeGlanceProIntegration.syncCodeGlanceProViewport("#FFCC66")
 
-        // Should not throw
-        invokePrivate("syncCodeGlanceProViewport", "#FFCC66")
+        assertTrue(outcome is IntegrationOutcome.Failed)
     }
 
     // Helpers
@@ -2346,25 +2222,7 @@ class AccentApplicatorTest {
     private companion object {
         private const val ACCENT_HEX_STRIPPED = "FFCC66"
         private const val EXTERNAL_CHROME_TEST_KEY = "Ayu.Test.externalChrome"
-        private const val CODE_GLANCE_FIELD_PREFIX = "c" + "g" + "p"
         private const val CODE_GLANCE_METHOD_RESOLUTION =
             "resolve" + "C" + "g" + "p" + "Methods"
-        private const val CODE_GLANCE_SERVICE_FIELD = CODE_GLANCE_FIELD_PREFIX + "Service"
-        private const val CODE_GLANCE_GET_STATE_FIELD =
-            CODE_GLANCE_FIELD_PREFIX + "GetState"
-        private const val CGP_GET_COLOR_FIELD =
-            CODE_GLANCE_FIELD_PREFIX + "GetColor"
-        private const val CGP_GET_BORDER_FIELD =
-            CODE_GLANCE_FIELD_PREFIX + "GetBorder"
-        private const val CGP_GET_THICKNESS_FIELD =
-            CODE_GLANCE_FIELD_PREFIX + "GetThickness"
-        private const val CODE_GLANCE_SET_COLOR_FIELD =
-            CODE_GLANCE_FIELD_PREFIX + "SetColor"
-        private const val CODE_GLANCE_SET_BORDER_COLOR_FIELD =
-            CODE_GLANCE_FIELD_PREFIX + "SetBorder"
-        private const val CODE_GLANCE_SET_BORDER_THICKNESS_FIELD =
-            CODE_GLANCE_FIELD_PREFIX + "SetThickness"
-        private const val CODE_GLANCE_METHODS_RESOLVED_FIELD =
-            CODE_GLANCE_FIELD_PREFIX + "MethodsResolved"
     }
 }


### PR DESCRIPTION
── Summary ─────────────────────────────────

The CodeGlance Pro integration cached eight reflection handles independently, which allowed impossible partial states and forced tests to mutate private fields by name. Consolidate those handles into one immutable bundle so resolution is all-or-nothing while preserving runtime behavior.

── Changes ─────────────────────────────────

| Type | File | Description |
|------|------|-------------|
| Refactor | [CodeGlanceProIntegration.kt:80](src/main/kotlin/dev/ayuislands/accent/CodeGlanceProIntegration.kt#L80) | Cache the service and reflection methods as one typed snapshot. |
| Test | [AccentApplicatorRevertAllIntegrationTest.kt:1168](src/test/kotlin/dev/ayuislands/accent/AccentApplicatorRevertAllIntegrationTest.kt#L1168) | Replace raw private-field writes with the typed test seam. |
| Test | [AccentApplicatorTest.kt:1793](src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt#L1793) | Assert observable outcomes and remove impossible partial-cache scenarios. |
| Docs | [features.yml:105](docs/features.yml#L105) | Refresh screenshot verification stamps after the preceding squash merge and this source change. |

── Validation ──────────────────────────────

- `./gradlew test --tests 'dev.ayuislands.accent.AccentApplicatorTest'` — passed.
- `./gradlew test integrationTest koverXmlReport koverVerify` — passed in 9m 1s.
- `./gradlew detekt ktlintCheck` — passed.
- `scripts/verify-docs.py` — passed.
- IntelliJ inspections on the three touched Kotlin files — no findings.
- `CodeGlanceProIntegration` line coverage — 167/194 lines (86.1%).

── Notes ───────────────────────────────────

No premium entitlement, licensing gate, or user preference behavior changes. Review focus: the atomic assignment in `resolveCgpMethods`, cache reset behavior, and the typed test-only seed.

## Summary by Sourcery

Refactor the CodeGlance Pro reflection cache into a single immutable bundle and update tests and docs to align with the new atomic caching model.

Enhancements:
- Replace multiple volatile CodeGlance Pro reflection fields with a single typed CgpMethods bundle and viewport method struct.
- Add a test-only seedReflectionMethods seam to initialize the CodeGlance Pro cache without direct private-field mutation.
- Simplify the reflection cache reset logic to clear the unified bundle and resolution state.

Documentation:
- Refresh screenshot verification metadata in docs/features.yml to reflect the updated accent and integration sources.

Tests:
- Rewrite CodeGlance Pro integration tests to drive sync and resolve flows via public integration methods and outcomes instead of raw field access.
- Introduce shared helpers for seeding mock CodeGlance Pro methods and tighten expectations around plugin lookup and integration outcomes.
- Remove tests that depended on impossible partial-cache states now that method caching is atomic.