### PR TITLE
chore(release): prepare v2.8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [2.8.7] - 2026-08-29
 
 - [Paid] **Universal per-language syntax tuning** — Custom syntax settings now
   follow the active file in the active project window and expose only controls

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup=com.ayuislands
 pluginName=Ayu Islands
-pluginVersion=2.8.6
+pluginVersion=2.8.7
 pluginSinceBuild=251
 platformVersion=2025.1
 

--- a/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
+++ b/src/main/kotlin/dev/ayuislands/UpdateNotifier.kt
@@ -70,6 +70,13 @@ internal object UpdateNotifier {
 
     private val RELEASE_NOTES =
         mapOf(
+            "2.8.7" to
+                releaseNotes(
+                    "[Paid] Custom syntax tuning follows the active language and shows supported controls",
+                    "[Paid] Individual syntax primitives can add Bold, Italic, or both",
+                    "[Fix] Ayu starts reliably in IntelliJ Platform 2025.1 IDEs",
+                    "[Fix] Retina preview and Glow buffers keep logical-pixel sizing",
+                ),
             "2.8.6" to
                 releaseNotes(
                     "[Fix] Chaotic ECG traces stay inside their editor and tool-window islands",

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -121,6 +121,13 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>2.8.7</h3>
+    <ul>
+      <li>[Paid] <b>Universal per-language syntax tuning</b> — Custom syntax settings now follow the active file in the active project window and expose only controls supported by the installed language tooling. Tune intensity against a representative native preview with immediate editor feedback; Apply keeps the result, while Cancel restores the exact previous scheme and preferences. Existing presets and saved choices remain unchanged until edited.</li>
+      <li>[Paid] <b>Bold and Italic for individual syntax primitives</b> — each available language primitive can independently add Bold, Italic, or both while keeping its inherited color and font style, with an explicit option to replace the inherited style when needed.</li>
+      <li>[Fix] <b>Reliable startup in IntelliJ Platform 2025.1</b> — coroutine-backed Ayu features now retain metadata compatible with the oldest supported IDE runtime instead of failing when the platform reads newer debug metadata.</li>
+      <li>[Fix] <b>Stable Retina preview and Glow buffers</b> — offscreen rendering keeps logical-pixel geometry on HiDPI displays instead of multiplying cache size and memory use with the ambient display scale.</li>
+    </ul>
     <h3>2.8.6</h3>
     <ul>
       <li>[Fix] <b>Contained chaotic waveform borders</b> — Chaotic ECG traces stay inside their editor and tool-window islands instead of spilling across neighboring panels, while route connectors remain visible during focus and window transitions.</li>

--- a/src/test/kotlin/dev/ayuislands/UpdateNotifierTest.kt
+++ b/src/test/kotlin/dev/ayuislands/UpdateNotifierTest.kt
@@ -230,6 +230,41 @@ class UpdateNotifierTest {
     }
 
     @Test
+    fun `2_8_7 balloon lists syntax and rendering changes`() {
+        state.lastSeenVersion = "2.8.6"
+        every {
+            AyuPlugin.findLoadedPlugin(any<PluginId>())
+        } returns descriptor
+        every { descriptor.version } returns "2.8.7"
+
+        val notification = mockk<Notification>(relaxed = true)
+        val group = mockk<NotificationGroup>(relaxed = true)
+        val groupManager = mockk<NotificationGroupManager>(relaxed = true)
+        every { NotificationGroupManager.getInstance() } returns groupManager
+        every { groupManager.getNotificationGroup("Ayu Islands") } returns group
+        every {
+            group.createNotification(any<String>(), any<String>(), any<NotificationType>())
+        } returns notification
+
+        UpdateNotifier.showIfUpdated(project)
+
+        assertEquals("2.8.7", state.lastSeenVersion)
+        verify(exactly = 1) {
+            group.createNotification(
+                "Ayu Islands updated to 2.8.7",
+                match<String> { body ->
+                    body.contains("[Paid] Custom syntax tuning follows the active language") &&
+                        body.contains("[Paid] Individual syntax primitives can add Bold, Italic, or both") &&
+                        body.contains("[Fix] Ayu starts reliably in IntelliJ Platform 2025.1 IDEs") &&
+                        body.contains("[Fix] Retina preview and Glow buffers keep logical-pixel sizing")
+                },
+                NotificationType.INFORMATION,
+            )
+        }
+        verify(exactly = 1) { notification.notify(project) }
+    }
+
+    @Test
     fun `updates lastSeenVersion on first install without notification`() {
         state.lastSeenVersion = null
         every {


### PR DESCRIPTION
── Summary ─────────────────────────────────

Prepare Ayu Islands 2.8.7 for publication with the reviewed user-facing changes since 2.8.6. The release highlights universal per-language syntax tuning, independent Bold and Italic controls for syntax primitives, IntelliJ Platform 2025.1 startup compatibility, and stable HiDPI preview/Glow buffers.

── Changes ─────────────────────────────────

- Chore: [gradle.properties](gradle.properties) — Set the plugin version to 2.8.7.
- Docs: [CHANGELOG.md](CHANGELOG.md) — Promote the reviewed Unreleased notes to the dated 2.8.7 section.
- Chore: [plugin.xml](src/main/resources/META-INF/plugin.xml) — Add matching Marketplace change notes while preserving the paid-product release metadata for the existing 2.8 line.
- Chore: [UpdateNotifier.kt](src/main/kotlin/dev/ayuislands/UpdateNotifier.kt) — Add concise in-IDE release notes in the same Paid, then Fix order.
- Test: [UpdateNotifierTest.kt](src/test/kotlin/dev/ayuislands/UpdateNotifierTest.kt) — Verify the 2.8.7 fallback balloon is dispatched once with all four release highlights.

── Validation ──────────────────────────────

- `scripts/verify-docs.py` — passed; feature metadata remains synchronized.
- `./gradlew detekt ktlintCheck --no-daemon` — passed.
- `./gradlew clean buildPlugin --no-daemon` — passed; produced `ayu-jetbrains-2.8.7.zip`.
- `./gradlew verifyPlugin --no-daemon` — passed; compatible with all 12 configured IDE targets.
- `scripts/gradle-retry.sh test integrationTest koverXmlReport koverVerify` — passed on final bytes in 11m 53s.
- IntelliJ inspections for `UpdateNotifier.kt` and `UpdateNotifierTest.kt` — no findings.

── Notes ───────────────────────────────────

The release changes only version and release-note surfaces; it does not rewrite theme settings, syntax preferences, or other persisted user state.
