### PR TITLE
docs(features): bind post-merge accent verification

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "200e99ac"
+          last_verified_sha: "08679b04"
           last_verified_date: "2026-07-30"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "200e99ac"
+          last_verified_sha: "08679b04"
           last_verified_date: "2026-07-30"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 


### PR DESCRIPTION
── Summary ─────────────────────────────────

Rebind the accent feature verification stamps after PR #299 was squash-merged.
The previous source commit became unreachable from `main`, so the documentation verifier requires the stamps to point at the exact merge commit.

── Changes ─────────────────────────────────

| Type | File | Description |
|------|------|-------------|
| Docs | [features.yml](docs/features.yml) | Bind the project- and language-scoped accent verification entries to `08679b04`. |

── Validation ──────────────────────────────

- `scripts/verify-docs.py` — passed; manifest is in sync with README, plugin.xml, and CHANGELOG.
- `git diff --check` — passed.
- Pre-commit and commit-msg hooks — passed, including YAML validation and documentation sync.

── Notes ───────────────────────────────────

This is the required post-squash restamp only; plugin source and runtime behavior are unchanged.

## Summary by Sourcery

Documentation:
- Retarget accent feature verification entries in docs/features.yml to the new merge commit SHA for project- and language-scoped entries.