### PR TITLE
fix(editor): preserve user-owned scheme values

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "222b3428"
+          last_verified_sha: "a40196c7"
           last_verified_date: "2026-08-02"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "222b3428"
+          last_verified_sha: "a40196c7"
           last_verified_date: "2026-08-02"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "8cb453f3"
+          last_verified_sha: "c47591c7"
           last_verified_date: "2026-08-02"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "8cb453f3"
+          last_verified_sha: "c47591c7"
           last_verified_date: "2026-08-02"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "c6e14a97"
+          last_verified_sha: "222b3428"
           last_verified_date: "2026-08-02"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "c6e14a97"
+          last_verified_sha: "222b3428"
           last_verified_date: "2026-08-02"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,8 +105,8 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "08679b04"
-          last_verified_date: "2026-07-30"
+          last_verified_sha: "db5f5771"
+          last_verified_date: "2026-08-02"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
       - id: accent-scoped-language
@@ -127,8 +127,8 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "08679b04"
-          last_verified_date: "2026-07-30"
+          last_verified_sha: "db5f5771"
+          last_verified_date: "2026-08-02"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
       - id: accent-language-breakdown

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "a40196c7"
+          last_verified_sha: "68df7123"
           last_verified_date: "2026-08-02"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "a40196c7"
+          last_verified_sha: "68df7123"
           last_verified_date: "2026-08-02"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "6eb6a779"
+          last_verified_sha: "e6e159bb"
           last_verified_date: "2026-08-02"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "6eb6a779"
+          last_verified_sha: "e6e159bb"
           last_verified_date: "2026-08-02"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "db5f5771"
+          last_verified_sha: "c6e14a97"
           last_verified_date: "2026-08-02"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "db5f5771"
+          last_verified_sha: "c6e14a97"
           last_verified_date: "2026-08-02"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "c47591c7"
+          last_verified_sha: "6eb6a779"
           last_verified_date: "2026-08-02"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "c47591c7"
+          last_verified_sha: "6eb6a779"
           last_verified_date: "2026-08-02"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "68df7123"
+          last_verified_sha: "8cb453f3"
           last_verified_date: "2026-08-02"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "68df7123"
+          last_verified_sha: "8cb453f3"
           last_verified_date: "2026-08-02"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -534,6 +534,7 @@ object AccentApplicator {
                 log.warn("Accent revert step $step failed; remaining steps still ran", error)
             }
         }
+        AyuEditorSchemeScope.releaseAccentClaims()
     }
 
     private fun clearReverseUiAndExtensions() {
@@ -705,7 +706,7 @@ object AccentApplicator {
     }
 
     private fun applyAlwaysOnEditorKeys(accent: Color) {
-        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
+        val scheme = AyuEditorSchemeScope.claimActiveScheme() ?: return
 
         // ColorKey entries
         for (colorKey in ALWAYS_ON_EDITOR_COLOR_KEYS) {
@@ -757,7 +758,7 @@ object AccentApplicator {
             ExternalChromeOwnership.releaseTabUnderline()
         }
         if (tabMode == GlowTabMode.OFF && variant != null) {
-            AyuEditorSchemeScope.activeScheme()?.setColor(
+            AyuEditorSchemeScope.claimActiveScheme()?.setColor(
                 ColorKey.find("TAB_UNDERLINE"),
                 Color.decode(variant.neutralGray),
             )
@@ -781,18 +782,21 @@ object AccentApplicator {
     }
 
     private fun revertAlwaysOnEditorKeys() {
-        val scheme = AyuEditorSchemeScope.ownedScheme() ?: return
+        val schemes = AyuEditorSchemeScope.claimedAccentSchemes()
+        if (schemes.isEmpty()) return
 
-        for (colorKey in ALWAYS_ON_EDITOR_COLOR_KEYS) {
-            scheme.setColor(colorKey, null)
-        }
+        for (scheme in schemes) {
+            for (colorKey in ALWAYS_ON_EDITOR_COLOR_KEYS) {
+                scheme.setColor(colorKey, null)
+            }
 
-        for ((key) in ALWAYS_ON_EDITOR_ATTR_OVERRIDES) {
-            val attrKey = TextAttributesKey.find(key)
-            val fallback = attrKey.fallbackAttributeKey
-            val defaultAttrs =
-                if (fallback != null) scheme.getAttributes(fallback) else null
-            scheme.setAttributes(attrKey, defaultAttrs ?: EMPTY_TEXT_ATTRIBUTES)
+            for ((key) in ALWAYS_ON_EDITOR_ATTR_OVERRIDES) {
+                val attrKey = TextAttributesKey.find(key)
+                val fallback = attrKey.fallbackAttributeKey
+                val defaultAttrs =
+                    if (fallback != null) scheme.getAttributes(fallback) else null
+                scheme.setAttributes(attrKey, defaultAttrs ?: EMPTY_TEXT_ATTRIBUTES)
+            }
         }
 
         val application = ApplicationManager.getApplication()

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -67,6 +67,16 @@ object AccentApplicator {
     private const val KEY_TAB_UNDERLINE_HEIGHT = "EditorTabs.underlineHeight"
     private const val KEY_TAB_UNDERLINE_ARC = "EditorTabs.underlineArc"
     private const val DEFAULT_UNDERLINE_ARC = 8
+    private val EDITOR_SCHEME_ELEMENTS =
+        setOf(
+            AccentElementId.INLAY_HINTS,
+            AccentElementId.CARET_ROW,
+            AccentElementId.PROGRESS_BAR,
+            AccentElementId.SCROLLBAR,
+            AccentElementId.LINKS,
+            AccentElementId.BRACKET_MATCH,
+            AccentElementId.MATCHING_TAG,
+        )
     private val TRANSPARENT_TAB_BACKGROUND =
         JBColor(
             ColorUtil.toAlpha(JBColor.BLACK, 0),
@@ -498,9 +508,30 @@ object AccentApplicator {
         val workers: Map<AccentApplyStep, () -> Unit> =
             buildMap {
                 put(AccentApplyStep.ClearUiAndExtensions) {
-                    clearReverseUiAndExtensions()?.let { throw it }
+                    AyuEditorSchemeScope.beginAccentCleanup()
+                    val clearResult = runCatchingPreservingCancellation { clearReverseUiAndExtensions() }
+                    clearResult.exceptionOrNull()?.let { error ->
+                        AyuEditorSchemeScope.retainAllAccentClaims()
+                        throw error
+                    }
+                    val failure = clearResult.getOrThrow()
+                    if (failure != null) {
+                        val hasUnattributedEditorFailure =
+                            failure.elementIds.any { it in EDITOR_SCHEME_ELEMENTS } &&
+                                !AyuEditorSchemeScope.hasAccentCleanupFailures()
+                        if (hasUnattributedEditorFailure) {
+                            AyuEditorSchemeScope.retainAllAccentClaims()
+                        }
+                        throw failure
+                    }
                 }
-                put(AccentApplyStep.RevertAlwaysOnEditorKeys) { revertAlwaysOnEditorKeys() }
+                put(AccentApplyStep.RevertAlwaysOnEditorKeys) {
+                    try {
+                        revertAlwaysOnEditorKeys()
+                    } finally {
+                        AyuEditorSchemeScope.releaseCleanAccentClaims()
+                    }
+                }
                 put(AccentApplyStep.RevertIndentRainbow) {
                     IndentRainbowSync.revert().propagateFailure()
                 }
@@ -535,18 +566,10 @@ object AccentApplicator {
             for ((step, error) in failures) {
                 log.warn("Accent revert step $step failed; remaining steps still ran", error)
             }
-            val editorCleanupFailed =
-                failures.any { failure ->
-                    failure.step == AccentApplyStep.ClearUiAndExtensions ||
-                        failure.step == AccentApplyStep.RevertAlwaysOnEditorKeys
-                }
-            if (!editorCleanupFailed) {
-                AyuEditorSchemeScope.releaseAccentClaims()
-            }
         }
     }
 
-    private fun clearReverseUiAndExtensions(): RuntimeException? {
+    private fun clearReverseUiAndExtensions(): ElementRevertFailure? {
         for (key in ALWAYS_ON_UI_KEYS) {
             UIManager.put(key, null)
         }
@@ -562,21 +585,18 @@ object AccentApplicator {
         ExternalChromeOwnership.releaseTabUnderline()
 
         val failedExternalReverts = mutableSetOf<AccentElementId>()
-        var firstFailure: RuntimeException? = null
+        var firstFailure: Throwable? = null
         for (element in EP_NAME.extensionList) {
-            try {
-                element.revert()
-            } catch (exception: RuntimeException) {
-                failedExternalReverts.add(element.id)
-                if (firstFailure == null) firstFailure = exception
-                log.warn(
-                    "Failed to revert ${element.displayName}",
-                    exception,
-                )
-            }
+            val failure = runCatchingPreservingCancellation { element.revert() }.exceptionOrNull() ?: continue
+            failedExternalReverts.add(element.id)
+            if (firstFailure == null) firstFailure = failure
+            log.warn(
+                "Failed to revert ${element.displayName}",
+                failure,
+            )
         }
         ExternalChromeOwnership.finishRevert(failedExternalReverts)
-        return firstFailure
+        return firstFailure?.let { ElementRevertFailure(failedExternalReverts, it) }
     }
 
     private fun neutralizeOrRevert(
@@ -794,10 +814,9 @@ object AccentApplicator {
     }
 
     private fun revertAlwaysOnEditorKeys() {
-        val schemes = AyuEditorSchemeScope.claimedAccentSchemes()
-        if (schemes.isEmpty()) return
+        if (AyuEditorSchemeScope.claimedAccentSchemes().isEmpty()) return
 
-        for (scheme in schemes) {
+        AyuEditorSchemeScope.cleanClaimedAccentSchemes { scheme ->
             for (colorKey in ALWAYS_ON_EDITOR_COLOR_KEYS) {
                 scheme.setColor(colorKey, null)
             }
@@ -819,6 +838,11 @@ object AccentApplicator {
                 .globalSchemeChange(null)
         }
     }
+
+    private class ElementRevertFailure(
+        val elementIds: Set<AccentElementId>,
+        cause: Throwable,
+    ) : RuntimeException(cause)
 
     /**
      * Write-side repaint pass over the JVM's window list. Filters by

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -743,11 +743,11 @@ object AccentApplicator {
     }
 
     private fun applyAlwaysOnEditorKeys(accent: Color) {
-        val scheme = AyuEditorSchemeScope.claimActiveScheme() ?: return
+        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
 
         // ColorKey entries
         for (colorKey in ALWAYS_ON_EDITOR_COLOR_KEYS) {
-            AyuEditorSchemeScope.writeColor(alwaysOnOwner, colorKey, accent)
+            AyuEditorSchemeScope.writeColor(scheme, alwaysOnOwner, colorKey, accent)
         }
 
         // TextAttributesKey entries -- clone existing, override only accent properties
@@ -758,7 +758,7 @@ object AccentApplicator {
             if (AttributeTarget.FOREGROUND in targets) updated.foregroundColor = accent
             if (AttributeTarget.EFFECT_COLOR in targets) updated.effectColor = accent
             if (AttributeTarget.ERROR_STRIPE in targets) updated.errorStripeColor = accent
-            AyuEditorSchemeScope.writeAttributes(alwaysOnOwner, attrKey, updated)
+            AyuEditorSchemeScope.writeAttributes(scheme, alwaysOnOwner, attrKey, updated)
         }
 
         // Notify editors to repaint with an updated scheme
@@ -795,11 +795,15 @@ object AccentApplicator {
             ExternalChromeOwnership.releaseTabUnderline()
         }
         if (tabMode == GlowTabMode.OFF && variant != null) {
-            AyuEditorSchemeScope.writeColor(
-                alwaysOnOwner,
-                ColorKey.find("TAB_UNDERLINE"),
-                Color.decode(variant.neutralGray),
-            )
+            val scheme = AyuEditorSchemeScope.activeScheme()
+            if (scheme != null) {
+                AyuEditorSchemeScope.writeColor(
+                    scheme,
+                    alwaysOnOwner,
+                    ColorKey.find("TAB_UNDERLINE"),
+                    Color.decode(variant.neutralGray),
+                )
+            }
         }
 
         val height =

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -497,7 +497,9 @@ object AccentApplicator {
         // everything after the theme switch.
         val workers: Map<AccentApplyStep, () -> Unit> =
             buildMap {
-                put(AccentApplyStep.ClearUiAndExtensions) { clearReverseUiAndExtensions() }
+                put(AccentApplyStep.ClearUiAndExtensions) {
+                    clearReverseUiAndExtensions()?.let { throw it }
+                }
                 put(AccentApplyStep.RevertAlwaysOnEditorKeys) { revertAlwaysOnEditorKeys() }
                 put(AccentApplyStep.RevertIndentRainbow) {
                     IndentRainbowSync.revert().propagateFailure()
@@ -533,11 +535,18 @@ object AccentApplicator {
             for ((step, error) in failures) {
                 log.warn("Accent revert step $step failed; remaining steps still ran", error)
             }
+            val editorCleanupFailed =
+                failures.any { failure ->
+                    failure.step == AccentApplyStep.ClearUiAndExtensions ||
+                        failure.step == AccentApplyStep.RevertAlwaysOnEditorKeys
+                }
+            if (!editorCleanupFailed) {
+                AyuEditorSchemeScope.releaseAccentClaims()
+            }
         }
-        AyuEditorSchemeScope.releaseAccentClaims()
     }
 
-    private fun clearReverseUiAndExtensions() {
+    private fun clearReverseUiAndExtensions(): RuntimeException? {
         for (key in ALWAYS_ON_UI_KEYS) {
             UIManager.put(key, null)
         }
@@ -553,11 +562,13 @@ object AccentApplicator {
         ExternalChromeOwnership.releaseTabUnderline()
 
         val failedExternalReverts = mutableSetOf<AccentElementId>()
+        var firstFailure: RuntimeException? = null
         for (element in EP_NAME.extensionList) {
             try {
                 element.revert()
             } catch (exception: RuntimeException) {
                 failedExternalReverts.add(element.id)
+                if (firstFailure == null) firstFailure = exception
                 log.warn(
                     "Failed to revert ${element.displayName}",
                     exception,
@@ -565,6 +576,7 @@ object AccentApplicator {
             }
         }
         ExternalChromeOwnership.finishRevert(failedExternalReverts)
+        return firstFailure
     }
 
     private fun neutralizeOrRevert(

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -781,7 +781,7 @@ object AccentApplicator {
     }
 
     private fun revertAlwaysOnEditorKeys() {
-        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
+        val scheme = AyuEditorSchemeScope.ownedScheme() ?: return
 
         for (colorKey in ALWAYS_ON_EDITOR_COLOR_KEYS) {
             scheme.setColor(colorKey, null)

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -26,6 +26,7 @@ import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
+import dev.ayuislands.theme.AyuEditorSchemeScope
 import dev.ayuislands.ui.ComponentTreeRefresher
 import org.jetbrains.annotations.TestOnly
 import java.awt.Color
@@ -704,7 +705,7 @@ object AccentApplicator {
     }
 
     private fun applyAlwaysOnEditorKeys(accent: Color) {
-        val scheme = EditorColorsManager.getInstance().globalScheme
+        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
 
         // ColorKey entries
         for (colorKey in ALWAYS_ON_EDITOR_COLOR_KEYS) {
@@ -756,8 +757,10 @@ object AccentApplicator {
             ExternalChromeOwnership.releaseTabUnderline()
         }
         if (tabMode == GlowTabMode.OFF && variant != null) {
-            val scheme = EditorColorsManager.getInstance().globalScheme
-            scheme.setColor(ColorKey.find("TAB_UNDERLINE"), Color.decode(variant.neutralGray))
+            AyuEditorSchemeScope.activeScheme()?.setColor(
+                ColorKey.find("TAB_UNDERLINE"),
+                Color.decode(variant.neutralGray),
+            )
         }
 
         val height =
@@ -778,7 +781,7 @@ object AccentApplicator {
     }
 
     private fun revertAlwaysOnEditorKeys() {
-        val scheme = EditorColorsManager.getInstance().globalScheme
+        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
 
         for (colorKey in ALWAYS_ON_EDITOR_COLOR_KEYS) {
             scheme.setColor(colorKey, null)

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -515,16 +515,14 @@ object AccentApplicator {
                         AyuEditorSchemeScope.retainAllAccentClaims()
                         throw error
                     }
-                    val failure = clearResult.getOrThrow()
-                    if (failure != null) {
-                        val hasUnattributedEditorFailure =
-                            failure.elementIds.any { it in EDITOR_SCHEME_ELEMENTS } &&
-                                !AyuEditorSchemeScope.hasAccentCleanupFailures()
-                        if (hasUnattributedEditorFailure) {
-                            AyuEditorSchemeScope.retainAllAccentClaims()
-                        }
-                        throw failure
+                    val failure = clearResult.getOrThrow() ?: return@put
+                    val hasUnattributedEditorFailure =
+                        failure.elementIds.any { it in EDITOR_SCHEME_ELEMENTS } &&
+                            !AyuEditorSchemeScope.hasAccentCleanupFailures()
+                    if (hasUnattributedEditorFailure) {
+                        AyuEditorSchemeScope.retainAllAccentClaims()
                     }
+                    throw failure
                 }
                 put(AccentApplyStep.RevertAlwaysOnEditorKeys) {
                     try {
@@ -550,10 +548,11 @@ object AccentApplicator {
                     // that path would crash here because LAF refresh is still
                     // mid-flight. Publishing a topic lets subscribers decide when to
                     // repaint.
-                    for (project in ProjectManager.getInstance().openProjects) {
-                        if (!project.isUsable()) continue
-                        ComponentTreeRefresher.notifyOnly(project)
-                    }
+                    ProjectManager
+                        .getInstance()
+                        .openProjects
+                        .filter { it.isUsable() }
+                        .forEach(ComponentTreeRefresher::notifyOnly)
                 }
             }
 
@@ -622,6 +621,14 @@ object AccentApplicator {
         isPremiumAllowed: Boolean,
     ) {
         if (context == AccentContext.External) {
+            EP_NAME.extensionList
+                .filter { it.id in EDITOR_SCHEME_ELEMENTS }
+                .forEach { element ->
+                    AyuEditorSchemeScope.observeElementEnabled(
+                        element.id,
+                        ChromeTintContext.isToggleEnabled(state, element.id),
+                    )
+                }
             ExternalChromeOwnership.apply(
                 elements = EP_NAME.extensionList,
                 state = state,
@@ -824,8 +831,6 @@ object AccentApplicator {
     }
 
     private fun revertAlwaysOnEditorKeys() {
-        if (AyuEditorSchemeScope.claimedAccentSchemes().isEmpty()) return
-
         AyuEditorSchemeScope.restore(alwaysOnOwner)
 
         val application = ApplicationManager.getApplication()

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -27,6 +27,7 @@ import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 import dev.ayuislands.theme.AyuEditorSchemeScope
+import dev.ayuislands.theme.EditorSchemeOwner
 import dev.ayuislands.ui.ComponentTreeRefresher
 import org.jetbrains.annotations.TestOnly
 import java.awt.Color
@@ -88,7 +89,7 @@ object AccentApplicator {
     // [CodeGlanceProIntegration.CGP_DEFAULT_VIEWPORT_COLOR] for the javap provenance and
     // re-verification recipe.
 
-    private val EMPTY_TEXT_ATTRIBUTES = TextAttributes()
+    private val alwaysOnOwner = EditorSchemeOwner.AlwaysOn
 
     // CodeGlance Pro reflection state and apply/revert workers live in
     // [CodeGlanceProIntegration] to keep this object below the TooManyFunctions threshold.
@@ -644,6 +645,10 @@ object AccentApplicator {
         variant: AyuVariant?,
         isPremiumAllowed: Boolean,
     ) {
+        AyuEditorSchemeScope.observeElementEnabled(
+            element.id,
+            ChromeTintContext.isToggleEnabled(state, element.id),
+        )
         if (element.id.group == AccentGroup.CHROME && !isPremiumAllowed) {
             neutralizeOrRevert(element, variant)
             return
@@ -742,7 +747,7 @@ object AccentApplicator {
 
         // ColorKey entries
         for (colorKey in ALWAYS_ON_EDITOR_COLOR_KEYS) {
-            scheme.setColor(colorKey, accent)
+            AyuEditorSchemeScope.writeColor(alwaysOnOwner, colorKey, accent)
         }
 
         // TextAttributesKey entries -- clone existing, override only accent properties
@@ -753,7 +758,7 @@ object AccentApplicator {
             if (AttributeTarget.FOREGROUND in targets) updated.foregroundColor = accent
             if (AttributeTarget.EFFECT_COLOR in targets) updated.effectColor = accent
             if (AttributeTarget.ERROR_STRIPE in targets) updated.errorStripeColor = accent
-            scheme.setAttributes(attrKey, updated)
+            AyuEditorSchemeScope.writeAttributes(alwaysOnOwner, attrKey, updated)
         }
 
         // Notify editors to repaint with an updated scheme
@@ -790,7 +795,8 @@ object AccentApplicator {
             ExternalChromeOwnership.releaseTabUnderline()
         }
         if (tabMode == GlowTabMode.OFF && variant != null) {
-            AyuEditorSchemeScope.claimActiveScheme()?.setColor(
+            AyuEditorSchemeScope.writeColor(
+                alwaysOnOwner,
                 ColorKey.find("TAB_UNDERLINE"),
                 Color.decode(variant.neutralGray),
             )
@@ -816,19 +822,7 @@ object AccentApplicator {
     private fun revertAlwaysOnEditorKeys() {
         if (AyuEditorSchemeScope.claimedAccentSchemes().isEmpty()) return
 
-        AyuEditorSchemeScope.cleanClaimedAccentSchemes { scheme ->
-            for (colorKey in ALWAYS_ON_EDITOR_COLOR_KEYS) {
-                scheme.setColor(colorKey, null)
-            }
-
-            for ((key) in ALWAYS_ON_EDITOR_ATTR_OVERRIDES) {
-                val attrKey = TextAttributesKey.find(key)
-                val fallback = attrKey.fallbackAttributeKey
-                val defaultAttrs =
-                    if (fallback != null) scheme.getAttributes(fallback) else null
-                scheme.setAttributes(attrKey, defaultAttrs ?: EMPTY_TEXT_ATTRIBUTES)
-            }
-        }
+        AyuEditorSchemeScope.restore(alwaysOnOwner)
 
         val application = ApplicationManager.getApplication()
         application.runReadAction {

--- a/src/main/kotlin/dev/ayuislands/accent/elements/BracketMatchElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/BracketMatchElement.kt
@@ -1,18 +1,19 @@
 package dev.ayuislands.accent.elements
 
-import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.editor.markup.TextAttributes
 import dev.ayuislands.accent.AccentElement
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.theme.AyuEditorSchemeScope
+import dev.ayuislands.theme.EditorSchemeOwner
 import java.awt.Color
 import java.awt.Font
 
 class BracketMatchElement : AccentElement {
     override val id = AccentElementId.BRACKET_MATCH
     override val displayName = "Bracket Match"
+    private val schemeOwner = EditorSchemeOwner.Element(id)
 
     private val braceAttrKey = TextAttributesKey.find("MATCHED_BRACE_ATTRIBUTES")
 
@@ -22,26 +23,17 @@ class BracketMatchElement : AccentElement {
         val updated = existing?.clone() ?: TextAttributes()
         updated.foregroundColor = color
         updated.fontType = Font.BOLD
-        scheme.setAttributes(braceAttrKey, updated)
+        AyuEditorSchemeScope.writeAttributes(schemeOwner, braceAttrKey, updated)
         BracketFadeManager.activate(color)
     }
 
     override fun applyNeutral(variant: AyuVariant) {
-        val scheme = AyuEditorSchemeScope.claimActiveScheme()
-        if (scheme != null) {
-            val parentScheme = EditorColorsManager.getInstance().getScheme(variant.parentSchemeName)
-            val parentAttrs = parentScheme?.getAttributes(braceAttrKey)
-            scheme.setAttributes(braceAttrKey, parentAttrs ?: TextAttributes())
-        }
+        AyuEditorSchemeScope.restore(schemeOwner)
         BracketFadeManager.deactivate()
     }
 
     override fun revert() {
-        AyuEditorSchemeScope.cleanClaimedAccentSchemes { scheme ->
-            val fallback = braceAttrKey.fallbackAttributeKey
-            val defaultAttrs = if (fallback != null) scheme.getAttributes(fallback) else null
-            scheme.setAttributes(braceAttrKey, defaultAttrs ?: TextAttributes())
-        }
+        AyuEditorSchemeScope.restore(schemeOwner)
         BracketFadeManager.deactivate()
     }
 }

--- a/src/main/kotlin/dev/ayuislands/accent/elements/BracketMatchElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/BracketMatchElement.kt
@@ -17,7 +17,7 @@ class BracketMatchElement : AccentElement {
     private val braceAttrKey = TextAttributesKey.find("MATCHED_BRACE_ATTRIBUTES")
 
     override fun apply(color: Color) {
-        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
+        val scheme = AyuEditorSchemeScope.claimActiveScheme() ?: return
         val existing = scheme.getAttributes(braceAttrKey)
         val updated = existing?.clone() ?: TextAttributes()
         updated.foregroundColor = color
@@ -27,7 +27,7 @@ class BracketMatchElement : AccentElement {
     }
 
     override fun applyNeutral(variant: AyuVariant) {
-        val scheme = AyuEditorSchemeScope.activeScheme()
+        val scheme = AyuEditorSchemeScope.claimActiveScheme()
         if (scheme != null) {
             val parentScheme = EditorColorsManager.getInstance().getScheme(variant.parentSchemeName)
             val parentAttrs = parentScheme?.getAttributes(braceAttrKey)
@@ -37,8 +37,7 @@ class BracketMatchElement : AccentElement {
     }
 
     override fun revert() {
-        val scheme = AyuEditorSchemeScope.ownedScheme()
-        if (scheme != null) {
+        for (scheme in AyuEditorSchemeScope.claimedAccentSchemes()) {
             val fallback = braceAttrKey.fallbackAttributeKey
             val defaultAttrs = if (fallback != null) scheme.getAttributes(fallback) else null
             scheme.setAttributes(braceAttrKey, defaultAttrs ?: TextAttributes())

--- a/src/main/kotlin/dev/ayuislands/accent/elements/BracketMatchElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/BracketMatchElement.kt
@@ -18,12 +18,12 @@ class BracketMatchElement : AccentElement {
     private val braceAttrKey = TextAttributesKey.find("MATCHED_BRACE_ATTRIBUTES")
 
     override fun apply(color: Color) {
-        val scheme = AyuEditorSchemeScope.claimActiveScheme() ?: return
+        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
         val existing = scheme.getAttributes(braceAttrKey)
         val updated = existing?.clone() ?: TextAttributes()
         updated.foregroundColor = color
         updated.fontType = Font.BOLD
-        AyuEditorSchemeScope.writeAttributes(schemeOwner, braceAttrKey, updated)
+        AyuEditorSchemeScope.writeAttributes(scheme, schemeOwner, braceAttrKey, updated)
         BracketFadeManager.activate(color)
     }
 

--- a/src/main/kotlin/dev/ayuislands/accent/elements/BracketMatchElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/BracketMatchElement.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.editor.markup.TextAttributes
 import dev.ayuislands.accent.AccentElement
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.theme.AyuEditorSchemeScope
 import java.awt.Color
 import java.awt.Font
 
@@ -16,7 +17,7 @@ class BracketMatchElement : AccentElement {
     private val braceAttrKey = TextAttributesKey.find("MATCHED_BRACE_ATTRIBUTES")
 
     override fun apply(color: Color) {
-        val scheme = EditorColorsManager.getInstance().globalScheme
+        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
         val existing = scheme.getAttributes(braceAttrKey)
         val updated = existing?.clone() ?: TextAttributes()
         updated.foregroundColor = color
@@ -26,18 +27,22 @@ class BracketMatchElement : AccentElement {
     }
 
     override fun applyNeutral(variant: AyuVariant) {
-        val scheme = EditorColorsManager.getInstance().globalScheme
-        val parentScheme = EditorColorsManager.getInstance().getScheme(variant.parentSchemeName)
-        val parentAttrs = parentScheme?.getAttributes(braceAttrKey)
-        scheme.setAttributes(braceAttrKey, parentAttrs ?: TextAttributes())
+        val scheme = AyuEditorSchemeScope.activeScheme()
+        if (scheme != null) {
+            val parentScheme = EditorColorsManager.getInstance().getScheme(variant.parentSchemeName)
+            val parentAttrs = parentScheme?.getAttributes(braceAttrKey)
+            scheme.setAttributes(braceAttrKey, parentAttrs ?: TextAttributes())
+        }
         BracketFadeManager.deactivate()
     }
 
     override fun revert() {
-        val scheme = EditorColorsManager.getInstance().globalScheme
-        val fallback = braceAttrKey.fallbackAttributeKey
-        val defaultAttrs = if (fallback != null) scheme.getAttributes(fallback) else null
-        scheme.setAttributes(braceAttrKey, defaultAttrs ?: TextAttributes())
+        val scheme = AyuEditorSchemeScope.activeScheme()
+        if (scheme != null) {
+            val fallback = braceAttrKey.fallbackAttributeKey
+            val defaultAttrs = if (fallback != null) scheme.getAttributes(fallback) else null
+            scheme.setAttributes(braceAttrKey, defaultAttrs ?: TextAttributes())
+        }
         BracketFadeManager.deactivate()
     }
 }

--- a/src/main/kotlin/dev/ayuislands/accent/elements/BracketMatchElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/BracketMatchElement.kt
@@ -37,7 +37,7 @@ class BracketMatchElement : AccentElement {
     }
 
     override fun revert() {
-        for (scheme in AyuEditorSchemeScope.claimedAccentSchemes()) {
+        AyuEditorSchemeScope.cleanClaimedAccentSchemes { scheme ->
             val fallback = braceAttrKey.fallbackAttributeKey
             val defaultAttrs = if (fallback != null) scheme.getAttributes(fallback) else null
             scheme.setAttributes(braceAttrKey, defaultAttrs ?: TextAttributes())

--- a/src/main/kotlin/dev/ayuislands/accent/elements/BracketMatchElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/BracketMatchElement.kt
@@ -37,7 +37,7 @@ class BracketMatchElement : AccentElement {
     }
 
     override fun revert() {
-        val scheme = AyuEditorSchemeScope.activeScheme()
+        val scheme = AyuEditorSchemeScope.ownedScheme()
         if (scheme != null) {
             val fallback = braceAttrKey.fallbackAttributeKey
             val defaultAttrs = if (fallback != null) scheme.getAttributes(fallback) else null

--- a/src/main/kotlin/dev/ayuislands/accent/elements/CaretRowElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/CaretRowElement.kt
@@ -19,14 +19,14 @@ class CaretRowElement : AccentElement {
 
     override fun apply(color: Color) {
         val caretRowColor = ColorUtil.toAlpha(color, CARET_ROW_ALPHA)
-        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
+        val scheme = AyuEditorSchemeScope.claimActiveScheme() ?: return
         scheme.setColor(caretRowKey, caretRowColor)
         scheme.setColor(caretKey, color)
         scheme.setColor(lineNumberKey, color)
     }
 
     override fun applyNeutral(variant: AyuVariant) {
-        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
+        val scheme = AyuEditorSchemeScope.claimActiveScheme() ?: return
         val parentScheme = EditorColorsManager.getInstance().getScheme(variant.parentSchemeName)
         for (colorKey in listOf(caretRowKey, caretKey, lineNumberKey)) {
             scheme.setColor(colorKey, parentScheme?.getColor(colorKey))
@@ -38,9 +38,10 @@ class CaretRowElement : AccentElement {
     }
 
     override fun revert() {
-        val scheme = AyuEditorSchemeScope.ownedScheme() ?: return
-        scheme.setColor(caretRowKey, null)
-        scheme.setColor(caretKey, null)
-        scheme.setColor(lineNumberKey, null)
+        for (scheme in AyuEditorSchemeScope.claimedAccentSchemes()) {
+            scheme.setColor(caretRowKey, null)
+            scheme.setColor(caretKey, null)
+            scheme.setColor(lineNumberKey, null)
+        }
     }
 }

--- a/src/main/kotlin/dev/ayuislands/accent/elements/CaretRowElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/CaretRowElement.kt
@@ -1,12 +1,12 @@
 package dev.ayuislands.accent.elements
 
 import com.intellij.openapi.editor.colors.ColorKey
-import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.ui.ColorUtil
 import dev.ayuislands.accent.AccentElement
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.theme.AyuEditorSchemeScope
+import dev.ayuislands.theme.EditorSchemeOwner
 import java.awt.Color
 
 class CaretRowElement : AccentElement {
@@ -16,21 +16,17 @@ class CaretRowElement : AccentElement {
     private val caretRowKey = ColorKey.find("CARET_ROW_COLOR")
     private val caretKey = ColorKey.find("CARET_COLOR")
     private val lineNumberKey = ColorKey.find("LINE_NUMBER_ON_CARET_ROW_COLOR")
+    private val schemeOwner = EditorSchemeOwner.Element(id)
 
     override fun apply(color: Color) {
         val caretRowColor = ColorUtil.toAlpha(color, CARET_ROW_ALPHA)
-        val scheme = AyuEditorSchemeScope.claimActiveScheme() ?: return
-        scheme.setColor(caretRowKey, caretRowColor)
-        scheme.setColor(caretKey, color)
-        scheme.setColor(lineNumberKey, color)
+        AyuEditorSchemeScope.writeColor(schemeOwner, caretRowKey, caretRowColor)
+        AyuEditorSchemeScope.writeColor(schemeOwner, caretKey, color)
+        AyuEditorSchemeScope.writeColor(schemeOwner, lineNumberKey, color)
     }
 
     override fun applyNeutral(variant: AyuVariant) {
-        val scheme = AyuEditorSchemeScope.claimActiveScheme() ?: return
-        val parentScheme = EditorColorsManager.getInstance().getScheme(variant.parentSchemeName)
-        for (colorKey in listOf(caretRowKey, caretKey, lineNumberKey)) {
-            scheme.setColor(colorKey, parentScheme?.getColor(colorKey))
-        }
+        AyuEditorSchemeScope.restore(schemeOwner)
     }
 
     companion object {
@@ -38,10 +34,6 @@ class CaretRowElement : AccentElement {
     }
 
     override fun revert() {
-        AyuEditorSchemeScope.cleanClaimedAccentSchemes { scheme ->
-            scheme.setColor(caretRowKey, null)
-            scheme.setColor(caretKey, null)
-            scheme.setColor(lineNumberKey, null)
-        }
+        AyuEditorSchemeScope.restore(schemeOwner)
     }
 }

--- a/src/main/kotlin/dev/ayuislands/accent/elements/CaretRowElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/CaretRowElement.kt
@@ -38,7 +38,7 @@ class CaretRowElement : AccentElement {
     }
 
     override fun revert() {
-        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
+        val scheme = AyuEditorSchemeScope.ownedScheme() ?: return
         scheme.setColor(caretRowKey, null)
         scheme.setColor(caretKey, null)
         scheme.setColor(lineNumberKey, null)

--- a/src/main/kotlin/dev/ayuislands/accent/elements/CaretRowElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/CaretRowElement.kt
@@ -19,10 +19,11 @@ class CaretRowElement : AccentElement {
     private val schemeOwner = EditorSchemeOwner.Element(id)
 
     override fun apply(color: Color) {
+        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
         val caretRowColor = ColorUtil.toAlpha(color, CARET_ROW_ALPHA)
-        AyuEditorSchemeScope.writeColor(schemeOwner, caretRowKey, caretRowColor)
-        AyuEditorSchemeScope.writeColor(schemeOwner, caretKey, color)
-        AyuEditorSchemeScope.writeColor(schemeOwner, lineNumberKey, color)
+        AyuEditorSchemeScope.writeColor(scheme, schemeOwner, caretRowKey, caretRowColor)
+        AyuEditorSchemeScope.writeColor(scheme, schemeOwner, caretKey, color)
+        AyuEditorSchemeScope.writeColor(scheme, schemeOwner, lineNumberKey, color)
     }
 
     override fun applyNeutral(variant: AyuVariant) {

--- a/src/main/kotlin/dev/ayuislands/accent/elements/CaretRowElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/CaretRowElement.kt
@@ -6,6 +6,7 @@ import com.intellij.ui.ColorUtil
 import dev.ayuislands.accent.AccentElement
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.theme.AyuEditorSchemeScope
 import java.awt.Color
 
 class CaretRowElement : AccentElement {
@@ -18,15 +19,15 @@ class CaretRowElement : AccentElement {
 
     override fun apply(color: Color) {
         val caretRowColor = ColorUtil.toAlpha(color, CARET_ROW_ALPHA)
-        val scheme = EditorColorsManager.getInstance().globalScheme
+        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
         scheme.setColor(caretRowKey, caretRowColor)
         scheme.setColor(caretKey, color)
         scheme.setColor(lineNumberKey, color)
     }
 
     override fun applyNeutral(variant: AyuVariant) {
+        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
         val parentScheme = EditorColorsManager.getInstance().getScheme(variant.parentSchemeName)
-        val scheme = EditorColorsManager.getInstance().globalScheme
         for (colorKey in listOf(caretRowKey, caretKey, lineNumberKey)) {
             scheme.setColor(colorKey, parentScheme?.getColor(colorKey))
         }
@@ -37,7 +38,7 @@ class CaretRowElement : AccentElement {
     }
 
     override fun revert() {
-        val scheme = EditorColorsManager.getInstance().globalScheme
+        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
         scheme.setColor(caretRowKey, null)
         scheme.setColor(caretKey, null)
         scheme.setColor(lineNumberKey, null)

--- a/src/main/kotlin/dev/ayuislands/accent/elements/CaretRowElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/CaretRowElement.kt
@@ -38,7 +38,7 @@ class CaretRowElement : AccentElement {
     }
 
     override fun revert() {
-        for (scheme in AyuEditorSchemeScope.claimedAccentSchemes()) {
+        AyuEditorSchemeScope.cleanClaimedAccentSchemes { scheme ->
             scheme.setColor(caretRowKey, null)
             scheme.setColor(caretKey, null)
             scheme.setColor(lineNumberKey, null)

--- a/src/main/kotlin/dev/ayuislands/accent/elements/InlayHintsElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/InlayHintsElement.kt
@@ -21,7 +21,7 @@ class InlayHintsElement : AccentElement {
     override fun apply(color: Color) {
         val mutedAccent = ColorUtil.toAlpha(color, MUTED_ALPHA)
         val muted = JBColor(mutedAccent, mutedAccent)
-        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
+        val scheme = AyuEditorSchemeScope.claimActiveScheme() ?: return
         val existing = scheme.getAttributes(INLAY_KEY)
         val updated = existing?.clone() ?: TextAttributes()
         updated.foregroundColor = muted
@@ -29,7 +29,7 @@ class InlayHintsElement : AccentElement {
     }
 
     override fun applyNeutral(variant: AyuVariant) {
-        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
+        val scheme = AyuEditorSchemeScope.claimActiveScheme() ?: return
         val parentScheme = EditorColorsManager.getInstance().getScheme(variant.parentSchemeName)
         scheme.setAttributes(
             INLAY_KEY,
@@ -38,7 +38,8 @@ class InlayHintsElement : AccentElement {
     }
 
     override fun revert() {
-        val scheme = AyuEditorSchemeScope.ownedScheme() ?: return
-        scheme.setAttributes(INLAY_KEY, null)
+        for (scheme in AyuEditorSchemeScope.claimedAccentSchemes()) {
+            scheme.setAttributes(INLAY_KEY, null)
+        }
     }
 }

--- a/src/main/kotlin/dev/ayuislands/accent/elements/InlayHintsElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/InlayHintsElement.kt
@@ -38,7 +38,7 @@ class InlayHintsElement : AccentElement {
     }
 
     override fun revert() {
-        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
+        val scheme = AyuEditorSchemeScope.ownedScheme() ?: return
         scheme.setAttributes(INLAY_KEY, null)
     }
 }

--- a/src/main/kotlin/dev/ayuislands/accent/elements/InlayHintsElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/InlayHintsElement.kt
@@ -1,6 +1,5 @@
 package dev.ayuislands.accent.elements
 
-import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.ui.ColorUtil
@@ -9,6 +8,7 @@ import dev.ayuislands.accent.AccentElement
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.theme.AyuEditorSchemeScope
+import dev.ayuislands.theme.EditorSchemeOwner
 import java.awt.Color
 
 private const val MUTED_ALPHA = 140
@@ -17,6 +17,7 @@ private val INLAY_KEY = TextAttributesKey.find("INLAY_TEXT_WITHOUT_BACKGROUND")
 class InlayHintsElement : AccentElement {
     override val id = AccentElementId.INLAY_HINTS
     override val displayName = "Inlay Hints"
+    private val schemeOwner = EditorSchemeOwner.Element(id)
 
     override fun apply(color: Color) {
         val mutedAccent = ColorUtil.toAlpha(color, MUTED_ALPHA)
@@ -25,21 +26,14 @@ class InlayHintsElement : AccentElement {
         val existing = scheme.getAttributes(INLAY_KEY)
         val updated = existing?.clone() ?: TextAttributes()
         updated.foregroundColor = muted
-        scheme.setAttributes(INLAY_KEY, updated)
+        AyuEditorSchemeScope.writeAttributes(schemeOwner, INLAY_KEY, updated)
     }
 
     override fun applyNeutral(variant: AyuVariant) {
-        val scheme = AyuEditorSchemeScope.claimActiveScheme() ?: return
-        val parentScheme = EditorColorsManager.getInstance().getScheme(variant.parentSchemeName)
-        scheme.setAttributes(
-            INLAY_KEY,
-            parentScheme?.getAttributes(INLAY_KEY),
-        )
+        AyuEditorSchemeScope.restore(schemeOwner)
     }
 
     override fun revert() {
-        AyuEditorSchemeScope.cleanClaimedAccentSchemes { scheme ->
-            scheme.setAttributes(INLAY_KEY, null)
-        }
+        AyuEditorSchemeScope.restore(schemeOwner)
     }
 }

--- a/src/main/kotlin/dev/ayuislands/accent/elements/InlayHintsElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/InlayHintsElement.kt
@@ -8,6 +8,7 @@ import com.intellij.ui.JBColor
 import dev.ayuislands.accent.AccentElement
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.theme.AyuEditorSchemeScope
 import java.awt.Color
 
 private const val MUTED_ALPHA = 140
@@ -20,7 +21,7 @@ class InlayHintsElement : AccentElement {
     override fun apply(color: Color) {
         val mutedAccent = ColorUtil.toAlpha(color, MUTED_ALPHA)
         val muted = JBColor(mutedAccent, mutedAccent)
-        val scheme = EditorColorsManager.getInstance().globalScheme
+        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
         val existing = scheme.getAttributes(INLAY_KEY)
         val updated = existing?.clone() ?: TextAttributes()
         updated.foregroundColor = muted
@@ -28,8 +29,8 @@ class InlayHintsElement : AccentElement {
     }
 
     override fun applyNeutral(variant: AyuVariant) {
+        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
         val parentScheme = EditorColorsManager.getInstance().getScheme(variant.parentSchemeName)
-        val scheme = EditorColorsManager.getInstance().globalScheme
         scheme.setAttributes(
             INLAY_KEY,
             parentScheme?.getAttributes(INLAY_KEY),
@@ -37,7 +38,7 @@ class InlayHintsElement : AccentElement {
     }
 
     override fun revert() {
-        val scheme = EditorColorsManager.getInstance().globalScheme
+        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
         scheme.setAttributes(INLAY_KEY, null)
     }
 }

--- a/src/main/kotlin/dev/ayuislands/accent/elements/InlayHintsElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/InlayHintsElement.kt
@@ -38,7 +38,7 @@ class InlayHintsElement : AccentElement {
     }
 
     override fun revert() {
-        for (scheme in AyuEditorSchemeScope.claimedAccentSchemes()) {
+        AyuEditorSchemeScope.cleanClaimedAccentSchemes { scheme ->
             scheme.setAttributes(INLAY_KEY, null)
         }
     }

--- a/src/main/kotlin/dev/ayuislands/accent/elements/InlayHintsElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/InlayHintsElement.kt
@@ -22,11 +22,11 @@ class InlayHintsElement : AccentElement {
     override fun apply(color: Color) {
         val mutedAccent = ColorUtil.toAlpha(color, MUTED_ALPHA)
         val muted = JBColor(mutedAccent, mutedAccent)
-        val scheme = AyuEditorSchemeScope.claimActiveScheme() ?: return
+        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
         val existing = scheme.getAttributes(INLAY_KEY)
         val updated = existing?.clone() ?: TextAttributes()
         updated.foregroundColor = muted
-        AyuEditorSchemeScope.writeAttributes(schemeOwner, INLAY_KEY, updated)
+        AyuEditorSchemeScope.writeAttributes(scheme, schemeOwner, INLAY_KEY, updated)
     }
 
     override fun applyNeutral(variant: AyuVariant) {

--- a/src/main/kotlin/dev/ayuislands/accent/elements/LinksElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/LinksElement.kt
@@ -42,7 +42,7 @@ class LinksElement : AccentElement {
         for (key in uiKeys) {
             UIManager.put(key, color)
         }
-        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
+        val scheme = AyuEditorSchemeScope.claimActiveScheme() ?: return
         for (key in editorColorKeys) {
             scheme.setColor(key, color)
         }
@@ -59,7 +59,7 @@ class LinksElement : AccentElement {
         for (key in uiKeys) {
             UIManager.put(key, null)
         }
-        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
+        val scheme = AyuEditorSchemeScope.claimActiveScheme() ?: return
         val parentScheme = EditorColorsManager.getInstance().getScheme(variant.parentSchemeName)
         for (colorKey in editorColorKeys) {
             scheme.setColor(colorKey, parentScheme?.getColor(colorKey))
@@ -74,12 +74,13 @@ class LinksElement : AccentElement {
         for (key in uiKeys) {
             UIManager.put(key, null)
         }
-        val scheme = AyuEditorSchemeScope.ownedScheme() ?: return
-        for (key in editorColorKeys) {
-            scheme.setColor(key, null)
-        }
-        for (attrKey in editorAttrKeys) {
-            scheme.setAttributes(attrKey, null)
+        for (scheme in AyuEditorSchemeScope.claimedAccentSchemes()) {
+            for (key in editorColorKeys) {
+                scheme.setColor(key, null)
+            }
+            for (attrKey in editorAttrKeys) {
+                scheme.setAttributes(attrKey, null)
+            }
         }
     }
 }

--- a/src/main/kotlin/dev/ayuislands/accent/elements/LinksElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/LinksElement.kt
@@ -74,7 +74,7 @@ class LinksElement : AccentElement {
         for (key in uiKeys) {
             UIManager.put(key, null)
         }
-        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
+        val scheme = AyuEditorSchemeScope.ownedScheme() ?: return
         for (key in editorColorKeys) {
             scheme.setColor(key, null)
         }

--- a/src/main/kotlin/dev/ayuislands/accent/elements/LinksElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/LinksElement.kt
@@ -74,7 +74,7 @@ class LinksElement : AccentElement {
         for (key in uiKeys) {
             UIManager.put(key, null)
         }
-        for (scheme in AyuEditorSchemeScope.claimedAccentSchemes()) {
+        AyuEditorSchemeScope.cleanClaimedAccentSchemes { scheme ->
             for (key in editorColorKeys) {
                 scheme.setColor(key, null)
             }

--- a/src/main/kotlin/dev/ayuislands/accent/elements/LinksElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/LinksElement.kt
@@ -1,19 +1,20 @@
 package dev.ayuislands.accent.elements
 
 import com.intellij.openapi.editor.colors.ColorKey
-import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.editor.markup.TextAttributes
 import dev.ayuislands.accent.AccentElement
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.theme.AyuEditorSchemeScope
+import dev.ayuislands.theme.EditorSchemeOwner
 import java.awt.Color
 import javax.swing.UIManager
 
 class LinksElement : AccentElement {
     override val id = AccentElementId.LINKS
     override val displayName = "Links"
+    private val schemeOwner = EditorSchemeOwner.Element(id)
 
     private val uiKeys =
         listOf(
@@ -44,14 +45,14 @@ class LinksElement : AccentElement {
         }
         val scheme = AyuEditorSchemeScope.claimActiveScheme() ?: return
         for (key in editorColorKeys) {
-            scheme.setColor(key, color)
+            AyuEditorSchemeScope.writeColor(schemeOwner, key, color)
         }
         for (attrKey in editorAttrKeys) {
             val existing = scheme.getAttributes(attrKey)
             val updated = existing?.clone() ?: TextAttributes()
             updated.foregroundColor = color
             updated.effectColor = color
-            scheme.setAttributes(attrKey, updated)
+            AyuEditorSchemeScope.writeAttributes(schemeOwner, attrKey, updated)
         }
     }
 
@@ -59,28 +60,13 @@ class LinksElement : AccentElement {
         for (key in uiKeys) {
             UIManager.put(key, null)
         }
-        val scheme = AyuEditorSchemeScope.claimActiveScheme() ?: return
-        val parentScheme = EditorColorsManager.getInstance().getScheme(variant.parentSchemeName)
-        for (colorKey in editorColorKeys) {
-            scheme.setColor(colorKey, parentScheme?.getColor(colorKey))
-        }
-        for (attrKey in editorAttrKeys) {
-            val parentAttrs = parentScheme?.getAttributes(attrKey)
-            scheme.setAttributes(attrKey, parentAttrs)
-        }
+        AyuEditorSchemeScope.restore(schemeOwner)
     }
 
     override fun revert() {
         for (key in uiKeys) {
             UIManager.put(key, null)
         }
-        AyuEditorSchemeScope.cleanClaimedAccentSchemes { scheme ->
-            for (key in editorColorKeys) {
-                scheme.setColor(key, null)
-            }
-            for (attrKey in editorAttrKeys) {
-                scheme.setAttributes(attrKey, null)
-            }
-        }
+        AyuEditorSchemeScope.restore(schemeOwner)
     }
 }

--- a/src/main/kotlin/dev/ayuislands/accent/elements/LinksElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/LinksElement.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.editor.markup.TextAttributes
 import dev.ayuislands.accent.AccentElement
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.theme.AyuEditorSchemeScope
 import java.awt.Color
 import javax.swing.UIManager
 
@@ -41,7 +42,7 @@ class LinksElement : AccentElement {
         for (key in uiKeys) {
             UIManager.put(key, color)
         }
-        val scheme = EditorColorsManager.getInstance().globalScheme
+        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
         for (key in editorColorKeys) {
             scheme.setColor(key, color)
         }
@@ -58,8 +59,8 @@ class LinksElement : AccentElement {
         for (key in uiKeys) {
             UIManager.put(key, null)
         }
+        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
         val parentScheme = EditorColorsManager.getInstance().getScheme(variant.parentSchemeName)
-        val scheme = EditorColorsManager.getInstance().globalScheme
         for (colorKey in editorColorKeys) {
             scheme.setColor(colorKey, parentScheme?.getColor(colorKey))
         }
@@ -73,7 +74,7 @@ class LinksElement : AccentElement {
         for (key in uiKeys) {
             UIManager.put(key, null)
         }
-        val scheme = EditorColorsManager.getInstance().globalScheme
+        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
         for (key in editorColorKeys) {
             scheme.setColor(key, null)
         }

--- a/src/main/kotlin/dev/ayuislands/accent/elements/LinksElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/LinksElement.kt
@@ -43,16 +43,16 @@ class LinksElement : AccentElement {
         for (key in uiKeys) {
             UIManager.put(key, color)
         }
-        val scheme = AyuEditorSchemeScope.claimActiveScheme() ?: return
+        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
         for (key in editorColorKeys) {
-            AyuEditorSchemeScope.writeColor(schemeOwner, key, color)
+            AyuEditorSchemeScope.writeColor(scheme, schemeOwner, key, color)
         }
         for (attrKey in editorAttrKeys) {
             val existing = scheme.getAttributes(attrKey)
             val updated = existing?.clone() ?: TextAttributes()
             updated.foregroundColor = color
             updated.effectColor = color
-            AyuEditorSchemeScope.writeAttributes(schemeOwner, attrKey, updated)
+            AyuEditorSchemeScope.writeAttributes(scheme, schemeOwner, attrKey, updated)
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/accent/elements/MatchingTagElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/MatchingTagElement.kt
@@ -19,7 +19,7 @@ class MatchingTagElement : AccentElement {
     private val tagAttrKey = TextAttributesKey.find("MATCHED_TAG_NAME")
 
     override fun apply(color: Color) {
-        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
+        val scheme = AyuEditorSchemeScope.claimActiveScheme() ?: return
         val existing = scheme.getAttributes(tagAttrKey)
         val updated = existing?.clone() ?: TextAttributes()
         updated.backgroundColor = blendWithEditorBackground(color, editorBackgroundFor(scheme))
@@ -67,17 +67,18 @@ class MatchingTagElement : AccentElement {
         ).toInt().coerceIn(0, MAX_CHANNEL_VALUE)
 
     override fun applyNeutral(variant: AyuVariant) {
-        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
+        val scheme = AyuEditorSchemeScope.claimActiveScheme() ?: return
         val parentScheme = EditorColorsManager.getInstance().getScheme(variant.parentSchemeName)
         val parentAttrs = parentScheme?.getAttributes(tagAttrKey)
         scheme.setAttributes(tagAttrKey, parentAttrs ?: TextAttributes())
     }
 
     override fun revert() {
-        val scheme = AyuEditorSchemeScope.ownedScheme() ?: return
-        val fallback = tagAttrKey.fallbackAttributeKey
-        val defaultAttrs = if (fallback != null) scheme.getAttributes(fallback) else null
-        scheme.setAttributes(tagAttrKey, defaultAttrs ?: TextAttributes())
+        for (scheme in AyuEditorSchemeScope.claimedAccentSchemes()) {
+            val fallback = tagAttrKey.fallbackAttributeKey
+            val defaultAttrs = if (fallback != null) scheme.getAttributes(fallback) else null
+            scheme.setAttributes(tagAttrKey, defaultAttrs ?: TextAttributes())
+        }
     }
 
     companion object {

--- a/src/main/kotlin/dev/ayuislands/accent/elements/MatchingTagElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/MatchingTagElement.kt
@@ -20,12 +20,12 @@ class MatchingTagElement : AccentElement {
     private val tagAttrKey = TextAttributesKey.find("MATCHED_TAG_NAME")
 
     override fun apply(color: Color) {
-        val scheme = AyuEditorSchemeScope.claimActiveScheme() ?: return
+        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
         val existing = scheme.getAttributes(tagAttrKey)
         val updated = existing?.clone() ?: TextAttributes()
         updated.backgroundColor = blendWithEditorBackground(color, editorBackgroundFor(scheme))
         updated.foregroundColor = null
-        AyuEditorSchemeScope.writeAttributes(schemeOwner, tagAttrKey, updated)
+        AyuEditorSchemeScope.writeAttributes(scheme, schemeOwner, tagAttrKey, updated)
     }
 
     private fun editorBackgroundFor(scheme: EditorColorsScheme): Color {

--- a/src/main/kotlin/dev/ayuislands/accent/elements/MatchingTagElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/MatchingTagElement.kt
@@ -9,6 +9,7 @@ import dev.ayuislands.accent.AccentElement
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.syntax.RgbBlend
+import dev.ayuislands.theme.AyuEditorSchemeScope
 import java.awt.Color
 
 class MatchingTagElement : AccentElement {
@@ -18,7 +19,7 @@ class MatchingTagElement : AccentElement {
     private val tagAttrKey = TextAttributesKey.find("MATCHED_TAG_NAME")
 
     override fun apply(color: Color) {
-        val scheme = EditorColorsManager.getInstance().globalScheme
+        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
         val existing = scheme.getAttributes(tagAttrKey)
         val updated = existing?.clone() ?: TextAttributes()
         updated.backgroundColor = blendWithEditorBackground(color, editorBackgroundFor(scheme))
@@ -66,14 +67,14 @@ class MatchingTagElement : AccentElement {
         ).toInt().coerceIn(0, MAX_CHANNEL_VALUE)
 
     override fun applyNeutral(variant: AyuVariant) {
-        val scheme = EditorColorsManager.getInstance().globalScheme
+        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
         val parentScheme = EditorColorsManager.getInstance().getScheme(variant.parentSchemeName)
         val parentAttrs = parentScheme?.getAttributes(tagAttrKey)
         scheme.setAttributes(tagAttrKey, parentAttrs ?: TextAttributes())
     }
 
     override fun revert() {
-        val scheme = EditorColorsManager.getInstance().globalScheme
+        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
         val fallback = tagAttrKey.fallbackAttributeKey
         val defaultAttrs = if (fallback != null) scheme.getAttributes(fallback) else null
         scheme.setAttributes(tagAttrKey, defaultAttrs ?: TextAttributes())

--- a/src/main/kotlin/dev/ayuislands/accent/elements/MatchingTagElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/MatchingTagElement.kt
@@ -1,6 +1,5 @@
 package dev.ayuislands.accent.elements
 
-import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.colors.EditorColorsScheme
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.editor.markup.TextAttributes
@@ -10,11 +9,13 @@ import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.syntax.RgbBlend
 import dev.ayuislands.theme.AyuEditorSchemeScope
+import dev.ayuislands.theme.EditorSchemeOwner
 import java.awt.Color
 
 class MatchingTagElement : AccentElement {
     override val id = AccentElementId.MATCHING_TAG
     override val displayName = "Matching Tag"
+    private val schemeOwner = EditorSchemeOwner.Element(id)
 
     private val tagAttrKey = TextAttributesKey.find("MATCHED_TAG_NAME")
 
@@ -24,7 +25,7 @@ class MatchingTagElement : AccentElement {
         val updated = existing?.clone() ?: TextAttributes()
         updated.backgroundColor = blendWithEditorBackground(color, editorBackgroundFor(scheme))
         updated.foregroundColor = null
-        scheme.setAttributes(tagAttrKey, updated)
+        AyuEditorSchemeScope.writeAttributes(schemeOwner, tagAttrKey, updated)
     }
 
     private fun editorBackgroundFor(scheme: EditorColorsScheme): Color {
@@ -67,18 +68,11 @@ class MatchingTagElement : AccentElement {
         ).toInt().coerceIn(0, MAX_CHANNEL_VALUE)
 
     override fun applyNeutral(variant: AyuVariant) {
-        val scheme = AyuEditorSchemeScope.claimActiveScheme() ?: return
-        val parentScheme = EditorColorsManager.getInstance().getScheme(variant.parentSchemeName)
-        val parentAttrs = parentScheme?.getAttributes(tagAttrKey)
-        scheme.setAttributes(tagAttrKey, parentAttrs ?: TextAttributes())
+        AyuEditorSchemeScope.restore(schemeOwner)
     }
 
     override fun revert() {
-        AyuEditorSchemeScope.cleanClaimedAccentSchemes { scheme ->
-            val fallback = tagAttrKey.fallbackAttributeKey
-            val defaultAttrs = if (fallback != null) scheme.getAttributes(fallback) else null
-            scheme.setAttributes(tagAttrKey, defaultAttrs ?: TextAttributes())
-        }
+        AyuEditorSchemeScope.restore(schemeOwner)
     }
 
     companion object {

--- a/src/main/kotlin/dev/ayuislands/accent/elements/MatchingTagElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/MatchingTagElement.kt
@@ -74,7 +74,7 @@ class MatchingTagElement : AccentElement {
     }
 
     override fun revert() {
-        for (scheme in AyuEditorSchemeScope.claimedAccentSchemes()) {
+        AyuEditorSchemeScope.cleanClaimedAccentSchemes { scheme ->
             val fallback = tagAttrKey.fallbackAttributeKey
             val defaultAttrs = if (fallback != null) scheme.getAttributes(fallback) else null
             scheme.setAttributes(tagAttrKey, defaultAttrs ?: TextAttributes())

--- a/src/main/kotlin/dev/ayuislands/accent/elements/MatchingTagElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/MatchingTagElement.kt
@@ -74,7 +74,7 @@ class MatchingTagElement : AccentElement {
     }
 
     override fun revert() {
-        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
+        val scheme = AyuEditorSchemeScope.ownedScheme() ?: return
         val fallback = tagAttrKey.fallbackAttributeKey
         val defaultAttrs = if (fallback != null) scheme.getAttributes(fallback) else null
         scheme.setAttributes(tagAttrKey, defaultAttrs ?: TextAttributes())

--- a/src/main/kotlin/dev/ayuislands/accent/elements/ProgressBarElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/ProgressBarElement.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.editor.colors.EditorColorsManager
 import dev.ayuislands.accent.AccentElement
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.theme.AyuEditorSchemeScope
 import java.awt.Color
 import javax.swing.SwingUtilities
 import javax.swing.UIManager
@@ -26,8 +27,7 @@ class ProgressBarElement : AccentElement {
             UIManager.put(key, color)
         }
         runOnEdt {
-            val scheme = EditorColorsManager.getInstance().globalScheme
-            scheme.setColor(editorKey, color)
+            AyuEditorSchemeScope.activeScheme()?.setColor(editorKey, color)
         }
     }
 
@@ -36,9 +36,11 @@ class ProgressBarElement : AccentElement {
             UIManager.put(key, null)
         }
         runOnEdt {
-            val parentScheme = EditorColorsManager.getInstance().getScheme(variant.parentSchemeName)
-            val scheme = EditorColorsManager.getInstance().globalScheme
-            scheme.setColor(editorKey, parentScheme?.getColor(editorKey))
+            val scheme = AyuEditorSchemeScope.activeScheme()
+            if (scheme != null) {
+                val parentScheme = EditorColorsManager.getInstance().getScheme(variant.parentSchemeName)
+                scheme.setColor(editorKey, parentScheme?.getColor(editorKey))
+            }
         }
     }
 
@@ -47,8 +49,7 @@ class ProgressBarElement : AccentElement {
             UIManager.put(key, null)
         }
         runOnEdt {
-            val scheme = EditorColorsManager.getInstance().globalScheme
-            scheme.setColor(editorKey, null)
+            AyuEditorSchemeScope.activeScheme()?.setColor(editorKey, null)
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/accent/elements/ProgressBarElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/ProgressBarElement.kt
@@ -24,11 +24,13 @@ class ProgressBarElement : AccentElement {
     private val editorKey = ColorKey.find("PROGRESS_BAR_TRACK")
 
     override fun apply(color: Color) {
+        val scheme = AyuEditorSchemeScope.activeScheme()
         for (key in uiKeys) {
             UIManager.put(key, color)
         }
+        if (scheme == null) return
         runOnEdt {
-            AyuEditorSchemeScope.writeColor(schemeOwner, editorKey, color)
+            AyuEditorSchemeScope.writeColor(scheme, schemeOwner, editorKey, color)
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/accent/elements/ProgressBarElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/ProgressBarElement.kt
@@ -1,11 +1,11 @@
 package dev.ayuislands.accent.elements
 
 import com.intellij.openapi.editor.colors.ColorKey
-import com.intellij.openapi.editor.colors.EditorColorsManager
 import dev.ayuislands.accent.AccentElement
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.theme.AyuEditorSchemeScope
+import dev.ayuislands.theme.EditorSchemeOwner
 import java.awt.Color
 import javax.swing.SwingUtilities
 import javax.swing.UIManager
@@ -13,6 +13,7 @@ import javax.swing.UIManager
 class ProgressBarElement : AccentElement {
     override val id = AccentElementId.PROGRESS_BAR
     override val displayName = "Progress Bar"
+    private val schemeOwner = EditorSchemeOwner.Element(id)
 
     private val uiKeys =
         listOf(
@@ -27,7 +28,7 @@ class ProgressBarElement : AccentElement {
             UIManager.put(key, color)
         }
         runOnEdt {
-            AyuEditorSchemeScope.claimActiveScheme()?.setColor(editorKey, color)
+            AyuEditorSchemeScope.writeColor(schemeOwner, editorKey, color)
         }
     }
 
@@ -36,11 +37,7 @@ class ProgressBarElement : AccentElement {
             UIManager.put(key, null)
         }
         runOnEdt {
-            val scheme = AyuEditorSchemeScope.claimActiveScheme()
-            if (scheme != null) {
-                val parentScheme = EditorColorsManager.getInstance().getScheme(variant.parentSchemeName)
-                scheme.setColor(editorKey, parentScheme?.getColor(editorKey))
-            }
+            AyuEditorSchemeScope.restore(schemeOwner)
         }
     }
 
@@ -49,9 +46,7 @@ class ProgressBarElement : AccentElement {
             UIManager.put(key, null)
         }
         runOnEdt {
-            AyuEditorSchemeScope.cleanClaimedAccentSchemes { scheme ->
-                scheme.setColor(editorKey, null)
-            }
+            AyuEditorSchemeScope.restore(schemeOwner)
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/accent/elements/ProgressBarElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/ProgressBarElement.kt
@@ -49,7 +49,7 @@ class ProgressBarElement : AccentElement {
             UIManager.put(key, null)
         }
         runOnEdt {
-            for (scheme in AyuEditorSchemeScope.claimedAccentSchemes()) {
+            AyuEditorSchemeScope.cleanClaimedAccentSchemes { scheme ->
                 scheme.setColor(editorKey, null)
             }
         }

--- a/src/main/kotlin/dev/ayuislands/accent/elements/ProgressBarElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/ProgressBarElement.kt
@@ -49,7 +49,7 @@ class ProgressBarElement : AccentElement {
             UIManager.put(key, null)
         }
         runOnEdt {
-            AyuEditorSchemeScope.activeScheme()?.setColor(editorKey, null)
+            AyuEditorSchemeScope.ownedScheme()?.setColor(editorKey, null)
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/accent/elements/ProgressBarElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/ProgressBarElement.kt
@@ -27,7 +27,7 @@ class ProgressBarElement : AccentElement {
             UIManager.put(key, color)
         }
         runOnEdt {
-            AyuEditorSchemeScope.activeScheme()?.setColor(editorKey, color)
+            AyuEditorSchemeScope.claimActiveScheme()?.setColor(editorKey, color)
         }
     }
 
@@ -36,7 +36,7 @@ class ProgressBarElement : AccentElement {
             UIManager.put(key, null)
         }
         runOnEdt {
-            val scheme = AyuEditorSchemeScope.activeScheme()
+            val scheme = AyuEditorSchemeScope.claimActiveScheme()
             if (scheme != null) {
                 val parentScheme = EditorColorsManager.getInstance().getScheme(variant.parentSchemeName)
                 scheme.setColor(editorKey, parentScheme?.getColor(editorKey))
@@ -49,7 +49,9 @@ class ProgressBarElement : AccentElement {
             UIManager.put(key, null)
         }
         runOnEdt {
-            AyuEditorSchemeScope.ownedScheme()?.setColor(editorKey, null)
+            for (scheme in AyuEditorSchemeScope.claimedAccentSchemes()) {
+                scheme.setColor(editorKey, null)
+            }
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/accent/elements/ScrollbarElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/ScrollbarElement.kt
@@ -58,11 +58,12 @@ class ScrollbarElement : AccentElement {
         // EditorColorsScheme keys (editor scrollbars via OpaqueAwareScrollBar).
         // Editor scrollbars bypass UIManager entirely — OpaqueAwareScrollBar installs
         // a ColorKey.FUNCTION_KEY that resolves colors from EditorColorsScheme.getColor().
+        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
         for (key in hoverKeys) {
-            AyuEditorSchemeScope.writeColor(schemeOwner, ColorKey.find(key), hoverColor)
+            AyuEditorSchemeScope.writeColor(scheme, schemeOwner, ColorKey.find(key), hoverColor)
         }
         for (key in defaultKeys) {
-            AyuEditorSchemeScope.writeColor(schemeOwner, ColorKey.find(key), defaultColor)
+            AyuEditorSchemeScope.writeColor(scheme, schemeOwner, ColorKey.find(key), defaultColor)
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/accent/elements/ScrollbarElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/ScrollbarElement.kt
@@ -71,7 +71,7 @@ class ScrollbarElement : AccentElement {
         for (key in hoverKeys + defaultKeys) {
             UIManager.put(key, null)
         }
-        for (scheme in AyuEditorSchemeScope.claimedAccentSchemes()) {
+        AyuEditorSchemeScope.cleanClaimedAccentSchemes { scheme ->
             for (key in hoverKeys + defaultKeys) {
                 scheme.setColor(ColorKey.find(key), null)
             }

--- a/src/main/kotlin/dev/ayuislands/accent/elements/ScrollbarElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/ScrollbarElement.kt
@@ -71,7 +71,7 @@ class ScrollbarElement : AccentElement {
         for (key in hoverKeys + defaultKeys) {
             UIManager.put(key, null)
         }
-        val scheme = AyuEditorSchemeScope.activeScheme()
+        val scheme = AyuEditorSchemeScope.ownedScheme()
         if (scheme != null) {
             for (key in hoverKeys + defaultKeys) {
                 scheme.setColor(ColorKey.find(key), null)

--- a/src/main/kotlin/dev/ayuislands/accent/elements/ScrollbarElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/ScrollbarElement.kt
@@ -1,10 +1,10 @@
 package dev.ayuislands.accent.elements
 
 import com.intellij.openapi.editor.colors.ColorKey
-import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.ui.ColorUtil
 import dev.ayuislands.accent.AccentElement
 import dev.ayuislands.accent.AccentElementId
+import dev.ayuislands.theme.AyuEditorSchemeScope
 import java.awt.Color
 import javax.swing.UIManager
 
@@ -56,12 +56,14 @@ class ScrollbarElement : AccentElement {
         // EditorColorsScheme keys (editor scrollbars via OpaqueAwareScrollBar).
         // Editor scrollbars bypass UIManager entirely — OpaqueAwareScrollBar installs
         // a ColorKey.FUNCTION_KEY that resolves colors from EditorColorsScheme.getColor().
-        val scheme = EditorColorsManager.getInstance().globalScheme
-        for (key in hoverKeys) {
-            scheme.setColor(ColorKey.find(key), hoverColor)
-        }
-        for (key in defaultKeys) {
-            scheme.setColor(ColorKey.find(key), defaultColor)
+        val scheme = AyuEditorSchemeScope.activeScheme()
+        if (scheme != null) {
+            for (key in hoverKeys) {
+                scheme.setColor(ColorKey.find(key), hoverColor)
+            }
+            for (key in defaultKeys) {
+                scheme.setColor(ColorKey.find(key), defaultColor)
+            }
         }
     }
 
@@ -69,9 +71,11 @@ class ScrollbarElement : AccentElement {
         for (key in hoverKeys + defaultKeys) {
             UIManager.put(key, null)
         }
-        val scheme = EditorColorsManager.getInstance().globalScheme
-        for (key in hoverKeys + defaultKeys) {
-            scheme.setColor(ColorKey.find(key), null)
+        val scheme = AyuEditorSchemeScope.activeScheme()
+        if (scheme != null) {
+            for (key in hoverKeys + defaultKeys) {
+                scheme.setColor(ColorKey.find(key), null)
+            }
         }
     }
 }

--- a/src/main/kotlin/dev/ayuislands/accent/elements/ScrollbarElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/ScrollbarElement.kt
@@ -5,12 +5,14 @@ import com.intellij.ui.ColorUtil
 import dev.ayuislands.accent.AccentElement
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.theme.AyuEditorSchemeScope
+import dev.ayuislands.theme.EditorSchemeOwner
 import java.awt.Color
 import javax.swing.UIManager
 
 class ScrollbarElement : AccentElement {
     override val id = AccentElementId.SCROLLBAR
     override val displayName = "Scrollbar"
+    private val schemeOwner = EditorSchemeOwner.Element(id)
 
     private val hoverKeys =
         listOf(
@@ -56,14 +58,11 @@ class ScrollbarElement : AccentElement {
         // EditorColorsScheme keys (editor scrollbars via OpaqueAwareScrollBar).
         // Editor scrollbars bypass UIManager entirely — OpaqueAwareScrollBar installs
         // a ColorKey.FUNCTION_KEY that resolves colors from EditorColorsScheme.getColor().
-        val scheme = AyuEditorSchemeScope.claimActiveScheme()
-        if (scheme != null) {
-            for (key in hoverKeys) {
-                scheme.setColor(ColorKey.find(key), hoverColor)
-            }
-            for (key in defaultKeys) {
-                scheme.setColor(ColorKey.find(key), defaultColor)
-            }
+        for (key in hoverKeys) {
+            AyuEditorSchemeScope.writeColor(schemeOwner, ColorKey.find(key), hoverColor)
+        }
+        for (key in defaultKeys) {
+            AyuEditorSchemeScope.writeColor(schemeOwner, ColorKey.find(key), defaultColor)
         }
     }
 
@@ -71,10 +70,6 @@ class ScrollbarElement : AccentElement {
         for (key in hoverKeys + defaultKeys) {
             UIManager.put(key, null)
         }
-        AyuEditorSchemeScope.cleanClaimedAccentSchemes { scheme ->
-            for (key in hoverKeys + defaultKeys) {
-                scheme.setColor(ColorKey.find(key), null)
-            }
-        }
+        AyuEditorSchemeScope.restore(schemeOwner)
     }
 }

--- a/src/main/kotlin/dev/ayuislands/accent/elements/ScrollbarElement.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/elements/ScrollbarElement.kt
@@ -56,7 +56,7 @@ class ScrollbarElement : AccentElement {
         // EditorColorsScheme keys (editor scrollbars via OpaqueAwareScrollBar).
         // Editor scrollbars bypass UIManager entirely — OpaqueAwareScrollBar installs
         // a ColorKey.FUNCTION_KEY that resolves colors from EditorColorsScheme.getColor().
-        val scheme = AyuEditorSchemeScope.activeScheme()
+        val scheme = AyuEditorSchemeScope.claimActiveScheme()
         if (scheme != null) {
             for (key in hoverKeys) {
                 scheme.setColor(ColorKey.find(key), hoverColor)
@@ -71,8 +71,7 @@ class ScrollbarElement : AccentElement {
         for (key in hoverKeys + defaultKeys) {
             UIManager.put(key, null)
         }
-        val scheme = AyuEditorSchemeScope.ownedScheme()
-        if (scheme != null) {
+        for (scheme in AyuEditorSchemeScope.claimedAccentSchemes()) {
             for (key in hoverKeys + defaultKeys) {
                 scheme.setColor(ColorKey.find(key), null)
             }

--- a/src/main/kotlin/dev/ayuislands/reapply/ReapplyReason.kt
+++ b/src/main/kotlin/dev/ayuislands/reapply/ReapplyReason.kt
@@ -34,6 +34,7 @@ enum class ReapplyStep {
     Glow,
     Syntax,
     RevertAccent,
+    VcsApply,
     VcsRevert,
 }
 

--- a/src/main/kotlin/dev/ayuislands/reapply/ReapplyReason.kt
+++ b/src/main/kotlin/dev/ayuislands/reapply/ReapplyReason.kt
@@ -34,7 +34,6 @@ enum class ReapplyStep {
     Glow,
     Syntax,
     RevertAccent,
-    RevertFont,
     VcsRevert,
 }
 

--- a/src/main/kotlin/dev/ayuislands/reapply/ThemeReapplication.kt
+++ b/src/main/kotlin/dev/ayuislands/reapply/ThemeReapplication.kt
@@ -17,7 +17,6 @@ import dev.ayuislands.reapply.ReapplyStep.Font
 import dev.ayuislands.reapply.ReapplyStep.Glow
 import dev.ayuislands.reapply.ReapplyStep.Notify
 import dev.ayuislands.reapply.ReapplyStep.RevertAccent
-import dev.ayuislands.reapply.ReapplyStep.RevertFont
 import dev.ayuislands.reapply.ReapplyStep.Syntax
 import dev.ayuislands.reapply.ReapplyStep.VcsRevert
 import dev.ayuislands.settings.AyuIslandsSettings
@@ -49,11 +48,11 @@ object ThemeReapplication {
                     }
 
                     AccentContext.External -> {
-                        listOf(RevertAccent, RevertFont, ApplyResolvedAccent, Glow)
+                        listOf(RevertAccent, ApplyResolvedAccent, Glow)
                     }
 
                     null -> {
-                        listOf(RevertAccent, RevertFont, Glow)
+                        listOf(RevertAccent, Glow)
                     }
                 }
             }
@@ -102,7 +101,7 @@ object ThemeReapplication {
     ) {
         when (step) {
             BindScheme, ApplyResolvedAccent, ApplyExplicitHex, RevertAccent -> runAccentStep(step, reason)
-            Font, RevertFont, Notify, Glow, Syntax, VcsRevert -> runSurfaceStep(step)
+            Font, Notify, Glow, Syntax, VcsRevert -> runSurfaceStep(step)
         }
     }
 
@@ -145,7 +144,7 @@ object ThemeReapplication {
             }
 
             // Surface steps are dispatched by runStep; unreachable here.
-            Font, RevertFont, Notify, Glow, Syntax, VcsRevert -> {
+            Font, Notify, Glow, Syntax, VcsRevert -> {
                 return
             }
         }
@@ -156,10 +155,6 @@ object ThemeReapplication {
         when (step) {
             Font -> {
                 FontPresetApplicator.applyFromState()
-            }
-
-            RevertFont -> {
-                FontPresetApplicator.revert()
             }
 
             Notify -> {

--- a/src/main/kotlin/dev/ayuislands/reapply/ThemeReapplication.kt
+++ b/src/main/kotlin/dev/ayuislands/reapply/ThemeReapplication.kt
@@ -18,6 +18,7 @@ import dev.ayuislands.reapply.ReapplyStep.Glow
 import dev.ayuislands.reapply.ReapplyStep.Notify
 import dev.ayuislands.reapply.ReapplyStep.RevertAccent
 import dev.ayuislands.reapply.ReapplyStep.Syntax
+import dev.ayuislands.reapply.ReapplyStep.VcsApply
 import dev.ayuislands.reapply.ReapplyStep.VcsRevert
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.syntax.SyntaxIntensityService
@@ -44,15 +45,15 @@ object ThemeReapplication {
             is ReapplyReason.ThemeSwitched -> {
                 when (reason.context) {
                     is AccentContext.Ayu -> {
-                        listOf(BindScheme, ApplyResolvedAccent, Font, Notify, Glow, Syntax)
+                        listOf(BindScheme, ApplyResolvedAccent, Font, Notify, Glow, Syntax, VcsApply)
                     }
 
                     AccentContext.External -> {
-                        listOf(RevertAccent, ApplyResolvedAccent, Glow)
+                        listOf(RevertAccent, VcsRevert, ApplyResolvedAccent, Glow)
                     }
 
                     null -> {
-                        listOf(RevertAccent, Glow)
+                        listOf(RevertAccent, VcsRevert, Glow)
                     }
                 }
             }
@@ -101,7 +102,7 @@ object ThemeReapplication {
     ) {
         when (step) {
             BindScheme, ApplyResolvedAccent, ApplyExplicitHex, RevertAccent -> runAccentStep(step, reason)
-            Font, Notify, Glow, Syntax, VcsRevert -> runSurfaceStep(step)
+            Font, Notify, Glow, Syntax, VcsApply, VcsRevert -> runSurfaceStep(step)
         }
     }
 
@@ -144,7 +145,7 @@ object ThemeReapplication {
             }
 
             // Surface steps are dispatched by runStep; unreachable here.
-            Font, Notify, Glow, Syntax, VcsRevert -> {
+            Font, Notify, Glow, Syntax, VcsApply, VcsRevert -> {
                 return
             }
         }
@@ -169,6 +170,10 @@ object ThemeReapplication {
                 if (AyuVariant.isAyuActive()) {
                     SyntaxIntensityService.getInstance().reapplyForActiveLaf()
                 }
+            }
+
+            VcsApply -> {
+                VcsColorApplier.applyAll()
             }
 
             VcsRevert -> {

--- a/src/main/kotlin/dev/ayuislands/settings/VcsColorPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/VcsColorPanel.kt
@@ -470,7 +470,7 @@ class VcsColorPanel : AyuIslandsSettingsPanel {
                 // Run the applier FIRST so a throw leaves persisted state untouched
                 // and the user can retry after fixing the cause.
                 VcsColorContext.withSnapshot(snapshot) {
-                    VcsColorApplier.applyAll()
+                    VcsColorApplier.applyCurrentScheme()
                 }
                 val state = AyuIslandsSettings.getInstance().state
                 state.vcsColorEnabled = pending.enabled

--- a/src/main/kotlin/dev/ayuislands/theme/AyuEditorSchemeBinder.kt
+++ b/src/main/kotlin/dev/ayuislands/theme/AyuEditorSchemeBinder.kt
@@ -83,7 +83,7 @@ internal object AyuEditorSchemeBinder {
         // binder has nothing to swap. Recognize it and stay quiet (debug, not
         // info) so it isn't misread as a user-custom skip in idea.log. A foreign
         // editable copy ("_@user_Solarized") falls through to the user-custom path.
-        if (current.removePrefix(EDITABLE_COPY_PREFIX) == target) {
+        if (isSchemeForVariant(current, variant)) {
             log.debug("Editor scheme '$current' is our editable copy for $variant; leaving in place")
             return false
         }
@@ -116,4 +116,9 @@ internal object AyuEditorSchemeBinder {
             AyuVariant.DARK -> "Ayu Islands Dark"
             AyuVariant.LIGHT -> "Ayu Islands Light"
         }
+
+    internal fun isSchemeForVariant(
+        schemeName: String,
+        variant: AyuVariant,
+    ): Boolean = schemeName.removePrefix(EDITABLE_COPY_PREFIX) == targetSchemeName(variant)
 }

--- a/src/main/kotlin/dev/ayuislands/theme/AyuEditorSchemeBinder.kt
+++ b/src/main/kotlin/dev/ayuislands/theme/AyuEditorSchemeBinder.kt
@@ -83,11 +83,11 @@ internal object AyuEditorSchemeBinder {
         // binder has nothing to swap. Recognize it and stay quiet (debug, not
         // info) so it isn't misread as a user-custom skip in idea.log. A foreign
         // editable copy ("_@user_Solarized") falls through to the user-custom path.
-        if (isSchemeForVariant(current, variant)) {
+        if (matchesVariant(current, variant)) {
             log.debug("Editor scheme '$current' is our editable copy for $variant; leaving in place")
             return false
         }
-        if (current !in NEUTRAL_SCHEMES) {
+        if (current !in NEUTRAL_SCHEMES && !isAyuScheme(current)) {
             log.info("Skipping editor-scheme bind for $variant — current scheme '$current' is user-custom")
             return false
         }
@@ -117,8 +117,10 @@ internal object AyuEditorSchemeBinder {
             AyuVariant.LIGHT -> "Ayu Islands Light"
         }
 
-    internal fun isSchemeForVariant(
+    internal fun matchesVariant(
         schemeName: String,
         variant: AyuVariant,
     ): Boolean = schemeName.removePrefix(EDITABLE_COPY_PREFIX) == targetSchemeName(variant)
+
+    internal fun isAyuScheme(schemeName: String): Boolean = AyuVariant.entries.any { matchesVariant(schemeName, it) }
 }

--- a/src/main/kotlin/dev/ayuislands/theme/AyuEditorSchemeScope.kt
+++ b/src/main/kotlin/dev/ayuislands/theme/AyuEditorSchemeScope.kt
@@ -1,10 +1,15 @@
 package dev.ayuislands.theme
 
+import com.intellij.openapi.editor.colors.ColorKey
 import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.colors.EditorColorsScheme
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.openapi.editor.markup.TextAttributes
+import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.runCatchingPreservingCancellation
 import org.jetbrains.annotations.TestOnly
+import java.awt.Color
 import java.util.Collections
 import java.util.IdentityHashMap
 
@@ -29,6 +34,37 @@ internal object AyuEditorSchemeScope {
                 accentClaims.add(scheme)
             }
         }
+
+    fun writeColor(
+        owner: EditorSchemeOwner,
+        key: ColorKey,
+        value: Color?,
+    ) {
+        val scheme = claimActiveScheme() ?: return
+        EditorSchemeOverrides.writeColor(scheme, owner, key, value)
+    }
+
+    fun writeAttributes(
+        owner: EditorSchemeOwner,
+        key: TextAttributesKey,
+        value: TextAttributes?,
+    ) {
+        val scheme = claimActiveScheme() ?: return
+        EditorSchemeOverrides.writeAttributes(scheme, owner, key, value)
+    }
+
+    fun restore(owner: EditorSchemeOwner) {
+        cleanClaimedAccentSchemes { scheme ->
+            EditorSchemeOverrides.restore(scheme, owner)
+        }
+    }
+
+    fun observeElementEnabled(
+        id: AccentElementId,
+        isEnabled: Boolean,
+    ) {
+        EditorSchemeOverrides.observeElementEnabled(id, isEnabled)
+    }
 
     fun currentAyuScheme(): EditorColorsScheme? =
         EditorColorsManager
@@ -95,5 +131,6 @@ internal object AyuEditorSchemeScope {
     @TestOnly
     fun resetClaims() {
         releaseAccentClaims()
+        EditorSchemeOverrides.reset()
     }
 }

--- a/src/main/kotlin/dev/ayuislands/theme/AyuEditorSchemeScope.kt
+++ b/src/main/kotlin/dev/ayuislands/theme/AyuEditorSchemeScope.kt
@@ -10,7 +10,13 @@ internal object AyuEditorSchemeScope {
         val scheme = EditorColorsManager.getInstance().globalScheme
 
         return scheme.takeIf {
-            AyuEditorSchemeBinder.isSchemeForVariant(it.name, variant)
+            AyuEditorSchemeBinder.matchesVariant(it.name, variant)
         }
     }
+
+    fun ownedScheme(): EditorColorsScheme? =
+        EditorColorsManager
+            .getInstance()
+            .globalScheme
+            .takeIf { AyuEditorSchemeBinder.isAyuScheme(it.name) }
 }

--- a/src/main/kotlin/dev/ayuislands/theme/AyuEditorSchemeScope.kt
+++ b/src/main/kotlin/dev/ayuislands/theme/AyuEditorSchemeScope.kt
@@ -74,16 +74,32 @@ internal object AyuEditorSchemeScope {
     }
 
     fun restore(owner: EditorSchemeOwner) {
+        val schemes = allSchemes()
+        val current = currentAyuScheme()
+        val variant =
+            current?.let { scheme ->
+                AyuVariant.entries.firstOrNull { AyuEditorSchemeBinder.matchesVariant(scheme.name, it) }
+            }
+        val canonicalName = variant?.let(AyuEditorSchemeBinder::targetSchemeName)
+        if (current != null && canonicalName != null && current.name != canonicalName) {
+            schemes.firstOrNull { it.name == canonicalName }?.let { canonical ->
+                EditorSchemeOverrides.inherit(current, canonical)
+            }
+        }
         cleanClaimedAccentSchemes { scheme ->
             EditorSchemeOverrides.restore(scheme, owner)
         }
+        val claimed = claimedAccentSchemes()
+        schemes
+            .filter { scheme -> claimed.none { it === scheme } && EditorSchemeOverrides.hasState(scheme, owner) }
+            .forEach { scheme -> EditorSchemeOverrides.restore(scheme, owner) }
     }
 
     fun observeElementEnabled(
         id: AccentElementId,
         isEnabled: Boolean,
     ) {
-        EditorSchemeOverrides.observeElementEnabled(id, isEnabled)
+        EditorSchemeOverrides.observeElementEnabled(id, isEnabled, ::allSchemes)
     }
 
     fun currentAyuScheme(): EditorColorsScheme? =
@@ -118,6 +134,8 @@ internal object AyuEditorSchemeScope {
         firstFailure?.let { throw it }
     }
 
+    private fun allSchemes(): List<EditorColorsScheme> = EditorColorsManager.getInstance().allSchemes.toList()
+
     fun retainAllAccentClaims() {
         synchronized(accentCleanupFailures) {
             accentCleanupFailures.addAll(claimedAccentSchemes())
@@ -149,8 +167,13 @@ internal object AyuEditorSchemeScope {
     }
 
     private fun claim(scheme: EditorColorsScheme) {
-        synchronized(accentClaims) {
-            accentClaims.add(scheme)
+        val isNew = synchronized(accentClaims) { accentClaims.add(scheme) }
+        if (!isNew) return
+        val variant = AyuVariant.detect() ?: return
+        val canonicalName = AyuEditorSchemeBinder.targetSchemeName(variant)
+        if (scheme.name == canonicalName) return
+        allSchemes().firstOrNull { it.name == canonicalName }?.let { canonical ->
+            EditorSchemeOverrides.inherit(scheme, canonical)
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/theme/AyuEditorSchemeScope.kt
+++ b/src/main/kotlin/dev/ayuislands/theme/AyuEditorSchemeScope.kt
@@ -1,0 +1,16 @@
+package dev.ayuislands.theme
+
+import com.intellij.openapi.editor.colors.EditorColorsManager
+import com.intellij.openapi.editor.colors.EditorColorsScheme
+import dev.ayuislands.accent.AyuVariant
+
+internal object AyuEditorSchemeScope {
+    fun activeScheme(): EditorColorsScheme? {
+        val variant = AyuVariant.detect() ?: return null
+        val scheme = EditorColorsManager.getInstance().globalScheme
+
+        return scheme.takeIf {
+            AyuEditorSchemeBinder.isSchemeForVariant(it.name, variant)
+        }
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/theme/AyuEditorSchemeScope.kt
+++ b/src/main/kotlin/dev/ayuislands/theme/AyuEditorSchemeScope.kt
@@ -3,12 +3,15 @@ package dev.ayuislands.theme
 import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.colors.EditorColorsScheme
 import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.accent.runCatchingPreservingCancellation
 import org.jetbrains.annotations.TestOnly
 import java.util.Collections
 import java.util.IdentityHashMap
 
 internal object AyuEditorSchemeScope {
     private val accentClaims: MutableSet<EditorColorsScheme> =
+        Collections.newSetFromMap(IdentityHashMap())
+    private val accentCleanupFailures: MutableSet<EditorColorsScheme> =
         Collections.newSetFromMap(IdentityHashMap())
 
     fun activeScheme(): EditorColorsScheme? {
@@ -38,9 +41,54 @@ internal object AyuEditorSchemeScope {
             accentClaims.toList()
         }
 
+    fun beginAccentCleanup() {
+        synchronized(accentCleanupFailures) {
+            accentCleanupFailures.clear()
+        }
+    }
+
+    fun cleanClaimedAccentSchemes(cleanup: (EditorColorsScheme) -> Unit) {
+        var firstFailure: Throwable? = null
+        for (scheme in claimedAccentSchemes()) {
+            runCatchingPreservingCancellation { cleanup(scheme) }
+                .exceptionOrNull()
+                ?.let { failure ->
+                    synchronized(accentCleanupFailures) {
+                        accentCleanupFailures.add(scheme)
+                    }
+                    if (firstFailure == null) firstFailure = failure
+                }
+        }
+        firstFailure?.let { throw it }
+    }
+
+    fun retainAllAccentClaims() {
+        synchronized(accentCleanupFailures) {
+            accentCleanupFailures.addAll(claimedAccentSchemes())
+        }
+    }
+
+    fun hasAccentCleanupFailures(): Boolean =
+        synchronized(accentCleanupFailures) {
+            accentCleanupFailures.isNotEmpty()
+        }
+
+    fun releaseCleanAccentClaims() {
+        val failed = synchronized(accentCleanupFailures) { accentCleanupFailures.toList() }
+        synchronized(accentClaims) {
+            accentClaims.removeIf { claim -> failed.none { failedScheme -> failedScheme === claim } }
+        }
+        synchronized(accentCleanupFailures) {
+            accentCleanupFailures.clear()
+        }
+    }
+
     fun releaseAccentClaims() {
         synchronized(accentClaims) {
             accentClaims.clear()
+        }
+        synchronized(accentCleanupFailures) {
+            accentCleanupFailures.clear()
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/theme/AyuEditorSchemeScope.kt
+++ b/src/main/kotlin/dev/ayuislands/theme/AyuEditorSchemeScope.kt
@@ -30,9 +30,7 @@ internal object AyuEditorSchemeScope {
 
     fun claimActiveScheme(): EditorColorsScheme? =
         activeScheme()?.also { scheme ->
-            synchronized(accentClaims) {
-                accentClaims.add(scheme)
-            }
+            claim(scheme)
         }
 
     fun writeColor(
@@ -40,7 +38,18 @@ internal object AyuEditorSchemeScope {
         key: ColorKey,
         value: Color?,
     ) {
-        val scheme = claimActiveScheme() ?: return
+        val scheme = activeScheme() ?: return
+        writeColor(scheme, owner, key, value)
+    }
+
+    fun writeColor(
+        scheme: EditorColorsScheme,
+        owner: EditorSchemeOwner,
+        key: ColorKey,
+        value: Color?,
+    ) {
+        if (activeScheme() !== scheme) return
+        claim(scheme)
         EditorSchemeOverrides.writeColor(scheme, owner, key, value)
     }
 
@@ -49,7 +58,18 @@ internal object AyuEditorSchemeScope {
         key: TextAttributesKey,
         value: TextAttributes?,
     ) {
-        val scheme = claimActiveScheme() ?: return
+        val scheme = activeScheme() ?: return
+        writeAttributes(scheme, owner, key, value)
+    }
+
+    fun writeAttributes(
+        scheme: EditorColorsScheme,
+        owner: EditorSchemeOwner,
+        key: TextAttributesKey,
+        value: TextAttributes?,
+    ) {
+        if (activeScheme() !== scheme) return
+        claim(scheme)
         EditorSchemeOverrides.writeAttributes(scheme, owner, key, value)
     }
 
@@ -125,6 +145,12 @@ internal object AyuEditorSchemeScope {
         }
         synchronized(accentCleanupFailures) {
             accentCleanupFailures.clear()
+        }
+    }
+
+    private fun claim(scheme: EditorColorsScheme) {
+        synchronized(accentClaims) {
+            accentClaims.add(scheme)
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/theme/AyuEditorSchemeScope.kt
+++ b/src/main/kotlin/dev/ayuislands/theme/AyuEditorSchemeScope.kt
@@ -3,8 +3,14 @@ package dev.ayuislands.theme
 import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.colors.EditorColorsScheme
 import dev.ayuislands.accent.AyuVariant
+import org.jetbrains.annotations.TestOnly
+import java.util.Collections
+import java.util.IdentityHashMap
 
 internal object AyuEditorSchemeScope {
+    private val accentClaims: MutableSet<EditorColorsScheme> =
+        Collections.newSetFromMap(IdentityHashMap())
+
     fun activeScheme(): EditorColorsScheme? {
         val variant = AyuVariant.detect() ?: return null
         val scheme = EditorColorsManager.getInstance().globalScheme
@@ -14,9 +20,32 @@ internal object AyuEditorSchemeScope {
         }
     }
 
-    fun ownedScheme(): EditorColorsScheme? =
+    fun claimActiveScheme(): EditorColorsScheme? =
+        activeScheme()?.also { scheme ->
+            synchronized(accentClaims) {
+                accentClaims.add(scheme)
+            }
+        }
+
+    fun currentAyuScheme(): EditorColorsScheme? =
         EditorColorsManager
             .getInstance()
             .globalScheme
             .takeIf { AyuEditorSchemeBinder.isAyuScheme(it.name) }
+
+    fun claimedAccentSchemes(): List<EditorColorsScheme> =
+        synchronized(accentClaims) {
+            accentClaims.toList()
+        }
+
+    fun releaseAccentClaims() {
+        synchronized(accentClaims) {
+            accentClaims.clear()
+        }
+    }
+
+    @TestOnly
+    fun resetClaims() {
+        releaseAccentClaims()
+    }
 }

--- a/src/main/kotlin/dev/ayuislands/theme/EditorSchemeOverrides.kt
+++ b/src/main/kotlin/dev/ayuislands/theme/EditorSchemeOverrides.kt
@@ -5,8 +5,11 @@ import com.intellij.openapi.editor.colors.ColorKey
 import com.intellij.openapi.editor.colors.EditorColorsScheme
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.editor.markup.TextAttributes
+import com.intellij.openapi.util.JDOMUtil
 import dev.ayuislands.accent.AccentElementId
+import org.jdom.Element
 import java.awt.Color
+import java.util.Base64
 import java.util.EnumMap
 import java.util.IdentityHashMap
 
@@ -16,6 +19,8 @@ internal sealed interface EditorSchemeOwner {
     ) : EditorSchemeOwner
 
     data object AlwaysOn : EditorSchemeOwner
+
+    data object Vcs : EditorSchemeOwner
 }
 
 internal object EditorSchemeOverrides {
@@ -52,17 +57,20 @@ internal object EditorSchemeOverrides {
         owner: EditorSchemeOwner,
     ) {
         synchronized(lock) {
+            hydrate(scheme)
             val schemeStates = states[scheme] ?: return
             var firstFailure: RuntimeException? = null
             for ((entry, state) in schemeStates.toList()) {
                 if (state.owner != owner || state !is OverrideState.Owned) continue
                 if (read(scheme, entry) != state.lastWritten) {
                     schemeStates[entry] = OverrideState.Relinquished(owner)
+                    scheme.metaProperties.setProperty(entry.metadataKey, encodeState(schemeStates.getValue(entry)))
                     continue
                 }
                 try {
                     writeValue(scheme, entry, state.original)
                     schemeStates.remove(entry)
+                    scheme.metaProperties.remove(entry.metadataKey)
                 } catch (exception: RuntimeException) {
                     if (firstFailure == null) firstFailure = exception
                 }
@@ -75,11 +83,12 @@ internal object EditorSchemeOverrides {
     fun observeElementEnabled(
         id: AccentElementId,
         isEnabled: Boolean,
+        schemes: () -> Iterable<EditorColorsScheme>,
     ) {
         synchronized(lock) {
             val wasEnabled = elementEnabled.put(id, isEnabled)
             if (wasEnabled == false && isEnabled) {
-                rearm(EditorSchemeOwner.Element(id))
+                rearm(EditorSchemeOwner.Element(id), schemes())
             }
         }
     }
@@ -99,11 +108,13 @@ internal object EditorSchemeOverrides {
     ) {
         synchronized(lock) {
             val schemeStates = states.getOrPut(scheme) { mutableMapOf() }
+            hydrate(scheme, entry)
             when (val state = schemeStates[entry]) {
                 null -> {
                     val original = read(scheme, entry)
                     writeValue(scheme, entry, value)
                     schemeStates[entry] = OverrideState.Owned(owner, original, value.snapshot())
+                    scheme.metaProperties.setProperty(entry.metadataKey, encodeState(schemeStates.getValue(entry)))
                 }
 
                 is OverrideState.Relinquished -> Unit
@@ -126,10 +137,12 @@ internal object EditorSchemeOverrides {
         }
         if (read(scheme, entry) != state.lastWritten) {
             schemeStates[entry] = OverrideState.Relinquished(owner)
+            scheme.metaProperties.setProperty(entry.metadataKey, encodeState(schemeStates.getValue(entry)))
             return
         }
         writeValue(scheme, entry, value)
         schemeStates[entry] = state.copy(lastWritten = value.snapshot())
+        scheme.metaProperties.setProperty(entry.metadataKey, encodeState(schemeStates.getValue(entry)))
     }
 
     private fun read(
@@ -162,23 +175,103 @@ internal object EditorSchemeOverrides {
         }
     }
 
-    private fun rearm(owner: EditorSchemeOwner) {
-        for (schemeStates in states.values) {
-            schemeStates.entries.removeIf { (_, state) ->
-                state is OverrideState.Relinquished && state.owner == owner
+    fun rearm(
+        owner: EditorSchemeOwner,
+        schemes: Iterable<EditorColorsScheme>,
+    ) = synchronized(lock) {
+        schemes.forEach(::hydrate)
+        for ((scheme, schemeStates) in states) {
+            schemeStates.entries.removeIf { (entry, state) ->
+                val shouldRemove = state is OverrideState.Relinquished && state.owner == owner
+                if (shouldRemove) scheme.metaProperties.remove(entry.metadataKey)
+                shouldRemove
             }
         }
         states.entries.removeIf { (_, schemeStates) -> schemeStates.isEmpty() }
     }
 
+    fun hasState(
+        scheme: EditorColorsScheme,
+        owner: EditorSchemeOwner,
+    ): Boolean =
+        synchronized(lock) {
+            hydrate(scheme)
+            states[scheme]?.values?.any { it.owner == owner } == true
+        }
+
+    fun inherit(
+        target: EditorColorsScheme,
+        canonical: EditorColorsScheme,
+    ) = synchronized(lock) {
+        hydrate(target)
+        hydrate(canonical)
+        val targetStates = states.getOrPut(target) { mutableMapOf() }
+        for ((entry, state) in states[canonical].orEmpty()) {
+            if (entry in targetStates) continue
+            val inherited =
+                when (state) {
+                    is OverrideState.Owned ->
+                        state.takeIf { read(target, entry) == it.lastWritten }?.copy(
+                            original = state.original.snapshot(),
+                            lastWritten = state.lastWritten.snapshot(),
+                        )
+                    is OverrideState.Relinquished -> state
+                } ?: continue
+            targetStates[entry] = inherited
+            target.metaProperties.setProperty(entry.metadataKey, encodeState(inherited))
+        }
+    }
+
+    private fun hydrate(scheme: EditorColorsScheme) {
+        scheme.metaProperties
+            .stringPropertyNames()
+            .filter { it.startsWith(METADATA_PREFIX) }
+            .forEach { key ->
+                val entry = SchemeEntry.fromMetadataKey(key) ?: return@forEach
+                hydrate(scheme, entry)
+            }
+    }
+
+    private fun hydrate(
+        scheme: EditorColorsScheme,
+        entry: SchemeEntry,
+    ) {
+        val schemeStates = states.getOrPut(scheme) { mutableMapOf() }
+        if (entry in schemeStates) return
+        scheme.metaProperties
+            .getProperty(entry.metadataKey)
+            .takeIf { it?.contains(';') == true }
+            ?.let { encoded -> schemeStates[entry] = decodeState(encoded) }
+    }
+
     private sealed interface SchemeEntry {
+        val metadataKey: String
+
         data class ColorEntry(
             val key: ColorKey,
-        ) : SchemeEntry
+        ) : SchemeEntry {
+            override val metadataKey = "$METADATA_PREFIX$COLOR_KIND.${key.externalName}"
+        }
 
         data class AttributesEntry(
             val key: TextAttributesKey,
-        ) : SchemeEntry
+        ) : SchemeEntry {
+            override val metadataKey = "$METADATA_PREFIX$ATTRIBUTES_KIND.${key.externalName}"
+        }
+
+        companion object {
+            fun fromMetadataKey(key: String): SchemeEntry? {
+                val encoded = key.removePrefix(METADATA_PREFIX)
+                val kind = encoded.substringBefore('.')
+                val name = encoded.substringAfter('.', missingDelimiterValue = "")
+                if (name.isEmpty()) return null
+                return when (kind) {
+                    COLOR_KIND -> ColorEntry(ColorKey.find(name))
+                    ATTRIBUTES_KIND -> AttributesEntry(TextAttributesKey.find(name))
+                    else -> null
+                }
+            }
+        }
     }
 
     private sealed interface SchemeValue {
@@ -210,4 +303,74 @@ internal object EditorSchemeOverrides {
             override val owner: EditorSchemeOwner,
         ) : OverrideState
     }
+
+    private fun encodeState(state: OverrideState): String {
+        val stateOwner = state.owner
+        val owner =
+            when (stateOwner) {
+                is EditorSchemeOwner.Element -> "E:${stateOwner.id.name}"
+                EditorSchemeOwner.AlwaysOn -> "A"
+                EditorSchemeOwner.Vcs -> "V"
+            }
+        return when (state) {
+            is OverrideState.Owned ->
+                listOf("O", owner, encodeValue(state.original), encodeValue(state.lastWritten))
+                    .joinToString(";")
+            is OverrideState.Relinquished -> "R;$owner"
+        }
+    }
+
+    private fun decodeState(encoded: String): OverrideState {
+        val parts = encoded.split(';')
+        val owner = decodeOwner(parts[1])
+        return if (parts[0] == "R") {
+            OverrideState.Relinquished(owner)
+        } else {
+            OverrideState.Owned(
+                owner,
+                decodeValue(parts[STATE_PAYLOAD_INDEX]),
+                decodeValue(parts.last()),
+            )
+        }
+    }
+
+    private fun decodeOwner(encoded: String): EditorSchemeOwner =
+        when (encoded) {
+            "A" -> EditorSchemeOwner.AlwaysOn
+            "V" -> EditorSchemeOwner.Vcs
+            else -> EditorSchemeOwner.Element(AccentElementId.valueOf(encoded.removePrefix("E:")))
+        }
+
+    private fun encodeValue(value: SchemeValue): String =
+        when (value) {
+            is SchemeValue.ColorValue -> "C,${value.value?.rgb?.toString().orEmpty()}"
+            is SchemeValue.AttributesValue ->
+                value.value?.let { attributes ->
+                    val element = Element("attributes")
+                    attributes.writeExternal(element)
+                    "A,${Base64.getEncoder().encodeToString(JDOMUtil.writeElement(element).encodeToByteArray())}"
+                } ?: "N"
+        }
+
+    private fun decodeValue(encoded: String): SchemeValue =
+        when (encoded.first()) {
+            'C' ->
+                SchemeValue.ColorValue(
+                    encoded
+                        .substringAfter(',')
+                        .takeIf(String::isNotEmpty)
+                        ?.toInt()
+                        ?.let { Color(it, true) },
+                )
+            'N' -> SchemeValue.AttributesValue(null)
+            else -> {
+                val xml = Base64.getDecoder().decode(encoded.substringAfter(',')).decodeToString()
+                SchemeValue.AttributesValue(TextAttributes(JDOMUtil.load(xml)))
+            }
+        }
+
+    private const val STATE_PAYLOAD_INDEX = 2
+    private const val METADATA_PREFIX = "dev.ayuislands.override.v1."
+    private const val COLOR_KIND = "color"
+    private const val ATTRIBUTES_KIND = "attributes"
 }

--- a/src/main/kotlin/dev/ayuislands/theme/EditorSchemeOverrides.kt
+++ b/src/main/kotlin/dev/ayuislands/theme/EditorSchemeOverrides.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.editor.colors.ColorKey
 import com.intellij.openapi.editor.colors.EditorColorsScheme
 import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.openapi.editor.colors.impl.AbstractColorsScheme
 import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.openapi.util.JDOMUtil
 import dev.ayuislands.accent.AccentElementId
@@ -59,21 +60,31 @@ internal object EditorSchemeOverrides {
         synchronized(lock) {
             hydrate(scheme)
             val schemeStates = states[scheme] ?: return
-            var firstFailure: RuntimeException? = null
-            for ((entry, state) in schemeStates.toList()) {
-                if (state.owner != owner || state !is OverrideState.Owned) continue
+
+            fun restoreEntry(
+                entry: SchemeEntry,
+                state: OverrideState,
+            ): RuntimeException? {
+                if (state.owner != owner || state !is OverrideState.Owned) return null
                 if (read(scheme, entry) != state.lastWritten) {
                     schemeStates[entry] = OverrideState.Relinquished(owner)
                     scheme.metaProperties.setProperty(entry.metadataKey, encodeState(schemeStates.getValue(entry)))
-                    continue
+                    return null
                 }
-                try {
+                return try {
                     writeValue(scheme, entry, state.original)
                     schemeStates.remove(entry)
                     scheme.metaProperties.remove(entry.metadataKey)
+                    null
                 } catch (exception: RuntimeException) {
-                    if (firstFailure == null) firstFailure = exception
+                    exception
                 }
+            }
+
+            var firstFailure: RuntimeException? = null
+            for ((entry, state) in schemeStates.toList()) {
+                val failure = restoreEntry(entry, state) ?: continue
+                if (firstFailure == null) firstFailure = failure
             }
             if (schemeStates.isEmpty()) states.remove(scheme)
             firstFailure?.let { throw it }
@@ -111,7 +122,7 @@ internal object EditorSchemeOverrides {
             hydrate(scheme, entry)
             when (val state = schemeStates[entry]) {
                 null -> {
-                    val original = read(scheme, entry)
+                    val original = read(scheme, entry, isBaseline = true)
                     writeValue(scheme, entry, value)
                     schemeStates[entry] = OverrideState.Owned(owner, original, value.snapshot())
                     scheme.metaProperties.setProperty(entry.metadataKey, encodeState(schemeStates.getValue(entry)))
@@ -148,14 +159,38 @@ internal object EditorSchemeOverrides {
     private fun read(
         scheme: EditorColorsScheme,
         entry: SchemeEntry,
-    ): SchemeValue =
-        when (entry) {
+        isBaseline: Boolean = false,
+    ): SchemeValue {
+        if (isBaseline && scheme is AbstractColorsScheme) {
+            return when (entry) {
+                is SchemeEntry.ColorEntry -> {
+                    val direct = scheme.directlyDefinedColors[entry.key]
+                    when {
+                        direct == null || direct === AbstractColorsScheme.INHERITED_COLOR_MARKER ->
+                            SchemeValue.InheritedColor
+                        direct === AbstractColorsScheme.NULL_COLOR_MARKER -> SchemeValue.ColorValue(null)
+                        else -> SchemeValue.ColorValue(direct)
+                    }
+                }
+
+                is SchemeEntry.AttributesEntry -> {
+                    val direct = scheme.directlyDefinedAttributes[entry.key.externalName]
+                    if (direct == null || direct === AbstractColorsScheme.INHERITED_ATTRS_MARKER) {
+                        SchemeValue.InheritedAttributes
+                    } else {
+                        SchemeValue.AttributesValue(direct.clone())
+                    }
+                }
+            }
+        }
+        return when (entry) {
             is SchemeEntry.ColorEntry -> SchemeValue.ColorValue(scheme.getColor(entry.key))
             is SchemeEntry.AttributesEntry ->
                 SchemeValue.AttributesValue(
                     scheme.getAttributes(entry.key)?.clone(),
                 )
         }
+    }
 
     private fun writeValue(
         scheme: EditorColorsScheme,
@@ -169,6 +204,14 @@ internal object EditorSchemeOverrides {
 
             entry is SchemeEntry.AttributesEntry && value is SchemeValue.AttributesValue -> {
                 scheme.setAttributes(entry.key, value.value?.clone())
+            }
+
+            entry is SchemeEntry.ColorEntry && value is SchemeValue.InheritedColor -> {
+                scheme.setColor(entry.key, AbstractColorsScheme.INHERITED_COLOR_MARKER)
+            }
+
+            entry is SchemeEntry.AttributesEntry && value is SchemeValue.InheritedAttributes -> {
+                scheme.setAttributes(entry.key, AbstractColorsScheme.INHERITED_ATTRS_MARKER)
             }
 
             else -> error("Editor scheme entry and value types must match")
@@ -208,15 +251,16 @@ internal object EditorSchemeOverrides {
         val targetStates = states.getOrPut(target) { mutableMapOf() }
         for ((entry, state) in states[canonical].orEmpty()) {
             if (entry in targetStates) continue
+            if (state is OverrideState.Owned && read(target, entry) != state.lastWritten) continue
             val inherited =
                 when (state) {
                     is OverrideState.Owned ->
-                        state.takeIf { read(target, entry) == it.lastWritten }?.copy(
+                        state.copy(
                             original = state.original.snapshot(),
                             lastWritten = state.lastWritten.snapshot(),
                         )
                     is OverrideState.Relinquished -> state
-                } ?: continue
+                }
             targetStates[entry] = inherited
             target.metaProperties.setProperty(entry.metadataKey, encodeState(inherited))
         }
@@ -288,6 +332,14 @@ internal object EditorSchemeOverrides {
         ) : SchemeValue {
             override fun snapshot(): SchemeValue = AttributesValue(value?.clone())
         }
+
+        data object InheritedColor : SchemeValue {
+            override fun snapshot(): SchemeValue = this
+        }
+
+        data object InheritedAttributes : SchemeValue {
+            override fun snapshot(): SchemeValue = this
+        }
     }
 
     private sealed interface OverrideState {
@@ -350,22 +402,30 @@ internal object EditorSchemeOverrides {
                     attributes.writeExternal(element)
                     "A,${Base64.getEncoder().encodeToString(JDOMUtil.writeElement(element).encodeToByteArray())}"
                 } ?: "N"
+            SchemeValue.InheritedColor -> "IC"
+            SchemeValue.InheritedAttributes -> "IA"
         }
 
     private fun decodeValue(encoded: String): SchemeValue =
-        when (encoded.first()) {
-            'C' ->
-                SchemeValue.ColorValue(
-                    encoded
-                        .substringAfter(',')
-                        .takeIf(String::isNotEmpty)
-                        ?.toInt()
-                        ?.let { Color(it, true) },
-                )
-            'N' -> SchemeValue.AttributesValue(null)
+        when (encoded) {
+            "IC" -> SchemeValue.InheritedColor
+            "IA" -> SchemeValue.InheritedAttributes
             else -> {
-                val xml = Base64.getDecoder().decode(encoded.substringAfter(',')).decodeToString()
-                SchemeValue.AttributesValue(TextAttributes(JDOMUtil.load(xml)))
+                when (encoded.first()) {
+                    'C' ->
+                        SchemeValue.ColorValue(
+                            encoded
+                                .substringAfter(',')
+                                .takeIf(String::isNotEmpty)
+                                ?.toInt()
+                                ?.let { Color(it, true) },
+                        )
+                    'N' -> SchemeValue.AttributesValue(null)
+                    else -> {
+                        val xml = Base64.getDecoder().decode(encoded.substringAfter(',')).decodeToString()
+                        SchemeValue.AttributesValue(TextAttributes(JDOMUtil.load(xml)))
+                    }
+                }
             }
         }
 

--- a/src/main/kotlin/dev/ayuislands/theme/EditorSchemeOverrides.kt
+++ b/src/main/kotlin/dev/ayuislands/theme/EditorSchemeOverrides.kt
@@ -1,0 +1,213 @@
+package dev.ayuislands.theme
+
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.editor.colors.ColorKey
+import com.intellij.openapi.editor.colors.EditorColorsScheme
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.openapi.editor.markup.TextAttributes
+import dev.ayuislands.accent.AccentElementId
+import java.awt.Color
+import java.util.EnumMap
+import java.util.IdentityHashMap
+
+internal sealed interface EditorSchemeOwner {
+    data class Element(
+        val id: AccentElementId,
+    ) : EditorSchemeOwner
+
+    data object AlwaysOn : EditorSchemeOwner
+}
+
+internal object EditorSchemeOverrides {
+    private val log = logger<EditorSchemeOverrides>()
+    private val lock = Any()
+    private val states = IdentityHashMap<EditorColorsScheme, MutableMap<SchemeEntry, OverrideState>>()
+    private val elementEnabled = EnumMap<AccentElementId, Boolean>(AccentElementId::class.java)
+
+    fun writeColor(
+        scheme: EditorColorsScheme,
+        owner: EditorSchemeOwner,
+        key: ColorKey,
+        value: Color?,
+    ) {
+        write(scheme, owner, SchemeEntry.ColorEntry(key), SchemeValue.ColorValue(value))
+    }
+
+    fun writeAttributes(
+        scheme: EditorColorsScheme,
+        owner: EditorSchemeOwner,
+        key: TextAttributesKey,
+        value: TextAttributes?,
+    ) {
+        write(
+            scheme,
+            owner,
+            SchemeEntry.AttributesEntry(key),
+            SchemeValue.AttributesValue(value?.clone()),
+        )
+    }
+
+    fun restore(
+        scheme: EditorColorsScheme,
+        owner: EditorSchemeOwner,
+    ) {
+        synchronized(lock) {
+            val schemeStates = states[scheme] ?: return
+            var firstFailure: RuntimeException? = null
+            for ((entry, state) in schemeStates.toList()) {
+                if (state.owner != owner || state !is OverrideState.Owned) continue
+                if (read(scheme, entry) != state.lastWritten) {
+                    schemeStates[entry] = OverrideState.Relinquished(owner)
+                    continue
+                }
+                try {
+                    writeValue(scheme, entry, state.original)
+                    schemeStates.remove(entry)
+                } catch (exception: RuntimeException) {
+                    if (firstFailure == null) firstFailure = exception
+                }
+            }
+            if (schemeStates.isEmpty()) states.remove(scheme)
+            firstFailure?.let { throw it }
+        }
+    }
+
+    fun observeElementEnabled(
+        id: AccentElementId,
+        isEnabled: Boolean,
+    ) {
+        synchronized(lock) {
+            val wasEnabled = elementEnabled.put(id, isEnabled)
+            if (wasEnabled == false && isEnabled) {
+                rearm(EditorSchemeOwner.Element(id))
+            }
+        }
+    }
+
+    fun reset() {
+        synchronized(lock) {
+            states.clear()
+            elementEnabled.clear()
+        }
+    }
+
+    private fun write(
+        scheme: EditorColorsScheme,
+        owner: EditorSchemeOwner,
+        entry: SchemeEntry,
+        value: SchemeValue,
+    ) {
+        synchronized(lock) {
+            val schemeStates = states.getOrPut(scheme) { mutableMapOf() }
+            when (val state = schemeStates[entry]) {
+                null -> {
+                    val original = read(scheme, entry)
+                    writeValue(scheme, entry, value)
+                    schemeStates[entry] = OverrideState.Owned(owner, original, value.snapshot())
+                }
+
+                is OverrideState.Relinquished -> Unit
+                is OverrideState.Owned -> updateOwned(scheme, owner, entry, value, state)
+            }
+        }
+    }
+
+    private fun updateOwned(
+        scheme: EditorColorsScheme,
+        owner: EditorSchemeOwner,
+        entry: SchemeEntry,
+        value: SchemeValue,
+        state: OverrideState.Owned,
+    ) {
+        val schemeStates = states.getValue(scheme)
+        if (state.owner != owner) {
+            log.warn("Skipping editor scheme override because $entry is already owned by ${state.owner}")
+            return
+        }
+        if (read(scheme, entry) != state.lastWritten) {
+            schemeStates[entry] = OverrideState.Relinquished(owner)
+            return
+        }
+        writeValue(scheme, entry, value)
+        schemeStates[entry] = state.copy(lastWritten = value.snapshot())
+    }
+
+    private fun read(
+        scheme: EditorColorsScheme,
+        entry: SchemeEntry,
+    ): SchemeValue =
+        when (entry) {
+            is SchemeEntry.ColorEntry -> SchemeValue.ColorValue(scheme.getColor(entry.key))
+            is SchemeEntry.AttributesEntry ->
+                SchemeValue.AttributesValue(
+                    scheme.getAttributes(entry.key)?.clone(),
+                )
+        }
+
+    private fun writeValue(
+        scheme: EditorColorsScheme,
+        entry: SchemeEntry,
+        value: SchemeValue,
+    ) {
+        when {
+            entry is SchemeEntry.ColorEntry && value is SchemeValue.ColorValue -> {
+                scheme.setColor(entry.key, value.value)
+            }
+
+            entry is SchemeEntry.AttributesEntry && value is SchemeValue.AttributesValue -> {
+                scheme.setAttributes(entry.key, value.value?.clone())
+            }
+
+            else -> error("Editor scheme entry and value types must match")
+        }
+    }
+
+    private fun rearm(owner: EditorSchemeOwner) {
+        for (schemeStates in states.values) {
+            schemeStates.entries.removeIf { (_, state) ->
+                state is OverrideState.Relinquished && state.owner == owner
+            }
+        }
+        states.entries.removeIf { (_, schemeStates) -> schemeStates.isEmpty() }
+    }
+
+    private sealed interface SchemeEntry {
+        data class ColorEntry(
+            val key: ColorKey,
+        ) : SchemeEntry
+
+        data class AttributesEntry(
+            val key: TextAttributesKey,
+        ) : SchemeEntry
+    }
+
+    private sealed interface SchemeValue {
+        fun snapshot(): SchemeValue
+
+        data class ColorValue(
+            val value: Color?,
+        ) : SchemeValue {
+            override fun snapshot(): SchemeValue = this
+        }
+
+        data class AttributesValue(
+            val value: TextAttributes?,
+        ) : SchemeValue {
+            override fun snapshot(): SchemeValue = AttributesValue(value?.clone())
+        }
+    }
+
+    private sealed interface OverrideState {
+        val owner: EditorSchemeOwner
+
+        data class Owned(
+            override val owner: EditorSchemeOwner,
+            val original: SchemeValue,
+            val lastWritten: SchemeValue,
+        ) : OverrideState
+
+        data class Relinquished(
+            override val owner: EditorSchemeOwner,
+        ) : OverrideState
+    }
+}

--- a/src/main/kotlin/dev/ayuislands/theme/EditorSchemeOverrides.kt
+++ b/src/main/kotlin/dev/ayuislands/theme/EditorSchemeOverrides.kt
@@ -61,29 +61,9 @@ internal object EditorSchemeOverrides {
             hydrate(scheme)
             val schemeStates = states[scheme] ?: return
 
-            fun restoreEntry(
-                entry: SchemeEntry,
-                state: OverrideState,
-            ): RuntimeException? {
-                if (state.owner != owner || state !is OverrideState.Owned) return null
-                if (read(scheme, entry) != state.lastWritten) {
-                    schemeStates[entry] = OverrideState.Relinquished(owner)
-                    scheme.metaProperties.setProperty(entry.metadataKey, encodeState(schemeStates.getValue(entry)))
-                    return null
-                }
-                return try {
-                    writeValue(scheme, entry, state.original)
-                    schemeStates.remove(entry)
-                    scheme.metaProperties.remove(entry.metadataKey)
-                    null
-                } catch (exception: RuntimeException) {
-                    exception
-                }
-            }
-
             var firstFailure: RuntimeException? = null
             for ((entry, state) in schemeStates.toList()) {
-                val failure = restoreEntry(entry, state) ?: continue
+                val failure = restoreEntry(scheme, owner, schemeStates, entry, state) ?: continue
                 if (firstFailure == null) firstFailure = failure
             }
             if (schemeStates.isEmpty()) states.remove(scheme)
@@ -266,6 +246,29 @@ internal object EditorSchemeOverrides {
         }
     }
 
+    private fun restoreEntry(
+        scheme: EditorColorsScheme,
+        owner: EditorSchemeOwner,
+        schemeStates: MutableMap<SchemeEntry, OverrideState>,
+        entry: SchemeEntry,
+        state: OverrideState,
+    ): RuntimeException? {
+        if (state.owner != owner || state !is OverrideState.Owned) return null
+        if (read(scheme, entry) != state.lastWritten) {
+            schemeStates[entry] = OverrideState.Relinquished(owner)
+            scheme.metaProperties.setProperty(entry.metadataKey, encodeState(schemeStates.getValue(entry)))
+            return null
+        }
+        return try {
+            writeValue(scheme, entry, state.original)
+            schemeStates.remove(entry)
+            scheme.metaProperties.remove(entry.metadataKey)
+            null
+        } catch (exception: RuntimeException) {
+            exception
+        }
+    }
+
     private fun hydrate(scheme: EditorColorsScheme) {
         scheme.metaProperties
             .stringPropertyNames()
@@ -374,7 +377,12 @@ internal object EditorSchemeOverrides {
 
     private fun decodeState(encoded: String): OverrideState {
         val parts = encoded.split(';')
-        val owner = decodeOwner(parts[1])
+        val owner =
+            when (val encodedOwner = parts[1]) {
+                "A" -> EditorSchemeOwner.AlwaysOn
+                "V" -> EditorSchemeOwner.Vcs
+                else -> EditorSchemeOwner.Element(AccentElementId.valueOf(encodedOwner.removePrefix("E:")))
+            }
         return if (parts[0] == "R") {
             OverrideState.Relinquished(owner)
         } else {
@@ -385,13 +393,6 @@ internal object EditorSchemeOverrides {
             )
         }
     }
-
-    private fun decodeOwner(encoded: String): EditorSchemeOwner =
-        when (encoded) {
-            "A" -> EditorSchemeOwner.AlwaysOn
-            "V" -> EditorSchemeOwner.Vcs
-            else -> EditorSchemeOwner.Element(AccentElementId.valueOf(encoded.removePrefix("E:")))
-        }
 
     private fun encodeValue(value: SchemeValue): String =
         when (value) {

--- a/src/main/kotlin/dev/ayuislands/vcs/VcsColorApplier.kt
+++ b/src/main/kotlin/dev/ayuislands/vcs/VcsColorApplier.kt
@@ -38,6 +38,8 @@ internal object VcsColorApplier {
     private val LOG = logger<VcsColorApplier>()
     private val claimedSchemes: MutableSet<EditorColorsScheme> =
         Collections.newSetFromMap(IdentityHashMap())
+    private val enrolledSchemes: MutableSet<EditorColorsScheme> =
+        Collections.newSetFromMap(IdentityHashMap())
 
     /**
      * Apply VCS colors for the currently active variant.
@@ -52,6 +54,7 @@ internal object VcsColorApplier {
      */
     fun applyAll() {
         if (!LicenseChecker.isLicensedOrGrace()) {
+            AyuEditorSchemeScope.activeScheme()?.let(::claim)
             revertAll()
             return
         }
@@ -64,12 +67,16 @@ internal object VcsColorApplier {
         ApplicationManager.getApplication().invokeLater {
             val currentVariant = AyuVariant.detect() ?: return@invokeLater
             if (VcsColorContext.isEnabled(state)) {
-                val scheme = AyuEditorSchemeScope.activeScheme() ?: return@invokeLater
+                val currentScheme = EditorColorsManager.getInstance().globalScheme
+                val scheme =
+                    currentScheme.takeIf(::isEnrolled)
+                        ?: AyuEditorSchemeScope.activeScheme()
+                        ?: return@invokeLater
                 claim(scheme)
                 writeAll(scheme, state, currentVariant)
                 repaintAllWindows()
             } else {
-                revertClaims()
+                revertClaims(removeEnrollments = true)
             }
         }
     }
@@ -77,21 +84,23 @@ internal object VcsColorApplier {
     /** Apply pending Settings values to the exact scheme selected by the user. */
     @RequiresEdt
     fun applyCurrentScheme() {
+        val state = AyuIslandsSettings.getInstance().state
+        if (!VcsColorContext.isEnabled(state)) {
+            claim(EditorColorsManager.getInstance().globalScheme)
+            revertClaims(removeEnrollments = true)
+            return
+        }
         if (!LicenseChecker.isLicensedOrGrace()) {
             revertAll()
             return
         }
         val variant = AyuVariant.detect() ?: return
-        val state = AyuIslandsSettings.getInstance().state
         val scheme = EditorColorsManager.getInstance().globalScheme
 
-        if (VcsColorContext.isEnabled(state)) {
-            claim(scheme)
-            writeAll(scheme, state, variant)
-            repaintAllWindows()
-        } else {
-            revertClaims(scheme)
-        }
+        enroll(scheme)
+        claim(scheme)
+        writeAll(scheme, state, variant)
+        repaintAllWindows()
     }
 
     /**
@@ -100,16 +109,24 @@ internal object VcsColorApplier {
      * (for TextAttributesKey entries) so the scheme falls back to the XML
      * baseline. Used when the master kill-switch flips ON → OFF and after an
      * Ayu LAF is deactivated. Runtime claims preserve exact scheme identity;
-     * the current Ayu scheme is only a restart fallback when persisted state
-     * says the feature was enabled.
+     * no current-scheme fallback may expand cleanup to an unclaimed scheme.
      */
     fun revertAll() {
         ApplicationManager.getApplication().invokeLater {
-            val state = AyuIslandsSettings.getInstance().state
-            val fallback = AyuEditorSchemeScope.currentAyuScheme().takeIf { state.vcsColorEnabled }
-            revertClaims(fallback)
+            revertClaims()
         }
     }
+
+    private fun enroll(scheme: EditorColorsScheme) {
+        synchronized(enrolledSchemes) {
+            enrolledSchemes.add(scheme)
+        }
+    }
+
+    private fun isEnrolled(scheme: EditorColorsScheme): Boolean =
+        synchronized(enrolledSchemes) {
+            enrolledSchemes.contains(scheme)
+        }
 
     private fun claim(scheme: EditorColorsScheme) {
         synchronized(claimedSchemes) {
@@ -117,22 +134,41 @@ internal object VcsColorApplier {
         }
     }
 
-    private fun revertClaims(fallback: EditorColorsScheme? = null) {
-        val schemes =
-            synchronized(claimedSchemes) {
-                claimedSchemes.toList().also { claimedSchemes.clear() }
-            }.ifEmpty { listOfNotNull(fallback) }
-        if (schemes.isEmpty()) return
+    private fun revertClaims(removeEnrollments: Boolean = false) {
+        val schemes = synchronized(claimedSchemes) { claimedSchemes.toList() }
+        val failedSchemes: MutableSet<EditorColorsScheme> =
+            Collections.newSetFromMap(IdentityHashMap())
+        var failedEntries = 0
 
-        val failed = schemes.sumOf(::revertEveryEntry)
-        if (failed > 0) LOG.warn("VcsColorApplier.revertAll: $failed entries failed to revert; see prior warnings")
-        repaintAllWindows()
+        for (scheme in schemes) {
+            val failures = revertEveryEntry(scheme)
+            failedEntries += failures
+            if (failures == 0) {
+                synchronized(claimedSchemes) {
+                    claimedSchemes.remove(scheme)
+                }
+            } else {
+                failedSchemes.add(scheme)
+            }
+        }
+        if (removeEnrollments) {
+            synchronized(enrolledSchemes) {
+                enrolledSchemes.retainAll(failedSchemes)
+            }
+        }
+        if (failedEntries > 0) {
+            LOG.warn("VcsColorApplier.revertAll: $failedEntries entries failed to revert; see prior warnings")
+        }
+        if (schemes.isNotEmpty()) repaintAllWindows()
     }
 
     @TestOnly
     fun resetClaims() {
         synchronized(claimedSchemes) {
             claimedSchemes.clear()
+        }
+        synchronized(enrolledSchemes) {
+            enrolledSchemes.clear()
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/vcs/VcsColorApplier.kt
+++ b/src/main/kotlin/dev/ayuislands/vcs/VcsColorApplier.kt
@@ -13,11 +13,11 @@ import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
 import dev.ayuislands.theme.AyuEditorSchemeScope
+import dev.ayuislands.theme.EditorSchemeOverrides
+import dev.ayuislands.theme.EditorSchemeOwner
 import org.jetbrains.annotations.TestOnly
 import java.awt.Color
 import java.awt.Window
-import java.util.Collections
-import java.util.IdentityHashMap
 
 /**
  * Applier — writes blended VCS colors into the live [EditorColorsScheme]
@@ -30,15 +30,12 @@ import java.util.IdentityHashMap
  *    blended background, preserve foreground / effect / error stripe / font
  *    type, write back via `scheme.setAttributes`.
  *
- * When master is OFF or the snapshot says "disabled", the applier issues
- * null-writes so the scheme falls back to the stock XML values — no leftover
- * tinted state when a user disables the feature.
+ * Writes are restricted to the exact Ayu scheme matching the active variant.
+ * Disabling restores each value captured before the first write, unless an
+ * external editor or plugin changed that entry while Ayu owned it.
  */
 internal object VcsColorApplier {
     private val LOG = logger<VcsColorApplier>()
-    private val claimedEntries: MutableMap<EditorColorsScheme, MutableSet<VcsPaletteEntry>> = IdentityHashMap()
-    private val enrolledSchemes: MutableSet<EditorColorsScheme> =
-        Collections.newSetFromMap(IdentityHashMap())
 
     /**
      * Apply VCS colors for the currently active variant.
@@ -65,15 +62,11 @@ internal object VcsColorApplier {
         ApplicationManager.getApplication().invokeLater {
             val currentVariant = AyuVariant.detect() ?: return@invokeLater
             if (VcsColorContext.isEnabled(state)) {
-                val currentScheme = EditorColorsManager.getInstance().globalScheme
-                val scheme =
-                    currentScheme.takeIf(::isEnrolled)
-                        ?: AyuEditorSchemeScope.activeScheme()
-                        ?: return@invokeLater
+                val scheme = AyuEditorSchemeScope.activeScheme() ?: return@invokeLater
                 writeAll(scheme, state, currentVariant)
                 repaintAllWindows()
             } else {
-                revertClaimsWithRetry(removeEnrollments = true)
+                restoreWithRetry(rearm = true)
             }
         }
     }
@@ -83,7 +76,7 @@ internal object VcsColorApplier {
     fun applyCurrentScheme() {
         val state = AyuIslandsSettings.getInstance().state
         if (!VcsColorContext.isEnabled(state)) {
-            revertClaimsWithRetry(removeEnrollments = true)
+            restoreWithRetry(rearm = true)
             return
         }
         if (!LicenseChecker.isLicensedOrGrace()) {
@@ -91,104 +84,48 @@ internal object VcsColorApplier {
             return
         }
         val variant = AyuVariant.detect() ?: return
-        val scheme = EditorColorsManager.getInstance().globalScheme
+        val scheme = AyuEditorSchemeScope.activeScheme() ?: return
 
-        enroll(scheme)
         writeAll(scheme, state, variant)
         repaintAllWindows()
     }
 
     /**
-     * Reverts every VCS color entry to stock — null-writes via
-     * `scheme.setColor` (for ColorKey entries) and `scheme.setAttributes`
-     * (for TextAttributesKey entries) so the scheme falls back to the XML
-     * baseline. Used when the master kill-switch flips ON → OFF and after an
-     * Ayu LAF is deactivated. Runtime claims preserve exact scheme identity;
-     * no current-scheme fallback may expand cleanup to an unclaimed scheme.
+     * Restores every VCS entry still owned by Ayu. Exact scheme identity and
+     * pre-write values are retained by the shared editor-scheme ledger.
      */
     fun revertAll() {
         ApplicationManager.getApplication().invokeLater {
-            revertClaimsWithRetry()
+            restoreWithRetry()
         }
     }
 
-    private fun enroll(scheme: EditorColorsScheme) {
-        synchronized(enrolledSchemes) {
-            enrolledSchemes.add(scheme)
-        }
-    }
-
-    private fun isEnrolled(scheme: EditorColorsScheme): Boolean =
-        synchronized(enrolledSchemes) {
-            enrolledSchemes.contains(scheme)
-        }
-
-    private fun claimEntry(
-        scheme: EditorColorsScheme,
-        entry: VcsPaletteEntry,
-    ) {
-        synchronized(claimedEntries) {
-            claimedEntries.getOrPut(scheme) { mutableSetOf() }.add(entry)
-        }
-    }
-
-    private fun releaseEntry(
-        scheme: EditorColorsScheme,
-        entry: VcsPaletteEntry,
-    ) {
-        synchronized(claimedEntries) {
-            claimedEntries[scheme]?.let { entries ->
-                entries.remove(entry)
-                if (entries.isEmpty()) claimedEntries.remove(scheme)
+    private fun restoreWithRetry(rearm: Boolean = false) {
+        var failure: RuntimeException? = null
+        try {
+            AyuEditorSchemeScope.restore(EditorSchemeOwner.Vcs)
+        } catch (firstFailure: RuntimeException) {
+            failure = firstFailure
+            try {
+                AyuEditorSchemeScope.restore(EditorSchemeOwner.Vcs)
+                failure = null
+            } catch (retryFailure: RuntimeException) {
+                failure = retryFailure
             }
         }
-    }
-
-    private fun revertClaimsWithRetry(removeEnrollments: Boolean = false) {
-        if (revertClaims(removeEnrollments)) {
-            revertClaims(removeEnrollments)
+        if (failure != null) LOG.warn("VcsColorApplier: VCS scheme restore failed after retry", failure)
+        if (rearm) {
+            EditorSchemeOverrides.rearm(
+                EditorSchemeOwner.Vcs,
+                EditorColorsManager.getInstance().allSchemes.asIterable(),
+            )
         }
-    }
-
-    /** Returns true when at least one exact claimed entry still needs cleanup. */
-    private fun revertClaims(removeEnrollments: Boolean): Boolean {
-        val claims =
-            synchronized(claimedEntries) {
-                claimedEntries.map { (scheme, entries) -> scheme to entries.toList() }
-            }
-        var failedEntries = 0
-
-        for ((scheme, entries) in claims) {
-            for (entry in entries) {
-                if (safeRevertEntry(scheme, entry)) {
-                    releaseEntry(scheme, entry)
-                } else {
-                    failedEntries++
-                }
-            }
-        }
-        if (removeEnrollments) {
-            synchronized(enrolledSchemes) {
-                enrolledSchemes.removeIf { scheme ->
-                    synchronized(claimedEntries) { scheme !in claimedEntries }
-                }
-            }
-        }
-        if (failedEntries > 0) {
-            LOG.warn("VcsColorApplier.revertAll: $failedEntries entries failed to revert; see prior warnings")
-        }
-        if (claims.isNotEmpty()) repaintAllWindows()
-        return failedEntries > 0
+        repaintAllWindows()
     }
 
     @TestOnly
     fun resetClaims() {
-        synchronized(claimedEntries) {
-            claimedEntries.clear()
-        }
-        synchronized(enrolledSchemes) {
-            enrolledSchemes.clear()
-        }
+        AyuEditorSchemeScope.resetClaims()
     }
 
     private fun writeAll(
@@ -209,9 +146,7 @@ internal object VcsColorApplier {
         for ((category, entries) in VcsColorPalette.allCategoriesAndEntries()) {
             val intensity = VcsColorContext.currentIntensity(category, state)
             for (entry in entries) {
-                if (safeWriteEntry(scheme, entry, blendFor(entry, variant, intensity))) {
-                    claimEntry(scheme, entry)
-                } else {
+                if (!safeWriteEntry(scheme, entry, blendFor(entry, variant, intensity))) {
                     failed++
                 }
             }
@@ -232,18 +167,6 @@ internal object VcsColorApplier {
             false
         }
 
-    private fun safeRevertEntry(
-        scheme: EditorColorsScheme,
-        entry: VcsPaletteEntry,
-    ): Boolean =
-        try {
-            revertEntry(scheme, entry)
-            true
-        } catch (exception: RuntimeException) {
-            LOG.warn("VcsColorApplier: reverting ${entry.keyName} (${entry.mode}) failed", exception)
-            false
-        }
-
     private fun blendFor(
         entry: VcsPaletteEntry,
         variant: AyuVariant,
@@ -259,18 +182,9 @@ internal object VcsColorApplier {
         tinted: Color,
     ) {
         when (entry.mode) {
-            VcsWriteMode.COLOR_KEY -> scheme.setColor(ColorKey.find(entry.keyName), tinted)
+            VcsWriteMode.COLOR_KEY ->
+                AyuEditorSchemeScope.writeColor(scheme, EditorSchemeOwner.Vcs, ColorKey.find(entry.keyName), tinted)
             VcsWriteMode.TEXT_ATTR_BG -> writeTextAttrBackground(scheme, entry.keyName, tinted)
-        }
-    }
-
-    private fun revertEntry(
-        scheme: EditorColorsScheme,
-        entry: VcsPaletteEntry,
-    ) {
-        when (entry.mode) {
-            VcsWriteMode.COLOR_KEY -> scheme.setColor(ColorKey.find(entry.keyName), null)
-            VcsWriteMode.TEXT_ATTR_BG -> scheme.setAttributes(TextAttributesKey.find(entry.keyName), null)
         }
     }
 
@@ -297,7 +211,7 @@ internal object VcsColorApplier {
                 existing?.fontType ?: 0,
             )
         updated.errorStripeColor = existing?.errorStripeColor
-        scheme.setAttributes(key, updated)
+        AyuEditorSchemeScope.writeAttributes(scheme, EditorSchemeOwner.Vcs, key, updated)
     }
 
     /**

--- a/src/main/kotlin/dev/ayuislands/vcs/VcsColorApplier.kt
+++ b/src/main/kotlin/dev/ayuislands/vcs/VcsColorApplier.kt
@@ -3,7 +3,6 @@ package dev.ayuislands.vcs
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.editor.colors.ColorKey
-import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.colors.EditorColorsScheme
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.editor.markup.TextAttributes
@@ -11,6 +10,7 @@ import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
+import dev.ayuislands.theme.AyuEditorSchemeScope
 import java.awt.Color
 import java.awt.Window
 
@@ -55,7 +55,9 @@ internal object VcsColorApplier {
             return
         }
         ApplicationManager.getApplication().invokeLater {
-            writeAll(state, variant)
+            val currentVariant = AyuVariant.detect() ?: return@invokeLater
+            val scheme = AyuEditorSchemeScope.activeScheme() ?: return@invokeLater
+            writeAll(scheme, state, currentVariant)
             repaintAllWindows()
         }
     }
@@ -64,16 +66,12 @@ internal object VcsColorApplier {
      * Reverts every VCS color entry to stock — null-writes via
      * `scheme.setColor` (for ColorKey entries) and `scheme.setAttributes`
      * (for TextAttributesKey entries) so the scheme falls back to the XML
-     * baseline. Used when the master kill-switch flips ON → OFF, and skipped
-     * after the active LAF is no longer an Ayu variant.
+     * baseline. Used when the master kill-switch flips ON → OFF and after an
+     * Ayu LAF is deactivated. Only a current Ayu-owned scheme is cleaned.
      */
     fun revertAll() {
-        if (AyuVariant.detect() == null) {
-            LOG.debug("VcsColorApplier.revertAll: no Ayu variant active; skipping")
-            return
-        }
         ApplicationManager.getApplication().invokeLater {
-            val scheme = EditorColorsManager.getInstance().globalScheme
+            val scheme = AyuEditorSchemeScope.ownedScheme() ?: return@invokeLater
             val failed = revertEveryEntry(scheme)
             if (failed > 0) LOG.warn("VcsColorApplier.revertAll: $failed entries failed to revert; see prior warnings")
             repaintAllWindows()
@@ -81,10 +79,10 @@ internal object VcsColorApplier {
     }
 
     private fun writeAll(
+        scheme: EditorColorsScheme,
         state: AyuIslandsState,
         variant: AyuVariant,
     ) {
-        val scheme = EditorColorsManager.getInstance().globalScheme
         val failed =
             if (VcsColorContext.isEnabled(state)) {
                 writeEveryEntry(scheme, state, variant)

--- a/src/main/kotlin/dev/ayuislands/vcs/VcsColorApplier.kt
+++ b/src/main/kotlin/dev/ayuislands/vcs/VcsColorApplier.kt
@@ -3,16 +3,21 @@ package dev.ayuislands.vcs
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.editor.colors.ColorKey
+import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.colors.EditorColorsScheme
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.editor.markup.TextAttributes
+import com.intellij.util.concurrency.annotations.RequiresEdt
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
 import dev.ayuislands.theme.AyuEditorSchemeScope
+import org.jetbrains.annotations.TestOnly
 import java.awt.Color
 import java.awt.Window
+import java.util.Collections
+import java.util.IdentityHashMap
 
 /**
  * Applier — writes blended VCS colors into the live [EditorColorsScheme]
@@ -31,6 +36,8 @@ import java.awt.Window
  */
 internal object VcsColorApplier {
     private val LOG = logger<VcsColorApplier>()
+    private val claimedSchemes: MutableSet<EditorColorsScheme> =
+        Collections.newSetFromMap(IdentityHashMap())
 
     /**
      * Apply VCS colors for the currently active variant.
@@ -56,9 +63,34 @@ internal object VcsColorApplier {
         }
         ApplicationManager.getApplication().invokeLater {
             val currentVariant = AyuVariant.detect() ?: return@invokeLater
-            val scheme = AyuEditorSchemeScope.activeScheme() ?: return@invokeLater
-            writeAll(scheme, state, currentVariant)
+            if (VcsColorContext.isEnabled(state)) {
+                val scheme = AyuEditorSchemeScope.activeScheme() ?: return@invokeLater
+                claim(scheme)
+                writeAll(scheme, state, currentVariant)
+                repaintAllWindows()
+            } else {
+                revertClaims()
+            }
+        }
+    }
+
+    /** Apply pending Settings values to the exact scheme selected by the user. */
+    @RequiresEdt
+    fun applyCurrentScheme() {
+        if (!LicenseChecker.isLicensedOrGrace()) {
+            revertAll()
+            return
+        }
+        val variant = AyuVariant.detect() ?: return
+        val state = AyuIslandsSettings.getInstance().state
+        val scheme = EditorColorsManager.getInstance().globalScheme
+
+        if (VcsColorContext.isEnabled(state)) {
+            claim(scheme)
+            writeAll(scheme, state, variant)
             repaintAllWindows()
+        } else {
+            revertClaims(scheme)
         }
     }
 
@@ -67,14 +99,40 @@ internal object VcsColorApplier {
      * `scheme.setColor` (for ColorKey entries) and `scheme.setAttributes`
      * (for TextAttributesKey entries) so the scheme falls back to the XML
      * baseline. Used when the master kill-switch flips ON → OFF and after an
-     * Ayu LAF is deactivated. Only a current Ayu-owned scheme is cleaned.
+     * Ayu LAF is deactivated. Runtime claims preserve exact scheme identity;
+     * the current Ayu scheme is only a restart fallback when persisted state
+     * says the feature was enabled.
      */
     fun revertAll() {
         ApplicationManager.getApplication().invokeLater {
-            val scheme = AyuEditorSchemeScope.ownedScheme() ?: return@invokeLater
-            val failed = revertEveryEntry(scheme)
-            if (failed > 0) LOG.warn("VcsColorApplier.revertAll: $failed entries failed to revert; see prior warnings")
-            repaintAllWindows()
+            val state = AyuIslandsSettings.getInstance().state
+            val fallback = AyuEditorSchemeScope.currentAyuScheme().takeIf { state.vcsColorEnabled }
+            revertClaims(fallback)
+        }
+    }
+
+    private fun claim(scheme: EditorColorsScheme) {
+        synchronized(claimedSchemes) {
+            claimedSchemes.add(scheme)
+        }
+    }
+
+    private fun revertClaims(fallback: EditorColorsScheme? = null) {
+        val schemes =
+            synchronized(claimedSchemes) {
+                claimedSchemes.toList().also { claimedSchemes.clear() }
+            }.ifEmpty { listOfNotNull(fallback) }
+        if (schemes.isEmpty()) return
+
+        val failed = schemes.sumOf(::revertEveryEntry)
+        if (failed > 0) LOG.warn("VcsColorApplier.revertAll: $failed entries failed to revert; see prior warnings")
+        repaintAllWindows()
+    }
+
+    @TestOnly
+    fun resetClaims() {
+        synchronized(claimedSchemes) {
+            claimedSchemes.clear()
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/vcs/VcsColorApplier.kt
+++ b/src/main/kotlin/dev/ayuislands/vcs/VcsColorApplier.kt
@@ -64,9 +64,14 @@ internal object VcsColorApplier {
      * Reverts every VCS color entry to stock — null-writes via
      * `scheme.setColor` (for ColorKey entries) and `scheme.setAttributes`
      * (for TextAttributesKey entries) so the scheme falls back to the XML
-     * baseline. Used when the master kill-switch flips ON → OFF.
+     * baseline. Used when the master kill-switch flips ON → OFF, and skipped
+     * after the active LAF is no longer an Ayu variant.
      */
     fun revertAll() {
+        if (AyuVariant.detect() == null) {
+            LOG.debug("VcsColorApplier.revertAll: no Ayu variant active; skipping")
+            return
+        }
         ApplicationManager.getApplication().invokeLater {
             val scheme = EditorColorsManager.getInstance().globalScheme
             val failed = revertEveryEntry(scheme)

--- a/src/main/kotlin/dev/ayuislands/vcs/VcsColorApplier.kt
+++ b/src/main/kotlin/dev/ayuislands/vcs/VcsColorApplier.kt
@@ -101,18 +101,18 @@ internal object VcsColorApplier {
     }
 
     private fun restoreWithRetry(rearm: Boolean = false) {
-        var failure: RuntimeException? = null
-        try {
-            AyuEditorSchemeScope.restore(EditorSchemeOwner.Vcs)
-        } catch (firstFailure: RuntimeException) {
-            failure = firstFailure
+        val failure =
             try {
                 AyuEditorSchemeScope.restore(EditorSchemeOwner.Vcs)
-                failure = null
-            } catch (retryFailure: RuntimeException) {
-                failure = retryFailure
+                null
+            } catch (_: RuntimeException) {
+                try {
+                    AyuEditorSchemeScope.restore(EditorSchemeOwner.Vcs)
+                    null
+                } catch (retryFailure: RuntimeException) {
+                    retryFailure
+                }
             }
-        }
         if (failure != null) LOG.warn("VcsColorApplier: VCS scheme restore failed after retry", failure)
         if (rearm) {
             EditorSchemeOverrides.rearm(

--- a/src/main/kotlin/dev/ayuislands/vcs/VcsColorApplier.kt
+++ b/src/main/kotlin/dev/ayuislands/vcs/VcsColorApplier.kt
@@ -36,8 +36,7 @@ import java.util.IdentityHashMap
  */
 internal object VcsColorApplier {
     private val LOG = logger<VcsColorApplier>()
-    private val claimedSchemes: MutableSet<EditorColorsScheme> =
-        Collections.newSetFromMap(IdentityHashMap())
+    private val claimedEntries: MutableMap<EditorColorsScheme, MutableSet<VcsPaletteEntry>> = IdentityHashMap()
     private val enrolledSchemes: MutableSet<EditorColorsScheme> =
         Collections.newSetFromMap(IdentityHashMap())
 
@@ -54,7 +53,6 @@ internal object VcsColorApplier {
      */
     fun applyAll() {
         if (!LicenseChecker.isLicensedOrGrace()) {
-            AyuEditorSchemeScope.activeScheme()?.let(::claim)
             revertAll()
             return
         }
@@ -72,11 +70,10 @@ internal object VcsColorApplier {
                     currentScheme.takeIf(::isEnrolled)
                         ?: AyuEditorSchemeScope.activeScheme()
                         ?: return@invokeLater
-                claim(scheme)
                 writeAll(scheme, state, currentVariant)
                 repaintAllWindows()
             } else {
-                revertClaims(removeEnrollments = true)
+                revertClaimsWithRetry(removeEnrollments = true)
             }
         }
     }
@@ -86,8 +83,7 @@ internal object VcsColorApplier {
     fun applyCurrentScheme() {
         val state = AyuIslandsSettings.getInstance().state
         if (!VcsColorContext.isEnabled(state)) {
-            claim(EditorColorsManager.getInstance().globalScheme)
-            revertClaims(removeEnrollments = true)
+            revertClaimsWithRetry(removeEnrollments = true)
             return
         }
         if (!LicenseChecker.isLicensedOrGrace()) {
@@ -98,7 +94,6 @@ internal object VcsColorApplier {
         val scheme = EditorColorsManager.getInstance().globalScheme
 
         enroll(scheme)
-        claim(scheme)
         writeAll(scheme, state, variant)
         repaintAllWindows()
     }
@@ -113,7 +108,7 @@ internal object VcsColorApplier {
      */
     fun revertAll() {
         ApplicationManager.getApplication().invokeLater {
-            revertClaims()
+            revertClaimsWithRetry()
         }
     }
 
@@ -128,44 +123,68 @@ internal object VcsColorApplier {
             enrolledSchemes.contains(scheme)
         }
 
-    private fun claim(scheme: EditorColorsScheme) {
-        synchronized(claimedSchemes) {
-            claimedSchemes.add(scheme)
+    private fun claimEntry(
+        scheme: EditorColorsScheme,
+        entry: VcsPaletteEntry,
+    ) {
+        synchronized(claimedEntries) {
+            claimedEntries.getOrPut(scheme) { mutableSetOf() }.add(entry)
         }
     }
 
-    private fun revertClaims(removeEnrollments: Boolean = false) {
-        val schemes = synchronized(claimedSchemes) { claimedSchemes.toList() }
-        val failedSchemes: MutableSet<EditorColorsScheme> =
-            Collections.newSetFromMap(IdentityHashMap())
+    private fun releaseEntry(
+        scheme: EditorColorsScheme,
+        entry: VcsPaletteEntry,
+    ) {
+        synchronized(claimedEntries) {
+            claimedEntries[scheme]?.let { entries ->
+                entries.remove(entry)
+                if (entries.isEmpty()) claimedEntries.remove(scheme)
+            }
+        }
+    }
+
+    private fun revertClaimsWithRetry(removeEnrollments: Boolean = false) {
+        if (revertClaims(removeEnrollments)) {
+            revertClaims(removeEnrollments)
+        }
+    }
+
+    /** Returns true when at least one exact claimed entry still needs cleanup. */
+    private fun revertClaims(removeEnrollments: Boolean): Boolean {
+        val claims =
+            synchronized(claimedEntries) {
+                claimedEntries.map { (scheme, entries) -> scheme to entries.toList() }
+            }
         var failedEntries = 0
 
-        for (scheme in schemes) {
-            val failures = revertEveryEntry(scheme)
-            failedEntries += failures
-            if (failures == 0) {
-                synchronized(claimedSchemes) {
-                    claimedSchemes.remove(scheme)
+        for ((scheme, entries) in claims) {
+            for (entry in entries) {
+                if (safeRevertEntry(scheme, entry)) {
+                    releaseEntry(scheme, entry)
+                } else {
+                    failedEntries++
                 }
-            } else {
-                failedSchemes.add(scheme)
             }
         }
         if (removeEnrollments) {
             synchronized(enrolledSchemes) {
-                enrolledSchemes.retainAll(failedSchemes)
+                enrolledSchemes.removeIf { scheme ->
+                    synchronized(claimedEntries) { scheme !in claimedEntries }
+                }
             }
         }
         if (failedEntries > 0) {
             LOG.warn("VcsColorApplier.revertAll: $failedEntries entries failed to revert; see prior warnings")
         }
-        if (schemes.isNotEmpty()) repaintAllWindows()
+        if (claims.isNotEmpty()) repaintAllWindows()
+        return failedEntries > 0
     }
 
     @TestOnly
     fun resetClaims() {
-        synchronized(claimedSchemes) {
-            claimedSchemes.clear()
+        synchronized(claimedEntries) {
+            claimedEntries.clear()
         }
         synchronized(enrolledSchemes) {
             enrolledSchemes.clear()
@@ -177,12 +196,7 @@ internal object VcsColorApplier {
         state: AyuIslandsState,
         variant: AyuVariant,
     ) {
-        val failed =
-            if (VcsColorContext.isEnabled(state)) {
-                writeEveryEntry(scheme, state, variant)
-            } else {
-                revertEveryEntry(scheme)
-            }
+        val failed = writeEveryEntry(scheme, state, variant)
         if (failed > 0) LOG.warn("VcsColorApplier.writeAll: $failed entries failed; see prior warnings")
     }
 
@@ -195,17 +209,11 @@ internal object VcsColorApplier {
         for ((category, entries) in VcsColorPalette.allCategoriesAndEntries()) {
             val intensity = VcsColorContext.currentIntensity(category, state)
             for (entry in entries) {
-                if (!safeWriteEntry(scheme, entry, blendFor(entry, variant, intensity))) failed++
-            }
-        }
-        return failed
-    }
-
-    private fun revertEveryEntry(scheme: EditorColorsScheme): Int {
-        var failed = 0
-        for ((_, entries) in VcsColorPalette.allCategoriesAndEntries()) {
-            for (entry in entries) {
-                if (!safeRevertEntry(scheme, entry)) failed++
+                if (safeWriteEntry(scheme, entry, blendFor(entry, variant, intensity))) {
+                    claimEntry(scheme, entry)
+                } else {
+                    failed++
+                }
             }
         }
         return failed

--- a/src/main/kotlin/dev/ayuislands/vcs/VcsColorSnapshot.kt
+++ b/src/main/kotlin/dev/ayuislands/vcs/VcsColorSnapshot.kt
@@ -65,7 +65,7 @@ internal data class VcsColorSnapshot(
  * ThreadLocal scoped-override channel for the pending [VcsColorSnapshot].
  *
  * Settings apply path wraps the applier call in
- * `VcsColorContext.withSnapshot(pendingSnapshot) { applier.applyAll() }` so
+ * `VcsColorContext.withSnapshot(pendingSnapshot) { applier.applyCurrentScheme() }` so
  * every category read during that apply sees the panel's pending values, not
  * whatever the persisted state currently holds. If apply throws, the snapshot
  * is rolled back and the persisted state is never touched — same "state

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsLafListenerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsLafListenerTest.kt
@@ -160,7 +160,7 @@ class AyuIslandsLafListenerTest {
 
         verify(exactly = 0) { AyuEditorSchemeBinder.bindForVariant(any()) }
         verify(exactly = 1) { AccentApplicator.revertAll() }
-        verify(exactly = 1) { FontPresetApplicator.revert() }
+        verify(exactly = 0) { FontPresetApplicator.revert() }
         verify(exactly = 1) { GlowOverlayManager.syncGlowForAllProjects() }
     }
 
@@ -179,9 +179,9 @@ class AyuIslandsLafListenerTest {
         verify(exactly = 0) { AyuEditorSchemeBinder.bindForVariant(any()) }
         verifyOrder {
             AccentApplicator.revertAll()
-            FontPresetApplicator.revert()
             AccentApplicator.applyForFocusedProject(AccentContext.External)
         }
+        verify(exactly = 0) { FontPresetApplicator.revert() }
         verify(exactly = 1) { AccentApplicator.applyForFocusedProject(AccentContext.External) }
         verify(exactly = 1) { GlowOverlayManager.syncGlowForAllProjects() }
         verify(exactly = 0) { mockSyntaxService.reapplyForActiveLaf() }

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
@@ -35,6 +35,7 @@ import io.mockk.verify
 import java.awt.Color
 import java.awt.Window
 import java.lang.reflect.Method
+import java.util.Properties
 import javax.swing.SwingUtilities
 import javax.swing.UIManager
 import kotlin.test.AfterTest
@@ -1517,6 +1518,20 @@ class AccentApplicatorTest {
     }
 
     @Test
+    fun `revertAll restores persisted always-on keys after runtime reset`() {
+        val store = EditorSchemeStore()
+        every { mockColorsManager.globalScheme } returns store.scheme
+        every { mockColorsManager.allSchemes } returns arrayOf(store.scheme)
+        mockEpExtensionList(emptyList())
+        invokePrivate("applyAlwaysOnEditorKeys", Color.RED)
+        AyuEditorSchemeScope.resetClaims()
+
+        AccentApplicator.revertAll()
+
+        store.assertOriginalValues()
+    }
+
+    @Test
     fun `revertAll posts to invokeLater when not on EDT`() {
         mockEpExtensionList(emptyList())
         every { SwingUtilities.isEventDispatchThread() } returns false
@@ -1576,6 +1591,27 @@ class AccentApplicatorTest {
 
         verify(exactly = 0) { mockElement.revert() }
         verify(exactly = 0) { mockElement.apply(any()) }
+    }
+
+    @Test
+    fun `external toggle cycle rearms relinquished editor ownership`() {
+        val store = EditorSchemeStore()
+        every { mockColorsManager.globalScheme } returns store.scheme
+        val element = CaretRowElement()
+        val accent = Color.RED
+        mockEpExtensionList(listOf(element))
+
+        state.setToggle(element.id, true)
+        invokeApplyElements(state, accent, AccentContext.Ayu(AyuVariant.MIRAGE))
+        store.replaceTouchedValues()
+        invokeApplyElements(state, Color.BLUE, AccentContext.Ayu(AyuVariant.MIRAGE))
+        state.setToggle(element.id, false)
+        invokeApplyElements(state, accent, AccentContext.External)
+        state.setToggle(element.id, true)
+        invokeApplyElements(state, accent, AccentContext.External)
+        invokeApplyElements(state, accent, AccentContext.Ayu(AyuVariant.MIRAGE))
+
+        store.assertWasChangedTo(accent)
     }
 
     @Test
@@ -2318,10 +2354,12 @@ class AccentApplicatorTest {
         private val touchedColors = linkedSetOf<ColorKey>()
         private val touchedAttributes = linkedSetOf<TextAttributesKey>()
         private var shouldFailRestore = false
+        private val metadata = Properties()
 
         val scheme: EditorColorsScheme =
             mockk(relaxed = true) {
                 every { name } returns "_@user_Ayu Islands Mirage"
+                every { metaProperties } returns metadata
                 every { getColor(any()) } answers {
                     val key = firstArg<ColorKey>()
                     if (!colors.containsKey(key)) colors[key] = originalColor

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
@@ -16,7 +16,7 @@ import dev.ayuislands.accent.conflict.ConflictEntry
 import dev.ayuislands.accent.conflict.ConflictRegistry
 import dev.ayuislands.accent.conflict.ConflictType
 import dev.ayuislands.accent.elements.AbstractChromeElement
-import dev.ayuislands.accent.elements.InlayHintsElement
+import dev.ayuislands.accent.elements.CaretRowElement
 import dev.ayuislands.glow.GlowTabMode
 import dev.ayuislands.indent.IndentRainbowSync
 import dev.ayuislands.integration.IntegrationOutcome
@@ -243,13 +243,6 @@ class AccentApplicatorTest {
     }
 
     @Test
-    fun `revertAll clears editor color keys`() {
-        revertWithoutExtensions()
-
-        verify(atLeast = 2) { mockScheme.setColor(any<ColorKey>(), null) }
-    }
-
-    @Test
     fun `accent editor writes preserve a foreign scheme`() {
         every { mockScheme.name } returns "Solarized Dark"
 
@@ -260,6 +253,80 @@ class AccentApplicatorTest {
         verify(exactly = 0) { mockScheme.setColor(any<ColorKey>(), null) }
         verify(exactly = 0) { mockScheme.setAttributes(any<TextAttributesKey>(), any<TextAttributes>()) }
         verify(exactly = 0) { mockScheme.setAttributes(any<TextAttributesKey>(), null) }
+    }
+
+    @Test
+    fun `always-on editor values restore their first explicit baseline`() {
+        val store = EditorSchemeStore()
+        every { mockColorsManager.globalScheme } returns store.scheme
+
+        invokePrivate("applyAlwaysOnEditorKeys", Color.RED)
+        invokePrivate("applyAlwaysOnEditorKeys", Color.BLUE)
+        invokePrivate("revertAlwaysOnEditorKeys")
+
+        store.assertOriginalValues()
+    }
+
+    @Test
+    fun `always-on editor values restore a null baseline`() {
+        val store = EditorSchemeStore(null, null)
+        every { mockColorsManager.globalScheme } returns store.scheme
+
+        invokePrivate("applyAlwaysOnEditorKeys", Color.RED)
+        invokePrivate("revertAlwaysOnEditorKeys")
+
+        store.assertOriginalValues()
+    }
+
+    @Test
+    fun `external changes permanently relinquish always-on editor keys`() {
+        val store = EditorSchemeStore()
+        every { mockColorsManager.globalScheme } returns store.scheme
+
+        invokePrivate("applyAlwaysOnEditorKeys", Color.RED)
+        store.replaceTouchedValues()
+        invokePrivate("applyAlwaysOnEditorKeys", Color.BLUE)
+        invokePrivate("revertAlwaysOnEditorKeys")
+
+        store.assertExternalValues()
+    }
+
+    @Test
+    fun `tab underline shares the always-on baseline`() {
+        val store = EditorSchemeStore()
+        every { mockColorsManager.globalScheme } returns store.scheme
+        state.glowTabMode = "OFF"
+
+        invokePrivate("applyAlwaysOnEditorKeys", Color.RED)
+        invokeApplyTabUnderline(state, AccentContext.Ayu(AyuVariant.MIRAGE))
+        invokePrivate("revertAlwaysOnEditorKeys")
+
+        store.assertOriginalValue(ColorKey.find("TAB_UNDERLINE"))
+    }
+
+    @Test
+    fun `element disable and re-enable explicitly re-arms editor ownership`() {
+        val store = EditorSchemeStore()
+        every { mockColorsManager.globalScheme } returns store.scheme
+        val element = CaretRowElement()
+        val accent = Color.RED
+
+        state.setToggle(element.id, true)
+        invokeApplyElement(state, element, accent)
+        store.replaceTouchedValues()
+        invokeApplyElement(state, element, Color.BLUE)
+
+        state.setToggle(element.id, false)
+        invokeApplyElement(state, element, accent)
+        store.assertExternalValues()
+
+        state.setToggle(element.id, true)
+        invokeApplyElement(state, element, accent)
+        store.assertWasChangedTo(accent)
+
+        state.setToggle(element.id, false)
+        invokeApplyElement(state, element, accent)
+        store.assertExternalValues()
     }
 
     @Test
@@ -584,24 +651,6 @@ class AccentApplicatorTest {
         verify(exactly = 1) { AyuPlugin.findLoadedPlugin(any()) }
     }
 
-    // revertAlwaysOnEditorKeys
-
-    @Test
-    fun `revertAlwaysOnEditorKeys clears all editor color keys`() {
-        AyuEditorSchemeScope.claimActiveScheme()
-        invokePrivate("revertAlwaysOnEditorKeys")
-
-        verify(atLeast = 2) { mockScheme.setColor(any<ColorKey>(), null) }
-    }
-
-    @Test
-    fun `revertAlwaysOnEditorKeys resets all attribute overrides`() {
-        AyuEditorSchemeScope.claimActiveScheme()
-        invokePrivate("revertAlwaysOnEditorKeys")
-
-        verify(atLeast = 9) { mockScheme.setAttributes(any<TextAttributesKey>(), any()) }
-    }
-
     // applyAlwaysOnEditorKeys detailed checks
 
     @Test
@@ -866,15 +915,6 @@ class AccentApplicatorTest {
         for (key in alwaysOnUiKeys) {
             verify { UIManager.put(key, null) }
         }
-    }
-
-    @Test
-    fun `apply then revert clears editor keys`() {
-        applyWithoutExtensions("#FFCC66")
-        revertWithoutExtensions()
-
-        verify(atLeast = 2) { mockScheme.setColor(any<ColorKey>(), null) }
-        verify(atLeast = 9) { mockScheme.setAttributes(any<TextAttributesKey>(), any()) }
     }
 
     // Tests for public apply() method
@@ -1419,21 +1459,20 @@ class AccentApplicatorTest {
 
     @Test
     fun `revertAll releases cleaned scheme and retains only failed scheme identity`() {
-        val inlayKey = TextAttributesKey.find("INLAY_TEXT_WITHOUT_BACKGROUND")
-        val cleanedScheme = mockk<EditorColorsScheme>(relaxed = true)
-        every { cleanedScheme.name } returns "Ayu Islands Mirage"
-        every { cleanedScheme.getAttributes(any<TextAttributesKey>()) } returns TextAttributes()
-        every { mockColorsManager.globalScheme } returns mockScheme
-        AyuEditorSchemeScope.claimActiveScheme()
-        every { mockColorsManager.globalScheme } returns cleanedScheme
-        AyuEditorSchemeScope.claimActiveScheme()
-        every { mockScheme.setAttributes(inlayKey, null) } throws IllegalStateException("cleanup failed")
-        mockEpExtensionList(listOf(InlayHintsElement()))
+        val failedStore = EditorSchemeStore()
+        val cleanedStore = EditorSchemeStore()
+        every { mockColorsManager.globalScheme } returns failedStore.scheme
+        invokePrivate("applyAlwaysOnEditorKeys", Color.RED)
+        every { mockColorsManager.globalScheme } returns cleanedStore.scheme
+        invokePrivate("applyAlwaysOnEditorKeys", Color.RED)
+        failedStore.failRestores()
+        mockEpExtensionList(emptyList())
 
         AccentApplicator.revertAll()
 
         assertEquals(1, AyuEditorSchemeScope.claimedAccentSchemes().size)
-        assertTrue(AyuEditorSchemeScope.claimedAccentSchemes().single() === mockScheme)
+        assertTrue(AyuEditorSchemeScope.claimedAccentSchemes().single() === failedStore.scheme)
+        cleanedStore.assertOriginalValues()
     }
 
     @Test
@@ -1466,14 +1505,15 @@ class AccentApplicatorTest {
     }
 
     @Test
-    fun `revertAll clears editor keys via revertAlwaysOnEditorKeys`() {
+    fun `revertAll restores editor keys via revertAlwaysOnEditorKeys`() {
+        val store = EditorSchemeStore()
+        every { mockColorsManager.globalScheme } returns store.scheme
         mockEpExtensionList(emptyList())
-        AyuEditorSchemeScope.claimActiveScheme()
+        invokePrivate("applyAlwaysOnEditorKeys", Color.RED)
 
         AccentApplicator.revertAll()
 
-        verify(atLeast = 2) { mockScheme.setColor(any<ColorKey>(), null) }
-        verify(atLeast = 9) { mockScheme.setAttributes(any<TextAttributesKey>(), any()) }
+        store.assertOriginalValues()
     }
 
     @Test
@@ -2249,6 +2289,108 @@ class AccentApplicatorTest {
             context,
             LicenseChecker.isLicensedOrGrace(),
         )
+    }
+
+    private fun invokeApplyElement(
+        state: AyuIslandsState,
+        element: AccentElement,
+        accent: Color,
+    ) {
+        invokePrivate(
+            "applyElement",
+            state,
+            element,
+            accent,
+            AyuVariant.MIRAGE,
+            true,
+        )
+    }
+
+    private class EditorSchemeStore(
+        private val originalColor: Color? = Color(0x12, 0x34, 0x56),
+        originalAttributes: TextAttributes? = originalAttributes(),
+    ) {
+        private val originalAttributes = originalAttributes?.clone()
+        private val externalColor = Color(0x65, 0x43, 0x21)
+        private val externalAttributes = originalAttributes(Color(0x56, 0x34, 0x12))
+        private val colors = mutableMapOf<ColorKey, Color?>()
+        private val attributes = mutableMapOf<TextAttributesKey, TextAttributes?>()
+        private val touchedColors = linkedSetOf<ColorKey>()
+        private val touchedAttributes = linkedSetOf<TextAttributesKey>()
+        private var shouldFailRestore = false
+
+        val scheme: EditorColorsScheme =
+            mockk(relaxed = true) {
+                every { name } returns "_@user_Ayu Islands Mirage"
+                every { getColor(any()) } answers {
+                    val key = firstArg<ColorKey>()
+                    if (!colors.containsKey(key)) colors[key] = originalColor
+                    colors[key]
+                }
+                every { setColor(any(), any()) } answers {
+                    val key = firstArg<ColorKey>()
+                    val value = secondArg<Color?>()
+                    check(!shouldFailRestore || value != originalColor) { "cleanup failed" }
+                    touchedColors.add(key)
+                    colors[key] = value
+                }
+                every { getAttributes(any<TextAttributesKey>()) } answers {
+                    val key = firstArg<TextAttributesKey>()
+                    if (!attributes.containsKey(key)) {
+                        attributes[key] = this@EditorSchemeStore.originalAttributes?.clone()
+                    }
+                    attributes[key]
+                }
+                every { setAttributes(any(), any()) } answers {
+                    val key = firstArg<TextAttributesKey>()
+                    val value = secondArg<TextAttributes?>()?.clone()
+                    check(
+                        !shouldFailRestore || value != this@EditorSchemeStore.originalAttributes,
+                    ) { "cleanup failed" }
+                    touchedAttributes.add(key)
+                    attributes[key] = value
+                }
+            }
+
+        fun replaceTouchedValues() {
+            touchedColors.forEach { key -> colors[key] = externalColor }
+            touchedAttributes.forEach { key -> attributes[key] = externalAttributes.clone() }
+        }
+
+        fun failRestores() {
+            shouldFailRestore = true
+        }
+
+        fun assertOriginalValues() {
+            touchedColors.forEach { key -> assertEquals(originalColor, colors[key]) }
+            touchedAttributes.forEach { key -> assertEquals(originalAttributes, attributes[key]) }
+        }
+
+        fun assertOriginalValue(key: ColorKey) {
+            assertEquals(originalColor, colors[key])
+        }
+
+        fun assertExternalValues() {
+            touchedColors.forEach { key -> assertEquals(externalColor, colors[key]) }
+            touchedAttributes.forEach { key -> assertEquals(externalAttributes, attributes[key]) }
+        }
+
+        fun assertWasChangedTo(accent: Color) {
+            assertTrue(touchedColors.isNotEmpty())
+            assertTrue(colors.values.none { value -> value == externalColor })
+            assertTrue(colors.values.any { value -> value == accent })
+        }
+
+        companion object {
+            private fun originalAttributes(foreground: Color = Color(0x21, 0x43, 0x65)): TextAttributes =
+                TextAttributes().apply {
+                    foregroundColor = foreground
+                    backgroundColor = Color.BLACK
+                    effectColor = Color.CYAN
+                    errorStripeColor = Color.MAGENTA
+                    fontType = 3
+                }
+        }
     }
 
     private fun resetCodeGlanceProState() {

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
@@ -9,12 +9,14 @@ import com.intellij.openapi.editor.colors.EditorColorsScheme
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.openapi.extensions.ExtensionPointName
+import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.util.messages.MessageBus
 import dev.ayuislands.AyuPlugin
 import dev.ayuislands.accent.conflict.ConflictEntry
 import dev.ayuislands.accent.conflict.ConflictRegistry
 import dev.ayuislands.accent.conflict.ConflictType
 import dev.ayuislands.accent.elements.AbstractChromeElement
+import dev.ayuislands.accent.elements.InlayHintsElement
 import dev.ayuislands.glow.GlowTabMode
 import dev.ayuislands.indent.IndentRainbowSync
 import dev.ayuislands.integration.IntegrationOutcome
@@ -39,6 +41,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -1398,6 +1401,53 @@ class AccentApplicatorTest {
         AccentApplicator.revertAll()
 
         assertEquals(1, AyuEditorSchemeScope.claimedAccentSchemes().size)
+    }
+
+    @Test
+    fun `revertAll releases editor claims after a chrome-only cleanup failure`() {
+        val failingElement = mockk<AccentElement>(relaxed = true)
+        every { failingElement.id } returns AccentElementId.STATUS_BAR
+        every { failingElement.displayName } returns "FailingChrome"
+        every { failingElement.revert() } throws RuntimeException("revert failed")
+        mockEpExtensionList(listOf(failingElement))
+        AyuEditorSchemeScope.claimActiveScheme()
+
+        AccentApplicator.revertAll()
+
+        assertTrue(AyuEditorSchemeScope.claimedAccentSchemes().isEmpty())
+    }
+
+    @Test
+    fun `revertAll releases cleaned scheme and retains only failed scheme identity`() {
+        val inlayKey = TextAttributesKey.find("INLAY_TEXT_WITHOUT_BACKGROUND")
+        val cleanedScheme = mockk<EditorColorsScheme>(relaxed = true)
+        every { cleanedScheme.name } returns "Ayu Islands Mirage"
+        every { cleanedScheme.getAttributes(any<TextAttributesKey>()) } returns TextAttributes()
+        every { mockColorsManager.globalScheme } returns mockScheme
+        AyuEditorSchemeScope.claimActiveScheme()
+        every { mockColorsManager.globalScheme } returns cleanedScheme
+        AyuEditorSchemeScope.claimActiveScheme()
+        every { mockScheme.setAttributes(inlayKey, null) } throws IllegalStateException("cleanup failed")
+        mockEpExtensionList(listOf(InlayHintsElement()))
+
+        AccentApplicator.revertAll()
+
+        assertEquals(1, AyuEditorSchemeScope.claimedAccentSchemes().size)
+        assertTrue(AyuEditorSchemeScope.claimedAccentSchemes().single() === mockScheme)
+    }
+
+    @Test
+    fun `later cancellation does not retain successfully cleaned editor claims`() {
+        mockEpExtensionList(emptyList())
+        AyuEditorSchemeScope.claimActiveScheme()
+        mockkObject(IndentRainbowSync)
+        every { IndentRainbowSync.revert() } throws ProcessCanceledException()
+
+        assertFailsWith<ProcessCanceledException> {
+            AccentApplicator.revertAll()
+        }
+
+        assertTrue(AyuEditorSchemeScope.claimedAccentSchemes().isEmpty())
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
@@ -70,6 +70,7 @@ class AccentApplicatorTest {
         mockkStatic(EditorColorsManager::class)
         every { EditorColorsManager.getInstance() } returns mockColorsManager
         every { mockColorsManager.globalScheme } returns mockScheme
+        every { mockScheme.name } returns "Ayu Islands Mirage"
         every { mockScheme.getAttributes(any<TextAttributesKey>()) } returns TextAttributes()
 
         // ApplicationManager must be mocked BEFORE AyuIslandsSettings.Companion,
@@ -239,6 +240,19 @@ class AccentApplicatorTest {
         revertWithoutExtensions()
 
         verify(atLeast = 2) { mockScheme.setColor(any<ColorKey>(), null) }
+    }
+
+    @Test
+    fun `accent editor writes preserve a foreign scheme`() {
+        every { mockScheme.name } returns "Solarized Dark"
+
+        applyWithoutExtensions("#FFCC66")
+        revertWithoutExtensions()
+
+        verify(exactly = 0) { mockScheme.setColor(any<ColorKey>(), any<Color>()) }
+        verify(exactly = 0) { mockScheme.setColor(any<ColorKey>(), null) }
+        verify(exactly = 0) { mockScheme.setAttributes(any<TextAttributesKey>(), any<TextAttributes>()) }
+        verify(exactly = 0) { mockScheme.setAttributes(any<TextAttributesKey>(), null) }
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
@@ -22,6 +22,7 @@ import dev.ayuislands.integration.IntegrationOwnership
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
+import dev.ayuislands.theme.AyuEditorSchemeScope
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
@@ -60,6 +61,7 @@ class AccentApplicatorTest {
 
     @BeforeTest
     fun setUp() {
+        AyuEditorSchemeScope.resetClaims()
         saveOriginalEpName()
 
         mockkStatic(SwingUtilities::class)
@@ -129,6 +131,7 @@ class AccentApplicatorTest {
 
     @AfterTest
     fun tearDown() {
+        AyuEditorSchemeScope.resetClaims()
         ExternalChromeOwnership.resetForTests()
         restoreOriginalEpName()
         unmockkAll()
@@ -173,6 +176,7 @@ class AccentApplicatorTest {
         UIManager.put("Button.default.endBorderColor", null)
         UIManager.put("EditorTabs.underlinedTabBackground", null)
 
+        AyuEditorSchemeScope.claimActiveScheme()
         invokePrivate("revertAlwaysOnEditorKeys")
 
         val windows = Window.getWindows()
@@ -581,6 +585,7 @@ class AccentApplicatorTest {
 
     @Test
     fun `revertAlwaysOnEditorKeys clears all editor color keys`() {
+        AyuEditorSchemeScope.claimActiveScheme()
         invokePrivate("revertAlwaysOnEditorKeys")
 
         verify(atLeast = 2) { mockScheme.setColor(any<ColorKey>(), null) }
@@ -588,6 +593,7 @@ class AccentApplicatorTest {
 
     @Test
     fun `revertAlwaysOnEditorKeys resets all attribute overrides`() {
+        AyuEditorSchemeScope.claimActiveScheme()
         invokePrivate("revertAlwaysOnEditorKeys")
 
         verify(atLeast = 9) { mockScheme.setAttributes(any<TextAttributesKey>(), any()) }
@@ -1381,8 +1387,38 @@ class AccentApplicatorTest {
     }
 
     @Test
+    fun `revertAll retains editor claims when an element cleanup fails`() {
+        val failingElement = mockk<AccentElement>(relaxed = true)
+        every { failingElement.id } returns AccentElementId.CARET_ROW
+        every { failingElement.displayName } returns "FailingElement"
+        every { failingElement.revert() } throws RuntimeException("revert failed")
+        mockEpExtensionList(listOf(failingElement))
+        AyuEditorSchemeScope.claimActiveScheme()
+
+        AccentApplicator.revertAll()
+
+        assertEquals(1, AyuEditorSchemeScope.claimedAccentSchemes().size)
+    }
+
+    @Test
+    fun `revertAll releases editor claims only after queued cleanup completes`() {
+        mockEpExtensionList(emptyList())
+        AyuEditorSchemeScope.claimActiveScheme()
+        every { SwingUtilities.isEventDispatchThread() } returns false
+        val callback = io.mockk.slot<Runnable>()
+        every { mockApplication.invokeLater(capture(callback), any<ModalityState>()) } returns Unit
+
+        AccentApplicator.revertAll()
+
+        assertEquals(1, AyuEditorSchemeScope.claimedAccentSchemes().size)
+        callback.captured.run()
+        assertTrue(AyuEditorSchemeScope.claimedAccentSchemes().isEmpty())
+    }
+
+    @Test
     fun `revertAll clears editor keys via revertAlwaysOnEditorKeys`() {
         mockEpExtensionList(emptyList())
+        AyuEditorSchemeScope.claimActiveScheme()
 
         AccentApplicator.revertAll()
 

--- a/src/test/kotlin/dev/ayuislands/accent/elements/AccentElementsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/AccentElementsTest.kt
@@ -178,6 +178,26 @@ class AccentElementsTest {
     }
 
     @Test
+    fun `scheme-backed reverts clean owned Ayu scheme after leaving Ayu`() {
+        every { AyuVariant.detect() } returns null
+        val elements =
+            listOf(
+                LinksElement(),
+                ScrollbarElement(),
+                ProgressBarElement(),
+                InlayHintsElement(),
+                CaretRowElement(),
+                BracketMatchElement(),
+                MatchingTagElement(),
+            )
+
+        elements.forEach { it.revert() }
+
+        verify(atLeast = 1) { mockScheme.setColor(any<ColorKey>(), null) }
+        verify(atLeast = 1) { mockScheme.setAttributes(any<TextAttributesKey>(), any()) }
+    }
+
+    @Test
     fun `editor-only elements call setAttributes on apply`() {
         val editorElements: List<AccentElement> =
             listOf(

--- a/src/test/kotlin/dev/ayuislands/accent/elements/AccentElementsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/AccentElementsTest.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.editor.colors.ColorKey
 import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.colors.EditorColorsScheme
 import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.openapi.editor.markup.EffectType
 import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.ui.JBColor
 import dev.ayuislands.accent.AccentElement
@@ -12,7 +13,6 @@ import dev.ayuislands.accent.AccentGroup
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.theme.AyuEditorSchemeScope
 import io.mockk.Runs
-import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -35,12 +35,16 @@ import kotlin.test.assertTrue
 class AccentElementsTest {
     private lateinit var mockScheme: EditorColorsScheme
     private lateinit var mockColorsManager: EditorColorsManager
+    private val colorKeys = mutableMapOf<String, ColorKey>()
+    private val attributeKeys = mutableMapOf<String, TextAttributesKey>()
 
     private val testColor = Color(255, 204, 102)
 
     @BeforeTest
     fun setUp() {
         AyuEditorSchemeScope.resetClaims()
+        colorKeys.clear()
+        attributeKeys.clear()
         mockScheme = mockk(relaxed = true)
         mockColorsManager = mockk(relaxed = true)
         every { mockColorsManager.globalScheme } returns mockScheme
@@ -57,10 +61,14 @@ class AccentElementsTest {
         every { SwingUtilities.invokeLater(any()) } answers { firstArg<Runnable>().run() }
 
         mockkStatic(ColorKey::class)
-        every { ColorKey.find(any<String>()) } answers { mockk(relaxed = true) }
+        every { ColorKey.find(any<String>()) } answers {
+            colorKeys.getOrPut(firstArg()) { mockk(relaxed = true) }
+        }
 
         mockkStatic(TextAttributesKey::class)
-        every { TextAttributesKey.find(any<String>()) } answers { mockk(relaxed = true) }
+        every { TextAttributesKey.find(any<String>()) } answers {
+            attributeKeys.getOrPut(firstArg()) { mockk(relaxed = true) }
+        }
 
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
@@ -84,6 +92,17 @@ class AccentElementsTest {
             SearchResultsElement(),
             InlayHintsElement(),
             CaretRowElement(),
+            BracketMatchElement(),
+            MatchingTagElement(),
+        )
+
+    private fun editorElements(): List<AccentElement> =
+        listOf(
+            InlayHintsElement(),
+            CaretRowElement(),
+            ProgressBarElement(),
+            ScrollbarElement(),
+            LinksElement(),
             BracketMatchElement(),
             MatchingTagElement(),
         )
@@ -168,6 +187,66 @@ class AccentElementsTest {
     }
 
     @Test
+    fun `disabled editor elements restore exact user values`() {
+        for (element in editorElements()) {
+            AyuEditorSchemeScope.resetClaims()
+            try {
+                val store = EditorSchemeStore()
+                every { mockColorsManager.globalScheme } returns store.scheme
+
+                element.apply(testColor)
+                store.assertWasChanged(element)
+                element.applyNeutral(AyuVariant.MIRAGE)
+
+                store.assertOriginalValues(element)
+            } finally {
+                AyuEditorSchemeScope.resetClaims()
+            }
+        }
+    }
+
+    @Test
+    fun `editor element revert restores exact user values`() {
+        for (element in editorElements()) {
+            AyuEditorSchemeScope.resetClaims()
+            try {
+                val store = EditorSchemeStore()
+                every { mockColorsManager.globalScheme } returns store.scheme
+
+                element.apply(testColor)
+                store.assertWasChanged(element)
+                element.revert()
+
+                store.assertOriginalValues(element)
+            } finally {
+                AyuEditorSchemeScope.resetClaims()
+            }
+        }
+    }
+
+    @Test
+    fun `external editor changes survive every later element action`() {
+        for (element in editorElements()) {
+            AyuEditorSchemeScope.resetClaims()
+            try {
+                val store = EditorSchemeStore()
+                every { mockColorsManager.globalScheme } returns store.scheme
+
+                element.apply(testColor)
+                store.assertWasChanged(element)
+                store.replaceTouchedValues()
+                element.apply(Color.YELLOW)
+                element.applyNeutral(AyuVariant.MIRAGE)
+                element.revert()
+
+                store.assertExternalValues(element)
+            } finally {
+                AyuEditorSchemeScope.resetClaims()
+            }
+        }
+    }
+
+    @Test
     fun `mixed elements still update UI keys for a foreign editor scheme`() {
         every { mockScheme.name } returns "Solarized Dark"
         val elements = listOf(LinksElement(), ScrollbarElement(), ProgressBarElement())
@@ -183,6 +262,8 @@ class AccentElementsTest {
 
     @Test
     fun `scheme-backed reverts clean owned Ayu scheme after leaving Ayu`() {
+        val store = EditorSchemeStore()
+        every { mockColorsManager.globalScheme } returns store.scheme
         val elements =
             listOf(
                 LinksElement(),
@@ -195,33 +276,30 @@ class AccentElementsTest {
             )
 
         elements.forEach { it.apply(testColor) }
-        clearMocks(mockScheme, answers = false, recordedCalls = true)
         every { AyuVariant.detect() } returns null
         elements.forEach { it.revert() }
 
-        verify(atLeast = 1) { mockScheme.setColor(any<ColorKey>(), null) }
-        verify(atLeast = 1) { mockScheme.setAttributes(any<TextAttributesKey>(), any()) }
+        elements.forEach(store::assertOriginalValues)
     }
 
     @Test
     fun `revert cleans every exact scheme claimed across Ayu variants`() {
-        val secondScheme = mockk<EditorColorsScheme>(relaxed = true)
-        every { secondScheme.name } returns "Ayu Islands Dark"
-        var currentScheme = mockScheme
+        val firstStore = EditorSchemeStore()
+        val secondStore = EditorSchemeStore("Ayu Islands Dark")
+        var currentScheme = firstStore.scheme
         every { mockColorsManager.globalScheme } answers { currentScheme }
         val element = CaretRowElement()
 
         element.apply(testColor)
-        currentScheme = secondScheme
+        currentScheme = secondStore.scheme
         every { AyuVariant.detect() } returns AyuVariant.DARK
         element.apply(testColor)
-        clearMocks(mockScheme, secondScheme, answers = false, recordedCalls = true)
         every { AyuVariant.detect() } returns null
 
         element.revert()
 
-        verify(exactly = 3) { mockScheme.setColor(any<ColorKey>(), null) }
-        verify(exactly = 3) { secondScheme.setColor(any<ColorKey>(), null) }
+        firstStore.assertOriginalValues(element)
+        secondStore.assertOriginalValues(element)
     }
 
     @Test
@@ -239,25 +317,6 @@ class AccentElementsTest {
         // InlayHintsElement and BracketMatchElement use setAttributes, CaretRowElement uses setColor
         verify(atLeast = 1) { mockScheme.setAttributes(any<TextAttributesKey>(), any()) }
         verify(atLeast = 1) { mockScheme.setColor(any<ColorKey>(), any()) }
-    }
-
-    @Test
-    fun `editor-only elements call setAttributes null on revert`() {
-        AyuEditorSchemeScope.claimActiveScheme()
-        val editorElements: List<AccentElement> =
-            listOf(
-                InlayHintsElement(),
-                CaretRowElement(),
-                BracketMatchElement(),
-                MatchingTagElement(),
-            )
-        for (element in editorElements) {
-            element.revert()
-        }
-        // InlayHintsElement reverts with setAttributes(key, null), BracketMatchElement uses setAttributes too
-        verify(atLeast = 1) { mockScheme.setAttributes(any<TextAttributesKey>(), any()) }
-        // CaretRowElement reverts with setColor(key, null)
-        verify(atLeast = 1) { mockScheme.setColor(any<ColorKey>(), null) }
     }
 
     @Test
@@ -357,16 +416,6 @@ class AccentElementsTest {
         verify(atLeast = 1) { UIManager.put(any<String>(), null) }
     }
 
-    @Test
-    fun `MatchingTagElement applyNeutral restores from parent scheme`() {
-        every { mockScheme.setAttributes(any<TextAttributesKey>(), any()) } just Runs
-
-        val element = MatchingTagElement()
-        element.applyNeutral(AyuVariant.DARK)
-
-        verify { mockScheme.setAttributes(any<TextAttributesKey>(), any()) }
-    }
-
     // ProgressBarElement coverage
 
     @Test
@@ -386,38 +435,11 @@ class AccentElementsTest {
     }
 
     @Test
-    fun `ProgressBarElement revert nulls UI keys and editor color key`() {
-        AyuEditorSchemeScope.claimActiveScheme()
+    fun `ProgressBarElement revert clears UI keys`() {
         val element = ProgressBarElement()
         element.revert()
         verify { UIManager.put("ProgressBar.foreground", null) }
         verify { UIManager.put("ProgressBar.progressCounterBackground", null) }
-        verify { mockScheme.setColor(any(), null) }
-    }
-
-    @Test
-    fun `ProgressBarElement applyNeutral restores from parent scheme`() {
-        val parentScheme: EditorColorsScheme = mockk(relaxed = true)
-        every { mockColorsManager.getScheme("Darcula") } returns parentScheme
-        every { parentScheme.getColor(any()) } returns Color(100, 100, 100)
-
-        val element = ProgressBarElement()
-        element.applyNeutral(AyuVariant.MIRAGE)
-
-        verify { UIManager.put("ProgressBar.foreground", null) }
-        verify { UIManager.put("ProgressBar.progressCounterBackground", null) }
-        verify { mockScheme.setColor(any(), Color(100, 100, 100)) }
-    }
-
-    @Test
-    fun `ProgressBarElement applyNeutral handles null parent scheme`() {
-        every { mockColorsManager.getScheme("Darcula") } returns null
-
-        val element = ProgressBarElement()
-        element.applyNeutral(AyuVariant.MIRAGE)
-
-        verify { UIManager.put("ProgressBar.foreground", null) }
-        verify { mockScheme.setColor(any(), null) }
     }
 
     @Test
@@ -433,14 +455,16 @@ class AccentElementsTest {
 
     @Test
     fun `ProgressBarElement revert off EDT uses invokeLater`() {
-        AyuEditorSchemeScope.claimActiveScheme()
+        val store = EditorSchemeStore()
+        every { mockColorsManager.globalScheme } returns store.scheme
+        val element = ProgressBarElement()
+        element.apply(testColor)
         every { SwingUtilities.isEventDispatchThread() } returns false
 
-        val element = ProgressBarElement()
         element.revert()
 
         verify { SwingUtilities.invokeLater(any()) }
-        verify { mockScheme.setColor(any(), null) }
+        store.assertOriginalValues(element)
     }
 
     // LinksElement coverage
@@ -490,49 +514,11 @@ class AccentElementsTest {
     }
 
     @Test
-    fun `LinksElement revert nulls all editor color keys and text attributes`() {
-        AyuEditorSchemeScope.claimActiveScheme()
+    fun `LinksElement revert clears all UI keys`() {
         val element = LinksElement()
         element.revert()
 
-        // 6 UI keys nulled
         verify(exactly = 6) { UIManager.put(any<String>(), null) }
-        // 2 editor color keys nulled
-        verify(exactly = 2) { mockScheme.setColor(any(), null) }
-        // 3 text attribute keys nulled
-        verify(exactly = 3) { mockScheme.setAttributes(any<TextAttributesKey>(), null) }
-    }
-
-    @Test
-    fun `LinksElement applyNeutral restores from parent scheme`() {
-        val parentScheme: EditorColorsScheme = mockk(relaxed = true)
-        val parentAttrs = TextAttributes()
-        parentAttrs.foregroundColor = Color.CYAN
-        every { mockColorsManager.getScheme("Darcula") } returns parentScheme
-        every { parentScheme.getColor(any()) } returns Color(80, 80, 80)
-        every { parentScheme.getAttributes(any<TextAttributesKey>()) } returns parentAttrs
-
-        val element = LinksElement()
-        element.applyNeutral(AyuVariant.DARK)
-
-        // UI keys nulled
-        verify(exactly = 6) { UIManager.put(any<String>(), null) }
-        // Editor color keys restored from parent
-        verify(exactly = 2) { mockScheme.setColor(any(), Color(80, 80, 80)) }
-        // Text attributes restored from parent
-        verify(exactly = 3) { mockScheme.setAttributes(any<TextAttributesKey>(), parentAttrs) }
-    }
-
-    @Test
-    fun `LinksElement applyNeutral handles null parent scheme`() {
-        every { mockColorsManager.getScheme("Darcula") } returns null
-
-        val element = LinksElement()
-        element.applyNeutral(AyuVariant.MIRAGE)
-
-        verify(exactly = 6) { UIManager.put(any<String>(), null) }
-        verify(exactly = 2) { mockScheme.setColor(any(), null) }
-        verify(exactly = 3) { mockScheme.setAttributes(any<TextAttributesKey>(), null) }
     }
 
     // InlayHintsElement coverage
@@ -565,39 +551,6 @@ class AccentElementsTest {
         assertEquals(testColor.blue, captured.foregroundColor!!.blue)
     }
 
-    @Test
-    fun `InlayHintsElement revert sets attributes to null`() {
-        AyuEditorSchemeScope.claimActiveScheme()
-        val element = InlayHintsElement()
-        element.revert()
-
-        verify(exactly = 1) { mockScheme.setAttributes(any<TextAttributesKey>(), null) }
-    }
-
-    @Test
-    fun `InlayHintsElement applyNeutral restores from parent scheme`() {
-        val parentScheme: EditorColorsScheme = mockk(relaxed = true)
-        val parentAttrs = TextAttributes()
-        parentAttrs.foregroundColor = Color.GRAY
-        every { mockColorsManager.getScheme("Darcula") } returns parentScheme
-        every { parentScheme.getAttributes(any<TextAttributesKey>()) } returns parentAttrs
-
-        val element = InlayHintsElement()
-        element.applyNeutral(AyuVariant.MIRAGE)
-
-        verify { mockScheme.setAttributes(any<TextAttributesKey>(), parentAttrs) }
-    }
-
-    @Test
-    fun `InlayHintsElement applyNeutral handles null parent scheme`() {
-        every { mockColorsManager.getScheme("Darcula") } returns null
-
-        val element = InlayHintsElement()
-        element.applyNeutral(AyuVariant.MIRAGE)
-
-        verify { mockScheme.setAttributes(any<TextAttributesKey>(), null) }
-    }
-
     // CaretRowElement coverage
 
     @Test
@@ -627,38 +580,6 @@ class AccentElementsTest {
         assertEquals(testColor, colorSlots[2])
     }
 
-    @Test
-    fun `CaretRowElement revert nulls all three color keys`() {
-        AyuEditorSchemeScope.claimActiveScheme()
-        val element = CaretRowElement()
-        element.revert()
-
-        verify(exactly = 3) { mockScheme.setColor(any(), null) }
-    }
-
-    @Test
-    fun `CaretRowElement applyNeutral restores from parent scheme`() {
-        val parentScheme: EditorColorsScheme = mockk(relaxed = true)
-        val parentColor = Color(50, 60, 70)
-        every { mockColorsManager.getScheme("Darcula") } returns parentScheme
-        every { parentScheme.getColor(any()) } returns parentColor
-
-        val element = CaretRowElement()
-        element.applyNeutral(AyuVariant.MIRAGE)
-
-        verify(exactly = 3) { mockScheme.setColor(any(), parentColor) }
-    }
-
-    @Test
-    fun `CaretRowElement applyNeutral handles null parent scheme`() {
-        every { mockColorsManager.getScheme("Darcula") } returns null
-
-        val element = CaretRowElement()
-        element.applyNeutral(AyuVariant.MIRAGE)
-
-        verify(exactly = 3) { mockScheme.setColor(any(), null) }
-    }
-
     // BracketMatchElement coverage
 
     @Test
@@ -684,37 +605,10 @@ class AccentElementsTest {
     }
 
     @Test
-    fun `BracketMatchElement revert restores fallback attributes`() {
-        AyuEditorSchemeScope.claimActiveScheme()
+    fun `BracketMatchElement revert deactivates bracket fade`() {
         val element = BracketMatchElement()
         element.revert()
 
-        verify(atLeast = 1) { mockScheme.setAttributes(any<TextAttributesKey>(), any()) }
-        verify { BracketFadeManager.deactivate() }
-    }
-
-    @Test
-    fun `BracketMatchElement applyNeutral restores from parent scheme`() {
-        val parentScheme: EditorColorsScheme = mockk(relaxed = true)
-        val parentAttrs = TextAttributes()
-        every { mockColorsManager.getScheme("Darcula") } returns parentScheme
-        every { parentScheme.getAttributes(any<TextAttributesKey>()) } returns parentAttrs
-
-        val element = BracketMatchElement()
-        element.applyNeutral(AyuVariant.MIRAGE)
-
-        verify { mockScheme.setAttributes(any<TextAttributesKey>(), parentAttrs) }
-        verify { BracketFadeManager.deactivate() }
-    }
-
-    @Test
-    fun `BracketMatchElement applyNeutral handles null parent scheme`() {
-        every { mockColorsManager.getScheme("Darcula") } returns null
-
-        val element = BracketMatchElement()
-        element.applyNeutral(AyuVariant.MIRAGE)
-
-        verify { mockScheme.setAttributes(any<TextAttributesKey>(), any()) }
         verify { BracketFadeManager.deactivate() }
     }
 
@@ -733,39 +627,6 @@ class AccentElementsTest {
         assertEquals(testColor, attributesSlot.captured.foregroundColor)
         assertEquals(java.awt.Font.BOLD, attributesSlot.captured.fontType)
         verify { BracketFadeManager.activate(testColor) }
-    }
-
-    @Test
-    fun `BracketMatchElement applyNeutral with non-null parent but null attrs`() {
-        val parentScheme: EditorColorsScheme = mockk(relaxed = true)
-        every { mockColorsManager.getScheme("Darcula") } returns parentScheme
-        every { parentScheme.getAttributes(any<TextAttributesKey>()) } returns null
-        val attributesSlot = slot<TextAttributes>()
-        every { mockScheme.setAttributes(any<TextAttributesKey>(), capture(attributesSlot)) } just Runs
-
-        val element = BracketMatchElement()
-        element.applyNeutral(AyuVariant.MIRAGE)
-
-        assertTrue(attributesSlot.isCaptured, "setAttributes should have been called")
-        assertNotNull(attributesSlot.captured, "Should use fallback TextAttributes when parent attrs are null")
-        verify { BracketFadeManager.deactivate() }
-    }
-
-    @Test
-    fun `BracketMatchElement revert with null fallback attribute key`() {
-        AyuEditorSchemeScope.claimActiveScheme()
-        val braceKey = mockk<TextAttributesKey>(relaxed = true)
-        every { braceKey.fallbackAttributeKey } returns null
-        every { TextAttributesKey.find("MATCHED_BRACE_ATTRIBUTES") } returns braceKey
-        val attributesSlot = slot<TextAttributes>()
-        every { mockScheme.setAttributes(any<TextAttributesKey>(), capture(attributesSlot)) } just Runs
-
-        val element = BracketMatchElement()
-        element.revert()
-
-        assertTrue(attributesSlot.isCaptured, "setAttributes should have been called")
-        assertNotNull(attributesSlot.captured, "Should use fallback TextAttributes when fallback key is null")
-        verify { BracketFadeManager.deactivate() }
     }
 
     // SearchResultsElement blend coverage
@@ -845,18 +706,92 @@ class AccentElementsTest {
         assertEquals(AccentGroup.INTERACTIVE, AccentElementId.MATCHING_TAG.group)
     }
 
-    // AyuVariant coverage for applyNeutral with different variants
+    private class EditorSchemeStore(
+        schemeName: String = "_@user_Ayu Islands Mirage",
+    ) {
+        private val originalColor = Color(0x12, 0x34, 0x56)
+        private val externalColor = Color(0x65, 0x43, 0x21)
+        private val originalAttributes = attributes(Color(0x21, 0x43, 0x65))
+        private val externalAttributes = attributes(Color(0x56, 0x34, 0x12))
+        private val colors = mutableMapOf<ColorKey, Color?>()
+        private val textAttributes = mutableMapOf<TextAttributesKey, TextAttributes?>()
+        private val touchedColors = linkedSetOf<ColorKey>()
+        private val touchedAttributes = linkedSetOf<TextAttributesKey>()
 
-    @Test
-    fun `applyNeutral works with Light variant using Default parent scheme`() {
-        val parentScheme: EditorColorsScheme = mockk(relaxed = true)
-        val parentAttrs = TextAttributes()
-        every { mockColorsManager.getScheme("Default") } returns parentScheme
-        every { parentScheme.getAttributes(any<TextAttributesKey>()) } returns parentAttrs
+        val scheme: EditorColorsScheme =
+            mockk(relaxed = true) {
+                every { name } returns schemeName
+                every { defaultBackground } returns Color(0x1F, 0x24, 0x30)
+                every { getColor(any()) } answers {
+                    val key = firstArg<ColorKey>()
+                    if (!colors.containsKey(key)) colors[key] = originalColor
+                    colors[key]
+                }
+                every { setColor(any(), any()) } answers {
+                    val key = firstArg<ColorKey>()
+                    touchedColors.add(key)
+                    colors[key] = secondArg()
+                }
+                every { getAttributes(any<TextAttributesKey>()) } answers {
+                    val key = firstArg<TextAttributesKey>()
+                    if (!textAttributes.containsKey(key)) textAttributes[key] = originalAttributes.clone()
+                    textAttributes[key]
+                }
+                every { setAttributes(any(), any()) } answers {
+                    val key = firstArg<TextAttributesKey>()
+                    touchedAttributes.add(key)
+                    textAttributes[key] = secondArg<TextAttributes?>()?.clone()
+                }
+            }
 
-        val element = BracketMatchElement()
-        element.applyNeutral(AyuVariant.LIGHT)
+        fun replaceTouchedValues() {
+            touchedColors.forEach { key -> colors[key] = externalColor }
+            touchedAttributes.forEach { key -> textAttributes[key] = externalAttributes.clone() }
+        }
 
-        verify { mockScheme.setAttributes(any<TextAttributesKey>(), parentAttrs) }
+        fun assertWasChanged(element: AccentElement) {
+            assertTrue(
+                touchedColors.isNotEmpty() || touchedAttributes.isNotEmpty(),
+                "${element.displayName} must exercise at least one editor scheme key",
+            )
+        }
+
+        fun assertOriginalValues(element: AccentElement) {
+            touchedColors.forEach { key ->
+                assertEquals(originalColor, colors[key], "${element.displayName} must restore its original color")
+            }
+            touchedAttributes.forEach { key ->
+                assertEquals(
+                    originalAttributes,
+                    textAttributes[key],
+                    "${element.displayName} must restore its original attributes",
+                )
+            }
+        }
+
+        fun assertExternalValues(element: AccentElement) {
+            touchedColors.forEach { key ->
+                assertEquals(externalColor, colors[key], "${element.displayName} must preserve an external color")
+            }
+            touchedAttributes.forEach { key ->
+                assertEquals(
+                    externalAttributes,
+                    textAttributes[key],
+                    "${element.displayName} must preserve external attributes",
+                )
+            }
+        }
+
+        companion object {
+            private fun attributes(foreground: Color): TextAttributes =
+                TextAttributes().apply {
+                    foregroundColor = foreground
+                    backgroundColor = Color.BLACK
+                    effectColor = Color.CYAN
+                    errorStripeColor = Color.MAGENTA
+                    effectType = EffectType.BOLD_DOTTED_LINE
+                    fontType = 3
+                }
+        }
     }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/elements/AccentElementsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/AccentElementsTest.kt
@@ -10,7 +10,9 @@ import dev.ayuislands.accent.AccentElement
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.AccentGroup
 import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.theme.AyuEditorSchemeScope
 import io.mockk.Runs
+import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -38,6 +40,7 @@ class AccentElementsTest {
 
     @BeforeTest
     fun setUp() {
+        AyuEditorSchemeScope.resetClaims()
         mockScheme = mockk(relaxed = true)
         mockColorsManager = mockk(relaxed = true)
         every { mockColorsManager.globalScheme } returns mockScheme
@@ -69,6 +72,7 @@ class AccentElementsTest {
 
     @AfterTest
     fun tearDown() {
+        AyuEditorSchemeScope.resetClaims()
         unmockkAll()
     }
 
@@ -179,7 +183,6 @@ class AccentElementsTest {
 
     @Test
     fun `scheme-backed reverts clean owned Ayu scheme after leaving Ayu`() {
-        every { AyuVariant.detect() } returns null
         val elements =
             listOf(
                 LinksElement(),
@@ -191,10 +194,34 @@ class AccentElementsTest {
                 MatchingTagElement(),
             )
 
+        elements.forEach { it.apply(testColor) }
+        clearMocks(mockScheme, answers = false, recordedCalls = true)
+        every { AyuVariant.detect() } returns null
         elements.forEach { it.revert() }
 
         verify(atLeast = 1) { mockScheme.setColor(any<ColorKey>(), null) }
         verify(atLeast = 1) { mockScheme.setAttributes(any<TextAttributesKey>(), any()) }
+    }
+
+    @Test
+    fun `revert cleans every exact scheme claimed across Ayu variants`() {
+        val secondScheme = mockk<EditorColorsScheme>(relaxed = true)
+        every { secondScheme.name } returns "Ayu Islands Dark"
+        var currentScheme = mockScheme
+        every { mockColorsManager.globalScheme } answers { currentScheme }
+        val element = CaretRowElement()
+
+        element.apply(testColor)
+        currentScheme = secondScheme
+        every { AyuVariant.detect() } returns AyuVariant.DARK
+        element.apply(testColor)
+        clearMocks(mockScheme, secondScheme, answers = false, recordedCalls = true)
+        every { AyuVariant.detect() } returns null
+
+        element.revert()
+
+        verify(exactly = 3) { mockScheme.setColor(any<ColorKey>(), null) }
+        verify(exactly = 3) { secondScheme.setColor(any<ColorKey>(), null) }
     }
 
     @Test
@@ -216,6 +243,7 @@ class AccentElementsTest {
 
     @Test
     fun `editor-only elements call setAttributes null on revert`() {
+        AyuEditorSchemeScope.claimActiveScheme()
         val editorElements: List<AccentElement> =
             listOf(
                 InlayHintsElement(),
@@ -359,6 +387,7 @@ class AccentElementsTest {
 
     @Test
     fun `ProgressBarElement revert nulls UI keys and editor color key`() {
+        AyuEditorSchemeScope.claimActiveScheme()
         val element = ProgressBarElement()
         element.revert()
         verify { UIManager.put("ProgressBar.foreground", null) }
@@ -404,6 +433,7 @@ class AccentElementsTest {
 
     @Test
     fun `ProgressBarElement revert off EDT uses invokeLater`() {
+        AyuEditorSchemeScope.claimActiveScheme()
         every { SwingUtilities.isEventDispatchThread() } returns false
 
         val element = ProgressBarElement()
@@ -461,6 +491,7 @@ class AccentElementsTest {
 
     @Test
     fun `LinksElement revert nulls all editor color keys and text attributes`() {
+        AyuEditorSchemeScope.claimActiveScheme()
         val element = LinksElement()
         element.revert()
 
@@ -536,6 +567,7 @@ class AccentElementsTest {
 
     @Test
     fun `InlayHintsElement revert sets attributes to null`() {
+        AyuEditorSchemeScope.claimActiveScheme()
         val element = InlayHintsElement()
         element.revert()
 
@@ -597,6 +629,7 @@ class AccentElementsTest {
 
     @Test
     fun `CaretRowElement revert nulls all three color keys`() {
+        AyuEditorSchemeScope.claimActiveScheme()
         val element = CaretRowElement()
         element.revert()
 
@@ -652,6 +685,7 @@ class AccentElementsTest {
 
     @Test
     fun `BracketMatchElement revert restores fallback attributes`() {
+        AyuEditorSchemeScope.claimActiveScheme()
         val element = BracketMatchElement()
         element.revert()
 
@@ -719,6 +753,7 @@ class AccentElementsTest {
 
     @Test
     fun `BracketMatchElement revert with null fallback attribute key`() {
+        AyuEditorSchemeScope.claimActiveScheme()
         val braceKey = mockk<TextAttributesKey>(relaxed = true)
         every { braceKey.fallbackAttributeKey } returns null
         every { TextAttributesKey.find("MATCHED_BRACE_ATTRIBUTES") } returns braceKey

--- a/src/test/kotlin/dev/ayuislands/accent/elements/AccentElementsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/elements/AccentElementsTest.kt
@@ -59,6 +59,9 @@ class AccentElementsTest {
         mockkStatic(TextAttributesKey::class)
         every { TextAttributesKey.find(any<String>()) } answers { mockk(relaxed = true) }
 
+        mockkObject(AyuVariant.Companion)
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+
         mockkObject(BracketFadeManager)
         every { BracketFadeManager.activate(any()) } returns Unit
         every { BracketFadeManager.deactivate() } returns Unit
@@ -131,6 +134,47 @@ class AccentElementsTest {
             element.revert()
             verify(atLeast = 1) { UIManager.put(any<String>(), null) }
         }
+    }
+
+    @Test
+    fun `scheme-backed elements preserve a foreign editor scheme`() {
+        every { mockScheme.name } returns "Solarized Dark"
+        val elements =
+            listOf(
+                LinksElement(),
+                ScrollbarElement(),
+                ProgressBarElement(),
+                InlayHintsElement(),
+                CaretRowElement(),
+                BracketMatchElement(),
+                MatchingTagElement(),
+            )
+
+        elements.forEach { element ->
+            element.apply(testColor)
+            element.applyNeutral(AyuVariant.MIRAGE)
+            element.revert()
+        }
+
+        verify(exactly = 0) { mockScheme.setColor(any<ColorKey>(), any<Color>()) }
+        verify(exactly = 0) { mockScheme.setColor(any<ColorKey>(), null) }
+        verify(exactly = 0) { mockScheme.setAttributes(any<TextAttributesKey>(), any<TextAttributes>()) }
+        verify(exactly = 0) { mockScheme.setAttributes(any<TextAttributesKey>(), null) }
+        verify(exactly = 2) { BracketFadeManager.deactivate() }
+    }
+
+    @Test
+    fun `mixed elements still update UI keys for a foreign editor scheme`() {
+        every { mockScheme.name } returns "Solarized Dark"
+        val elements = listOf(LinksElement(), ScrollbarElement(), ProgressBarElement())
+
+        elements.forEach { element ->
+            element.apply(testColor)
+            element.revert()
+        }
+
+        verify(atLeast = 1) { UIManager.put(any<String>(), any<Color>()) }
+        verify(atLeast = 1) { UIManager.put(any<String>(), null) }
     }
 
     @Test
@@ -234,6 +278,7 @@ class AccentElementsTest {
     @Test
     fun `MatchingTagElement apply keeps light background when light scheme is unresolved`() {
         val attributesSlot = slot<TextAttributes>()
+        every { AyuVariant.detect() } returns AyuVariant.LIGHT
         every { mockScheme.defaultBackground } returns Color.WHITE
         every { mockScheme.name } returns "Ayu Islands Light"
         every { mockScheme.getAttributes(any<TextAttributesKey>()) } returns null

--- a/src/test/kotlin/dev/ayuislands/reapply/ThemeReapplicationPlanTest.kt
+++ b/src/test/kotlin/dev/ayuislands/reapply/ThemeReapplicationPlanTest.kt
@@ -9,7 +9,6 @@ import dev.ayuislands.reapply.ReapplyStep.Font
 import dev.ayuislands.reapply.ReapplyStep.Glow
 import dev.ayuislands.reapply.ReapplyStep.Notify
 import dev.ayuislands.reapply.ReapplyStep.RevertAccent
-import dev.ayuislands.reapply.ReapplyStep.RevertFont
 import dev.ayuislands.reapply.ReapplyStep.Syntax
 import dev.ayuislands.reapply.ReapplyStep.VcsRevert
 import kotlin.test.Test
@@ -26,15 +25,15 @@ class ThemeReapplicationPlanTest {
     }
 
     @Test
-    fun `theme switch to External reverts accent and font, then applies external accent and glow`() {
+    fun `theme switch to External cleans accent then applies external accent and glow`() {
         val plan = ThemeReapplication.planFor(ReapplyReason.ThemeSwitched(AccentContext.External))
-        assertEquals(listOf(RevertAccent, RevertFont, ApplyResolvedAccent, Glow), plan)
+        assertEquals(listOf(RevertAccent, ApplyResolvedAccent, Glow), plan)
     }
 
     @Test
-    fun `theme switch away reverts accent and font, then syncs glow`() {
+    fun `theme switch away cleans accent then syncs glow`() {
         val plan = ThemeReapplication.planFor(ReapplyReason.ThemeSwitched(null))
-        assertEquals(listOf(RevertAccent, RevertFont, Glow), plan)
+        assertEquals(listOf(RevertAccent, Glow), plan)
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/reapply/ThemeReapplicationPlanTest.kt
+++ b/src/test/kotlin/dev/ayuislands/reapply/ThemeReapplicationPlanTest.kt
@@ -10,6 +10,7 @@ import dev.ayuislands.reapply.ReapplyStep.Glow
 import dev.ayuislands.reapply.ReapplyStep.Notify
 import dev.ayuislands.reapply.ReapplyStep.RevertAccent
 import dev.ayuislands.reapply.ReapplyStep.Syntax
+import dev.ayuislands.reapply.ReapplyStep.VcsApply
 import dev.ayuislands.reapply.ReapplyStep.VcsRevert
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -21,19 +22,19 @@ class ThemeReapplicationPlanTest {
             ThemeReapplication.planFor(
                 ReapplyReason.ThemeSwitched(AccentContext.Ayu(AyuVariant.DARK)),
             )
-        assertEquals(listOf(BindScheme, ApplyResolvedAccent, Font, Notify, Glow, Syntax), plan)
+        assertEquals(listOf(BindScheme, ApplyResolvedAccent, Font, Notify, Glow, Syntax, VcsApply), plan)
     }
 
     @Test
     fun `theme switch to External cleans accent then applies external accent and glow`() {
         val plan = ThemeReapplication.planFor(ReapplyReason.ThemeSwitched(AccentContext.External))
-        assertEquals(listOf(RevertAccent, ApplyResolvedAccent, Glow), plan)
+        assertEquals(listOf(RevertAccent, VcsRevert, ApplyResolvedAccent, Glow), plan)
     }
 
     @Test
     fun `theme switch away cleans accent then syncs glow`() {
         val plan = ThemeReapplication.planFor(ReapplyReason.ThemeSwitched(null))
-        assertEquals(listOf(RevertAccent, Glow), plan)
+        assertEquals(listOf(RevertAccent, VcsRevert, Glow), plan)
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/settings/VcsColorPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/VcsColorPanelTest.kt
@@ -67,7 +67,7 @@ class VcsColorPanelTest {
         every { LicenseChecker.isLicensedOrGrace() } returns true
 
         mockkObject(VcsColorApplier)
-        every { VcsColorApplier.applyAll() } returns Unit
+        every { VcsColorApplier.applyCurrentScheme() } returns Unit
         every { VcsColorApplier.revertAll() } returns Unit
 
         // UI DSL plumbing — collapsibleGroup builders resolve ActionManager through
@@ -367,7 +367,7 @@ class VcsColorPanelTest {
         assertEquals(VcsColorPreset.NEON.name, state.vcsDiffPreset)
         assertEquals(VcsColorPreset.CYBERPUNK.name, state.vcsMergePreset)
         assertEquals(VcsColorPreset.WHISPER.name, state.vcsBlamePreset)
-        verify(exactly = 1) { VcsColorApplier.applyAll() }
+        verify(exactly = 1) { VcsColorApplier.applyCurrentScheme() }
     }
 
     @Test
@@ -383,7 +383,7 @@ class VcsColorPanelTest {
         every {
             VcsColorContext.withSnapshot(capture(capturedSnapshot), any<() -> Any?>())
         } answers {
-            // Run the block so the inner VcsColorApplier.applyAll mock still
+            // Run the block so the inner explicit applier mock still
             // fires once — keeps the existing apply-fires-applier assertion
             // semantics intact.
             @Suppress("UNCHECKED_CAST")
@@ -418,14 +418,14 @@ class VcsColorPanelTest {
         // BLAME section → WHISPER → BLAME_GUTTER lands on WHISPER_SLIDER.
         assertEquals(VcsColorPreset.WHISPER_SLIDER, intensities[VcsColorCategory.BLAME_GUTTER])
 
-        verify(exactly = 1) { VcsColorApplier.applyAll() }
+        verify(exactly = 1) { VcsColorApplier.applyCurrentScheme() }
     }
 
     @Test
     fun `apply without modifications does not call the applier`() {
         val panel = newBuiltPanel()
         panel.apply()
-        verify(exactly = 0) { VcsColorApplier.applyAll() }
+        verify(exactly = 0) { VcsColorApplier.applyCurrentScheme() }
     }
 
     @Test
@@ -437,12 +437,12 @@ class VcsColorPanelTest {
         panel.apply()
 
         assertFalse(state.vcsColorEnabled, "License revoke must abort persistence")
-        verify(exactly = 0) { VcsColorApplier.applyAll() }
+        verify(exactly = 0) { VcsColorApplier.applyCurrentScheme() }
     }
 
     @Test
     fun `apply leaves state untouched when applier throws`() {
-        every { VcsColorApplier.applyAll() } throws RuntimeException("simulated apply failure")
+        every { VcsColorApplier.applyCurrentScheme() } throws RuntimeException("simulated apply failure")
         val panel = newBuiltPanel()
         panel.setPendingEnabledForTest(true)
         panel.setPendingPresetForTest(VcsSection.DIFF, VcsColorPreset.NEON)
@@ -478,7 +478,7 @@ class VcsColorPanelTest {
         assertFalse(diffSlider(panel).isEnabled, "Unlicensed VCS gate must lock sliders")
         panel.setPendingEnabledForTest(true)
         panel.apply()
-        verify(exactly = 0) { VcsColorApplier.applyAll() }
+        verify(exactly = 0) { VcsColorApplier.applyCurrentScheme() }
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/theme/AyuEditorSchemeBinderTest.kt
+++ b/src/test/kotlin/dev/ayuislands/theme/AyuEditorSchemeBinderTest.kt
@@ -60,7 +60,7 @@ class AyuEditorSchemeBinderTest {
     }
 
     @Test
-    fun `isSchemeForVariant identifies only matching canonical and editable schemes`() {
+    fun `matchesVariant identifies only matching canonical and editable schemes`() {
         val cases =
             listOf(
                 Triple("Ayu Islands Mirage", AyuVariant.MIRAGE, true),
@@ -73,7 +73,7 @@ class AyuEditorSchemeBinderTest {
         cases.forEach { (schemeName, variant, expected) ->
             assertEquals(
                 expected,
-                AyuEditorSchemeBinder.isSchemeForVariant(schemeName, variant),
+                AyuEditorSchemeBinder.matchesVariant(schemeName, variant),
                 "Unexpected scheme match for '$schemeName' and $variant",
             )
         }
@@ -104,6 +104,19 @@ class AyuEditorSchemeBinderTest {
         val switched = AyuEditorSchemeBinder.bindForVariant(AyuVariant.DARK)
 
         assertTrue(switched, "Ayu Mirage → Ayu Dark transition must swap schemes")
+        verify(exactly = 1) { globalSchemeSetter(mockEcm, targetScheme) }
+    }
+
+    @Test
+    fun `bindForVariant switches when current is editable copy of another Ayu scheme`() {
+        val targetScheme = mockScheme("Ayu Islands Light")
+        every { mockEcm.globalScheme } returns mockScheme("_@user_Ayu Islands Mirage")
+        every { mockEcm.allSchemes } returns arrayOf(targetScheme)
+        every { globalSchemeSetter(mockEcm, any()) } just Runs
+
+        val switched = AyuEditorSchemeBinder.bindForVariant(AyuVariant.LIGHT)
+
+        assertTrue(switched, "Editable Ayu Mirage copy must follow the Ayu Light transition")
         verify(exactly = 1) { globalSchemeSetter(mockEcm, targetScheme) }
     }
 

--- a/src/test/kotlin/dev/ayuislands/theme/AyuEditorSchemeBinderTest.kt
+++ b/src/test/kotlin/dev/ayuislands/theme/AyuEditorSchemeBinderTest.kt
@@ -29,6 +29,7 @@ import kotlin.test.assertTrue
  */
 class AyuEditorSchemeBinderTest {
     private val mockEcm = mockk<EditorColorsManager>(relaxed = true)
+    private val globalSchemeSetter = EditorColorsManager::setGlobalScheme
 
     @BeforeTest
     fun setUp() {
@@ -85,12 +86,12 @@ class AyuEditorSchemeBinderTest {
         val targetScheme = mockScheme("Ayu Islands Mirage")
         every { mockEcm.globalScheme } returns mockScheme("Default")
         every { mockEcm.allSchemes } returns arrayOf(targetScheme)
-        every { mockEcm.setGlobalScheme(any()) } just Runs
+        every { globalSchemeSetter(mockEcm, any()) } just Runs
 
         val switched = AyuEditorSchemeBinder.bindForVariant(AyuVariant.MIRAGE)
 
         assertTrue(switched, "Default → Ayu Mirage transition must apply scheme")
-        verify(exactly = 1) { mockEcm.setGlobalScheme(targetScheme) }
+        verify(exactly = 1) { globalSchemeSetter(mockEcm, targetScheme) }
     }
 
     @Test
@@ -98,12 +99,12 @@ class AyuEditorSchemeBinderTest {
         val targetScheme = mockScheme("Ayu Islands Dark")
         every { mockEcm.globalScheme } returns mockScheme("Ayu Islands Mirage")
         every { mockEcm.allSchemes } returns arrayOf(mockScheme("Ayu Islands Mirage"), targetScheme)
-        every { mockEcm.setGlobalScheme(any()) } just Runs
+        every { globalSchemeSetter(mockEcm, any()) } just Runs
 
         val switched = AyuEditorSchemeBinder.bindForVariant(AyuVariant.DARK)
 
         assertTrue(switched, "Ayu Mirage → Ayu Dark transition must swap schemes")
-        verify(exactly = 1) { mockEcm.setGlobalScheme(targetScheme) }
+        verify(exactly = 1) { globalSchemeSetter(mockEcm, targetScheme) }
     }
 
     // ── bindForVariant: gate paths ────────────────────────────────────────
@@ -115,7 +116,7 @@ class AyuEditorSchemeBinderTest {
         val switched = AyuEditorSchemeBinder.bindForVariant(AyuVariant.LIGHT)
 
         assertFalse(switched, "Already-correct scheme must not be reapplied")
-        verify(exactly = 0) { mockEcm.setGlobalScheme(any()) }
+        verify(exactly = 0) { globalSchemeSetter(mockEcm, any()) }
     }
 
     @Test
@@ -128,7 +129,7 @@ class AyuEditorSchemeBinderTest {
             switched,
             "User intent is sacred — custom non-Ayu, non-platform scheme MUST NOT be overwritten",
         )
-        verify(exactly = 0) { mockEcm.setGlobalScheme(any()) }
+        verify(exactly = 0) { globalSchemeSetter(mockEcm, any()) }
     }
 
     @Test
@@ -142,7 +143,7 @@ class AyuEditorSchemeBinderTest {
             switched,
             "Plugin install incomplete (target scheme missing) must not throw — graceful no-op",
         )
-        verify(exactly = 0) { mockEcm.setGlobalScheme(any()) }
+        verify(exactly = 0) { globalSchemeSetter(mockEcm, any()) }
     }
 
     // ── NEUTRAL_SCHEMES allowlist contract ────────────────────────────────
@@ -177,7 +178,7 @@ class AyuEditorSchemeBinderTest {
                 "Foreign scheme '$custom' must NOT be overwritten by binder",
             )
         }
-        verify(exactly = 0) { mockEcm.setGlobalScheme(any()) }
+        verify(exactly = 0) { globalSchemeSetter(mockEcm, any()) }
     }
 
     @Test
@@ -190,7 +191,7 @@ class AyuEditorSchemeBinderTest {
         val switched = AyuEditorSchemeBinder.bindForVariant(AyuVariant.MIRAGE)
 
         assertFalse(switched, "Our own editable copy must be left in place, not swapped")
-        verify(exactly = 0) { mockEcm.setGlobalScheme(any()) }
+        verify(exactly = 0) { globalSchemeSetter(mockEcm, any()) }
     }
 
     @Test
@@ -203,7 +204,7 @@ class AyuEditorSchemeBinderTest {
         val switched = AyuEditorSchemeBinder.bindForVariant(AyuVariant.MIRAGE)
 
         assertFalse(switched, "Foreign editable copy is still user-custom — must skip")
-        verify(exactly = 0) { mockEcm.setGlobalScheme(any()) }
+        verify(exactly = 0) { globalSchemeSetter(mockEcm, any()) }
     }
 
     private fun mockScheme(name: String): EditorColorsScheme {

--- a/src/test/kotlin/dev/ayuislands/theme/AyuEditorSchemeBinderTest.kt
+++ b/src/test/kotlin/dev/ayuislands/theme/AyuEditorSchemeBinderTest.kt
@@ -58,6 +58,26 @@ class AyuEditorSchemeBinderTest {
         assertEquals("Ayu Islands Light", AyuEditorSchemeBinder.targetSchemeName(AyuVariant.LIGHT))
     }
 
+    @Test
+    fun `isSchemeForVariant identifies only matching canonical and editable schemes`() {
+        val cases =
+            listOf(
+                Triple("Ayu Islands Mirage", AyuVariant.MIRAGE, true),
+                Triple("_@user_Ayu Islands Mirage", AyuVariant.MIRAGE, true),
+                Triple("Ayu Islands Dark", AyuVariant.MIRAGE, false),
+                Triple("Solarized Dark", AyuVariant.MIRAGE, false),
+                Triple("_@user_Solarized Dark", AyuVariant.MIRAGE, false),
+            )
+
+        cases.forEach { (schemeName, variant, expected) ->
+            assertEquals(
+                expected,
+                AyuEditorSchemeBinder.isSchemeForVariant(schemeName, variant),
+                "Unexpected scheme match for '$schemeName' and $variant",
+            )
+        }
+    }
+
     // ── bindForVariant: happy paths ───────────────────────────────────────
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/theme/AyuEditorSchemeScopeTest.kt
+++ b/src/test/kotlin/dev/ayuislands/theme/AyuEditorSchemeScopeTest.kt
@@ -58,6 +58,22 @@ class AyuEditorSchemeScopeTest {
         verify(exactly = 0) { EditorColorsManager.getInstance() }
     }
 
+    @Test
+    fun `ownedScheme returns Ayu scheme when Ayu is inactive`() {
+        val scheme = scheme("_@user_Ayu Islands Mirage")
+        every { AyuVariant.detect() } returns null
+        every { editorColorsManager.globalScheme } returns scheme
+
+        assertSame(scheme, AyuEditorSchemeScope.ownedScheme())
+    }
+
+    @Test
+    fun `ownedScheme rejects foreign scheme`() {
+        every { editorColorsManager.globalScheme } returns scheme("Solarized Dark")
+
+        assertNull(AyuEditorSchemeScope.ownedScheme())
+    }
+
     private fun scheme(name: String): EditorColorsScheme =
         mockk {
             every { this@mockk.name } returns name

--- a/src/test/kotlin/dev/ayuislands/theme/AyuEditorSchemeScopeTest.kt
+++ b/src/test/kotlin/dev/ayuislands/theme/AyuEditorSchemeScopeTest.kt
@@ -1,0 +1,65 @@
+package dev.ayuislands.theme
+
+import com.intellij.openapi.editor.colors.EditorColorsManager
+import com.intellij.openapi.editor.colors.EditorColorsScheme
+import dev.ayuislands.accent.AyuVariant
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+class AyuEditorSchemeScopeTest {
+    private val editorColorsManager = mockk<EditorColorsManager>()
+
+    @BeforeTest
+    fun setUp() {
+        mockkObject(AyuVariant.Companion)
+        mockkStatic(EditorColorsManager::class)
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        every { EditorColorsManager.getInstance() } returns editorColorsManager
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `activeScheme returns matching canonical and editable schemes`() {
+        listOf("Ayu Islands Mirage", "_@user_Ayu Islands Mirage").forEach { schemeName ->
+            val scheme = scheme(schemeName)
+            every { editorColorsManager.globalScheme } returns scheme
+
+            assertSame(scheme, AyuEditorSchemeScope.activeScheme())
+        }
+    }
+
+    @Test
+    fun `activeScheme rejects foreign and different variant schemes`() {
+        listOf("Solarized Dark", "_@user_Solarized Dark", "Ayu Islands Dark").forEach { schemeName ->
+            every { editorColorsManager.globalScheme } returns scheme(schemeName)
+
+            assertNull(AyuEditorSchemeScope.activeScheme(), "Scheme '$schemeName' must remain outside accent scope")
+        }
+    }
+
+    @Test
+    fun `activeScheme does not read editor manager when Ayu is inactive`() {
+        every { AyuVariant.detect() } returns null
+
+        assertNull(AyuEditorSchemeScope.activeScheme())
+        verify(exactly = 0) { EditorColorsManager.getInstance() }
+    }
+
+    private fun scheme(name: String): EditorColorsScheme =
+        mockk {
+            every { this@mockk.name } returns name
+        }
+}

--- a/src/test/kotlin/dev/ayuislands/theme/AyuEditorSchemeScopeTest.kt
+++ b/src/test/kotlin/dev/ayuislands/theme/AyuEditorSchemeScopeTest.kt
@@ -20,6 +20,7 @@ class AyuEditorSchemeScopeTest {
 
     @BeforeTest
     fun setUp() {
+        AyuEditorSchemeScope.resetClaims()
         mockkObject(AyuVariant.Companion)
         mockkStatic(EditorColorsManager::class)
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
@@ -28,6 +29,7 @@ class AyuEditorSchemeScopeTest {
 
     @AfterTest
     fun tearDown() {
+        AyuEditorSchemeScope.resetClaims()
         unmockkAll()
     }
 
@@ -59,19 +61,30 @@ class AyuEditorSchemeScopeTest {
     }
 
     @Test
-    fun `ownedScheme returns Ayu scheme when Ayu is inactive`() {
+    fun `currentAyuScheme returns Ayu scheme when Ayu is inactive`() {
         val scheme = scheme("_@user_Ayu Islands Mirage")
         every { AyuVariant.detect() } returns null
         every { editorColorsManager.globalScheme } returns scheme
 
-        assertSame(scheme, AyuEditorSchemeScope.ownedScheme())
+        assertSame(scheme, AyuEditorSchemeScope.currentAyuScheme())
     }
 
     @Test
-    fun `ownedScheme rejects foreign scheme`() {
+    fun `currentAyuScheme rejects foreign scheme`() {
         every { editorColorsManager.globalScheme } returns scheme("Solarized Dark")
 
-        assertNull(AyuEditorSchemeScope.ownedScheme())
+        assertNull(AyuEditorSchemeScope.currentAyuScheme())
+    }
+
+    @Test
+    fun `accent claim retains exact scheme after global scheme changes`() {
+        val claimed = scheme("Ayu Islands Mirage")
+        every { editorColorsManager.globalScheme } returns claimed
+        assertSame(claimed, AyuEditorSchemeScope.claimActiveScheme())
+
+        every { editorColorsManager.globalScheme } returns scheme("Ayu Islands Dark")
+
+        assertSame(claimed, AyuEditorSchemeScope.claimedAccentSchemes().single())
     }
 
     private fun scheme(name: String): EditorColorsScheme =

--- a/src/test/kotlin/dev/ayuislands/theme/AyuEditorSchemeScopeTest.kt
+++ b/src/test/kotlin/dev/ayuislands/theme/AyuEditorSchemeScopeTest.kt
@@ -12,6 +12,8 @@ import io.mockk.verify
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 
@@ -85,6 +87,27 @@ class AyuEditorSchemeScopeTest {
         every { editorColorsManager.globalScheme } returns scheme("Ayu Islands Dark")
 
         assertSame(claimed, AyuEditorSchemeScope.claimedAccentSchemes().single())
+    }
+
+    @Test
+    fun `cleanup releases successful scheme and retains only failed identity`() {
+        val failedScheme = scheme("Ayu Islands Mirage")
+        val cleanedScheme = scheme("Ayu Islands Mirage")
+        every { editorColorsManager.globalScheme } returns failedScheme
+        AyuEditorSchemeScope.claimActiveScheme()
+        every { editorColorsManager.globalScheme } returns cleanedScheme
+        AyuEditorSchemeScope.claimActiveScheme()
+        AyuEditorSchemeScope.beginAccentCleanup()
+
+        assertFailsWith<IllegalStateException> {
+            AyuEditorSchemeScope.cleanClaimedAccentSchemes { scheme ->
+                if (scheme === failedScheme) error("cleanup failed")
+            }
+        }
+        AyuEditorSchemeScope.releaseCleanAccentClaims()
+
+        assertEquals(1, AyuEditorSchemeScope.claimedAccentSchemes().size)
+        assertSame(failedScheme, AyuEditorSchemeScope.claimedAccentSchemes().single())
     }
 
     private fun scheme(name: String): EditorColorsScheme =

--- a/src/test/kotlin/dev/ayuislands/theme/EditorSchemeLifecycleTest.kt
+++ b/src/test/kotlin/dev/ayuislands/theme/EditorSchemeLifecycleTest.kt
@@ -38,6 +38,7 @@ class EditorSchemeLifecycleTest {
         mockkStatic(EditorColorsManager::class)
         every { EditorColorsManager.getInstance() } returns manager
         every { manager.globalScheme } answers { currentScheme }
+        every { manager.allSchemes } answers { arrayOf(currentScheme) }
 
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } answers { variant }

--- a/src/test/kotlin/dev/ayuislands/theme/EditorSchemeLifecycleTest.kt
+++ b/src/test/kotlin/dev/ayuislands/theme/EditorSchemeLifecycleTest.kt
@@ -1,0 +1,250 @@
+package dev.ayuislands.theme
+
+import com.intellij.openapi.editor.colors.ColorKey
+import com.intellij.openapi.editor.colors.EditorColorsManager
+import com.intellij.openapi.editor.colors.EditorColorsScheme
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.openapi.editor.markup.EffectType
+import com.intellij.openapi.editor.markup.TextAttributes
+import dev.ayuislands.accent.AyuVariant
+import dev.ayuislands.accent.elements.BracketFadeManager
+import dev.ayuislands.accent.elements.BracketMatchElement
+import dev.ayuislands.accent.elements.CaretRowElement
+import dev.ayuislands.accent.elements.ProgressBarElement
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import java.awt.Color
+import javax.swing.SwingUtilities
+import javax.swing.UIManager
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class EditorSchemeLifecycleTest {
+    private val manager = mockk<EditorColorsManager>()
+    private val colorKeys = mutableMapOf<String, ColorKey>()
+    private val attributeKeys = mutableMapOf<String, TextAttributesKey>()
+    private var variant: AyuVariant? = AyuVariant.MIRAGE
+    private lateinit var currentScheme: EditorColorsScheme
+
+    @BeforeTest
+    fun setUp() {
+        AyuEditorSchemeScope.resetClaims()
+        mockkStatic(EditorColorsManager::class)
+        every { EditorColorsManager.getInstance() } returns manager
+        every { manager.globalScheme } answers { currentScheme }
+
+        mockkObject(AyuVariant.Companion)
+        every { AyuVariant.detect() } answers { variant }
+
+        mockkStatic(ColorKey::class)
+        every { ColorKey.find(any<String>()) } answers {
+            colorKeys.getOrPut(firstArg()) { mockk(relaxed = true) }
+        }
+        mockkStatic(TextAttributesKey::class)
+        every { TextAttributesKey.find(any<String>()) } answers {
+            attributeKeys.getOrPut(firstArg()) { mockk(relaxed = true) }
+        }
+        mockkStatic(SwingUtilities::class)
+        every { SwingUtilities.isEventDispatchThread() } returns true
+        every { SwingUtilities.invokeLater(any()) } answers { firstArg<Runnable>().run() }
+        mockkStatic(UIManager::class)
+        mockkObject(BracketFadeManager)
+        every { BracketFadeManager.activate(any()) } returns Unit
+        every { BracketFadeManager.deactivate() } returns Unit
+    }
+
+    @AfterTest
+    fun tearDown() {
+        AyuEditorSchemeScope.resetClaims()
+        unmockkAll()
+    }
+
+    @Test
+    fun `scheme eligibility matrix changes only the active matching Ayu identity`() {
+        val cases =
+            listOf(
+                "Ayu Islands Mirage" to true,
+                "_@user_Ayu Islands Mirage" to true,
+                "Solarized Dark" to false,
+                "_@user_Solarized Dark" to false,
+                "Ayu Islands Dark" to false,
+            )
+
+        for ((name, shouldApply) in cases) {
+            AyuEditorSchemeScope.resetClaims()
+            val store = SchemeStore(name)
+            currentScheme = store.scheme
+            val caret = CaretRowElement()
+            val brace = BracketMatchElement()
+
+            caret.apply(Color.ORANGE)
+            brace.apply(Color.ORANGE)
+
+            if (shouldApply) {
+                store.assertChanged()
+                caret.revert()
+                brace.revert()
+            }
+            store.assertOriginalValues()
+        }
+    }
+
+    @Test
+    fun `manual and appearance variant round trips restore every claimed scheme`() {
+        val mirage = SchemeStore("Ayu Islands Mirage")
+        val dark = SchemeStore("_@user_Ayu Islands Dark")
+        val light = SchemeStore("Ayu Islands Light")
+        val foreign = SchemeStore("Solarized Dark")
+        val caret = CaretRowElement()
+        val brace = BracketMatchElement()
+
+        listOf(
+            AyuVariant.MIRAGE to mirage,
+            AyuVariant.DARK to dark,
+            AyuVariant.LIGHT to light,
+        ).forEach { (nextVariant, store) ->
+            variant = nextVariant
+            currentScheme = store.scheme
+            caret.apply(Color.ORANGE)
+            brace.apply(Color.ORANGE)
+            store.assertChanged()
+        }
+
+        variant = null
+        currentScheme = foreign.scheme
+        caret.revert()
+        brace.revert()
+
+        listOf(mirage, dark, light, foreign).forEach(SchemeStore::assertOriginalValues)
+    }
+
+    @Test
+    fun `user edits win before during and after ownership transitions`() {
+        val store = SchemeStore("_@user_Ayu Islands Mirage")
+        currentScheme = store.scheme
+        val caret = CaretRowElement()
+
+        store.replaceCaret(Color.PINK)
+        caret.apply(Color.ORANGE)
+        caret.revert()
+        store.assertCaret(Color.PINK)
+
+        caret.apply(Color.ORANGE)
+        store.replaceCaret(Color.GREEN)
+        caret.apply(Color.YELLOW)
+        caret.revert()
+        store.assertCaret(Color.GREEN)
+
+        store.replaceCaret(Color.BLUE)
+        caret.apply(Color.ORANGE)
+        caret.revert()
+        store.assertCaret(Color.BLUE)
+    }
+
+    @Test
+    fun `scheme replacement between attribute read and write leaves both identities unchanged`() {
+        val first = SchemeStore("Ayu Islands Mirage")
+        val second = SchemeStore("_@user_Ayu Islands Mirage")
+        var readCount = 0
+        every { manager.globalScheme } answers {
+            if (readCount++ == 0) first.scheme else second.scheme
+        }
+
+        BracketMatchElement().apply(Color.ORANGE)
+
+        first.assertOriginalValues()
+        second.assertOriginalValues()
+    }
+
+    @Test
+    fun `queued editor apply ignores a replaced scheme identity`() {
+        val first = SchemeStore("Ayu Islands Mirage")
+        val second = SchemeStore("_@user_Ayu Islands Mirage")
+        currentScheme = first.scheme
+        val callback = slot<Runnable>()
+        every { SwingUtilities.isEventDispatchThread() } returns false
+        every { SwingUtilities.invokeLater(capture(callback)) } returns Unit
+
+        ProgressBarElement().apply(Color.ORANGE)
+        currentScheme = second.scheme
+        callback.captured.run()
+
+        first.assertOriginalValues()
+        second.assertOriginalValues()
+    }
+
+    private inner class SchemeStore(
+        name: String,
+    ) {
+        private val originalColor = Color(0x12, 0x34, 0x56)
+        private val originalAttributes = attributes(Color(0x21, 0x43, 0x65))
+        private val colors =
+            mutableMapOf<ColorKey, Color?>(
+                ColorKey.find("CARET_ROW_COLOR") to originalColor,
+                ColorKey.find("CARET_COLOR") to originalColor,
+                ColorKey.find("LINE_NUMBER_ON_CARET_ROW_COLOR") to originalColor,
+                ColorKey.find("PROGRESS_BAR_TRACK") to originalColor,
+            )
+        private val textAttributes =
+            mutableMapOf<TextAttributesKey, TextAttributes?>(
+                TextAttributesKey.find("MATCHED_BRACE_ATTRIBUTES") to originalAttributes.clone(),
+            )
+
+        val scheme: EditorColorsScheme =
+            mockk(relaxed = true) {
+                every { this@mockk.name } returns name
+                every { defaultBackground } returns Color(0x1F, 0x24, 0x30)
+                every { getColor(any()) } answers {
+                    val key = firstArg<ColorKey>()
+                    colors.getOrPut(key) { originalColor }
+                }
+                every { setColor(any(), any()) } answers {
+                    colors[firstArg()] = secondArg()
+                }
+                every { getAttributes(any<TextAttributesKey>()) } answers {
+                    val key = firstArg<TextAttributesKey>()
+                    textAttributes.getOrPut(key) { originalAttributes.clone() }
+                }
+                every { setAttributes(any(), any()) } answers {
+                    textAttributes[firstArg()] = secondArg<TextAttributes?>()?.clone()
+                }
+            }
+
+        fun replaceCaret(color: Color) {
+            listOf("CARET_ROW_COLOR", "CARET_COLOR", "LINE_NUMBER_ON_CARET_ROW_COLOR")
+                .forEach { key -> colors[ColorKey.find(key)] = color }
+        }
+
+        fun assertCaret(color: Color) {
+            listOf("CARET_ROW_COLOR", "CARET_COLOR", "LINE_NUMBER_ON_CARET_ROW_COLOR")
+                .forEach { key -> assertEquals(color, colors[ColorKey.find(key)]) }
+        }
+
+        fun assertChanged() {
+            assertEquals(Color.ORANGE, colors[ColorKey.find("CARET_COLOR")])
+            val braceAttributes = textAttributes[TextAttributesKey.find("MATCHED_BRACE_ATTRIBUTES")]
+            assertEquals(Color.ORANGE, braceAttributes?.foregroundColor)
+        }
+
+        fun assertOriginalValues() {
+            colors.values.forEach { value -> assertEquals(originalColor, value) }
+            textAttributes.values.forEach { value -> assertEquals(originalAttributes, value) }
+        }
+    }
+
+    private fun attributes(foreground: Color): TextAttributes =
+        TextAttributes().apply {
+            foregroundColor = foreground
+            backgroundColor = Color.BLACK
+            effectColor = Color.CYAN
+            errorStripeColor = Color.MAGENTA
+            effectType = EffectType.WAVE_UNDERSCORE
+            fontType = 3
+        }
+}

--- a/src/test/kotlin/dev/ayuislands/theme/EditorSchemeOverridesTest.kt
+++ b/src/test/kotlin/dev/ayuislands/theme/EditorSchemeOverridesTest.kt
@@ -14,6 +14,7 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import java.awt.Color
+import java.util.Properties
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -33,6 +34,9 @@ class EditorSchemeOverridesTest {
         mockkStatic(EditorColorsManager::class)
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
         every { EditorColorsManager.getInstance() } returns editorColorsManager
+        every { editorColorsManager.allSchemes } answers { arrayOf(editorColorsManager.globalScheme) }
+        every { colorKey.externalName } returns "TEST_COLOR"
+        every { attributesKey.externalName } returns "TEST_ATTRIBUTES"
     }
 
     @AfterTest
@@ -149,13 +153,47 @@ class EditorSchemeOverridesTest {
         assertEquals(Color.GREEN, colors[colorKey])
     }
 
+    @Test
+    fun `persisted ownership restores the user value after runtime state is lost`() {
+        val colors = mutableMapOf<ColorKey, Color?>(colorKey to Color.RED)
+        val scheme = scheme(colors = colors)
+        every { editorColorsManager.globalScheme } returns scheme
+
+        AyuEditorSchemeScope.writeColor(elementOwner, colorKey, Color.ORANGE)
+        AyuEditorSchemeScope.resetClaims()
+        AyuEditorSchemeScope.writeColor(elementOwner, colorKey, Color.YELLOW)
+        AyuEditorSchemeScope.restore(elementOwner)
+
+        assertEquals(Color.RED, colors[colorKey])
+    }
+
+    @Test
+    fun `editable copy inherits the canonical restoration ledger`() {
+        val canonicalColors = mutableMapOf<ColorKey, Color?>(colorKey to Color.RED)
+        val canonical = scheme(name = "Ayu Islands Mirage", colors = canonicalColors)
+        var current = canonical
+        every { editorColorsManager.globalScheme } answers { current }
+
+        AyuEditorSchemeScope.writeColor(elementOwner, colorKey, Color.ORANGE)
+        val editableColors = canonicalColors.toMutableMap()
+        val editable = scheme(colors = editableColors)
+        every { editorColorsManager.allSchemes } returns arrayOf(canonical, editable)
+        current = editable
+
+        AyuEditorSchemeScope.restore(elementOwner)
+
+        assertEquals(Color.RED, editableColors[colorKey])
+    }
+
     private fun scheme(
         name: String = "_@user_Ayu Islands Mirage",
         colors: MutableMap<ColorKey, Color?> = mutableMapOf(),
         attributes: MutableMap<TextAttributesKey, TextAttributes?> = mutableMapOf(),
     ): EditorColorsScheme =
         mockk(relaxed = true) {
+            val metadata = Properties()
             every { this@mockk.name } returns name
+            every { metaProperties } returns metadata
             every { getColor(any()) } answers { colors[firstArg()] }
             every { setColor(any(), any()) } answers {
                 colors[firstArg()] = secondArg()

--- a/src/test/kotlin/dev/ayuislands/theme/EditorSchemeOverridesTest.kt
+++ b/src/test/kotlin/dev/ayuislands/theme/EditorSchemeOverridesTest.kt
@@ -2,8 +2,8 @@ package dev.ayuislands.theme
 
 import com.intellij.openapi.editor.colors.ColorKey
 import com.intellij.openapi.editor.colors.EditorColorsManager
-import com.intellij.openapi.editor.colors.EditorColorsScheme
 import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.openapi.editor.colors.impl.AbstractColorsScheme
 import com.intellij.openapi.editor.markup.EffectType
 import com.intellij.openapi.editor.markup.TextAttributes
 import dev.ayuislands.accent.AccentElementId
@@ -19,6 +19,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 
 class EditorSchemeOverridesTest {
@@ -83,6 +84,21 @@ class EditorSchemeOverridesTest {
     }
 
     @Test
+    fun `inherited color remains inherited after restore`() {
+        val colors = mutableMapOf<ColorKey, Color?>()
+        val inheritedColors = mutableMapOf(colorKey to Color.RED)
+        val scheme = scheme(colors = colors, inheritedColors = inheritedColors)
+        every { editorColorsManager.globalScheme } returns scheme
+
+        AyuEditorSchemeScope.writeColor(elementOwner, colorKey, Color.ORANGE)
+        AyuEditorSchemeScope.restore(elementOwner)
+        inheritedColors[colorKey] = Color.GREEN
+
+        assertFalse(colors.containsKey(colorKey))
+        assertEquals(Color.GREEN, scheme.getColor(colorKey))
+    }
+
+    @Test
     fun `attribute snapshot is isolated from later mutation of the source object`() {
         val original = fullAttributes(Color.RED)
         val expected = original.clone()
@@ -112,6 +128,21 @@ class EditorSchemeOverridesTest {
         AyuEditorSchemeScope.restore(elementOwner)
 
         assertEquals(external, attributes[attributesKey])
+    }
+
+    @Test
+    fun `inherited attributes remain inherited after restore`() {
+        val attributes = mutableMapOf<TextAttributesKey, TextAttributes?>()
+        val inheritedAttributes = mutableMapOf(attributesKey to fullAttributes(Color.RED))
+        val scheme = scheme(attributes = attributes, inheritedAttributes = inheritedAttributes)
+        every { editorColorsManager.globalScheme } returns scheme
+
+        AyuEditorSchemeScope.writeAttributes(elementOwner, attributesKey, fullAttributes(Color.ORANGE))
+        AyuEditorSchemeScope.restore(elementOwner)
+        inheritedAttributes[attributesKey] = fullAttributes(Color.GREEN)
+
+        assertFalse(attributes.containsKey(attributesKey))
+        assertEquals(inheritedAttributes[attributesKey], scheme.getAttributes(attributesKey))
     }
 
     @Test
@@ -189,18 +220,47 @@ class EditorSchemeOverridesTest {
         name: String = "_@user_Ayu Islands Mirage",
         colors: MutableMap<ColorKey, Color?> = mutableMapOf(),
         attributes: MutableMap<TextAttributesKey, TextAttributes?> = mutableMapOf(),
-    ): EditorColorsScheme =
-        mockk(relaxed = true) {
+        inheritedColors: MutableMap<ColorKey, Color> = mutableMapOf(),
+        inheritedAttributes: MutableMap<TextAttributesKey, TextAttributes> = mutableMapOf(),
+    ): AbstractColorsScheme =
+        mockk<AbstractColorsScheme>(relaxed = true) {
             val metadata = Properties()
             every { this@mockk.name } returns name
             every { metaProperties } returns metadata
-            every { getColor(any()) } answers { colors[firstArg()] }
-            every { setColor(any(), any()) } answers {
-                colors[firstArg()] = secondArg()
+            every { directlyDefinedColors } answers {
+                colors.mapValues { (_, value) -> value ?: AbstractColorsScheme.NULL_COLOR_MARKER }
             }
-            every { getAttributes(any<TextAttributesKey>()) } answers { attributes[firstArg()] }
+            every { directlyDefinedAttributes } answers {
+                attributes
+                    .mapNotNull { (key, value) ->
+                        value?.let { key.externalName to it }
+                    }.toMap()
+            }
+            every { getColor(any()) } answers {
+                val key = firstArg<ColorKey>()
+                if (colors.containsKey(key)) colors[key] else inheritedColors[key]
+            }
+            every { setColor(any(), any()) } answers {
+                val key = firstArg<ColorKey>()
+                val value = secondArg<Color?>()
+                if (value === AbstractColorsScheme.INHERITED_COLOR_MARKER) {
+                    colors.remove(key)
+                } else {
+                    colors[key] = value
+                }
+            }
+            every { getAttributes(any<TextAttributesKey>()) } answers {
+                val key = firstArg<TextAttributesKey>()
+                if (attributes.containsKey(key)) attributes[key] else inheritedAttributes[key]
+            }
             every { setAttributes(any(), any()) } answers {
-                attributes[firstArg()] = secondArg()
+                val key = firstArg<TextAttributesKey>()
+                val value = secondArg<TextAttributes?>()
+                if (value === AbstractColorsScheme.INHERITED_ATTRS_MARKER) {
+                    attributes.remove(key)
+                } else {
+                    attributes[key] = value
+                }
             }
         }
 

--- a/src/test/kotlin/dev/ayuislands/theme/EditorSchemeOverridesTest.kt
+++ b/src/test/kotlin/dev/ayuislands/theme/EditorSchemeOverridesTest.kt
@@ -1,0 +1,178 @@
+package dev.ayuislands.theme
+
+import com.intellij.openapi.editor.colors.ColorKey
+import com.intellij.openapi.editor.colors.EditorColorsManager
+import com.intellij.openapi.editor.colors.EditorColorsScheme
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.openapi.editor.markup.EffectType
+import com.intellij.openapi.editor.markup.TextAttributes
+import dev.ayuislands.accent.AccentElementId
+import dev.ayuislands.accent.AyuVariant
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import java.awt.Color
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class EditorSchemeOverridesTest {
+    private val editorColorsManager = mockk<EditorColorsManager>()
+    private val colorKey = mockk<ColorKey>()
+    private val attributesKey = mockk<TextAttributesKey>()
+    private val elementOwner = EditorSchemeOwner.Element(AccentElementId.BRACKET_MATCH)
+
+    @BeforeTest
+    fun setUp() {
+        AyuEditorSchemeScope.resetClaims()
+        mockkObject(AyuVariant.Companion)
+        mockkStatic(EditorColorsManager::class)
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        every { EditorColorsManager.getInstance() } returns editorColorsManager
+    }
+
+    @AfterTest
+    fun tearDown() {
+        AyuEditorSchemeScope.resetClaims()
+        unmockkAll()
+    }
+
+    @Test
+    fun `repeated color writes restore the first user value`() {
+        val colors = mutableMapOf<ColorKey, Color?>(colorKey to Color.RED)
+        every { editorColorsManager.globalScheme } returns scheme(colors = colors)
+
+        AyuEditorSchemeScope.writeColor(elementOwner, colorKey, Color.ORANGE)
+        AyuEditorSchemeScope.writeColor(elementOwner, colorKey, Color.YELLOW)
+        AyuEditorSchemeScope.restore(elementOwner)
+
+        assertEquals(Color.RED, colors[colorKey])
+    }
+
+    @Test
+    fun `external color change relinquishes ownership across reapply and restore`() {
+        val colors = mutableMapOf<ColorKey, Color?>(colorKey to Color.RED)
+        every { editorColorsManager.globalScheme } returns scheme(colors = colors)
+
+        AyuEditorSchemeScope.writeColor(elementOwner, colorKey, Color.ORANGE)
+        colors[colorKey] = Color.GREEN
+        AyuEditorSchemeScope.writeColor(elementOwner, colorKey, Color.YELLOW)
+        AyuEditorSchemeScope.restore(elementOwner)
+        AyuEditorSchemeScope.writeColor(elementOwner, colorKey, Color.BLUE)
+
+        assertEquals(Color.GREEN, colors[colorKey])
+    }
+
+    @Test
+    fun `null color baseline remains null after restore`() {
+        val colors = mutableMapOf<ColorKey, Color?>()
+        every { editorColorsManager.globalScheme } returns scheme(colors = colors)
+
+        AyuEditorSchemeScope.writeColor(elementOwner, colorKey, Color.ORANGE)
+        AyuEditorSchemeScope.restore(elementOwner)
+
+        assertNull(colors[colorKey])
+    }
+
+    @Test
+    fun `attribute snapshot is isolated from later mutation of the source object`() {
+        val original = fullAttributes(Color.RED)
+        val expected = original.clone()
+        val attributes = mutableMapOf<TextAttributesKey, TextAttributes?>(attributesKey to original)
+        every { editorColorsManager.globalScheme } returns scheme(attributes = attributes)
+
+        AyuEditorSchemeScope.writeAttributes(elementOwner, attributesKey, fullAttributes(Color.ORANGE))
+        original.foregroundColor = Color.GREEN
+        original.fontType = 0
+        AyuEditorSchemeScope.restore(elementOwner)
+
+        assertEquals(expected, attributes[attributesKey])
+    }
+
+    @Test
+    fun `external attribute change relinquishes ownership`() {
+        val attributes =
+            mutableMapOf<TextAttributesKey, TextAttributes?>(
+                attributesKey to fullAttributes(Color.RED),
+            )
+        every { editorColorsManager.globalScheme } returns scheme(attributes = attributes)
+
+        AyuEditorSchemeScope.writeAttributes(elementOwner, attributesKey, fullAttributes(Color.ORANGE))
+        val external = fullAttributes(Color.GREEN)
+        attributes[attributesKey] = external
+        AyuEditorSchemeScope.writeAttributes(elementOwner, attributesKey, fullAttributes(Color.YELLOW))
+        AyuEditorSchemeScope.restore(elementOwner)
+
+        assertEquals(external, attributes[attributesKey])
+    }
+
+    @Test
+    fun `same-name schemes keep independent original values`() {
+        val firstColors = mutableMapOf<ColorKey, Color?>(colorKey to Color.RED)
+        val secondColors = mutableMapOf<ColorKey, Color?>(colorKey to Color.BLUE)
+        val firstScheme = scheme(colors = firstColors)
+        val secondScheme = scheme(colors = secondColors)
+        var currentScheme = firstScheme
+        every { editorColorsManager.globalScheme } answers { currentScheme }
+
+        AyuEditorSchemeScope.writeColor(elementOwner, colorKey, Color.ORANGE)
+        currentScheme = secondScheme
+        AyuEditorSchemeScope.writeColor(elementOwner, colorKey, Color.YELLOW)
+        AyuEditorSchemeScope.restore(elementOwner)
+
+        assertEquals(Color.RED, firstColors[colorKey])
+        assertEquals(Color.BLUE, secondColors[colorKey])
+    }
+
+    @Test
+    fun `only an explicit disable enable transition rearms a relinquished element`() {
+        val colors = mutableMapOf<ColorKey, Color?>(colorKey to Color.RED)
+        every { editorColorsManager.globalScheme } returns scheme(colors = colors)
+        AyuEditorSchemeScope.observeElementEnabled(AccentElementId.BRACKET_MATCH, true)
+        AyuEditorSchemeScope.writeColor(elementOwner, colorKey, Color.ORANGE)
+        colors[colorKey] = Color.GREEN
+        AyuEditorSchemeScope.writeColor(elementOwner, colorKey, Color.YELLOW)
+
+        AyuEditorSchemeScope.observeElementEnabled(AccentElementId.BRACKET_MATCH, true)
+        AyuEditorSchemeScope.writeColor(elementOwner, colorKey, Color.BLUE)
+        assertEquals(Color.GREEN, colors[colorKey])
+
+        AyuEditorSchemeScope.observeElementEnabled(AccentElementId.BRACKET_MATCH, false)
+        AyuEditorSchemeScope.observeElementEnabled(AccentElementId.BRACKET_MATCH, true)
+        AyuEditorSchemeScope.writeColor(elementOwner, colorKey, Color.BLUE)
+        AyuEditorSchemeScope.restore(elementOwner)
+
+        assertEquals(Color.GREEN, colors[colorKey])
+    }
+
+    private fun scheme(
+        name: String = "_@user_Ayu Islands Mirage",
+        colors: MutableMap<ColorKey, Color?> = mutableMapOf(),
+        attributes: MutableMap<TextAttributesKey, TextAttributes?> = mutableMapOf(),
+    ): EditorColorsScheme =
+        mockk(relaxed = true) {
+            every { this@mockk.name } returns name
+            every { getColor(any()) } answers { colors[firstArg()] }
+            every { setColor(any(), any()) } answers {
+                colors[firstArg()] = secondArg()
+            }
+            every { getAttributes(any<TextAttributesKey>()) } answers { attributes[firstArg()] }
+            every { setAttributes(any(), any()) } answers {
+                attributes[firstArg()] = secondArg()
+            }
+        }
+
+    private fun fullAttributes(foreground: Color): TextAttributes =
+        TextAttributes().apply {
+            foregroundColor = foreground
+            backgroundColor = Color.BLACK
+            effectColor = Color.CYAN
+            errorStripeColor = Color.MAGENTA
+            effectType = EffectType.WAVE_UNDERSCORE
+            fontType = 3
+        }
+}

--- a/src/test/kotlin/dev/ayuislands/vcs/VcsColorApplierTest.kt
+++ b/src/test/kotlin/dev/ayuislands/vcs/VcsColorApplierTest.kt
@@ -53,6 +53,7 @@ class VcsColorApplierTest {
         mockkStatic(EditorColorsManager::class)
         every { EditorColorsManager.getInstance() } returns mockColorsManager
         every { mockColorsManager.globalScheme } returns mockScheme
+        every { mockScheme.name } returns "Ayu Islands Mirage"
         // Default: empty TextAttributes — overridden per test for the
         // clone-preserve check.
         every { mockScheme.getAttributes(any<TextAttributesKey>()) } returns TextAttributes()
@@ -98,14 +99,48 @@ class VcsColorApplierTest {
     }
 
     @Test
-    fun `revertAll - variant null is a no-op (no scheme writes)`() {
+    fun `revertAll - inactive Ayu with foreign scheme is a no-op`() {
         every { AyuVariant.detect() } returns null
+        every { mockScheme.name } returns "Solarized Dark"
 
         VcsColorApplier.revertAll()
 
         verify(exactly = 0) { mockScheme.setColor(any<ColorKey>(), any()) }
         verify(exactly = 0) { mockScheme.setAttributes(any<TextAttributesKey>(), any()) }
-        verify(exactly = 0) { mockApplication.invokeLater(any()) }
+    }
+
+    @Test
+    fun `revertAll - inactive Ayu cleans current owned scheme`() {
+        every { AyuVariant.detect() } returns null
+
+        VcsColorApplier.revertAll()
+
+        val (colorKeyEntries, textAttrEntries) = partitionPaletteByMode()
+        verify(exactly = colorKeyEntries.size) { mockScheme.setColor(any<ColorKey>(), null) }
+        verify(exactly = textAttrEntries.size) { mockScheme.setAttributes(any<TextAttributesKey>(), null) }
+    }
+
+    @Test
+    fun `applyAll - foreign scheme is a no-op`() {
+        every { mockScheme.name } returns "Solarized Dark"
+
+        VcsColorApplier.applyAll()
+
+        verify(exactly = 0) { mockScheme.setColor(any<ColorKey>(), any()) }
+        verify(exactly = 0) { mockScheme.setAttributes(any<TextAttributesKey>(), any()) }
+    }
+
+    @Test
+    fun `applyAll - queued callback rechecks current scheme ownership`() {
+        val callback = slot<Runnable>()
+        every { mockApplication.invokeLater(capture(callback)) } returns Unit
+
+        VcsColorApplier.applyAll()
+        every { mockScheme.name } returns "Solarized Dark"
+        callback.captured.run()
+
+        verify(exactly = 0) { mockScheme.setColor(any<ColorKey>(), any()) }
+        verify(exactly = 0) { mockScheme.setAttributes(any<TextAttributesKey>(), any()) }
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/vcs/VcsColorApplierTest.kt
+++ b/src/test/kotlin/dev/ayuislands/vcs/VcsColorApplierTest.kt
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.awt.Color
 import java.awt.Font
+import java.util.Properties
 
 /**
  * Behavioral coverage for [VcsColorApplier]. The applier reads the persisted
@@ -48,17 +49,27 @@ class VcsColorApplierTest {
     private val mockApplication = mockk<Application>(relaxed = true)
     private val mockSettings = mockk<AyuIslandsSettings>(relaxed = true)
     private val state = AyuIslandsState()
+    private val metadata = Properties()
+    private val colors = mutableMapOf<ColorKey, Color?>()
+    private val attributes = mutableMapOf<TextAttributesKey, TextAttributes?>()
 
     @BeforeEach
     fun setUp() {
         VcsColorApplier.resetClaims()
+        metadata.clear()
+        colors.clear()
+        attributes.clear()
         mockkStatic(EditorColorsManager::class)
         every { EditorColorsManager.getInstance() } returns mockColorsManager
         every { mockColorsManager.globalScheme } returns mockScheme
         every { mockScheme.name } returns "Ayu Islands Mirage"
-        // Default: empty TextAttributes — overridden per test for the
-        // clone-preserve check.
-        every { mockScheme.getAttributes(any<TextAttributesKey>()) } returns TextAttributes()
+        every { mockScheme.metaProperties } returns metadata
+        every { mockScheme.getColor(any<ColorKey>()) } answers { colors[firstArg()] }
+        every { mockScheme.setColor(any<ColorKey>(), any()) } answers { colors[firstArg()] = secondArg() }
+        every { mockScheme.getAttributes(any<TextAttributesKey>()) } answers { attributes[firstArg()] }
+        every { mockScheme.setAttributes(any<TextAttributesKey>(), any()) } answers {
+            attributes[firstArg()] = secondArg()
+        }
 
         mockkStatic(ApplicationManager::class)
         every { ApplicationManager.getApplication() } returns mockApplication
@@ -113,8 +124,19 @@ class VcsColorApplierTest {
     }
 
     @Test
-    fun `revertAll - inactive Ayu cleans current owned scheme`() {
+    fun `revertAll - inactive Ayu restores exact values on the owned scheme`() {
+        val originalColor = Color.RED
+        val originalAttributes =
+            TextAttributes(Color.BLUE, Color.BLACK, Color.GREEN, EffectType.LINE_UNDERSCORE, Font.BOLD).apply {
+                errorStripeColor = Color.YELLOW
+            }
+        val (colorEntries, attributeEntries) = partitionPaletteByMode()
+        colorEntries.forEach { colors[ColorKey.find(it.keyName)] = originalColor }
+        attributeEntries.forEach { attributes[TextAttributesKey.find(it.keyName)] = originalAttributes.clone() }
         state.vcsColorEnabled = true
+        VcsColorApplier.applyAll()
+        val colorKey = ColorKey.find(partitionPaletteByMode().first.first().keyName)
+        colors[colorKey] = Color.GREEN
         VcsColorApplier.applyAll()
         clearMocks(mockScheme, answers = false, recordedCalls = true)
         every { AyuVariant.detect() } returns null
@@ -122,13 +144,16 @@ class VcsColorApplierTest {
         VcsColorApplier.revertAll()
 
         val (colorKeyEntries, textAttrEntries) = partitionPaletteByMode()
-        verify(exactly = colorKeyEntries.size) { mockScheme.setColor(any<ColorKey>(), null) }
-        verify(exactly = textAttrEntries.size) { mockScheme.setAttributes(any<TextAttributesKey>(), null) }
+        verify(exactly = colorKeyEntries.size - 1) { mockScheme.setColor(any<ColorKey>(), originalColor) }
+        verify(exactly = textAttrEntries.size) {
+            mockScheme.setAttributes(any<TextAttributesKey>(), originalAttributes)
+        }
+        assertEquals(Color.GREEN, colors[colorKey])
     }
 
     @Test
     fun `applyAll - foreign scheme is a no-op`() {
-        every { mockScheme.name } returns "Solarized Dark"
+        every { mockScheme.name } returns "Ayu Islands Dark"
 
         VcsColorApplier.applyAll()
 
@@ -137,19 +162,18 @@ class VcsColorApplierTest {
     }
 
     @Test
-    fun `applyCurrentScheme - explicit apply writes foreign scheme`() {
+    fun `applyCurrentScheme - explicit apply rejects a foreign scheme`() {
         state.vcsColorEnabled = true
         every { mockScheme.name } returns "Solarized Dark"
 
         VcsColorApplier.applyCurrentScheme()
 
-        val (colorKeyEntries, textAttrEntries) = partitionPaletteByMode()
-        verify(exactly = colorKeyEntries.size) { mockScheme.setColor(any<ColorKey>(), any()) }
-        verify(exactly = textAttrEntries.size) { mockScheme.setAttributes(any<TextAttributesKey>(), any()) }
+        verify(exactly = 0) { mockScheme.setColor(any<ColorKey>(), any()) }
+        verify(exactly = 0) { mockScheme.setAttributes(any<TextAttributesKey>(), any()) }
     }
 
     @Test
-    fun `explicit foreign scheme enrollment survives Ayu exit and reapplies on return`() {
+    fun `foreign scheme never becomes eligible for later automatic reapply`() {
         state.vcsColorEnabled = true
         every { mockScheme.name } returns "Solarized Dark"
 
@@ -163,11 +187,8 @@ class VcsColorApplierTest {
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
         VcsColorApplier.applyAll()
 
-        val (colorKeyEntries, textAttrEntries) = partitionPaletteByMode()
-        verify(exactly = colorKeyEntries.size) { mockScheme.setColor(any<ColorKey>(), any<Color>()) }
-        verify(exactly = textAttrEntries.size) {
-            mockScheme.setAttributes(any<TextAttributesKey>(), any<TextAttributes>())
-        }
+        verify(exactly = 0) { mockScheme.setColor(any<ColorKey>(), any()) }
+        verify(exactly = 0) { mockScheme.setAttributes(any<TextAttributesKey>(), any()) }
     }
 
     @Test
@@ -184,7 +205,7 @@ class VcsColorApplierTest {
     }
 
     @Test
-    fun `revertAll cleans exact claimed scheme after current scheme changes`() {
+    fun `revertAll restores exact claimed scheme after current scheme changes`() {
         state.vcsColorEnabled = true
         VcsColorApplier.applyAll()
         clearMocks(mockScheme, answers = false, recordedCalls = true)

--- a/src/test/kotlin/dev/ayuislands/vcs/VcsColorApplierTest.kt
+++ b/src/test/kotlin/dev/ayuislands/vcs/VcsColorApplierTest.kt
@@ -13,6 +13,7 @@ import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
 import io.mockk.clearAllMocks
+import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -50,6 +51,7 @@ class VcsColorApplierTest {
 
     @BeforeEach
     fun setUp() {
+        VcsColorApplier.resetClaims()
         mockkStatic(EditorColorsManager::class)
         every { EditorColorsManager.getInstance() } returns mockColorsManager
         every { mockColorsManager.globalScheme } returns mockScheme
@@ -78,6 +80,7 @@ class VcsColorApplierTest {
 
     @AfterEach
     fun tearDown() {
+        VcsColorApplier.resetClaims()
         unmockkAll()
         clearAllMocks()
     }
@@ -111,6 +114,9 @@ class VcsColorApplierTest {
 
     @Test
     fun `revertAll - inactive Ayu cleans current owned scheme`() {
+        state.vcsColorEnabled = true
+        VcsColorApplier.applyAll()
+        clearMocks(mockScheme, answers = false, recordedCalls = true)
         every { AyuVariant.detect() } returns null
 
         VcsColorApplier.revertAll()
@@ -131,6 +137,18 @@ class VcsColorApplierTest {
     }
 
     @Test
+    fun `applyCurrentScheme - explicit apply writes foreign scheme`() {
+        state.vcsColorEnabled = true
+        every { mockScheme.name } returns "Solarized Dark"
+
+        VcsColorApplier.applyCurrentScheme()
+
+        val (colorKeyEntries, textAttrEntries) = partitionPaletteByMode()
+        verify(exactly = colorKeyEntries.size) { mockScheme.setColor(any<ColorKey>(), any()) }
+        verify(exactly = textAttrEntries.size) { mockScheme.setAttributes(any<TextAttributesKey>(), any()) }
+    }
+
+    @Test
     fun `applyAll - queued callback rechecks current scheme ownership`() {
         val callback = slot<Runnable>()
         every { mockApplication.invokeLater(capture(callback)) } returns Unit
@@ -144,10 +162,30 @@ class VcsColorApplierTest {
     }
 
     @Test
+    fun `revertAll cleans exact claimed scheme after current scheme changes`() {
+        state.vcsColorEnabled = true
+        VcsColorApplier.applyAll()
+        clearMocks(mockScheme, answers = false, recordedCalls = true)
+
+        val replacement = mockk<EditorColorsScheme>(relaxed = true)
+        every { replacement.name } returns "Ayu Islands Dark"
+        every { mockColorsManager.globalScheme } returns replacement
+        every { AyuVariant.detect() } returns null
+
+        VcsColorApplier.revertAll()
+
+        val (colorKeyEntries, textAttrEntries) = partitionPaletteByMode()
+        verify(exactly = colorKeyEntries.size) { mockScheme.setColor(any<ColorKey>(), null) }
+        verify(exactly = textAttrEntries.size) { mockScheme.setAttributes(any<TextAttributesKey>(), null) }
+        verify(exactly = 0) { replacement.setColor(any<ColorKey>(), any()) }
+        verify(exactly = 0) { replacement.setAttributes(any<TextAttributesKey>(), any()) }
+    }
+
+    @Test
     fun `applyAll - master disabled writes null to every palette entry (revert fan-out)`() {
         state.vcsColorEnabled = false
 
-        VcsColorApplier.applyAll()
+        VcsColorApplier.applyCurrentScheme()
 
         // Iterate the same source the applier iterates so counts adapt as the
         // palette evolves — explicit literal counts would rot the moment a new
@@ -209,7 +247,7 @@ class VcsColorApplierTest {
             mockScheme.setAttributes(any<TextAttributesKey>(), capture(capturedSlot))
         } returns Unit
 
-        VcsColorApplier.applyAll()
+        VcsColorApplier.applyCurrentScheme()
 
         // At least one TEXT_ATTR_BG entry must exist for the slot to be filled —
         // sanity-check the palette shape before asserting the clone-preserve
@@ -274,7 +312,7 @@ class VcsColorApplierTest {
         every { mockScheme.setColor(poisonKey, null) } throws RuntimeException("revert-boom on $poisonKeyName")
 
         // No throw expected — safeRevertEntry swallows.
-        VcsColorApplier.applyAll()
+        VcsColorApplier.applyCurrentScheme()
 
         val textAttrEntries = partitionPaletteByMode().second
         // Same total-invocation invariant as the safeWriteEntry test: MockK
@@ -290,6 +328,10 @@ class VcsColorApplierTest {
 
     @Test
     fun `revertAll - iterates every palette entry with null`() {
+        state.vcsColorEnabled = true
+        VcsColorApplier.applyAll()
+        clearMocks(mockScheme, answers = false, recordedCalls = true)
+
         VcsColorApplier.revertAll()
 
         val (colorKeyEntries, textAttrEntries) = partitionPaletteByMode()

--- a/src/test/kotlin/dev/ayuislands/vcs/VcsColorApplierTest.kt
+++ b/src/test/kotlin/dev/ayuislands/vcs/VcsColorApplierTest.kt
@@ -214,7 +214,28 @@ class VcsColorApplierTest {
     }
 
     @Test
+    fun `disabling VCS does not clean the newly selected unclaimed scheme`() {
+        state.vcsColorEnabled = true
+        VcsColorApplier.applyAll()
+
+        val replacement = mockk<EditorColorsScheme>(relaxed = true)
+        every { replacement.name } returns "Solarized Dark"
+        every { mockColorsManager.globalScheme } returns replacement
+        clearMocks(mockScheme, answers = false, recordedCalls = true)
+        state.vcsColorEnabled = false
+
+        VcsColorApplier.applyCurrentScheme()
+
+        verify(exactly = 0) { replacement.setColor(any<ColorKey>(), any()) }
+        verify(exactly = 0) { replacement.setAttributes(any<TextAttributesKey>(), any()) }
+        verify(atLeast = 1) { mockScheme.setColor(any<ColorKey>(), null) }
+    }
+
+    @Test
     fun `applyAll - master disabled writes null to every palette entry (revert fan-out)`() {
+        state.vcsColorEnabled = true
+        VcsColorApplier.applyCurrentScheme()
+        clearMocks(mockScheme, answers = false, recordedCalls = true)
         state.vcsColorEnabled = false
 
         VcsColorApplier.applyCurrentScheme()
@@ -337,6 +358,9 @@ class VcsColorApplierTest {
         // Symmetric to safeWriteEntry: one failing scheme.setColor must not
         // abandon the rest of the revert. Fire through applyAll with
         // vcsColorEnabled=false (routes to revertEveryEntry).
+        state.vcsColorEnabled = true
+        VcsColorApplier.applyCurrentScheme()
+        clearMocks(mockScheme, answers = false, recordedCalls = true)
         state.vcsColorEnabled = false
         val colorKeyEntries = partitionPaletteByMode().first
         val poisonKeyName = colorKeyEntries.first().keyName
@@ -347,10 +371,9 @@ class VcsColorApplierTest {
         VcsColorApplier.applyCurrentScheme()
 
         val textAttrEntries = partitionPaletteByMode().second
-        // Same total-invocation invariant as the safeWriteEntry test: MockK
-        // records the throwing call, so total setColor invocations stay at
-        // colorKeyEntries.size. The remaining n-1 reverts landed successfully.
-        verify(exactly = colorKeyEntries.size) {
+        // The first pass still reaches every entry, then the bounded retry
+        // targets only the one failed key.
+        verify(exactly = colorKeyEntries.size + 1) {
             mockScheme.setColor(any<ColorKey>(), null)
         }
         verify(exactly = textAttrEntries.size) {
@@ -395,13 +418,16 @@ class VcsColorApplierTest {
         every { mockScheme.setColor(poisonKey, null) } returns Unit
         VcsColorApplier.revertAll()
 
-        val (colorKeyEntries, textAttrEntries) = partitionPaletteByMode()
-        verify(exactly = colorKeyEntries.size) { mockScheme.setColor(any<ColorKey>(), null) }
-        verify(exactly = textAttrEntries.size) { mockScheme.setAttributes(any<TextAttributesKey>(), null) }
+        verify(exactly = 1) { mockScheme.setColor(poisonKey, null) }
+        verify(exactly = 1) { mockScheme.setColor(any<ColorKey>(), null) }
+        verify(exactly = 0) { mockScheme.setAttributes(any<TextAttributesKey>(), null) }
     }
 
     @Test
-    fun `applyAll without a license reverts persisted premium colors`() {
+    fun `applyAll without a license reverts claimed premium colors`() {
+        state.vcsColorEnabled = true
+        VcsColorApplier.applyAll()
+        clearMocks(mockScheme, answers = false, recordedCalls = true)
         state.vcsColorEnabled = true
         every { LicenseChecker.isLicensedOrGrace() } returns false
 
@@ -415,6 +441,17 @@ class VcsColorApplierTest {
             mockScheme.setAttributes(any<TextAttributesKey>(), null)
         }
         assertTrue(state.vcsColorEnabled)
+    }
+
+    @Test
+    fun `applyAll without a license does not clean an unclaimed scheme`() {
+        state.vcsColorEnabled = true
+        every { LicenseChecker.isLicensedOrGrace() } returns false
+
+        VcsColorApplier.applyAll()
+
+        verify(exactly = 0) { mockScheme.setColor(any<ColorKey>(), any()) }
+        verify(exactly = 0) { mockScheme.setAttributes(any<TextAttributesKey>(), any()) }
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/src/test/kotlin/dev/ayuislands/vcs/VcsColorApplierTest.kt
+++ b/src/test/kotlin/dev/ayuislands/vcs/VcsColorApplierTest.kt
@@ -98,6 +98,17 @@ class VcsColorApplierTest {
     }
 
     @Test
+    fun `revertAll - variant null is a no-op (no scheme writes)`() {
+        every { AyuVariant.detect() } returns null
+
+        VcsColorApplier.revertAll()
+
+        verify(exactly = 0) { mockScheme.setColor(any<ColorKey>(), any()) }
+        verify(exactly = 0) { mockScheme.setAttributes(any<TextAttributesKey>(), any()) }
+        verify(exactly = 0) { mockApplication.invokeLater(any()) }
+    }
+
+    @Test
     fun `applyAll - master disabled writes null to every palette entry (revert fan-out)`() {
         state.vcsColorEnabled = false
 

--- a/src/test/kotlin/dev/ayuislands/vcs/VcsColorApplierTest.kt
+++ b/src/test/kotlin/dev/ayuislands/vcs/VcsColorApplierTest.kt
@@ -149,6 +149,28 @@ class VcsColorApplierTest {
     }
 
     @Test
+    fun `explicit foreign scheme enrollment survives Ayu exit and reapplies on return`() {
+        state.vcsColorEnabled = true
+        every { mockScheme.name } returns "Solarized Dark"
+
+        VcsColorApplier.applyCurrentScheme()
+        clearMocks(mockScheme, answers = false, recordedCalls = true)
+
+        every { AyuVariant.detect() } returns null
+        VcsColorApplier.revertAll()
+        clearMocks(mockScheme, answers = false, recordedCalls = true)
+
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        VcsColorApplier.applyAll()
+
+        val (colorKeyEntries, textAttrEntries) = partitionPaletteByMode()
+        verify(exactly = colorKeyEntries.size) { mockScheme.setColor(any<ColorKey>(), any<Color>()) }
+        verify(exactly = textAttrEntries.size) {
+            mockScheme.setAttributes(any<TextAttributesKey>(), any<TextAttributes>())
+        }
+    }
+
+    @Test
     fun `applyAll - queued callback rechecks current scheme ownership`() {
         val callback = slot<Runnable>()
         every { mockApplication.invokeLater(capture(callback)) } returns Unit
@@ -179,6 +201,16 @@ class VcsColorApplierTest {
         verify(exactly = textAttrEntries.size) { mockScheme.setAttributes(any<TextAttributesKey>(), null) }
         verify(exactly = 0) { replacement.setColor(any<ColorKey>(), any()) }
         verify(exactly = 0) { replacement.setAttributes(any<TextAttributesKey>(), any()) }
+    }
+
+    @Test
+    fun `revertAll does not clean an unclaimed Ayu scheme`() {
+        state.vcsColorEnabled = true
+
+        VcsColorApplier.revertAll()
+
+        verify(exactly = 0) { mockScheme.setColor(any<ColorKey>(), any()) }
+        verify(exactly = 0) { mockScheme.setAttributes(any<TextAttributesKey>(), any()) }
     }
 
     @Test
@@ -347,6 +379,25 @@ class VcsColorApplierTest {
         verify(exactly = textAttrEntries.size) {
             mockScheme.setAttributes(any<TextAttributesKey>(), null)
         }
+    }
+
+    @Test
+    fun `revertAll retains a claim when cleanup fails so the next call retries`() {
+        state.vcsColorEnabled = true
+        VcsColorApplier.applyAll()
+        clearMocks(mockScheme, answers = false, recordedCalls = true)
+
+        val poisonKey = ColorKey.find(partitionPaletteByMode().first.first().keyName)
+        every { mockScheme.setColor(poisonKey, null) } throws RuntimeException("transient revert failure")
+        VcsColorApplier.revertAll()
+        clearMocks(mockScheme, answers = false, recordedCalls = true)
+
+        every { mockScheme.setColor(poisonKey, null) } returns Unit
+        VcsColorApplier.revertAll()
+
+        val (colorKeyEntries, textAttrEntries) = partitionPaletteByMode()
+        verify(exactly = colorKeyEntries.size) { mockScheme.setColor(any<ColorKey>(), null) }
+        verify(exactly = textAttrEntries.size) { mockScheme.setAttributes(any<TextAttributesKey>(), null) }
     }
 
     @Test


### PR DESCRIPTION
── Summary ─────────────────────────────────

Ayu accent reapplication could overwrite user-owned editor colors or restore the wrong baseline after LAF changes, OS appearance sync, scheme copies, and IDE restarts. This change tracks ownership per editor-scheme entry and exact scheme identity so Ayu restores only values it still owns while preserving external edits and foreign schemes.

**Context**: Fixes #295 and the matching Marketplace report about `Matched Brace` values being reset when appearance sync is enabled.

── Changes ─────────────────────────────────

- Fix: [EditorSchemeOverrides.kt](src/main/kotlin/dev/ayuislands/theme/EditorSchemeOverrides.kt) — Persist original and last-written color or text-attribute values per owner, relinquish entries changed externally, and transfer the ledger to editable scheme copies.
- Fix: [AyuEditorSchemeScope.kt](src/main/kotlin/dev/ayuislands/theme/AyuEditorSchemeScope.kt) — Restrict writes to the exact active Ayu variant and restore every claimed or persisted scheme identity without touching foreign schemes.
- Fix: [Accent elements](src/main/kotlin/dev/ayuislands/accent/elements) — Route caret, matched brace, links, inlay hints, matching tags, progress bars, and scrollbars through the shared ownership boundary.
- Fix: [VcsColorApplier.kt](src/main/kotlin/dev/ayuislands/vcs/VcsColorApplier.kt) — Replace null-based cleanup with exact baseline restoration for VCS colors and full text attributes.
- Test: [EditorSchemeLifecycleTest.kt](src/test/kotlin/dev/ayuislands/theme/EditorSchemeLifecycleTest.kt) — Cover canonical/editable/foreign schemes, all Ayu variants, external edits, queued callbacks, identity replacement, restart persistence, and canonical-to-editable transitions.
- Docs: [features.yml](docs/features.yml) — Rebind feature verification metadata to the implementation commits.

── Validation ──────────────────────────────

```bash
./gradlew --no-daemon --console=plain test integrationTest detekt ktlintCheck koverVerify build verifyPlugin
# Passed; Plugin Verifier reports all 12 configured IDE targets as Compatible.

UV_CACHE_DIR=/private/tmp/ayu-jetbrains-uv-cache scripts/verify-docs.py
# Passed: features.yml is in sync with README, plugin.xml, and CHANGELOG.

./gradlew buildPlugin --no-build-cache --rerun-tasks
# Passed; deployed to IntelliJIdea2026.2, installed JAR checksum matched the build artifact, ownership methods were confirmed with javap, and the restarted IDE logged no Ayu SEVERE or exception entries.
```

── Notes ───────────────────────────────────

Review the persistence and ownership transitions in `EditorSchemeOverrides` first, especially external edits, editable-copy inheritance, and retry behavior during restore. This intentionally adds no master toggle: user-owned values are preserved automatically at the per-entry boundary.
