### PR TITLE
ci(build): retry Gradle jobs once on the layoutIndex flake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,7 +201,7 @@ jobs:
           java-version: 21
       - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       - name: Compile and build plugin
-        run: ./gradlew buildPlugin
+        run: scripts/gradle-retry.sh buildPlugin
 
   # ── Tier 3: Parallel analysis (after build, PRs only) ──
   analyze:
@@ -221,7 +221,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       - name: Ktlint + Detekt + Kotlin warnings
         run: >
-          ./gradlew ktlintCheck detekt compileKotlin
+          scripts/gradle-retry.sh ktlintCheck detekt compileKotlin
           -Pkotlin.compiler.option.allWarningsAsErrors=true
 
   test:
@@ -240,7 +240,7 @@ jobs:
           java-version: 21
       - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       - name: Run tests with coverage
-        run: ./gradlew test integrationTest koverXmlReport koverVerify
+        run: scripts/gradle-retry.sh test integrationTest koverXmlReport koverVerify
       - name: Upload coverage to Codecov
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
@@ -267,7 +267,7 @@ jobs:
           java-version: 21
       - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       - name: Build plugin JAR
-        run: ./gradlew buildPlugin
+        run: scripts/gradle-retry.sh buildPlugin
       - name: Verify bytecode freshness
         run: python3 scripts/verify-bytecode.py
       - name: Verify ProGuard keep rules
@@ -298,7 +298,7 @@ jobs:
           java-version: 21
       - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
       - name: Verify plugin (group ${{ matrix.group }})
-        run: ./gradlew verifyPlugin -DverifyGroup=${{ matrix.group }}
+        run: scripts/gradle-retry.sh verifyPlugin -DverifyGroup=${{ matrix.group }}
       - name: Fail on internal API verifier findings
         run: python3 scripts/verify-plugin-verifier.py
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/scripts/gradle-retry.sh
+++ b/scripts/gradle-retry.sh
@@ -7,7 +7,7 @@
 # state); every other failure keeps its original exit code untouched.
 set -uo pipefail
 
-FLAKE_SIGNATURE="Cannot access 'com.intellij"
+FLAKE_SIGNATURE="Cannot access 'com.intellij.psi"
 
 LOG_FILE=$(mktemp)
 trap 'rm -f "$LOG_FILE"' EXIT
@@ -26,4 +26,6 @@ fi
 echo "::warning::layoutIndex flake detected (com.intellij.java dropped from platform layout) — wiping project Gradle state and retrying once"
 ./gradlew --stop >/dev/null 2>&1 || true
 rm -rf build .gradle
-exec ./gradlew "$@"
+# No exec: let the EXIT trap clean up the temp log; the retry output still
+# streams straight to stdout and nothing needs to inspect it.
+./gradlew "$@"

--- a/scripts/gradle-retry.sh
+++ b/scripts/gradle-retry.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Gradle wrapper with a single signature-gated retry for the transient
+# IntelliJ Platform layoutIndex flake: the resolved platform layout
+# nondeterministically drops com.intellij.java and compileKotlin fails with
+# "Cannot access 'com.intellij.psi...'" on the Groovy annotator.
+# Only that signature triggers a retry (after wiping project-local Gradle
+# state); every other failure keeps its original exit code untouched.
+set -uo pipefail
+
+FLAKE_SIGNATURE="Cannot access 'com.intellij"
+
+LOG_FILE=$(mktemp)
+trap 'rm -f "$LOG_FILE"' EXIT
+
+./gradlew "$@" 2>&1 | tee "$LOG_FILE"
+EXIT_CODE="${PIPESTATUS[0]}"
+
+if [ "$EXIT_CODE" -eq 0 ]; then
+  exit 0
+fi
+
+if ! grep -qF "$FLAKE_SIGNATURE" "$LOG_FILE"; then
+  exit "$EXIT_CODE"
+fi
+
+echo "::warning::layoutIndex flake detected (com.intellij.java dropped from platform layout) — wiping project Gradle state and retrying once"
+./gradlew --stop >/dev/null 2>&1 || true
+rm -rf build .gradle
+exec ./gradlew "$@"


### PR DESCRIPTION
── Summary ─────────────────────────────────

The resolved IntelliJ Platform layout nondeterministically drops `com.intellij.java` on fresh CI runners, and compileKotlin dies with `Cannot access 'com.intellij.psi.PsiAnnotationMemberValue'` on the Groovy annotator. It has burned 7+ jobs to date (latest: Build on #304, Verify A1/B on #305) and the only cure was manually re-running the job. This PR gives every Gradle CI step a single, signature-gated retry so the flake self-heals.

── Changes ─────────────────────────────────

| Type | Where | What |
|-------|------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
| Feat | `scripts/gradle-retry.sh:1` | wrapper: stream output via tee; on the flake signature stop daemons, wipe build/.gradle, retry once; other failures keep their exit code |
| Chore | `.github/workflows/build.yml:204` | build → gradle-retry.sh buildPlugin |
| Chore | `.github/workflows/build.yml:224` | analyze → gradle-retry.sh ktlintCheck detekt compileKotlin |
| Chore | `.github/workflows/build.yml:243` | test → gradle-retry.sh test integrationTest koverXmlReport koverVerify |
| Chore | `.github/workflows/build.yml:270` | jar-integrity → gradle-retry.sh buildPlugin |
| Chore | `.github/workflows/build.yml:301` | verify → gradle-retry.sh verifyPlugin |

── Validation ──────────────────────────────

- Stubbed-gradlew smoke test: success passes through (exit 0); flake signature triggers exactly one wipe+retry; unrelated failure exits with the original code after a single invocation
- `shellcheck scripts/gradle-retry.sh` → clean; `uvx zizmor --min-severity medium .` → no findings
- CI on this PR exercises the pass-through path in all five Gradle jobs

── Notes ───────────────────────────────────

- Same-runner wipe+retry is a best-effort reproduction of a fresh runner; if the retry fails too, the job fails exactly as before (worst case = today plus a few minutes)
- codeql.yml's manual Kotlin build keeps its own bespoke handler (Kotlin version-ceiling downgrade); intentionally not entangled here

## Summary by Sourcery

Add a Gradle wrapper script that retries builds once on the known IntelliJ layoutIndex flake and wire it into all CI Gradle jobs.

Enhancements:
- Introduce a Gradle retry shell wrapper that detects the layoutIndex flake, wipes local Gradle state, and re-runs the command once.

CI:
- Route all GitHub Actions Gradle build, analysis, test, jar-integrity, and verify jobs through the new retry wrapper script.