### PR TITLE
chore(release): prepare v2.8.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,6 +104,8 @@ jobs:
         run: uv run --project scripts python scripts/tests/test-generate-campaign.py
       - name: Test Plugin Verifier API gate
         run: python3 scripts/tests/test-verify-plugin-verifier.py
+      - name: Test Gradle retry cache recovery
+        run: python3 scripts/tests/test-gradle-retry.py
       - name: Test font fallback URL smoke
         run: python3 scripts/tests/test-verify-font-fallback-urls.py
       - name: Verify font fallback URLs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [2.8.3] - 2026-08-10
+
+- [Fix] **Safer Accent settings reset** — resetting the Accent section now
+  restores only its default accent mode without resetting Glow, rotation,
+  project icons, syntax, or other Ayu preferences. The change still requires
+  Apply and can be discarded with Cancel.
+- [Fix] **Reliable Accent override editing** — project and language mappings
+  now preserve one consistent pending state across Add, Edit, Remove, Pin,
+  Reset, Cancel, and Apply. Losing Pro access no longer discards pending
+  mappings or partially applies related Accent settings.
+- [Fix] **Accurate Accent override preview** — the “Currently active” preview
+  and diagnostics now refresh from the same detected-language result after a
+  rescan, while reopening Settings no longer duplicates or blanks the Projects
+  and Languages controls.
+
 ## [2.8.2] - 2026-08-07
 
 - [Fix] **Java syntax colors** — classes, fields, constants, and annotations

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,13 @@ plugins {
 group = providers.gradleProperty("pluginGroup").get()
 version = providers.gradleProperty("pluginVersion").get()
 
+val integrationPlugins =
+    listOf(
+        "dev.j-a.swift" to "1.11.1.435-251",
+        "com.nasller.CodeGlancePro" to "2.0.2",
+        "indent-rainbow.indent-rainbow" to "2.2.0",
+    )
+
 kotlin {
     jvmToolchain(21)
 }
@@ -39,9 +46,9 @@ dependencies {
     intellijPlatform {
         intellijIdeaCommunity(providers.gradleProperty("platformVersion"))
         bundledPlugin("org.intellij.groovy")
-        plugin("dev.j-a.swift", "1.11.1.435-251")
-        plugin("com.nasller.CodeGlancePro", "2.0.2")
-        plugin("indent-rainbow.indent-rainbow", "2.2.0")
+        integrationPlugins.forEach { (pluginId, pluginVersion) ->
+            plugin(pluginId, pluginVersion)
+        }
         pluginVerifier()
         testFramework(TestFrameworkType.Platform)
         testBundledPlugin("org.intellij.groovy")
@@ -84,11 +91,7 @@ tasks.register<Test>("integrationTest") {
 
 tasks {
     named<PrepareSandboxTask>("prepareTestSandbox") {
-        disabledPlugins.addAll(
-            "dev.j-a.swift",
-            "com.nasller.CodeGlancePro",
-            "indent-rainbow.indent-rainbow",
-        )
+        disabledPlugins.addAll(integrationPlugins.map { (pluginId, _) -> pluginId })
     }
 
     named<JavaExec>("runIde") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.intellij.platform.gradle.models.ProductRelease
+import org.jetbrains.intellij.platform.gradle.tasks.PrepareSandboxTask
 
 buildscript {
     repositories { mavenCentral() }
@@ -38,6 +39,9 @@ dependencies {
     intellijPlatform {
         intellijIdeaCommunity(providers.gradleProperty("platformVersion"))
         bundledPlugin("org.intellij.groovy")
+        plugin("dev.j-a.swift", "1.11.1.435-251")
+        plugin("com.nasller.CodeGlancePro", "2.0.2")
+        plugin("indent-rainbow.indent-rainbow", "2.2.0")
         pluginVerifier()
         testFramework(TestFrameworkType.Platform)
         testBundledPlugin("org.intellij.groovy")
@@ -79,6 +83,14 @@ tasks.register<Test>("integrationTest") {
 }
 
 tasks {
+    named<PrepareSandboxTask>("prepareTestSandbox") {
+        disabledPlugins.addAll(
+            "dev.j-a.swift",
+            "com.nasller.CodeGlancePro",
+            "indent-rainbow.indent-rainbow",
+        )
+    }
+
     named<JavaExec>("runIde") {
         jvmArgumentProviders +=
             CommandLineArgumentProvider {
@@ -105,7 +117,7 @@ intellijPlatform {
         freeArgs =
             listOf(
                 "-mute",
-                "ReleaseVersionAndPluginVersionMismatch,ExperimentalApiUsage",
+                "ReleaseVersionAndPluginVersionMismatch",
             )
         ides {
             // verifyGroup splits the 12 IDE targets across hosted runners to keep

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "d8110e58"
+          last_verified_sha: "ceb6df98"
           last_verified_date: "2026-08-09"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "d8110e58"
+          last_verified_sha: "ceb6df98"
           last_verified_date: "2026-08-09"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.8.2
+pluginVersion=2.8.3
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/scripts/gradle-retry.sh
+++ b/scripts/gradle-retry.sh
@@ -3,8 +3,8 @@
 # IntelliJ Platform layoutIndex flake: the resolved platform layout
 # nondeterministically drops com.intellij.java and compileKotlin fails with
 # "Cannot access 'com.intellij.psi...'" on the Groovy annotator.
-# Only that signature triggers a retry (after wiping project-local Gradle
-# state); every other failure keeps its original exit code untouched.
+# Only that signature triggers a retry (after wiping the generated build and
+# IntelliJ layout caches); every other failure keeps its original exit code.
 set -uo pipefail
 
 FLAKE_SIGNATURE="Cannot access 'com.intellij.psi"
@@ -23,9 +23,9 @@ if ! grep -qF "$FLAKE_SIGNATURE" "$LOG_FILE"; then
   exit "$EXIT_CODE"
 fi
 
-echo "::warning::layoutIndex flake detected (com.intellij.java dropped from platform layout) — wiping project Gradle state and retrying once"
+echo "::warning::layoutIndex flake detected (com.intellij.java dropped from platform layout) — rebuilding project layout state and retrying once"
 ./gradlew --stop >/dev/null 2>&1 || true
-rm -rf build .gradle
+rm -rf build .gradle .intellijPlatform/layoutIndex .intellijPlatform/localPlatformArtifacts
 # No exec: let the EXIT trap clean up the temp log; the retry output still
 # streams straight to stdout and nothing needs to inspect it.
 ./gradlew "$@"

--- a/scripts/tests/test-gradle-retry.py
+++ b/scripts/tests/test-gradle-retry.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Behavior tests for the signature-gated Gradle retry wrapper."""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "gradle-retry.sh"
+
+
+class GradleRetryTest(unittest.TestCase):
+    def test_retry_rebuilds_generated_caches_only(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            make_gradle_fixture(root)
+            stale_paths = [
+                root / "build" / "stale",
+                root / ".gradle" / "stale",
+                root / ".intellijPlatform" / "layoutIndex" / "stale",
+                root / ".intellijPlatform" / "localPlatformArtifacts" / "stale",
+            ]
+            for stale_path in stale_paths:
+                stale_path.parent.mkdir(parents=True, exist_ok=True)
+                stale_path.touch()
+            sandbox_state = root / ".intellijPlatform" / "sandbox" / "preserved"
+            sandbox_state.parent.mkdir(parents=True)
+            sandbox_state.touch()
+
+            result = subprocess.run(
+                [str(SCRIPT), "compileKotlin"],
+                cwd=root,
+                check=False,
+                text=True,
+                capture_output=True,
+            )
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertEqual("2", (root / ".attempt-count").read_text(encoding="utf-8"))
+            for stale_path in stale_paths:
+                self.assertFalse(stale_path.exists(), stale_path)
+            self.assertTrue(sandbox_state.exists())
+
+
+def make_gradle_fixture(root: Path) -> None:
+    gradle = root / "gradlew"
+    gradle.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            set -eu
+
+            if [ "${1:-}" = "--stop" ]; then
+              exit 0
+            fi
+
+            attempt_file=.attempt-count
+            attempt=0
+            if [ -f "$attempt_file" ]; then
+              attempt=$(<"$attempt_file")
+            fi
+            attempt=$((attempt + 1))
+            printf '%s' "$attempt" > "$attempt_file"
+
+            if [ "$attempt" -eq 1 ]; then
+              echo "Cannot access 'com.intellij.psi.PsiAnnotationMemberValue'"
+              exit 1
+            fi
+            """,
+        ),
+        encoding="utf-8",
+    )
+    gradle.chmod(0o755)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
@@ -72,9 +72,12 @@ internal object UpdateNotifier {
         mapOf(
             "2.8.3" to
                 releaseNotes(
-                    "[Fix] Accent reset preserves unrelated Ayu preferences until Apply",
-                    "[Fix] Project and language overrides keep pending edits across license changes",
-                    "[Fix] Accent override previews refresh consistently after rescans and Settings reopens",
+                    items =
+                        arrayOf(
+                            "[Fix] Accent reset preserves unrelated Ayu preferences until Apply",
+                            "[Fix] Project and language overrides keep pending edits across license changes",
+                            "[Fix] Accent override previews refresh consistently after rescans and Settings reopens",
+                        ),
                 ),
             "2.8.2" to
                 releaseNotes(

--- a/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
@@ -70,6 +70,12 @@ internal object UpdateNotifier {
 
     private val RELEASE_NOTES =
         mapOf(
+            "2.8.3" to
+                releaseNotes(
+                    "[Fix] Accent reset preserves unrelated Ayu preferences until Apply",
+                    "[Fix] Project and language overrides keep pending edits across license changes",
+                    "[Fix] Accent override previews refresh consistently after rescans and Settings reopens",
+                ),
             "2.8.2" to
                 releaseNotes(
                     "[Fix] Java classes, fields, constants and annotations keep their colors on references",

--- a/src/main/kotlin/dev/ayuislands/accent/statusbar/AccentStatusBarWidget.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/statusbar/AccentStatusBarWidget.kt
@@ -9,6 +9,7 @@ import dev.ayuislands.accent.AccentChangedTopic
 import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolutionChain
+import dev.ayuislands.accent.AccentResolutionStep
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.ProjectLanguageDetectionListener
 import dev.ayuislands.accent.StepOutcome
@@ -38,6 +39,7 @@ import javax.swing.JPanel
  * Hidden entirely when the license gate fails (premium feature) via
  * [AccentStatusBarWidgetFactory.isAvailable].
  */
+@JvmDefaultWithoutCompatibility
 internal class AccentStatusBarWidget(
     private val project: Project,
 ) : CustomStatusBarWidget {
@@ -181,10 +183,14 @@ internal class AccentStatusBarPanel(
 
     private fun StringBuilder.appendChainRows(chain: AccentResolutionChain) {
         for (step in chain.steps) {
-            val marker = if (step.outcome == StepOutcome.WON) "✓" else " "
-            append(escapeHtml("$marker ${AccentResolver.sourceLabel(step.source)}: ${step.detail}"))
-            append("<br>")
+            appendChainRow(step)
         }
+    }
+
+    private fun StringBuilder.appendChainRow(step: AccentResolutionStep) {
+        val marker = if (step.outcome == StepOutcome.WON) "✓" else " "
+        append(escapeHtml("$marker ${AccentResolver.sourceLabel(step.source)}: ${step.detail}"))
+        append("<br>")
     }
 
     private fun escapeHtml(text: String): String =

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -121,6 +121,12 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>2.8.3</h3>
+    <ul>
+      <li>[Fix] <b>Safer Accent settings reset</b> — resetting the Accent section now restores only its default accent mode without resetting Glow, rotation, project icons, syntax, or other Ayu preferences. The change still requires Apply and can be discarded with Cancel.</li>
+      <li>[Fix] <b>Reliable Accent override editing</b> — project and language mappings now preserve one consistent pending state across Add, Edit, Remove, Pin, Reset, Cancel, and Apply. Losing Pro access no longer discards pending mappings or partially applies related Accent settings.</li>
+      <li>[Fix] <b>Accurate Accent override preview</b> — the “Currently active” preview and diagnostics now refresh from the same detected-language result after a rescan, while reopening Settings no longer duplicates or blanks the Projects and Languages controls.</li>
+    </ul>
     <h3>2.8.2</h3>
     <ul>
       <li>[Fix] <b>Java syntax colors</b> — classes, fields, constants, and annotations keep their colors wherever they are referenced, not only where they are declared. Java code no longer flattens to a single gray tone, and editor schemes that already lost these colors are repaired automatically the first time each one is used.</li>

--- a/src/test/kotlin/dev/ayuislands/accent/statusbar/AccentStatusBarSurfaceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/statusbar/AccentStatusBarSurfaceTest.kt
@@ -34,6 +34,7 @@ import javax.swing.JScrollPane
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
@@ -111,6 +112,14 @@ class AccentStatusBarSurfaceTest {
         every { LicenseChecker.isLicensedOrGrace() } returns false
 
         assertEquals(false, factory.isAvailable(project))
+    }
+
+    @Test
+    fun `widget bytecode does not expose deprecated presentation bridges`() {
+        assertFalse(
+            AccentStatusBarWidget::class.java.declaredMethods.any { it.name == "getPresentation" },
+            "CustomStatusBarWidget must not generate deprecated presentation compatibility bridges",
+        )
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/indent/IndentRainbowSyncTest.kt
+++ b/src/test/kotlin/dev/ayuislands/indent/IndentRainbowSyncTest.kt
@@ -23,6 +23,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -768,12 +769,22 @@ class IndentRainbowSyncTest {
     fun `apply keeps ownership retryable when Indent Rainbow schema is unavailable`() {
         state.irIntegrationEnabled = true
         val mockPlugin = mockk<IdeaPluginDescriptor>(relaxed = true)
+        val schemaUnavailableLoader =
+            object : ClassLoader(this::class.java.classLoader) {
+                override fun loadClass(
+                    name: String,
+                    resolve: Boolean,
+                ): Class<*> {
+                    if (name.startsWith("indent.rainbow.")) throw ClassNotFoundException(name)
+                    return super.loadClass(name, resolve)
+                }
+            }
         every { AyuPlugin.findLoadedPlugin(any()) } returns mockPlugin
-        every { mockPlugin.pluginClassLoader } returns this::class.java.classLoader
+        every { mockPlugin.pluginClassLoader } returns schemaUnavailableLoader
 
         val outcome = callApply()
 
-        assertTrue(outcome is IntegrationOutcome.Failed)
+        assertIs<ClassNotFoundException>(assertIs<IntegrationOutcome.Failed>(outcome).error)
         assertEquals(IntegrationOwnership.UNOWNED.name, state.irOwnership)
         assertEquals(false, getPrivateField("methodsResolved"))
         assertNull(getPrivateField("irConfig"))


### PR DESCRIPTION
── Summary ────────────────────────────────

Prepare the v2.8.3 patch release with user-facing fixes for Accent settings reset, override editing, and preview refresh behavior.

The release also makes optional integration plugins resolvable to IntelliJ inspections without activating them in the default test sandbox, and removes deprecated status-widget bridge bytecode while retaining IntelliJ 2025.1 support.

── Changes ────────────────────────────────

- Release: bump the plugin to `2.8.3` and align the changelog, Marketplace change notes, and in-IDE update notification.
- Build: resolve Noctule, CodeGlance Pro, and Indent Rainbow for IDE analysis while disabling them in the test sandbox.
- Compatibility: prevent deprecated `CustomStatusBarWidget.getPresentation` compatibility bridges.
- Tests: lock status-widget bytecode and missing Indent Rainbow schema behavior to their intended boundaries.

── Validation ─────────────────────────────

```bash
./gradlew test integrationTest detekt ktlintCheck koverVerify build verifyPlugin --console=plain
python3 scripts/verify-docs.py
python3 scripts/tests/test-release-policy.py
python3 scripts/verify-plugin-verifier.py --reports-dir build/reports/pluginVerifier
```

- Unit tests: 3562/3562 passed
- Integration tests: 15/15 passed
- IntelliJ inspections: clean for all changed supported files
- Plugin Verifier: 12/12 targets compatible; 0 internal and 0 deprecated API findings
- Artifact SHA-256: `d936c2c2485743805bc94c71ff1aaae2ce93d9e920f8397e191b679e54be270a`

── Notes ──────────────────────────────────

Plugin Verifier still reports the six previously reviewed experimental LAF API usages. They are intentionally retained to preserve theme switching behavior and IntelliJ 2025.1 support; the release does not mute or suppress them.
