### PR TITLE
chore(release): prepare v2.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [2.8.1] - 2026-08-03
+
+- [Paid] **Connected-island ECG routing** — Chaotic waveform mode can finish
+  its current loop and continue across adjacent editor, tool-window, and
+  neighboring IDE-window islands. Routes stay continuous through focus changes,
+  empty editors, touching perimeters, and window lifecycle transitions without
+  rewriting existing Glow preferences.
+- [Fix] **License and trial transitions** — premium effects and integrations
+  return to free behavior immediately when access ends, while saved premium
+  preferences remain untouched and resume after relicensing. Premium font
+  installs are blocked without access, uninstall remains available, and
+  temporary entitlement failures retry instead of becoming permanent.
+- [Fix] **Editor color-scheme ownership** — Ayu restores only caret, matched
+  brace, link, inlay-hint, matching-tag, progress-bar, scrollbar, and VCS values
+  it still owns. Manual edits, inherited values, editable copies, and foreign
+  schemes now survive theme changes, OS appearance changes, restarts, and
+  feature toggles.
+
 ## [2.8.0] - 2026-07-18
 
 - [Paid] **Chrome tint on external themes** — selected chrome surfaces and the

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -332,6 +332,7 @@ categories:
         title: "ECG waveform glow"
         keyword: "Glow"
         introduced: "2.8.0"
+        updated: "2.8.1"
         tier: paid
         description: >
           Trace the focused island with a continuous perimeter loop rendered as
@@ -339,18 +340,10 @@ categories:
           typing tempo, so sustained typing accelerates the waveform. Configure
           direction, loop duration, trace length, spike density from 1x to 4x,
           trace position outside or centered on the border, amplitude, and
-          signal intensity without changing saved solid-glow preferences.
-
-      - id: glow-chaotic-routing
-        title: "Chaotic waveform routing"
-        keyword: "Glow"
-        introduced: "2.8.0"
-        updated: "2.8.1"
-        tier: paid
-        description: >
-          Let the ECG waveform leave one island after a full loop and continue
-          across adjacent editor, tool-window, and neighboring IDE-window
-          perimeters through their closest shared transition points.
+          signal intensity without changing saved solid-glow preferences. In
+          Chaotic mode, the waveform can leave one island after a full loop and
+          continue across adjacent editor, tool-window, and neighboring
+          IDE-window perimeters through their closest shared transition points.
 
       - id: glow-external-themes
         title: "Glow on external themes"

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -27,9 +27,9 @@
 #      last published Marketplace version unless the plugin version changes.
 #
 #   7. Semantic release policy: a latest release with `features.yml` entries
-#      introduced in that version must be a minor bump; a release with no new
-#      feature entries must be a patch bump. `gradle.properties.pluginVersion`
-#      and plugin.xml change-notes must point at the same latest version.
+#      introduced in that version must be a minor bump; updates to existing
+#      features and fix-only releases use a patch bump. `pluginVersion` and
+#      plugin.xml change-notes must point at the same latest version.
 #
 # When adding a feature: pick a distinctive keyword (short phrase that will
 # always appear verbatim in the marketing copy). When the UI changes: either
@@ -344,7 +344,8 @@ categories:
       - id: glow-chaotic-routing
         title: "Chaotic waveform routing"
         keyword: "Glow"
-        introduced: "2.8.1"
+        introduced: "2.8.0"
+        updated: "2.8.1"
         tier: paid
         description: >
           Let the ECG waveform leave one island after a full loop and continue

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.8.0
+pluginVersion=2.8.1
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/scripts/tests/test-release-policy.py
+++ b/scripts/tests/test-release-policy.py
@@ -97,6 +97,34 @@ class VerifyReleasePolicyTest(unittest.TestCase):
 
         self.assertFalse(report.has_errors, report.findings)
 
+    def test_paid_update_allows_patch(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = make_repository(
+                Path(temporary_directory),
+                plugin_version="2.8.1",
+                plugin_xml_version="2.8.1",
+                changelog_text="""
+                    ## [2.8.1] - 2026-08-03
+
+                    - [Paid] Chaotic ECG routes across connected islands.
+
+                    ## [2.8.0] - 2026-07-18
+
+                    - [Paid] ECG waveform glow.
+                """,
+            )
+
+            report = run_release_policy(
+                root,
+                features_data(
+                    feature_id="glow-chaotic-routing",
+                    introduced="2.8.0",
+                    updated="2.8.1",
+                ),
+            )
+
+        self.assertFalse(report.has_errors, report.findings)
+
     def test_gradle_version_must_match_latest_changelog(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = make_repository(
@@ -221,6 +249,7 @@ def run_release_policy(root: Path, data: dict[str, object]) -> Report:
     changelog.GRADLE_PROPERTIES = root / "gradle.properties"
     changelog.PLUGIN_XML = root / "plugin.xml"
     report = Report()
+    changelog.check_changelog_cross_ref(data, report)
     changelog.check_semantic_release_policy(data, report)
     return report
 
@@ -229,16 +258,18 @@ def features_data(
     *,
     feature_id: str = "previous-feature",
     introduced: str = "2.7.5",
+    updated: str | None = None,
 ) -> dict[str, object]:
+    feature: dict[str, str] = {
+        "id": feature_id,
+        "introduced": introduced,
+    }
+    if updated is not None:
+        feature["updated"] = updated
     return {
         "categories": {
             "accent": {
-                "features": [
-                    {
-                        "id": feature_id,
-                        "introduced": introduced,
-                    }
-                ]
+                "features": [feature]
             }
         }
     }

--- a/scripts/tests/test-release-policy.py
+++ b/scripts/tests/test-release-policy.py
@@ -117,7 +117,7 @@ class VerifyReleasePolicyTest(unittest.TestCase):
             report = run_release_policy(
                 root,
                 features_data(
-                    feature_id="glow-chaotic-routing",
+                    feature_id="glow-waveform",
                     introduced="2.8.0",
                     updated="2.8.1",
                 ),

--- a/scripts/verify_docs/changelog.py
+++ b/scripts/verify_docs/changelog.py
@@ -69,7 +69,7 @@ def extract_tier_bullets(section: str) -> list[tuple[str, str]]:
 
 
 def check_changelog_cross_ref(data: dict[str, Any], report: Report) -> None:
-    """Invariant 2: tier-tagged bullets in latest changelog map to features with matching `introduced`."""
+    """Invariant 2: tier-tagged bullets map to features introduced or updated in the release."""
     version, bullets = extract_latest_changelog_section()
     if not bullets:
         # No tier-tagged bullets — could be a fix-only patch release. OK.
@@ -77,14 +77,14 @@ def check_changelog_cross_ref(data: dict[str, Any], report: Report) -> None:
     matching_features = [
         feature
         for feature in iter_features(data)
-        if feature.get("introduced") == version
+        if feature.get("introduced") == version or feature.get("updated") == version
     ]
     if not matching_features:
         report.error(
             "_changelog_xref_",
             f"CHANGELOG [{version}] has {len(bullets)} tagged bullet(s) but "
-            f"no features.yml entry with introduced: {version}. Add one feature "
-            f"per new bullet or mark the bullets as bug-fixes (drop [Paid]/[Free]).",
+            f"no features.yml entry introduced or updated in {version}. Add one "
+            f"feature per paid/free bullet or mark the bullets as bug-fixes.",
         )
 
 

--- a/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
@@ -70,6 +70,12 @@ internal object UpdateNotifier {
 
     private val RELEASE_NOTES =
         mapOf(
+            "2.8.1" to
+                releaseNotes(
+                    "[Paid] Chaotic ECG routes across connected editor, tool-window, and IDE-window islands",
+                    "[Fix] License and trial changes preserve premium preferences while reverting active effects",
+                    "[Fix] Ayu preserves manual and foreign editor color-scheme values across transitions",
+                ),
             "2.8.0" to
                 releaseNotes(
                     "[Paid] External chrome tint and project-icon accents extend automatic color across more projects",

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -351,7 +351,7 @@
          Marketplace reject the upload. -->
     <product-descriptor
             code="PAYUISLANDS"
-            release-date="20260803"
+            release-date="20260718"
             release-version="28"
             optional="true"/>
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -121,6 +121,12 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>2.8.1</h3>
+    <ul>
+      <li>[Paid] <b>Connected-island ECG routing</b> — Chaotic waveform mode can finish its current loop and continue across adjacent editor, tool-window, and neighboring IDE-window islands. Routes stay continuous through focus changes, empty editors, touching perimeters, and window lifecycle transitions without rewriting existing Glow preferences.</li>
+      <li>[Fix] <b>License and trial transitions</b> — premium effects and integrations return to free behavior immediately when access ends, while saved premium preferences remain untouched and resume after relicensing. Premium font installs are blocked without access, uninstall remains available, and temporary entitlement failures retry instead of becoming permanent.</li>
+      <li>[Fix] <b>Editor color-scheme ownership</b> — Ayu restores only caret, matched brace, link, inlay-hint, matching-tag, progress-bar, scrollbar, and VCS values it still owns. Manual edits, inherited values, editable copies, and foreign schemes survive theme changes, OS appearance changes, restarts, and feature toggles.</li>
+    </ul>
     <h3>2.8.0</h3>
     <ul>
       <li>[Paid] <b>Chrome tint on external themes</b> — selected chrome surfaces and the active tab underline can follow the Ayu accent on non-Ayu themes when explicitly enabled. It stays off by default, respects individual tint targets, and restores the host theme cleanly when disabled.</li>
@@ -345,7 +351,7 @@
          Marketplace reject the upload. -->
     <product-descriptor
             code="PAYUISLANDS"
-            release-date="20260718"
+            release-date="20260803"
             release-version="28"
             optional="true"/>
 


### PR DESCRIPTION
── Summary ─────────────────────────────────

Prepare Ayu Islands 2.8.1 with user-facing notes for connected-island ECG routing, safer license transitions, and preservation of user-owned editor scheme values. Keep paid updates to existing features distinct from newly introduced features so patch releases remain correctly classified.

── Changes ─────────────────────────────────

- Release: [CHANGELOG.md](CHANGELOG.md), [plugin.xml](src/main/resources/META-INF/plugin.xml), [UpdateNotifier.kt](src/main/kotlin/dev/ayuislands/UpdateNotifier.kt), and [gradle.properties](gradle.properties) — Align version metadata and user-facing notes for 2.8.1.
- Policy: [features.yml](docs/features.yml) and [changelog.py](scripts/verify_docs/changelog.py) — Record Chaotic routing as a paid update to the ECG feature and accept `updated` entries in changelog cross-references without weakening the minor-bump rule for newly introduced features.
- Test: [test-release-policy.py](scripts/tests/test-release-policy.py) — Cover a paid update shipping in a patch release.

── Validation ──────────────────────────────

- `scripts/verify-docs.py` — Passed with no errors; two expected orphaned screenshot-SHA warnings remain after squash merges.
- `./gradlew detekt ktlintCheck` — Passed.
- `./gradlew clean buildPlugin` — Passed; produced `ayu-jetbrains-2.8.1.zip`.
- `./gradlew verifyPlugin` — Passed; compatible with all 12 configured IDE targets.
- `./gradlew test koverVerify` — Passed, including integration tests and coverage verification.
- Exact Python commands from `.github/workflows/build.yml` — Passed: 41 + 4 + 16 + 8 tests.
- Packaged JAR inspection — Confirmed version 2.8.1, paid ECG note, release date 20260803, and paid release-version 28.

── Notes ───────────────────────────────────

Review the `introduced` versus `updated` distinction first: only `introduced` features require a SemVer minor bump, while both fields satisfy paid/free changelog traceability.

## Summary by Sourcery

Prepare the 2.8.1 release with aligned metadata, changelog, and IDE plugin change-notes while classifying paid feature updates correctly for semantic versioning.

New Features:
- Document connected-island ECG routing as a paid enhancement to the existing Glow feature rather than a new feature.

Bug Fixes:
- Document fixes for license and trial transition handling so premium behavior reverts safely without losing user preferences.
- Document preservation of user-owned editor color-scheme values across theme and lifecycle changes.

Enhancements:
- Extend changelog cross-reference checks to accept both newly introduced and updated features when validating tier-tagged bullets.
- Clarify semantic release policy documentation to distinguish newly introduced features from updates and fix-only releases.
- Add structured release notes for 2.8.1 to the in-IDE update notifier.

Build:
- Bump plugin version and release metadata to 2.8.1, including Marketplace release date and version.

Tests:
- Add coverage ensuring paid feature updates are allowed in patch releases and participate in changelog cross-reference validation.