### PR TITLE
chore(release): prepare v2.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## [Unreleased]
+## [2.8.5] - 2026-08-20
 
-- [Paid] **Smoother Glow in large and background windows** — Glow keeps the
+- [Fix] **Smoother Glow in large and background windows** — Glow keeps the
   same visuals while using less memory for large panels, pauses waveform work
   in inactive IDE windows, and stops deferred updates after an overlay is
   hidden or removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [Unreleased]
+
+- [Paid] **Smoother Glow in large and background windows** — Glow keeps the
+  same visuals while using less memory for large panels, pauses waveform work
+  in inactive IDE windows, and stops deferred updates after an overlay is
+  hidden or removed.
+- [Fix] **Reliable startup in 2026.2 IDEs** — fixes the write-unsafe startup
+  exception reported in [#330](https://github.com/barad1tos/ayu-jetbrains/issues/330)
+  while Ayu refreshes the interface, syntax colors, accents, or fonts.
+- [Fix] **Correct translucent syntax colors** — diff and caret backgrounds keep
+  their intended opacity instead of loading as corrupted colors or emitting
+  parsing warnings.
+
 ## [2.8.4] - 2026-08-14
 
 - [Fix] **Reliable editor color refreshes in Rider** — startup and settings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 - [Fix] **Smoother Glow in large and background windows** — Glow keeps the
   same visuals while using less memory for large panels, pauses waveform work
-  in inactive IDE windows, and stops deferred updates after an overlay is
-  hidden or removed.
+  in inactive IDE windows, and stops deferred updates after their host is
+  hidden or the project is closed.
 - [Fix] **Reliable startup in 2026.2 IDEs** — fixes the write-unsafe startup
   exception reported in [#330](https://github.com/barad1tos/ayu-jetbrains/issues/330)
   while Ayu refreshes the interface, syntax colors, accents, or fonts.

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -52,8 +52,8 @@ schema_version: 1
 # release. Between releases the hash is intentionally frozen to the last
 # published state — any copy edit without a version bump fails lint.
 release_sync:
-  last_published_version: "2.6.4"
-  last_published_description_sha256: "1a82d3d65aecbfbfdf86762d5ef5df584e1cdd14b7177f94f778d6e1a2e26839"
+  last_published_version: "2.8.5"
+  last_published_description_sha256: "74d76d289ba9f80142c89fbcbd66d18bf0211dddece5364e6e7b40c902d9254b"
 
 categories:
   accent:

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -52,8 +52,8 @@ schema_version: 1
 # release. Between releases the hash is intentionally frozen to the last
 # published state — any copy edit without a version bump fails lint.
 release_sync:
-  last_published_version: "2.8.5"
-  last_published_description_sha256: "74d76d289ba9f80142c89fbcbd66d18bf0211dddece5364e6e7b40c902d9254b"
+  last_published_version: "2.8.4"
+  last_published_description_sha256: "974f88c095fa34f5bcddebb0df7194768c8755495a49145bee933b5b3352d7ab"
 
 categories:
   accent:

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "d1527289"
+          last_verified_sha: "66af5671"
           last_verified_date: "2026-08-09"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "d1527289"
+          last_verified_sha: "66af5671"
           last_verified_date: "2026-08-09"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -324,7 +324,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "e7e3349f"
+          last_verified_sha: "66af5671"
           last_verified_date: "2026-08-09"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 
@@ -393,7 +393,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/FontPresetPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/FontPreviewComponent.kt
             - src/main/kotlin/dev/ayuislands/font
-          last_verified_sha: "d1527289"
+          last_verified_sha: "66af5671"
           last_verified_date: "2026-08-09"
           content_sha256: "2303011928e4246c32edfcc3c4caa923d536aa73f848e225708da4374ce17b41"
 
@@ -445,7 +445,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/gitpanel
             - src/main/kotlin/dev/ayuislands/projectview
             - src/main/kotlin/dev/ayuislands/editor/EditorScrollbarManager.kt
-          last_verified_sha: "7e2cf29a"
+          last_verified_sha: "66af5671"
           last_verified_date: "2026-08-09"
           content_sha256: ad849b17308901bc2dac85f895978be656f578c9c31f857b9e9578e5cf4289f2
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.8.4
+pluginVersion=2.8.5
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
@@ -70,6 +70,12 @@ internal object UpdateNotifier {
 
     private val RELEASE_NOTES =
         mapOf(
+            "2.8.5" to
+                releaseNotes(
+                    "[Fix] Glow stays smooth in large panels and pauses work in inactive windows",
+                    "[Fix] Startup refreshes in 2026.2 IDEs no longer trigger the exception reported in #330",
+                    "[Fix] Translucent diff and caret backgrounds keep their intended opacity",
+                ),
             "2.8.4" to
                 releaseNotes(
                     "[Fix] Rider editor color refreshes no longer trigger write-thread access errors",

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -121,6 +121,12 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>2.8.5</h3>
+    <ul>
+      <li>[Fix] <b>Smoother Glow in large and background windows</b> — Glow keeps the same visuals while using less memory for large panels, pauses waveform work in inactive IDE windows, and stops deferred updates after an overlay is hidden or removed.</li>
+      <li>[Fix] <b>Reliable startup in 2026.2 IDEs</b> — fixes the write-unsafe startup exception reported in <a href="https://github.com/barad1tos/ayu-jetbrains/issues/330">#330</a> while Ayu refreshes the interface, syntax colors, accents, or fonts.</li>
+      <li>[Fix] <b>Correct translucent syntax colors</b> — diff and caret backgrounds keep their intended opacity instead of loading as corrupted colors or emitting parsing warnings.</li>
+    </ul>
     <h3>2.8.4</h3>
     <ul>
       <li>[Fix] <b>Reliable editor color refreshes in Rider</b> — startup and settings changes no longer trigger write-thread access errors while Ayu refreshes the active editor color scheme.</li>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -123,7 +123,7 @@
     <change-notes><![CDATA[
     <h3>2.8.5</h3>
     <ul>
-      <li>[Fix] <b>Smoother Glow in large and background windows</b> — Glow keeps the same visuals while using less memory for large panels, pauses waveform work in inactive IDE windows, and stops deferred updates after an overlay is hidden or removed.</li>
+      <li>[Fix] <b>Smoother Glow in large and background windows</b> — Glow keeps the same visuals while using less memory for large panels, pauses waveform work in inactive IDE windows, and stops deferred updates after their host is hidden or the project is closed.</li>
       <li>[Fix] <b>Reliable startup in 2026.2 IDEs</b> — fixes the write-unsafe startup exception reported in <a href="https://github.com/barad1tos/ayu-jetbrains/issues/330">#330</a> while Ayu refreshes the interface, syntax colors, accents, or fonts.</li>
       <li>[Fix] <b>Correct translucent syntax colors</b> — diff and caret backgrounds keep their intended opacity instead of loading as corrupted colors or emitting parsing warnings.</li>
     </ul>

--- a/src/test/kotlin/dev/ayuislands/UpdateNotifierTest.kt
+++ b/src/test/kotlin/dev/ayuislands/UpdateNotifierTest.kt
@@ -7,7 +7,6 @@ import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
-import dev.ayuislands.AyuPlugin
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
 import dev.ayuislands.settings.SettingsBadges
@@ -79,7 +78,7 @@ class UpdateNotifierTest {
     @Test
     fun `same-version startup expires overdue settings badges`() {
         state.lastSeenVersion = "2.8.0"
-        for (anchor in SettingsBadges.registry) state.settingsBadgeDeadlines[anchor.id] = "1"
+        for ((id) in SettingsBadges.registry) state.settingsBadgeDeadlines[id] = "1"
         every {
             AyuPlugin.findLoadedPlugin(any<PluginId>())
         } returns descriptor
@@ -157,6 +156,40 @@ class UpdateNotifierTest {
                         body.contains("[Paid] Typing-responsive ECG glow") &&
                         body.contains("[Free] New-setting wayfinding") &&
                         body.contains("[Fix] Commit panel accessibility")
+                },
+                NotificationType.INFORMATION,
+            )
+        }
+        verify(exactly = 1) { notification.notify(project) }
+    }
+
+    @Test
+    fun `2_8_5 balloon lists release fixes`() {
+        state.lastSeenVersion = "2.8.4"
+        every {
+            AyuPlugin.findLoadedPlugin(any<PluginId>())
+        } returns descriptor
+        every { descriptor.version } returns "2.8.5"
+
+        val notification = mockk<Notification>(relaxed = true)
+        val group = mockk<NotificationGroup>(relaxed = true)
+        val groupManager = mockk<NotificationGroupManager>(relaxed = true)
+        every { NotificationGroupManager.getInstance() } returns groupManager
+        every { groupManager.getNotificationGroup("Ayu Islands") } returns group
+        every {
+            group.createNotification(any<String>(), any<String>(), any<NotificationType>())
+        } returns notification
+
+        UpdateNotifier.showIfUpdated(project)
+
+        assertEquals("2.8.5", state.lastSeenVersion)
+        verify(exactly = 1) {
+            group.createNotification(
+                "Ayu Islands updated to 2.8.5",
+                match<String> { body ->
+                    body.contains("[Fix] Glow stays smooth") &&
+                        body.contains("[Fix] Startup refreshes") &&
+                        body.contains("[Fix] Translucent diff and caret backgrounds")
                 },
                 NotificationType.INFORMATION,
             )


### PR DESCRIPTION
── Summary ─────────────────────────────────

Prepare Ayu Islands 2.8.5 for publication with startup reliability, translucent syntax color, and Glow performance fixes. The release notes explicitly link the confirmed startup bug report in [#330](https://github.com/barad1tos/ayu-jetbrains/issues/330).

── Changes ─────────────────────────────────

- Fix: Reduce Glow memory and inactive-window work while preserving the existing visual result.
- Fix: Prevent write-unsafe startup refreshes in 2026.2 IDEs and correct translucent syntax color parsing.
- Chore: Align the plugin version, changelog, Marketplace notes, update notification, and release-sync metadata for v2.8.5.

── Validation ──────────────────────────────

- `scripts/verify-docs.py` — passed.
- `./gradlew clean buildPlugin` — passed; produced `ayu-jetbrains-2.8.5.zip`.
- `./gradlew verifyPlugin` — passed for all 12 target IDEs.
- `./gradlew detekt ktlintCheck test koverVerify` — passed; 3,598 tests, 0 failures/errors/skips.
- IDEA inspections for `UpdateNotifier.kt` and `plugin.xml` — 0 problems.

── Notes ───────────────────────────────────

The paid product descriptor remains at `release-version=28` and `release-date=20260718`; Marketplace requires the date to remain aligned with the existing entry while the paid release version is unchanged.

## Summary by Sourcery

Prepare Ayu Islands 2.8.5 with startup reliability, translucent color, and Glow performance fixes.

Bug Fixes:
- Improve Glow performance and memory usage while preserving its existing appearance, including reduced work in inactive or closed windows.
- Fix startup refresh failures in 2026.2 IDEs and preserve opacity when parsing translucent syntax colors.

Build:
- Bump the plugin version to 2.8.5.

Documentation:
- Add 2.8.5 release notes, Marketplace change notes, and update notifications, including a link to issue #330.

Tests:
- Add coverage verifying that the 2.8.5 update notification lists its release fixes.

Chores:
- Synchronize release metadata and feature verification records for version 2.8.5.