### PR TITLE
fix: eliminate syntax and glow startup anomalies

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -324,7 +324,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "5ce0243b"
+          last_verified_sha: "cfb06f32"
           last_verified_date: "2026-08-09"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -324,7 +324,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "7e2cf29a"
+          last_verified_sha: "e7e3349f"
           last_verified_date: "2026-08-09"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "c06a1411"
+          last_verified_sha: "d1527289"
           last_verified_date: "2026-08-09"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "c06a1411"
+          last_verified_sha: "d1527289"
           last_verified_date: "2026-08-09"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -393,7 +393,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "c06a1411"
+          last_verified_sha: "d1527289"
           last_verified_date: "2026-08-09"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -324,7 +324,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "fe11eb27"
+          last_verified_sha: "8f06b8be"
           last_verified_date: "2026-08-09"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -324,7 +324,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "88e28516"
+          last_verified_sha: "7e2cf29a"
           last_verified_date: "2026-08-09"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -445,7 +445,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "fe11eb27"
+          last_verified_sha: "7e2cf29a"
           last_verified_date: "2026-08-09"
           content_sha256: ad849b17308901bc2dac85f895978be656f578c9c31f857b9e9578e5cf4289f2
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -324,7 +324,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "cfb06f32"
+          last_verified_sha: "88e28516"
           last_verified_date: "2026-08-09"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -324,7 +324,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "8f06b8be"
+          last_verified_sha: "86e613ea"
           last_verified_date: "2026-08-09"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -324,7 +324,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "86e613ea"
+          last_verified_sha: "5ce0243b"
           last_verified_date: "2026-08-09"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -2,6 +2,7 @@ package dev.ayuislands
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.EDT
+import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
@@ -214,7 +215,7 @@ internal class AyuIslandsStartupActivity(
         // The notification fires exactly once per install via a distinct
         // PropertiesComponent flag (`ayu.syntax.intensity.notified`) so users
         // who saw the prior syntax notification still receive this message.
-        SwingUtilities.invokeLater { SyntaxIntensityService.getInstance().reapplyForActiveLaf() }
+        dispatchWriteSafe { SyntaxIntensityService.getInstance().reapplyForActiveLaf() }
         SwingUtilities.invokeLater { SyntaxIntensityMigrationNotifier.maybeFire(project) }
 
         // Initialize the glow overlay system if the glow is enabled
@@ -402,8 +403,8 @@ internal class AyuIslandsStartupActivity(
         // catch used to produce a generic "License defaults failed" with no way to tell
         // whether migration, orchestrator routing, defaults, workspace init, wizard
         // scheduling, or trial warning blew up.
-        SwingUtilities.invokeLater {
-            if (project.isDisposed) return@invokeLater
+        dispatchWriteSafe {
+            if (project.isDisposed) return@dispatchWriteSafe
             var wizardAction: WizardAction? = null
 
             runStep("onboarding-migration") { StartupLicenseHandler.runOnboardingMigration(settings) }
@@ -436,6 +437,15 @@ internal class AyuIslandsStartupActivity(
                 runStep("check-trial-expiry") { LicenseChecker.checkTrialExpiryWarning(project) }
             }
         }
+    }
+
+    private fun dispatchWriteSafe(action: Runnable) {
+        val application = ApplicationManager.getApplication()
+        if (application == null) {
+            SwingUtilities.invokeLater(action)
+            return
+        }
+        application.invokeLater(action, ModalityState.nonModal())
     }
 
     private fun applyDefinitiveEntitlement(
@@ -596,8 +606,8 @@ internal class AyuIslandsStartupActivity(
      * log line, and the JVM's error-escalation path stays intact for genuinely fatal errors.
      *
      * Most production call sites (the license-handling block in [checkLicenseState]
-     * and friends) run inside `SwingUtilities.invokeLater { ... }`, so the surrounding
-     * Runnable is dispatched by `IdeEventQueue`. The `apply-persisted-vcs-colors` step
+     * and friends) run inside `Application.invokeLater`, so the surrounding
+     * [Runnable] is dispatched by `IdeEventQueue`. The `apply-persisted-vcs-colors` step
      * runs from the coroutine body of [execute] instead — RuntimeException semantics
      * are identical regardless of thread context:
      *

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -171,10 +171,7 @@ internal class AyuIslandsStartupActivity(
         // AccentApplicator only updates UIManager + editor scheme; cached JBColor instances on
         // already-painted components otherwise keep the global-accent values they captured when
         // the frame first rendered.
-        SwingUtilities.invokeLater {
-            val frame = WindowManager.getInstance().getFrame(project) ?: return@invokeLater
-            ComponentTreeRefresher.walkAndNotify(project, frame)
-        }
+        scheduleFrameRefresh(project)
 
         // Apply persisted font preset (FontPresetApplicator ensures EDT internally)
         // Migrate legacy preset names (GLOW_WRITER→WHISPER, CLEAN→AMBIENT, etc.)
@@ -446,6 +443,13 @@ internal class AyuIslandsStartupActivity(
             return
         }
         application.invokeLater(action, ModalityState.nonModal())
+    }
+
+    private fun scheduleFrameRefresh(project: Project) {
+        dispatchWriteSafe {
+            val frame = WindowManager.getInstance().getFrame(project) ?: return@dispatchWriteSafe
+            ComponentTreeRefresher.walkAndNotify(project, frame)
+        }
     }
 
     private fun applyDefinitiveEntitlement(

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -213,7 +213,7 @@ internal class AyuIslandsStartupActivity(
         // PropertiesComponent flag (`ayu.syntax.intensity.notified`) so users
         // who saw the prior syntax notification still receive this message.
         dispatchWriteSafe { SyntaxIntensityService.getInstance().reapplyForActiveLaf() }
-        SwingUtilities.invokeLater { SyntaxIntensityMigrationNotifier.maybeFire(project) }
+        dispatchWriteSafe { SyntaxIntensityMigrationNotifier.maybeFire(project) }
 
         // Initialize the glow overlay system if the glow is enabled
         // Uses ApplicationManager.invokeLater with project.disposed condition to skip

--- a/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt
@@ -1,6 +1,7 @@
 package dev.ayuislands.accent
 
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.DumbService
@@ -358,22 +359,33 @@ object ProjectLanguageDetector {
             LOG.debug("publishScanCompleted dropped before invokeLater: project already disposed")
             return
         }
-        SwingUtilities.invokeLater {
-            if (project.isDisposed) {
-                if (cacheKey != null && cacheEntry != null) {
-                    verdictCache.remove(cacheKey, cacheEntry)
+        dispatchWriteSafe(
+            Runnable {
+                if (project.isDisposed) {
+                    if (cacheKey != null && cacheEntry != null) {
+                        verdictCache.remove(cacheKey, cacheEntry)
+                    }
+                    LOG.debug("publishScanCompleted dropped inside invokeLater: project disposed during EDT hop")
+                    return@Runnable
                 }
-                LOG.debug("publishScanCompleted dropped inside invokeLater: project disposed during EDT hop")
-                return@invokeLater
-            }
-            runCatchingPreservingCancellation {
-                project.messageBus
-                    .syncPublisher(ProjectLanguageDetectionListener.TOPIC)
-                    .scanCompleted(outcome)
-            }.onFailure { exception ->
-                LOG.warn("scanCompleted publish failed; subscribers will not refresh for this scan", exception)
-            }
+                runCatchingPreservingCancellation {
+                    project.messageBus
+                        .syncPublisher(ProjectLanguageDetectionListener.TOPIC)
+                        .scanCompleted(outcome)
+                }.onFailure { exception ->
+                    LOG.warn("scanCompleted publish failed; subscribers will not refresh for this scan", exception)
+                }
+            },
+        )
+    }
+
+    private fun dispatchWriteSafe(action: Runnable) {
+        val application = ApplicationManager.getApplication()
+        if (application == null) {
+            SwingUtilities.invokeLater(action)
+            return
         }
+        application.invokeLater(action, ModalityState.nonModal())
     }
 
     /**

--- a/src/main/kotlin/dev/ayuislands/accent/ScanCompletionAccentRefresher.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ScanCompletionAccentRefresher.kt
@@ -22,9 +22,9 @@ import dev.ayuislands.settings.mappings.ProjectAccentSwapService
  * one. [ScanOutcome.Unavailable] is transient — the cache was not populated,
  * so there is nothing new to apply and the previous accent stays put.
  *
- * Threading: [ProjectLanguageDetectionListener] handlers run on the EDT
- * (`publishScanCompleted` dispatches the publish via `invokeLater`), so the
- * resolver + apply chain here needs no additional dispatch. The subscription
+ * Threading: [ProjectLanguageDetectionListener] handlers run in an IntelliJ
+ * write-safe EDT context (`publishScanCompleted` uses `Application.invokeLater`),
+ * so the resolver + apply chain here needs no additional dispatch. The subscription
  * is anchored to this service's own [Disposable], so it is torn down with
  * the project (the service container disposes project services on close).
  */
@@ -60,8 +60,8 @@ internal class ScanCompletionAccentRefresher(
      * EDT body of the post-scan refresh. Returns early on disposal, logs and
      * swallows any downstream apply failure. The EDT contract is enforced only
      * transitively by `publishScanCompleted`'s dispatch choice — a future
-     * producer publishing off-EDT would race the UIManager writes downstream,
-     * so keep that dispatch the sole publish path.
+     * producer publishing outside the platform EDT context would race the
+     * `UIManager` writes downstream, so keep that dispatch the sole publish path.
      */
     private fun refreshAccent() {
         if (project.isDisposed) return

--- a/src/main/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManager.kt
+++ b/src/main/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManager.kt
@@ -32,6 +32,7 @@ class CommitPanelAutoFitManager(
         }
     private var pathRendererTree: JTree? = null
     private var pathRendererListener: PropertyChangeListener? = null
+    private var canShortenPaths = false
 
     init {
         project.messageBus.connect(this).subscribe(
@@ -58,7 +59,8 @@ class CommitPanelAutoFitManager(
     }
 
     fun apply() {
-        if (!LicenseChecker.isLicensedOrGrace()) {
+        canShortenPaths = LicenseChecker.isLicensedOrGrace()
+        if (!canShortenPaths) {
             removePathRenderer()
             autoFitter.removeExpansionListener()
             return
@@ -74,6 +76,7 @@ class CommitPanelAutoFitManager(
     }
 
     override fun dispose() {
+        canShortenPaths = false
         removePathRenderer()
         autoFitter.removeExpansionListener()
     }
@@ -103,7 +106,7 @@ class CommitPanelAutoFitManager(
             tree.cellRenderer =
                 CommitPathShorteningRenderer(
                     current,
-                    canApply = { LicenseChecker.isLicensedOrGrace() },
+                    canApply = { canShortenPaths },
                 )
             refreshTree(tree)
         }
@@ -134,7 +137,8 @@ class CommitPanelAutoFitManager(
                 val newRenderer = event.newValue as? TreeCellRenderer ?: return@PropertyChangeListener
                 if (newRenderer is CommitPathShorteningRenderer) return@PropertyChangeListener
 
-                if (!LicenseChecker.isLicensedOrGrace()) {
+                canShortenPaths = LicenseChecker.isLicensedOrGrace()
+                if (!canShortenPaths) {
                     removePathRenderer()
                     return@PropertyChangeListener
                 }
@@ -150,7 +154,7 @@ class CommitPanelAutoFitManager(
                 tree.cellRenderer =
                     CommitPathShorteningRenderer(
                         newRenderer,
-                        canApply = { LicenseChecker.isLicensedOrGrace() },
+                        canApply = { canShortenPaths },
                     )
                 refreshTree(tree)
             }

--- a/src/main/kotlin/dev/ayuislands/font/FontPresetApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/font/FontPresetApplicator.kt
@@ -1,5 +1,7 @@
 package dev.ayuislands.font
 
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.colors.ModifiableFontPreferences
@@ -93,7 +95,12 @@ object FontPresetApplicator {
         if (SwingUtilities.isEventDispatchThread()) {
             action()
         } else {
-            SwingUtilities.invokeLater(action)
+            val application = ApplicationManager.getApplication()
+            if (application == null) {
+                SwingUtilities.invokeLater(action)
+            } else {
+                application.invokeLater(action, ModalityState.nonModal())
+            }
         }
     }
 }

--- a/src/main/kotlin/dev/ayuislands/glow/EditorTabGeometry.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/EditorTabGeometry.kt
@@ -71,10 +71,13 @@ object EditorTabGeometry {
      */
     fun calculateEditorOverlayBounds(host: JComponent): Rectangle = editorOverlayGeometry(host).contentBounds
 
-    internal fun editorOverlayGeometry(host: JComponent): EditorOverlayGeometry {
+    internal fun editorOverlayGeometry(
+        host: JComponent,
+        shouldReportFallback: Boolean = true,
+    ): EditorOverlayGeometry {
         val editorTabs = findEditorTabsRecursive(host) as? Container
         if (editorTabs == null) {
-            if (warnedHosts.add("EditorTabsOverlay:${host.javaClass.name}")) {
+            if (shouldReportFallback && warnedHosts.add("EditorTabsOverlay:${host.javaClass.name}")) {
                 log.warn("EditorTabs not found in ${host.javaClass.name}, using DEFAULT_TAB_HEIGHT for overlay")
             }
             val tabStripBottom = DEFAULT_TAB_HEIGHT
@@ -122,7 +125,7 @@ object EditorTabGeometry {
             return geometryFor(fullHostBounds, editorTabs, host)
         }
 
-        if (warnedHosts.add("TabLabelOverlay:${editorTabs.javaClass.name}")) {
+        if (shouldReportFallback && warnedHosts.add("TabLabelOverlay:${editorTabs.javaClass.name}")) {
             log.warn("TabLabel not found in EditorTabs, using DEFAULT_TAB_HEIGHT for overlay")
         }
         val tabStripBottom = DEFAULT_TAB_HEIGHT

--- a/src/main/kotlin/dev/ayuislands/glow/GlowGlassPane.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/GlowGlassPane.kt
@@ -454,10 +454,6 @@ class GlowGlassPane(
         waveformFrame = null
         waveformPlan = null
     }
-
-    fun invalidateRendererCache() {
-        renderer.invalidateCache()
-    }
 }
 
 private data class SolidPaintStyle(

--- a/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
@@ -383,10 +383,12 @@ class GlowOverlayManager(
         if (!host.isShowing) return
         try {
             val point = SwingUtilities.convertPoint(host, 0, 0, layeredPane)
+            val canReportFallback =
+                !glassPane.isEditorOverlay || FileEditorManager.getInstance(project).selectedEditor != null
             if (glassPane.usesWaveformBounds) {
                 val geometry =
                     if (glassPane.isEditorOverlay) {
-                        EditorTabGeometry.editorOverlayGeometry(host, shouldReportFallback)
+                        EditorTabGeometry.editorOverlayGeometry(host, shouldReportFallback && canReportFallback)
                     } else {
                         EditorOverlayGeometry(
                             contentBounds = Rectangle(0, 0, host.width, host.height),
@@ -407,7 +409,10 @@ class GlowOverlayManager(
                 glassPane.waveformInwardEdges = clippedWaveformEdges(overlayBounds, layeredPane.visibleRect)
             } else if (glassPane.isEditorOverlay) {
                 glassPane.waveformInwardEdges = emptySet()
-                val bounds = EditorTabGeometry.editorOverlayGeometry(host, shouldReportFallback).contentBounds
+                val bounds =
+                    EditorTabGeometry
+                        .editorOverlayGeometry(host, shouldReportFallback && canReportFallback)
+                        .contentBounds
                 glassPane.bounds = Rectangle(point.x + bounds.x, point.y + bounds.y, bounds.width, bounds.height)
             } else {
                 glassPane.waveformInwardEdges = emptySet()

--- a/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
@@ -430,10 +430,12 @@ class GlowOverlayManager(
         layeredPane: JLayeredPane,
     ) {
         SwingUtilities.invokeLater {
+            if (disposed || !host.isShowing) return@invokeLater
             updateOverlayBounds(glassPane, host, layeredPane, shouldReportFallback = false)
             if (!glassPane.isEditorOverlay) return@invokeLater
 
             SwingUtilities.invokeLater {
+                if (disposed || !host.isShowing) return@invokeLater
                 updateOverlayBounds(glassPane, host, layeredPane, shouldReportFallback = true)
             }
         }

--- a/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
@@ -372,6 +372,13 @@ class GlowOverlayManager(
         glassPane: GlowGlassPane,
         host: JComponent,
         layeredPane: JLayeredPane,
+    ) = updateOverlayBounds(glassPane, host, layeredPane, shouldReportFallback = true)
+
+    private fun updateOverlayBounds(
+        glassPane: GlowGlassPane,
+        host: JComponent,
+        layeredPane: JLayeredPane,
+        shouldReportFallback: Boolean,
     ) {
         if (!host.isShowing) return
         try {
@@ -379,7 +386,7 @@ class GlowOverlayManager(
             if (glassPane.usesWaveformBounds) {
                 val geometry =
                     if (glassPane.isEditorOverlay) {
-                        EditorTabGeometry.editorOverlayGeometry(host)
+                        EditorTabGeometry.editorOverlayGeometry(host, shouldReportFallback)
                     } else {
                         EditorOverlayGeometry(
                             contentBounds = Rectangle(0, 0, host.width, host.height),
@@ -400,7 +407,7 @@ class GlowOverlayManager(
                 glassPane.waveformInwardEdges = clippedWaveformEdges(overlayBounds, layeredPane.visibleRect)
             } else if (glassPane.isEditorOverlay) {
                 glassPane.waveformInwardEdges = emptySet()
-                val bounds = EditorTabGeometry.calculateEditorOverlayBounds(host)
+                val bounds = EditorTabGeometry.editorOverlayGeometry(host, shouldReportFallback).contentBounds
                 glassPane.bounds = Rectangle(point.x + bounds.x, point.y + bounds.y, bounds.width, bounds.height)
             } else {
                 glassPane.waveformInwardEdges = emptySet()
@@ -410,6 +417,21 @@ class GlowOverlayManager(
             log.debug("Component hierarchy changed during overlay bounds update", exception)
         }
         routeController.scheduleGraphRefresh()
+    }
+
+    private fun scheduleBoundsSettling(
+        glassPane: GlowGlassPane,
+        host: JComponent,
+        layeredPane: JLayeredPane,
+    ) {
+        SwingUtilities.invokeLater {
+            updateOverlayBounds(glassPane, host, layeredPane, shouldReportFallback = false)
+            if (!glassPane.isEditorOverlay) return@invokeLater
+
+            SwingUtilities.invokeLater {
+                updateOverlayBounds(glassPane, host, layeredPane, shouldReportFallback = true)
+            }
+        }
     }
 
     private fun attachOverlay(
@@ -448,7 +470,7 @@ class GlowOverlayManager(
             )
         if (isEditorOverlay) {
             glassPane.topSpansProvider = {
-                EditorTabGeometry.editorOverlayGeometry(host).occupiedTopSpans
+                EditorTabGeometry.editorOverlayGeometry(host, shouldReportFallback = false).occupiedTopSpans
             }
         }
         glassPane.configureWaveform(
@@ -461,7 +483,7 @@ class GlowOverlayManager(
 
         layeredPane.setLayer(glassPane, JLayeredPane.PALETTE_LAYER)
         layeredPane.add(glassPane)
-        updateOverlayBounds(glassPane, host, layeredPane)
+        updateOverlayBounds(glassPane, host, layeredPane, shouldReportFallback = false)
 
         val compListener =
             object : ComponentAdapter() {
@@ -479,9 +501,7 @@ class GlowOverlayManager(
             }
         host.addHierarchyBoundsListener(boundsListener)
 
-        SwingUtilities.invokeLater {
-            updateOverlayBounds(glassPane, host, layeredPane)
-        }
+        scheduleBoundsSettling(glassPane, host, layeredPane)
 
         overlays[id] = OverlayEntry(glassPane, host, layeredPane, compListener, boundsListener)
         routeController.scheduleGraphRefresh()

--- a/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt
@@ -744,7 +744,6 @@ class GlowOverlayManager(
                 resolveGlowPlacement(isEditorOverlay = glassPane.isEditorOverlay, state = state)
             glassPane.configureWaveform(GlowShape.fromName(state.glowShape), resolveWaveformConfig(state))
             updateOverlayBounds(glassPane, host, layeredPane)
-            glassPane.invalidateRendererCache()
             glassPane.repaint()
         }
     }

--- a/src/main/kotlin/dev/ayuislands/glow/GlowRenderer.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/GlowRenderer.kt
@@ -9,6 +9,7 @@ import java.awt.Component
 import java.awt.Graphics2D
 import java.awt.Rectangle
 import java.awt.RenderingHints
+import java.awt.Shape
 import java.awt.geom.Area
 import java.awt.geom.RoundRectangle2D
 import java.awt.image.BufferedImage
@@ -30,6 +31,7 @@ class GlowRenderer {
         private const val NEON_BLOOM_INTENSITY = 0.6f
         private const val FRAME_RENDER_BUDGET_MS = 16.0
         private const val NANOS_PER_MS = 1_000_000.0
+        private const val CACHE_EDGE_PADDING = 2
     }
 
     // Style cache (lightweight, recomputed on style/color change)
@@ -38,6 +40,7 @@ class GlowRenderer {
         val color: Color,
         val intensity: Int,
         val glowWidth: Int,
+        val isLightTheme: Boolean,
     )
 
     private var styleKey: StyleKey? = null
@@ -57,8 +60,38 @@ class GlowRenderer {
         val edgesOnly: Boolean,
     )
 
+    private data class GlowLayer(
+        val shape: Shape,
+        val color: Color,
+    )
+
+    private data class FrameSlice(
+        val image: BufferedImage,
+        val x: Int,
+        val y: Int,
+    )
+
+    private data class FrameCache(
+        val slices: List<FrameSlice>,
+    ) {
+        val pixelCount: Long = slices.sumOf { it.image.width.toLong() * it.image.height }
+
+        fun paint(
+            graphics: Graphics2D,
+            x: Int,
+            y: Int,
+        ) {
+            slices.forEach { slice ->
+                graphics.drawImage(slice.image, x + slice.x, y + slice.y, null)
+            }
+        }
+    }
+
     private var frameKey: FrameKey? = null
-    private var cachedFrame: BufferedImage? = null
+    private var cachedFrame: FrameCache? = null
+
+    internal val cachedPixelCount: Long
+        get() = cachedFrame?.pixelCount ?: 0L
 
     fun ensureCache(
         accentColor: Color,
@@ -66,15 +99,14 @@ class GlowRenderer {
         intensity: Int = 40,
         glowWidth: Int = DEFAULT_GLOW_WIDTH,
     ) {
-        val key = StyleKey(style, accentColor, intensity, glowWidth)
+        val panelBackground = UIManager.getColor("Panel.background")
+        val isLightTheme = panelBackground != null && !ColorUtil.isDark(panelBackground)
+        val key = StyleKey(style, accentColor, intensity, glowWidth, isLightTheme)
         if (key == styleKey) return
 
         val baseAlpha = (intensity / PERCENTAGE_DIVISOR * MAX_ALPHA).toInt().coerceIn(0, MAX_ALPHA)
-
-        val panelBackground = UIManager.getColor("Panel.background")
-        val isLight = panelBackground != null && !ColorUtil.isDark(panelBackground)
         cachedBaseAlpha =
-            if (isLight) {
+            if (isLightTheme) {
                 (baseAlpha * LIGHT_THEME_ALPHA_MULTIPLIER).toInt().coerceIn(0, MAX_ALPHA)
             } else {
                 baseAlpha
@@ -89,7 +121,7 @@ class GlowRenderer {
     }
 
     /**
-     * Paints glow from a cached BufferedImage (~0.5ms after first render):
+     * Paints glow from cached border slices:
      * concentric rounded rectangles from edge inward, or — with [edgesOnly] —
      * straight full-height vertical falloff strips on the left and right,
      * with no corner arcs at all.
@@ -103,7 +135,7 @@ class GlowRenderer {
     ) {
         if (bounds.width <= 0 || bounds.height <= 0) return
 
-        val fKey =
+        val nextFrameKey =
             FrameKey(
                 bounds.width,
                 bounds.height,
@@ -115,7 +147,7 @@ class GlowRenderer {
                 edgesOnly,
             )
 
-        if (fKey != frameKey || cachedFrame == null) {
+        if (nextFrameKey != frameKey || cachedFrame == null) {
             val startNanos = System.nanoTime()
             cachedFrame =
                 if (edgesOnly) {
@@ -123,14 +155,14 @@ class GlowRenderer {
                 } else {
                     renderFrame(bounds.width, bounds.height, arcWidth, glowWidth)
                 }
-            frameKey = fKey
+            frameKey = nextFrameKey
             val elapsedMs = (System.nanoTime() - startNanos) / NANOS_PER_MS
             if (elapsedMs > FRAME_RENDER_BUDGET_MS) {
                 log.warn("Glow frame render took %.2fms (target: <16ms) — cached for reuse".format(elapsedMs))
             }
         }
 
-        graphics.drawImage(cachedFrame, bounds.x, bounds.y, null)
+        cachedFrame?.paint(graphics, bounds.x, bounds.y)
     }
 
     private fun renderFrame(
@@ -138,45 +170,14 @@ class GlowRenderer {
         height: Int,
         arcWidth: Int,
         glowWidth: Int,
-    ): BufferedImage {
-        val image = UIUtil.createImage(null as Component?, width, height, BufferedImage.TYPE_INT_ARGB)
-        val g2 = image.createGraphics()
-        try {
-            g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+    ): FrameCache {
+        val layers = frameLayers(width, height, arcWidth, glowWidth)
+        if (layers.isEmpty()) return FrameCache(emptyList())
 
-            for (i in 0 until glowWidth) {
-                val progress = i.toFloat() / glowWidth.toFloat()
-                val alpha = computeAlpha(progress)
-                if (alpha <= 0) continue
-
-                g2.color = ColorUtil.toAlpha(cachedColor, alpha)
-
-                val inset = i.toDouble()
-                val outerW = (width - 2.0 * inset).coerceAtLeast(0.0)
-                val outerH = (height - 2.0 * inset).coerceAtLeast(0.0)
-                if (outerW <= 0 || outerH <= 0) break
-
-                val outerArc = if (arcWidth > 0) (arcWidth.toDouble() - 2.0 * i).coerceAtLeast(0.0) else 0.0
-                val outer = RoundRectangle2D.Double(inset, inset, outerW, outerH, outerArc, outerArc)
-
-                val nextInset = inset + 1.0
-                val innerW = (width - 2.0 * nextInset).coerceAtLeast(0.0)
-                val innerH = (height - 2.0 * nextInset).coerceAtLeast(0.0)
-
-                if (innerW > 0 && innerH > 0) {
-                    val innerArc = if (arcWidth > 0) (arcWidth.toDouble() - 2.0 * (i + 1)).coerceAtLeast(0.0) else 0.0
-                    val inner = RoundRectangle2D.Double(nextInset, nextInset, innerW, innerH, innerArc, innerArc)
-                    val ring = Area(outer)
-                    ring.subtract(Area(inner))
-                    g2.fill(ring)
-                } else {
-                    g2.fill(outer)
-                }
-            }
-        } finally {
-            g2.dispose()
-        }
-        return image
+        val arcExtent = (arcWidth.coerceAtLeast(0) + 1) / 2
+        val thickness = maxOf(glowWidth + CACHE_EDGE_PADDING, arcExtent + CACHE_EDGE_PADDING)
+        val slices = borderRegions(width, height, thickness).map { region -> renderSlice(region, layers) }
+        return FrameCache(slices)
     }
 
     // Side-edges placement: two mirrored vertical falloff strips, every column
@@ -185,28 +186,148 @@ class GlowRenderer {
         width: Int,
         height: Int,
         glowWidth: Int,
-    ): BufferedImage {
-        val image = UIUtil.createImage(null as Component?, width, height, BufferedImage.TYPE_INT_ARGB)
-        val g2 = image.createGraphics()
-        try {
-            val columns = glowWidth.coerceAtMost((width + 1) / 2)
-            for (i in 0 until columns) {
-                val progress = i.toFloat() / glowWidth.toFloat()
+    ): FrameCache {
+        val columns = glowWidth.coerceAtMost((width + 1) / 2)
+        if (columns <= 0) return FrameCache(emptyList())
+
+        val slices =
+            sideRegions(width, height, columns).map { region ->
+                renderSideSlice(region, width, height, glowWidth)
+            }
+        return FrameCache(slices)
+    }
+
+    private fun frameLayers(
+        width: Int,
+        height: Int,
+        arcWidth: Int,
+        glowWidth: Int,
+    ): List<GlowLayer> =
+        buildList {
+            for (index in 0 until glowWidth) {
+                val progress = index.toFloat() / glowWidth.toFloat()
                 val alpha = computeAlpha(progress)
                 if (alpha <= 0) continue
 
-                g2.color = ColorUtil.toAlpha(cachedColor, alpha)
-                g2.fillRect(i, 0, 1, height)
-                // On odd-width overlays the strips meet in the middle; paint
-                // the shared center column once or SrcOver doubles its alpha
-                // into a bright seam.
-                val rightX = width - 1 - i
-                if (rightX != i) g2.fillRect(rightX, 0, 1, height)
+                val inset = index.toDouble()
+                val outerWidth = (width - 2.0 * inset).coerceAtLeast(0.0)
+                val outerHeight = (height - 2.0 * inset).coerceAtLeast(0.0)
+                if (outerWidth <= 0 || outerHeight <= 0) break
+
+                val outerArc = if (arcWidth > 0) (arcWidth.toDouble() - 2.0 * index).coerceAtLeast(0.0) else 0.0
+                val outer = RoundRectangle2D.Double(inset, inset, outerWidth, outerHeight, outerArc, outerArc)
+                val nextInset = inset + 1.0
+                val innerWidth = (width - 2.0 * nextInset).coerceAtLeast(0.0)
+                val innerHeight = (height - 2.0 * nextInset).coerceAtLeast(0.0)
+                val shape =
+                    if (innerWidth > 0 && innerHeight > 0) {
+                        val innerArc =
+                            if (arcWidth > 0) {
+                                (arcWidth.toDouble() - 2.0 * (index + 1)).coerceAtLeast(0.0)
+                            } else {
+                                0.0
+                            }
+                        Area(outer).apply {
+                            subtract(
+                                Area(
+                                    RoundRectangle2D.Double(
+                                        nextInset,
+                                        nextInset,
+                                        innerWidth,
+                                        innerHeight,
+                                        innerArc,
+                                        innerArc,
+                                    ),
+                                ),
+                            )
+                        }
+                    } else {
+                        outer
+                    }
+                add(GlowLayer(shape, ColorUtil.toAlpha(cachedColor, alpha)))
+            }
+        }
+
+    private fun renderSlice(
+        region: Rectangle,
+        layers: List<GlowLayer>,
+    ): FrameSlice {
+        val image = UIUtil.createImage(null as Component?, region.width, region.height, BufferedImage.TYPE_INT_ARGB)
+        val g2 = image.createGraphics()
+        try {
+            g2.translate(-region.x, -region.y)
+            g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+            layers.forEach { layer ->
+                g2.color = layer.color
+                g2.fill(layer.shape)
             }
         } finally {
             g2.dispose()
         }
-        return image
+        return FrameSlice(image, region.x, region.y)
+    }
+
+    private fun renderSideSlice(
+        region: Rectangle,
+        frameWidth: Int,
+        frameHeight: Int,
+        glowWidth: Int,
+    ): FrameSlice {
+        val image = UIUtil.createImage(null as Component?, region.width, region.height, BufferedImage.TYPE_INT_ARGB)
+        val g2 = image.createGraphics()
+        try {
+            g2.translate(-region.x, -region.y)
+            val columns = glowWidth.coerceAtMost((frameWidth + 1) / 2)
+            for (index in 0 until columns) {
+                val progress = index.toFloat() / glowWidth.toFloat()
+                val alpha = computeAlpha(progress)
+                if (alpha <= 0) continue
+
+                g2.color = ColorUtil.toAlpha(cachedColor, alpha)
+                g2.fillRect(index, 0, 1, frameHeight)
+                // On odd-width overlays the strips meet in the middle; paint
+                // the shared center column once or SrcOver doubles its alpha
+                // into a bright seam.
+                val rightX = frameWidth - 1 - index
+                if (rightX != index) g2.fillRect(rightX, 0, 1, frameHeight)
+            }
+        } finally {
+            g2.dispose()
+        }
+        return FrameSlice(image, region.x, region.y)
+    }
+
+    private fun borderRegions(
+        width: Int,
+        height: Int,
+        thickness: Int,
+    ): List<Rectangle> {
+        val topHeight = thickness.coerceAtMost(height)
+        val bottomY = maxOf(topHeight, height - thickness)
+        val middleHeight = bottomY - topHeight
+        val leftWidth = thickness.coerceAtMost(width)
+        val rightX = maxOf(leftWidth, width - thickness)
+        return buildList {
+            add(Rectangle(0, 0, width, topHeight))
+            if (bottomY < height) add(Rectangle(0, bottomY, width, height - bottomY))
+            if (middleHeight > 0) {
+                add(Rectangle(0, topHeight, leftWidth, middleHeight))
+                if (rightX < width) add(Rectangle(rightX, topHeight, width - rightX, middleHeight))
+            }
+        }
+    }
+
+    private fun sideRegions(
+        width: Int,
+        height: Int,
+        columns: Int,
+    ): List<Rectangle> {
+        val leftWidth = columns.coerceAtMost(width)
+        val rightX = maxOf(leftWidth, width - columns)
+        return buildList {
+            add(Rectangle(0, 0, leftWidth, height))
+            if (rightX < width) add(Rectangle(rightX, 0, width - rightX, height))
+        }
     }
 
     internal fun computeAlpha(progress: Float): Int =

--- a/src/main/kotlin/dev/ayuislands/glow/GlowRenderer.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/GlowRenderer.kt
@@ -209,44 +209,50 @@ class GlowRenderer {
                 val alpha = computeAlpha(progress)
                 if (alpha <= 0) continue
 
-                val inset = index.toDouble()
-                val outerWidth = (width - 2.0 * inset).coerceAtLeast(0.0)
-                val outerHeight = (height - 2.0 * inset).coerceAtLeast(0.0)
-                if (outerWidth <= 0 || outerHeight <= 0) break
-
-                val outerArc = if (arcWidth > 0) (arcWidth.toDouble() - 2.0 * index).coerceAtLeast(0.0) else 0.0
-                val outer = RoundRectangle2D.Double(inset, inset, outerWidth, outerHeight, outerArc, outerArc)
-                val nextInset = inset + 1.0
-                val innerWidth = (width - 2.0 * nextInset).coerceAtLeast(0.0)
-                val innerHeight = (height - 2.0 * nextInset).coerceAtLeast(0.0)
-                val shape =
-                    if (innerWidth > 0 && innerHeight > 0) {
-                        val innerArc =
-                            if (arcWidth > 0) {
-                                (arcWidth.toDouble() - 2.0 * (index + 1)).coerceAtLeast(0.0)
-                            } else {
-                                0.0
-                            }
-                        Area(outer).apply {
-                            subtract(
-                                Area(
-                                    RoundRectangle2D.Double(
-                                        nextInset,
-                                        nextInset,
-                                        innerWidth,
-                                        innerHeight,
-                                        innerArc,
-                                        innerArc,
-                                    ),
-                                ),
-                            )
-                        }
-                    } else {
-                        outer
-                    }
+                val shape = frameLayerShape(width, height, arcWidth, index) ?: break
                 add(GlowLayer(shape, ColorUtil.toAlpha(cachedColor, alpha)))
             }
         }
+
+    private fun frameLayerShape(
+        width: Int,
+        height: Int,
+        arcWidth: Int,
+        index: Int,
+    ): Shape? {
+        val inset = index.toDouble()
+        val outerWidth = (width - 2.0 * inset).coerceAtLeast(0.0)
+        val outerHeight = (height - 2.0 * inset).coerceAtLeast(0.0)
+        if (outerWidth <= 0 || outerHeight <= 0) return null
+
+        val outerArc = if (arcWidth > 0) (arcWidth.toDouble() - 2.0 * index).coerceAtLeast(0.0) else 0.0
+        val outer = RoundRectangle2D.Double(inset, inset, outerWidth, outerHeight, outerArc, outerArc)
+        val nextInset = inset + 1.0
+        val innerWidth = (width - 2.0 * nextInset).coerceAtLeast(0.0)
+        val innerHeight = (height - 2.0 * nextInset).coerceAtLeast(0.0)
+        if (innerWidth <= 0 || innerHeight <= 0) return outer
+
+        val innerArc =
+            if (arcWidth > 0) {
+                (arcWidth.toDouble() - 2.0 * (index + 1)).coerceAtLeast(0.0)
+            } else {
+                0.0
+            }
+        return Area(outer).apply {
+            subtract(
+                Area(
+                    RoundRectangle2D.Double(
+                        nextInset,
+                        nextInset,
+                        innerWidth,
+                        innerHeight,
+                        innerArc,
+                        innerArc,
+                    ),
+                ),
+            )
+        }
+    }
 
     private fun renderSlice(
         region: Rectangle,

--- a/src/main/kotlin/dev/ayuislands/glow/GlowRenderer.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/GlowRenderer.kt
@@ -34,7 +34,7 @@ class GlowRenderer {
         private const val CACHE_EDGE_PADDING = 2
     }
 
-    // Style cache (lightweight, recomputed on style/color change)
+    // Render-input cache (lightweight, recomputed when any style input changes)
     private data class StyleKey(
         val style: GlowStyle,
         val color: Color,
@@ -48,7 +48,7 @@ class GlowRenderer {
     internal var cachedStyle: GlowStyle = GlowStyle.SOFT
     internal var cachedBaseAlpha: Int = 0
 
-    // Frame image cache (expensive, keyed on size + style)
+    // Border-slice cache (expensive, keyed on geometry and resolved style)
     private data class FrameKey(
         val width: Int,
         val height: Int,
@@ -115,7 +115,7 @@ class GlowRenderer {
         cachedStyle = style
         styleKey = key
 
-        // Style changed — invalidate frame cache
+        // Render inputs changed — discard the cached border slices
         cachedFrame = null
         frameKey = null
     }

--- a/src/main/kotlin/dev/ayuislands/glow/RouteController.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/RouteController.kt
@@ -98,8 +98,15 @@ internal class RouteController(
 
     private fun dispatch(event: RouteEvent): Boolean {
         val current = coordinator ?: return false
+        val handledEvent =
+            if (event is RouteEvent.Tick) {
+                event.copy(isWindowActive = roots.values.any { root -> root.window.isActive })
+            } else {
+                event
+            }
         try {
-            applyUpdate(current.handle(event))
+            val update = current.handle(handledEvent)
+            if (handledEvent !is RouteEvent.Tick || handledEvent.isWindowActive) applyUpdate(update)
         } catch (exception: RuntimeException) {
             fail(exception)
         }

--- a/src/main/kotlin/dev/ayuislands/glow/waveform/RouteCoordinator.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/waveform/RouteCoordinator.kt
@@ -41,6 +41,10 @@ internal class RouteCoordinator(
 
     @RequiresEdt
     fun handle(event: RouteEvent): RouteUpdate {
+        if (event is RouteEvent.Tick && !event.isWindowActive) {
+            clock.resetWallTick()
+            return RouteUpdate()
+        }
         val transition =
             when (val current = state) {
                 LifecycleState.Dormant -> handleDormant(event)

--- a/src/main/kotlin/dev/ayuislands/glow/waveform/RouteModel.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/waveform/RouteModel.kt
@@ -11,6 +11,7 @@ internal sealed interface RouteEvent {
 
     data class Tick(
         val nowMs: Long,
+        val isWindowActive: Boolean = true,
     ) : RouteEvent
 
     data class Keystroke(

--- a/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
+++ b/src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt
@@ -47,6 +47,7 @@ class ProjectViewScrollbarManager(
     private var trackedTree: JTree? = null
     private var lastAppliedHidePath: Boolean? = null
     private var rendererListener: PropertyChangeListener? = null
+    private var canFilterRoot = false
     private var rootPathLeaseProvider: () -> RootPathLease = RootPathLease::getInstance
     private var registryValueProvider: () -> RegistryValue = { Registry.get(SHOW_URL_KEY) }
     private val rootPathLease: RootPathLease
@@ -103,7 +104,8 @@ class ProjectViewScrollbarManager(
     }
 
     fun apply() {
-        if (!LicenseChecker.isLicensedOrGrace()) {
+        canFilterRoot = LicenseChecker.isLicensedOrGrace()
+        if (!canFilterRoot) {
             cleanupRuntime()
             return
         }
@@ -190,7 +192,7 @@ class ProjectViewScrollbarManager(
     private fun installRendererWrapper(tree: JTree) {
         val current = tree.cellRenderer
         if (current is RootFilteringRenderer) return
-        tree.cellRenderer = RootFilteringRenderer(current, project)
+        tree.cellRenderer = RootFilteringRenderer(current, project) { canFilterRoot }
     }
 
     private fun unwrapRenderer(tree: JTree) {
@@ -211,12 +213,13 @@ class ProjectViewScrollbarManager(
                     val newRenderer =
                         event.newValue as? TreeCellRenderer
                             ?: return@PropertyChangeListener
+                    canFilterRoot = LicenseChecker.isLicensedOrGrace()
                     if (newRenderer !is RootFilteringRenderer &&
-                        LicenseChecker.isLicensedOrGrace() &&
+                        canFilterRoot &&
                         AyuIslandsSettings.getInstance().state.hideProjectRootPath
                     ) {
                         tree.cellRenderer =
-                            RootFilteringRenderer(newRenderer, project)
+                            RootFilteringRenderer(newRenderer, project) { canFilterRoot }
                     }
                 }
             }
@@ -271,6 +274,7 @@ class ProjectViewScrollbarManager(
     }
 
     private fun cleanupRuntime() {
+        canFilterRoot = false
         removeRendererGuard()
         autoFitter.removeExpansionListener()
         val scrollPane = findProjectScrollPane()
@@ -309,7 +313,7 @@ class ProjectViewScrollbarManager(
 
 /**
  * Filters root node path fragments.
- * Reads settings LIVE on every render — no state caching needed.
+ * Reads the path-display setting live; entitlement is supplied by the owning manager.
  */
 internal class RootFilteringRenderer(
     val delegate: TreeCellRenderer,

--- a/src/main/kotlin/dev/ayuislands/syntax/SyntaxOverlayLoader.kt
+++ b/src/main/kotlin/dev/ayuislands/syntax/SyntaxOverlayLoader.kt
@@ -6,7 +6,20 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.openapi.util.JDOMUtil
+import com.intellij.ui.ColorUtil
+import com.intellij.ui.JBColor
+import org.jdom.Element
 import java.util.concurrent.ConcurrentHashMap
+
+private data class ParsedColorField(
+    val name: String,
+    val color: JBColor,
+)
+
+private data class NormalizedAttributes(
+    val element: Element,
+    val colors: List<ParsedColorField>,
+)
 
 /**
  * Overlay loader for the `AyuIslands{Variant}.extended.xml` scheme overlays
@@ -104,7 +117,7 @@ class SyntaxOverlayLoader internal constructor(
         return javaClass.classLoader.getResourceAsStream(normalized)
     }
 
-    private fun buildOverlayMap(attributesEl: org.jdom.Element): Map<TextAttributesKey, TextAttributes> {
+    private fun buildOverlayMap(attributesEl: Element): Map<TextAttributesKey, TextAttributes> {
         val map = mutableMapOf<TextAttributesKey, TextAttributes>()
         for (optionEl in JDOMUtil.getChildren(attributesEl, "option")) {
             val keyName = optionEl.getAttributeValue("name") ?: continue
@@ -123,7 +136,7 @@ class SyntaxOverlayLoader internal constructor(
                     else -> {
                         val valueEl = optionEl.getChild("value") ?: continue
                         try {
-                            TextAttributes(valueEl)
+                            parseTextAttributes(valueEl)
                         } catch (cancellation: kotlinx.coroutines.CancellationException) {
                             throw cancellation
                         } catch (runtime: RuntimeException) {
@@ -135,6 +148,46 @@ class SyntaxOverlayLoader internal constructor(
             map[key] = attrs
         }
         return map
+    }
+
+    private fun parseTextAttributes(valueElement: Element): TextAttributes {
+        val input = normalizeRgbaFields(valueElement)
+        return TextAttributes(input.element).also { attributes ->
+            input.colors.forEach { field -> applyColor(attributes, field) }
+        }
+    }
+
+    private fun normalizeRgbaFields(valueElement: Element): NormalizedAttributes {
+        val normalizedElement = valueElement.clone()
+        val colors = mutableListOf<ParsedColorField>()
+        for (fieldElement in JDOMUtil.getChildren(normalizedElement, "option")) {
+            val fieldName = fieldElement.getAttributeValue("name") ?: continue
+            val value = fieldElement.getAttributeValue("value") ?: continue
+            if (fieldName !in COLOR_FIELDS || value.length != RGBA_LENGTH) continue
+
+            colors += ParsedColorField(fieldName, parseRgba(value))
+            fieldElement.setAttribute("value", value.take(RGB_LENGTH))
+        }
+        return NormalizedAttributes(normalizedElement, colors)
+    }
+
+    private fun applyColor(
+        attributes: TextAttributes,
+        field: ParsedColorField,
+    ) {
+        when (field.name) {
+            "FOREGROUND" -> attributes.foregroundColor = field.color
+            "BACKGROUND" -> attributes.backgroundColor = field.color
+            "EFFECT_COLOR" -> attributes.effectColor = field.color
+            "ERROR_STRIPE_COLOR" -> attributes.errorStripeColor = field.color
+            else -> error("Unsupported text-attribute color field: ${field.name}")
+        }
+    }
+
+    private fun parseRgba(value: String): JBColor {
+        val rgb = ColorUtil.fromHex(value.take(RGB_LENGTH))
+        val rgba = ColorUtil.toAlpha(rgb, value.drop(RGB_LENGTH).toInt(HEX_RADIX))
+        return JBColor(rgba, rgba)
     }
 
     private fun logResourceOnce(
@@ -149,6 +202,10 @@ class SyntaxOverlayLoader internal constructor(
     companion object {
         internal const val DEFAULT_RESOURCE_BASE = "/themes/extended"
         internal const val DEFAULT_BASELINE_BASE = "/themes"
+        private const val HEX_RADIX = 16
+        private const val RGB_LENGTH = 6
+        private const val RGBA_LENGTH = 8
+        private val COLOR_FIELDS = setOf("FOREGROUND", "BACKGROUND", "EFFECT_COLOR", "ERROR_STRIPE_COLOR")
 
         fun getInstance(): SyntaxOverlayLoader {
             val app = ApplicationManager.getApplication()

--- a/src/main/kotlin/dev/ayuislands/syntax/SyntaxOverlayLoader.kt
+++ b/src/main/kotlin/dev/ayuislands/syntax/SyntaxOverlayLoader.kt
@@ -40,9 +40,9 @@ private data class NormalizedAttributes(
  * - Malformed XML or missing resource files → log WARN once per resource via
  *   the [warnedResources] latch (Pattern A — no silent `?: continue`), return
  *   empty map for that variant.
- * - `baseAttributes="REF"` entries: resolve via `TextAttributesKey.find(REF)
- *   .defaultAttributes`. If null (plugin absent), fall back to empty
- *   `TextAttributes()` and continue (no throw).
+ * - `baseAttributes="REF"` entries: return empty `TextAttributes()` so the
+ *   active editor scheme resolves the reference through its own inheritance
+ *   chain instead of baking platform-default colors into the overlay.
  *
  * **Baseline path:** [loadBaselineForVariant] returns the variant's baseline
  * `<attributes>` section so downstream consumers can read the curated baseline

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
@@ -1,5 +1,8 @@
 package dev.ayuislands
 
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.project.Project
 import com.intellij.testFramework.LoggedErrorProcessor
 import dev.ayuislands.licensing.LicenseChecker
@@ -14,6 +17,7 @@ import dev.ayuislands.vcs.VcsColorApplier
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
 import java.util.EnumSet
@@ -40,8 +44,48 @@ import kotlin.test.assertTrue
 class AyuIslandsStartupActivityTest {
     private val activity = AyuIslandsStartupActivity()
 
-    // No @AfterTest needed - LoggedErrorProcessor.executeWith restores the default
-    // processor at block end, and we don't mockkStatic/mockkObject anything global.
+    // Tests that mock global objects restore them in a local finally block;
+    // LoggedErrorProcessor.executeWith restores the default processor itself.
+
+    @Test
+    fun `license startup uses IntelliJ write-safe dispatcher`() {
+        val application = mockk<Application>(relaxed = true)
+        val project = mockk<Project>(relaxed = true)
+        val settings = mockk<AyuIslandsSettings>(relaxed = true)
+        val scheduledActions = mutableListOf<Runnable>()
+        mockkStatic(ApplicationManager::class)
+        mockkObject(LicenseChecker)
+        mockkObject(StartupLicenseHandler)
+        every { ApplicationManager.getApplication() } returns application
+        every {
+            application.invokeLater(capture(scheduledActions), ModalityState.nonModal())
+        } returns Unit
+        every { LicenseChecker.getTrialDaysRemaining() } returns null
+        every { StartupLicenseHandler.computeAdaptiveDelay() } returns 1
+        val startupActivity =
+            AyuIslandsStartupActivity(
+                entitlementProvider = { LicenseEntitlement.UNKNOWN },
+            )
+
+        try {
+            val method =
+                AyuIslandsStartupActivity::class.java.getDeclaredMethod(
+                    "checkLicenseState",
+                    Project::class.java,
+                    AyuIslandsSettings::class.java,
+                    Boolean::class.javaPrimitiveType,
+                )
+            method.isAccessible = true
+            method.invoke(startupActivity, project, settings, false)
+
+            assertEquals(1, scheduledActions.size)
+            verify(exactly = 1) {
+                application.invokeLater(any<Runnable>(), ModalityState.nonModal())
+            }
+        } finally {
+            unmockkAll()
+        }
+    }
 
     @Test
     fun `runStep swallows RuntimeException so the next step can run`() {
@@ -1060,10 +1104,13 @@ class AyuIslandsStartupActivityTest {
     fun `startup re-applies persisted syntax intensity before migration notification`() {
         val source = readStartupActivitySource()
         val reapplyCall =
-            "SwingUtilities.invokeLater { SyntaxIntensityService.getInstance().reapplyForActiveLaf() }"
+            Regex(
+                """dispatchWriteSafe\s*\{\s*""" +
+                    """SyntaxIntensityService\.getInstance\(\)\.reapplyForActiveLaf\(\)\s*}""",
+            )
         val notificationCall =
             "SwingUtilities.invokeLater { SyntaxIntensityMigrationNotifier.maybeFire(project) }"
-        val reapplyIndex = source.indexOf(reapplyCall)
+        val reapplyIndex = reapplyCall.find(source)?.range?.first ?: -1
         val notificationIndex = source.indexOf(notificationCall)
 
         assertTrue(reapplyIndex >= 0, "startup must reapply persisted syntax intensity after scheme registration")

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
@@ -24,6 +24,10 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
+import org.jetbrains.org.objectweb.asm.ClassReader
+import org.jetbrains.org.objectweb.asm.ClassVisitor
+import org.jetbrains.org.objectweb.asm.MethodVisitor
+import org.jetbrains.org.objectweb.asm.Opcodes
 import java.util.EnumSet
 import javax.swing.JFrame
 import javax.swing.SwingUtilities
@@ -128,6 +132,50 @@ class AyuIslandsStartupActivityTest {
         } finally {
             unmockkAll()
         }
+    }
+
+    @Test
+    fun `execute routes frame refresh through write-safe helper`() {
+        val invokedMethods = mutableListOf<Pair<String, String>>()
+        val classBytes =
+            requireNotNull(
+                AyuIslandsStartupActivity::class.java.getResourceAsStream("AyuIslandsStartupActivity.class"),
+            )
+        classBytes.use { input ->
+            ClassReader(input).accept(
+                object : ClassVisitor(Opcodes.ASM9) {
+                    override fun visitMethod(
+                        access: Int,
+                        name: String,
+                        descriptor: String,
+                        signature: String?,
+                        exceptions: Array<out String>?,
+                    ): MethodVisitor? {
+                        if (name != "execute") return null
+                        return object : MethodVisitor(Opcodes.ASM9) {
+                            override fun visitMethodInsn(
+                                opcode: Int,
+                                owner: String,
+                                name: String,
+                                descriptor: String,
+                                isInterface: Boolean,
+                            ) {
+                                invokedMethods += owner to name
+                            }
+                        }
+                    }
+                },
+                ClassReader.SKIP_DEBUG or ClassReader.SKIP_FRAMES,
+            )
+        }
+
+        assertTrue(
+            invokedMethods.any {
+                it.first == "dev/ayuislands/AyuIslandsStartupActivity" &&
+                    it.second == "scheduleFrameRefresh"
+            },
+            "execute must keep the issue #330 component refresh on the write-safe helper path",
+        )
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
@@ -1200,15 +1200,25 @@ class AyuIslandsStartupActivityTest {
                     """SyntaxIntensityService\.getInstance\(\)\.reapplyForActiveLaf\(\)\s*}""",
             )
         val notificationCall =
-            "SwingUtilities.invokeLater { SyntaxIntensityMigrationNotifier.maybeFire(project) }"
+            Regex(
+                """dispatchWriteSafe\s*\{\s*""" +
+                    """SyntaxIntensityMigrationNotifier\.maybeFire\(project\)\s*}""",
+            )
         val reapplyIndex = reapplyCall.find(source)?.range?.first ?: -1
-        val notificationIndex = source.indexOf(notificationCall)
+        val notificationIndex = notificationCall.find(source)?.range?.first ?: -1
 
         assertTrue(reapplyIndex >= 0, "startup must reapply persisted syntax intensity after scheme registration")
-        assertTrue(notificationIndex >= 0, "startup must still show the syntax intensity migration notification")
+        assertTrue(
+            notificationIndex >= 0,
+            "startup must queue the syntax intensity migration notification in a write-safe context",
+        )
+        assertFalse(
+            source.contains("SwingUtilities.invokeLater { SyntaxIntensityMigrationNotifier.maybeFire(project) }"),
+            "the migration notification must not bypass the non-modal IntelliJ queue",
+        )
         assertTrue(
             reapplyIndex < notificationIndex,
-            "persisted syntax intensity should be restored before the migration notification is queued",
+            "persisted syntax intensity must enter the non-modal queue before the migration notification",
         )
     }
 

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.WindowManager
 import com.intellij.testFramework.LoggedErrorProcessor
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.licensing.LicenseEntitlement
@@ -13,14 +14,18 @@ import dev.ayuislands.onboarding.WizardAction
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
 import dev.ayuislands.settings.mappings.AccentMappingsState
+import dev.ayuislands.ui.ComponentTreeRefresher
 import dev.ayuislands.vcs.VcsColorApplier
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
 import java.util.EnumSet
+import javax.swing.JFrame
 import javax.swing.SwingUtilities
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -82,6 +87,44 @@ class AyuIslandsStartupActivityTest {
             verify(exactly = 1) {
                 application.invokeLater(any<Runnable>(), ModalityState.nonModal())
             }
+        } finally {
+            unmockkAll()
+        }
+    }
+
+    @Test
+    fun `startup frame refresh uses IntelliJ write-safe dispatcher`() {
+        val application = mockk<Application>(relaxed = true)
+        val project = mockk<Project>(relaxed = true)
+        val windowManager = mockk<WindowManager>()
+        val frame = mockk<JFrame>(relaxed = true)
+        val scheduledActions = mutableListOf<Runnable>()
+        mockkStatic(ApplicationManager::class)
+        mockkStatic(WindowManager::class)
+        mockkObject(ComponentTreeRefresher)
+        every { ApplicationManager.getApplication() } returns application
+        every {
+            application.invokeLater(capture(scheduledActions), ModalityState.nonModal())
+        } returns Unit
+        every { WindowManager.getInstance() } returns windowManager
+        every { windowManager.getFrame(project) } returns frame
+        every { ComponentTreeRefresher.walkAndNotify(project, frame) } just Runs
+
+        try {
+            val method =
+                AyuIslandsStartupActivity::class.java.getDeclaredMethod(
+                    "scheduleFrameRefresh",
+                    Project::class.java,
+                )
+            method.isAccessible = true
+            method.invoke(activity, project)
+
+            assertEquals(1, scheduledActions.size)
+            scheduledActions.single().run()
+            verify(exactly = 1) {
+                application.invokeLater(any<Runnable>(), ModalityState.nonModal())
+            }
+            verify(exactly = 1) { ComponentTreeRefresher.walkAndNotify(project, frame) }
         } finally {
             unmockkAll()
         }

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
@@ -1,6 +1,8 @@
 package dev.ayuislands.accent
 
+import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.Project
@@ -654,7 +656,7 @@ class ProjectLanguageDetectorTest {
             error("EDT dominant must schedule scan instead of reading project files synchronously")
         }
         mockkStatic(ApplicationManager::class)
-        val application = mockk<com.intellij.openapi.application.Application>()
+        val application = mockk<Application>()
         every { ApplicationManager.getApplication() } returns application
         every { application.isDispatchThread } returns true
         mockkObject(ProjectLanguageScanAsync)
@@ -974,6 +976,35 @@ class ProjectLanguageDetectorTest {
 
         ProjectLanguageDetector.rescan(project)
 
+        verify(exactly = 1) { listener.scanCompleted(ScanOutcome.Detected("python")) }
+    }
+
+    @Test
+    fun `rescan publishes through IntelliJ write-safe dispatcher`() {
+        val project = stubProject("/tmp/rescan-write-safe-publish-${System.nanoTime()}")
+        every { ProjectLanguageScanner.scan(project) } returns mapOf("python" to 900L)
+        wireProjectRootManager(project, sdkName = null)
+        wireModuleManager(project, moduleNames = emptyList())
+        stubDumbServiceSmart(project)
+        val listener = mockk<ProjectLanguageDetectionListener>(relaxed = true)
+        val messageBus = mockk<com.intellij.util.messages.MessageBus>()
+        every { project.messageBus } returns messageBus
+        every { messageBus.syncPublisher(ProjectLanguageDetectionListener.TOPIC) } returns listener
+        val application = mockk<Application>(relaxed = true)
+        mockkStatic(ApplicationManager::class)
+        every { ApplicationManager.getApplication() } returns application
+        every {
+            application.invokeLater(any<Runnable>(), ModalityState.nonModal())
+        } answers {
+            firstArg<Runnable>().run()
+        }
+        runSchedulerInline()
+
+        ProjectLanguageDetector.rescan(project)
+
+        verify(exactly = 1) {
+            application.invokeLater(any<Runnable>(), ModalityState.nonModal())
+        }
         verify(exactly = 1) { listener.scanCompleted(ScanOutcome.Detected("python")) }
     }
 

--- a/src/test/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManagerTest.kt
@@ -584,6 +584,23 @@ class CommitPanelAutoFitManagerTest {
                 renderer.delegate,
                 "Renderer guard must preserve the IDE replacement as the delegate",
             )
+            clearMocks(LicenseChecker, answers = false, recordedCalls = true)
+            val isSelected = false
+            val isExpanded = false
+            val isLeaf = false
+            val hasFocus = false
+
+            renderer.getTreeCellRendererComponent(
+                tree,
+                tree.model.root,
+                isSelected,
+                isExpanded,
+                isLeaf,
+                0,
+                hasFocus,
+            )
+
+            verify(exactly = 0) { LicenseChecker.isLicensedOrGrace() }
         }
     }
 

--- a/src/test/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManagerTest.kt
@@ -16,6 +16,7 @@ import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
 import dev.ayuislands.settings.PanelWidthMode
 import dev.ayuislands.toolwindow.AutoFitCalculator
+import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -612,6 +613,38 @@ class CommitPanelAutoFitManagerTest {
                 tree.cellRenderer,
                 "repeated apply must not stack renderer wrappers",
             )
+        }
+    }
+
+    @Test
+    fun `installed renderer does not recheck license while painting rows`() {
+        SwingUtilities.invokeAndWait {
+            every { LicenseChecker.isLicensedOrGrace() } returns true
+            realState.commitPanelWidthMode = PanelWidthMode.FIXED.name
+            realState.commitPanelFixedWidth = 350
+            val tree = JTree()
+            val panel =
+                JPanel(FlowLayout()).apply {
+                    add(tree)
+                    setSize(200, 400)
+                }
+            setupCommitToolWindow(panel)
+            val manager = CommitPanelAutoFitManager(project)
+            manager.apply()
+            clearMocks(LicenseChecker, answers = false, recordedCalls = true)
+
+            tree.cellRenderer.getTreeCellRendererComponent(
+                tree,
+                tree.model.root,
+                false,
+                false,
+                false,
+                0,
+                false,
+            )
+
+            verify(exactly = 0) { LicenseChecker.isLicensedOrGrace() }
+            manager.dispose()
         }
     }
 

--- a/src/test/kotlin/dev/ayuislands/font/FontPresetApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/font/FontPresetApplicatorTest.kt
@@ -1,0 +1,50 @@
+package dev.ayuislands.font
+
+import com.intellij.openapi.application.Application
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import javax.swing.SwingUtilities
+import kotlin.test.AfterTest
+import kotlin.test.Test
+
+class FontPresetApplicatorTest {
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `background apply uses IntelliJ write-safe dispatcher`() {
+        val application = mockk<Application>(relaxed = true)
+        mockkStatic(ApplicationManager::class)
+        mockkStatic(SwingUtilities::class)
+        every { ApplicationManager.getApplication() } returns application
+        every { SwingUtilities.isEventDispatchThread() } returns false
+        every { application.invokeLater(any<Runnable>(), ModalityState.nonModal()) } returns Unit
+
+        FontPresetApplicator.apply(FontSettings.fromPreset(FontPreset.AMBIENT))
+
+        verify(exactly = 1) {
+            application.invokeLater(any<Runnable>(), ModalityState.nonModal())
+        }
+        verify(exactly = 0) { SwingUtilities.invokeLater(any()) }
+    }
+
+    @Test
+    fun `background apply keeps Swing fallback without an Application`() {
+        mockkStatic(ApplicationManager::class)
+        mockkStatic(SwingUtilities::class)
+        every { ApplicationManager.getApplication() } returns null
+        every { SwingUtilities.isEventDispatchThread() } returns false
+        every { SwingUtilities.invokeLater(any()) } returns Unit
+
+        FontPresetApplicator.apply(FontSettings.fromPreset(FontPreset.AMBIENT))
+
+        verify(exactly = 1) { SwingUtilities.invokeLater(any()) }
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/glow/EditorTabGeometryTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/EditorTabGeometryTest.kt
@@ -1,5 +1,6 @@
 package dev.ayuislands.glow
 
+import com.intellij.testFramework.LoggedErrorProcessor
 import java.awt.Color
 import java.awt.Rectangle
 import javax.swing.JComponent
@@ -8,6 +9,8 @@ import javax.swing.JPanel
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
 
 class EditorTabGeometryTest {
     @Test
@@ -77,7 +80,21 @@ class EditorTabGeometryTest {
         assertNull(EditorTabGeometry.findEditorTabsComponent(child))
     }
 
-    // --- calculateEditorOverlayBounds tests ---
+    @Test
+    fun `selection fake exposes the reflective editor tab contract`() {
+        val content = JPanel()
+        val info = TabInfoFake(content)
+        val label = MockTabLabel()
+        val editorTabs = SelectionEditorTabsFake()
+        editorTabs.infoForTest = info
+        editorTabs.labelForTest = label
+
+        assertSame(info, editorTabs.getSelectedInfo())
+        assertSame(label, editorTabs.getSelectedLabel())
+        assertSame(content, info.getComponent())
+    }
+
+    // calculateEditorOverlayBounds tests
 
     @Test
     fun `calculateEditorOverlayBounds uses default when no EditorTabs found`() {
@@ -246,6 +263,34 @@ class EditorTabGeometryTest {
     }
 
     @Test
+    fun `transient fallback stays silent until a confirming geometry pass`() {
+        val host = TransientEditorsSplittersFake()
+        host.setSize(800, 600)
+        val warnings = mutableListOf<String>()
+        val processor =
+            object : LoggedErrorProcessor() {
+                override fun processWarn(
+                    category: String,
+                    message: String,
+                    throwable: Throwable?,
+                ): Boolean {
+                    if (category.contains("EditorTabGeometry")) warnings += message
+                    return false
+                }
+            }
+
+        LoggedErrorProcessor.executeWith<RuntimeException>(processor) {
+            val settling = EditorTabGeometry.editorOverlayGeometry(host, shouldReportFallback = false)
+            assertEquals(Rectangle(0, 28, 800, 572), settling.contentBounds)
+            assertTrue(warnings.isEmpty(), "transient layout fallback must not warn: $warnings")
+
+            val confirmed = EditorTabGeometry.editorOverlayGeometry(host, shouldReportFallback = true)
+            assertEquals(settling, confirmed)
+            assertEquals(1, warnings.size, "stable fallback must retain one actionable warning")
+        }
+    }
+
+    @Test
     fun `tab label bottom converts through offset containers into host coordinates`() {
         // The strip anchor must be measured in HOST coordinates: a tabs
         // component sitting 10px below the host top means the strip starts at
@@ -290,6 +335,8 @@ class EditorTabGeometryTest {
     private class MockTabLabel : JComponent()
 
     private class MockActionToolbar : JComponent()
+
+    private class TransientEditorsSplittersFake : JPanel()
 }
 
 // File-level fakes (NOT private nested classes): the production code invokes

--- a/src/test/kotlin/dev/ayuislands/glow/GlowOverlayManagerLifecycleTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/GlowOverlayManagerLifecycleTest.kt
@@ -1109,6 +1109,36 @@ class GlowOverlayManagerLifecycleTest {
     }
 
     @Test
+    fun `editor settling stops after manager disposal`() {
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        val scheduled = mutableListOf<Runnable>()
+        every { SwingUtilities.invokeLater(any()) } answers { scheduled += firstArg<Runnable>() }
+        val project = stubProject("disposed-settling-project")
+        val editorManager = mockk<FileEditorManager>()
+        mockkStatic(FileEditorManager::class)
+        every { FileEditorManager.getInstance(project) } returns editorManager
+        every { editorManager.selectedEditor } returns mockk()
+        val host = SettlingEditorHost().apply { setSize(800, 600) }
+        val rootPane = mockk<javax.swing.JRootPane>(relaxed = true)
+        val layeredPane = mockk<JLayeredPane>(relaxed = true)
+        every { rootPane.layeredPane } returns layeredPane
+        every { SwingUtilities.getRootPane(host) } returns rootPane
+        every { SwingUtilities.convertPoint(host, 0, 0, layeredPane) } returns Point(0, 0)
+        val manager = GlowOverlayManager(project)
+
+        invokeAttachOverlay(manager, "disposed-settling-editor", host, isEditorOverlay = true)
+        assertEquals(1, scheduled.size)
+
+        scheduled.removeAt(0).run()
+        assertEquals(1, scheduled.size)
+        manager.dispose()
+
+        scheduled.removeAt(0).run()
+
+        verify(exactly = 2) { SwingUtilities.convertPoint(host, 0, 0, layeredPane) }
+    }
+
+    @Test
     fun `waveform directs clipped edges inward and clears them when space returns`() {
         val project = stubProject("clipped-waveform-project")
         val manager = GlowOverlayManager(project)

--- a/src/test/kotlin/dev/ayuislands/glow/GlowOverlayManagerLifecycleTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/GlowOverlayManagerLifecycleTest.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.wm.IdeFrame
 import com.intellij.openapi.wm.ToolWindowManager
+import com.intellij.testFramework.LoggedErrorProcessor
 import com.intellij.util.messages.MessageBus
 import com.intellij.util.messages.MessageBusConnection
 import dev.ayuislands.accent.AccentChangeListener
@@ -1062,6 +1063,45 @@ class GlowOverlayManagerLifecycleTest {
             Rectangle(50 - margin, 40 - margin, 120 + margin * 2, 80 + margin * 2),
             readGlassPane(waveformManager, "waveform").bounds,
         )
+    }
+
+    @Test
+    fun `editor attach reports missing tab hierarchy only after settling`() {
+        every { AyuVariant.detect() } returns AyuVariant.MIRAGE
+        val scheduled = mutableListOf<Runnable>()
+        every { SwingUtilities.invokeLater(any()) } answers { scheduled += firstArg<Runnable>() }
+        val project = stubProject("settling-editor-project")
+        val host = SettlingEditorHost().apply { setSize(800, 600) }
+        val rootPane = mockk<javax.swing.JRootPane>(relaxed = true)
+        val layeredPane = mockk<JLayeredPane>(relaxed = true)
+        every { rootPane.layeredPane } returns layeredPane
+        every { SwingUtilities.getRootPane(host) } returns rootPane
+        every { SwingUtilities.convertPoint(host, 0, 0, layeredPane) } returns Point(0, 0)
+        val warnings = mutableListOf<String>()
+        val processor =
+            object : LoggedErrorProcessor() {
+                override fun processWarn(
+                    category: String,
+                    message: String,
+                    throwable: Throwable?,
+                ): Boolean {
+                    if (category.contains("EditorTabGeometry")) warnings += message
+                    return false
+                }
+            }
+
+        LoggedErrorProcessor.executeWith<RuntimeException>(processor) {
+            invokeAttachOverlay(GlowOverlayManager(project), "settling-editor", host, isEditorOverlay = true)
+            assertTrue(warnings.isEmpty(), "initial fallback must remain silent: $warnings")
+            assertEquals(1, scheduled.size)
+
+            scheduled.removeAt(0).run()
+            assertTrue(warnings.isEmpty(), "first post-layout correction must remain silent: $warnings")
+            assertEquals(1, scheduled.size)
+
+            scheduled.removeAt(0).run()
+            assertEquals(1, warnings.size, "settled fallback must retain one actionable warning")
+        }
     }
 
     @Test
@@ -2163,5 +2203,9 @@ class GlowOverlayManagerLifecycleTest {
 
         /** Sentinel key for the late-overlay attach-path test. */
         private const val LATE_OVERLAY_KEY = "LateOverlay"
+    }
+
+    private class SettlingEditorHost : javax.swing.JComponent() {
+        override fun isShowing(): Boolean = true
     }
 }

--- a/src/test/kotlin/dev/ayuislands/glow/GlowOverlayManagerLifecycleTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/GlowOverlayManagerLifecycleTest.kt
@@ -2055,6 +2055,7 @@ class GlowOverlayManagerLifecycleTest {
         val editorHost = mockk<javax.swing.JComponent>(relaxed = true)
         val commitHost = mockk<javax.swing.JComponent>(relaxed = true)
         val toolWindowManager = mockk<ToolWindowManager>(relaxed = true)
+        every { window.isActive } returns true
         every { editorHost.isShowing } returns true
         every { editorHost.isDisplayable } returns true
         every { editorHost.width } returns 400

--- a/src/test/kotlin/dev/ayuislands/glow/GlowOverlayManagerLifecycleTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/GlowOverlayManagerLifecycleTest.kt
@@ -1071,6 +1071,10 @@ class GlowOverlayManagerLifecycleTest {
         val scheduled = mutableListOf<Runnable>()
         every { SwingUtilities.invokeLater(any()) } answers { scheduled += firstArg<Runnable>() }
         val project = stubProject("settling-editor-project")
+        val editorManager = mockk<FileEditorManager>()
+        mockkStatic(FileEditorManager::class)
+        every { FileEditorManager.getInstance(project) } returns editorManager
+        every { editorManager.selectedEditor } returns mockk()
         val host = SettlingEditorHost().apply { setSize(800, 600) }
         val rootPane = mockk<javax.swing.JRootPane>(relaxed = true)
         val layeredPane = mockk<JLayeredPane>(relaxed = true)
@@ -1152,6 +1156,7 @@ class GlowOverlayManagerLifecycleTest {
     fun `existing editor overlay refreshes top spans when editor selection changes`() {
         val project = stubProject("editor-tab-geometry-project")
         val manager = GlowOverlayManager(project)
+        val editorManager = mockk<FileEditorManager>()
         val host = mockk<javax.swing.JComponent>(relaxed = true)
         val layeredPane = mockk<JLayeredPane>(relaxed = true)
         val pane =
@@ -1163,10 +1168,13 @@ class GlowOverlayManagerLifecycleTest {
                 isEditorOverlay = true,
             )
         pane.configureWaveform(GlowShape.WAVEFORM, WaveformConfig())
+        mockkStatic(FileEditorManager::class)
+        every { FileEditorManager.getInstance(project) } returns editorManager
+        every { editorManager.selectedEditor } returns mockk()
         every { host.isShowing } returns true
         every { SwingUtilities.convertPoint(host, 0, 0, layeredPane) } returns Point(10, 20)
         mockkObject(EditorTabGeometry)
-        every { EditorTabGeometry.editorOverlayGeometry(host) } returns
+        every { EditorTabGeometry.editorOverlayGeometry(host, any()) } returns
             EditorOverlayGeometry(Rectangle(0, 28, 120, 80), listOf(0..72))
         seedOverlaysMapWithMocks(manager, pane, host, layeredPane, key = "Editor")
 
@@ -1204,10 +1212,25 @@ class GlowOverlayManagerLifecycleTest {
         every { rootPane.layeredPane } returns layeredPane
         every { SwingUtilities.getRootPane(host) } returns rootPane
         every { SwingUtilities.convertPoint(host, 0, 0, layeredPane) } returns Point(0, 0)
+        val warnings = mutableListOf<String>()
+        val processor =
+            object : LoggedErrorProcessor() {
+                override fun processWarn(
+                    category: String,
+                    message: String,
+                    throwable: Throwable?,
+                ): Boolean {
+                    if (category.contains("EditorTabGeometry")) warnings += message
+                    return false
+                }
+            }
 
-        invokeAttachEditorOverlayIfNeeded(manager)
+        LoggedErrorProcessor.executeWith<RuntimeException>(processor) {
+            invokeAttachEditorOverlayIfNeeded(manager)
+        }
 
         assertTrue(readOverlaysMap(manager).containsKey("Editor"))
+        assertTrue(warnings.isEmpty(), "an empty editor has no tab hierarchy to warn about: $warnings")
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/glow/GlowRendererTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/GlowRendererTest.kt
@@ -11,6 +11,7 @@ import java.awt.image.BufferedImage
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class GlowRendererTest {
@@ -79,20 +80,35 @@ class GlowRendererTest {
     }
 
     @Test
-    fun `ensureCache invalidates frame cache on style change`() {
+    fun `ensureCache invalidates rendered frame when color changes`() {
         val renderer = GlowRenderer()
         renderer.ensureCache(Color.RED, GlowStyle.SOFT, 40, 12)
+        val redFrame = BufferedImage(100, 100, BufferedImage.TYPE_INT_ARGB)
+        val redGraphics = redFrame.createGraphics()
+        try {
+            renderer.paintGlow(redGraphics, Rectangle(0, 0, 100, 100), 12, 0)
+        } finally {
+            redGraphics.dispose()
+        }
 
-        val image = BufferedImage(100, 100, BufferedImage.TYPE_INT_ARGB)
-        val g2 = image.createGraphics()
-        renderer.paintGlow(g2, Rectangle(0, 0, 100, 100), 12, 8)
-        g2.dispose()
+        renderer.ensureCache(Color.BLUE, GlowStyle.SOFT, 40, 12)
+        val blueFrame = BufferedImage(100, 100, BufferedImage.TYPE_INT_ARGB)
+        val blueGraphics = blueFrame.createGraphics()
+        try {
+            renderer.paintGlow(blueGraphics, Rectangle(0, 0, 100, 100), 12, 0)
+        } finally {
+            blueGraphics.dispose()
+        }
 
-        renderer.ensureCache(Color.BLUE, GlowStyle.SHARP_NEON, 85, 20)
-
-        renderer.invalidateCache()
-        // After invalidation, accessing ensureCache with new params should work without error
-        renderer.ensureCache(Color.GREEN, GlowStyle.GRADIENT, 50, 12)
+        assertFalse(
+            pixels(redFrame).contentEquals(pixels(blueFrame)),
+            "Changing cache parameters must replace the previously rendered frame",
+        )
+        val paintedPixel = pixels(blueFrame).map { Color(it, true) }.first { it.alpha > 0 }
+        assertTrue(
+            paintedPixel.blue > paintedPixel.red,
+            "The replacement frame must use the new blue accent",
+        )
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/glow/GlowRendererTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/GlowRendererTest.kt
@@ -1,9 +1,15 @@
 package dev.ayuislands.glow
 
+import com.intellij.ui.ColorUtil
+import java.awt.AlphaComposite
 import java.awt.Color
 import java.awt.Rectangle
+import java.awt.RenderingHints
+import java.awt.geom.Area
+import java.awt.geom.RoundRectangle2D
 import java.awt.image.BufferedImage
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -92,10 +98,10 @@ class GlowRendererTest {
     @Test
     fun `ensureCache boosts alpha for light theme`() {
         val renderer = GlowRenderer()
-        val uiMgr = javax.swing.UIManager.getDefaults()
-        val original = uiMgr.getColor("Panel.background")
+        val uiDefaults = javax.swing.UIManager.getDefaults()
+        val original = uiDefaults.getColor("Panel.background")
         try {
-            uiMgr.put("Panel.background", Color(240, 240, 240))
+            uiDefaults["Panel.background"] = Color(240, 240, 240)
             renderer.ensureCache(
                 Color.RED,
                 GlowStyle.SOFT,
@@ -104,8 +110,7 @@ class GlowRendererTest {
             )
             val lightAlpha = renderer.cachedBaseAlpha
 
-            uiMgr.put("Panel.background", Color(30, 30, 30))
-            renderer.invalidateCache()
+            uiDefaults["Panel.background"] = Color(30, 30, 30)
             renderer.ensureCache(
                 Color.RED,
                 GlowStyle.SOFT,
@@ -120,7 +125,60 @@ class GlowRendererTest {
                     "be higher than dark ($darkAlpha)",
             )
         } finally {
-            uiMgr.put("Panel.background", original)
+            uiDefaults["Panel.background"] = original
+        }
+    }
+
+    @Test
+    fun `large frame cache stores border pixels instead of transparent interior`() {
+        val width = 1939
+        val height = 1277
+        val renderer = GlowRenderer()
+        renderer.ensureCache(Color.CYAN, GlowStyle.SHARP_NEON, 50, 4)
+        val image = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+        val graphics = image.createGraphics()
+
+        renderer.paintGlow(graphics, Rectangle(0, 0, width, height), glowWidth = 4, arcWidth = 16)
+        graphics.dispose()
+
+        assertTrue(renderer.cachedPixelCount > 0)
+        assertTrue(renderer.cachedPixelCount < width.toLong() * height / 10)
+    }
+
+    @Test
+    fun `border cache preserves full frame pixels across geometry and alpha`() {
+        val cases =
+            listOf(
+                RenderCase(width = 80, height = 80, arcWidth = 0, glowWidth = 4),
+                RenderCase(width = 800, height = 600, arcWidth = 100, glowWidth = 4),
+                RenderCase(width = 31, height = 29, arcWidth = 40, glowWidth = 24),
+                RenderCase(width = 800, height = 600, arcWidth = 16, glowWidth = 4, edgesOnly = true),
+            )
+
+        cases.forEach { case ->
+            listOf(0.08f, 0.5f, 1f).forEach { alpha ->
+                val renderer = GlowRenderer()
+                val accent = Color(0x5CCFE6)
+                renderer.ensureCache(accent, GlowStyle.SHARP_NEON, 50, case.glowWidth)
+                val expected = renderLegacyFrame(renderer, accent, case, alpha)
+                val actual = BufferedImage(case.width, case.height, BufferedImage.TYPE_INT_ARGB)
+                val graphics = actual.createGraphics()
+                graphics.composite = AlphaComposite.SrcOver.derive(alpha)
+                renderer.paintGlow(
+                    graphics,
+                    Rectangle(0, 0, case.width, case.height),
+                    case.glowWidth,
+                    case.arcWidth,
+                    case.edgesOnly,
+                )
+                graphics.dispose()
+
+                assertContentEquals(
+                    pixels(expected),
+                    pixels(actual),
+                    "render changed for $case at alpha=$alpha",
+                )
+            }
         }
     }
 
@@ -160,4 +218,99 @@ class GlowRendererTest {
         renderer.paintGlow(g2, Rectangle(0, 0, -1, -1), 12, 8)
         g2.dispose()
     }
+
+    private fun renderLegacyFrame(
+        renderer: GlowRenderer,
+        accent: Color,
+        case: RenderCase,
+        alpha: Float,
+    ): BufferedImage {
+        val frame = BufferedImage(case.width, case.height, BufferedImage.TYPE_INT_ARGB)
+        val frameGraphics = frame.createGraphics()
+        try {
+            frameGraphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+            if (case.edgesOnly) {
+                val columns = case.glowWidth.coerceAtMost((case.width + 1) / 2)
+                for (index in 0 until columns) {
+                    val layerAlpha = renderer.computeAlpha(index.toFloat() / case.glowWidth)
+                    if (layerAlpha <= 0) continue
+
+                    frameGraphics.color = ColorUtil.toAlpha(accent, layerAlpha)
+                    frameGraphics.fillRect(index, 0, 1, case.height)
+                    val rightX = case.width - 1 - index
+                    if (rightX != index) frameGraphics.fillRect(rightX, 0, 1, case.height)
+                }
+            } else {
+                paintLegacyRings(frameGraphics, renderer, accent, case)
+            }
+        } finally {
+            frameGraphics.dispose()
+        }
+
+        val target = BufferedImage(case.width, case.height, BufferedImage.TYPE_INT_ARGB)
+        val targetGraphics = target.createGraphics()
+        targetGraphics.composite = AlphaComposite.SrcOver.derive(alpha)
+        targetGraphics.drawImage(frame, 0, 0, null)
+        targetGraphics.dispose()
+        return target
+    }
+
+    private fun paintLegacyRings(
+        graphics: java.awt.Graphics2D,
+        renderer: GlowRenderer,
+        accent: Color,
+        case: RenderCase,
+    ) {
+        for (index in 0 until case.glowWidth) {
+            val layerAlpha = renderer.computeAlpha(index.toFloat() / case.glowWidth)
+            if (layerAlpha <= 0) continue
+
+            graphics.color = ColorUtil.toAlpha(accent, layerAlpha)
+            val inset = index.toDouble()
+            val outerWidth = (case.width - 2.0 * inset).coerceAtLeast(0.0)
+            val outerHeight = (case.height - 2.0 * inset).coerceAtLeast(0.0)
+            if (outerWidth <= 0 || outerHeight <= 0) break
+
+            val outerArc = if (case.arcWidth > 0) (case.arcWidth - 2.0 * index).coerceAtLeast(0.0) else 0.0
+            val outer = RoundRectangle2D.Double(inset, inset, outerWidth, outerHeight, outerArc, outerArc)
+            val innerInset = inset + 1.0
+            val innerWidth = (case.width - 2.0 * innerInset).coerceAtLeast(0.0)
+            val innerHeight = (case.height - 2.0 * innerInset).coerceAtLeast(0.0)
+            if (innerWidth > 0 && innerHeight > 0) {
+                val innerArc =
+                    if (case.arcWidth > 0) {
+                        (case.arcWidth - 2.0 * (index + 1)).coerceAtLeast(0.0)
+                    } else {
+                        0.0
+                    }
+                val ring = Area(outer)
+                ring.subtract(
+                    Area(
+                        RoundRectangle2D.Double(
+                            innerInset,
+                            innerInset,
+                            innerWidth,
+                            innerHeight,
+                            innerArc,
+                            innerArc,
+                        ),
+                    ),
+                )
+                graphics.fill(ring)
+            } else {
+                graphics.fill(outer)
+            }
+        }
+    }
+
+    private fun pixels(image: BufferedImage): IntArray =
+        image.getRGB(0, 0, image.width, image.height, null, 0, image.width)
+
+    private data class RenderCase(
+        val width: Int,
+        val height: Int,
+        val arcWidth: Int,
+        val glowWidth: Int,
+        val edgesOnly: Boolean = false,
+    )
 }

--- a/src/test/kotlin/dev/ayuislands/glow/RouteControllerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/RouteControllerTest.kt
@@ -16,6 +16,7 @@ import dev.ayuislands.glow.waveform.RouteRootId
 import dev.ayuislands.glow.waveform.RouteSide
 import dev.ayuislands.glow.waveform.RouteSlice
 import dev.ayuislands.glow.waveform.RouteUpdate
+import dev.ayuislands.glow.waveform.TimerDirective
 import dev.ayuislands.glow.waveform.TravelDirection
 import dev.ayuislands.glow.waveform.WaveformConfig
 import dev.ayuislands.glow.waveform.WaveformFrame
@@ -34,27 +35,35 @@ import java.awt.Color
 import java.awt.Point
 import java.awt.Window
 import javax.swing.JLayeredPane
+import javax.swing.Timer
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 class RouteControllerTest {
     @Test
     fun `inactive route does not advance until one route window is active`() {
         val controller = controller()
         val coordinator = mockk<RouteCoordinator>()
-        every { coordinator.handle(any()) } returns RouteUpdate()
+        every { coordinator.handle(any()) } returns RouteUpdate(timerDirective = TimerDirective.START)
         seedCoordinator(controller, coordinator)
-        val window = mockk<Window>()
-        every { window.isActive } returns false
-        seedRouteRoot(controller, window)
+        val firstWindow = mockk<Window>()
+        val secondWindow = mockk<Window>()
+        every { firstWindow.isActive } returns false
+        every { secondWindow.isActive } returns false
+        seedRouteRoot(controller, RouteRootId(1), firstWindow)
+        seedRouteRoot(controller, RouteRootId(2), secondWindow)
 
         controller.handle(RouteEvent.Tick(100L))
 
         verify(exactly = 1) { coordinator.handle(RouteEvent.Tick(100L, isWindowActive = false)) }
+        assertNull(routeTimer(controller))
 
-        every { window.isActive } returns true
+        every { secondWindow.isActive } returns true
         controller.handle(RouteEvent.Tick(200L))
 
         verify(exactly = 1) { coordinator.handle(RouteEvent.Tick(200L, isWindowActive = true)) }
+        assertNotNull(routeTimer(controller)).stop()
     }
 
     @Test
@@ -307,6 +316,7 @@ class RouteControllerTest {
 
     private fun seedRouteRoot(
         controller: RouteController,
+        rootId: RouteRootId,
         window: Window,
     ) {
         val rootClass = Class.forName("dev.ayuislands.glow.RouteRoot")
@@ -322,7 +332,13 @@ class RouteControllerTest {
         field.isAccessible = true
         val roots = field.get(controller)
         val put = roots.javaClass.getMethod("put", Any::class.java, Any::class.java)
-        put.invoke(roots, RouteRootId(1), root)
+        put.invoke(roots, rootId, root)
+    }
+
+    private fun routeTimer(controller: RouteController): Timer? {
+        val field = controller.javaClass.getDeclaredField("timer")
+        field.isAccessible = true
+        return field.get(controller) as Timer?
     }
 
     private fun renderBridge(

--- a/src/test/kotlin/dev/ayuislands/glow/RouteControllerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/RouteControllerTest.kt
@@ -4,14 +4,18 @@ import com.intellij.openapi.project.Project
 import dev.ayuislands.glow.waveform.CrossWindowBridge
 import dev.ayuislands.glow.waveform.RouteConnector
 import dev.ayuislands.glow.waveform.RouteConnectorId
+import dev.ayuislands.glow.waveform.RouteCoordinator
 import dev.ayuislands.glow.waveform.RouteEndpoint
+import dev.ayuislands.glow.waveform.RouteEvent
 import dev.ayuislands.glow.waveform.RouteFrame
 import dev.ayuislands.glow.waveform.RouteGraph
 import dev.ayuislands.glow.waveform.RouteLayerStyle
 import dev.ayuislands.glow.waveform.RoutePaintTarget
 import dev.ayuislands.glow.waveform.RoutePoint
+import dev.ayuislands.glow.waveform.RouteRootId
 import dev.ayuislands.glow.waveform.RouteSide
 import dev.ayuislands.glow.waveform.RouteSlice
+import dev.ayuislands.glow.waveform.RouteUpdate
 import dev.ayuislands.glow.waveform.TravelDirection
 import dev.ayuislands.glow.waveform.WaveformConfig
 import dev.ayuislands.glow.waveform.WaveformFrame
@@ -27,10 +31,32 @@ import io.mockk.unmockkConstructor
 import io.mockk.verify
 import org.junit.jupiter.api.Test
 import java.awt.Color
+import java.awt.Point
 import java.awt.Window
+import javax.swing.JLayeredPane
 import kotlin.test.assertEquals
 
 class RouteControllerTest {
+    @Test
+    fun `inactive route does not advance until one route window is active`() {
+        val controller = controller()
+        val coordinator = mockk<RouteCoordinator>()
+        every { coordinator.handle(any()) } returns RouteUpdate()
+        seedCoordinator(controller, coordinator)
+        val window = mockk<Window>()
+        every { window.isActive } returns false
+        seedRouteRoot(controller, window)
+
+        controller.handle(RouteEvent.Tick(100L))
+
+        verify(exactly = 1) { coordinator.handle(RouteEvent.Tick(100L, isWindowActive = false)) }
+
+        every { window.isActive } returns true
+        controller.handle(RouteEvent.Tick(200L))
+
+        verify(exactly = 1) { coordinator.handle(RouteEvent.Tick(200L, isWindowActive = true)) }
+    }
+
     @Test
     fun `every visible window bridge slice is rendered`() {
         mockkConstructor(CrossWindowBridge::class)
@@ -269,6 +295,35 @@ class RouteControllerTest {
             state = { AyuIslandsState() },
             onFailure = {},
         )
+
+    private fun seedCoordinator(
+        controller: RouteController,
+        coordinator: RouteCoordinator,
+    ) {
+        val field = controller.javaClass.getDeclaredField("coordinator")
+        field.isAccessible = true
+        field.set(controller, coordinator)
+    }
+
+    private fun seedRouteRoot(
+        controller: RouteController,
+        window: Window,
+    ) {
+        val rootClass = Class.forName("dev.ayuislands.glow.RouteRoot")
+        val constructor =
+            rootClass.getDeclaredConstructor(
+                JLayeredPane::class.java,
+                Window::class.java,
+                Point::class.java,
+            )
+        constructor.isAccessible = true
+        val root = constructor.newInstance(JLayeredPane(), window, Point())
+        val field = controller.javaClass.getDeclaredField("roots")
+        field.isAccessible = true
+        val roots = field.get(controller)
+        val put = roots.javaClass.getMethod("put", Any::class.java, Any::class.java)
+        put.invoke(roots, RouteRootId(1), root)
+    }
 
     private fun renderBridge(
         controller: RouteController,

--- a/src/test/kotlin/dev/ayuislands/glow/waveform/RouteCoordinatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/waveform/RouteCoordinatorTest.kt
@@ -715,6 +715,28 @@ class RouteCoordinatorTest {
     }
 
     @TestCase
+    fun `paused wall clock excludes an inactive window interval`() {
+        val coordinator = testCoordinator(seededRandom(44))
+        val graph = testGraph(mapOf("Editor" to 400f), emptyList())
+        coordinator.handle(RouteEvent.Activate(graph, "Editor", false))
+        coordinator.handle(RouteEvent.Tick(0L))
+        coordinator.handle(RouteEvent.Tick(5_000L))
+        val before = coordinator.snapshot.distanceOnLeg
+
+        coordinator.handle(RouteEvent.Tick(900_000L, isWindowActive = false))
+
+        assertEquals(before, coordinator.snapshot.distanceOnLeg, 0.001f)
+
+        coordinator.handle(RouteEvent.Tick(901_000L))
+
+        assertEquals(before, coordinator.snapshot.distanceOnLeg, 0.001f)
+
+        coordinator.handle(RouteEvent.Tick(902_000L))
+
+        assertTrue(coordinator.snapshot.distanceOnLeg > before)
+    }
+
+    @TestCase
     fun `resume preserves the pre-suspend frame`() {
         val coordinator = testCoordinator(seededRandom(97))
         val graph = testGraph(mapOf("Editor" to 400f), emptyList())

--- a/src/test/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManagerTest.kt
@@ -214,42 +214,61 @@ class ProjectViewScrollbarManagerTest {
     @Test
     fun `installed root renderer does not recheck license while painting rows`() {
         realState.hideProjectRootPath = true
-        val tree = JTree()
-        val wrapper = JPanel(FlowLayout()).apply { add(JScrollPane(tree)) }
+        lateinit var tree: JTree
+        lateinit var wrapper: JPanel
+        SwingUtilities.invokeAndWait {
+            tree = JTree()
+            wrapper = JPanel(FlowLayout()).apply { add(JScrollPane(tree)) }
+        }
         setupToolWindowContent(wrapper)
         val manager = createAndDrain()
-        val renderer = assertIs<RootFilteringRenderer>(tree.cellRenderer)
-        clearMocks(LicenseChecker, answers = false, recordedCalls = true)
+        try {
+            lateinit var renderer: RootFilteringRenderer
+            SwingUtilities.invokeAndWait {
+                renderer = assertIs(tree.cellRenderer)
+            }
+            clearMocks(LicenseChecker, answers = false, recordedCalls = true)
 
-        SwingUtilities.invokeAndWait {
-            paintRootRow(tree, renderer)
+            SwingUtilities.invokeAndWait {
+                paintRootRow(tree, renderer)
+            }
+
+            verify(exactly = 0) { LicenseChecker.isLicensedOrGrace() }
+        } finally {
+            SwingUtilities.invokeAndWait { manager.dispose() }
         }
-
-        verify(exactly = 0) { LicenseChecker.isLicensedOrGrace() }
-        SwingUtilities.invokeAndWait { manager.dispose() }
     }
 
     @Test
     fun `renderer guard keeps replacement paint free of license checks`() {
         realState.hideProjectRootPath = true
-        val tree = JTree()
-        val wrapper = JPanel(FlowLayout()).apply { add(JScrollPane(tree)) }
+        lateinit var tree: JTree
+        lateinit var wrapper: JPanel
+        lateinit var replacement: DefaultTreeCellRenderer
+        SwingUtilities.invokeAndWait {
+            tree = JTree()
+            wrapper = JPanel(FlowLayout()).apply { add(JScrollPane(tree)) }
+            replacement = DefaultTreeCellRenderer()
+        }
         setupToolWindowContent(wrapper)
         val manager = createAndDrain()
-        val replacement = DefaultTreeCellRenderer()
+        try {
+            lateinit var renderer: RootFilteringRenderer
+            SwingUtilities.invokeAndWait {
+                tree.cellRenderer = replacement
+                renderer = assertIs(tree.cellRenderer)
+                assertSame(replacement, renderer.delegate)
+            }
+            clearMocks(LicenseChecker, answers = false, recordedCalls = true)
 
-        SwingUtilities.invokeAndWait { tree.cellRenderer = replacement }
+            SwingUtilities.invokeAndWait {
+                paintRootRow(tree, renderer)
+            }
 
-        val renderer = assertIs<RootFilteringRenderer>(tree.cellRenderer)
-        assertSame(replacement, renderer.delegate)
-        clearMocks(LicenseChecker, answers = false, recordedCalls = true)
-
-        SwingUtilities.invokeAndWait {
-            paintRootRow(tree, renderer)
+            verify(exactly = 0) { LicenseChecker.isLicensedOrGrace() }
+        } finally {
+            SwingUtilities.invokeAndWait { manager.dispose() }
         }
-
-        verify(exactly = 0) { LicenseChecker.isLicensedOrGrace() }
-        SwingUtilities.invokeAndWait { manager.dispose() }
     }
 
     private fun paintRootRow(

--- a/src/test/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManagerTest.kt
@@ -34,11 +34,14 @@ import javax.swing.JScrollPane
 import javax.swing.JTree
 import javax.swing.ScrollPaneConstants
 import javax.swing.SwingUtilities
+import javax.swing.tree.DefaultTreeCellRenderer
 import javax.swing.tree.TreeCellRenderer
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertSame
 
 class ProjectViewScrollbarManagerTest {
     private lateinit var project: Project
@@ -215,22 +218,57 @@ class ProjectViewScrollbarManagerTest {
         val wrapper = JPanel(FlowLayout()).apply { add(JScrollPane(tree)) }
         setupToolWindowContent(wrapper)
         val manager = createAndDrain()
+        val renderer = assertIs<RootFilteringRenderer>(tree.cellRenderer)
         clearMocks(LicenseChecker, answers = false, recordedCalls = true)
 
         SwingUtilities.invokeAndWait {
-            tree.cellRenderer.getTreeCellRendererComponent(
-                tree,
-                tree.model.root,
-                false,
-                false,
-                false,
-                0,
-                false,
-            )
+            paintRootRow(tree, renderer)
         }
 
         verify(exactly = 0) { LicenseChecker.isLicensedOrGrace() }
         SwingUtilities.invokeAndWait { manager.dispose() }
+    }
+
+    @Test
+    fun `renderer guard keeps replacement paint free of license checks`() {
+        realState.hideProjectRootPath = true
+        val tree = JTree()
+        val wrapper = JPanel(FlowLayout()).apply { add(JScrollPane(tree)) }
+        setupToolWindowContent(wrapper)
+        val manager = createAndDrain()
+        val replacement = DefaultTreeCellRenderer()
+
+        SwingUtilities.invokeAndWait { tree.cellRenderer = replacement }
+
+        val renderer = assertIs<RootFilteringRenderer>(tree.cellRenderer)
+        assertSame(replacement, renderer.delegate)
+        clearMocks(LicenseChecker, answers = false, recordedCalls = true)
+
+        SwingUtilities.invokeAndWait {
+            paintRootRow(tree, renderer)
+        }
+
+        verify(exactly = 0) { LicenseChecker.isLicensedOrGrace() }
+        SwingUtilities.invokeAndWait { manager.dispose() }
+    }
+
+    private fun paintRootRow(
+        tree: JTree,
+        renderer: TreeCellRenderer,
+    ) {
+        val isSelected = false
+        val isExpanded = false
+        val isLeaf = false
+        val hasFocus = false
+        renderer.getTreeCellRendererComponent(
+            tree,
+            tree.model.root,
+            isSelected,
+            isExpanded,
+            isLeaf,
+            0,
+            hasFocus,
+        )
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManagerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManagerTest.kt
@@ -209,6 +209,31 @@ class ProjectViewScrollbarManagerTest {
     }
 
     @Test
+    fun `installed root renderer does not recheck license while painting rows`() {
+        realState.hideProjectRootPath = true
+        val tree = JTree()
+        val wrapper = JPanel(FlowLayout()).apply { add(JScrollPane(tree)) }
+        setupToolWindowContent(wrapper)
+        val manager = createAndDrain()
+        clearMocks(LicenseChecker, answers = false, recordedCalls = true)
+
+        SwingUtilities.invokeAndWait {
+            tree.cellRenderer.getTreeCellRendererComponent(
+                tree,
+                tree.model.root,
+                false,
+                false,
+                false,
+                0,
+                false,
+            )
+        }
+
+        verify(exactly = 0) { LicenseChecker.isLicensedOrGrace() }
+        SwingUtilities.invokeAndWait { manager.dispose() }
+    }
+
+    @Test
     fun `applyScrollbar hides horizontal scrollbar`() {
         realState.hideProjectViewHScrollbar = true
         realState.hideProjectRootPath = false

--- a/src/test/kotlin/dev/ayuislands/syntax/SyntaxOverlayLoaderBaselineTest.kt
+++ b/src/test/kotlin/dev/ayuislands/syntax/SyntaxOverlayLoaderBaselineTest.kt
@@ -6,6 +6,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
+import java.awt.Color
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -17,7 +18,7 @@ import kotlin.test.assertTrue
 
 /**
  * Baseline-loader behaviour for [SyntaxOverlayLoader]. Validates
- * [loadBaselineForVariant] returns the parsed baseline `<attributes>` section
+ * [SyntaxOverlayLoader.loadBaselineForVariant] returns the parsed baseline `<attributes>` section
  * for each Ayu variant from the `baselineResourceBase` path, caches per
  * variant, and degrades gracefully on missing/malformed resources.
  *
@@ -398,6 +399,41 @@ class SyntaxOverlayLoaderBaselineTest {
                 "$variant baseline scheme must map inlay type hints to the Ayu type color",
             )
         }
+    }
+
+    @Test
+    fun `production Light baseline preserves translucent attribute backgrounds`() {
+        val baselineByName =
+            SyntaxOverlayLoader()
+                .loadBaselineForVariant("Light")
+                .entries
+                .associate { it.key.externalName to it.value }
+
+        assertEquals(
+            Color(0xE6, 0x50, 0x50, 0x20),
+            baselineByName["DIFF_CONFLICT"]?.backgroundColor,
+            "Light diff-conflict background must preserve its 12.5% alpha",
+        )
+        assertEquals(
+            Color(0xFF, 0x73, 0x83, 0x14),
+            baselineByName["DIFF_DELETED"]?.backgroundColor,
+            "Light deleted-line background must preserve its 7.8% alpha",
+        )
+        assertEquals(
+            Color(0x6C, 0xBF, 0x43, 0x20),
+            baselineByName["DIFF_INSERTED"]?.backgroundColor,
+            "Light inserted-line background must not shift a parseable RGBA value into opaque RGB",
+        )
+        assertEquals(
+            Color(0xFF, 0xE2, 0x94, 0x80),
+            baselineByName["IDENTIFIER_UNDER_CARET_ATTRIBUTES"]?.backgroundColor,
+            "Light identifier-under-caret background must preserve its 50% alpha",
+        )
+        assertEquals(
+            Color(0xE6, 0x50, 0x50),
+            baselineByName["DIFF_CONFLICT"]?.errorStripeColor,
+            "RGBA compatibility must keep neighboring opaque fields intact",
+        )
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/syntax/SyntaxOverlayLoaderTest.kt
+++ b/src/test/kotlin/dev/ayuislands/syntax/SyntaxOverlayLoaderTest.kt
@@ -138,8 +138,8 @@ class SyntaxOverlayLoaderTest {
     @Test
     fun `baseAttributes-only entry is loaded without throw (no value child)`() {
         // FAKE_KEY_WITH_BASE_REF has baseAttributes="JAVA_KEYWORD" and no <value>.
-        // Loader must resolve via TextAttributesKey.find(baseRef).defaultAttributes
-        // or fall back to empty TextAttributes when defaultAttributes is null.
+        // The loader keeps its own attributes unset so the active editor scheme
+        // resolves JAVA_KEYWORD through its normal inheritance chain.
         val overlay = loader().loadOverlayForVariant("Mirage")
         val names = overlay.keys.map { it.externalName }
         assertTrue("FAKE_KEY_WITH_BASE_REF" in names)


### PR DESCRIPTION
── Summary ─────────────────────────────────

Fix #330's translucent syntax-color regression and the startup/render anomalies exposed while validating it in a real IntelliJ installation. The fix preserves scheme inheritance and existing user settings while making scheme refreshes write-safe, glow lifecycle handling quieter and bounded, and active/inactive rendering substantially cheaper.

── Changes ─────────────────────────────────

- Fix: [SyntaxOverlayLoader.kt](src/main/kotlin/dev/ayuislands/syntax/SyntaxOverlayLoader.kt) — Preserve alpha in `#RRGGBBAA` colors without materializing inherited text attributes.
- Fix: [AyuIslandsStartupActivity.kt](src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt), [ProjectLanguageDetector.kt](src/main/kotlin/dev/ayuislands/accent/ProjectLanguageDetector.kt), [ScanCompletionAccentRefresher.kt](src/main/kotlin/dev/ayuislands/accent/ScanCompletionAccentRefresher.kt), and [FontPresetApplicator.kt](src/main/kotlin/dev/ayuislands/font/FontPresetApplicator.kt) — Route scheme refreshes through IntelliJ's non-modal write-safe queue while preserving ordering, cancellation, disposal, and headless fallbacks.
- Fix: [EditorTabGeometry.kt](src/main/kotlin/dev/ayuislands/glow/EditorTabGeometry.kt), [GlowGlassPane.kt](src/main/kotlin/dev/ayuislands/glow/GlowGlassPane.kt), and [GlowOverlayManager.kt](src/main/kotlin/dev/ayuislands/glow/GlowOverlayManager.kt) — Treat empty/transient geometry as expected lifecycle state, retain persistent-failure diagnostics, and stop deferred settling after disposal or host hiding.
- Perf: [GlowRenderer.kt](src/main/kotlin/dev/ayuislands/glow/GlowRenderer.kt), [RouteController.kt](src/main/kotlin/dev/ayuislands/glow/RouteController.kt), [RouteCoordinator.kt](src/main/kotlin/dev/ayuislands/glow/waveform/RouteCoordinator.kt), and [RouteModel.kt](src/main/kotlin/dev/ayuislands/glow/waveform/RouteModel.kt) — Cache pixel-equivalent border slices and stop clock/tick/render work for inactive windows.
- Perf: [CommitPanelAutoFitManager.kt](src/main/kotlin/dev/ayuislands/commitpanel/CommitPanelAutoFitManager.kt) and [ProjectViewScrollbarManager.kt](src/main/kotlin/dev/ayuislands/projectview/ProjectViewScrollbarManager.kt) — Cache entitlement at manager/renderer lifecycle boundaries instead of rechecking it per rendered row.
- Test: Add regression coverage for translucent colors, write-safe dispatch, transient geometry, pixel/cache equivalence, inactive-window routing, entitlement hot paths, disposal, and EDT-confined renderer tests.
- Docs: Rebind affected screenshot verification metadata in [features.yml](docs/features.yml) without changing screenshot bytes or verification dates.

── Validation ──────────────────────────────

```bash
./gradlew build koverVerify verifyPlugin                                              # Passed: 3,596 tests, 93.26% line coverage, 12/12 IDE targets compatible
./gradlew test --tests 'dev.ayuislands.projectview.ProjectViewScrollbarManagerTest'  # Passed on the final test bytes
./gradlew detekt ktlintCheck                                                         # Passed
scripts/verify-docs.py                                                               # Passed
git diff --check                                                                     # Clean
```

- IntelliJ inspections: 0 findings on every file touched by the final repair deltas.
- Installed artifact: the live plugin JAR exactly matched the built ZIP JAR (`2a4a8da23f1edb7b339325ba6aeee5ab011636e92774b42efd66e44b91d710c0`).
- Latest IntelliJ startup: Ayu loaded and applied accent `#5CCFE6`; 0 Ayu `WARN`/`ERROR`/`SEVERE` entries and no new freeze dump.
- Active-window JFR: Ayu EDT samples fell from 79/128 (61.7%) to 34/548 (6.2%); `WaveformPainter` fell from 61 samples to 0 and license checks from 17 to 1.
- Inactive-window JFR: 0 Ayu, route-controller, waveform, license, commit-panel, or project-view execution samples over 20 seconds.
- GitHub exact-head CI: all required checks passed for `6a862cb2`; Codecov patch coverage is 86.11%; Sourcery was skipped/unavailable.

── Notes ───────────────────────────────────

- Existing granular settings, theme JSON, animation choices, intensities, and per-surface selections are intentionally unchanged.
- A separate IntelliJ/JBR macOS accessibility anomaly remains outside this diff: `JTree.AccessibleJTreeNode.getSize()` emitted short NPE bursts with no Ayu frames. Focus and accessibility probes did not reproduce it, no new freeze dump was created, and the current profiles do not attribute that hot path to Ayu.
- Review focus: alpha preservation across inheritance, write-safe dispatch ordering, border-slice pixel equivalence, and lifecycle-bound entitlement/renderer state.

Closes #330
