### PR TITLE
docs(features): rebind v2.8.3 verification metadata

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "ceb6df98"
+          last_verified_sha: "65c10ffa"
           last_verified_date: "2026-08-09"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "ceb6df98"
+          last_verified_sha: "65c10ffa"
           last_verified_date: "2026-08-09"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 


### PR DESCRIPTION
── Summary ─────────────────────────────────

Rebind the Accent screenshot verification metadata after the v2.8.3 release PR was squash-merged.

Why: the feature manifest must reference a commit reachable from `main` before the release tag is created.

── Changes ─────────────────────────────────

| Type | File | Description |
|------|------|-------------|
| Docs | [features.yml](docs/features.yml) | Point both Accent screenshot verification entries at the v2.8.3 squash merge commit without changing content hashes. |

── Validation ───────────────────────────────

- `scripts/verify-docs.py` - passed; `docs/features.yml` is in sync with README, plugin.xml, and CHANGELOG.
- `git diff --cached --check` - passed.

── Notes ──────────────────────────────────

No screenshot assets or product behavior change.

## Summary by Sourcery

Documentation:
- Refresh Accent screenshot verification entries in docs/features.yml to point at the v2.8.3 squash-merge commit without altering content hashes.