### PR TITLE
chore(docs): rebind settings verification to merge

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "c184bf9a"
+          last_verified_sha: "fe11eb27"
           last_verified_date: "2026-08-09"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "c184bf9a"
+          last_verified_sha: "fe11eb27"
           last_verified_date: "2026-08-09"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -324,7 +324,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "8bff498e"
+          last_verified_sha: "fe11eb27"
           last_verified_date: "2026-08-09"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -393,7 +393,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "8bff498e"
+          last_verified_sha: "fe11eb27"
           last_verified_date: "2026-08-09"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -445,7 +445,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "8bff498e"
+          last_verified_sha: "fe11eb27"
           last_verified_date: "2026-08-09"
           content_sha256: ad849b17308901bc2dac85f895978be656f578c9c31f857b9e9578e5cf4289f2
 
@@ -507,7 +507,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/PluginsPanel.kt
             - src/main/kotlin/dev/ayuislands/indent
             - src/main/kotlin/dev/ayuislands/accent/elements/BracketScopeRenderer.kt
-          last_verified_sha: "8bff498e"
+          last_verified_sha: "fe11eb27"
           last_verified_date: "2026-08-09"
           content_sha256: "c5c1eea5a119bd19bf98518d394d698bf09983a1e0a3472e255358c50e41ed16"
 


### PR DESCRIPTION
── Summary ─────────────────────────────────

Rebind six settings screenshot verification stamps to the squash-merge commit from #312.

This keeps future source changes subject to the normal screenshot freshness check instead of inheriting orphaned feature-branch SHAs.

── Changes ─────────────────────────────────

- Chore: [features.yml](docs/features.yml) — Replace six orphaned `last_verified_sha` values with merge commit `fe11eb27`; preserve dates and screenshot content hashes.

── Validation ──────────────────────────────

- `scripts/verify-docs.py` — Passed: `docs/features.yml in sync with README + plugin.xml + CHANGELOG`.
- Pre-commit hooks — Passed, including YAML validation and docs synchronization.
- `git diff --check origin/main...HEAD` — Passed.

── Notes ───────────────────────────────────

Metadata-only follow-up to #312. No source code or screenshot assets changed.

## Summary by Sourcery

Documentation:
- Refresh six `last_verified_sha` entries in docs/features.yml to reference merge commit fe11eb27 while preserving existing verification dates and content hashes.