### PR TITLE
chore(docs): rebind feature verification to v2.8.1 merge

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "e6e159bb"
+          last_verified_sha: "74e35e87"
           last_verified_date: "2026-08-02"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "e6e159bb"
+          last_verified_sha: "74e35e87"
           last_verified_date: "2026-08-02"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 


### PR DESCRIPTION
── Summary ─────────────────────────────────

Rebind the feature screenshot verification metadata to the v2.8.1 squash-merge commit so the product SSOT no longer points at an orphaned branch commit.

── Changes ─────────────────────────────────

- Chore: [features.yml](docs/features.yml) — Re-stamp the two accent-scoping entries to merge commit `74e35e87` without changing their content hashes.

── Validation ──────────────────────────────

- `scripts/verify-docs.py` — Passed; feature manifest is in sync with README, plugin.xml, and CHANGELOG.
- Pre-commit hooks — Passed, including YAML validation and docs sync.

── Notes ───────────────────────────────────

This is the required post-squash metadata rebind for PR #302. It does not change plugin behavior or release content.

## Summary by Sourcery

Documentation:
- Update docs/features.yml to reference the v2.8.1 squash-merge commit for accent-scoping feature verification without altering documented content.