### PR TITLE
ci(codeql): move all codeql-action steps to v4.37.3 in lockstep

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,12 @@ updates:
       # applies uniformly to every action update.
       default-days: 7
     open-pull-requests-limit: 3
+    groups:
+      # init/analyze/upload-sarif must move in lockstep — a solo bump makes
+      # CodeQL fail with a config/runner version mismatch.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
     labels:
       - "dependencies"
       - "github-actions"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,7 +56,7 @@ jobs:
       - if: matrix.language == 'java-kotlin'
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
 
-      - uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+      - uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -95,6 +95,6 @@ jobs:
           echo "$OUTPUT"
           exit $EXIT_CODE
 
-      - uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+      - uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: /language:${{ matrix.language }}

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -45,7 +45,7 @@ jobs:
 
       # Upload SARIF file generated in the previous step
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v4.37.1
+        uses: github/codeql-action/upload-sarif@v4.37.3
         with:
           sarif_file: semgrep.sarif
         if: always()

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -45,7 +45,7 @@ jobs:
 
       # Upload SARIF file generated in the previous step
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v4.37.3
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: semgrep.sarif
         if: always()


### PR DESCRIPTION
── Summary ─────────────────────────────────

Dependabot splits the codeql-action bump into per-step PRs (#304 analyze, #305 upload-sarif, #306 init), but init and analyze version-couple at runtime: any solo bump fails CodeQL with `Loaded a configuration file for version '4.37.3', but running version '4.37.1'`. All three open PRs are therefore unmergeable by design. This PR moves all three references in one change and groups future codeql-action updates so Dependabot can never split them again.

── Changes ─────────────────────────────────

| Type | Where | What |
|-------|-------------------------------------|-----------------------------------------------------------|
| Chore | `.github/workflows/codeql.yml:59` | init pin 7188fc36 → e4fba868 (v4.37.3) |
| Chore | `.github/workflows/codeql.yml:98` | analyze pin 7188fc36 → e4fba868 (v4.37.3) |
| Chore | `.github/workflows/semgrep.yml:48` | upload-sarif v4.37.1 → v4.37.3 |
| Chore | `.github/dependabot.yml:15` | group `github/codeql-action*` into a single Dependabot PR |

── Validation ──────────────────────────────

- `uvx zizmor --min-severity medium .` → no findings
- `gh api repos/github/codeql-action/commits/v4.37.3 --jq .sha` → `e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81` (pin matches the tag)
- CI on this PR: all three CodeQL jobs green, no "Not all workflow steps … use the same version" warning in logs

── Notes ───────────────────────────────────

- Supersedes #304, #305, #306 (closing via `@dependabot close`)

## Summary by Sourcery

Update CodeQL GitHub Actions to v4.37.3 and ensure all CodeQL-related steps are versioned in lockstep via Dependabot grouping.

Chores:
- Bump CodeQL init and analyze workflow steps to v4.37.3 using the corresponding pinned commit SHA.
- Update the CodeQL SARIF upload step in the Semgrep workflow to use version v4.37.3.
- Configure Dependabot to group all github/codeql-action updates into a single PR to prevent mismatched step versions.