### PR TITLE
chore(docs): rebind accent verification to merge

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "fa63471b"
+          last_verified_sha: "d8110e58"
           last_verified_date: "2026-08-09"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "fa63471b"
+          last_verified_sha: "d8110e58"
           last_verified_date: "2026-08-09"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 


### PR DESCRIPTION
-- Summary ------------------------------------------------

Squash-merging PR #314 left its screenshot verification stamps outside the live main history. Rebind those stamps to the merge commit so future source changes are compared from a stable ancestor.

-- Changes ------------------------------------------------

- Chore: update the two accent-related last_verified_sha values in docs/features.yml from fa63471b to d8110e58.

-- Validation ---------------------------------------------

- scripts/verify-docs.py --restamp - re-stamped exactly 2 orphaned entries.
- scripts/verify-docs.py - passed.
- git diff --check - passed.
- Pre-commit hooks, including docs sync and YAML validation - passed.

-- Notes --------------------------------------------------

Metadata-only follow-up to PR #314; screenshot content hashes and dates are unchanged.

## Summary by Sourcery

Update accent screenshot verification metadata to point at the merge commit rather than the pre-squash commit.

Enhancements:
- Refresh last_verified_sha for two accent-related documentation entries to rebind their verification stamps to the current main history.

Documentation:
- Adjust docs/features.yml verification metadata for accent-related screenshots without changing their content.