### PR TITLE
chore(release): prepare v2.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [2.8.6] - 2026-08-23
 
 - [Fix] **Contained chaotic waveform borders** — Chaotic ECG traces stay
   inside their editor and tool-window islands instead of spilling across

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -324,7 +324,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "1dca5eee"
+          last_verified_sha: "5a40a1cb"
           last_verified_date: "2026-08-09"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.8.5
+pluginVersion=2.8.6
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
@@ -70,6 +70,10 @@ internal object UpdateNotifier {
 
     private val RELEASE_NOTES =
         mapOf(
+            "2.8.6" to
+                releaseNotes(
+                    "[Fix] Chaotic ECG traces stay inside their editor and tool-window islands",
+                ),
             "2.8.5" to
                 releaseNotes(
                     "[Fix] Glow stays smooth in large panels and pauses work in inactive windows",

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -121,6 +121,10 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>2.8.6</h3>
+    <ul>
+      <li>[Fix] <b>Contained chaotic waveform borders</b> — Chaotic ECG traces stay inside their editor and tool-window islands instead of spilling across neighboring panels, while route connectors remain visible during focus and window transitions.</li>
+    </ul>
     <h3>2.8.5</h3>
     <ul>
       <li>[Fix] <b>Smoother Glow in large and background windows</b> — Glow keeps the same visuals while using less memory for large panels, pauses waveform work in inactive IDE windows, and stops deferred updates after their host is hidden or the project is closed.</li>

--- a/src/test/kotlin/dev/ayuislands/UpdateNotifierTest.kt
+++ b/src/test/kotlin/dev/ayuislands/UpdateNotifierTest.kt
@@ -198,6 +198,38 @@ class UpdateNotifierTest {
     }
 
     @Test
+    fun `2_8_6 balloon lists waveform containment fix`() {
+        state.lastSeenVersion = "2.8.5"
+        every {
+            AyuPlugin.findLoadedPlugin(any<PluginId>())
+        } returns descriptor
+        every { descriptor.version } returns "2.8.6"
+
+        val notification = mockk<Notification>(relaxed = true)
+        val group = mockk<NotificationGroup>(relaxed = true)
+        val groupManager = mockk<NotificationGroupManager>(relaxed = true)
+        every { NotificationGroupManager.getInstance() } returns groupManager
+        every { groupManager.getNotificationGroup("Ayu Islands") } returns group
+        every {
+            group.createNotification(any<String>(), any<String>(), any<NotificationType>())
+        } returns notification
+
+        UpdateNotifier.showIfUpdated(project)
+
+        assertEquals("2.8.6", state.lastSeenVersion)
+        verify(exactly = 1) {
+            group.createNotification(
+                "Ayu Islands updated to 2.8.6",
+                match<String> { body ->
+                    body.contains("[Fix] Chaotic ECG traces stay inside their editor and tool-window islands")
+                },
+                NotificationType.INFORMATION,
+            )
+        }
+        verify(exactly = 1) { notification.notify(project) }
+    }
+
+    @Test
     fun `updates lastSeenVersion on first install without notification`() {
         state.lastSeenVersion = null
         every {


### PR DESCRIPTION
── Summary ─────────────────────────────────

Prepare Ayu Islands 2.8.6 so the contained chaotic waveform fix can be published through the protected `main` branch.

── Changes ─────────────────────────────────

| Type | File | Description |
|------|------|-------------|
| Chore | [gradle.properties](gradle.properties) | Bump the plugin version to 2.8.6. |
| Docs | [CHANGELOG.md](CHANGELOG.md) | Promote the reviewed waveform containment note from Unreleased. |
| Docs | [plugin.xml](src/main/resources/META-INF/plugin.xml) | Add Marketplace change notes for 2.8.6. |
| Chore | [UpdateNotifier.kt](src/main/kotlin/dev/ayuislands/UpdateNotifier.kt) | Add concise in-IDE update notes for 2.8.6. |
| Docs | [features.yml](docs/features.yml) | Re-bind Glow verification metadata to the squash-merge commit. |
| Test | [UpdateNotifierTest.kt](src/test/kotlin/dev/ayuislands/UpdateNotifierTest.kt) | Verify the 2.8.6 update balloon copy and delivery. |

── Validation ──────────────────────────────

- `./gradlew clean buildPlugin` — passed; built `ayu-jetbrains-2.8.6.zip`.
- `./gradlew verifyPlugin` — passed; all 12 IDE targets compatible, including IntelliJ IDEA 2026.2.
- `./gradlew test koverVerify` — passed; tests and protected coverage gate green.
- `./gradlew detekt ktlintCheck` — passed.
- `scripts/verify-docs.py` — passed; feature manifest in sync.
- IntelliJ inspection of `UpdateNotifier.kt` — no problems.

── Notes ───────────────────────────────────

The release tag has not been pushed. After this PR merges, `v2.8.6` will be created on the resulting `main` commit to trigger the release workflow.
