### PR TITLE
ci: route release verifier through retry wrapper

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           java-version: 21
       - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
       - name: Verify plugin
-        run: ./gradlew verifyPlugin -DverifyGroup=${{ matrix.group }}
+        run: scripts/gradle-retry.sh verifyPlugin -DverifyGroup=${{ matrix.group }}
       - name: Fail on internal API verifier findings
         run: python3 scripts/verify-plugin-verifier.py
 

--- a/scripts/tests/test-gradle-retry.py
+++ b/scripts/tests/test-gradle-retry.py
@@ -10,9 +10,19 @@ import unittest
 from pathlib import Path
 
 SCRIPT = Path(__file__).resolve().parent.parent / "gradle-retry.sh"
+REPOSITORY_ROOT = SCRIPT.parent.parent
+RELEASE_WORKFLOW = REPOSITORY_ROOT / ".github" / "workflows" / "release.yml"
 
 
 class GradleRetryTest(unittest.TestCase):
+    def test_release_verifier_uses_retry_wrapper(self) -> None:
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "run: scripts/gradle-retry.sh verifyPlugin -DverifyGroup=${{ matrix.group }}",
+            workflow,
+        )
+
     def test_retry_rebuilds_generated_caches_only(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)


### PR DESCRIPTION
── Summary ─────────────────────────────────

Release verification can fail on a transient IntelliJ `layoutIndex` cache corruption even when the same commit passes pull-request CI. Route every release verifier shard through the existing signature-gated Gradle retry wrapper so only that known failure is retried after generated caches are rebuilt.

── Changes ─────────────────────────────────

| Type | File | Description |
|------|------|-------------|
| Chore | [release.yml:30](.github/workflows/release.yml#L30) | Run all verifier matrix groups through the existing retry wrapper. |
| Test | [test-gradle-retry.py:18](scripts/tests/test-gradle-retry.py#L18) | Lock the release workflow to the wrapper contract. |

── Validation ──────────────────────────────

- `python3 scripts/tests/test-gradle-retry.py` — 2 tests passed.
- `pre-commit run --files .github/workflows/release.yml scripts/tests/test-gradle-retry.py` — all applicable hooks passed, including YAML and zizmor.
- `./gradlew detekt ktlintCheck` — build successful.
- `git diff --check origin/main...HEAD` — passed.

── Notes ───────────────────────────────────

The retry signature, retry count, cache cleanup policy, plugin userspace, and published 2.8.4 release are unchanged.

## Summary by Sourcery

Route release verifier workflow jobs through the Gradle retry wrapper to mitigate transient cache-related failures and lock this behavior in with a test.

Bug Fixes:
- Ensure release verification reruns via the retry wrapper when transient IntelliJ layoutIndex cache corruption occurs.

Enhancements:
- Update the release workflow to invoke verifyPlugin via the shared gradle-retry.sh wrapper for all matrix groups.

Tests:
- Add a test that asserts the release workflow uses the gradle-retry.sh wrapper for plugin verification.

Chores:
- Tie the release CI configuration to the established Gradle retry contract for verifier jobs.