### PR TITLE
chore(release): bump version to 2.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.8.2] - 2026-08-07
+
+- [Fix] **Java syntax colors** — classes, fields, constants, and annotations
+  keep their colors wherever they are referenced, not only where they are
+  declared. Java code no longer flattens to a single gray tone, and editor
+  schemes that already lost these colors are repaired automatically the first
+  time each one is used.
+
 ## [2.8.1] - 2026-08-03
 
 - [Paid] **Connected-island ECG routing** — Chaotic waveform mode can finish

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.8.1
+pluginVersion=2.8.2
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
@@ -70,6 +70,11 @@ internal object UpdateNotifier {
 
     private val RELEASE_NOTES =
         mapOf(
+            "2.8.2" to
+                releaseNotes(
+                    "[Fix] Java classes, fields, constants and annotations keep their colors on references",
+                    "[Fix] Editor schemes that lost those colors are repaired the first time each is used",
+                ),
             "2.8.1" to
                 releaseNotes(
                     "[Paid] Chaotic ECG routes across connected editor, tool-window, and IDE-window islands",

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -121,6 +121,11 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>2.8.2</h3>
+    <ul>
+      <li>[Fix] <b>Java syntax colors</b> — classes, fields, constants, and annotations keep their colors wherever they are referenced, not only where they are declared. Java code no longer flattens to a single gray tone, and editor schemes that already lost these colors are repaired automatically the first time each one is used.</li>
+    </ul>
+
     <h3>2.8.1</h3>
     <ul>
       <li>[Paid] <b>Connected-island ECG routing</b> — Chaotic waveform mode can finish its current loop and continue across adjacent editor, tool-window, and neighboring IDE-window islands. Routes stay continuous through focus changes, empty editors, touching perimeters, and window lifecycle transitions without rewriting existing Glow preferences.</li>


### PR DESCRIPTION
Patch release shipping the Java syntax colour fix from #310.

── Changes ─────────────────────────────────

| File | Change |
|------|--------|
| `gradle.properties` | `pluginVersion` 2.8.1 → 2.8.2 |
| `CHANGELOG.md` | new 2.8.2 section |
| `src/main/resources/META-INF/plugin.xml` | new 2.8.2 change-notes block |
| `src/main/kotlin/dev/ayuislands/UpdateNotifier.kt` | 2.8.2 balloon notes entry |

`release-date` stays `20260718` on purpose — `release-version` remains `28`, and Marketplace rejects a date change that is not paired with a release-version change.

── Validation ──────────────────────────────

Run before opening this PR, against the 2.8.2 artifact:

```bash
./gradlew clean buildPlugin      # ayu-jetbrains-2.8.2.zip
./gradlew verifyPlugin           # all 12 targets
./gradlew detekt ktlintCheck
python3 scripts/verify-docs.py   # in sync
```

`verifyPlugin` returned **Compatible** on all twelve IDEs, including the ones without a Java plugin (PyCharm, GoLand, DataGrip, RubyMine, Rider, CLion, PhpStorm, WebStorm). Deprecated-usage count is unchanged at 3.

── Notes ───────────────────────────────────

- Only one of the four commits since `v2.8.1` is user-facing; the other three touch workflow files only and are deliberately absent from the changelog.
- Tagging `v2.8.2` after this merges is what triggers the Marketplace publish.

## Summary by Sourcery

Release version 2.8.2 of the plugin with updated metadata and user-facing notes for a Java syntax color fix.

Bug Fixes:
- Document and surface the fix that restores distinct Java syntax colors for classes, fields, constants, and annotations and repairs affected editor schemes.

Build:
- Bump pluginVersion to 2.8.2 in gradle.properties.

Deployment:
- Update plugin.xml change-notes and in-IDE update notifier entries for the 2.8.2 release.

Documentation:
- Add a 2.8.2 changelog entry describing the Java syntax color restoration.