### PR TITLE
fix(glow): contain chaotic traces within islands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+- [Fix] **Contained chaotic waveform borders** — Chaotic ECG traces stay
+  inside their editor and tool-window islands instead of spilling across
+  neighboring panels, while route connectors remain visible during focus and
+  window transitions. [#333](https://github.com/barad1tos/ayu-jetbrains/issues/333)
+
 ## [2.8.5] - 2026-08-20
 
 - [Fix] **Smoother Glow in large and background windows** — Glow keeps the

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -324,7 +324,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "de7d9883"
+          last_verified_sha: "1dca5eee"
           last_verified_date: "2026-08-09"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -324,7 +324,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "66af5671"
+          last_verified_sha: "de7d9883"
           last_verified_date: "2026-08-09"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 

--- a/src/main/kotlin/dev/ayuislands/glow/RouteController.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/RouteController.kt
@@ -31,6 +31,7 @@ import dev.ayuislands.settings.effectiveLoopSeconds
 import dev.ayuislands.settings.effectiveTraceDensity
 import dev.ayuislands.settings.effectiveTraceLength
 import java.awt.Point
+import java.awt.Rectangle
 import java.awt.Window
 import java.util.IdentityHashMap
 import javax.swing.JComponent
@@ -298,7 +299,16 @@ internal class RouteController(
                     }
             layer.setBounds(0, 0, root.layeredPane.width, root.layeredPane.height)
             layer.updateStyle(style)
-            layer.showFrame(frame, slices.map { slice -> slice.relativeTo(root.screenOrigin) })
+            val surfaceBounds =
+                routeOverlays
+                    .asSequence()
+                    .filter { overlay -> overlay.layeredPane === root.layeredPane }
+                    .associate { overlay -> overlay.id to Rectangle(overlay.pane.bounds) }
+            layer.showFrame(
+                frame = frame,
+                slices = slices.map { slice -> slice.relativeTo(root.screenOrigin) },
+                surfaceBounds = surfaceBounds,
+            )
             if (!isActive) return
         }
         layers

--- a/src/main/kotlin/dev/ayuislands/glow/waveform/CrossWindowBridge.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/waveform/CrossWindowBridge.kt
@@ -128,7 +128,11 @@ internal class CrossWindowBridge(
             window.bounds = bounds
             layer.setBounds(0, 0, bounds.width, bounds.height)
             layer.updateStyle(style)
-            layer.showFrame(frame, visibleSlices.map { slice -> localSlice(slice, bounds) })
+            layer.showFrame(
+                frame = frame,
+                slices = visibleSlices.map { slice -> localSlice(slice, bounds) },
+                surfaceBounds = emptyMap(),
+            )
             if (disposed) return
             if (!visible) {
                 window.isVisible = true

--- a/src/main/kotlin/dev/ayuislands/glow/waveform/WaveformRouteLayer.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/waveform/WaveformRouteLayer.kt
@@ -18,13 +18,18 @@ internal data class RouteLayerStyle(
     val config: WaveformConfig,
 )
 
+private data class ClippedPlan(
+    val plan: WaveformRenderPlan,
+    val clip: Rectangle?,
+)
+
 internal class WaveformRouteLayer(
     val rootId: RouteRootId,
     private val onFailure: (RuntimeException) -> Unit,
 ) : JComponent() {
     private val painter = WaveformPainter()
     private var style: RouteLayerStyle? = null
-    private var plans: List<WaveformRenderPlan> = emptyList()
+    private var plans: List<ClippedPlan> = emptyList()
     private var frameAlpha = 1f
     private var failureReported = false
 
@@ -47,6 +52,7 @@ internal class WaveformRouteLayer(
     fun showFrame(
         frame: RouteFrame,
         slices: List<RouteSlice>,
+        surfaceBounds: Map<String, Rectangle> = emptyMap(),
     ) {
         val currentStyle = style ?: return
         try {
@@ -56,8 +62,12 @@ internal class WaveformRouteLayer(
                     .filter { slice ->
                         val target = slice.target as? RoutePaintTarget.Root
                         target?.rootId == rootId
-                    }.map { slice -> preparePlan(frame, slice, currentStyle) }
-                    .toList()
+                    }.map { slice ->
+                        ClippedPlan(
+                            plan = preparePlan(frame, slice, currentStyle),
+                            clip = slice.surfaceId?.let(surfaceBounds::get)?.let(::Rectangle),
+                        )
+                    }.toList()
             replacePlans(nextPlans, frame.alpha.coerceIn(0f, 1f))
         } catch (exception: RuntimeException) {
             reportFailure(exception)
@@ -76,7 +86,20 @@ internal class WaveformRouteLayer(
             routeGraphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
             routeGraphics.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY)
             routeGraphics.composite = AlphaComposite.SrcOver.derive(frameAlpha)
-            plans.forEach { plan -> painter.paint(routeGraphics, plan) }
+            plans.forEach { clippedPlan ->
+                val clip = clippedPlan.clip
+                if (clip == null) {
+                    painter.paint(routeGraphics, clippedPlan.plan)
+                    return@forEach
+                }
+                val planGraphics = routeGraphics.create() as Graphics2D
+                try {
+                    planGraphics.clip(clip)
+                    painter.paint(planGraphics, clippedPlan.plan)
+                } finally {
+                    planGraphics.dispose()
+                }
+            }
         } catch (exception: RuntimeException) {
             reportFailure(exception)
         } finally {
@@ -118,7 +141,7 @@ internal class WaveformRouteLayer(
     }
 
     private fun replacePlans(
-        nextPlans: List<WaveformRenderPlan>,
+        nextPlans: List<ClippedPlan>,
         frameAlpha: Float,
     ) {
         val oldBounds = planBounds(plans)
@@ -140,8 +163,8 @@ internal class WaveformRouteLayer(
         onFailure(exception)
     }
 
-    private fun planBounds(renderPlans: List<WaveformRenderPlan>): Rectangle? =
+    private fun planBounds(renderPlans: List<ClippedPlan>): Rectangle? =
         renderPlans
-            .mapNotNull(WaveformRenderPlan::signalBounds)
+            .mapNotNull { clippedPlan -> clippedPlan.plan.signalBounds }
             .reduceOrNull(Rectangle::union)
 }

--- a/src/main/kotlin/dev/ayuislands/glow/waveform/WaveformRouteLayer.kt
+++ b/src/main/kotlin/dev/ayuislands/glow/waveform/WaveformRouteLayer.kt
@@ -52,7 +52,7 @@ internal class WaveformRouteLayer(
     fun showFrame(
         frame: RouteFrame,
         slices: List<RouteSlice>,
-        surfaceBounds: Map<String, Rectangle> = emptyMap(),
+        surfaceBounds: Map<String, Rectangle>,
     ) {
         val currentStyle = style ?: return
         try {
@@ -62,10 +62,14 @@ internal class WaveformRouteLayer(
                     .filter { slice ->
                         val target = slice.target as? RoutePaintTarget.Root
                         target?.rootId == rootId
-                    }.map { slice ->
+                    }.mapNotNull { slice ->
+                        val clip =
+                            slice.surfaceId?.let { surfaceId ->
+                                surfaceBounds[surfaceId]?.let(::Rectangle) ?: return@mapNotNull null
+                            }
                         ClippedPlan(
                             plan = preparePlan(frame, slice, currentStyle),
-                            clip = slice.surfaceId?.let(surfaceBounds::get)?.let(::Rectangle),
+                            clip = clip,
                         )
                     }.toList()
             replacePlans(nextPlans, frame.alpha.coerceIn(0f, 1f))

--- a/src/test/kotlin/dev/ayuislands/glow/waveform/RouteLayerPixelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/waveform/RouteLayerPixelTest.kt
@@ -22,7 +22,7 @@ class RouteLayerPixelTest {
         layer.setBounds(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT)
         layer.updateStyle(testStyle())
         val frame = transitionFrame()
-        layer.showFrame(frame, frame.slices)
+        layer.showFrame(frame, frame.slices, fullSurfaceBounds(frame))
 
         val image = render(layer)
 
@@ -58,6 +58,32 @@ class RouteLayerPixelTest {
         assertFalse(hasPaintedPixel(image, Rectangle(280, 130, 18, 14)))
         assertFalse(hasPaintedPixel(image, Rectangle(280, 157, 18, 14)))
         assertTrue(hasPaintedPixel(image, Rectangle(314, 138, 12, 24)), "connector must remain visible")
+    }
+
+    @Test
+    fun `recovery omits a missing current island while preserving its route`() {
+        val layer = WaveformRouteLayer(RouteRootId(1)) { throw it }
+        layer.setBounds(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT)
+        layer.updateStyle(testStyle())
+        val frame = transitionFrame()
+        val editorBounds = Rectangle(280, 144, 18, 13)
+
+        layer.showFrame(
+            frame = frame,
+            slices = frame.slices,
+            surfaceBounds = mapOf("Editor" to editorBounds),
+        )
+
+        val image = render(layer)
+        val missingPerimeterRegion = Rectangle(354, 138, 6, 24)
+
+        assertTrue(
+            hasPaintedPixel(renderFrame(frame), missingPerimeterRegion),
+            "fixture must include the current perimeter",
+        )
+        assertTrue(hasPaintedPixel(image, editorBounds), "surviving perimeter must remain visible")
+        assertTrue(hasPaintedPixel(image, Rectangle(314, 138, 12, 24)), "connector must remain visible")
+        assertFalse(hasPaintedPixel(image, missingPerimeterRegion), "missing perimeter must not leave a ghost")
     }
 
     @Test
@@ -272,7 +298,7 @@ class RouteLayerPixelTest {
         layer.setBounds(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT)
         layer.updateStyle(testStyle())
         val frame = transitionFrame()
-        layer.showFrame(frame, frame.slices)
+        layer.showFrame(frame, frame.slices, fullSurfaceBounds(frame))
 
         val image = render(layer)
 
@@ -337,11 +363,11 @@ class RouteLayerPixelTest {
         val recordingManager = RecordingRepaintManager()
         RepaintManager.setCurrentManager(recordingManager)
         try {
-            layer.showFrame(firstFrame, firstFrame.slices)
+            layer.showFrame(firstFrame, firstFrame.slices, fullSurfaceBounds(firstFrame))
             val firstBounds = assertNotNull(paintedBounds(render(layer)))
             recordingManager.clear()
 
-            layer.showFrame(secondFrame, secondFrame.slices)
+            layer.showFrame(secondFrame, secondFrame.slices, fullSurfaceBounds(secondFrame))
             val secondBounds = assertNotNull(paintedBounds(render(layer)))
             val dirtyBounds = assertNotNull(recordingManager.dirtyBounds())
 
@@ -376,7 +402,7 @@ class RouteLayerPixelTest {
         WaveformRouteLayer(RouteRootId(1)) { throw it }.also { layer ->
             layer.setBounds(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT)
             layer.updateStyle(testStyle())
-            layer.showFrame(frame, frame.slices)
+            layer.showFrame(frame, frame.slices, fullSurfaceBounds(frame))
         }
 
     private fun renderFrame(frame: RouteFrame): BufferedImage = render(routeLayer(frame))
@@ -431,6 +457,12 @@ private fun testStyle(): RouteLayerStyle =
                 traceLength = 360,
             ),
     )
+
+private fun fullSurfaceBounds(frame: RouteFrame): Map<String, Rectangle> =
+    frame.slices
+        .mapNotNull(RouteSlice::surfaceId)
+        .distinct()
+        .associateWith { Rectangle(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT) }
 
 private fun transitionFrame(): RouteFrame {
     val target = RoutePaintTarget.Root(RouteRootId(1))

--- a/src/test/kotlin/dev/ayuislands/glow/waveform/RouteLayerPixelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/glow/waveform/RouteLayerPixelTest.kt
@@ -38,6 +38,29 @@ class RouteLayerPixelTest {
     }
 
     @Test
+    fun `perimeter traces stay inside their islands while connector remains visible`() {
+        val layer = WaveformRouteLayer(RouteRootId(1)) { throw it }
+        layer.setBounds(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT)
+        layer.updateStyle(testStyle())
+        val frame = transitionFrame()
+        val editorBounds = Rectangle(280, 144, 18, 13)
+        val commitBounds = Rectangle(342, 144, 18, 13)
+
+        layer.showFrame(
+            frame = frame,
+            slices = frame.slices,
+            surfaceBounds = mapOf("Editor" to editorBounds, "Commit" to commitBounds),
+        )
+
+        val image = render(layer)
+
+        assertTrue(hasPaintedPixel(image, editorBounds), "source perimeter must remain visible")
+        assertFalse(hasPaintedPixel(image, Rectangle(280, 130, 18, 14)))
+        assertFalse(hasPaintedPixel(image, Rectangle(280, 157, 18, 14)))
+        assertTrue(hasPaintedPixel(image, Rectangle(314, 138, 12, 24)), "connector must remain visible")
+    }
+
+    @Test
     fun `touching perimeter handoff keeps brightness and bounded motion`() {
         val frames = touchingCoordinatorFrames()
         val images = frames.map(::renderFrame)


### PR DESCRIPTION
── Summary ─────────────────────────────────

Chaotic routed waveform traces could bleed beyond their owning tool window because perimeter slices were painted on a root-wide overlay without an island clip. This clips live perimeter traces to their corresponding overlay bounds, omits detached perimeters during recovery, and keeps connector transitions visible between islands.

**Context**: Fixes #333

── Changes ─────────────────────────────────

- Pass root-local bounds for every routed island.
- Clip perimeter render plans while leaving connector slices visible.
- Drop stale perimeter slices when their owning overlay has been removed or rebound.
- Cover containment, connector continuity, and missing-overlay recovery with pixel tests.
- Add the user-facing fix to `[Unreleased]` and refresh the unchanged Glow screenshot metadata.

── Validation ───────────────────────────────

- `./gradlew detekt ktlintCheck` — passed.
- `./gradlew test koverVerify` — passed, including integration tests and the protected coverage gate.
- `./gradlew buildPlugin verifyPlugin` — passed; all 12 IDE targets compatible, including IntelliJ IDEA 2026.2.
- `scripts/verify-docs.py` — passed on the final head.
- IDEA inspections and targeted IDE build for all changed Kotlin files — no problems.
- Clean `$deploy-to-ide` pipeline — installed in IntelliJ IDEA 2026.2; composed JAR hash and `javap -c` bytecode verified.
- Runtime log check — active Ayu Mirage Islands overlays with no Ayu `WARN`, `ERROR`, `SEVERE`, stack traces, or render-budget warnings.
- Live visual check — waveform spill was no longer observed with the deployed build.
- Internal code and test review loop — clean after the missing-overlay recovery repair.

── Notes ───────────────────────────────────

Review the root-coordinate bounds mapping and the deliberate fail-closed behavior for perimeter slices whose live overlay bounds are unavailable.

## Summary by Sourcery

Contain chaotic waveform traces within their routed islands without interrupting inter-island connectors.

Bug Fixes:
- Keep routed waveform perimeter traces contained within their owning islands while preserving visible connector transitions between islands.

Tests:
- Add pixel coverage for island containment and continuous connector rendering.
