### PR TITLE
chore(release): prepare v2.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [2.8.4] - 2026-08-14
+
+- [Fix] **Reliable editor color refreshes in Rider** — startup and settings
+  changes no longer trigger write-thread access errors while Ayu refreshes the
+  active editor color scheme.
+- [Fix] **Syntax preview highlighting in WebStorm** — syntax preset previews
+  now use an available language in the host IDE instead of falling back to a
+  plain-text Kotlin sample.
+
 ## [2.8.3] - 2026-08-10
 
 - [Fix] **Safer Accent settings reset** — resetting the Accent section now

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.8.3
+pluginVersion=2.8.4
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
@@ -70,6 +70,11 @@ internal object UpdateNotifier {
 
     private val RELEASE_NOTES =
         mapOf(
+            "2.8.4" to
+                releaseNotes(
+                    "[Fix] Rider editor color refreshes no longer trigger write-thread access errors",
+                    "[Fix] WebStorm syntax previews use an available language instead of plain text",
+                ),
             "2.8.3" to
                 releaseNotes(
                     items =

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -121,6 +121,11 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>2.8.4</h3>
+    <ul>
+      <li>[Fix] <b>Reliable editor color refreshes in Rider</b> — startup and settings changes no longer trigger write-thread access errors while Ayu refreshes the active editor color scheme.</li>
+      <li>[Fix] <b>Syntax preview highlighting in WebStorm</b> — syntax preset previews now use an available language in the host IDE instead of falling back to a plain-text Kotlin sample.</li>
+    </ul>
     <h3>2.8.3</h3>
     <ul>
       <li>[Fix] <b>Safer Accent settings reset</b> — resetting the Accent section now restores only its default accent mode without resetting Glow, rotation, project icons, syntax, or other Ayu preferences. The change still requires Apply and can be discarded with Cancel.</li>


### PR DESCRIPTION
── Summary ─────────────────────────────────

Prepare Ayu Islands 2.8.4 so Rider users receive reliable editor color refreshes and WebStorm syntax previews retain real highlighting.

── Changes ─────────────────────────────────

- Chore: [gradle.properties](gradle.properties) — Bump the plugin version to 2.8.4.
- Docs: [CHANGELOG.md](CHANGELOG.md) and [plugin.xml](src/main/resources/META-INF/plugin.xml) — Publish the two user-facing fixes in the changelog and Marketplace notes.
- Chore: [UpdateNotifier.kt](src/main/kotlin/dev/ayuislands/UpdateNotifier.kt) — Show matching concise notes after the IDE updates the plugin.

── Validation ──────────────────────────────

```bash
scripts/verify-docs.py
./gradlew detekt ktlintCheck
./gradlew clean buildPlugin
./gradlew test koverVerify
./gradlew verifyPlugin
```

- Full unit and integration suite passed; Kover verification passed.
- Plugin Verifier reported `Compatible` for all 12 configured IDE targets.
- IDEA inspections reported no warnings in the changed Kotlin or XML files.
- Built artifact: `ayu-jetbrains-2.8.4.zip` (`c7be9265fcc78db79c19cd3e0013b7ab4747e7ebe1cb80f9f88811b33454b922`).

── Notes ───────────────────────────────────

The paid product metadata remains `release-date="20260718"` and `release-version="28"`; Marketplace requires that pair to stay aligned throughout the 2.8.x patch line.

## Summary by Sourcery

Prepare the Ayu Islands plugin 2.8.4 release with documented fixes and in-IDE update notes.

Bug Fixes:
- Ensure Rider reliably refreshes editor color schemes without write-thread access errors during startup or settings changes.
- Restore proper syntax preview highlighting in WebStorm by using an available host language instead of a plain-text Kotlin sample.

Enhancements:
- Add concise 2.8.4 release notes to the in-IDE update notifier so users see the new fixes after updating.

Build:
- Bump the plugin version to 2.8.4 in Gradle properties.

Documentation:
- Document the 2.8.4 fixes in the changelog and Marketplace change notes.