### PR TITLE
chore(release): prepare 2.8.7 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [Unreleased]
+
+- [Paid] **Universal per-language syntax tuning** — Custom syntax settings now
+  follow the active file in the active project window and expose only controls
+  supported by the installed language tooling. Tune intensity against a
+  representative native preview with immediate editor feedback; Apply keeps
+  the result, while Cancel restores the exact previous scheme and preferences.
+  Existing presets and saved choices remain unchanged until edited.
+- [Paid] **Bold and Italic for individual syntax primitives** — each available
+  language primitive can independently add Bold, Italic, or both while keeping
+  its inherited color and font style, with an explicit option to replace the
+  inherited style when needed.
+- [Fix] **Reliable startup in IntelliJ Platform 2025.1** — coroutine-backed Ayu
+  features now retain metadata compatible with the oldest supported IDE
+  runtime instead of failing when the platform reads newer debug metadata.
+- [Fix] **Stable Retina preview and Glow buffers** — offscreen rendering keeps
+  logical-pixel geometry on HiDPI displays instead of multiplying cache size
+  and memory use with the ambient display scale.
+
 ## [2.8.6] - 2026-08-23
 
 - [Fix] **Contained chaotic waveform borders** — Chaotic ECG traces stay

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -540,7 +540,7 @@ categories:
         title: "Per-language syntax tuning"
         keyword: "Syntax tuning"
         introduced: "2.7.0"
-        updated: "2.9.0"
+        updated: "2.8.7"
         tier: paid
         description: >
           Per-language sliders tune only primitives confirmed by the active

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "76feb123"
+          last_verified_sha: "79e4a98c"
           last_verified_date: "2026-08-09"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "76feb123"
+          last_verified_sha: "79e4a98c"
           last_verified_date: "2026-08-09"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 
@@ -324,7 +324,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/GlowGroupPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/AyuIslandsEffectsPanel.kt
             - src/main/kotlin/dev/ayuislands/glow
-          last_verified_sha: "585c8161"
+          last_verified_sha: "79e4a98c"
           last_verified_date: "2026-08-28"
           content_sha256: "3ef51add4539d9c82ce6ad559bce68f6d88fb97606986910ea9b9d13da64fef5"
 

--- a/src/test/kotlin/dev/ayuislands/integration/NativePreviewContractTest.kt
+++ b/src/test/kotlin/dev/ayuislands/integration/NativePreviewContractTest.kt
@@ -15,6 +15,7 @@ import com.intellij.openapi.fileTypes.UnknownFileType
 import com.intellij.psi.TokenType
 import com.intellij.psi.tree.IElementType
 import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixture4TestCase
+import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl
 import dev.ayuislands.settings.ConditionalAbsence
 import dev.ayuislands.settings.HighlightEvidence
 import dev.ayuislands.settings.HighlightEvidenceCollector
@@ -399,7 +400,20 @@ class NativePreviewContractTest : LightPlatformCodeInsightFixture4TestCase() {
             ) {
                 "No syntax highlighter for ${previewFile.fileName}"
             }
-        val highlightInfos = myFixture.doHighlighting()
+        val fixture = myFixture as CodeInsightTestFixtureImpl
+        val previewText = fixture.editor.document.text
+        fixture.canChangeDocumentDuringHighlighting(runtime.allowsHighlightingRestart)
+        val highlightInfos =
+            try {
+                fixture.doHighlighting()
+            } finally {
+                fixture.canChangeDocumentDuringHighlighting(false)
+            }
+        assertEquals(
+            "${runtime.id} changed ${previewFile.fileName} during native highlighting",
+            previewText,
+            fixture.editor.document.text,
+        )
         val semanticKeys =
             highlightInfos.mapTo(linkedSetOf()) { info ->
                 (info.forcedTextAttributesKey ?: info.type.attributesKey).externalName

--- a/src/test/kotlin/dev/ayuislands/integration/SyntaxRuntimeCatalog.kt
+++ b/src/test/kotlin/dev/ayuislands/integration/SyntaxRuntimeCatalog.kt
@@ -22,6 +22,7 @@ internal data class SyntaxRuntime(
     val productId: String,
     val version: String,
     val candidateLanguages: Set<String>,
+    val allowsHighlightingRestart: Boolean = false,
     val marketplaceDependency: MarketplaceDependency? = null,
     val provisioning: RuntimeProvisioning = RuntimeProvisioning.Ready,
 )
@@ -100,6 +101,7 @@ internal object SyntaxRuntimeCatalog {
                 productId = "INTELLIJ_IDEA_COMMUNITY",
                 version = "2025.1",
                 candidateLanguages = setOf("Dart"),
+                allowsHighlightingRestart = true,
                 marketplaceDependency = MarketplaceDependency("Dart", "506.1.0"),
             ),
             SyntaxRuntime(

--- a/src/test/kotlin/dev/ayuislands/integration/SyntaxRuntimeCatalogTest.kt
+++ b/src/test/kotlin/dev/ayuislands/integration/SyntaxRuntimeCatalogTest.kt
@@ -92,6 +92,12 @@ class SyntaxRuntimeCatalogTest {
         val runtime = SyntaxRuntimeCatalog.require("dart")
 
         assertEquals(setOf("Dart"), runtime.candidateLanguages)
+        assertTrue(runtime.allowsHighlightingRestart)
+        assertTrue(
+            SyntaxRuntimeCatalog.entries
+                .filterNot { candidate -> candidate.id == runtime.id }
+                .none(SyntaxRuntime::allowsHighlightingRestart),
+        )
         assertEquals(MarketplaceDependency("Dart", "506.1.0"), runtime.marketplaceDependency)
     }
 


### PR DESCRIPTION
── Summary ─────────────────────────────────

Prepare the reviewed user-facing changes since v2.8.6 for the 2.8.7 release pipeline.

── Changes ─────────────────────────────────

- Chore: [CHANGELOG.md](CHANGELOG.md) — Add ordered `[Unreleased]` notes for universal per-language syntax tuning, per-primitive Bold / Italic controls, IntelliJ Platform 2025.1 compatibility, and Retina buffer stability.
- Chore: [docs/features.yml](docs/features.yml) — Rebind three orphaned screenshot verification SHAs after the squash merge without changing their content hashes.

── Validation ──────────────────────────────

- `scripts/verify-docs.py` — passed; feature manifest is in sync.
- `./gradlew detekt ktlintCheck` — passed.
- `./gradlew test koverVerify` — passed.
- `./gradlew buildPlugin verifyPlugin` — passed; compatible with all 12 configured IDE targets.
- IDEA inspections for both changed files — clean.

── Notes ───────────────────────────────────

This PR does not bump the plugin version, create a tag, or publish to Marketplace. The release pipeline will perform those steps from `main` after merge.

## Summary by Sourcery

Prepare the reviewed changes and documentation metadata for the 2.8.7 release pipeline.

Enhancements:
- Record the reviewed user-facing changes planned for the 2.8.7 release, including syntax customization, primitive font styling, IntelliJ Platform compatibility, and Retina rendering stability.

Documentation:
- Add the 2.8.7 unreleased changelog entries and update the feature manifest metadata for the release.

Tests:
- Extend native preview integration coverage for runtimes that may restart highlighting and verify previews remain unchanged.

Chores:
- Rebind orphaned feature verification references without changing their content hashes.