### PR TITLE
Fix editor scheme change threading in Rider

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "65c10ffa"
+          last_verified_sha: "c06a1411"
           last_verified_date: "2026-08-09"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "65c10ffa"
+          last_verified_sha: "c06a1411"
           last_verified_date: "2026-08-09"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -393,7 +393,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "fe11eb27"
+          last_verified_sha: "c06a1411"
           last_verified_date: "2026-08-09"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -6,7 +6,6 @@ import com.intellij.notification.Notifications
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.editor.colors.ColorKey
-import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.openapi.extensions.ExtensionPointName
@@ -27,6 +26,7 @@ import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 import dev.ayuislands.theme.AyuEditorSchemeScope
+import dev.ayuislands.theme.EditorSchemeChange
 import dev.ayuislands.theme.EditorSchemeOwner
 import dev.ayuislands.ui.ComponentTreeRefresher
 import org.jetbrains.annotations.TestOnly
@@ -768,16 +768,7 @@ object AccentApplicator {
             AyuEditorSchemeScope.writeAttributes(scheme, alwaysOnOwner, attrKey, updated)
         }
 
-        // Notify editors to repaint with an updated scheme
-        // Wrapped in a read action because Jupyter's NotebookEditorColorsListener
-        // accesses PSI from globalSchemeChange, which requires read access.
-        val application = ApplicationManager.getApplication()
-        application.runReadAction {
-            application
-                .messageBus
-                .syncPublisher(EditorColorsManager.TOPIC)
-                .globalSchemeChange(null)
-        }
+        EditorSchemeChange.publish()
     }
 
     private fun applyTabUnderline(
@@ -833,13 +824,7 @@ object AccentApplicator {
     private fun revertAlwaysOnEditorKeys() {
         AyuEditorSchemeScope.restore(alwaysOnOwner)
 
-        val application = ApplicationManager.getApplication()
-        application.runReadAction {
-            application
-                .messageBus
-                .syncPublisher(EditorColorsManager.TOPIC)
-                .globalSchemeChange(null)
-        }
+        EditorSchemeChange.publish()
     }
 
     private class ElementRevertFailure(

--- a/src/main/kotlin/dev/ayuislands/font/FontPresetApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontPresetApplicator.kt
@@ -1,10 +1,10 @@
 package dev.ayuislands.font
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.colors.ModifiableFontPreferences
 import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.theme.EditorSchemeChange
 import javax.swing.SwingUtilities
 
 /** Applies and reverts font presets to the IDE editor (and optionally console). */
@@ -56,11 +56,7 @@ object FontPresetApplicator {
                 scheme.consoleLineSpacing = settings.lineSpacing
             }
 
-            ApplicationManager
-                .getApplication()
-                .messageBus
-                .syncPublisher(EditorColorsManager.TOPIC)
-                .globalSchemeChange(null)
+            EditorSchemeChange.publish()
             LOG.info(
                 "Font preset applied: ${settings.preset.displayName} " +
                     "($resolvedFamily, subFamily=$subFamily, " +
@@ -88,11 +84,7 @@ object FontPresetApplicator {
             scheme.setConsoleFontSize(DEFAULT_FONT_SIZE)
             scheme.consoleLineSpacing = DEFAULT_LINE_SPACING
 
-            ApplicationManager
-                .getApplication()
-                .messageBus
-                .syncPublisher(EditorColorsManager.TOPIC)
-                .globalSchemeChange(null)
+            EditorSchemeChange.publish()
             LOG.info("Font preset reverted to defaults")
         }
     }

--- a/src/main/kotlin/dev/ayuislands/syntax/SyntaxIntensityService.kt
+++ b/src/main/kotlin/dev/ayuislands/syntax/SyntaxIntensityService.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.ui.JBColor
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
+import dev.ayuislands.theme.EditorSchemeChange
 import java.awt.Color
 import java.awt.Font
 import java.util.concurrent.ConcurrentHashMap
@@ -26,11 +27,9 @@ import java.util.concurrent.atomic.AtomicBoolean
  *    active `globalScheme` whenever it isn't one of the named instances we
  *    already touched (identity dedup avoids double-writes on a clean
  *    install).
- *  - R-7 single publish: exactly one
- *    `MessageBus.syncPublisher(EditorColorsManager.TOPIC)` invocation
- *    publishing a single global-scheme-change event per apply call. The
- *    publish must stay outside read actions because downstream editor
- *    listeners may refresh highlighters through write-intent read actions.
+ *  - R-7 single publish: exactly one [EditorSchemeChange] event per apply call.
+ *    The shared publisher supplies the write-intent context required by
+ *    downstream editor listeners.
  *  - Pattern A latches: a missing named scheme logs WARN once per (scheme,
  *    session); an unknown overlay variant tag arriving via
  *    [resolveActiveAyuOverlayVariant] (a future Ayu variant outside the whitelist)
@@ -415,11 +414,7 @@ class SyntaxIntensityService {
         PropertiesComponent.getInstance().getList(RETIREMENT_FLAG_KEY)?.toSet() ?: emptySet()
 
     private fun publishSchemeChange() {
-        val application = ApplicationManager.getApplication()
-        application
-            .messageBus
-            .syncPublisher(EditorColorsManager.TOPIC)
-            .globalSchemeChange(null)
+        EditorSchemeChange.publish()
     }
 
     companion object {

--- a/src/main/kotlin/dev/ayuislands/theme/EditorSchemeChange.kt
+++ b/src/main/kotlin/dev/ayuislands/theme/EditorSchemeChange.kt
@@ -1,0 +1,19 @@
+package dev.ayuislands.theme
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.editor.colors.EditorColorsManager
+import com.intellij.util.concurrency.annotations.RequiresEdt
+
+internal object EditorSchemeChange {
+    @RequiresEdt
+    fun publish() {
+        val application = ApplicationManager.getApplication()
+        WriteAction.run<RuntimeException> {
+            application
+                .messageBus
+                .syncPublisher(EditorColorsManager.TOPIC)
+                .globalSchemeChange(null)
+        }
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
@@ -25,6 +25,7 @@ import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
 import dev.ayuislands.theme.AyuEditorSchemeScope
+import dev.ayuislands.theme.EditorSchemeChange
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
@@ -85,11 +86,13 @@ class AccentApplicatorTest {
         mockkStatic(ApplicationManager::class)
         every { ApplicationManager.getApplication() } returns mockApplication
         every { mockApplication.messageBus } returns mockMessageBus
-        every { mockMessageBus.syncPublisher(EditorColorsManager.TOPIC) } returns mockk(relaxed = true)
         // AccentChangedTopic publish — Apply path casts the syncPublisher
         // return value to AccentChangeListener. Stub a relaxed mock so the
         // cast succeeds in this legacy headless test.
         every { mockMessageBus.syncPublisher(AccentChangedTopic.TOPIC) } returns mockk(relaxed = true)
+
+        mockkObject(EditorSchemeChange)
+        every { EditorSchemeChange.publish() } returns Unit
 
         mockkObject(AyuIslandsSettings.Companion)
         every { AyuIslandsSettings.getInstance() } returns mockSettings

--- a/src/test/kotlin/dev/ayuislands/integration/EditorSchemeChangeTest.kt
+++ b/src/test/kotlin/dev/ayuislands/integration/EditorSchemeChangeTest.kt
@@ -1,0 +1,70 @@
+package dev.ayuislands.integration
+
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.editor.colors.EditorColorsListener
+import com.intellij.openapi.editor.colors.EditorColorsManager
+import com.intellij.openapi.editor.colors.EditorColorsScheme
+import com.intellij.openapi.util.Disposer
+import com.intellij.testFramework.ApplicationRule
+import dev.ayuislands.theme.EditorSchemeChange
+import org.junit.Rule
+import org.junit.Test
+import javax.swing.SwingUtilities
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class EditorSchemeChangeTest {
+    @get:Rule
+    val applicationRule = ApplicationRule()
+
+    @Test
+    fun publishesWithWriteIntent() {
+        val application = ApplicationManager.getApplication()
+        val listenerLifetime = Disposer.newDisposable("EditorSchemeChangeTest.listener")
+        val listener = LockCheckingListener(application)
+
+        try {
+            application.messageBus.connect(listenerLifetime).subscribe(EditorColorsManager.TOPIC, listener)
+            val action = PublishAction(application)
+
+            SwingUtilities.invokeAndWait(action)
+
+            assertTrue(action.wasCalled, "Swing callback must execute")
+            assertFalse(
+                action.enteredWithWriteIntent,
+                "Swing callbacks must enter this regression test without a write-intent lock",
+            )
+            assertTrue(listener.wasCalled, "Editor scheme listeners must receive the published change")
+        } finally {
+            Disposer.dispose(listenerLifetime)
+        }
+    }
+
+    private class PublishAction(
+        private val application: Application,
+    ) : Runnable {
+        var wasCalled = false
+            private set
+        var enteredWithWriteIntent = false
+            private set
+
+        override fun run() {
+            wasCalled = true
+            enteredWithWriteIntent = application.isWriteIntentLockAcquired
+            EditorSchemeChange.publish()
+        }
+    }
+
+    private class LockCheckingListener(
+        private val application: Application,
+    ) : EditorColorsListener {
+        var wasCalled = false
+            private set
+
+        override fun globalSchemeChange(scheme: EditorColorsScheme?) {
+            application.assertWriteIntentLockAcquired()
+            wasCalled = true
+        }
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/syntax/SyntaxIntensityServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/syntax/SyntaxIntensityServiceTest.kt
@@ -3,17 +3,16 @@ package dev.ayuislands.syntax
 import com.intellij.ide.util.PropertiesComponent
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.editor.colors.EditorColorsListener
 import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.colors.EditorColorsScheme
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.editor.colors.impl.AbstractColorsScheme
 import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.ui.JBColor
-import com.intellij.util.messages.MessageBus
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
+import dev.ayuislands.theme.EditorSchemeChange
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -35,8 +34,8 @@ import kotlin.test.assertTrue
  * Orchestration tests for [SyntaxIntensityService]. Reuses the prior
  * service-orchestrator MockK harness - mocks the three named Ayu schemes
  * via `EditorColorsManager.getScheme(...)` plus the active `globalScheme`,
- * verifies a single read-action-free `globalSchemeChange` publish per
- * `apply()` invocation (R-7), and pins the R-1 fallback + service-layer
+ * verifies a single shared scheme-change publish per `apply()` invocation
+ * (R-7), and pins the R-1 fallback + service-layer
  * `CUSTOM` premium gate behaviour through `mockkObject` calls into
  * `RgbBlend` / `LicenseChecker` / `SyntaxIntensityApplicator`.
  */
@@ -63,8 +62,6 @@ class SyntaxIntensityServiceTest {
     private lateinit var mockDark: EditorColorsScheme
     private lateinit var mockLight: EditorColorsScheme
     private lateinit var mockManager: EditorColorsManager
-    private lateinit var mockMessageBus: MessageBus
-    private lateinit var mockPublisher: EditorColorsListener
     private lateinit var mockApp: Application
     private lateinit var loader: SyntaxOverlayLoader
     private lateinit var stateInstance: SyntaxIntensityState
@@ -97,8 +94,6 @@ class SyntaxIntensityServiceTest {
         every { mockLight.defaultBackground } returns Color(0xFC, 0xFC, 0xFC)
 
         mockManager = mockk(relaxed = true)
-        mockMessageBus = mockk(relaxed = true)
-        mockPublisher = mockk(relaxed = true)
         mockApp = mockk(relaxed = true)
         ayuState = AyuIslandsState()
         ayuSettings = mockk(relaxed = true)
@@ -116,12 +111,12 @@ class SyntaxIntensityServiceTest {
 
         mockkStatic(ApplicationManager::class)
         every { ApplicationManager.getApplication() } returns mockApp
-        every { mockApp.messageBus } returns mockMessageBus
-        every { mockMessageBus.syncPublisher(EditorColorsManager.TOPIC) } returns mockPublisher
-
         every { mockApp.runReadAction(any<Runnable>()) } answers {
             firstArg<Runnable>().run()
         }
+
+        mockkObject(EditorSchemeChange)
+        every { EditorSchemeChange.publish() } returns Unit
 
         loader = mockk(relaxed = true)
         val payload =
@@ -211,18 +206,18 @@ class SyntaxIntensityServiceTest {
     // ---------- Test 3: R-7 single publish per apply ----------
 
     @Test
-    fun `apply fires globalSchemeChange exactly once per call (R-7)`() {
+    fun `apply publishes one shared scheme change per call (R-7)`() {
         SyntaxIntensityService().apply(SyntaxPreset.WHISPER, emptyMap())
-        verify(exactly = 1) { mockPublisher.globalSchemeChange(null) }
+        verify(exactly = 1) { EditorSchemeChange.publish() }
     }
 
-    // ---------- Test 4: R-7 publish without read-action wrap ----------
+    // ---------- Test 4: R-7 delegates read-action handling ----------
 
     @Test
-    fun `globalSchemeChange publish is not wrapped in read action (R-7)`() {
+    fun `apply delegates scheme change without application read action (R-7)`() {
         SyntaxIntensityService().apply(SyntaxPreset.WHISPER, emptyMap())
         verify(exactly = 0) { mockApp.runReadAction(any<Runnable>()) }
-        verify(exactly = 1) { mockPublisher.globalSchemeChange(null) }
+        verify(exactly = 1) { EditorSchemeChange.publish() }
     }
 
     // ---------- Test 5: R-1 fallback engages for dark variant + WHITE bg ----------
@@ -346,7 +341,7 @@ class SyntaxIntensityServiceTest {
         SyntaxIntensityService().apply(SyntaxPreset.WHISPER, emptyMap())
         verify(atLeast = 1) { mockDark.setAttributes(any(), any<TextAttributes>()) }
         verify(atLeast = 1) { mockLight.setAttributes(any(), any<TextAttributes>()) }
-        verify(exactly = 1) { mockPublisher.globalSchemeChange(null) }
+        verify(exactly = 1) { EditorSchemeChange.publish() }
     }
 
     @Test


### PR DESCRIPTION
── Summary ─────────────────────────────────

Rider 2026.2 requires editor scheme change notifications to run under a write-intent context. Publish accent, syntax, and font scheme refreshes through one stable `WriteAction` boundary to prevent the internal startup errors reported by the IDE.

**Context**: Fixes #322

── Changes ─────────────────────────────────

- Fix: [EditorSchemeChange.kt](src/main/kotlin/dev/ayuislands/theme/EditorSchemeChange.kt) — Centralize editor scheme notifications under a stable write action on the EDT.
- Fix: [AccentApplicator.kt](src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt), [FontPresetApplicator.kt](src/main/kotlin/dev/ayuislands/font/FontPresetApplicator.kt), and [SyntaxIntensityService.kt](src/main/kotlin/dev/ayuislands/syntax/SyntaxIntensityService.kt) — Route every affected refresh path through the shared publisher.
- Test: [EditorSchemeChangeTest.kt](src/test/kotlin/dev/ayuislands/integration/EditorSchemeChangeTest.kt) and focused service tests — Verify delivery under the required write-intent contract.

── Validation ─────────────────────────────

```bash
./gradlew test --rerun-tasks --no-build-cache --console=plain
./gradlew integrationTest detekt ktlintCheck koverVerify build verifyPlugin --console=plain
scripts/verify-docs.py
```

- Full uncached unit suite passed.
- Integration tests, Detekt, ktlint, Kover, build, and documentation verification passed.
- Plugin Verifier reported all 12 targets compatible, including Rider and WebStorm 2026.2.

── Notes ──────────────────────────────────

The change does not alter persisted theme settings or user-selected presets. Review the shared publisher and the five migrated notification sites first.
