### PR TITLE
Fix syntax preview language fallback in WebStorm

### DIFF
--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanel.kt
@@ -699,7 +699,7 @@ class AyuIslandsSyntaxPanel : SettingsParticipant {
             SyntaxLanguageRegistry.supportedLanguages().map {
                 it.displayName
             },
-    ): String = languages.firstOrNull { it == DEFAULT_PREVIEW_LANGUAGE } ?: languages.firstOrNull().orEmpty()
+    ): String = SyntaxPreviewComponent.preferredAvailableLanguage(languages, DEFAULT_PREVIEW_LANGUAGE)
 
     private fun readabilityOptions(): SyntaxReadabilityOptions =
         SyntaxReadabilityOptions(

--- a/src/main/kotlin/dev/ayuislands/settings/SyntaxPreviewComponent.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/SyntaxPreviewComponent.kt
@@ -214,7 +214,7 @@ internal class SyntaxPreviewComponent(
         val resourceName: String,
     )
 
-    private companion object {
+    internal companion object {
         private val LOG = logger<SyntaxPreviewComponent>()
 
         private const val PREVIEW_WIDTH = 560
@@ -293,10 +293,25 @@ internal class SyntaxPreviewComponent(
         private fun previewFileType(
             language: String,
             sample: PreviewSample,
-        ): FileType =
+        ): FileType = availableFileType(language, sample) ?: PlainTextFileType.INSTANCE
+
+        internal fun preferredAvailableLanguage(
+            languages: List<String>,
+            preferred: String,
+        ): String =
+            languages.firstOrNull { it == preferred && hasFileType(it) }
+                ?: languages.firstOrNull(::hasFileType)
+                ?: languages.firstOrNull { it == preferred }
+                ?: languages.firstOrNull().orEmpty()
+
+        private fun hasFileType(language: String): Boolean = availableFileType(language, sampleFor(language)) != null
+
+        private fun availableFileType(
+            language: String,
+            sample: PreviewSample,
+        ): FileType? =
             standardFileType(sample)
                 ?: registeredLanguageFileType(language)
-                ?: PlainTextFileType.INSTANCE
 
         private fun standardFileType(sample: PreviewSample): FileType? {
             val standardName = sample.standardFileTypeName ?: return null

--- a/src/test/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManagerTest.kt
@@ -269,16 +269,19 @@ class ProjectViewScrollbarManagerTest {
         realState.hideProjectRootPath = true
         realState.hideProjectViewHScrollbar = false
 
-        every {
-            Registry.get(any<String>())
-        } throws
-            MissingResourceException(
-                "Not found",
-                "Registry",
-                "project.tree.structure.show.url",
+        val manager =
+            ProjectViewScrollbarManager(
+                project = project,
+                rootPathLease = rootPathLease,
+                registryValueProvider = {
+                    throw MissingResourceException(
+                        "Not found",
+                        "Registry",
+                        "project.tree.structure.show.url",
+                    )
+                },
             )
-
-        val manager = createAndDrain()
+        SwingUtilities.invokeAndWait {}
 
         SwingUtilities.invokeAndWait {
             // Should not throw

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanelTest.kt
@@ -199,6 +199,35 @@ class AyuIslandsSyntaxPanelTest {
     }
 
     @Test
+    fun `selects available preview language`() {
+        val unavailableFileType = syntaxPreviewEditorFixture.mockFileType("Unavailable", "txt")
+        val javaScriptFileType = syntaxPreviewEditorFixture.mockFileType("JavaScript", "js")
+        every { syntaxPreviewEditorFixture.fileTypeManager.getStdFileType("Kotlin") } returns unavailableFileType
+        every { syntaxPreviewEditorFixture.fileTypeManager.getStdFileType("JAVA") } returns unavailableFileType
+        every { syntaxPreviewEditorFixture.fileTypeManager.getStdFileType("JavaScript") } returns javaScriptFileType
+        val syntaxPanel = AyuIslandsSyntaxPanel()
+        val dialogPanel = buildFullSyntaxPanel(syntaxPanel)
+
+        try {
+            val preview =
+                assertNotNull(
+                    findComponent(dialogPanel, SyntaxPreviewComponent::class.java),
+                    "Syntax tab must include the native syntax preview component.",
+                )
+            val editor =
+                assertNotNull(
+                    findComponent(preview, EditorTextField::class.java),
+                    "Syntax preview must embed EditorTextField for native syntax highlighting.",
+                )
+
+            assertEquals("JavaScript", preview.languageForTest())
+            assertEquals(javaScriptFileType, editor.fileType)
+        } finally {
+            syntaxPanel.dispose()
+        }
+    }
+
+    @Test
     fun `language selector updates syntax preview language and file type`() {
         stateBase.selectedPreset = "CUSTOM"
         val syntaxPanel = AyuIslandsSyntaxPanel()

--- a/src/test/kotlin/dev/ayuislands/settings/SyntaxPreviewComponentTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/SyntaxPreviewComponentTest.kt
@@ -166,6 +166,22 @@ class SyntaxPreviewComponentTest {
     }
 
     @Test
+    fun `preserves language fallbacks without file types`() {
+        val unavailableFileType = editorFixture.mockFileType("Unavailable", "txt")
+        every { editorFixture.fileTypeManager.getStdFileType(any()) } returns unavailableFileType
+
+        assertEquals(
+            "Kotlin",
+            SyntaxPreviewComponent.preferredAvailableLanguage(listOf("Java", "Kotlin"), "Kotlin"),
+        )
+        assertEquals(
+            "Java",
+            SyntaxPreviewComponent.preferredAvailableLanguage(listOf("Java", "Python"), "Kotlin"),
+        )
+        assertEquals("", SyntaxPreviewComponent.preferredAvailableLanguage(emptyList(), "Kotlin"))
+    }
+
+    @Test
     fun `preferred size is non-zero`() {
         val component = SyntaxPreviewComponent(AyuVariant.MIRAGE)
         val preferred = component.preferredSize


### PR DESCRIPTION
## Summary

WebStorm does not provide the Kotlin file type used by the syntax preview's default language. The preview therefore fell back to plain text and made syntax controls appear ineffective.

## Changes

- Select the preferred preview language only when its file type is available.
- Fall back to the first supported language with an available file type.
- Keep the existing plain-text fallback when no supported file type is installed.
- Cover the WebStorm-like Kotlin-unavailable, Java-unavailable, JavaScript-available case.

## Validation

- `./gradlew test --rerun-tasks`
- `./gradlew integrationTest detekt ktlintCheck koverVerify build verifyPlugin`
- `scripts/verify-docs.py`

## Notes

This changes only the initial preview language selection. Manual language choices and persisted user preferences are untouched.

Fixes #321

## Summary by Sourcery

Improve initial syntax preview language selection to prefer languages with available file types and maintain a plain-text fallback when none are available.

Bug Fixes:
- Ensure the initial syntax preview language does not fall back to plain text when a supported language with an available file type is installed.

Enhancements:
- Introduce a preferred-available-language selection helper reused by the syntax panel.
- Expose the syntax preview component companion for reuse in language selection.

Tests:
- Add a test covering the case where Kotlin and Java file types are unavailable but JavaScript is available, verifying language and file type selection.