### PR TITLE
fix(accent): report completed application outcomes

### DIFF
--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "e752b11b"
+          last_verified_sha: "0503371f"
           last_verified_date: "2026-08-09"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "e752b11b"
+          last_verified_sha: "0503371f"
           last_verified_date: "2026-08-09"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "79e4a98c"
+          last_verified_sha: "e752b11b"
           last_verified_date: "2026-08-09"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "79e4a98c"
+          last_verified_sha: "e752b11b"
           last_verified_date: "2026-08-09"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/docs/features.yml
+++ b/docs/features.yml
@@ -105,7 +105,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "0503371f"
+          last_verified_sha: "360e90d1"
           last_verified_date: "2026-08-09"
           content_sha256: "4c86c5d855c6dcefd703f647451bac4117397e435b05dd9cae6b9cbc7f479616"
 
@@ -127,7 +127,7 @@ categories:
             - src/main/kotlin/dev/ayuislands/settings/AccentColorPanel.kt
             - src/main/kotlin/dev/ayuislands/settings/mappings
             - src/main/kotlin/dev/ayuislands/accent
-          last_verified_sha: "0503371f"
+          last_verified_sha: "360e90d1"
           last_verified_date: "2026-08-09"
           content_sha256: "ea83498db84a5cd122dd1d09132d74774c6e24295188b93464fddb0d784bf4e1"
 

--- a/scripts/guard-test-source-reads.py
+++ b/scripts/guard-test-source-reads.py
@@ -87,10 +87,6 @@ ALLOWLIST: dict[tuple[str, str], Allowance] = {
         "src/main/kotlin/dev/ayuislands/accent/elements/$elementName.kt",
     ): Allowance(1, "documented chrome live-refresh symmetry compromise"),
     (
-        "src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt",
-        "src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt",
-    ): Allowance(1, "documented focused-project publish-gate compromise"),
-    (
         "src/test/kotlin/dev/ayuislands/accent/Gap4BannedApiGuardTest.kt",
         "src/main/kotlin/dev/ayuislands/accent",
     ): Allowance(1, "banned platform API guard directory"),
@@ -111,7 +107,7 @@ ALLOWLIST: dict[tuple[str, str], Allowance] = {
 
 def main() -> int:
     occurrences = find_source_path_literals()
-    errors = []
+    errors: list[str] = []
 
     for key, count in sorted(occurrences.items()):
         allowance = ALLOWLIST.get(key)
@@ -171,7 +167,7 @@ def string_literals(text: str) -> list[str]:
 
 
 def split_path_literals(text: str) -> list[str]:
-    paths = []
+    paths: list[str] = []
     for match in PATH_FACTORY_RE.finditer(text):
         closing_paren = find_closing_paren(text, match.end() - 1)
         if closing_paren is None:

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsAppListener.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsAppListener.kt
@@ -3,6 +3,7 @@ package dev.ayuislands
 import com.intellij.ide.AppLifecycleListener
 import com.intellij.openapi.diagnostic.logger
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.settings.AyuIslandsSettings
@@ -41,23 +42,30 @@ internal class AyuIslandsAppListener : AppLifecycleListener {
         // against a torn half-apply.
         val trustedCached = settings.state.trustedCachedAccent()
         val accentHex = trustedCached?.value ?: AccentResolver.resolve(null, variant)
-        val applied = AccentApplicator.applyFromHexString(accentHex)
         val source =
             when {
                 trustedCached != null -> "cached"
                 validCached != null -> "cached-untrusted"
                 else -> "resolved"
             }
-        if (applied) {
-            LOG.info(
-                "Ayu Islands accent applied in appFrameCreated " +
-                    "(source=$source, hex='$accentHex') for ${variant.name}",
-            )
-        } else {
-            LOG.warn(
-                "Ayu Islands accent rejected in appFrameCreated " +
-                    "(source=$source, hex='$accentHex') for ${variant.name}",
-            )
+        AccentApplicator.requestApply(accentHex) { outcome ->
+            when (outcome) {
+                is AccentApplyOutcome.Applied ->
+                    LOG.info(
+                        "Ayu Islands accent applied in appFrameCreated " +
+                            "(source=$source, hex='$accentHex') for ${variant.name}",
+                    )
+                is AccentApplyOutcome.Rejected ->
+                    LOG.warn(
+                        "Ayu Islands accent rejected in appFrameCreated " +
+                            "(source=$source, hex='$accentHex') for ${variant.name}",
+                    )
+                is AccentApplyOutcome.Torn ->
+                    LOG.warn(
+                        "Ayu Islands accent incomplete in appFrameCreated " +
+                            "(source=$source, hex='$accentHex') for ${variant.name}",
+                    )
+            }
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
+++ b/src/main/kotlin/dev/ayuislands/AyuIslandsStartupActivity.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.startup.ProjectActivity
 import com.intellij.openapi.wm.WindowManager
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
 import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
@@ -326,8 +327,7 @@ internal class AyuIslandsStartupActivity(
                 runCatchingPreservingCancellation {
                     val focusedProject = AccentApplicator.resolveFocusedProject() ?: project
                     val resolved = AccentResolver.resolve(focusedProject, context)
-                    val applied = AccentApplicator.applyFromHexString(resolved)
-                    if (applied) resolved else null
+                    AccentApplicator.applyFromHexString(resolved).takeUnless { it is AccentApplyOutcome.Rejected }
                 }
             applyOutcome.onFailure { exception ->
                 LOG.error(
@@ -336,14 +336,9 @@ internal class AyuIslandsStartupActivity(
                     exception,
                 )
             }
-            val hex = applyOutcome.getOrNull()
-            if (hex == null) {
-                // apply-failure already logged via onFailure above. Hex is null
-                // in two cases: (a) the runCatching caught an exception,
-                // (b) applyFromHexString returned false (rejected hex — the
-                // user-facing notification already fired inside the applicator).
-                // In (b), suppress the install+notify because there's no applied
-                // color to publish to the swap cache.
+            val outcome = applyOutcome.getOrNull()
+            if (outcome == null) {
+                // Rejection and thrown failure both skip listener installation.
                 if (applyOutcome.isSuccess) {
                     LOG.warn(
                         "Startup accent apply was rejected by applyFromHexString " +
@@ -365,14 +360,14 @@ internal class AyuIslandsStartupActivity(
                 }.onFailure { exception ->
                     LOG.error(
                         "Startup accent-swap install failed for project '$projectName' " +
-                            "AFTER a successful apply; multi-project focus-swap cycling " +
+                            "AFTER an accepted accent request; multi-project focus-swap cycling " +
                             "will be inert this session until the user re-triggers apply",
                         exception,
                     )
                 }.isSuccess
             if (!installed) return@withContext
             runCatchingPreservingCancellation {
-                swapService.notifyExternalApply(hex)
+                swapService.notifyExternalApply(outcome)
             }.onFailure { exception ->
                 LOG.error(
                     "Startup accent-swap cache publish (notifyExternalApply) failed for " +

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.editor.colors.ColorKey
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.openapi.extensions.ExtensionPointName
+import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.wm.IdeFocusManager
 import com.intellij.openapi.wm.WindowManager
@@ -33,6 +34,7 @@ import dev.ayuislands.ui.ComponentTreeRefresher
 import org.jetbrains.annotations.TestOnly
 import java.awt.Color
 import java.awt.Window
+import java.util.concurrent.CancellationException
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.swing.SwingUtilities
 import javax.swing.UIManager
@@ -183,39 +185,10 @@ object AccentApplicator {
             ),
         )
 
-    /**
-     * Applies [accentHex] across UIManager, editor keys, and the EP chain.
-     *
-     * Takes an [AccentHex] whose `#RRGGBB` shape is proven by construction —
-     * no internal regex, no `NumberFormatException` path through [Color.decode].
-     * Callers with a raw `String` from an untrusted boundary should use the
-     * top-level [applyFromHexString] helper which centralizes the
-     * notification-on-bad-hex + `false` return contract.
-     *
-     * Cache write ordering: [AyuIslandsState.lastAppliedAccentHex] is written BEFORE the EP
-     * iteration runs, not after — a mid-EP throw would otherwise drop the anti-flicker
-     * cache and re-flash Gold on the next startup. The paired
-     * [AyuIslandsState.lastApplyOk] flag is reset to `false` before EP iteration and
-     * flipped to `true` only by the [AccentApplyStep.MarkApplyClean] step, so the
-     * startup listener can distinguish "cached hex from a clean apply" from "cached hex
-     * from a torn apply" and fall back to the resolver in the torn case. A throwing
-     * step aborts the plan ([AccentApplyFailurePolicy.AbortOnFirstFailure]) and is
-     * contained into an [AccentApplyOutcome.Torn] WARN — it never reaches the caller.
-     *
-     * ### Threading contract
-     *
-     * Synchronous when called on the EDT; posts the full plan via
-     * [AccentApplyPlanRunner] when called off-EDT. The ordering invariant —
-     * applyElements / editor keys / repaint all happen BEFORE the method
-     * returns on EDT — is load-bearing for callers that publish follow-on
-     * cache state (for example [ProjectAccentSwapService.notifyExternalApply]
-     * reached via [applyForFocusedProject]): those callers MUST already be on
-     * the EDT so their cache write happens after the full apply sequence.
-     * Off-EDT callers get scheduling semantics only — paint completion is
-     * asynchronous, and the `lastApplyOk` flag on [AyuIslandsState] is the
-     * correct signal for "apply finished cleanly" in those flows.
-     */
-    fun apply(accentHex: AccentHex) {
+    /** Apply synchronously on EDT, retaining restart metadata and returning this invocation's outcome. */
+    @RequiresEdt
+    internal fun apply(accentHex: AccentHex): AccentApplyOutcome {
+        check(SwingUtilities.isEventDispatchThread()) { "Accent application must run on EDT" }
         val trimmedHex = accentHex.value
         val accent = accentHex.toColor()
         val state = AyuIslandsSettings.getInstance().state
@@ -303,100 +276,30 @@ object AccentApplicator {
                 }
             }
 
-        AccentApplyPlanRunner.run(
-            plan = applyPlanFor(context),
-            executeStep = { step -> workers.getValue(step)() },
-        ) { failures ->
-            for ((step, error) in failures) {
-                log.warn("Accent apply torn at $step (hex=$trimmedHex)", error)
-            }
+        val failures =
+            AccentApplyPlanRunner.runNow(
+                plan = applyPlanFor(context),
+                executeStep = { step -> workers.getValue(step)() },
+            )
+        for ((step, error) in failures) {
+            log.warn("Accent apply torn at $step (hex=$trimmedHex)", error)
         }
+        return AccentApplyOutcome.of(accentHex, containedFailures + failures)
     }
 
-    /**
-     * Publish [AccentChangedTopic.TOPIC] once per usable open project AFTER
-     * `state.lastApplyOk = true` so subscribers (toolbar stripe, toolbar chip)
-     * only fire on a fully-painted apply. Extracted from [apply] to keep the
-     * outer method's cognitive complexity below the IDE inspector's cap.
-     *
-     * Application-scoped: one apply may legitimately affect every open window;
-     * per-project filtering belongs to the subscriber. Per-project try/catch
-     * isolates Pattern B — a throwing subscriber must NOT tear down the apply
-     * pipeline. Source is re-resolved per project so subscribers see THIS
-     * window's resolution layer (project A may carry a project-override while
-     * project B is global).
-     */
-    private fun publishAccentChanged(
-        accentHex: AccentHex,
-        onFailure: (AccentApplyStepFailure) -> Unit,
-    ) {
-        val publisher =
-            ApplicationManager
-                .getApplication()
-                .messageBus
-                .syncPublisher(AccentChangedTopic.TOPIC)
-        for (openProject in ProjectManager.getInstance().openProjects) {
-            if (!openProject.isUsable()) continue
-            captureAccentFailure(
-                AccentApplyStep.PublishAccentChanged,
-                "Publish accent for ${openProject.name}",
-            ) {
-                val source = AccentResolver.source(openProject)
-                publisher.accentChanged(openProject, accentHex, source)
-            }?.let(onFailure)
-        }
-    }
-
-    /**
-     * Convenience wrapper around [AccentResolver.resolve] + [apply] for the "currently focused
-     * project" use case. Called from the settings panels (Accent / Elements / Plugins), the
-     * LAF listener, and the rotation tick. Pre-helper, those sites hand-wired variants of
-     * the same sequence and were *inconsistent*: only the rotation path called
-     * [ProjectAccentSwapService.notifyExternalApply]; the panels and LAF listener skipped it,
-     * leaving the swap-cache stale and causing one redundant apply on the next WINDOW_ACTIVATED.
-     *
-     * Centralizing the sequence makes focused-project selection, override-priority resolution,
-     * and swap-cache synchronization uniformly correct across callers. Returns the applied
-     * hex so callers can log or display it.
-     *
-     * Note: [dev.ayuislands.AyuIslandsStartupActivity] is NOT a caller — it operates on the
-     * specific project the platform hands it, not the focused one, so it bypasses this helper
-     * and calls [AccentResolver.resolve] + [apply] directly with that project.
-     *
-     * EDT-only. Neither this helper nor [resolveFocusedProject] self-dispatch; only the
-     * inner [apply] call hops to the EDT internally via [AccentApplyPlanRunner], and that hop
-     * does NOT rescue the preceding [resolveFocusedProject] + [AccentResolver.resolve]
-     * steps (the first traverses EDT-only platform APIs, the second reads settings state
-     * that may race off-EDT). [ProjectAccentSwapService.notifyExternalApply] is likewise
-     * a bare volatile write with no dispatch. Callers MUST already be on the EDT.
-     */
+    /** Resolve the focused project's existing override chain and update the cache from its outcome. */
     @RequiresEdt
-    fun applyForFocusedProject(context: AccentContext): String {
+    internal fun applyForFocusedProject(context: AccentContext): AccentApplyOutcome {
         val focusedProject = resolveFocusedProject()
         val hex = AccentResolver.resolve(focusedProject, context)
-        // apply returns a validation flag. If the resolver hands back a hex
-        // that fails shape validation (corrupted per-project override, manual
-        // XML edit, future resolver bug), skip the swap-cache publish so the
-        // cache does not drift to a hex that was never actually painted; the
-        // apply call surfaces the user-visible notification for that case.
-        // The torn-apply half of the same invariant (valid hex, mid-step
-        // throw) is gated inside [ProjectAccentSwapService.notifyExternalApply],
-        // which consults the persisted clean flag before recording the hex.
-        val applied = applyFromHexString(hex)
-        // Pattern D — regression lock: if you remove this gate, the swap cache
-        // will publish hexes that `applyFromHexString` rejected (malformed XML,
-        // manual edits, rotation palette bug) and drift from the paint state.
-        // The `AccentApplicatorFocusedProjectTest` "skips swap cache publish
-        // when applyFromHexString rejects the resolver output" test must fail
-        // first if you touch this branch.
-        if (applied) {
-            ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
-        }
-        return hex
+        val outcome = applyFromHexString(hex)
+        ProjectAccentSwapService.getInstance().notifyExternalApply(outcome)
+        return outcome
     }
 
     @RequiresEdt
-    fun applyForFocusedProject(variant: AyuVariant): String = applyForFocusedProject(AccentContext.Ayu(variant))
+    internal fun applyForFocusedProject(variant: AyuVariant): AccentApplyOutcome =
+        applyForFocusedProject(AccentContext.Ayu(variant))
 
     /**
      * Resolves the *actually* focused project — the one whose window is currently on top
@@ -862,19 +765,10 @@ object AccentApplicator {
         CodeGlanceProIntegration.syncCodeGlanceProViewport(hex, context)
     }
 
-    /**
-     * String-accepting entry point for callers that hold a raw hex from an
-     * untrusted boundary (persisted XML, settings-panel input, resolver
-     * output that is still `String`).
-     * Validates the shape via [AccentHex.of], surfaces the user-visible
-     * notification + returns `false` on rejection, and forwards to [apply]
-     * on success.
-     *
-     * Deliberately NOT named `apply(String)` — MockK's `every { apply(any()) }`
-     * can't resolve across overloads of the same name, so tests that lock in
-     * the cache-publish ordering against the apply path would all break.
-     */
-    fun applyFromHexString(accentHex: String): Boolean {
+    /** Reject malformed input without mutating preferences or the restart cache. */
+    @RequiresEdt
+    internal fun applyFromHexString(accentHex: String): AccentApplyOutcome {
+        check(SwingUtilities.isEventDispatchThread()) { "Accent application must run on EDT" }
         val accent =
             AccentHex.of(accentHex) ?: run {
                 log.warn("AccentApplicator.apply: invalid hex '$accentHex' — skipping apply")
@@ -901,13 +795,24 @@ object AccentApplicator {
                             NotificationType.WARNING,
                         ),
                     )
+                } catch (cancelled: ProcessCanceledException) {
+                    throw cancelled
+                } catch (cancelled: CancellationException) {
+                    throw cancelled
                 } catch (exception: RuntimeException) {
                     log.warn("AccentApplicator invalid-hex notification failed to post", exception)
                 }
-                return false
+                return AccentApplyOutcome.Rejected(accentHex)
             }
-        apply(accent)
-        return true
+        return apply(accent)
+    }
+
+    /** Complete inline on EDT or after one queued EDT turn; cancellation does not invoke the callback. */
+    internal fun requestApply(
+        accentHex: String,
+        onComplete: (AccentApplyOutcome) -> Unit,
+    ) {
+        AccentApplyPlanRunner.dispatch { onComplete(applyFromHexString(accentHex)) }
     }
 }
 
@@ -1061,10 +966,37 @@ internal fun resolveUnderlineHeight(
 }
 
 /**
- * File-scope extension because [AccentApplicator] is at the cap of its
- * `TooManyFunctions` budget; moving this trivial guard out of the object
- * frees one function slot for `publishAccentChanged` extracted from [AccentApplicator.apply].
- * Shape preserved exactly so the 6+ existing call-sites and the tests'
- * commentary stay accurate.
+ * Publish [AccentChangedTopic.TOPIC] once per usable open project AFTER
+ * `state.lastApplyOk = true` so subscribers (toolbar stripe, toolbar chip)
+ * only fire on a fully-painted apply. Extracted from [AccentApplicator.apply] to keep the
+ * outer method's cognitive complexity below the IDE inspector's cap.
+ *
+ * Application-scoped: one apply may legitimately affect every open window;
+ * per-project filtering belongs to the subscriber. Per-project try/catch
+ * isolates Pattern B — a throwing subscriber must NOT tear down the apply
+ * pipeline. Source is re-resolved per project so subscribers see THIS
+ * window's resolution layer (project A may carry a project-override while
+ * project B is global).
  */
+private fun publishAccentChanged(
+    accentHex: AccentHex,
+    onFailure: (AccentApplyStepFailure) -> Unit,
+) {
+    val publisher =
+        ApplicationManager
+            .getApplication()
+            .messageBus
+            .syncPublisher(AccentChangedTopic.TOPIC)
+    for (openProject in ProjectManager.getInstance().openProjects) {
+        if (!openProject.isUsable()) continue
+        captureAccentFailure(
+            AccentApplyStep.PublishAccentChanged,
+            "Publish accent for ${openProject.name}",
+        ) {
+            val source = AccentResolver.source(openProject)
+            publisher.accentChanged(openProject, accentHex, source)
+        }?.let(onFailure)
+    }
+}
+
 private fun com.intellij.openapi.project.Project.isUsable(): Boolean = !isDefault && !isDisposed

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt
@@ -237,6 +237,11 @@ object AccentApplicator {
         // worker. Context-shaped steps guard with checkNotNull so a plan bug
         // that schedules them without their input fails with a precise message
         // (surfaced as that step's failure) instead of an NPE.
+        val containedFailures = mutableListOf<AccentApplyStepFailure>()
+        val recordFailure: (AccentApplyStepFailure) -> Unit = { failure ->
+            containedFailures += failure
+            log.warn("Accent apply torn at ${failure.step} (hex=$trimmedHex)", failure.error)
+        }
         val workers: Map<AccentApplyStep, () -> Unit> =
             buildMap {
                 put(AccentApplyStep.ApplyAlwaysOnUiKeys) {
@@ -248,6 +253,7 @@ object AccentApplicator {
                         accent,
                         checkNotNull(context) { "ApplyElements planned without accent context" },
                         isChromeAllowed,
+                        onFailure = recordFailure,
                     )
                 }
                 put(AccentApplyStep.ApplyTabUnderline) {
@@ -289,27 +295,25 @@ object AccentApplicator {
                 // write, leaving the flag false so the startup listener
                 // (AyuIslandsAppListener.appFrameCreated) falls through to the
                 // resolver rather than trusting the cached hex.
-                put(AccentApplyStep.MarkApplyClean) { state.lastApplyOk = true }
-                put(AccentApplyStep.PublishAccentChanged) { publishAccentChanged(accentHex) }
+                put(AccentApplyStep.MarkApplyClean) { state.lastApplyOk = containedFailures.isEmpty() }
+                put(AccentApplyStep.PublishAccentChanged) {
+                    if (containedFailures.isEmpty()) {
+                        publishAccentChanged(accentHex, recordFailure)
+                    }
+                }
             }
 
         AccentApplyPlanRunner.run(
             plan = applyPlanFor(context),
             executeStep = { step -> workers.getValue(step)() },
         ) { failures ->
-            val outcome = AccentApplyOutcome.of(accentHex, failures)
-            if (outcome is AccentApplyOutcome.Torn) {
-                val first = outcome.failures.first()
-                log.warn(
-                    "Accent apply torn at ${first.step} (hex=$trimmedHex, " +
-                        "lastApplyOk=${state.lastApplyOk}); later steps (if any) were skipped",
-                    first.error,
-                )
+            for ((step, error) in failures) {
+                log.warn("Accent apply torn at $step (hex=$trimmedHex)", error)
             }
         }
     }
 
-/**
+    /**
      * Publish [AccentChangedTopic.TOPIC] once per usable open project AFTER
      * `state.lastApplyOk = true` so subscribers (toolbar stripe, toolbar chip)
      * only fire on a fully-painted apply. Extracted from [apply] to keep the
@@ -322,7 +326,10 @@ object AccentApplicator {
      * window's resolution layer (project A may carry a project-override while
      * project B is global).
      */
-    private fun publishAccentChanged(accentHex: AccentHex) {
+    private fun publishAccentChanged(
+        accentHex: AccentHex,
+        onFailure: (AccentApplyStepFailure) -> Unit,
+    ) {
         val publisher =
             ApplicationManager
                 .getApplication()
@@ -330,19 +337,13 @@ object AccentApplicator {
                 .syncPublisher(AccentChangedTopic.TOPIC)
         for (openProject in ProjectManager.getInstance().openProjects) {
             if (!openProject.isUsable()) continue
-            try {
+            captureAccentFailure(
+                AccentApplyStep.PublishAccentChanged,
+                "Publish accent for ${openProject.name}",
+            ) {
                 val source = AccentResolver.source(openProject)
-                // Pattern K — the [AccentHex] parameter is the validated
-                // proof; pass it straight through to the listener so
-                // subscribers receive the typed wrapper and never see a raw
-                // `String`.
                 publisher.accentChanged(openProject, accentHex, source)
-            } catch (exception: RuntimeException) {
-                log.warn(
-                    "AccentChangedTopic publish failed for ${openProject.name}",
-                    exception,
-                )
-            }
+            }?.let(onFailure)
         }
     }
 
@@ -608,23 +609,17 @@ object AccentApplicator {
     private fun neutralizeOrRevert(
         element: AccentElement,
         variant: AyuVariant?,
-    ) {
-        try {
-            if (variant != null) {
-                element.applyNeutral(variant)
-            } else {
-                element.revert()
-            }
-        } catch (exception: RuntimeException) {
-            log.warn("Failed to neutralize ${element.displayName}", exception)
+    ): AccentApplyStepFailure? =
+        captureAccentFailure(AccentApplyStep.ApplyElements, "Neutralize ${element.displayName}") {
+            if (variant != null) element.applyNeutral(variant) else element.revert()
         }
-    }
 
     private fun applyElements(
         state: AyuIslandsState,
         accent: Color,
         context: AccentContext,
         isPremiumAllowed: Boolean,
+        onFailure: (AccentApplyStepFailure) -> Unit,
     ) {
         if (context == AccentContext.External) {
             EP_NAME.extensionList
@@ -640,6 +635,7 @@ object AccentApplicator {
                 state = state,
                 accent = accent,
                 isAllowed = canTintExternalChrome(state, context, isPremiumAllowed),
+                onFailure = onFailure,
             )
             return
         }
@@ -647,7 +643,7 @@ object AccentApplicator {
 
         val variant = context.variant
         for (element in EP_NAME.extensionList) {
-            applyElement(state, element, accent, variant, isPremiumAllowed)
+            applyElement(state, element, accent, variant, isPremiumAllowed)?.let(onFailure)
         }
     }
 
@@ -657,53 +653,31 @@ object AccentApplicator {
         accent: Color,
         variant: AyuVariant?,
         isPremiumAllowed: Boolean,
-    ) {
+    ): AccentApplyStepFailure? {
         AyuEditorSchemeScope.observeElementEnabled(
             element.id,
             ChromeTintContext.isToggleEnabled(state, element.id),
         )
         if (element.id.group == AccentGroup.CHROME && !isPremiumAllowed) {
-            neutralizeOrRevert(element, variant)
-            return
+            return neutralizeOrRevert(element, variant)
         }
         if (!isElementEnabled(state, element.id, isPremiumAllowed)) {
-            neutralizeOrRevert(element, variant)
-            return
+            return neutralizeOrRevert(element, variant)
         }
         val conflict = ConflictRegistry.getConflictFor(element.id)
         if (conflict != null && !canForceOverride(state, element.id, isPremiumAllowed)) {
-            neutralizeOrRevert(element, variant)
-            return
+            return neutralizeOrRevert(element, variant)
         }
         if (conflict != null) {
             log.warn(
                 "Force-overriding ${conflict.pluginDisplayName} conflict for ${element.displayName}",
             )
         }
-        try {
-            element.apply(accent)
-        } catch (exception: RuntimeException) {
-            log.warn(
-                "Failed to apply accent to ${element.displayName}",
-                exception,
-            )
-            // A partial apply can leave UIManager / live peers in a
-            // mixed tinted+stock state; a subsequent `ChromeBaseColors.get()`
-            // would capture those tinted values as the stock baseline and
-            // poison the cache for the rest of the session. Roll back this
-            // element so the next apply starts from a clean slate.
-            // Narrow the catch to RuntimeException so
-            // Error / CancellationException still propagate and don't get
-            // demoted to a WARN line.
-            try {
-                element.revert()
-            } catch (revertException: RuntimeException) {
-                log.warn(
-                    "Revert after failed apply also failed for ${element.displayName}",
-                    revertException,
-                )
-            }
-        }
+        return captureAccentFailure(
+            step = AccentApplyStep.ApplyElements,
+            operation = "Apply ${element.displayName}",
+            rollback = { element.revert() },
+        ) { element.apply(accent) }
     }
 
     /**
@@ -950,14 +924,15 @@ internal object ExternalChromeOwnership {
         state: AyuIslandsState,
         accent: Color,
         isAllowed: Boolean,
+        onFailure: (AccentApplyStepFailure) -> Unit,
     ) {
         if (!isAllowed) {
-            revertAll(elements)
+            revertAll(elements, onFailure)
             return
         }
         for (element in elements) {
             if (element.id.group != AccentGroup.CHROME) continue
-            applyElement(element, state, accent)
+            applyElement(element, state, accent)?.let(onFailure)
         }
     }
 
@@ -990,12 +965,11 @@ internal object ExternalChromeOwnership {
         element: AccentElement,
         state: AyuIslandsState,
         accent: Color,
-    ) {
+    ): AccentApplyStepFailure? {
         val conflict = ConflictRegistry.getConflictFor(element.id)
         val isForced = element.id.name in state.forceOverrides
         if (!ChromeTintContext.isToggleEnabled(state, element.id) || (conflict != null && !isForced)) {
-            revertOne(element)
-            return
+            return revertOne(element)
         }
         if (conflict != null) {
             log.warn("Force-overriding ${conflict.pluginDisplayName} conflict for ${element.displayName}")
@@ -1004,15 +978,14 @@ internal object ExternalChromeOwnership {
         val chromeElement = element as? AbstractChromeElement
         if (chromeElement == null) {
             logTypeMismatch(element)
-            return
+            return null
         }
-        try {
-            chromeElement.applyExternal(accent) {
-                ownedElements.add(element.id)
-            }
-        } catch (exception: RuntimeException) {
-            log.warn("Failed to apply external chrome accent to ${element.displayName}", exception)
-            revertOne(element)
+        return captureAccentFailure(
+            step = AccentApplyStep.ApplyElements,
+            operation = "Apply external chrome ${element.displayName}",
+            rollback = { revertOne(element)?.let { throw it.error } },
+        ) {
+            chromeElement.applyExternal(accent) { ownedElements.add(element.id) }
         }
     }
 
@@ -1024,21 +997,23 @@ internal object ExternalChromeOwnership {
         )
     }
 
-    private fun revertAll(elements: List<AccentElement>) {
+    private fun revertAll(
+        elements: List<AccentElement>,
+        onFailure: (AccentApplyStepFailure) -> Unit,
+    ) {
         if (ownedElements.isEmpty()) return
         for (element in elements) {
-            revertOne(element)
+            revertOne(element)?.let(onFailure)
         }
     }
 
-    private fun revertOne(element: AccentElement) {
-        if (!ownedElements.remove(element.id)) return
-        try {
-            element.revert()
-        } catch (exception: RuntimeException) {
-            ownedElements.add(element.id)
-            log.warn("Failed to restore external chrome surface ${element.displayName}", exception)
-        }
+    private fun revertOne(element: AccentElement): AccentApplyStepFailure? {
+        if (!ownedElements.remove(element.id)) return null
+        return captureAccentFailure(
+            step = AccentApplyStep.ApplyElements,
+            operation = "Restore external chrome ${element.displayName}",
+            rollback = { ownedElements.add(element.id) },
+        ) { element.revert() }
     }
 }
 

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplyFailure.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplyFailure.kt
@@ -1,0 +1,32 @@
+package dev.ayuislands.accent
+
+import com.intellij.openapi.progress.ProcessCanceledException
+import java.util.concurrent.CancellationException
+
+internal fun captureAccentFailure(
+    step: AccentApplyStep,
+    operation: String,
+    rollback: () -> Unit = {},
+    action: () -> Unit,
+): AccentApplyStepFailure? =
+    try {
+        action()
+        null
+    } catch (failure: RuntimeException) {
+        try {
+            rollback()
+        } catch (recovery: RuntimeException) {
+            if (recovery !== failure) {
+                if (recovery.isAccentCancellation() && !failure.isAccentCancellation()) {
+                    recovery.addSuppressed(failure)
+                    throw recovery
+                }
+                failure.addSuppressed(recovery)
+            }
+        }
+        if (failure.isAccentCancellation()) throw failure
+        AccentApplyStepFailure(step, IllegalStateException(operation, failure))
+    }
+
+private fun RuntimeException.isAccentCancellation(): Boolean =
+    this is ProcessCanceledException || this is CancellationException

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplyFailure.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplyFailure.kt
@@ -28,5 +28,9 @@ internal fun captureAccentFailure(
         AccentApplyStepFailure(step, IllegalStateException(operation, failure))
     }
 
-private fun RuntimeException.isAccentCancellation(): Boolean =
+internal fun RuntimeException.rethrowIfCancelled() {
+    if (isAccentCancellation()) throw this
+}
+
+internal fun RuntimeException.isAccentCancellation(): Boolean =
     this is ProcessCanceledException || this is CancellationException

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplyPlan.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplyPlan.kt
@@ -111,6 +111,36 @@ internal data class AccentApplyStepFailure(
  * flag itself remains the cross-restart torn-state marker.
  */
 internal sealed interface AccentApplyOutcome {
+    /** Invalid input; no application was attempted. */
+    data class Rejected(
+        val rawHex: String,
+    ) : AccentApplyOutcome
+
+    val isClean: Boolean
+        get() = this is Applied
+
+    val visualsApplied: Boolean
+        get() =
+            when (this) {
+                is Applied -> true
+                is Rejected -> false
+                is Torn -> failures.all { it.step == AccentApplyStep.PublishAccentChanged }
+            }
+
+    /** Escalate inside an existing orchestration failure boundary, retaining all causes. */
+    fun requireClean() {
+        when (this) {
+            is Applied -> Unit
+            is Rejected -> throw IllegalArgumentException("Accent rejected: $rawHex")
+            is Torn -> {
+                val failure =
+                    IllegalStateException("Accent apply failed for ${accentHex.value}", failures.first().error)
+                failures.drop(1).forEach { failure.addSuppressed(it.error) }
+                throw failure
+            }
+        }
+    }
+
     /** Every step of the plan completed. */
     data class Applied(
         val accentHex: AccentHex,
@@ -135,7 +165,7 @@ internal sealed interface AccentApplyOutcome {
         fun of(
             accentHex: AccentHex,
             failures: List<AccentApplyStepFailure>,
-        ): AccentApplyOutcome = if (failures.isEmpty()) Applied(accentHex) else Torn(accentHex, failures)
+        ): AccentApplyOutcome = if (failures.isEmpty()) Applied(accentHex) else Torn(accentHex, failures.toList())
     }
 }
 

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplyPlan.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplyPlan.kt
@@ -117,8 +117,8 @@ internal sealed interface AccentApplyOutcome {
     ) : AccentApplyOutcome
 
     /**
-     * A step threw; later steps (if any) were skipped. The persisted clean
-     * flag is false unless the sole failure was the final
+     * A step or contained operation failed; independent work may have continued.
+     * The persisted clean flag is false unless all failures belong to
      * [AccentApplyStep.PublishAccentChanged], which runs after
      * [AccentApplyStep.MarkApplyClean] already flipped it true.
      */

--- a/src/main/kotlin/dev/ayuislands/accent/AccentApplyPlanRunner.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentApplyPlanRunner.kt
@@ -3,6 +3,7 @@ package dev.ayuislands.accent
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.diagnostic.logger
+import com.intellij.util.concurrency.annotations.RequiresEdt
 import javax.swing.SwingUtilities
 
 /**
@@ -21,7 +22,7 @@ import javax.swing.SwingUtilities
  * Cancellation ([com.intellij.openapi.progress.ProcessCanceledException],
  * coroutine cancellation) and [VirtualMachineError] (OOM, stack overflow)
  * always rethrow — only genuine step failures are captured into
- * [AccentApplyStepFailure]s. Note [onComplete] is NOT invoked when a rethrow
+ * [AccentApplyStepFailure]s. Note `onComplete` is NOT invoked when a rethrow
  * interrupts the plan mid-run: it reports completed runs (clean or torn), not
  * cancelled ones, so cleanup must not live in it.
  */
@@ -33,12 +34,20 @@ internal object AccentApplyPlanRunner {
         executeStep: (AccentApplyStep) -> Unit,
         onComplete: (List<AccentApplyStepFailure>) -> Unit,
     ) {
-        val work = Runnable { onComplete(runSteps(plan, executeStep)) }
-        if (SwingUtilities.isEventDispatchThread()) {
-            work.run()
-        } else {
-            invokeLaterSafe(work)
-        }
+        dispatch { onComplete(runNow(plan, executeStep)) }
+    }
+
+    @RequiresEdt
+    fun runNow(
+        plan: AccentApplyPlan,
+        executeStep: (AccentApplyStep) -> Unit,
+    ): List<AccentApplyStepFailure> {
+        check(SwingUtilities.isEventDispatchThread()) { "Accent plan must execute on EDT" }
+        return runSteps(plan, executeStep)
+    }
+
+    fun dispatch(work: Runnable) {
+        if (SwingUtilities.isEventDispatchThread()) work.run() else invokeLaterSafe(work)
     }
 
     private fun runSteps(

--- a/src/main/kotlin/dev/ayuislands/accent/AccentChangedTopic.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/AccentChangedTopic.kt
@@ -19,16 +19,8 @@ import com.intellij.util.messages.Topic
  * re-validating; call [AccentHex.value] to get the raw `String` for
  * downstream [com.intellij.ui.ColorUtil.fromHex] APIs.
  *
- * This is a `fun interface` because IntelliJ's MessageBus listener shape is a
- * single-method contract. Subscribers that receive [AccentHex] should still use
- * object expressions instead of SAM lambdas: Kotlin's SAM conversion of a
- * value-class parameter mangles the JVM name with a hash
- * (`accentChanged-Czfobf0`) while the metafactory-generated lambda implements
- * the un-mangled name, producing a runtime [AbstractMethodError] when the
- * topic fan-out invokes the SAM. Object expressions (`object : ...`) work
- * because the compiler emits both the mangled member AND a `String`-typed
- * bridge for the public surface. Pattern K — type lift discipline takes
- * precedence over lambda ergonomics.
+ * The single-method contract supports SAM lambdas. Subscribers receive a
+ * validated value class; the Kotlin compiler owns its JVM bridge.
  */
 fun interface AccentChangeListener {
     fun accentChanged(

--- a/src/main/kotlin/dev/ayuislands/accent/ScanCompletionAccentRefresher.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/ScanCompletionAccentRefresher.kt
@@ -79,9 +79,9 @@ internal class ScanCompletionAccentRefresher(
             }
             val variant = AyuVariant.detect() ?: return@runCatchingPreservingCancellation
             val hex = AccentResolver.resolve(project, variant)
-            val applied = AccentApplicator.applyFromHexString(hex)
-            if (applied) {
-                ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
+            val outcome = AccentApplicator.applyFromHexString(hex)
+            if (outcome !is AccentApplyOutcome.Rejected) {
+                ProjectAccentSwapService.getInstance().notifyExternalApply(outcome)
             } else {
                 LOG.warn("Skipping swap publish: applyFromHexString rejected '$hex'")
             }

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentGrid.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentGrid.kt
@@ -10,6 +10,7 @@ import com.intellij.ui.components.ActionLink
 import com.intellij.util.ui.JBUI
 import dev.ayuislands.accent.AYU_ACCENT_PRESETS
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
 import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
@@ -115,10 +116,10 @@ internal class QuickSwitcherAccentGrid {
     private fun applyPreset(hex: AccentHex) {
         val raw = hex.value
         try {
-            val applied = AccentApplicator.applyFromHexString(raw)
-            if (applied) {
+            val outcome = AccentApplicator.applyFromHexString(raw)
+            if (outcome !is AccentApplyOutcome.Rejected) {
                 AccentContext.detectQuickSwitcher()?.persistExternalManualAccentIfNeeded(raw)
-                ProjectAccentSwapService.getInstance().notifyExternalApply(raw)
+                ProjectAccentSwapService.getInstance().notifyExternalApply(outcome)
                 swatches.forEach { swatch -> swatch.setSelected(swatch.hex.value.equals(raw, ignoreCase = true)) }
             } else {
                 LOG.warn("Accent preset apply rejected hex=$raw")

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentGrid.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentGrid.kt
@@ -15,6 +15,7 @@ import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.persistExternalManualAccentIfNeeded
+import dev.ayuislands.accent.rethrowIfCancelled
 import dev.ayuislands.accent.toolbar.popup.Density
 import dev.ayuislands.accent.toolbar.popup.PopupSwatch
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
@@ -108,6 +109,7 @@ internal class QuickSwitcherAccentGrid {
         return try {
             AccentResolver.resolve(project, context)
         } catch (exception: RuntimeException) {
+            exception.rethrowIfCancelled()
             LOG.warn("Accent resolve failed for grid construction", exception)
             AYU_ACCENT_PRESETS.first().hex
         }
@@ -125,6 +127,7 @@ internal class QuickSwitcherAccentGrid {
                 LOG.warn("Accent preset apply rejected hex=$raw")
             }
         } catch (exception: RuntimeException) {
+            exception.rethrowIfCancelled()
             LOG.warn("Accent preset apply failed hex=$raw", exception)
         }
     }

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipComponent.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipComponent.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.wm.IdeFrame
 import com.intellij.util.messages.MessageBusConnection
 import com.intellij.util.ui.JBUI
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
 import dev.ayuislands.accent.AccentChangeListener
 import dev.ayuislands.accent.AccentChangedTopic
 import dev.ayuislands.accent.AccentContext
@@ -151,9 +152,9 @@ internal class QuickSwitcherChipComponent : JLabel() {
             // pin path lands on the just-written override — `AccentResolver`
             // reads `mappings` directly.
             val targetHex = AccentResolver.resolve(project, variant)
-            val applied = AccentApplicator.applyFromHexString(targetHex)
-            if (applied) {
-                ProjectAccentSwapService.getInstance().notifyExternalApply(targetHex)
+            val outcome = AccentApplicator.applyFromHexString(targetHex)
+            if (outcome !is AccentApplyOutcome.Rejected) {
+                ProjectAccentSwapService.getInstance().notifyExternalApply(outcome)
             } else {
                 LOG.warn("Pin toggle: applyFromHexString rejected hex=$targetHex; rolling back")
                 restorePin(mappings, key, previousPin)
@@ -202,22 +203,10 @@ internal class QuickSwitcherChipComponent : JLabel() {
         connectionParent = parent
         val conn = ApplicationManager.getApplication().messageBus.connect(parent)
         connection = conn
-        // Object expression rather than SAM lambda: [AccentChangeListener] is
-        // a `fun interface` for the IntelliJ MessageBus listener shape, but
-        // Kotlin's SAM conversion of a value-class parameter (`AccentHex`)
-        // can fail to bridge, throwing [AbstractMethodError] at fan-out time.
-        // See KDoc on the interface.
         conn.subscribe(
             AccentChangedTopic.TOPIC,
-            @Suppress("ObjectLiteralToLambda")
-            object : AccentChangeListener {
-                override fun accentChanged(
-                    project: com.intellij.openapi.project.Project,
-                    hex: AccentHex,
-                    source: AccentResolver.Source,
-                ) {
-                    SwingUtilities.invokeLater { refreshFromFocusedProject() }
-                }
+            AccentChangeListener { _, _, _ ->
+                SwingUtilities.invokeLater { refreshFromFocusedProject() }
             },
         )
         conn.subscribe(

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipComponent.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipComponent.kt
@@ -14,6 +14,7 @@ import dev.ayuislands.accent.AccentChangedTopic
 import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
+import dev.ayuislands.accent.rethrowIfCancelled
 import dev.ayuislands.accent.toolbar.actions.QuickSwitcherActionGroup
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.mappings.AccentMappingsSettings
@@ -116,17 +117,9 @@ internal class QuickSwitcherChipComponent : JLabel() {
     }
 
     /**
-     * Pin / unpin the focused project's accent and roll back the persisted
-     * `projectAccents` mutation if [AccentApplicator.applyFromHexString]
-     * rejects the hex or any of the resolve / apply / notify calls throw —
-     * keeps the persisted store consistent with the live accent state at
-     * all times. Mirrors [dev.ayuislands.accent.toolbar.actions.PinAccentAction]
-     * for the write path so all three pin entry points (popup quick-action,
-     * right-click context menu, chip inner click) stay consistent.
-     *
-     * The Pattern B `RuntimeException` catch wraps the entire toggle so
-     * a single restore-pin helper handles both the rejection branch
-     * (`applied == false`) and the thrown-exception branch the same way.
+     * Restore the previous pin after rejection or a thrown apply.
+     * Accepted outcomes retain the user's pin choice, including torn paints.
+     * Cancellation propagates after rollback; ordinary failures are logged.
      */
     private fun togglePin() {
         val context = AccentContext.detectQuickSwitcher()
@@ -160,13 +153,13 @@ internal class QuickSwitcherChipComponent : JLabel() {
                 restorePin(mappings, key, previousPin)
             }
         } catch (exception: RuntimeException) {
-            LOG.warn("Pin toggle failed; rolling back", exception)
             restorePin(mappings, key, previousPin)
+            exception.rethrowIfCancelled()
+            LOG.warn("Pin toggle failed; rolling back", exception)
         }
     }
 
-    /** Restore [previous] under [key] (or remove the key entry) so the persisted store
-     *  matches the runtime accent after a rejected / thrown apply. */
+    /** Restore only this pin, preserving current unrelated values. */
     private fun restorePin(
         mappings: AccentMappingsState,
         key: String,
@@ -268,6 +261,7 @@ internal class QuickSwitcherChipComponent : JLabel() {
             try {
                 AccentResolver.resolve(project, context)
             } catch (exception: RuntimeException) {
+                exception.rethrowIfCancelled()
                 LOG.warn("QuickSwitcher chip resolve failed", exception)
                 return
             }

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/DarkerAccentAction.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/DarkerAccentAction.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.DumbAwareAction
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
 import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
@@ -44,10 +45,10 @@ class DarkerAccentAction : DumbAwareAction("Darker", "Darken the current accent 
         // wrap via `unsafeOf` to lift the contract into the type (Pattern K).
         val newHex = AccentHsl.darken(AccentHex.unsafeOf(currentHex)).value
         try {
-            val applied = AccentApplicator.applyFromHexString(newHex)
-            if (applied) {
+            val outcome = AccentApplicator.applyFromHexString(newHex)
+            if (outcome !is AccentApplyOutcome.Rejected) {
                 context.persistExternalManualAccentIfNeeded(newHex)
-                ProjectAccentSwapService.getInstance().notifyExternalApply(newHex)
+                ProjectAccentSwapService.getInstance().notifyExternalApply(outcome)
             } else {
                 LOG.warn("Darker: applyFromHexString rejected hex=$newHex")
             }

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/DarkerAccentAction.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/DarkerAccentAction.kt
@@ -11,6 +11,7 @@ import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.color.AccentHsl
 import dev.ayuislands.accent.persistExternalManualAccentIfNeeded
+import dev.ayuislands.accent.rethrowIfCancelled
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 
@@ -38,6 +39,7 @@ class DarkerAccentAction : DumbAwareAction("Darker", "Darken the current accent 
             try {
                 AccentResolver.resolve(project, context)
             } catch (exception: RuntimeException) {
+                exception.rethrowIfCancelled()
                 LOG.warn("Darker: resolve failed", exception)
                 return
             }
@@ -53,6 +55,7 @@ class DarkerAccentAction : DumbAwareAction("Darker", "Darken the current accent 
                 LOG.warn("Darker: applyFromHexString rejected hex=$newHex")
             }
         } catch (exception: RuntimeException) {
+            exception.rethrowIfCancelled()
             LOG.warn("Darker: apply failed hex=$newHex", exception)
         }
     }

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/LighterAccentAction.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/LighterAccentAction.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.DumbAwareAction
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
 import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
@@ -44,10 +45,10 @@ class LighterAccentAction : DumbAwareAction("Lighter", "Lighten the current acce
         // wrap via `unsafeOf` to lift the contract into the type (Pattern K).
         val newHex = AccentHsl.lighten(AccentHex.unsafeOf(currentHex)).value
         try {
-            val applied = AccentApplicator.applyFromHexString(newHex)
-            if (applied) {
+            val outcome = AccentApplicator.applyFromHexString(newHex)
+            if (outcome !is AccentApplyOutcome.Rejected) {
                 context.persistExternalManualAccentIfNeeded(newHex)
-                ProjectAccentSwapService.getInstance().notifyExternalApply(newHex)
+                ProjectAccentSwapService.getInstance().notifyExternalApply(outcome)
             } else {
                 LOG.warn("Lighter: applyFromHexString rejected hex=$newHex")
             }

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/LighterAccentAction.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/LighterAccentAction.kt
@@ -11,6 +11,7 @@ import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.color.AccentHsl
 import dev.ayuislands.accent.persistExternalManualAccentIfNeeded
+import dev.ayuislands.accent.rethrowIfCancelled
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 
@@ -38,6 +39,7 @@ class LighterAccentAction : DumbAwareAction("Lighter", "Lighten the current acce
             try {
                 AccentResolver.resolve(project, context)
             } catch (exception: RuntimeException) {
+                exception.rethrowIfCancelled()
                 LOG.warn("Lighter: resolve failed", exception)
                 return
             }
@@ -53,6 +55,7 @@ class LighterAccentAction : DumbAwareAction("Lighter", "Lighten the current acce
                 LOG.warn("Lighter: applyFromHexString rejected hex=$newHex")
             }
         } catch (exception: RuntimeException) {
+            exception.rethrowIfCancelled()
             LOG.warn("Lighter: apply failed hex=$newHex", exception)
         }
     }

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/PinAccentAction.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/PinAccentAction.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.DumbAwareAction
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
 import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.licensing.LicenseChecker
@@ -56,9 +57,9 @@ class PinAccentAction : DumbAwareAction("Pin Accent", "Pin the current accent to
         // goes through the app-level map below (FOLLOWUP-PIN-LANE-SPLIT).
         AccentMappingsSettings.getInstance().state.projectAccents[key] = hex
         try {
-            val applied = AccentApplicator.applyFromHexString(hex)
-            if (applied) {
-                ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
+            val outcome = AccentApplicator.applyFromHexString(hex)
+            if (outcome !is AccentApplyOutcome.Rejected) {
+                ProjectAccentSwapService.getInstance().notifyExternalApply(outcome)
             } else {
                 LOG.warn("Pin: applyFromHexString rejected hex=$hex")
             }

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/PinAccentAction.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/PinAccentAction.kt
@@ -8,6 +8,8 @@ import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentApplyOutcome
 import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentResolver
+import dev.ayuislands.accent.isAccentCancellation
+import dev.ayuislands.accent.rethrowIfCancelled
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.settings.mappings.AccentMappingsSettings
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
@@ -44,6 +46,7 @@ class PinAccentAction : DumbAwareAction("Pin Accent", "Pin the current accent to
             try {
                 AccentResolver.resolve(project, variant)
             } catch (exception: RuntimeException) {
+                exception.rethrowIfCancelled()
                 LOG.warn("Pin: resolve failed", exception)
                 return
             }
@@ -55,7 +58,9 @@ class PinAccentAction : DumbAwareAction("Pin Accent", "Pin the current accent to
         // Follow-up: split shared vs personal pin lanes — write to .idea/
         // for shared pins, app-level state for personal. Today everything
         // goes through the app-level map below (FOLLOWUP-PIN-LANE-SPLIT).
-        AccentMappingsSettings.getInstance().state.projectAccents[key] = hex
+        val pins = AccentMappingsSettings.getInstance().state.projectAccents
+        val previousPin = pins[key]
+        pins[key] = hex
         try {
             val outcome = AccentApplicator.applyFromHexString(hex)
             if (outcome !is AccentApplyOutcome.Rejected) {
@@ -64,6 +69,14 @@ class PinAccentAction : DumbAwareAction("Pin Accent", "Pin the current accent to
                 LOG.warn("Pin: applyFromHexString rejected hex=$hex")
             }
         } catch (exception: RuntimeException) {
+            if (exception.isAccentCancellation()) {
+                if (previousPin == null) {
+                    pins.remove(key)
+                } else {
+                    pins[key] = previousPin
+                }
+                throw exception
+            }
             LOG.warn("Pin: apply failed hex=$hex", exception)
         }
     }

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/RandomAccentAction.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/RandomAccentAction.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.DumbAwareAction
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
 import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.persistExternalManualAccentIfNeeded
@@ -18,7 +19,7 @@ import dev.ayuislands.settings.mappings.ProjectAccentSwapService
  * rotation-surface generator — do NOT introduce a parallel palette.
  *
  * Pattern J premium gate on `update`; Pattern B catches RuntimeException only
- * around the generator + apply chain; Pattern D Boolean gate on
+ * around the generator + apply chain; Pattern D rejection gate on
  * `applyFromHexString` before publishing `notifyExternalApply`.
  */
 class RandomAccentAction : DumbAwareAction("Random Accent", "Pick a random readable accent", null) {
@@ -44,10 +45,10 @@ class RandomAccentAction : DumbAwareAction("Random Accent", "Pick a random reada
                 return
             }
         try {
-            val applied = AccentApplicator.applyFromHexString(hex)
-            if (applied) {
+            val outcome = AccentApplicator.applyFromHexString(hex)
+            if (outcome !is AccentApplyOutcome.Rejected) {
                 context.persistExternalManualAccentIfNeeded(hex)
-                ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
+                ProjectAccentSwapService.getInstance().notifyExternalApply(outcome)
             } else {
                 LOG.warn("Random: applyFromHexString rejected hex=$hex")
             }

--- a/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/RandomAccentAction.kt
+++ b/src/main/kotlin/dev/ayuislands/accent/toolbar/actions/RandomAccentAction.kt
@@ -9,6 +9,7 @@ import dev.ayuislands.accent.AccentApplyOutcome
 import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.persistExternalManualAccentIfNeeded
+import dev.ayuislands.accent.rethrowIfCancelled
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.rotation.ContrastAwareColorGenerator
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
@@ -41,6 +42,7 @@ class RandomAccentAction : DumbAwareAction("Random Accent", "Pick a random reada
                     AccentContext.External -> ContrastAwareColorGenerator.generate(AyuVariant.MIRAGE)
                 }
             } catch (exception: RuntimeException) {
+                exception.rethrowIfCancelled()
                 LOG.warn("Random: generate failed", exception)
                 return
             }
@@ -53,6 +55,7 @@ class RandomAccentAction : DumbAwareAction("Random Accent", "Pick a random reada
                 LOG.warn("Random: applyFromHexString rejected hex=$hex")
             }
         } catch (exception: RuntimeException) {
+            exception.rethrowIfCancelled()
             LOG.warn("Random: apply failed hex=$hex", exception)
         }
     }

--- a/src/main/kotlin/dev/ayuislands/licensing/EntitlementReconciler.kt
+++ b/src/main/kotlin/dev/ayuislands/licensing/EntitlementReconciler.kt
@@ -99,10 +99,7 @@ internal object EntitlementReconciler {
         }
         runSurface(failures, "re-apply accent") {
             AccentContext.detect()?.let { context ->
-                AccentApplicator.applyForFocusedProject(context)
-                check(AyuIslandsSettings.getInstance().state.lastApplyOk) {
-                    "Accent apply did not complete every planned step"
-                }
+                AccentApplicator.applyForFocusedProject(context).requireClean()
             }
         }
         runSurface(failures, "refresh glow") {

--- a/src/main/kotlin/dev/ayuislands/onboarding/FreeOnboardingPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/onboarding/FreeOnboardingPanel.kt
@@ -15,6 +15,7 @@ import com.intellij.util.ui.JBUI
 import dev.ayuislands.AyuLaf
 import dev.ayuislands.accent.AYU_ACCENT_PRESETS
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
 import dev.ayuislands.accent.AccentColor
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.onboarding.OnboardingCardChrome.CARD_BORDER_COLOR
@@ -477,9 +478,11 @@ internal class FreeOnboardingPanel(
             updateTrialHeadline(fontPx)
         }
         ApplicationManager.getApplication().invokeLater {
-            val applied = AccentApplicator.applyFromHexString(preset.hex)
-            if (!applied) {
-                LOG.warn("Onboarding preset apply rejected (hex='${preset.hex}')")
+            val outcome = AccentApplicator.applyFromHexString(preset.hex)
+            when (outcome) {
+                is AccentApplyOutcome.Applied -> Unit
+                is AccentApplyOutcome.Rejected -> LOG.warn("Onboarding preset apply rejected (hex='${preset.hex}')")
+                is AccentApplyOutcome.Torn -> LOG.warn("Onboarding preset apply incomplete (hex='${preset.hex}')")
             }
         }
     }

--- a/src/main/kotlin/dev/ayuislands/reapply/ThemeReapplication.kt
+++ b/src/main/kotlin/dev/ayuislands/reapply/ThemeReapplication.kt
@@ -5,7 +5,6 @@ import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.project.ProjectManager
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentContext
-import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.runCatchingPreservingCancellation
 import dev.ayuislands.font.FontPresetApplicator
@@ -120,24 +119,12 @@ object ThemeReapplication {
 
             ApplyResolvedAccent -> {
                 val context = accentContextOf(reason) ?: return
-                val hex = AccentApplicator.applyForFocusedProject(context)
-                // A shape-invalid hex is the ONE case where the applicator skips
-                // apply() entirely (leaving lastApplyOk stale from the previous
-                // apply), so the clean-flag check below cannot see it. The hex
-                // itself carries the signal: mirror ApplyExplicitHex's rejection
-                // failure by validating the returned value.
-                check(AccentHex.of(hex) != null) {
-                    "resolver produced a shape-invalid hex '$hex'; apply was skipped"
-                }
-                ensureAccentApplyClean(step)
+                AccentApplicator.applyForFocusedProject(context).requireClean()
             }
 
             ApplyExplicitHex -> {
                 val hex = (reason as? ReapplyReason.LicenseRevert)?.freeHex ?: return
-                check(AccentApplicator.applyFromHexString(hex)) {
-                    "free-default hex rejected by the applicator: '$hex'"
-                }
-                ensureAccentApplyClean(step)
+                AccentApplicator.applyFromHexString(hex).requireClean()
             }
 
             RevertAccent -> {
@@ -184,30 +171,6 @@ object ThemeReapplication {
             BindScheme, ApplyResolvedAccent, ApplyExplicitHex, RevertAccent -> {
                 return
             }
-        }
-    }
-
-    /**
-     * Escalate a torn accent apply into this step's [StepFailure]. The applicator
-     * contains mid-step throws internally (WARN + skipped tail — see
-     * `AccentApplyPlanRunner`), so the only in-process tear signal available to
-     * plan consumers is the persisted clean flag: [reapply] runs on the EDT and
-     * the apply is EDT-synchronous, so after the apply call returns the flag
-     * reflects THAT apply. Throwing here restores what consumers relied on
-     * before the containment refactor: the rotation circuit breaker counts the
-     * failure and the license revert surfaces its "restart to complete" notice.
-     *
-     * Synchronicity coupling: this contract holds only while [reapply]'s EDT
-     * check (`Application.isDispatchThread`) and the runner's
-     * (`SwingUtilities.isEventDispatchThread`) agree — they delegate to the same
-     * EDT in production. A runner dispatch refactor must preserve that.
-     *
-     * Does NOT cover the rejected-hex skip (apply never ran, flag stale) — the
-     * callers validate the hex shape separately before consulting this.
-     */
-    private fun ensureAccentApplyClean(step: ReapplyStep) {
-        check(AyuIslandsSettings.getInstance().state.lastApplyOk) {
-            "accent apply torn during $step — see the 'Accent apply torn at' warning above"
         }
     }
 

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -11,6 +11,7 @@ import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.dsl.builder.selected
 import dev.ayuislands.accent.AYU_ACCENT_PRESETS
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.SystemAccentProvider
@@ -250,9 +251,9 @@ class AyuIslandsAccentPanel : SettingsParticipant {
     private fun applyRotationRespectingOverrides(currentVariant: AyuVariant) {
         val focusedProject = AccentApplicator.resolveFocusedProject()
         val resolvedHex = AccentResolver.resolve(focusedProject, currentVariant)
-        val applied = AccentApplicator.applyFromHexString(resolvedHex)
-        if (applied) {
-            ProjectAccentSwapService.getInstance().notifyExternalApply(resolvedHex)
+        val outcome = AccentApplicator.applyFromHexString(resolvedHex)
+        if (outcome !is AccentApplyOutcome.Rejected) {
+            ProjectAccentSwapService.getInstance().notifyExternalApply(outcome)
         } else {
             LOG.warn("Skipping swap publish: applyFromHexString rejected '$resolvedHex'")
         }
@@ -677,7 +678,7 @@ class AyuIslandsAccentPanel : SettingsParticipant {
         // `notifyExternalApply` after a successful `apply` means the accent DID change and
         // only the swap cache is stale. Log them separately so triage doesn't get an "also
         // failed" breadcrumb on a path where apply actually worked.
-        val fallbackApplied =
+        val fallbackOutcome =
             try {
                 AccentApplicator.applyFromHexString(effectiveAccent)
             } catch (exception: RuntimeException) {
@@ -688,7 +689,7 @@ class AyuIslandsAccentPanel : SettingsParticipant {
                 )
                 return
             }
-        if (!fallbackApplied) {
+        if (fallbackOutcome is AccentApplyOutcome.Rejected) {
             LOG.warn(
                 "Global accent fallback rejected by applyFromHexString " +
                     "(variant=$currentVariant, hex='$effectiveAccent'); skipping swap publish",
@@ -696,7 +697,7 @@ class AyuIslandsAccentPanel : SettingsParticipant {
             return
         }
         try {
-            ProjectAccentSwapService.getInstance().notifyExternalApply(effectiveAccent)
+            ProjectAccentSwapService.getInstance().notifyExternalApply(fallbackOutcome)
         } catch (exception: RuntimeException) {
             LOG.warn(
                 "Global accent applied but swap-cache sync failed " +

--- a/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanel.kt
@@ -15,6 +15,7 @@ import dev.ayuislands.accent.AccentApplyOutcome
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.SystemAccentProvider
+import dev.ayuislands.accent.rethrowIfCancelled
 import dev.ayuislands.licensing.LicenseChecker
 import dev.ayuislands.rotation.AccentRotationMode
 import dev.ayuislands.rotation.AccentRotationService
@@ -666,6 +667,7 @@ class AyuIslandsAccentPanel : SettingsParticipant {
             AccentApplicator.applyForFocusedProject(currentVariant)
             return
         } catch (exception: RuntimeException) {
+            exception.rethrowIfCancelled()
             LOG.error(
                 "Failed to apply resolved accent for focused project " +
                     "(variant=$currentVariant, fallbackHex=$effectiveAccent); falling back to global",
@@ -682,6 +684,7 @@ class AyuIslandsAccentPanel : SettingsParticipant {
             try {
                 AccentApplicator.applyFromHexString(effectiveAccent)
             } catch (exception: RuntimeException) {
+                exception.rethrowIfCancelled()
                 LOG.error(
                     "Global accent fallback also failed (variant=$currentVariant, hex=$effectiveAccent); " +
                         "Settings panel leaving visible accent unchanged",
@@ -699,6 +702,7 @@ class AyuIslandsAccentPanel : SettingsParticipant {
         try {
             ProjectAccentSwapService.getInstance().notifyExternalApply(fallbackOutcome)
         } catch (exception: RuntimeException) {
+            exception.rethrowIfCancelled()
             LOG.warn(
                 "Global accent applied but swap-cache sync failed " +
                     "(variant=$currentVariant, hex=$effectiveAccent); " +

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilder.kt
@@ -11,6 +11,7 @@ import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.table.JBTable
 import com.intellij.util.messages.MessageBusConnection
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
 import dev.ayuislands.accent.AccentDetectorLookup
 import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentHexPolicy
@@ -325,9 +326,9 @@ internal class OverridesGroupBuilder(
                 // bound yet — same helper every apply path ultimately converges on.
                 val project = parentProject ?: AccentApplicator.resolveFocusedProject()
                 val hex = AccentResolver.resolve(project, variant)
-                val applied = AccentApplicator.applyFromHexString(hex)
-                if (applied) {
-                    ProjectAccentSwapService.getInstance().notifyExternalApply(hex)
+                val outcome = AccentApplicator.applyFromHexString(hex)
+                if (outcome !is AccentApplyOutcome.Rejected) {
+                    ProjectAccentSwapService.getInstance().notifyExternalApply(outcome)
                 } else {
                     LOG.warn("Skipping swap publish: applyFromHexString rejected '$hex'")
                 }

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapService.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapService.kt
@@ -14,6 +14,7 @@ import dev.ayuislands.accent.AccentChangedTopic
 import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
+import dev.ayuislands.accent.rethrowIfCancelled
 import dev.ayuislands.indent.IndentRainbowSync
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
@@ -100,10 +101,12 @@ class ProjectAccentSwapService : Disposable {
         // dispatcher. AWT does not remove failing listeners, so the listener would keep firing
         // — but each failure would dump a generic uncaught-exception trace into idea.log (SEVERE
         // in some IDE builds, which triggers a user-visible error balloon) with no project /
-        // hex context. The catch here converts that into an actionable LOG.error.
+        // hex context. Ordinary failures become actionable LOG.error entries;
+        // platform and coroutine cancellation still propagate to the caller.
         try {
             handleWindowActivated(event)
         } catch (exception: RuntimeException) {
+            exception.rethrowIfCancelled()
             LOG.error("Project accent swap failed on window activation", exception)
         }
     }
@@ -226,11 +229,12 @@ class ProjectAccentSwapService : Disposable {
         }
     }
 
-    /** Cache only a completed visual application, independently of persisted restart metadata. */
+    /** Cache completed visuals; a partial visual apply invalidates the previously cached accent. */
     @RequiresEdt
     internal fun notifyExternalApply(outcome: AccentApplyOutcome) {
         if (!outcome.visualsApplied) {
-            LOG.warn("Swap cache not updated: accent visuals did not complete ($outcome)")
+            if (outcome is AccentApplyOutcome.Torn) lastAppliedHex = null
+            LOG.warn("Accent visuals did not complete; swap cache is '$lastAppliedHex' ($outcome)")
             return
         }
         lastAppliedHex =

--- a/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapService.kt
+++ b/src/main/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapService.kt
@@ -7,7 +7,9 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.WindowManager
+import com.intellij.util.concurrency.annotations.RequiresEdt
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
 import dev.ayuislands.accent.AccentChangedTopic
 import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentHex
@@ -151,22 +153,12 @@ class ProjectAccentSwapService : Disposable {
     }
 
     private fun applyChangedHex(hex: String): Boolean {
-        // Different hex from last apply: re-run the full apply path. UIManager
-        // writes, EP elements, editor keys, AND integrations are all refreshed
-        // through AccentApplicator.applyFromHexString -> apply.
-        val applied = AccentApplicator.applyFromHexString(hex)
-        if (!applied) {
+        val outcome = AccentApplicator.applyFromHexString(hex)
+        if (outcome is AccentApplyOutcome.Rejected) {
             LOG.warn("Skipping swap publish: applyFromHexString rejected '$hex'")
             return false
         }
-        // Route the cache write through the torn-apply gate rather than
-        // assigning lastAppliedHex directly: `applied == true` only proves the
-        // hex shape was valid, not that the plan painted cleanly. Priming the
-        // torn hex here would make every subsequent same-hex activation take
-        // the cheap same-hex branch and freeze the tear; the gated skip keeps
-        // this activation path retrying (WARN per attempt) — the same
-        // retry-per-activation behavior the pre-plan code had.
-        notifyExternalApply(hex)
+        notifyExternalApply(outcome)
         return true
     }
 
@@ -234,23 +226,19 @@ class ProjectAccentSwapService : Disposable {
         }
     }
 
-    /**
-     * Record [hex] as the last painted accent after an apply — external callers
-     * (settings panel, rotation, startup activity) and this service's own
-     * focus-swap apply both route through here so the cache matches the current
-     * UIManager state and we don't skip the next real swap.
-     *
-     * Gated on [AyuIslandsState.lastApplyOk]: a torn apply never fully painted [hex],
-     * so recording it would make the next same-hex WINDOW_ACTIVATED skip the re-apply
-     * that would have self-healed the tear. Callers already sit right after their own
-     * apply call on the EDT (apply is EDT-synchronous), so the flag reflects THAT apply.
-     */
-    fun notifyExternalApply(hex: String) {
-        if (!AyuIslandsSettings.getInstance().state.lastApplyOk) {
-            LOG.warn("Swap cache not updated for '$hex': the last accent apply did not complete cleanly")
+    /** Cache only a completed visual application, independently of persisted restart metadata. */
+    @RequiresEdt
+    internal fun notifyExternalApply(outcome: AccentApplyOutcome) {
+        if (!outcome.visualsApplied) {
+            LOG.warn("Swap cache not updated: accent visuals did not complete ($outcome)")
             return
         }
-        lastAppliedHex = hex
+        lastAppliedHex =
+            when (outcome) {
+                is AccentApplyOutcome.Applied -> outcome.accentHex.value
+                is AccentApplyOutcome.Torn -> outcome.accentHex.value
+                is AccentApplyOutcome.Rejected -> return
+            }
     }
 
     private fun findProjectForWindow(window: Window): Project? {

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsAppListenerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsAppListenerTest.kt
@@ -3,6 +3,8 @@ package dev.ayuislands
 import com.intellij.ide.ui.LafManager
 import com.intellij.ide.ui.laf.UIThemeLookAndFeelInfo
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
+import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.settings.AyuIslandsSettings
@@ -56,7 +58,13 @@ class AyuIslandsAppListenerTest {
 
         mockkStatic(LafManager::class)
         mockkObject(AccentApplicator)
-        every { AccentApplicator.applyFromHexString(any()) } returns true
+        every { AccentApplicator.requestApply(any(), any()) } answers {
+            val raw = firstArg<String>()
+            secondArg<(AccentApplyOutcome) -> Unit>()(
+                AccentHex.of(raw)?.let { validatedHex -> AccentApplyOutcome.Applied(validatedHex) }
+                    ?: AccentApplyOutcome.Rejected(raw),
+            )
+        }
     }
 
     @AfterTest
@@ -77,7 +85,7 @@ class AyuIslandsAppListenerTest {
         listener.appFrameCreated(mutableListOf())
 
         verify(exactly = 1) {
-            AccentApplicator.applyFromHexString("#FF0000")
+            AccentApplicator.requestApply("#FF0000", any())
         }
     }
 
@@ -94,7 +102,7 @@ class AyuIslandsAppListenerTest {
         listener.appFrameCreated(mutableListOf())
 
         verify(exactly = 0) {
-            AccentApplicator.applyFromHexString(any())
+            AccentApplicator.requestApply(any(), any())
         }
     }
 
@@ -125,7 +133,7 @@ class AyuIslandsAppListenerTest {
             listener.appFrameCreated(mutableListOf())
 
             verify(atLeast = 1) {
-                AccentApplicator.applyFromHexString(expectedAccent)
+                AccentApplicator.requestApply(expectedAccent, any())
             }
         }
     }
@@ -150,7 +158,7 @@ class AyuIslandsAppListenerTest {
 
         listener.appFrameCreated(mutableListOf())
 
-        verify(exactly = 1) { AccentApplicator.applyFromHexString("#5CCFE6") }
+        verify(exactly = 1) { AccentApplicator.requestApply("#5CCFE6", any()) }
         // Resolver must NOT be consulted when cached hex is available — that's the whole
         // point of the anti-flicker cache.
         verify(exactly = 0) { AccentResolver.resolve(any(), any<AyuVariant>()) }
@@ -175,8 +183,8 @@ class AyuIslandsAppListenerTest {
 
         listener.appFrameCreated(mutableListOf())
 
-        verify(exactly = 1) { AccentApplicator.applyFromHexString("#FF0000") }
-        verify(exactly = 0) { AccentApplicator.applyFromHexString("#5CCFE6") }
+        verify(exactly = 1) { AccentApplicator.requestApply("#FF0000", any()) }
+        verify(exactly = 0) { AccentApplicator.requestApply("#5CCFE6", any()) }
     }
 
     @Test
@@ -197,7 +205,7 @@ class AyuIslandsAppListenerTest {
         listener.appFrameCreated(mutableListOf())
 
         verify(exactly = 1) { AccentResolver.resolve(null, AyuVariant.MIRAGE) }
-        verify(exactly = 1) { AccentApplicator.applyFromHexString("#FF0000") }
+        verify(exactly = 1) { AccentApplicator.requestApply("#FF0000", any()) }
     }
 
     @Test
@@ -222,9 +230,9 @@ class AyuIslandsAppListenerTest {
 
         // Resolver MUST be consulted — cached hex was invalid.
         verify(exactly = 1) { AccentResolver.resolve(null, AyuVariant.MIRAGE) }
-        verify(exactly = 1) { AccentApplicator.applyFromHexString("#FF0000") }
+        verify(exactly = 1) { AccentApplicator.requestApply("#FF0000", any()) }
         // Applier must NOT have been called with the poison value.
-        verify(exactly = 0) { AccentApplicator.applyFromHexString("garbage") }
+        verify(exactly = 0) { AccentApplicator.requestApply("garbage", any()) }
         // Bad persisted hex cleared so next boot starts clean.
         assertNull(state.lastAppliedAccentHex, "invalid cached hex must be cleared")
     }
@@ -279,7 +287,7 @@ class AyuIslandsAppListenerTest {
 
         listener.appFrameCreated(mutableListOf())
 
-        verify(exactly = 1) { AccentApplicator.applyFromHexString("#5CCFE6") }
+        verify(exactly = 1) { AccentApplicator.requestApply("#5CCFE6", any()) }
         verify(exactly = 0) { AccentResolver.resolve(any(), any<AyuVariant>()) }
         assertEquals("#5CCFE6", state.lastAppliedAccentHex, "valid cached hex must remain persisted")
     }
@@ -302,8 +310,8 @@ class AyuIslandsAppListenerTest {
         listener.appFrameCreated(mutableListOf())
 
         // Both calls must land on the Mirage accent — never the Dark or Light one.
-        verify(exactly = 2) { AccentApplicator.applyFromHexString("#FF0000") }
-        verify(exactly = 0) { AccentApplicator.applyFromHexString("#00FF00") }
-        verify(exactly = 0) { AccentApplicator.applyFromHexString("#0000FF") }
+        verify(exactly = 2) { AccentApplicator.requestApply("#FF0000", any()) }
+        verify(exactly = 0) { AccentApplicator.requestApply("#00FF00", any()) }
+        verify(exactly = 0) { AccentApplicator.requestApply("#0000FF", any()) }
     }
 }

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsLafListenerSyntaxReapplyTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsLafListenerSyntaxReapplyTest.kt
@@ -6,7 +6,9 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.util.io.FileUtil
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
 import dev.ayuislands.accent.AccentContext
+import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.font.FontPresetApplicator
 import dev.ayuislands.glow.GlowOverlayManager
@@ -24,7 +26,7 @@ import java.io.File
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
-import kotlin.test.assertTrue
+import kotlin.test.assertEquals
 
 /**
  * Verifies that [AyuIslandsLafListener.lookAndFeelChanged] invokes
@@ -76,8 +78,10 @@ class AyuIslandsLafListenerSyntaxReapplyTest {
         mockkObject(AppearanceSyncService.Companion)
         mockkObject(SyntaxIntensityService.Companion)
 
-        every { AccentApplicator.applyForFocusedProject(any<AccentContext>()) } returns "#FFCC66"
-        every { AccentApplicator.applyForFocusedProject(any<AyuVariant>()) } returns "#FFCC66"
+        every { AccentApplicator.applyForFocusedProject(any<AccentContext>()) } returns
+            AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#FFCC66")))
+        every { AccentApplicator.applyForFocusedProject(any<AyuVariant>()) } returns
+            AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#FFCC66")))
         every { AccentApplicator.revertAll() } returns Unit
         every { FontPresetApplicator.applyFromState() } returns Unit
         every { FontPresetApplicator.revert() } returns Unit
@@ -142,8 +146,9 @@ class AyuIslandsLafListenerSyntaxReapplyTest {
                 RegexOption.IGNORE_CASE,
             )
         val matches = regex.findAll(xmlText).count()
-        assertTrue(
-            matches == 1,
+        assertEquals(
+            1,
+            matches,
             "Expected EXACTLY ONE `AyuIslandsLafListener` registration, got $matches " +
                 "— the syntax intensity wiring must extend the existing listener, not duplicate it.",
         )

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsLafListenerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsLafListenerTest.kt
@@ -5,7 +5,9 @@ import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.ProjectManager
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
 import dev.ayuislands.accent.AccentContext
+import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.font.FontPresetApplicator
 import dev.ayuislands.glow.GlowOverlayManager
@@ -79,8 +81,10 @@ class AyuIslandsLafListenerTest {
         // resolves without reaching into `ApplicationManager.getApplication().getService(...)`.
         mockkObject(SyntaxIntensityService.Companion)
 
-        every { AccentApplicator.applyForFocusedProject(any<AccentContext>()) } returns "#FFCC66"
-        every { AccentApplicator.applyForFocusedProject(any<AyuVariant>()) } returns "#FFCC66"
+        every { AccentApplicator.applyForFocusedProject(any<AccentContext>()) } returns
+            AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#FFCC66")))
+        every { AccentApplicator.applyForFocusedProject(any<AyuVariant>()) } returns
+            AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#FFCC66")))
         every { AccentApplicator.revertAll() } returns Unit
         every { FontPresetApplicator.applyFromState() } returns Unit
         every { FontPresetApplicator.revert() } returns Unit
@@ -170,7 +174,8 @@ class AyuIslandsLafListenerTest {
         state.externalThemeEnhancementsEnabled = true
         every { AyuVariant.detect() } returns null
         every { AyuVariant.isAyuActive() } returns false
-        every { AccentApplicator.applyForFocusedProject(AccentContext.External) } returns "#AABBCC"
+        every { AccentApplicator.applyForFocusedProject(AccentContext.External) } returns
+            AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#AABBCC")))
         val mockLafManager = mockk<LafManager>(relaxed = true)
         every { mockLafManager.currentUIThemeLookAndFeel.name } returns "Darcula"
 

--- a/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
+++ b/src/test/kotlin/dev/ayuislands/AyuIslandsStartupActivityTest.kt
@@ -1003,25 +1003,21 @@ class AyuIslandsStartupActivityTest {
 
     @Test
     fun `startup helper WARNs when applyFromHexString rejects hex as a defensive branch`() {
-        // Regression lock: `applyFromHexString` returns Boolean (false =
-        // rejected); when rejected, `hex` becomes null via
-        // `if (applied) resolved else null`. That branch must log a WARN so
-        // operators can tell rejected-hex from throw-hex. Source-level lock on
-        // the WARN literal AND the structural `applyOutcome.isSuccess` check
-        // inside `if (hex == null)`.
+        // Rejected maps to a successful null result; a thrown failure also has
+        // no outcome. The nested isSuccess branch must distinguish their logs.
         val source = readStartupActivitySource()
         assertTrue(
             source.contains("Startup accent apply was rejected by applyFromHexString"),
-            "WARN-on-rejected-hex branch must remain against Boolean-gating regressions",
+            "WARN-on-rejected-hex branch must remain against rejection-gating regressions",
         )
         val isSuccessInNullBranch =
             Regex(
-                """if\s*\(\s*hex\s*==\s*null\s*\)\s*\{\s*[^}]*if\s*\(\s*applyOutcome\.isSuccess\s*\)""",
+                """if\s*\(\s*outcome\s*==\s*null\s*\)\s*\{\s*[^}]*if\s*\(\s*applyOutcome\.isSuccess\s*\)""",
                 RegexOption.DOT_MATCHES_ALL,
             )
         assertTrue(
             isSuccessInNullBranch.containsMatchIn(source),
-            "isSuccess check must sit INSIDE the `if (hex == null)` block - " +
+            "isSuccess check must sit INSIDE the `if (outcome == null)` block - " +
                 "that distinguishes Success(null=rejected) from Failure(throw)",
         )
     }

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorFocusedProjectTest.kt
@@ -9,7 +9,6 @@ import com.intellij.openapi.wm.WindowManager
 import com.intellij.testFramework.LoggedErrorProcessor
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 import io.mockk.every
-import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
@@ -24,6 +23,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 /**
@@ -55,8 +55,13 @@ class AccentApplicatorFocusedProjectTest {
         mockkStatic(ProjectManager::class)
         mockkObject(AccentResolver)
         mockkObject(AccentApplicator, recordPrivateCalls = false)
-        every { AccentApplicator.applyFromHexString(any()) } returns true
-        justRun { AccentApplicator.apply(any()) }
+        every { AccentApplicator.applyFromHexString(any()) } answers
+            {
+                AccentHex.of(firstArg<String>())?.let { validatedHex -> AccentApplyOutcome.Applied(validatedHex) }
+                    ?: AccentApplyOutcome.Rejected(firstArg())
+            }
+        every { AccentApplicator.apply(any()) } answers
+            { AccentApplyOutcome.Applied(requireNotNull(AccentHex.of(firstArg<String>()))) }
 
         mockkObject(ProjectAccentSwapService.Companion)
         swapService = mockk(relaxed = true)
@@ -79,6 +84,7 @@ class AccentApplicatorFocusedProjectTest {
 
         mockkStatic(SwingUtilities::class)
         every { SwingUtilities.getWindowAncestor(any()) } returns null
+        every { SwingUtilities.isEventDispatchThread() } returns true
     }
 
     @AfterTest
@@ -102,9 +108,11 @@ class AccentApplicatorFocusedProjectTest {
 
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
 
-        assertEquals("#ABCDEF", applied)
+        assertEquals("#ABCDEF", assertIs<AccentApplyOutcome.Applied>(applied).accentHex.value)
         verify(exactly = 1) { AccentApplicator.applyFromHexString("#ABCDEF") }
-        verify(exactly = 1) { swapService.notifyExternalApply("#ABCDEF") }
+        verify(exactly = 1) {
+            swapService.notifyExternalApply(AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#ABCDEF"))))
+        }
     }
 
     @Test
@@ -117,10 +125,12 @@ class AccentApplicatorFocusedProjectTest {
 
         val applied = AccentApplicator.applyForFocusedProject(AccentContext.External)
 
-        assertEquals("#AABBCC", applied)
+        assertEquals("#AABBCC", assertIs<AccentApplyOutcome.Applied>(applied).accentHex.value)
         verify(exactly = 1) { AccentResolver.resolve(focused, AccentContext.External) }
         verify(exactly = 1) { AccentApplicator.applyFromHexString("#AABBCC") }
-        verify(exactly = 1) { swapService.notifyExternalApply("#AABBCC") }
+        verify(exactly = 1) {
+            swapService.notifyExternalApply(AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#AABBCC"))))
+        }
     }
 
     @Test
@@ -135,7 +145,7 @@ class AccentApplicatorFocusedProjectTest {
 
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.DARK)
 
-        assertEquals("#123456", applied)
+        assertEquals("#123456", assertIs<AccentApplyOutcome.Applied>(applied).accentHex.value)
         verify(exactly = 1) { AccentResolver.resolve(realFocus, ayu(AyuVariant.DARK)) }
     }
 
@@ -150,9 +160,11 @@ class AccentApplicatorFocusedProjectTest {
 
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.LIGHT)
 
-        assertEquals("#F29718", applied)
+        assertEquals("#F29718", assertIs<AccentApplyOutcome.Applied>(applied).accentHex.value)
         verify(exactly = 1) { AccentApplicator.applyFromHexString("#F29718") }
-        verify(exactly = 1) { swapService.notifyExternalApply("#F29718") }
+        verify(exactly = 1) {
+            swapService.notifyExternalApply(AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#F29718"))))
+        }
     }
 
     @Test
@@ -182,11 +194,11 @@ class AccentApplicatorFocusedProjectTest {
         every { manager.openProjects } returns arrayOf(otherProject, focusedProject)
         every { ProjectManager.getInstance() } returns manager
 
-        every { AccentResolver.resolve(focusedProject, ayu(AyuVariant.MIRAGE)) } returns "#FOCUSED"
+        every { AccentResolver.resolve(focusedProject, ayu(AyuVariant.MIRAGE)) } returns "#123ABC"
 
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
 
-        assertEquals("#FOCUSED", applied)
+        assertEquals("#123ABC", assertIs<AccentApplyOutcome.Applied>(applied).accentHex.value)
         verify(exactly = 1) { AccentResolver.resolve(focusedProject, ayu(AyuVariant.MIRAGE)) }
         verify(exactly = 0) { AccentResolver.resolve(otherProject, any<AccentContext>()) }
     }
@@ -211,12 +223,12 @@ class AccentApplicatorFocusedProjectTest {
         val manager = mockk<ProjectManager>()
         every { manager.openProjects } returns arrayOf(staleFocusedProject, activeProject)
         every { ProjectManager.getInstance() } returns manager
-        every { AccentResolver.resolve(activeProject, ayu(AyuVariant.MIRAGE)) } returns "#ACTIVE"
+        every { AccentResolver.resolve(activeProject, ayu(AyuVariant.MIRAGE)) } returns "#234BCD"
         every { AccentResolver.resolve(staleFocusedProject, ayu(AyuVariant.MIRAGE)) } returns "#STALE"
 
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
 
-        assertEquals("#ACTIVE", applied)
+        assertEquals("#234BCD", assertIs<AccentApplyOutcome.Applied>(applied).accentHex.value)
         verify(exactly = 1) { AccentResolver.resolve(activeProject, ayu(AyuVariant.MIRAGE)) }
         verify(exactly = 0) { AccentResolver.resolve(staleFocusedProject, any<AccentContext>()) }
     }
@@ -242,11 +254,11 @@ class AccentApplicatorFocusedProjectTest {
         every { manager.openProjects } returns arrayOf(healthyProject)
         every { ProjectManager.getInstance() } returns manager
 
-        every { AccentResolver.resolve(healthyProject, ayu(AyuVariant.MIRAGE)) } returns "#FALLBACK"
+        every { AccentResolver.resolve(healthyProject, ayu(AyuVariant.MIRAGE)) } returns "#345CDE"
 
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
 
-        assertEquals("#FALLBACK", applied)
+        assertEquals("#345CDE", assertIs<AccentApplyOutcome.Applied>(applied).accentHex.value)
         verify(exactly = 1) { AccentResolver.resolve(healthyProject, ayu(AyuVariant.MIRAGE)) }
     }
 
@@ -273,11 +285,11 @@ class AccentApplicatorFocusedProjectTest {
         every { manager.openProjects } returns arrayOf(healthyProject)
         every { ProjectManager.getInstance() } returns manager
 
-        every { AccentResolver.resolve(healthyProject, ayu(AyuVariant.MIRAGE)) } returns "#FALLBACK"
+        every { AccentResolver.resolve(healthyProject, ayu(AyuVariant.MIRAGE)) } returns "#345CDE"
 
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
 
-        assertEquals("#FALLBACK", applied)
+        assertEquals("#345CDE", assertIs<AccentApplyOutcome.Applied>(applied).accentHex.value)
         verify(exactly = 1) { AccentResolver.resolve(healthyProject, ayu(AyuVariant.MIRAGE)) }
     }
 
@@ -296,7 +308,7 @@ class AccentApplicatorFocusedProjectTest {
         io.mockk.verifyOrder {
             AccentResolver.resolve(focused, ayu(AyuVariant.MIRAGE))
             AccentApplicator.applyFromHexString("#FFCC66")
-            swapService.notifyExternalApply("#FFCC66")
+            swapService.notifyExternalApply(AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#FFCC66"))))
         }
     }
 
@@ -328,11 +340,11 @@ class AccentApplicatorFocusedProjectTest {
         mockkStatic(IdeFocusManager::class)
         every { IdeFocusManager.getGlobalInstance() } returns focusManager
 
-        every { AccentResolver.resolve(osActiveProject, ayu(AyuVariant.MIRAGE)) } returns "#OS"
+        every { AccentResolver.resolve(osActiveProject, ayu(AyuVariant.MIRAGE)) } returns "#456DEF"
 
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
 
-        assertEquals("#OS", applied)
+        assertEquals("#456DEF", assertIs<AccentApplyOutcome.Applied>(applied).accentHex.value)
         verify(exactly = 1) { AccentResolver.resolve(osActiveProject, ayu(AyuVariant.MIRAGE)) }
         verify(exactly = 0) { AccentResolver.resolve(lastFocusedProject, any<AccentContext>()) }
     }
@@ -365,11 +377,11 @@ class AccentApplicatorFocusedProjectTest {
         mockkStatic(IdeFocusManager::class)
         every { IdeFocusManager.getGlobalInstance() } returns focusManager
 
-        every { AccentResolver.resolve(lastFocusedProject, ayu(AyuVariant.MIRAGE)) } returns "#LAST"
+        every { AccentResolver.resolve(lastFocusedProject, ayu(AyuVariant.MIRAGE)) } returns "#567EF0"
 
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
 
-        assertEquals("#LAST", applied)
+        assertEquals("#567EF0", assertIs<AccentApplyOutcome.Applied>(applied).accentHex.value)
         verify(exactly = 1) { AccentResolver.resolve(lastFocusedProject, ayu(AyuVariant.MIRAGE)) }
     }
 
@@ -395,11 +407,11 @@ class AccentApplicatorFocusedProjectTest {
         every { manager.openProjects } returns arrayOf(healthyProject)
         every { ProjectManager.getInstance() } returns manager
 
-        every { AccentResolver.resolve(healthyProject, ayu(AyuVariant.MIRAGE)) } returns "#FALLBACK"
+        every { AccentResolver.resolve(healthyProject, ayu(AyuVariant.MIRAGE)) } returns "#345CDE"
 
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
 
-        assertEquals("#FALLBACK", applied)
+        assertEquals("#345CDE", assertIs<AccentApplyOutcome.Applied>(applied).accentHex.value)
         verify(exactly = 0) { AccentResolver.resolve(disposedProject, any<AccentContext>()) }
     }
 
@@ -423,11 +435,11 @@ class AccentApplicatorFocusedProjectTest {
         mockkStatic(IdeFocusManager::class)
         every { IdeFocusManager.getGlobalInstance() } returns focusManager
 
-        every { AccentResolver.resolve(focusedProject, ayu(AyuVariant.MIRAGE)) } returns "#FALLBACK"
+        every { AccentResolver.resolve(focusedProject, ayu(AyuVariant.MIRAGE)) } returns "#345CDE"
 
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
 
-        assertEquals("#FALLBACK", applied)
+        assertEquals("#345CDE", assertIs<AccentApplyOutcome.Applied>(applied).accentHex.value)
         verify(exactly = 1) { AccentResolver.resolve(focusedProject, ayu(AyuVariant.MIRAGE)) }
     }
 
@@ -505,11 +517,11 @@ class AccentApplicatorFocusedProjectTest {
             WindowManager.getInstance().allProjectFrames
         } returns arrayOf(nullProjectFrame, healthyFrame)
 
-        every { AccentResolver.resolve(healthyProject, ayu(AyuVariant.MIRAGE)) } returns "#HEALTHY"
+        every { AccentResolver.resolve(healthyProject, ayu(AyuVariant.MIRAGE)) } returns "#678F01"
 
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
 
-        assertEquals("#HEALTHY", applied)
+        assertEquals("#678F01", assertIs<AccentApplyOutcome.Applied>(applied).accentHex.value)
         verify(exactly = 1) { AccentResolver.resolve(healthyProject, ayu(AyuVariant.MIRAGE)) }
     }
 
@@ -539,11 +551,11 @@ class AccentApplicatorFocusedProjectTest {
             WindowManager.getInstance().allProjectFrames
         } returns arrayOf(firstFrame, secondFrame)
 
-        every { AccentResolver.resolve(firstProject, ayu(AyuVariant.MIRAGE)) } returns "#FIRST"
+        every { AccentResolver.resolve(firstProject, ayu(AyuVariant.MIRAGE)) } returns "#789012"
 
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
 
-        assertEquals("#FIRST", applied)
+        assertEquals("#789012", assertIs<AccentApplyOutcome.Applied>(applied).accentHex.value)
         verify(exactly = 1) { AccentResolver.resolve(firstProject, ayu(AyuVariant.MIRAGE)) }
         verify(exactly = 0) { AccentResolver.resolve(secondProject, any<AccentContext>()) }
     }
@@ -570,11 +582,11 @@ class AccentApplicatorFocusedProjectTest {
             WindowManager.getInstance().allProjectFrames
         } returns arrayOf(detachedFrame, healthyFrame)
 
-        every { AccentResolver.resolve(healthyProject, ayu(AyuVariant.MIRAGE)) } returns "#HEALTHY"
+        every { AccentResolver.resolve(healthyProject, ayu(AyuVariant.MIRAGE)) } returns "#678F01"
 
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
 
-        assertEquals("#HEALTHY", applied)
+        assertEquals("#678F01", assertIs<AccentApplyOutcome.Applied>(applied).accentHex.value)
         verify(exactly = 1) { AccentResolver.resolve(healthyProject, ayu(AyuVariant.MIRAGE)) }
         verify(exactly = 0) { AccentResolver.resolve(detachedProject, any<AccentContext>()) }
     }
@@ -612,11 +624,11 @@ class AccentApplicatorFocusedProjectTest {
         every { projectManager.openProjects } returns arrayOf(projectManagerProject)
         every { ProjectManager.getInstance() } returns projectManager
 
-        every { AccentResolver.resolve(focusedProject, ayu(AyuVariant.MIRAGE)) } returns "#FOCUS"
+        every { AccentResolver.resolve(focusedProject, ayu(AyuVariant.MIRAGE)) } returns "#890123"
 
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
 
-        assertEquals("#FOCUS", applied)
+        assertEquals("#890123", assertIs<AccentApplyOutcome.Applied>(applied).accentHex.value)
         verify(exactly = 1) { AccentResolver.resolve(focusedProject, ayu(AyuVariant.MIRAGE)) }
         verify(exactly = 0) { AccentResolver.resolve(projectManagerProject, any<AccentContext>()) }
     }
@@ -639,7 +651,7 @@ class AccentApplicatorFocusedProjectTest {
 
         every { WindowManager.getInstance().allProjectFrames } returns arrayOf(brokenFrame, healthyFrame)
 
-        every { AccentResolver.resolve(healthyProject, ayu(AyuVariant.MIRAGE)) } returns "#HEALTHY"
+        every { AccentResolver.resolve(healthyProject, ayu(AyuVariant.MIRAGE)) } returns "#678F01"
 
         val loggedErrors = mutableListOf<Throwable?>()
         val processor =
@@ -655,12 +667,12 @@ class AccentApplicatorFocusedProjectTest {
                 }
             }
 
-        var applied: String? = null
+        var applied: AccentApplyOutcome? = null
         LoggedErrorProcessor.executeWith<Throwable>(processor) {
             applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
         }
 
-        assertEquals("#HEALTHY", applied)
+        assertEquals("#678F01", assertIs<AccentApplyOutcome.Applied>(applied).accentHex.value)
         verify(exactly = 1) { AccentResolver.resolve(healthyProject, ayu(AyuVariant.MIRAGE)) }
     }
 
@@ -773,12 +785,8 @@ class AccentApplicatorFocusedProjectTest {
     // ── Pattern D regression lock: swap publish must observe applyFromHexString's verdict ──
 
     @Test
-    fun `applyForFocusedProject skips swap cache publish when applyFromHexString rejects the resolver output`() {
-        // Round 2 lifted `applyFromHexString` from Unit to Boolean and sealed the gap
-        // with `if (applied) { swapService.notifyExternalApply(hex) }` at line ~268 of
-        // AccentApplicator. A refactor that drops the gate would still compile green;
-        // this test forces the rejection branch (resolver hands back a malformed hex)
-        // and asserts that the swap cache is NOT told about a paint that never happened.
+    fun `applyForFocusedProject forwards rejection without applying the resolver output`() {
+        // The real validation boundary rejects malformed resolver output.
         val focused = stubProject(isDefault = false, isDisposed = false)
         val manager = mockk<ProjectManager>()
         every { manager.openProjects } returns arrayOf(focused)
@@ -787,58 +795,17 @@ class AccentApplicatorFocusedProjectTest {
 
         // Override the recordPrivateCalls=false BeforeTest default: we want the real
         // applyFromHexString to run so its AccentHex.of shape-validation rejects the
-        // malformed input and returns false. The inner `apply(AccentHex)` must never
+        // malformed input and returns Rejected. The inner `apply(AccentHex)` must never
         // be called because the hex never validates.
         every { AccentApplicator.applyFromHexString("not-a-hex") } answers { callOriginal() }
 
         val applied = AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE)
 
-        assertEquals("not-a-hex", applied)
+        assertEquals("not-a-hex", assertIs<AccentApplyOutcome.Rejected>(applied).rawHex)
         verify(exactly = 1) { AccentApplicator.applyFromHexString("not-a-hex") }
-        // The critical assertion — regression would surface as a non-zero count.
-        verify(exactly = 0) { swapService.notifyExternalApply(any()) }
+        verify(exactly = 1) { swapService.notifyExternalApply(AccentApplyOutcome.Rejected("not-a-hex")) }
         // Sanity: apply(AccentHex) was never called — the hex was rejected before it.
         verify(exactly = 0) { AccentApplicator.apply(any()) }
-    }
-
-    @Test
-    fun `AccentApplicator source retains the applied-gate around swap publish`() {
-        // Pattern L — source-regex regression lock. The `if (applied) { ... }` branch
-        // at the swap-publish site is today unreachable in unit tests without mocking
-        // the full applyFromHexString surface (above test does that), but we additionally
-        // grep the source so a refactor that removes the gate itself — not just the
-        // negative-path test — fails fast with a decoded reason.
-        val sourceFile = java.io.File("src/main/kotlin/dev/ayuislands/accent/AccentApplicator.kt")
-        assertTrue(
-            sourceFile.exists(),
-            "Could not locate AccentApplicator.kt for Pattern D source-regex regression lock",
-        )
-        val source = sourceFile.readText()
-        // Literal gate — if this match fails, the `if (applied)` wrapper was removed or
-        // renamed. The companion paragraph comment names this test as the alarm.
-        assertTrue(
-            source.contains("if (applied) {"),
-            "AccentApplicator.applyForFocusedProject must retain `if (applied) {` before " +
-                "`ProjectAccentSwapService.getInstance().notifyExternalApply(hex)` — removing the " +
-                "gate reintroduces Round 2 Pattern D regression (swap cache drifts from paint state).",
-        )
-        // Structural match — the `applied` flag must sit between the apply call and the
-        // notifyExternalApply call. A refactor that moves the gate elsewhere (e.g., outside
-        // the swap-publish branch) would still pass the literal match above.
-        val applyIndex = source.indexOf("applyFromHexString(hex)")
-        val gateIndex = source.indexOf("if (applied) {", applyIndex.takeIf { it >= 0 } ?: 0)
-        val notifyIndex =
-            source.indexOf(
-                "ProjectAccentSwapService.getInstance().notifyExternalApply(hex)",
-                gateIndex.takeIf { it >= 0 } ?: 0,
-            )
-        assertTrue(
-            applyIndex in 0 until gateIndex && gateIndex < notifyIndex,
-            "Pattern D structural lock: `applyFromHexString(hex)` must precede " +
-                "`if (applied) {` which must precede " +
-                "`ProjectAccentSwapService.getInstance().notifyExternalApply(hex)`. " +
-                "Got applyIndex=$applyIndex, gateIndex=$gateIndex, notifyIndex=$notifyIndex.",
-        )
     }
 
     private fun stubProject(

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
@@ -2570,12 +2570,10 @@ class AccentApplicatorTest {
         every { ChromeBaseColors.forgetPluginTint(any()) } returns Unit
     }
 
-    // apply() with an invalid hex returns false AND posts a user-visible
-    // notification on the "Ayu Islands" group. A prior apply() returned Unit
-    // and silently swallowed corruption — a regression that let a single bad
-    // hex in per-project XML go undiagnosed.
+    // Invalid input returns Rejected and posts an "Ayu Islands" notification
+    // so a malformed persisted color cannot silently inherit prior success.
     @Test
-    fun `apply with invalid hex returns false and notifies the user`() {
+    fun `invalid hex is rejected and notifies the user`() {
         mockkStatic(com.intellij.notification.Notifications.Bus::class)
         every {
             com.intellij.notification.Notifications.Bus

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
@@ -46,6 +46,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertSame
@@ -1368,21 +1369,54 @@ class AccentApplicatorTest {
     }
 
     @Test
-    fun `apply posts to invokeLater when not on EDT`() {
+    fun `queued requests mutate only on EDT and report their own result`() {
         mockEpExtensionList(emptyList())
         mockkObject(IndentRainbowSync)
-        every { IndentRainbowSync.apply(any<AyuVariant>(), any()) } returns IntegrationOutcome.Skipped
+        every { IndentRainbowSync.apply(any<AccentContext>(), any()) } returns IntegrationOutcome.Skipped
         state.cgpIntegrationEnabled = false
+        val queued = mutableListOf<Runnable>()
+        val completed = mutableListOf<AccentApplyOutcome>()
+        val previousHex = state.lastAppliedAccentHex
+        val previousClean = state.lastApplyOk
         every { SwingUtilities.isEventDispatchThread() } returns false
         every { mockApplication.invokeLater(any(), any<ModalityState>()) } answers {
-            firstArg<Runnable>().run()
+            queued += firstArg<Runnable>()
         }
 
-        AccentApplicator.applyFromHexString("#FFCC66")
+        AccentApplicator.requestApply("#FFCC66") { completed += it }
+        AccentApplicator.requestApply("#5CCFE6") { completed += it }
 
-        verify { mockApplication.invokeLater(any(), any<ModalityState>()) }
-        verify(exactly = 0) { SwingUtilities.invokeLater(any()) }
-        verify(atLeast = 1) { UIManager.put(any<String>(), any()) }
+        assertEquals(previousHex, state.lastAppliedAccentHex)
+        assertEquals(previousClean, state.lastApplyOk)
+        assertTrue(completed.isEmpty())
+        verify(exactly = 0) { UIManager.put(any<String>(), any()) }
+        assertEquals(2, queued.size)
+        every { SwingUtilities.isEventDispatchThread() } returns true
+        queued[0].run()
+        assertEquals(
+            "#FFCC66",
+            assertIs<AccentApplyOutcome.Applied>(completed.single())
+                .accentHex.value,
+        )
+        queued[1].run()
+        assertEquals(
+            listOf("#FFCC66", "#5CCFE6"),
+            completed.map {
+                assertIs<AccentApplyOutcome.Applied>(it)
+                    .accentHex.value
+            },
+        )
+    }
+
+    @Test
+    fun `direct off EDT apply fails before state mutation`() {
+        val previousHex = state.lastAppliedAccentHex
+        every { SwingUtilities.isEventDispatchThread() } returns false
+        assertFailsWith<IllegalStateException> {
+            AccentApplicator.applyFromHexString("#5CCFE6")
+        }
+        assertEquals(previousHex, state.lastAppliedAccentHex)
+        verify(exactly = 0) { UIManager.put(any<String>(), any()) }
     }
 
     @Test
@@ -1395,7 +1429,8 @@ class AccentApplicatorTest {
         every { IndentRainbowSync.apply(any<AccentContext>(), any()) } returns IntegrationOutcome.Skipped
         state.cgpIntegrationEnabled = false
 
-        AccentApplicator.applyFromHexString("#5CCFE6")
+        val outcome = assertIs<AccentApplyOutcome.Torn>(AccentApplicator.applyFromHexString("#5CCFE6"))
+        assertEquals(AccentApplyStep.ApplyElements, outcome.failures.single().step)
 
         verify(exactly = 1) { broken.revert() }
         verify(exactly = 1) { survivor.apply(any()) }
@@ -1570,6 +1605,7 @@ class AccentApplicatorTest {
         AccentApplicator.revertAll()
 
         assertEquals(1, AyuEditorSchemeScope.claimedAccentSchemes().size)
+        every { SwingUtilities.isEventDispatchThread() } returns true
         callback.captured.run()
         assertTrue(AyuEditorSchemeScope.claimedAccentSchemes().isEmpty())
     }
@@ -1605,6 +1641,7 @@ class AccentApplicatorTest {
         mockEpExtensionList(emptyList())
         every { SwingUtilities.isEventDispatchThread() } returns false
         every { mockApplication.invokeLater(any(), any<ModalityState>()) } answers {
+            every { SwingUtilities.isEventDispatchThread() } returns true
             firstArg<Runnable>().run()
         }
 
@@ -2547,7 +2584,7 @@ class AccentApplicatorTest {
 
         val result = AccentApplicator.applyFromHexString("garbage-hex")
 
-        assertEquals(false, result, "Invalid hex must return false from applyFromHexString()")
+        assertTrue(result is AccentApplyOutcome.Rejected, "Invalid hex must be rejected")
         verify(exactly = 1) {
             com.intellij.notification.Notifications.Bus
                 .notify(any())
@@ -2565,7 +2602,7 @@ class AccentApplicatorTest {
         val source = sourceFile.readText()
         val edtGuard =
             Regex(
-                """@RequiresEdt\s*\n\s*fun\s+applyForFocusedProject""",
+                """@RequiresEdt\s*\n\s*internal\s+fun\s+applyForFocusedProject""",
                 RegexOption.DOT_MATCHES_ALL,
             )
         assertTrue(

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.testFramework.LoggedErrorProcessor
 import com.intellij.util.messages.MessageBus
 import dev.ayuislands.AyuPlugin
 import dev.ayuislands.accent.conflict.ConflictEntry
@@ -47,6 +48,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 /**
@@ -1105,6 +1107,7 @@ class AccentApplicatorTest {
         every { UIManager.put(EXTERNAL_CHROME_TEST_KEY, null) } returns Unit
 
         AccentApplicator.applyFromHexString("#AABBCC")
+        assertFalse(state.lastApplyOk)
 
         verify(exactly = 2) { UIManager.put(EXTERNAL_CHROME_TEST_KEY, any()) }
         verify(exactly = 1) { UIManager.put(EXTERNAL_CHROME_TEST_KEY, null) }
@@ -1382,6 +1385,69 @@ class AccentApplicatorTest {
         verify(atLeast = 1) { UIManager.put(any<String>(), any()) }
     }
 
+    @Test
+    fun `contained element failure leaves apply marked torn`() {
+        val broken = createFakeAccentElement(AccentElementId.CARET_ROW, "Caret Row")
+        val survivor = createFakeAccentElement(AccentElementId.SCROLLBAR, "Scrollbar")
+        every { broken.apply(any()) } throws IllegalStateException("element failed")
+        mockEpExtensionList(listOf(broken, survivor))
+        mockkObject(IndentRainbowSync)
+        every { IndentRainbowSync.apply(any<AccentContext>(), any()) } returns IntegrationOutcome.Skipped
+        state.cgpIntegrationEnabled = false
+
+        AccentApplicator.applyFromHexString("#5CCFE6")
+
+        verify(exactly = 1) { broken.revert() }
+        verify(exactly = 1) { survivor.apply(any()) }
+        assertFalse(state.lastApplyOk)
+    }
+
+    @Test
+    fun `element cancellation restores element and escapes apply`() {
+        val cancelled = ProcessCanceledException()
+        val element = createFakeAccentElement(AccentElementId.CARET_ROW, "Caret Row")
+        every { element.apply(any()) } throws cancelled
+        mockEpExtensionList(listOf(element))
+
+        assertSame(
+            cancelled,
+            assertFailsWith<ProcessCanceledException> {
+                AccentApplicator.applyFromHexString("#5CCFE6")
+            },
+        )
+        verify(exactly = 1) { element.revert() }
+        assertFalse(state.lastApplyOk)
+    }
+
+    @Test
+    fun `later cancellation preserves an earlier element failure diagnostic`() {
+        val failed = createFakeAccentElement(AccentElementId.CARET_ROW, "Caret Row")
+        val cancelled = createFakeAccentElement(AccentElementId.SCROLLBAR, "Scrollbar")
+        every { failed.apply(any()) } throws IllegalStateException("first element failure")
+        every { cancelled.apply(any()) } throws ProcessCanceledException()
+        mockEpExtensionList(listOf(failed, cancelled))
+        val warnings = mutableListOf<Throwable>()
+        val processor =
+            object : LoggedErrorProcessor() {
+                override fun processWarn(
+                    category: String,
+                    message: String,
+                    t: Throwable?,
+                ): Boolean {
+                    if (t != null) warnings += t
+                    return false
+                }
+            }
+
+        LoggedErrorProcessor.executeWith<RuntimeException>(processor) {
+            assertFailsWith<ProcessCanceledException> {
+                AccentApplicator.applyFromHexString("#5CCFE6")
+            }
+        }
+
+        assertTrue(warnings.any { it.cause?.message == "first element failure" })
+    }
+
     // Tests for public revertAll() method
 
     @Test
@@ -1475,7 +1541,7 @@ class AccentApplicatorTest {
         AccentApplicator.revertAll()
 
         assertEquals(1, AyuEditorSchemeScope.claimedAccentSchemes().size)
-        assertTrue(AyuEditorSchemeScope.claimedAccentSchemes().single() === failedStore.scheme)
+        assertSame(failedStore.scheme, AyuEditorSchemeScope.claimedAccentSchemes().single())
         cleanedStore.assertOriginalValues()
     }
 
@@ -1944,7 +2010,10 @@ class AccentApplicatorTest {
 
         val accent = Color.decode("#FFCC66")
         // Must not propagate either the apply or the revert exception.
-        invokeApplyElements(state, accent, AccentContext.Ayu(AyuVariant.MIRAGE))
+        val failures = invokeApplyElements(state, accent, AccentContext.Ayu(AyuVariant.MIRAGE))
+        val cause = requireNotNull(failures.single().error.cause)
+        assertEquals("apply broke", cause.message)
+        assertEquals("revert broke too", cause.suppressed.single().message)
 
         // Revert WAS attempted on the failing element, even though it
         // threw — locks that the cleanup path runs unconditionally after
@@ -2177,7 +2246,8 @@ class AccentApplicatorTest {
         targetState: AyuIslandsState,
         accent: Color,
         context: AccentContext,
-    ) {
+    ): List<AccentApplyStepFailure> {
+        val capturedFailures = mutableListOf<AccentApplyStepFailure>()
         val method =
             AccentApplicator::class.java.declaredMethods
                 .first { it.name == "applyElements" }
@@ -2188,7 +2258,9 @@ class AccentApplicatorTest {
             accent,
             context,
             LicenseChecker.isLicensedOrGrace(),
+            { failure: AccentApplyStepFailure -> capturedFailures += failure },
         )
+        return capturedFailures
     }
 
     // Helper for invoking private methods that accept nullable parameters

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTornApplyTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTornApplyTest.kt
@@ -197,11 +197,16 @@ class AccentApplicatorTornApplyTest {
     }
 
     @Test
-    fun `applyFromHexString still reports the dispatch as accepted on a torn apply`() {
-        // The Boolean contract is validation + scheduling, not paint completion —
-        // torn-state signaling belongs to lastApplyOk / trustedCachedAccent.
-        val accepted = AccentApplicator.applyFromHexString("#FFCC66")
-        assertTrue(accepted)
+    fun `applyFromHexString returns the failed invocation`() {
+        val outcome: Any = AccentApplicator.applyFromHexString("#FFCC66")
+        val torn = kotlin.test.assertIs<AccentApplyOutcome.Torn>(outcome)
+        assertEquals(AccentApplyStep.SyncIndentRainbow, torn.failures.single().step)
+        assertEquals(
+            "synthetic tear",
+            torn.failures
+                .single()
+                .error.message,
+        )
         assertFalse(state.lastApplyOk)
     }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplyFailureTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplyFailureTest.kt
@@ -1,0 +1,104 @@
+package dev.ayuislands.accent
+
+import com.intellij.openapi.progress.ProcessCanceledException
+import java.util.concurrent.CancellationException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+class AccentApplyFailureTest {
+    @Test
+    fun `success does not run rollback`() {
+        var rollbackCalls = 0
+        assertNull(
+            captureAccentFailure(
+                AccentApplyStep.ApplyElements,
+                "apply caret",
+                { rollbackCalls++ },
+                {},
+            ),
+        )
+        assertEquals(0, rollbackCalls)
+    }
+
+    @Test
+    fun `failed rollback retains both causes`() {
+        val original = IllegalStateException("apply failed")
+        val recovery = IllegalStateException("restore failed")
+        val captured =
+            requireNotNull(
+                captureAccentFailure(
+                    AccentApplyStep.ApplyElements,
+                    "apply caret",
+                    { throw recovery },
+                    { throw original },
+                ),
+            )
+        assertSame(original, captured.error.cause)
+        assertSame(recovery, original.suppressed.single())
+    }
+
+    @Test
+    fun `cancellation runs rollback and escapes unchanged`() {
+        for (cancelled in listOf(ProcessCanceledException(), CancellationException("cancelled"))) {
+            var rollbackCalls = 0
+            val thrown =
+                assertFailsWith<RuntimeException> {
+                    captureAccentFailure(
+                        AccentApplyStep.ApplyElements,
+                        "apply caret",
+                        { rollbackCalls++ },
+                        { throw cancelled },
+                    )
+                }
+            assertSame(cancelled, thrown)
+            assertEquals(1, rollbackCalls)
+        }
+    }
+
+    @Test
+    fun `cancellation during rollback is not demoted to an ordinary failure`() {
+        val original = IllegalStateException("apply failed")
+        val cancelled = ProcessCanceledException()
+        val thrown =
+            assertFailsWith<ProcessCanceledException> {
+                captureAccentFailure(
+                    AccentApplyStep.ApplyElements,
+                    "apply caret",
+                    { throw cancelled },
+                    { throw original },
+                )
+            }
+        assertSame(cancelled, thrown)
+        assertSame(original, thrown.suppressed.single())
+    }
+
+    @Test
+    fun `same exception from apply and rollback does not suppress itself`() {
+        val cancelled = ProcessCanceledException()
+        assertSame(
+            cancelled,
+            assertFailsWith<ProcessCanceledException> {
+                captureAccentFailure(
+                    AccentApplyStep.ApplyElements,
+                    "apply caret",
+                    { throw cancelled },
+                    { throw cancelled },
+                )
+            },
+        )
+    }
+
+    @Test
+    fun `fatal error escapes without ordinary failure handling`() {
+        val fatal = object : VirtualMachineError("fatal") {}
+        assertSame(
+            fatal,
+            assertFailsWith<VirtualMachineError> {
+                captureAccentFailure(AccentApplyStep.ApplyElements, "apply caret") { throw fatal }
+            },
+        )
+    }
+}

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplyPlanRunnerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplyPlanRunnerTest.kt
@@ -136,6 +136,7 @@ class AccentApplyPlanRunnerTest {
         mockkStatic(ApplicationManager::class)
         every { ApplicationManager.getApplication() } returns mockApplication
         every { mockApplication.invokeLater(any(), any<ModalityState>()) } answers {
+            every { SwingUtilities.isEventDispatchThread() } returns true
             firstArg<Runnable>().run()
         }
         val executed = mutableListOf<AccentApplyStep>()
@@ -160,6 +161,7 @@ class AccentApplyPlanRunnerTest {
         mockkStatic(ApplicationManager::class)
         every { ApplicationManager.getApplication() } returns null
         every { SwingUtilities.invokeLater(any()) } answers {
+            every { SwingUtilities.isEventDispatchThread() } returns true
             firstArg<Runnable>().run()
         }
         val executed = mutableListOf<AccentApplyStep>()

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplyPlanTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplyPlanTest.kt
@@ -175,8 +175,8 @@ class AccentApplyPlanTest {
 
     @Test
     fun `torn outcome refuses an empty failure list by construction`() {
-        // AccentApplicator logs `failures.first()` on Torn — an empty-failures
-        // Torn would crash the logging path, so the type rejects it outright.
+        // A Torn outcome needs a cause; requireClean preserves the first
+        // failure as its primary exception and attaches the remaining causes.
         val hex = requireNotNull(AccentHex.of("#FFCC66"))
         assertFailsWith<IllegalArgumentException> {
             AccentApplyOutcome.Torn(hex, emptyList())

--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplyPlanTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplyPlanTest.kt
@@ -190,4 +190,40 @@ class AccentApplyPlanTest {
             NotifyComponentTrees -> "Notify"
             else -> null
         }
+
+    @Test
+    fun `publication failure preserves visual completion but is not clean`() {
+        val hex = requireNotNull(AccentHex.of("#5CCFE6"))
+        val outcome =
+            AccentApplyOutcome.Torn(
+                hex,
+                listOf(
+                    AccentApplyStepFailure(PublishAccentChanged, IllegalStateException("subscriber")),
+                ),
+            )
+        assertTrue(outcome.visualsApplied)
+        assertFalse(outcome.isClean)
+        assertFailsWith<IllegalStateException> { outcome.requireClean() }
+    }
+
+    @Test
+    fun `rejection cannot inherit a previous result`() {
+        val rejected = AccentApplyOutcome.Rejected("broken")
+        assertFalse(rejected.isClean)
+        assertFalse(rejected.visualsApplied)
+        assertFailsWith<IllegalArgumentException> { rejected.requireClean() }
+    }
+
+    @Test
+    fun `outcome owns a snapshot of the failure list`() {
+        val hex = requireNotNull(AccentHex.of("#5CCFE6"))
+        val failures =
+            mutableListOf(
+                AccentApplyStepFailure(ApplyElements, IllegalStateException("element")),
+            )
+        val outcome = assertIs<AccentApplyOutcome.Torn>(AccentApplyOutcome.of(hex, failures))
+        failures.clear()
+        assertEquals(1, outcome.failures.size)
+        assertFalse(outcome.visualsApplied)
+    }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/AccentChangedPublishTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentChangedPublishTest.kt
@@ -241,7 +241,12 @@ class AccentChangedPublishTest {
             }
 
         LoggedErrorProcessor.executeWith<Throwable>(processor) {
-            AccentApplicator.apply(AccentHex.of("#DFBFFF")!!)
+            val outcome =
+                kotlin.test.assertIs<AccentApplyOutcome.Torn>(
+                    AccentApplicator.apply(requireNotNull(AccentHex.of("#DFBFFF"))),
+                )
+            assertTrue(outcome.visualsApplied)
+            kotlin.test.assertEquals(AccentApplyStep.PublishAccentChanged, outcome.failures.single().step)
         }
 
         verify(exactly = 1) {

--- a/src/test/kotlin/dev/ayuislands/accent/AccentChangedPublishTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentChangedPublishTest.kt
@@ -217,6 +217,15 @@ class AccentChangedPublishTest {
             error("boom subscriber")
         }
 
+        val otherProject =
+            mockk<Project> {
+                every { isDefault } returns false
+                every { isDisposed } returns false
+                every { name } returns "other-project"
+            }
+        every { mockProjectManager.openProjects } returns arrayOf(project, otherProject)
+        every { AccentResolver.source(otherProject) } returns AccentResolver.Source.GLOBAL
+
         val capturedWarns = mutableListOf<String>()
         val processor =
             object : LoggedErrorProcessor() {
@@ -225,7 +234,7 @@ class AccentChangedPublishTest {
                     message: String,
                     throwable: Throwable?,
                 ): Boolean {
-                    if (!message.contains("AccentChangedTopic publish failed")) return true
+                    if (!message.contains("Accent apply torn at PublishAccentChanged")) return true
                     capturedWarns += message
                     return false
                 }
@@ -235,6 +244,9 @@ class AccentChangedPublishTest {
             AccentApplicator.apply(AccentHex.of("#DFBFFF")!!)
         }
 
+        verify(exactly = 1) {
+            listener.accentChanged(otherProject, requireNotNull(AccentHex.of("#DFBFFF")), AccentResolver.Source.GLOBAL)
+        }
         assertTrue(
             state.lastApplyOk,
             "state.lastApplyOk must remain true — the throw is contained by the per-project try/catch",
@@ -244,8 +256,24 @@ class AccentChangedPublishTest {
             "AccentChanged publish must run on EDT (Pattern C) — captured EDT flags: $onEdtCapture",
         )
         assertTrue(
-            capturedWarns.any { it.contains("AccentChangedTopic publish failed") },
+            capturedWarns.any { it.contains("Accent apply torn at PublishAccentChanged") },
             "Pattern B: subscriber exception must surface as WARN with the topic-failed marker; got: $capturedWarns",
         )
+    }
+
+    @Test
+    fun `publication cancellation escapes unchanged`() {
+        val cancelled =
+            com.intellij.openapi.progress
+                .ProcessCanceledException()
+        every { listener.accentChanged(project, any(), any()) } throws cancelled
+
+        kotlin.test.assertSame(
+            cancelled,
+            kotlin.test.assertFailsWith<com.intellij.openapi.progress.ProcessCanceledException> {
+                AccentApplicator.apply(requireNotNull(AccentHex.of("#DFBFFF")))
+            },
+        )
+        assertTrue(state.lastApplyOk)
     }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/AccentChangedTopicTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentChangedTopicTest.kt
@@ -1,10 +1,12 @@
 package dev.ayuislands.accent
 
 import com.intellij.openapi.project.Project
+import io.mockk.mockk
 import java.lang.reflect.Modifier
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 /**
@@ -16,8 +18,8 @@ import kotlin.test.assertTrue
  * would surface as `NoClassDefFoundError` deep inside a subscriber's `init {}`),
  * the `displayName` is the human-readable tag JetBrains' bus diagnostics use,
  * and the listener class must be a real `fun interface` for IntelliJ's
- * single-method listener shape. Subscribers that receive [AccentHex] still use
- * object expressions where the value-class SAM bridge matters. The topic is
+ * single-method listener shape. The value-class SAM bridge is exercised through
+ * both Kotlin calls and reflective JVM dispatch. The topic is
  * application-scoped so subscribers connected on either `Application.messageBus`
  * or any `Project.messageBus` receive the event.
  *
@@ -51,14 +53,6 @@ class AccentChangedTopicTest {
     fun `AccentChangeListener is a fun interface with a single accentChanged method`() {
         val klass = AccentChangeListener::class.java
         assertTrue(klass.isInterface, "AccentChangeListener must be an interface")
-        val samListener =
-            AccentChangeListener { _, _, _ ->
-                error("SAM construction contract only; do not invoke the value-class lambda bridge")
-            }
-        assertTrue(
-            klass.isAssignableFrom(samListener.javaClass),
-            "AccentChangeListener must remain SAM-constructible for IDE listener inspections",
-        )
         val abstractMethods =
             klass.declaredMethods.filter { Modifier.isAbstract(it.modifiers) }
         assertEquals(
@@ -97,6 +91,27 @@ class AccentChangedTopicTest {
             params[2],
             "Third parameter must be AccentResolver.Source so subscribers can filter by resolution layer",
         )
+    }
+
+    @Test
+    fun `SAM listener receives value class payload through Kotlin and JVM dispatch`() {
+        val expectedProject = mockk<Project>()
+        val expectedHex = requireNotNull(AccentHex.of("#AABBCC"))
+        val expectedSource = AccentResolver.Source.GLOBAL
+        var deliveryCount = 0
+        val listener =
+            AccentChangeListener { project, hex, source ->
+                assertSame(expectedProject, project)
+                assertEquals(expectedHex, hex)
+                assertEquals(expectedSource, source)
+                deliveryCount += 1
+            }
+
+        listener.accentChanged(expectedProject, expectedHex, expectedSource)
+        val method = AccentChangeListener::class.java.declaredMethods.single { Modifier.isAbstract(it.modifiers) }
+        method.invoke(listener, expectedProject, expectedHex.value, expectedSource)
+
+        assertEquals(2, deliveryCount)
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ProjectLanguageDetectorTest.kt
@@ -14,7 +14,6 @@ import dev.ayuislands.settings.mappings.AccentMappingsState
 import io.mockk.clearMocks
 import io.mockk.clearStaticMockk
 import io.mockk.every
-import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
@@ -1066,7 +1065,8 @@ class ProjectLanguageDetectorTest {
         every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returns "#FFCC66"
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns project
-        justRun { AccentApplicator.apply(any()) }
+        every { AccentApplicator.apply(any()) } answers
+            { AccentApplyOutcome.Applied(requireNotNull(AccentHex.of(firstArg<String>()))) }
 
         ProjectLanguageDetector.rescan(project)
 
@@ -1120,7 +1120,8 @@ class ProjectLanguageDetectorTest {
         every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returns "#FFCC66"
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns project
-        justRun { AccentApplicator.apply(any()) }
+        every { AccentApplicator.apply(any()) } answers
+            { AccentApplyOutcome.Applied(requireNotNull(AccentHex.of(firstArg<String>()))) }
         val swapService = mockk<dev.ayuislands.settings.mappings.ProjectAccentSwapService>(relaxed = true)
         mockkObject(dev.ayuislands.settings.mappings.ProjectAccentSwapService.Companion)
         every {
@@ -1132,7 +1133,9 @@ class ProjectLanguageDetectorTest {
 
         verify(exactly = 1) { listener.scanCompleted(ScanOutcome.Polyglot) }
         verify(exactly = 1) { AccentApplicator.applyFromHexString("#FFCC66") }
-        verify(exactly = 1) { swapService.notifyExternalApply("#FFCC66") }
+        verify(exactly = 1) {
+            swapService.notifyExternalApply(AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#FFCC66"))))
+        }
     }
 
     @Test
@@ -1477,6 +1480,7 @@ class ProjectLanguageDetectorTest {
     private fun runInvokeLaterInline() {
         mockkStatic(javax.swing.SwingUtilities::class)
         every { javax.swing.SwingUtilities.invokeLater(any()) } answers {
+            every { javax.swing.SwingUtilities.isEventDispatchThread() } returns true
             firstArg<Runnable>().run()
         }
     }

--- a/src/test/kotlin/dev/ayuislands/accent/ScanCompletionAccentRefresherTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/ScanCompletionAccentRefresherTest.kt
@@ -6,12 +6,13 @@ import com.intellij.util.messages.MessageBus
 import com.intellij.util.messages.MessageBusConnection
 import dev.ayuislands.settings.mappings.ProjectAccentSwapService
 import io.mockk.every
-import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.verify
+import javax.swing.SwingUtilities
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertSame
@@ -48,7 +49,9 @@ class ScanCompletionAccentRefresherTest {
         subscriber.scanCompleted(ScanOutcome.Detected("kotlin"))
 
         verify(exactly = 1) { AccentApplicator.applyFromHexString("#FFCC66") }
-        verify(exactly = 1) { swapService.notifyExternalApply("#FFCC66") }
+        verify(exactly = 1) {
+            swapService.notifyExternalApply(AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#FFCC66"))))
+        }
     }
 
     @Test
@@ -65,7 +68,9 @@ class ScanCompletionAccentRefresherTest {
         subscriber.scanCompleted(ScanOutcome.Polyglot)
 
         verify(exactly = 1) { AccentApplicator.applyFromHexString("#FFCC66") }
-        verify(exactly = 1) { swapService.notifyExternalApply("#FFCC66") }
+        verify(exactly = 1) {
+            swapService.notifyExternalApply(AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#FFCC66"))))
+        }
     }
 
     @Test
@@ -78,7 +83,8 @@ class ScanCompletionAccentRefresherTest {
         val project = stubProject()
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns project
-        justRun { AccentApplicator.apply(any()) }
+        every { AccentApplicator.apply(any()) } answers
+            { AccentApplyOutcome.Applied(requireNotNull(AccentHex.of(firstArg<String>()))) }
         val subscriber = installRefresher(project)
 
         subscriber.scanCompleted(ScanOutcome.Unavailable)
@@ -96,7 +102,8 @@ class ScanCompletionAccentRefresherTest {
         val focusedProject = stubProject()
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns focusedProject
-        justRun { AccentApplicator.apply(any()) }
+        every { AccentApplicator.apply(any()) } answers
+            { AccentApplyOutcome.Applied(requireNotNull(AccentHex.of(firstArg<String>()))) }
         val subscriber = installRefresher(scannedProject)
 
         subscriber.scanCompleted(ScanOutcome.Detected("kotlin"))
@@ -115,7 +122,8 @@ class ScanCompletionAccentRefresherTest {
         every { AyuVariant.detect() } returns null
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns project
-        justRun { AccentApplicator.apply(any()) }
+        every { AccentApplicator.apply(any()) } answers
+            { AccentApplyOutcome.Applied(requireNotNull(AccentHex.of(firstArg<String>()))) }
         val subscriber = installRefresher(project)
 
         subscriber.scanCompleted(ScanOutcome.Detected("kotlin"))
@@ -130,7 +138,8 @@ class ScanCompletionAccentRefresherTest {
         // writing UIManager entries for a dead project's swap-cache.
         val project = stubProject()
         mockkObject(AccentApplicator)
-        justRun { AccentApplicator.apply(any()) }
+        every { AccentApplicator.apply(any()) } answers
+            { AccentApplyOutcome.Applied(requireNotNull(AccentHex.of(firstArg<String>()))) }
         val subscriber = installRefresher(project)
         every { project.isDisposed } returns true
 
@@ -175,7 +184,8 @@ class ScanCompletionAccentRefresherTest {
         every { AccentResolver.resolve(any(), any<AyuVariant>()) } throws RuntimeException("resolver boom")
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns project
-        justRun { AccentApplicator.apply(any()) }
+        every { AccentApplicator.apply(any()) } answers
+            { AccentApplyOutcome.Applied(requireNotNull(AccentHex.of(firstArg<String>()))) }
         val subscriber = installRefresher(project)
 
         // Must not throw — the runCatching contains the resolver.
@@ -187,14 +197,14 @@ class ScanCompletionAccentRefresherTest {
 
     @Test
     fun `rejected hex suppresses the swap-cache publish`() {
-        // applyFromHexString returns false for a rejected hex (user-facing
+        // applyFromHexString returns Rejected for an invalid hex (user-facing
         // notification already fired inside the applicator). Publishing the
         // rejected value to the swap cache would make the next
-        // WINDOW_ACTIVATED treat an unapplied color as current — the Boolean
+        // WINDOW_ACTIVATED treat an unapplied color as current — the rejection
         // gate must suppress notifyExternalApply.
         val project = stubProject()
         val swapService = wireHappyApplyChain(project)
-        every { AccentApplicator.applyFromHexString(any()) } returns false
+        every { AccentApplicator.applyFromHexString(any()) } answers { AccentApplyOutcome.Rejected(firstArg()) }
         val subscriber = installRefresher(project)
 
         subscriber.scanCompleted(ScanOutcome.Detected("kotlin"))
@@ -259,13 +269,16 @@ class ScanCompletionAccentRefresherTest {
      * Returns the swap-service mock for publish assertions.
      */
     private fun wireHappyApplyChain(project: Project): ProjectAccentSwapService {
+        mockkStatic(SwingUtilities::class)
+        every { SwingUtilities.isEventDispatchThread() } returns true
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
         mockkObject(AccentResolver)
         every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#FFCC66"
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns project
-        justRun { AccentApplicator.apply(any()) }
+        every { AccentApplicator.apply(any()) } answers
+            { AccentApplyOutcome.Applied(requireNotNull(AccentHex.of(firstArg<String>()))) }
         val swapService = mockk<ProjectAccentSwapService>(relaxed = true)
         mockkObject(ProjectAccentSwapService.Companion)
         every { ProjectAccentSwapService.getInstance() } returns swapService

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentGridTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentGridTest.kt
@@ -4,6 +4,9 @@ import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import dev.ayuislands.accent.AYU_ACCENT_PRESETS
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
+import dev.ayuislands.accent.AccentApplyStep
+import dev.ayuislands.accent.AccentApplyStepFailure
 import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
@@ -112,8 +115,12 @@ class QuickSwitcherAccentGridTest {
     }
 
     @Test
-    fun `click invokes applyFromHexString AND notifyExternalApply when apply returns true (Pattern D)`() {
-        every { AccentApplicator.applyFromHexString(any()) } returns true
+    fun `click invokes applyFromHexString AND notifyExternalApply when apply accepts the hex (Pattern D)`() {
+        every { AccentApplicator.applyFromHexString(any()) } answers
+            {
+                AccentHex.of(firstArg<String>())?.let { validatedHex -> AccentApplyOutcome.Applied(validatedHex) }
+                    ?: AccentApplyOutcome.Rejected(firstArg())
+            }
         mockkObject(ProjectAccentSwapService.Companion)
         val swapService = mockk<ProjectAccentSwapService>(relaxed = true)
         every { ProjectAccentSwapService.getInstance() } returns swapService
@@ -126,12 +133,16 @@ class QuickSwitcherAccentGridTest {
         firstSwatch.dispatchEvent(makeRelease(firstSwatch))
 
         verify(exactly = 1) { AccentApplicator.applyFromHexString(AYU_ACCENT_PRESETS.first().hex) }
-        verify(exactly = 1) { swapService.notifyExternalApply(AYU_ACCENT_PRESETS.first().hex) }
+        verify(exactly = 1) {
+            swapService.notifyExternalApply(
+                AccentApplyOutcome.Applied(requireNotNull(AccentHex.of(AYU_ACCENT_PRESETS.first().hex))),
+            )
+        }
     }
 
     @Test
-    fun `click does NOT call notifyExternalApply when apply returns false (Pattern D inverse)`() {
-        every { AccentApplicator.applyFromHexString(any()) } returns false
+    fun `click does NOT call notifyExternalApply when apply rejects the hex (Pattern D inverse)`() {
+        every { AccentApplicator.applyFromHexString(any()) } answers { AccentApplyOutcome.Rejected(firstArg()) }
         mockkObject(ProjectAccentSwapService.Companion)
         val swapService = mockk<ProjectAccentSwapService>(relaxed = true)
         every { ProjectAccentSwapService.getInstance() } returns swapService
@@ -261,7 +272,11 @@ class QuickSwitcherAccentGridTest {
         every { AccentContext.detectQuickSwitcher() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns null
-        every { AccentApplicator.applyFromHexString(any()) } returns true
+        every { AccentApplicator.applyFromHexString(any()) } answers
+            {
+                AccentHex.of(firstArg<String>())?.let { validatedHex -> AccentApplyOutcome.Applied(validatedHex) }
+                    ?: AccentApplyOutcome.Rejected(firstArg())
+            }
         mockkObject(AccentResolver)
         every { AccentResolver.resolve(any(), any<AccentContext>()) } returns "#FFB454"
         mockkStatic(com.intellij.ui.ColorPicker::class)
@@ -310,7 +325,11 @@ class QuickSwitcherAccentGridTest {
         every { AccentContext.detectQuickSwitcher() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns null
-        every { AccentApplicator.applyFromHexString(any()) } returns true
+        every { AccentApplicator.applyFromHexString(any()) } answers
+            {
+                AccentHex.of(firstArg<String>())?.let { validatedHex -> AccentApplyOutcome.Applied(validatedHex) }
+                    ?: AccentApplyOutcome.Rejected(firstArg())
+            }
         mockkObject(AccentResolver)
         every { AccentResolver.resolve(any(), any<AccentContext>()) } returns "#FFB454"
         mockkObject(ProjectAccentSwapService.Companion)
@@ -333,7 +352,9 @@ class QuickSwitcherAccentGridTest {
         val links = collectActionLinks(south)
         links[0].doClick()
         verify(exactly = 1) { AccentApplicator.applyFromHexString("#0F00AB") }
-        verify(exactly = 1) { swap.notifyExternalApply("#0F00AB") }
+        verify(
+            exactly = 1,
+        ) { swap.notifyExternalApply(AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#0F00AB")))) }
     }
 
     @Test
@@ -363,7 +384,11 @@ class QuickSwitcherAccentGridTest {
         every { AccentContext.detectQuickSwitcher() } returns AccentContext.Ayu(AyuVariant.MIRAGE)
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns null
-        every { AccentApplicator.applyFromHexString(any()) } returns true
+        every { AccentApplicator.applyFromHexString(any()) } answers
+            {
+                AccentHex.of(firstArg<String>())?.let { validatedHex -> AccentApplyOutcome.Applied(validatedHex) }
+                    ?: AccentApplyOutcome.Rejected(firstArg())
+            }
         mockkObject(AccentResolver)
         every { AccentResolver.resolve(any(), any<AccentContext>()) } returns "#FFB454"
         mockkObject(AccentHex.Companion)
@@ -435,7 +460,11 @@ class QuickSwitcherAccentGridTest {
         // User-space restamp coverage. After applyPreset(hex), exactly one
         // swatch is selected (the clicked one); previously-selected swatches clear.
         // Locks the for-each restamp in `QuickSwitcherAccentGrid`.
-        every { AccentApplicator.applyFromHexString(any()) } returns true
+        every { AccentApplicator.applyFromHexString(any()) } answers
+            {
+                AccentHex.of(firstArg<String>())?.let { validatedHex -> AccentApplyOutcome.Applied(validatedHex) }
+                    ?: AccentApplyOutcome.Rejected(firstArg())
+            }
         mockkObject(ProjectAccentSwapService.Companion)
         val swapService = mockk<ProjectAccentSwapService>(relaxed = true)
         every { ProjectAccentSwapService.getInstance() } returns swapService
@@ -461,7 +490,11 @@ class QuickSwitcherAccentGridTest {
     @Test
     fun `clicking a swatch in external context persists manual external accent`() {
         every { AccentContext.detectQuickSwitcher() } returns AccentContext.External
-        every { AccentApplicator.applyFromHexString(any()) } returns true
+        every { AccentApplicator.applyFromHexString(any()) } answers
+            {
+                AccentHex.of(firstArg<String>())?.let { validatedHex -> AccentApplyOutcome.Applied(validatedHex) }
+                    ?: AccentApplyOutcome.Rejected(firstArg())
+            }
         mockkObject(ProjectAccentSwapService.Companion)
         val swapService = mockk<ProjectAccentSwapService>(relaxed = true)
         every { ProjectAccentSwapService.getInstance() } returns swapService
@@ -546,5 +579,40 @@ class QuickSwitcherAccentGridTest {
             if (child is java.awt.Container) collectJLabels(child, out)
         }
         return out
+    }
+
+    @Test
+    fun `torn paint preserves manual external accent and selected swatch`() {
+        every { AccentContext.detectQuickSwitcher() } returns AccentContext.External
+        mockkObject(ProjectAccentSwapService.Companion)
+        val swapService = mockk<ProjectAccentSwapService>(relaxed = true)
+        every { ProjectAccentSwapService.getInstance() } returns swapService
+        val state = AyuIslandsState()
+        val settings = mockk<AyuIslandsSettings>(relaxed = true)
+        every { settings.state } returns state
+        mockkObject(AyuIslandsSettings.Companion)
+        every { AyuIslandsSettings.getInstance() } returns settings
+        val grid = QuickSwitcherAccentGrid()
+        val north = (grid.component as JPanel).components.filterIsInstance<JPanel>().first()
+        val swatches = north.components.filterIsInstance<PopupSwatch>()
+        val chosen = swatches[1]
+        val failedPaint =
+            AccentApplyOutcome.Torn(
+                chosen.hex,
+                listOf(
+                    AccentApplyStepFailure(AccentApplyStep.ApplyElements, IllegalStateException("paint")),
+                ),
+            )
+        every { AccentApplicator.applyFromHexString(chosen.hex.value) } returns failedPaint
+
+        chosen.setSize(36, 24)
+        chosen.dispatchEvent(makePress(chosen))
+        chosen.dispatchEvent(makeRelease(chosen))
+
+        assertEquals(chosen.hex.value, state.externalThemeAccent)
+        assertEquals(ExternalAccentSource.MANUAL.name, state.externalThemeAccentSource)
+        assertTrue(chosen.selected)
+        assertEquals(1, swatches.count { it.selected })
+        verify(exactly = 1) { swapService.notifyExternalApply(failedPaint) }
     }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentGridTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherAccentGridTest.kt
@@ -2,6 +2,7 @@ package dev.ayuislands.accent.toolbar
 
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.progress.ProcessCanceledException
 import dev.ayuislands.accent.AYU_ACCENT_PRESETS
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentApplyOutcome
@@ -27,11 +28,14 @@ import java.awt.Color
 import java.awt.GridLayout
 import javax.swing.JLabel
 import javax.swing.JPanel
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 /**
@@ -544,6 +548,31 @@ class QuickSwitcherAccentGridTest {
         assertTrue(firstSwatch.isEnabled, "Swatch must stay enabled after a swallowed RuntimeException")
     }
 
+    @Test
+    fun `swatch click propagates platform cancellation`() {
+        assertApplyCancellation(ProcessCanceledException())
+    }
+
+    @Test
+    fun `swatch click propagates coroutine cancellation`() {
+        assertApplyCancellation(CancellationException("cancelled apply"))
+    }
+
+    private fun assertApplyCancellation(cancelled: RuntimeException) {
+        every { AccentApplicator.applyFromHexString(any()) } throws cancelled
+        val grid = QuickSwitcherAccentGrid()
+        val north = (grid.component as JPanel).components.filterIsInstance<JPanel>().first()
+        val firstSwatch = north.components.first() as PopupSwatch
+        firstSwatch.setSize(36, 24)
+        firstSwatch.dispatchEvent(makePress(firstSwatch))
+
+        val thrown =
+            assertFailsWith<RuntimeException> {
+                firstSwatch.dispatchEvent(makeRelease(firstSwatch))
+            }
+        assertSame(cancelled, thrown)
+    }
+
     private fun makePress(source: javax.swing.JComponent) =
         java.awt.event.MouseEvent(
             source,
@@ -614,5 +643,25 @@ class QuickSwitcherAccentGridTest {
         assertTrue(chosen.selected)
         assertEquals(1, swatches.count { it.selected })
         verify(exactly = 1) { swapService.notifyExternalApply(failedPaint) }
+    }
+
+    @Test
+    fun `grid construction propagates platform cancellation from resolve`() {
+        val cancelled = ProcessCanceledException()
+        every { AccentResolver.resolve(any(), any<AccentContext>()) } throws cancelled
+
+        val thrown = assertFailsWith<RuntimeException> { QuickSwitcherAccentGrid() }
+
+        assertSame(cancelled, thrown)
+    }
+
+    @Test
+    fun `grid construction propagates coroutine cancellation from resolve`() {
+        val cancelled = CancellationException("cancelled resolve")
+        every { AccentResolver.resolve(any(), any<AccentContext>()) } throws cancelled
+
+        val thrown = assertFailsWith<RuntimeException> { QuickSwitcherAccentGrid() }
+
+        assertSame(cancelled, thrown)
     }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipPinToggleTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipPinToggleTest.kt
@@ -8,7 +8,11 @@ import com.intellij.util.messages.MessageBus
 import com.intellij.util.messages.MessageBusConnection
 import com.intellij.util.ui.JBUI
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
+import dev.ayuislands.accent.AccentApplyStep
+import dev.ayuislands.accent.AccentApplyStepFailure
 import dev.ayuislands.accent.AccentContext
+import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.licensing.LicenseChecker
@@ -89,7 +93,11 @@ class QuickSwitcherChipPinToggleTest {
 
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns mockProject
-        every { AccentApplicator.applyFromHexString(any()) } returns true
+        every { AccentApplicator.applyFromHexString(any()) } answers
+            {
+                AccentHex.of(firstArg<String>())?.let { validatedHex -> AccentApplyOutcome.Applied(validatedHex) }
+                    ?: AccentApplyOutcome.Rejected(firstArg())
+            }
 
         mockkObject(AccentResolver)
         every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#FFB454"
@@ -124,7 +132,9 @@ class QuickSwitcherChipPinToggleTest {
             "Pin path must write currentHex to projectAccents under the project key",
         )
         verify(exactly = 1) { AccentApplicator.applyFromHexString("#FFB454") }
-        verify(exactly = 1) { mockSwap.notifyExternalApply("#FFB454") }
+        verify(exactly = 1) {
+            mockSwap.notifyExternalApply(AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#FFB454"))))
+        }
         verify(exactly = 0) { QuickSwitcherPopup.show(any(), any()) }
     }
 
@@ -146,7 +156,9 @@ class QuickSwitcherChipPinToggleTest {
             "Unpin path must remove the project key from projectAccents",
         )
         verify(exactly = 1) { AccentApplicator.applyFromHexString("#73D0FF") }
-        verify(exactly = 1) { mockSwap.notifyExternalApply("#73D0FF") }
+        verify(exactly = 1) {
+            mockSwap.notifyExternalApply(AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#73D0FF"))))
+        }
         verify(exactly = 0) { QuickSwitcherPopup.show(any(), any()) }
     }
 
@@ -194,14 +206,14 @@ class QuickSwitcherChipPinToggleTest {
     }
 
     @Test
-    fun `pin path rolls back projectAccents when applyFromHexString returns false`() {
+    fun `pin path rolls back projectAccents when applyFromHexString rejects the hex`() {
         // Pin from unpinned + apply rejects (e.g. corrupted upstream
         // settings produce an invalid hex). The pin write must NOT persist
         // ahead of runtime state - restore the pre-toggle map and skip the
         // notify so the persisted store stays consistent with what the
         // accent applicator actually applied.
         every { AccentResolver.source(mockProject) } returns AccentResolver.Source.GLOBAL
-        every { AccentApplicator.applyFromHexString(any()) } returns false
+        every { AccentApplicator.applyFromHexString(any()) } answers { AccentApplyOutcome.Rejected(firstArg()) }
 
         val chip = QuickSwitcherChipComponent()
         chip.dispatchEvent(innerClick(chip))
@@ -214,14 +226,14 @@ class QuickSwitcherChipPinToggleTest {
     }
 
     @Test
-    fun `unpin path rolls back projectAccents when applyFromHexString returns false`() {
+    fun `unpin path rolls back projectAccents when applyFromHexString rejects the hex`() {
         // Unpin + apply rejects. The pin must be RESTORED (not just left
         // removed) so the next focus refresh re-resolves through the same
         // override the user thought they were unpinning.
         state.projectAccents[PROJECT_KEY] = "#FFB454"
         every { AccentResolver.source(mockProject) } returns AccentResolver.Source.PROJECT_OVERRIDE
         every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#73D0FF"
-        every { AccentApplicator.applyFromHexString(any()) } returns false
+        every { AccentApplicator.applyFromHexString(any()) } answers { AccentApplyOutcome.Rejected(firstArg()) }
 
         val chip = QuickSwitcherChipComponent()
         chip.dispatchEvent(innerClick(chip))
@@ -285,5 +297,48 @@ class QuickSwitcherChipPinToggleTest {
 
     private companion object {
         const val PROJECT_KEY: String = "/path/to/project"
+    }
+
+    @Test
+    fun `torn paint preserves a newly selected pin and existing order`() {
+        every { AccentResolver.source(mockProject) } returns AccentResolver.Source.GLOBAL
+        state.projectAccents["/unavailable-first"] = "#123456"
+        val failedPaint =
+            AccentApplyOutcome.Torn(
+                requireNotNull(AccentHex.of("#FFB454")),
+                listOf(
+                    AccentApplyStepFailure(AccentApplyStep.ApplyElements, IllegalStateException("paint")),
+                ),
+            )
+        every { AccentApplicator.applyFromHexString("#FFB454") } returns failedPaint
+        val chip = QuickSwitcherChipComponent()
+
+        chip.dispatchEvent(innerClick(chip))
+
+        assertEquals("#FFB454", state.projectAccents[PROJECT_KEY])
+        assertEquals("#123456", state.projectAccents["/unavailable-first"])
+        assertEquals(listOf("/unavailable-first", PROJECT_KEY), state.projectAccents.keys.toList())
+        verify(exactly = 1) { mockSwap.notifyExternalApply(failedPaint) }
+    }
+
+    @Test
+    fun `torn paint preserves the users unpin choice`() {
+        state.projectAccents[PROJECT_KEY] = "#FFB454"
+        every { AccentResolver.source(mockProject) } returns AccentResolver.Source.PROJECT_OVERRIDE
+        every { AccentResolver.resolve(any(), any<AyuVariant>()) } returns "#73D0FF"
+        val failedPaint =
+            AccentApplyOutcome.Torn(
+                requireNotNull(AccentHex.of("#73D0FF")),
+                listOf(
+                    AccentApplyStepFailure(AccentApplyStep.ApplyElements, IllegalStateException("paint")),
+                ),
+            )
+        every { AccentApplicator.applyFromHexString("#73D0FF") } returns failedPaint
+        val chip = QuickSwitcherChipComponent()
+
+        chip.dispatchEvent(innerClick(chip))
+
+        assertFalse(state.projectAccents.containsKey(PROJECT_KEY))
+        verify(exactly = 1) { mockSwap.notifyExternalApply(failedPaint) }
     }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipPinToggleTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherChipPinToggleTest.kt
@@ -3,6 +3,7 @@ package dev.ayuislands.accent.toolbar
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.project.Project
 import com.intellij.util.messages.MessageBus
 import com.intellij.util.messages.MessageBusConnection
@@ -27,11 +28,14 @@ import io.mockk.unmockkAll
 import io.mockk.verify
 import java.awt.event.MouseEvent
 import javax.swing.JComponent
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 /**
@@ -340,5 +344,117 @@ class QuickSwitcherChipPinToggleTest {
 
         assertFalse(state.projectAccents.containsKey(PROJECT_KEY))
         verify(exactly = 1) { mockSwap.notifyExternalApply(failedPaint) }
+    }
+
+    @Test
+    fun `pin restores previous state before propagating platform cancellation`() {
+        val cancelled = ProcessCanceledException()
+        state.projectAccents["/unavailable"] = "#123456"
+        val previousPins = state.projectAccents.toMap()
+        every { AccentApplicator.applyFromHexString(any()) } throws cancelled
+        val chip = QuickSwitcherChipComponent()
+
+        val thrown = assertFailsWith<RuntimeException> { chip.dispatchEvent(innerClick(chip)) }
+
+        assertSame(cancelled, thrown)
+        assertEquals(previousPins, state.projectAccents)
+        verify(exactly = 0) { mockSwap.notifyExternalApply(any()) }
+    }
+
+    @Test
+    fun `unpin restores previous state before propagating platform cancellation`() {
+        val cancelled = ProcessCanceledException()
+        state.projectAccents["/first"] = "#654321"
+        state.projectAccents[PROJECT_KEY] = "#FFB454"
+        every { AccentResolver.source(mockProject) } returns AccentResolver.Source.PROJECT_OVERRIDE
+        state.projectAccents["/unavailable"] = "#123456"
+        val previousPins = state.projectAccents.toMap()
+        every { AccentApplicator.applyFromHexString(any()) } throws cancelled
+        val chip = QuickSwitcherChipComponent()
+
+        val thrown = assertFailsWith<RuntimeException> { chip.dispatchEvent(innerClick(chip)) }
+
+        assertSame(cancelled, thrown)
+        assertEquals(previousPins, state.projectAccents)
+        verify(exactly = 0) { mockSwap.notifyExternalApply(any()) }
+    }
+
+    @Test
+    fun `pin restores previous state before propagating coroutine cancellation`() {
+        val cancelled = CancellationException("cancelled accent")
+        state.projectAccents["/unavailable"] = "#123456"
+        val previousPins = state.projectAccents.toMap()
+        every { AccentApplicator.applyFromHexString(any()) } throws cancelled
+        val chip = QuickSwitcherChipComponent()
+
+        val thrown = assertFailsWith<RuntimeException> { chip.dispatchEvent(innerClick(chip)) }
+
+        assertSame(cancelled, thrown)
+        assertEquals(previousPins, state.projectAccents)
+        verify(exactly = 0) { mockSwap.notifyExternalApply(any()) }
+    }
+
+    @Test
+    fun `unpin restores previous state before propagating coroutine cancellation`() {
+        val cancelled = CancellationException("cancelled accent")
+        state.projectAccents["/first"] = "#654321"
+        state.projectAccents[PROJECT_KEY] = "#FFB454"
+        every { AccentResolver.source(mockProject) } returns AccentResolver.Source.PROJECT_OVERRIDE
+        state.projectAccents["/unavailable"] = "#123456"
+        val previousPins = state.projectAccents.toMap()
+        every { AccentApplicator.applyFromHexString(any()) } throws cancelled
+        val chip = QuickSwitcherChipComponent()
+
+        val thrown = assertFailsWith<RuntimeException> { chip.dispatchEvent(innerClick(chip)) }
+
+        assertSame(cancelled, thrown)
+        assertEquals(previousPins, state.projectAccents)
+        verify(exactly = 0) { mockSwap.notifyExternalApply(any()) }
+    }
+
+    @Test
+    fun `chip refresh propagates platform cancellation from resolve`() {
+        val cancelled = ProcessCanceledException()
+        every { AccentResolver.resolve(any(), any<AccentContext>()) } throws cancelled
+        val chip = QuickSwitcherChipComponent()
+
+        val thrown = assertFailsWith<RuntimeException> { chip.refreshFromFocusedProject() }
+
+        assertSame(cancelled, thrown)
+    }
+
+    @Test
+    fun `chip refresh propagates coroutine cancellation from resolve`() {
+        val cancelled = CancellationException("cancelled refresh")
+        every { AccentResolver.resolve(any(), any<AccentContext>()) } throws cancelled
+        val chip = QuickSwitcherChipComponent()
+
+        val thrown = assertFailsWith<RuntimeException> { chip.refreshFromFocusedProject() }
+
+        assertSame(cancelled, thrown)
+    }
+
+    @Test
+    fun `cancelled unpin restores prior pin and preserves other pin edits`() {
+        val cancelled = ProcessCanceledException()
+        state.projectAccents["/first"] = "#123456"
+        state.projectAccents[PROJECT_KEY] = "#abcdef"
+        state.projectAccents["/last"] = "#654321"
+        every { AccentResolver.source(mockProject) } returns AccentResolver.Source.PROJECT_OVERRIDE
+        every { AccentApplicator.applyFromHexString(any()) } answers {
+            state.projectAccents["/first"] = "#112233"
+            state.projectAccents["/new"] = "#445566"
+            throw cancelled
+        }
+        val chip = QuickSwitcherChipComponent()
+
+        val thrown = assertFailsWith<RuntimeException> { chip.dispatchEvent(innerClick(chip)) }
+
+        assertSame(cancelled, thrown)
+        assertEquals(setOf("/first", PROJECT_KEY, "/last", "/new"), state.projectAccents.keys)
+        assertEquals("#112233", state.projectAccents["/first"])
+        assertEquals("#abcdef", state.projectAccents[PROJECT_KEY])
+        assertEquals("#654321", state.projectAccents["/last"])
+        assertEquals("#445566", state.projectAccents["/new"])
     }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherRelatedTogglesSectionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/QuickSwitcherRelatedTogglesSectionTest.kt
@@ -1,7 +1,9 @@
 package dev.ayuislands.accent.toolbar
 
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
 import dev.ayuislands.accent.AccentContext
+import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.toolbar.popup.Density
@@ -107,7 +109,8 @@ class QuickSwitcherRelatedTogglesSectionTest {
         state.chromeNavBar = false
         state.chromePanelBorder = false
         state.chromeTintingEnabled = true
-        every { AccentApplicator.applyForFocusedProject(any<AccentContext>()) } returns "#FFB454"
+        every { AccentApplicator.applyForFocusedProject(any<AccentContext>()) } returns
+            AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#FFB454")))
 
         val section = QuickSwitcherRelatedTogglesSection()
         val chromeTile =
@@ -140,7 +143,8 @@ class QuickSwitcherRelatedTogglesSectionTest {
         state.chromeNavBar = false
         state.chromePanelBorder = false
         state.chromeTintingEnabled = false
-        every { AccentApplicator.applyForFocusedProject(any<AccentContext>()) } returns "#FFB454"
+        every { AccentApplicator.applyForFocusedProject(any<AccentContext>()) } returns
+            AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#FFB454")))
 
         val section = QuickSwitcherRelatedTogglesSection()
         val chromeTile =
@@ -229,7 +233,8 @@ class QuickSwitcherRelatedTogglesSectionTest {
         val rotationService = mockk<AccentRotationService>(relaxed = true)
         mockkObject(AccentRotationService.Companion)
         every { AccentRotationService.getInstance() } returns rotationService
-        every { AccentApplicator.applyForFocusedProject(any<AccentContext>()) } returns "#7DCFFF"
+        every { AccentApplicator.applyForFocusedProject(any<AccentContext>()) } returns
+            AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#7DCFFF")))
 
         val section = QuickSwitcherRelatedTogglesSection()
         val followTile =
@@ -254,7 +259,8 @@ class QuickSwitcherRelatedTogglesSectionTest {
         val rotationService = mockk<AccentRotationService>(relaxed = true)
         mockkObject(AccentRotationService.Companion)
         every { AccentRotationService.getInstance() } returns rotationService
-        every { AccentApplicator.applyForFocusedProject(any<AccentContext>()) } returns "#7DCFFF"
+        every { AccentApplicator.applyForFocusedProject(any<AccentContext>()) } returns
+            AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#7DCFFF")))
         every { LicenseChecker.isLicensedOrGrace() } returns false
 
         val section = QuickSwitcherRelatedTogglesSection(showPremiumToggles = false)
@@ -280,7 +286,8 @@ class QuickSwitcherRelatedTogglesSectionTest {
         val rotationService = mockk<AccentRotationService>(relaxed = true)
         mockkObject(AccentRotationService.Companion)
         every { AccentRotationService.getInstance() } returns rotationService
-        every { AccentApplicator.applyForFocusedProject(any<AccentContext>()) } returns "#7DCFFF"
+        every { AccentApplicator.applyForFocusedProject(any<AccentContext>()) } returns
+            AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#7DCFFF")))
 
         val licensedSection = QuickSwitcherRelatedTogglesSection(showPremiumToggles = false)
         val licensedFollowTile =

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/DarkerAccentActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/DarkerAccentActionTest.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
 import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
@@ -56,7 +57,11 @@ class DarkerAccentActionTest {
 
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns mockProject
-        every { AccentApplicator.applyFromHexString(any()) } returns true
+        every { AccentApplicator.applyFromHexString(any()) } answers
+            {
+                AccentHex.of(firstArg<String>())?.let { validatedHex -> AccentApplyOutcome.Applied(validatedHex) }
+                    ?: AccentApplyOutcome.Rejected(firstArg())
+            }
 
         mockkObject(AccentResolver)
         every { AccentResolver.resolve(any(), any<AccentContext>()) } returns "#FFCC66"
@@ -135,7 +140,9 @@ class DarkerAccentActionTest {
         val expected = AccentHsl.darken(AccentHex.unsafeOf("#FFCC66")).value
         DarkerAccentAction().actionPerformed(newEvent())
         verify(exactly = 1) { AccentApplicator.applyFromHexString(expected) }
-        verify(exactly = 1) { mockSwap.notifyExternalApply(expected) }
+        verify(
+            exactly = 1,
+        ) { mockSwap.notifyExternalApply(AccentApplyOutcome.Applied(requireNotNull(AccentHex.of(expected)))) }
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/DarkerAccentActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/DarkerAccentActionTest.kt
@@ -1,10 +1,14 @@
 package dev.ayuislands.accent.toolbar.actions
 
 import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.Presentation
+import com.intellij.openapi.actionSystem.ex.ActionManagerEx
+import com.intellij.openapi.actionSystem.ex.ActionUtil
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.project.Project
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentApplyOutcome
@@ -26,11 +30,14 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkObject
 import io.mockk.unmockkStatic
 import io.mockk.verify
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 /**
@@ -179,5 +186,78 @@ class DarkerAccentActionTest {
         every { AccentResolver.resolve(any(), any<AccentContext>()) } returns floorHex
         DarkerAccentAction().actionPerformed(newEvent())
         verify(exactly = 1) { AccentApplicator.applyFromHexString(floorHex) }
+    }
+
+    @Test
+    fun `action propagates platform cancellation from resolve`() {
+        val cancelled = ProcessCanceledException()
+        every { AccentResolver.resolve(any(), any<AccentContext>()) } throws cancelled
+
+        val thrown = assertFailsWith<RuntimeException> { DarkerAccentAction().performInTest(newEvent()) }
+
+        assertSame(cancelled, thrown)
+        verify(exactly = 0) { mockSwap.notifyExternalApply(any()) }
+    }
+
+    @Test
+    fun `action propagates platform cancellation from apply`() {
+        val cancelled = ProcessCanceledException()
+        every { AccentApplicator.applyFromHexString(any()) } throws cancelled
+
+        val thrown = assertFailsWith<RuntimeException> { DarkerAccentAction().performInTest(newEvent()) }
+
+        assertSame(cancelled, thrown)
+        verify(exactly = 0) { mockSwap.notifyExternalApply(any()) }
+    }
+
+    @Test
+    fun `action propagates platform cancellation from cache sync`() {
+        val cancelled = ProcessCanceledException()
+        every { mockSwap.notifyExternalApply(any()) } throws cancelled
+
+        val thrown = assertFailsWith<RuntimeException> { DarkerAccentAction().performInTest(newEvent()) }
+
+        assertSame(cancelled, thrown)
+    }
+
+    @Test
+    fun `action propagates coroutine cancellation from resolve`() {
+        val cancelled = CancellationException("cancelled accent")
+        every { AccentResolver.resolve(any(), any<AccentContext>()) } throws cancelled
+
+        val thrown = assertFailsWith<RuntimeException> { DarkerAccentAction().performInTest(newEvent()) }
+
+        assertSame(cancelled, thrown)
+        verify(exactly = 0) { mockSwap.notifyExternalApply(any()) }
+    }
+
+    @Test
+    fun `action propagates coroutine cancellation from apply`() {
+        val cancelled = CancellationException("cancelled accent")
+        every { AccentApplicator.applyFromHexString(any()) } throws cancelled
+
+        val thrown = assertFailsWith<RuntimeException> { DarkerAccentAction().performInTest(newEvent()) }
+
+        assertSame(cancelled, thrown)
+        verify(exactly = 0) { mockSwap.notifyExternalApply(any()) }
+    }
+
+    @Test
+    fun `action propagates coroutine cancellation from cache sync`() {
+        val cancelled = CancellationException("cancelled accent")
+        every { mockSwap.notifyExternalApply(any()) } throws cancelled
+
+        val thrown = assertFailsWith<RuntimeException> { DarkerAccentAction().performInTest(newEvent()) }
+
+        assertSame(cancelled, thrown)
+    }
+
+    private fun AnAction.performInTest(event: AnActionEvent) {
+        val actionManager = mockk<ActionManagerEx>(relaxed = true)
+        every { event.actionManager } returns actionManager
+        every { actionManager.performWithActionCallbacks(any(), any(), any()) } answers {
+            thirdArg<Runnable>().run()
+        }
+        ActionUtil.performActionDumbAwareWithCallbacks(this, event)
     }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/LighterAccentActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/LighterAccentActionTest.kt
@@ -1,10 +1,14 @@
 package dev.ayuislands.accent.toolbar.actions
 
 import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.Presentation
+import com.intellij.openapi.actionSystem.ex.ActionManagerEx
+import com.intellij.openapi.actionSystem.ex.ActionUtil
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.project.Project
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentApplyOutcome
@@ -25,11 +29,14 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 /**
@@ -174,5 +181,78 @@ class LighterAccentActionTest {
         LighterAccentAction().actionPerformed(newEvent())
         // AccentHsl.lighten at the ceiling returns the input unchanged.
         verify(exactly = 1) { AccentApplicator.applyFromHexString(ceilingHex) }
+    }
+
+    @Test
+    fun `action propagates platform cancellation from resolve`() {
+        val cancelled = ProcessCanceledException()
+        every { AccentResolver.resolve(any(), any<AccentContext>()) } throws cancelled
+
+        val thrown = assertFailsWith<RuntimeException> { LighterAccentAction().performInTest(newEvent()) }
+
+        assertSame(cancelled, thrown)
+        verify(exactly = 0) { mockSwap.notifyExternalApply(any()) }
+    }
+
+    @Test
+    fun `action propagates platform cancellation from apply`() {
+        val cancelled = ProcessCanceledException()
+        every { AccentApplicator.applyFromHexString(any()) } throws cancelled
+
+        val thrown = assertFailsWith<RuntimeException> { LighterAccentAction().performInTest(newEvent()) }
+
+        assertSame(cancelled, thrown)
+        verify(exactly = 0) { mockSwap.notifyExternalApply(any()) }
+    }
+
+    @Test
+    fun `action propagates platform cancellation from cache sync`() {
+        val cancelled = ProcessCanceledException()
+        every { mockSwap.notifyExternalApply(any()) } throws cancelled
+
+        val thrown = assertFailsWith<RuntimeException> { LighterAccentAction().performInTest(newEvent()) }
+
+        assertSame(cancelled, thrown)
+    }
+
+    @Test
+    fun `action propagates coroutine cancellation from resolve`() {
+        val cancelled = CancellationException("cancelled accent")
+        every { AccentResolver.resolve(any(), any<AccentContext>()) } throws cancelled
+
+        val thrown = assertFailsWith<RuntimeException> { LighterAccentAction().performInTest(newEvent()) }
+
+        assertSame(cancelled, thrown)
+        verify(exactly = 0) { mockSwap.notifyExternalApply(any()) }
+    }
+
+    @Test
+    fun `action propagates coroutine cancellation from apply`() {
+        val cancelled = CancellationException("cancelled accent")
+        every { AccentApplicator.applyFromHexString(any()) } throws cancelled
+
+        val thrown = assertFailsWith<RuntimeException> { LighterAccentAction().performInTest(newEvent()) }
+
+        assertSame(cancelled, thrown)
+        verify(exactly = 0) { mockSwap.notifyExternalApply(any()) }
+    }
+
+    @Test
+    fun `action propagates coroutine cancellation from cache sync`() {
+        val cancelled = CancellationException("cancelled accent")
+        every { mockSwap.notifyExternalApply(any()) } throws cancelled
+
+        val thrown = assertFailsWith<RuntimeException> { LighterAccentAction().performInTest(newEvent()) }
+
+        assertSame(cancelled, thrown)
+    }
+
+    private fun AnAction.performInTest(event: AnActionEvent) {
+        val actionManager = mockk<ActionManagerEx>(relaxed = true)
+        every { event.actionManager } returns actionManager
+        every { actionManager.performWithActionCallbacks(any(), any(), any()) } answers {
+            thirdArg<Runnable>().run()
+        }
+        ActionUtil.performActionDumbAwareWithCallbacks(this, event)
     }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/LighterAccentActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/LighterAccentActionTest.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
 import dev.ayuislands.accent.AccentContext
 import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
@@ -55,7 +56,11 @@ class LighterAccentActionTest {
 
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns mockProject
-        every { AccentApplicator.applyFromHexString(any()) } returns true
+        every { AccentApplicator.applyFromHexString(any()) } answers
+            {
+                AccentHex.of(firstArg<String>())?.let { validatedHex -> AccentApplyOutcome.Applied(validatedHex) }
+                    ?: AccentApplyOutcome.Rejected(firstArg())
+            }
 
         mockkObject(AccentResolver)
         every { AccentResolver.resolve(any(), any<AccentContext>()) } returns "#FFCC66"
@@ -128,7 +133,9 @@ class LighterAccentActionTest {
         val expected = AccentHsl.lighten(AccentHex.unsafeOf("#FFCC66")).value
         LighterAccentAction().actionPerformed(newEvent())
         verify(exactly = 1) { AccentApplicator.applyFromHexString(expected) }
-        verify(exactly = 1) { mockSwap.notifyExternalApply(expected) }
+        verify(
+            exactly = 1,
+        ) { mockSwap.notifyExternalApply(AccentApplyOutcome.Applied(requireNotNull(AccentHex.of(expected)))) }
     }
 
     @Test

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/PinAccentActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/PinAccentActionTest.kt
@@ -7,7 +7,9 @@ import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
 import dev.ayuislands.accent.AccentContext
+import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.licensing.LicenseChecker
@@ -29,7 +31,7 @@ import kotlin.test.assertTrue
 /**
  * Locks [PinAccentAction]'s Pattern J two-level gate (`isAyuActive && licensed`),
  * `AccentMappingsState.projectAccents` writer path (shared / personal pin-lane
- * split deferred), and Pattern D Boolean gate on `notifyExternalApply`.
+ * split deferred), and Pattern D rejection gate on `notifyExternalApply`.
  */
 class PinAccentActionTest {
     private val mockApp = mockk<Application>(relaxed = true)
@@ -57,7 +59,11 @@ class PinAccentActionTest {
 
         mockkObject(AccentApplicator)
         every { AccentApplicator.resolveFocusedProject() } returns mockProject
-        every { AccentApplicator.applyFromHexString(any()) } returns true
+        every { AccentApplicator.applyFromHexString(any()) } answers
+            {
+                AccentHex.of(firstArg<String>())?.let { validatedHex -> AccentApplyOutcome.Applied(validatedHex) }
+                    ?: AccentApplyOutcome.Rejected(firstArg())
+            }
 
         mockkObject(AccentResolver)
         every { AccentResolver.resolve(any(), any<AccentContext>()) } returns "#7F52FF"
@@ -137,15 +143,21 @@ class PinAccentActionTest {
     }
 
     @Test
-    fun `actionPerformed calls notifyExternalApply only when applyFromHexString returns true (Pattern D)`() {
-        // Pattern D Boolean gate.
-        every { AccentApplicator.applyFromHexString("#7F52FF") } returns true
+    fun `actionPerformed calls notifyExternalApply only when applyFromHexString accepts the hex (Pattern D)`() {
+        // Pattern D rejection gate.
+        every { AccentApplicator.applyFromHexString("#7F52FF") } answers
+            {
+                AccentHex.of(firstArg<String>())?.let { validatedHex -> AccentApplyOutcome.Applied(validatedHex) }
+                    ?: AccentApplyOutcome.Rejected(firstArg())
+            }
         PinAccentAction().actionPerformed(newEvent())
-        verify(exactly = 1) { mockSwap.notifyExternalApply("#7F52FF") }
+        verify(exactly = 1) {
+            mockSwap.notifyExternalApply(AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#7F52FF"))))
+        }
 
         // When apply rejects, swap must NOT be published.
         io.mockk.clearMocks(mockSwap)
-        every { AccentApplicator.applyFromHexString("#7F52FF") } returns false
+        every { AccentApplicator.applyFromHexString("#7F52FF") } answers { AccentApplyOutcome.Rejected(firstArg()) }
         PinAccentAction().actionPerformed(newEvent())
         verify(exactly = 0) { mockSwap.notifyExternalApply(any()) }
     }

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/PinAccentActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/PinAccentActionTest.kt
@@ -1,10 +1,14 @@
 package dev.ayuislands.accent.toolbar.actions
 
 import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.Presentation
+import com.intellij.openapi.actionSystem.ex.ActionManagerEx
+import com.intellij.openapi.actionSystem.ex.ActionUtil
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.project.Project
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentApplyOutcome
@@ -21,11 +25,14 @@ import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import io.mockk.verify
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 /**
@@ -176,5 +183,136 @@ class PinAccentActionTest {
         PinAccentAction().actionPerformed(newEvent())
         assertTrue(state.projectAccents.isEmpty(), "Must not write state when projectKey null")
         verify(exactly = 0) { AccentApplicator.applyFromHexString(any()) }
+    }
+
+    @Test
+    fun `action propagates platform cancellation from resolve`() {
+        val cancelled = ProcessCanceledException()
+        every { AccentResolver.resolve(any(), any<AyuVariant>()) } throws cancelled
+
+        val thrown = assertFailsWith<RuntimeException> { PinAccentAction().performInTest(newEvent()) }
+
+        assertSame(cancelled, thrown)
+        verify(exactly = 0) { mockSwap.notifyExternalApply(any()) }
+    }
+
+    @Test
+    fun `action propagates platform cancellation from apply`() {
+        val cancelled = ProcessCanceledException()
+        every { AccentApplicator.applyFromHexString(any()) } throws cancelled
+
+        val thrown = assertFailsWith<RuntimeException> { PinAccentAction().performInTest(newEvent()) }
+
+        assertSame(cancelled, thrown)
+        verify(exactly = 0) { mockSwap.notifyExternalApply(any()) }
+    }
+
+    @Test
+    fun `action propagates platform cancellation from cache sync`() {
+        val cancelled = ProcessCanceledException()
+        every { mockSwap.notifyExternalApply(any()) } throws cancelled
+
+        val thrown = assertFailsWith<RuntimeException> { PinAccentAction().performInTest(newEvent()) }
+
+        assertSame(cancelled, thrown)
+    }
+
+    @Test
+    fun `action propagates coroutine cancellation from resolve`() {
+        val cancelled = CancellationException("cancelled accent")
+        every { AccentResolver.resolve(any(), any<AyuVariant>()) } throws cancelled
+
+        val thrown = assertFailsWith<RuntimeException> { PinAccentAction().performInTest(newEvent()) }
+
+        assertSame(cancelled, thrown)
+        verify(exactly = 0) { mockSwap.notifyExternalApply(any()) }
+    }
+
+    @Test
+    fun `action propagates coroutine cancellation from apply`() {
+        val cancelled = CancellationException("cancelled accent")
+        every { AccentApplicator.applyFromHexString(any()) } throws cancelled
+
+        val thrown = assertFailsWith<RuntimeException> { PinAccentAction().performInTest(newEvent()) }
+
+        assertSame(cancelled, thrown)
+        verify(exactly = 0) { mockSwap.notifyExternalApply(any()) }
+    }
+
+    @Test
+    fun `action propagates coroutine cancellation from cache sync`() {
+        val cancelled = CancellationException("cancelled accent")
+        every { mockSwap.notifyExternalApply(any()) } throws cancelled
+
+        val thrown = assertFailsWith<RuntimeException> { PinAccentAction().performInTest(newEvent()) }
+
+        assertSame(cancelled, thrown)
+    }
+
+    @Test
+    fun `pin action restores absent pin before propagating platform cancellation`() {
+        val cancelled = ProcessCanceledException()
+        state.projectAccents["/first"] = "#123456"
+        state.projectAccents["/last"] = "#654321"
+        val previousPins = state.projectAccents.toMap()
+        every { AccentApplicator.applyFromHexString(any()) } throws cancelled
+
+        val thrown = assertFailsWith<RuntimeException> { PinAccentAction().performInTest(newEvent()) }
+
+        assertSame(cancelled, thrown)
+        assertEquals(previousPins, state.projectAccents)
+    }
+
+    @Test
+    fun `pin action restores existing pin before propagating platform cancellation`() {
+        val cancelled = ProcessCanceledException()
+        state.projectAccents["/first"] = "#123456"
+        state.projectAccents["/path/to/project"] = "#abcdef"
+        state.projectAccents["/last"] = "#654321"
+        val previousPins = state.projectAccents.toMap()
+        every { AccentApplicator.applyFromHexString(any()) } throws cancelled
+
+        val thrown = assertFailsWith<RuntimeException> { PinAccentAction().performInTest(newEvent()) }
+
+        assertSame(cancelled, thrown)
+        assertEquals(previousPins, state.projectAccents)
+    }
+
+    @Test
+    fun `pin action restores absent pin before propagating coroutine cancellation`() {
+        val cancelled = CancellationException("cancelled pin")
+        state.projectAccents["/first"] = "#123456"
+        state.projectAccents["/last"] = "#654321"
+        val previousPins = state.projectAccents.toMap()
+        every { AccentApplicator.applyFromHexString(any()) } throws cancelled
+
+        val thrown = assertFailsWith<RuntimeException> { PinAccentAction().performInTest(newEvent()) }
+
+        assertSame(cancelled, thrown)
+        assertEquals(previousPins, state.projectAccents)
+    }
+
+    @Test
+    fun `pin action restores existing pin before propagating coroutine cancellation`() {
+        val cancelled = CancellationException("cancelled pin")
+        state.projectAccents["/first"] = "#123456"
+        state.projectAccents["/path/to/project"] = "#abcdef"
+        state.projectAccents["/last"] = "#654321"
+        val previousPins = state.projectAccents.toMap()
+        every { AccentApplicator.applyFromHexString(any()) } throws cancelled
+
+        val thrown = assertFailsWith<RuntimeException> { PinAccentAction().performInTest(newEvent()) }
+
+        assertSame(cancelled, thrown)
+        assertEquals(previousPins, state.projectAccents)
+    }
+
+    private fun AnAction.performInTest(event: AnActionEvent) {
+        val actionManager = mockk<ActionManagerEx>(relaxed = true)
+        every { event.actionManager } returns actionManager
+        every { actionManager.performWithActionCallbacks(any(), any(), any()) } answers {
+            thirdArg<Runnable>().run()
+        }
+        ActionUtil.performActionDumbAwareWithCallbacks(this, event)
     }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/RandomAccentActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/RandomAccentActionTest.kt
@@ -1,10 +1,14 @@
 package dev.ayuislands.accent.toolbar.actions
 
 import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.Presentation
+import com.intellij.openapi.actionSystem.ex.ActionManagerEx
+import com.intellij.openapi.actionSystem.ex.ActionUtil
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.progress.ProcessCanceledException
 import dev.ayuislands.accent.AccentApplicator
 import dev.ayuislands.accent.AccentApplyOutcome
 import dev.ayuislands.accent.AccentContext
@@ -23,11 +27,14 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 /**
@@ -171,5 +178,78 @@ class RandomAccentActionTest {
         RandomAccentAction().actionPerformed(newEvent())
         verify(exactly = 0) { AccentApplicator.applyFromHexString(any()) }
         verify(exactly = 0) { mockSwap.notifyExternalApply(any()) }
+    }
+
+    @Test
+    fun `action propagates platform cancellation from generate`() {
+        val cancelled = ProcessCanceledException()
+        every { ContrastAwareColorGenerator.generate(any()) } throws cancelled
+
+        val thrown = assertFailsWith<RuntimeException> { RandomAccentAction().performInTest(newEvent()) }
+
+        assertSame(cancelled, thrown)
+        verify(exactly = 0) { mockSwap.notifyExternalApply(any()) }
+    }
+
+    @Test
+    fun `action propagates platform cancellation from apply`() {
+        val cancelled = ProcessCanceledException()
+        every { AccentApplicator.applyFromHexString(any()) } throws cancelled
+
+        val thrown = assertFailsWith<RuntimeException> { RandomAccentAction().performInTest(newEvent()) }
+
+        assertSame(cancelled, thrown)
+        verify(exactly = 0) { mockSwap.notifyExternalApply(any()) }
+    }
+
+    @Test
+    fun `action propagates platform cancellation from cache sync`() {
+        val cancelled = ProcessCanceledException()
+        every { mockSwap.notifyExternalApply(any()) } throws cancelled
+
+        val thrown = assertFailsWith<RuntimeException> { RandomAccentAction().performInTest(newEvent()) }
+
+        assertSame(cancelled, thrown)
+    }
+
+    @Test
+    fun `action propagates coroutine cancellation from generate`() {
+        val cancelled = CancellationException("cancelled accent")
+        every { ContrastAwareColorGenerator.generate(any()) } throws cancelled
+
+        val thrown = assertFailsWith<RuntimeException> { RandomAccentAction().performInTest(newEvent()) }
+
+        assertSame(cancelled, thrown)
+        verify(exactly = 0) { mockSwap.notifyExternalApply(any()) }
+    }
+
+    @Test
+    fun `action propagates coroutine cancellation from apply`() {
+        val cancelled = CancellationException("cancelled accent")
+        every { AccentApplicator.applyFromHexString(any()) } throws cancelled
+
+        val thrown = assertFailsWith<RuntimeException> { RandomAccentAction().performInTest(newEvent()) }
+
+        assertSame(cancelled, thrown)
+        verify(exactly = 0) { mockSwap.notifyExternalApply(any()) }
+    }
+
+    @Test
+    fun `action propagates coroutine cancellation from cache sync`() {
+        val cancelled = CancellationException("cancelled accent")
+        every { mockSwap.notifyExternalApply(any()) } throws cancelled
+
+        val thrown = assertFailsWith<RuntimeException> { RandomAccentAction().performInTest(newEvent()) }
+
+        assertSame(cancelled, thrown)
+    }
+
+    private fun AnAction.performInTest(event: AnActionEvent) {
+        val actionManager = mockk<ActionManagerEx>(relaxed = true)
+        every { event.actionManager } returns actionManager
+        every { actionManager.performWithActionCallbacks(any(), any(), any()) } answers {
+            thirdArg<Runnable>().run()
+        }
+        ActionUtil.performActionDumbAwareWithCallbacks(this, event)
     }
 }

--- a/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/RandomAccentActionTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/toolbar/actions/RandomAccentActionTest.kt
@@ -6,7 +6,9 @@ import com.intellij.openapi.actionSystem.Presentation
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
 import dev.ayuislands.accent.AccentContext
+import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.ExternalAccentSource
 import dev.ayuislands.licensing.LicenseChecker
@@ -50,7 +52,11 @@ class RandomAccentActionTest {
         every { LicenseChecker.isLicensedOrGrace() } returns true
 
         mockkObject(AccentApplicator)
-        every { AccentApplicator.applyFromHexString(any()) } returns true
+        every { AccentApplicator.applyFromHexString(any()) } answers
+            {
+                AccentHex.of(firstArg<String>())?.let { validatedHex -> AccentApplyOutcome.Applied(validatedHex) }
+                    ?: AccentApplyOutcome.Rejected(firstArg())
+            }
 
         mockkObject(ContrastAwareColorGenerator)
         every { ContrastAwareColorGenerator.generate(any()) } returns "#5CCFE6"
@@ -121,11 +127,13 @@ class RandomAccentActionTest {
         RandomAccentAction().actionPerformed(newEvent())
         verify(exactly = 1) { ContrastAwareColorGenerator.generate(AyuVariant.MIRAGE) }
         verify(exactly = 1) { AccentApplicator.applyFromHexString("#5CCFE6") }
-        verify(exactly = 1) { mockSwap.notifyExternalApply("#5CCFE6") }
+        verify(exactly = 1) {
+            mockSwap.notifyExternalApply(AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#5CCFE6"))))
+        }
 
         // Pattern D rejection path — no swap publish
         clearMocks(mockSwap)
-        every { AccentApplicator.applyFromHexString(any()) } returns false
+        every { AccentApplicator.applyFromHexString(any()) } answers { AccentApplyOutcome.Rejected(firstArg()) }
         RandomAccentAction().actionPerformed(newEvent())
         verify(exactly = 0) { mockSwap.notifyExternalApply(any()) }
     }

--- a/src/test/kotlin/dev/ayuislands/licensing/EntitlementReconcilerTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/EntitlementReconcilerTest.kt
@@ -2,7 +2,11 @@ package dev.ayuislands.licensing
 
 import com.intellij.openapi.project.Project
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
+import dev.ayuislands.accent.AccentApplyStep
+import dev.ayuislands.accent.AccentApplyStepFailure
 import dev.ayuislands.accent.AccentContext
+import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.CodeGlanceProIntegration
 import dev.ayuislands.accent.toolbar.QuickSwitcherPopup
@@ -73,7 +77,8 @@ class EntitlementReconcilerTest {
         mockkObject(AccentContext.Companion)
         every { AccentContext.detect() } returns context
         mockkObject(AccentApplicator)
-        every { AccentApplicator.applyForFocusedProject(context) } returns "#FFCC66"
+        every { AccentApplicator.applyForFocusedProject(context) } returns
+            AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#FFCC66")))
         mockkObject(CodeGlanceProIntegration)
         every { CodeGlanceProIntegration.restoreOwnedState() } returns IntegrationOutcome.Skipped
         mockkObject(IndentRainbowSync)
@@ -245,8 +250,13 @@ class EntitlementReconcilerTest {
     @Test
     fun `incomplete accent cascade is included in the structured reconciliation result`() {
         every { AccentApplicator.applyForFocusedProject(context) } answers {
-            state.lastApplyOk = false
-            "#FFCC66"
+            state.lastApplyOk = true
+            AccentApplyOutcome.Torn(
+                requireNotNull(AccentHex.of("#FFCC66")),
+                listOf(
+                    AccentApplyStepFailure(AccentApplyStep.ApplyElements, IllegalStateException("paint")),
+                ),
+            )
         }
 
         val result = EntitlementReconciler.reconcile(LicenseEntitlement.UNLICENSED, listOf(project))

--- a/src/test/kotlin/dev/ayuislands/licensing/FreeTierLockdownTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/FreeTierLockdownTest.kt
@@ -7,8 +7,10 @@ import com.intellij.notification.NotificationType
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.AccentGroup
+import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.glow.GlowShape
@@ -64,7 +66,8 @@ class FreeTierLockdownTest {
         every { AyuIslandsSettings.getInstance() } returns settings
 
         mockkObject(AccentApplicator)
-        every { AccentApplicator.apply(any()) } just runs
+        every { AccentApplicator.apply(any()) } answers
+            { AccentApplyOutcome.Applied(requireNotNull(AccentHex.of(firstArg<String>()))) }
 
         mockkObject(GlowOverlayManager.Companion)
         every { GlowOverlayManager.syncGlowForAllProjects() } just runs

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerProDefaultsTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerProDefaultsTest.kt
@@ -5,8 +5,10 @@ import com.intellij.notification.NotificationGroupManager
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
 import dev.ayuislands.accent.AccentElementId
 import dev.ayuislands.accent.AccentGroup
+import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.glow.GlowAnimation
 import dev.ayuislands.glow.GlowOverlayManager
@@ -25,6 +27,7 @@ import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.unmockkAll
 import io.mockk.verify
+import javax.swing.SwingUtilities
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -38,9 +41,8 @@ class LicenseCheckerProDefaultsTest {
     @BeforeTest
     fun setUp() {
         state = AyuIslandsState()
-        // Stubbed applies report success, so the persisted clean flag must read
-        // clean too — ThemeReapplication's tear-escalation check consults it.
-        state.lastApplyOk = true
+        mockkStatic(SwingUtilities::class)
+        every { SwingUtilities.isEventDispatchThread() } returns true
         val settingsMock = mockk<AyuIslandsSettings>()
         mockkObject(AyuIslandsSettings.Companion)
         every { AyuIslandsSettings.getInstance() } returns settingsMock
@@ -343,7 +345,8 @@ class LicenseCheckerProDefaultsTest {
         every { settingsMock.state } returns state
         every { settingsMock.getAccentForVariant(any()) } returns "#FFCC66"
         mockkObject(AccentApplicator)
-        every { AccentApplicator.apply(any()) } just runs
+        every { AccentApplicator.apply(any()) } answers
+            { AccentApplyOutcome.Applied(requireNotNull(AccentHex.of(firstArg<String>()))) }
 
         // Mock ApplicationManager for AccentRotationService.stopRotation() call
         mockkStatic(ApplicationManager::class)

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerQuickSwitcherRevertTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerQuickSwitcherRevertTest.kt
@@ -7,6 +7,8 @@ import com.intellij.notification.NotificationType
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
+import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.rotation.AccentRotationService
@@ -46,7 +48,11 @@ class LicenseCheckerQuickSwitcherRevertTest {
         every { AyuIslandsSettings.getInstance() } returns settings
 
         mockkObject(AccentApplicator)
-        every { AccentApplicator.applyFromHexString(any()) } returns true
+        every { AccentApplicator.applyFromHexString(any()) } answers
+            {
+                AccentHex.of(firstArg<String>())?.let { validatedHex -> AccentApplyOutcome.Applied(validatedHex) }
+                    ?: AccentApplyOutcome.Rejected(firstArg())
+            }
 
         mockkObject(GlowOverlayManager.Companion)
         every { GlowOverlayManager.syncGlowForAllProjects() } just runs

--- a/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerVcsRevokeTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/LicenseCheckerVcsRevokeTest.kt
@@ -7,6 +7,8 @@ import com.intellij.notification.NotificationType
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
+import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.rotation.AccentRotationService
@@ -68,8 +70,13 @@ class LicenseCheckerVcsRevokeTest {
         every { AyuIslandsSettings.getInstance() } returns settings
 
         mockkObject(AccentApplicator)
-        every { AccentApplicator.apply(any()) } just runs
-        every { AccentApplicator.applyFromHexString(any()) } returns true
+        every { AccentApplicator.apply(any()) } answers
+            { AccentApplyOutcome.Applied(requireNotNull(AccentHex.of(firstArg<String>()))) }
+        every { AccentApplicator.applyFromHexString(any()) } answers
+            {
+                AccentHex.of(firstArg<String>())?.let { validatedHex -> AccentApplyOutcome.Applied(validatedHex) }
+                    ?: AccentApplyOutcome.Rejected(firstArg())
+            }
 
         mockkObject(GlowOverlayManager.Companion)
         every { GlowOverlayManager.syncGlowForAllProjects() } just runs

--- a/src/test/kotlin/dev/ayuislands/licensing/TrialLifecycleIntegrationTest.kt
+++ b/src/test/kotlin/dev/ayuislands/licensing/TrialLifecycleIntegrationTest.kt
@@ -9,6 +9,8 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.PathManager
 import com.intellij.ui.LicensingFacade
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
+import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.rotation.AccentRotationService
@@ -16,7 +18,6 @@ import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
 import io.mockk.every
 import io.mockk.just
-import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
@@ -26,6 +27,7 @@ import io.mockk.verify
 import java.time.LocalDate
 import java.time.ZoneId
 import java.util.Date
+import javax.swing.SwingUtilities
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -67,9 +69,8 @@ class TrialLifecycleIntegrationTest {
     @BeforeTest
     fun setUp() {
         state = AyuIslandsState()
-        // Stubbed applies report success, so the persisted clean flag must read
-        // clean too — ThemeReapplication's tear-escalation check consults it.
-        state.lastApplyOk = true
+        mockkStatic(SwingUtilities::class)
+        every { SwingUtilities.isEventDispatchThread() } returns true
         settings = mockk()
         every { settings.state } returns state
         every { settings.getAccentForVariant(any()) } returns "#FFCC66"
@@ -98,7 +99,8 @@ class TrialLifecycleIntegrationTest {
         System.clearProperty("ayu.islands.dev")
 
         mockkObject(AccentApplicator)
-        justRun { AccentApplicator.apply(any()) }
+        every { AccentApplicator.apply(any()) } answers
+            { AccentApplyOutcome.Applied(requireNotNull(AccentHex.of(firstArg<String>()))) }
 
         mockkObject(GlowOverlayManager.Companion)
         every { GlowOverlayManager.syncGlowForAllProjects() } just runs

--- a/src/test/kotlin/dev/ayuislands/reapply/ThemeReapplicationTearEscalationTest.kt
+++ b/src/test/kotlin/dev/ayuislands/reapply/ThemeReapplicationTearEscalationTest.kt
@@ -1,6 +1,10 @@
 package dev.ayuislands.reapply
 
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
+import dev.ayuislands.accent.AccentApplyStep
+import dev.ayuislands.accent.AccentApplyStepFailure
+import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.settings.AyuIslandsSettings
 import dev.ayuislands.settings.AyuIslandsState
@@ -46,8 +50,13 @@ class ThemeReapplicationTearEscalationTest {
         every { mockSettings.state } returns state
 
         mockkObject(AccentApplicator)
-        every { AccentApplicator.applyForFocusedProject(any<dev.ayuislands.accent.AccentContext>()) } returns "#FFCC66"
-        every { AccentApplicator.applyFromHexString(any()) } returns true
+        every { AccentApplicator.applyForFocusedProject(any<dev.ayuislands.accent.AccentContext>()) } returns
+            AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#FFCC66")))
+        every { AccentApplicator.applyFromHexString(any()) } answers
+            {
+                AccentHex.of(firstArg<String>())?.let { validatedHex -> AccentApplyOutcome.Applied(validatedHex) }
+                    ?: AccentApplyOutcome.Rejected(firstArg())
+            }
     }
 
     @AfterTest
@@ -57,7 +66,15 @@ class ThemeReapplicationTearEscalationTest {
 
     @Test
     fun `rotation tick reports the apply step failed when the apply tore`() {
-        state.lastApplyOk = false
+        state.lastApplyOk = true
+        val failedPaint =
+            AccentApplyOutcome.Torn(
+                requireNotNull(AccentHex.of("#FFCC66")),
+                listOf(AccentApplyStepFailure(AccentApplyStep.ApplyElements, IllegalStateException("paint"))),
+            )
+        every { AccentApplicator.applyForFocusedProject(any<dev.ayuislands.accent.AccentContext>()) } returns
+            failedPaint
+        every { AccentApplicator.applyFromHexString(any()) } returns failedPaint
 
         var result: ReapplyResult? = null
         ThemeReapplication.reapply(ReapplyReason.RotationTick(AyuVariant.DARK)) { result = it }
@@ -70,7 +87,7 @@ class ThemeReapplicationTearEscalationTest {
 
     @Test
     fun `rotation tick is clean when the apply completed cleanly`() {
-        state.lastApplyOk = true
+        state.lastApplyOk = false
 
         var result: ReapplyResult? = null
         ThemeReapplication.reapply(ReapplyReason.RotationTick(AyuVariant.DARK)) { result = it }
@@ -80,7 +97,15 @@ class ThemeReapplicationTearEscalationTest {
 
     @Test
     fun `license revert reports the explicit-hex step failed when the apply tore`() {
-        state.lastApplyOk = false
+        state.lastApplyOk = true
+        val failedPaint =
+            AccentApplyOutcome.Torn(
+                requireNotNull(AccentHex.of("#FFCC66")),
+                listOf(AccentApplyStepFailure(AccentApplyStep.ApplyElements, IllegalStateException("paint"))),
+            )
+        every { AccentApplicator.applyForFocusedProject(any<dev.ayuislands.accent.AccentContext>()) } returns
+            failedPaint
+        every { AccentApplicator.applyFromHexString(any()) } returns failedPaint
 
         var result: ReapplyResult? = null
         ThemeReapplication.reapply(ReapplyReason.LicenseRevert("#E6B450")) { result = it }
@@ -99,7 +124,7 @@ class ThemeReapplicationTearEscalationTest {
         state.lastApplyOk = true
         every {
             AccentApplicator.applyForFocusedProject(any<dev.ayuislands.accent.AccentContext>())
-        } returns "not-a-hex"
+        } returns AccentApplyOutcome.Rejected("not-a-hex")
 
         var result: ReapplyResult? = null
         ThemeReapplication.reapply(ReapplyReason.RotationTick(AyuVariant.DARK)) { result = it }
@@ -110,7 +135,7 @@ class ThemeReapplicationTearEscalationTest {
     @Test
     fun `license revert reports the explicit-hex step failed when the hex is rejected`() {
         state.lastApplyOk = true
-        every { AccentApplicator.applyFromHexString(any()) } returns false
+        every { AccentApplicator.applyFromHexString(any()) } answers { AccentApplyOutcome.Rejected(firstArg()) }
 
         var result: ReapplyResult? = null
         ThemeReapplication.reapply(ReapplyReason.LicenseRevert("#E6B450")) { result = it }

--- a/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/rotation/AccentRotationServiceTest.kt
@@ -12,7 +12,9 @@ import com.intellij.openapi.wm.IdeFrame
 import com.intellij.testFramework.LoggedErrorProcessor
 import dev.ayuislands.accent.AYU_ACCENT_PRESETS
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
 import dev.ayuislands.accent.AccentContext
+import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.glow.GlowOverlayManager
@@ -182,7 +184,11 @@ class AccentRotationServiceTest {
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
 
         mockkObject(AccentApplicator)
-        every { AccentApplicator.applyFromHexString(any()) } returns true
+        every { AccentApplicator.applyFromHexString(any()) } answers
+            {
+                AccentHex.of(firstArg<String>())?.let { validatedHex -> AccentApplyOutcome.Applied(validatedHex) }
+                    ?: AccentApplyOutcome.Rejected(firstArg())
+            }
 
         mockkObject(GlowOverlayManager.Companion)
         every { GlowOverlayManager.syncGlowForAllProjects() } just Runs
@@ -375,7 +381,7 @@ class AccentRotationServiceTest {
             if (applyCalls.size != THREE) {
                 throw RotationTestException("fail ${applyCalls.size}")
             }
-            true
+            AccentApplyOutcome.Applied(requireNotNull(AccentHex.of(firstArg<String>())))
         }
 
         val service = AccentRotationService()

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanelTest.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.ex.ActionManagerEx
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogPanel
 import com.intellij.testFramework.LoggedErrorProcessor
@@ -38,9 +39,12 @@ import java.io.File
 import javax.swing.JCheckBox
 import javax.swing.JComboBox
 import javax.swing.JEditorPane
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
 
 /**
  * Locks in the [AyuIslandsAccentPanel.applyWithFallback] failure-recovery contract:
@@ -365,7 +369,7 @@ class AyuIslandsAccentPanelTest {
             accentPanel.overrides.setPendingFallbackAccent("/tmp/locked", "#AABBCC")
             every { LicenseChecker.isLicensedOrGrace() } returns false
 
-            kotlin.test.assertFailsWith<IllegalStateException> { accentPanel.apply() }
+            assertFailsWith<IllegalStateException> { accentPanel.apply() }
 
             kotlin.test.assertEquals(storedAccent, state.mirageAccent)
             verify(exactly = 0) { settings.setAccentForVariant(any(), any()) }
@@ -503,5 +507,101 @@ class AyuIslandsAccentPanelTest {
             current = current.parent
         }
         return current === root && root.isVisible
+    }
+
+    @Test
+    fun `applyWithFallback propagates platform cancellation from focused apply`() {
+        val cancelled = ProcessCanceledException()
+        every { AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE) } throws cancelled
+        val accentPanel = AyuIslandsAccentPanel()
+
+        LoggedErrorProcessor.executeWith<Throwable>(suppressLoggedErrors()) {
+            val thrown =
+                assertFailsWith<RuntimeException> { accentPanel.applyWithFallback(AyuVariant.MIRAGE, "#FFCC66") }
+            assertSame(cancelled, thrown)
+        }
+        verify(exactly = 0) { AccentApplicator.applyFromHexString(any()) }
+        verify(exactly = 0) { swapService.notifyExternalApply(any()) }
+    }
+
+    @Test
+    fun `applyWithFallback propagates platform cancellation from fallback apply`() {
+        val cancelled = ProcessCanceledException()
+        every { AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE) } throws
+            IllegalStateException("invalid override")
+        every { AccentApplicator.applyFromHexString("#FFCC66") } throws cancelled
+        val accentPanel = AyuIslandsAccentPanel()
+
+        LoggedErrorProcessor.executeWith<Throwable>(suppressLoggedErrors()) {
+            val thrown =
+                assertFailsWith<RuntimeException> { accentPanel.applyWithFallback(AyuVariant.MIRAGE, "#FFCC66") }
+            assertSame(cancelled, thrown)
+        }
+        verify(exactly = 0) { swapService.notifyExternalApply(any()) }
+    }
+
+    @Test
+    fun `applyWithFallback propagates platform cancellation from cache sync`() {
+        val cancelled = ProcessCanceledException()
+        every { AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE) } throws
+            IllegalStateException("invalid override")
+        every { AccentApplicator.applyFromHexString("#FFCC66") } returns
+            AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#FFCC66")))
+        every { swapService.notifyExternalApply(any()) } throws cancelled
+        val accentPanel = AyuIslandsAccentPanel()
+
+        LoggedErrorProcessor.executeWith<Throwable>(suppressLoggedErrors()) {
+            val thrown =
+                assertFailsWith<RuntimeException> { accentPanel.applyWithFallback(AyuVariant.MIRAGE, "#FFCC66") }
+            assertSame(cancelled, thrown)
+        }
+    }
+
+    @Test
+    fun `applyWithFallback propagates coroutine cancellation from focused apply`() {
+        val cancelled = CancellationException("cancelled accent")
+        every { AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE) } throws cancelled
+        val accentPanel = AyuIslandsAccentPanel()
+
+        LoggedErrorProcessor.executeWith<Throwable>(suppressLoggedErrors()) {
+            val thrown =
+                assertFailsWith<RuntimeException> { accentPanel.applyWithFallback(AyuVariant.MIRAGE, "#FFCC66") }
+            assertSame(cancelled, thrown)
+        }
+        verify(exactly = 0) { AccentApplicator.applyFromHexString(any()) }
+        verify(exactly = 0) { swapService.notifyExternalApply(any()) }
+    }
+
+    @Test
+    fun `applyWithFallback propagates coroutine cancellation from fallback apply`() {
+        val cancelled = CancellationException("cancelled accent")
+        every { AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE) } throws
+            IllegalStateException("invalid override")
+        every { AccentApplicator.applyFromHexString("#FFCC66") } throws cancelled
+        val accentPanel = AyuIslandsAccentPanel()
+
+        LoggedErrorProcessor.executeWith<Throwable>(suppressLoggedErrors()) {
+            val thrown =
+                assertFailsWith<RuntimeException> { accentPanel.applyWithFallback(AyuVariant.MIRAGE, "#FFCC66") }
+            assertSame(cancelled, thrown)
+        }
+        verify(exactly = 0) { swapService.notifyExternalApply(any()) }
+    }
+
+    @Test
+    fun `applyWithFallback propagates coroutine cancellation from cache sync`() {
+        val cancelled = CancellationException("cancelled accent")
+        every { AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE) } throws
+            IllegalStateException("invalid override")
+        every { AccentApplicator.applyFromHexString("#FFCC66") } returns
+            AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#FFCC66")))
+        every { swapService.notifyExternalApply(any()) } throws cancelled
+        val accentPanel = AyuIslandsAccentPanel()
+
+        LoggedErrorProcessor.executeWith<Throwable>(suppressLoggedErrors()) {
+            val thrown =
+                assertFailsWith<RuntimeException> { accentPanel.applyWithFallback(AyuVariant.MIRAGE, "#FFCC66") }
+            assertSame(cancelled, thrown)
+        }
     }
 }

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsAccentPanelTest.kt
@@ -10,6 +10,8 @@ import com.intellij.testFramework.LoggedErrorProcessor
 import com.intellij.ui.TitledSeparator
 import com.intellij.ui.dsl.builder.panel
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
+import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.ProjectLanguageDetector
@@ -88,7 +90,8 @@ class AyuIslandsAccentPanelTest {
 
     @Test
     fun `applyWithFallback happy path delegates to applyForFocusedProject and skips fallback`() {
-        every { AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE) } returns "#ABCDEF"
+        every { AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE) } returns
+            AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#ABCDEF")))
 
         val panel = AyuIslandsAccentPanel()
         panel.applyWithFallback(AyuVariant.MIRAGE, "#FFCC66")
@@ -107,7 +110,11 @@ class AyuIslandsAccentPanelTest {
         // to prevent (next WINDOW_ACTIVATED would redundantly re-apply).
         every { AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE) } throws
             IllegalStateException("override hex corrupted")
-        every { AccentApplicator.applyFromHexString("#FFCC66") } returns true
+        every { AccentApplicator.applyFromHexString("#FFCC66") } answers
+            {
+                AccentHex.of(firstArg<String>())?.let { validatedHex -> AccentApplyOutcome.Applied(validatedHex) }
+                    ?: AccentApplyOutcome.Rejected(firstArg())
+            }
 
         val panel = AyuIslandsAccentPanel()
         LoggedErrorProcessor.executeWith<Throwable>(suppressLoggedErrors()) {
@@ -115,7 +122,9 @@ class AyuIslandsAccentPanelTest {
         }
 
         verify(exactly = 1) { AccentApplicator.applyFromHexString("#FFCC66") }
-        verify(exactly = 1) { swapService.notifyExternalApply("#FFCC66") }
+        verify(exactly = 1) {
+            swapService.notifyExternalApply(AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#FFCC66"))))
+        }
     }
 
     @Test
@@ -149,8 +158,16 @@ class AyuIslandsAccentPanelTest {
         // save" dialog on a path where the user's intent was actually applied.
         every { AccentApplicator.applyForFocusedProject(AyuVariant.MIRAGE) } throws
             IllegalStateException("override hex corrupted")
-        every { AccentApplicator.applyFromHexString("#FFCC66") } returns true
-        every { swapService.notifyExternalApply("#FFCC66") } throws
+        every { AccentApplicator.applyFromHexString("#FFCC66") } answers
+            {
+                AccentHex.of(firstArg<String>())?.let { validatedHex -> AccentApplyOutcome.Applied(validatedHex) }
+                    ?: AccentApplyOutcome.Rejected(firstArg())
+            }
+        every {
+            swapService.notifyExternalApply(
+                AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#FFCC66"))),
+            )
+        } throws
             IllegalStateException("swap service disposed mid-save")
 
         val expectedWarnSubstring = "swap-cache sync failed"
@@ -181,7 +198,9 @@ class AyuIslandsAccentPanelTest {
         }
 
         verify(exactly = 1) { AccentApplicator.applyFromHexString("#FFCC66") }
-        verify(exactly = 1) { swapService.notifyExternalApply("#FFCC66") }
+        verify(exactly = 1) {
+            swapService.notifyExternalApply(AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#FFCC66"))))
+        }
         kotlin.test.assertEquals(
             1,
             capturedWarns.size,

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsChromePanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsChromePanelTest.kt
@@ -11,7 +11,9 @@ import com.intellij.openapi.ui.DialogPanel
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.ui.dsl.builder.panel
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
 import dev.ayuislands.accent.AccentElementId
+import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.ChromeDecorationsProbe
 import dev.ayuislands.accent.ChromeTintContext
@@ -77,7 +79,8 @@ class AyuIslandsChromePanelTest {
         every { ChromeDecorationsProbe.isCustomHeaderActive() } returns true
 
         mockkObject(AccentApplicator)
-        every { AccentApplicator.applyForFocusedProject(any<dev.ayuislands.accent.AyuVariant>()) } returns "#E6B450"
+        every { AccentApplicator.applyForFocusedProject(any<AyuVariant>()) } returns
+            AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#E6B450")))
 
         // The Kotlin UI DSL `collapsibleGroup { … }` builder resolves the CollapsiblePanel
         // toggle action through `ActionManager.getInstance()` which goes via
@@ -430,7 +433,7 @@ class AyuIslandsChromePanelTest {
                 state.chromeTintIntensity,
                 "State intensity must remain old while the applicator consumes the pending snapshot",
             )
-            "#E6B450"
+            AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#E6B450")))
         }
 
         chromePanel.apply()
@@ -593,7 +596,7 @@ class AyuIslandsChromePanelTest {
             chromePanel.getPendingChromeTintIntensityForTest(),
         )
         // Reset must not call the applicator.
-        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any<dev.ayuislands.accent.AyuVariant>()) }
+        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any<AyuVariant>()) }
     }
 
     // ── Mid-session license flip must not persist ──────────────────────────────
@@ -631,7 +634,7 @@ class AyuIslandsChromePanelTest {
             "Post-license-revocation apply must not persist chromeTintIntensity",
         )
         // No EP re-apply.
-        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any<dev.ayuislands.accent.AyuVariant>()) }
+        verify(exactly = 0) { AccentApplicator.applyForFocusedProject(any<AyuVariant>()) }
     }
 
     // ── Test 9: premium gate ──────────────────────────────────────────────────

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateSnapshotTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsStateSnapshotTest.kt
@@ -2,6 +2,8 @@ package dev.ayuislands.settings
 
 import com.intellij.openapi.application.ApplicationManager
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
+import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.glow.GlowOverlayManager
 import dev.ayuislands.licensing.LicenseChecker
@@ -9,7 +11,6 @@ import dev.ayuislands.rotation.AccentRotationService
 import dev.ayuislands.testing.SnapshotAssert.assertMatchesSnapshot
 import io.mockk.every
 import io.mockk.just
-import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
@@ -26,7 +27,8 @@ class AyuIslandsStateSnapshotTest {
         mockkObject(AccentApplicator)
         mockkObject(GlowOverlayManager.Companion)
         mockkStatic(ApplicationManager::class)
-        justRun { AccentApplicator.apply(any()) }
+        every { AccentApplicator.apply(any()) } answers
+            { AccentApplyOutcome.Applied(requireNotNull(AccentHex.of(firstArg<String>()))) }
         every { GlowOverlayManager.syncGlowForAllProjects() } just runs
         val rotationService = mockk<AccentRotationService>(relaxed = true)
         val appMock = mockk<com.intellij.openapi.application.Application>(relaxed = true)

--- a/src/test/kotlin/dev/ayuislands/settings/PluginsPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/PluginsPanelTest.kt
@@ -7,7 +7,9 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.ui.DialogPanel
 import com.intellij.ui.dsl.builder.panel
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
 import dev.ayuislands.accent.AccentContext
+import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.accent.CodeGlanceProIntegration
 import dev.ayuislands.accent.conflict.ConflictRegistry
@@ -217,6 +219,9 @@ class PluginsPanelTest {
 
     @Test
     fun `external theme toggle persists opt-in`() {
+        mockkObject(AccentApplicator)
+        every { AccentApplicator.applyForFocusedProject(any<AccentContext>()) } returns
+            AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#AABBCC")))
         val pluginsPanel = PluginsPanel()
         val dialogPanel = buildDialogPanel(pluginsPanel)
         val checkbox =
@@ -235,7 +240,8 @@ class PluginsPanelTest {
         mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns null
         mockkObject(AccentApplicator)
-        every { AccentApplicator.applyForFocusedProject(AccentContext.External) } returns "#AABBCC"
+        every { AccentApplicator.applyForFocusedProject(AccentContext.External) } returns
+            AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#AABBCC")))
         mockkObject(GlowOverlayManager)
         every { GlowOverlayManager.syncGlowForAllProjects() } returns Unit
 
@@ -316,7 +322,7 @@ class PluginsPanelTest {
         mockkObject(AccentApplicator)
         every {
             AccentApplicator.applyForFocusedProject(any<AccentContext>())
-        } returns "#AABBCC"
+        } returns AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#AABBCC")))
 
         val pluginsPanel = PluginsPanel()
         val dialogPanel = buildDialogPanel(pluginsPanel)
@@ -351,7 +357,7 @@ class PluginsPanelTest {
         mockkObject(AccentApplicator)
         every {
             AccentApplicator.applyForFocusedProject(any<AccentContext>())
-        } returns "#AABBCC"
+        } returns AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#AABBCC")))
 
         val pluginsPanel = PluginsPanel()
         val dialogPanel = buildDialogPanel(pluginsPanel)
@@ -384,7 +390,7 @@ class PluginsPanelTest {
         mockkObject(AccentApplicator)
         every {
             AccentApplicator.applyForFocusedProject(any<AccentContext>())
-        } returns "#AABBCC"
+        } returns AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#AABBCC")))
 
         val pluginsPanel = PluginsPanel()
         val dialogPanel = buildDialogPanel(pluginsPanel)

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderApplyTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/OverridesGroupBuilderApplyTest.kt
@@ -7,6 +7,8 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.actionSystem.Presentation
+import com.intellij.openapi.actionSystem.ex.ActionManagerEx
+import com.intellij.openapi.actionSystem.ex.ActionUtil
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
@@ -14,6 +16,8 @@ import com.intellij.ui.CommonActionsPanel
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.table.JBTable
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
+import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.licensing.LicenseChecker
@@ -84,7 +88,11 @@ class OverridesGroupBuilderApplyTest {
     @Test
     fun `apply persists complete pending state before resolver applicator and swap`() {
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
-        every { AccentApplicator.applyFromHexString("#AABBCC") } returns true
+        every { AccentApplicator.applyFromHexString("#AABBCC") } answers
+            {
+                AccentHex.of(firstArg<String>())?.let { validatedHex -> AccentApplyOutcome.Applied(validatedHex) }
+                    ?: AccentApplyOutcome.Rejected(firstArg())
+            }
         val swapService = mockk<ProjectAccentSwapService>(relaxed = true)
         every { ProjectAccentSwapService.getInstance() } returns swapService
         val project = mockk<Project>(relaxed = true)
@@ -126,12 +134,12 @@ class OverridesGroupBuilderApplyTest {
             verify(exactly = 1) {
                 AccentResolver.resolve(project, AyuVariant.MIRAGE)
                 AccentApplicator.applyFromHexString("#AABBCC")
-                swapService.notifyExternalApply("#AABBCC")
+                swapService.notifyExternalApply(AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#AABBCC"))))
             }
             verifyOrder {
                 AccentResolver.resolve(project, AyuVariant.MIRAGE)
                 AccentApplicator.applyFromHexString("#AABBCC")
-                swapService.notifyExternalApply("#AABBCC")
+                swapService.notifyExternalApply(AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#AABBCC"))))
             }
         } finally {
             builder.dispose()
@@ -197,9 +205,9 @@ class OverridesGroupBuilderApplyTest {
                     val presentation = Presentation()
                     val event = mockk<AnActionEvent>(relaxed = true)
                     every { event.presentation } returns presentation
-                    action.update(event)
+                    updateInTest(action, event)
                     assertFalse(presentation.isEnabled, "$button must disable after license loss")
-                    action.actionPerformed(event)
+                    action.performInTest(event)
                 }
             }
             assertEquals(listOf(projectMapping), draft.projectMappings)
@@ -232,7 +240,7 @@ class OverridesGroupBuilderApplyTest {
             var changeCount = 0
             builder.addPendingChangeListener { changeCount += 1 }
 
-            actionGroups.tableAction(isProject = true, text = "Remove").actionPerformed(mockk(relaxed = true))
+            actionGroups.tableAction(isProject = true, text = "Remove").performInTest(mockk(relaxed = true))
 
             assertTrue(draft.projectMappings.isEmpty())
             assertEquals(1, draft.languageMappings.size)
@@ -265,7 +273,7 @@ class OverridesGroupBuilderApplyTest {
             var changeCount = 0
             builder.addPendingChangeListener { changeCount += 1 }
 
-            actionGroups.tableAction(isProject = false, text = "Remove").actionPerformed(mockk(relaxed = true))
+            actionGroups.tableAction(isProject = false, text = "Remove").performInTest(mockk(relaxed = true))
 
             assertEquals(1, draft.projectMappings.size)
             assertEquals(projectMapping.canonicalPath, draft.projectMappings.single().canonicalPath)
@@ -309,7 +317,7 @@ class OverridesGroupBuilderApplyTest {
         actions.decorateLanguageTable()
 
         SwingUtilities.invokeAndWait {
-            actionGroups.tableAction(isProject = true, text = "Add").actionPerformed(mockk(relaxed = true))
+            actionGroups.tableAction(isProject = true, text = "Add").performInTest(mockk(relaxed = true))
         }
         assertEquals(
             listOf(ProjectMapping("/tmp/added-project", "Added project", "#AABBCC")),
@@ -318,7 +326,7 @@ class OverridesGroupBuilderApplyTest {
         assertTrue(draft.languageMappings.isEmpty())
 
         SwingUtilities.invokeAndWait {
-            actionGroups.tableAction(isProject = false, text = "Add").actionPerformed(mockk(relaxed = true))
+            actionGroups.tableAction(isProject = false, text = "Add").performInTest(mockk(relaxed = true))
         }
         assertEquals(listOf(LanguageMapping("kotlin", "Kotlin", "#112233")), draft.languageMappings)
     }
@@ -362,13 +370,13 @@ class OverridesGroupBuilderApplyTest {
         actions.decorateLanguageTable()
 
         SwingUtilities.invokeAndWait {
-            actionGroups.tableAction(isProject = true, text = "Edit Color").actionPerformed(mockk(relaxed = true))
+            actionGroups.tableAction(isProject = true, text = "Edit Color").performInTest(mockk(relaxed = true))
         }
         assertEquals("#334455", draft.projectMappings.single().hex)
         assertEquals("#112233", draft.languageMappings.single().hex)
 
         SwingUtilities.invokeAndWait {
-            actionGroups.tableAction(isProject = false, text = "Edit Color").actionPerformed(mockk(relaxed = true))
+            actionGroups.tableAction(isProject = false, text = "Edit Color").performInTest(mockk(relaxed = true))
         }
         assertEquals("#667788", draft.languageMappings.single().hex)
     }
@@ -399,14 +407,14 @@ class OverridesGroupBuilderApplyTest {
             val event = mockk<AnActionEvent>(relaxed = true)
             every { event.presentation } returns presentation
 
-            pinAction.update(event)
+            updateInTest(pinAction, event)
             assertTrue(presentation.isEnabled)
 
             every { LicenseChecker.isLicensedOrGrace() } returns false
-            pinAction.update(event)
+            updateInTest(pinAction, event)
             assertFalse(presentation.isEnabled)
 
-            pinAction.actionPerformed(event)
+            pinAction.performInTest(event)
             assertTrue(draft.projectMappings.isEmpty())
         } finally {
             builder.dispose()
@@ -446,13 +454,13 @@ class OverridesGroupBuilderApplyTest {
                     hex = "#5CCFE6",
                 )
 
-            pinAction.actionPerformed(event)
+            pinAction.performInTest(event)
 
             assertEquals(listOf(expectedMapping), draft.projectMappings)
-            pinAction.update(event)
+            updateInTest(pinAction, event)
             assertFalse(presentation.isEnabled)
 
-            pinAction.actionPerformed(event)
+            pinAction.performInTest(event)
             assertEquals(listOf(expectedMapping), draft.projectMappings)
         } finally {
             builder.dispose()
@@ -469,7 +477,11 @@ class OverridesGroupBuilderApplyTest {
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
         every { AccentApplicator.resolveFocusedProject() } returns focusedProject
         every { AccentResolver.resolve(focusedProject, AyuVariant.MIRAGE) } returns "#5CCFE6"
-        every { AccentApplicator.applyFromHexString("#5CCFE6") } returns true
+        every { AccentApplicator.applyFromHexString("#5CCFE6") } answers
+            {
+                AccentHex.of(firstArg<String>())?.let { validatedHex -> AccentApplyOutcome.Applied(validatedHex) }
+                    ?: AccentApplyOutcome.Rejected(firstArg())
+            }
         val swapService = mockk<ProjectAccentSwapService>(relaxed = true)
         every { ProjectAccentSwapService.getInstance() } returns swapService
         val state = AccentMappingsState()
@@ -487,6 +499,23 @@ class OverridesGroupBuilderApplyTest {
         } finally {
             builder.dispose()
         }
+    }
+
+    private fun AnAction.performInTest(event: AnActionEvent) {
+        val actionManager = mockk<ActionManagerEx>(relaxed = true)
+        every { event.actionManager } returns actionManager
+        every { actionManager.performWithActionCallbacks(any(), any(), any()) } answers {
+            thirdArg<Runnable>().run()
+        }
+        ActionUtil.performActionDumbAwareWithCallbacks(this, event)
+    }
+
+    private fun updateInTest(
+        action: AnAction,
+        event: AnActionEvent,
+    ) {
+        every { event.project } returns null
+        ActionUtil.performDumbAwareUpdate(action, event, false)
     }
 
     private fun buildGroup(

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServicePublishTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServicePublishTest.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.wm.IdeFrame
 import com.intellij.openapi.wm.WindowManager
 import com.intellij.util.messages.MessageBus
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
 import dev.ayuislands.accent.AccentChangeListener
 import dev.ayuislands.accent.AccentChangedTopic
 import dev.ayuislands.accent.AccentHex
@@ -75,7 +76,11 @@ class ProjectAccentSwapServicePublishTest {
         mockkObject(AyuVariant.Companion)
         mockkObject(ComponentTreeRefresher)
         mockkObject(IndentRainbowSync)
-        every { AccentApplicator.applyFromHexString(any()) } returns true
+        every { AccentApplicator.applyFromHexString(any()) } answers
+            {
+                AccentHex.of(firstArg<String>())?.let { validatedHex -> AccentApplyOutcome.Applied(validatedHex) }
+                    ?: AccentApplyOutcome.Rejected(firstArg())
+            }
         every { AccentApplicator.syncCodeGlanceProViewportForSwap(any()) } just Runs
         every {
             IndentRainbowSync.apply(any<AyuVariant>(), any())

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt
@@ -3,6 +3,7 @@ package dev.ayuislands.settings.mappings
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.IdeFrame
 import com.intellij.openapi.wm.WindowManager
@@ -37,10 +38,12 @@ import java.awt.event.WindowEvent
 import javax.swing.JComponent
 import javax.swing.JPanel
 import javax.swing.SwingUtilities
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
@@ -67,8 +70,7 @@ class ProjectAccentSwapServiceTest {
         // Default: IR integration enabled. The disabled-IR test flips this to
         // assert the gate skips `IR.apply` on the same-hex branch.
         state.irIntegrationEnabled = true
-        // Default: previous apply completed cleanly, so notifyExternalApply's
-        // torn-apply gate lets cache writes through. The gate tests flip this.
+        // Restart metadata is independent of each invocation's cache outcome.
         state.lastApplyOk = true
 
         mockkObject(AyuIslandsSettings.Companion)
@@ -157,6 +159,37 @@ class ProjectAccentSwapServiceTest {
             matched.second,
             "LOG.error must carry the ORIGINAL exception so triage doesn't lose the stack",
         )
+    }
+
+    @Test
+    fun `window activation propagates cancellation without reporting failure`() {
+        val (window, project) = wireMatchingFrame()
+        every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returns "#FFCC66"
+        val service = ProjectAccentSwapService()
+        val capturedErrors = mutableListOf<Throwable?>()
+        val processor =
+            object : LoggedErrorProcessor() {
+                override fun processError(
+                    category: String,
+                    message: String,
+                    details: Array<out String>,
+                    throwable: Throwable?,
+                ): Set<Action> {
+                    capturedErrors += throwable
+                    return java.util.EnumSet.noneOf(Action::class.java)
+                }
+            }
+
+        for (cancellation in listOf(ProcessCanceledException(), CancellationException("cancelled"))) {
+            every { AccentApplicator.applyFromHexString(any()) } throws cancellation
+            LoggedErrorProcessor.executeWith<Throwable>(processor) {
+                assertSame(
+                    cancellation,
+                    assertFailsWith<RuntimeException> { service.onWindowActivatedForTest(makeEvent(window)) },
+                )
+            }
+        }
+        assertTrue(capturedErrors.isEmpty(), "Cancellation must not be logged as an application failure")
     }
 
     @Test
@@ -493,6 +526,38 @@ class ProjectAccentSwapServiceTest {
     }
 
     @Test
+    fun `visual tear forces full apply when returning to the previous accent`() {
+        val (window, project) = wireMatchingFrame()
+        every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returnsMany
+            listOf("#FFCC66", "#DFBFFF", "#FFCC66")
+        every { AccentApplicator.applyFromHexString("#DFBFFF") } returns
+            AccentApplyOutcome.Torn(
+                requireNotNull(AccentHex.of("#DFBFFF")),
+                listOf(AccentApplyStepFailure(AccentApplyStep.ApplyElements, IllegalStateException("partial paint"))),
+            )
+        val service = ProjectAccentSwapService()
+
+        repeat(3) { service.onWindowActivatedForTest(makeEvent(window)) }
+
+        verify(exactly = 2) { AccentApplicator.applyFromHexString("#FFCC66") }
+        verify(exactly = 1) { AccentApplicator.applyFromHexString("#DFBFFF") }
+        verify(exactly = 3) { ComponentTreeRefresher.walkAndNotify(project, window) }
+    }
+
+    @Test
+    fun `rejected input preserves the previous visual cache`() {
+        val (window, project) = wireMatchingFrame()
+        every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returns "#FFCC66"
+        val service = ProjectAccentSwapService()
+        service.notifyExternalApply(AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#FFCC66"))))
+
+        service.notifyExternalApply(AccentApplyOutcome.Rejected("invalid"))
+        service.onWindowActivatedForTest(makeEvent(window))
+
+        verify(exactly = 0) { AccentApplicator.applyFromHexString(any()) }
+    }
+
+    @Test
     fun `completed outcome primes cache despite a stale torn flag`() {
         state.lastApplyOk = false
         val (window, project) = wireMatchingFrame()
@@ -507,11 +572,8 @@ class ProjectAccentSwapServiceTest {
 
     @Test
     fun `focus-swap apply does not prime the cache when the apply tears`() {
-        // The internal write site must route through the same torn-apply gate:
-        // applyFromHexString returning true only proves the hex shape was valid.
-        // If the plan tore (lastApplyOk=false), priming the cache would freeze
-        // the tear behind the same-hex branch; the swap path must keep retrying
-        // on every activation instead — pre-plan behavior.
+        // A visual Torn outcome must keep retrying on every activation even
+        // when persisted restart metadata still claims an earlier clean apply.
         state.lastApplyOk = true
         every { AccentApplicator.applyFromHexString(any()) } answers {
             AccentApplyOutcome.Torn(

--- a/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/mappings/ProjectAccentSwapServiceTest.kt
@@ -8,7 +8,11 @@ import com.intellij.openapi.wm.IdeFrame
 import com.intellij.openapi.wm.WindowManager
 import com.intellij.testFramework.LoggedErrorProcessor
 import dev.ayuislands.accent.AccentApplicator
+import dev.ayuislands.accent.AccentApplyOutcome
+import dev.ayuislands.accent.AccentApplyStep
+import dev.ayuislands.accent.AccentApplyStepFailure
 import dev.ayuislands.accent.AccentContext
+import dev.ayuislands.accent.AccentHex
 import dev.ayuislands.accent.AccentResolver
 import dev.ayuislands.accent.AyuVariant
 import dev.ayuislands.indent.IndentRainbowSync
@@ -81,7 +85,11 @@ class ProjectAccentSwapServiceTest {
         // cleanly; per-test verifies still scope the assertion to whichever
         // case is under test.
         mockkObject(IndentRainbowSync)
-        every { AccentApplicator.applyFromHexString(any()) } returns true
+        every { AccentApplicator.applyFromHexString(any()) } answers
+            {
+                AccentHex.of(firstArg<String>())?.let { validatedHex -> AccentApplyOutcome.Applied(validatedHex) }
+                    ?: AccentApplyOutcome.Rejected(firstArg())
+            }
         every { AccentApplicator.syncCodeGlanceProViewportForSwap(any()) } just Runs
         every { AccentApplicator.syncCodeGlanceProViewportForSwap(any(), any()) } just Runs
         every { IndentRainbowSync.apply(any<AyuVariant>(), any()) } returns IntegrationOutcome.Skipped
@@ -212,7 +220,7 @@ class ProjectAccentSwapServiceTest {
         every { AccentResolver.resolve(project, AccentContext.External) } returns "#AABBCC"
         val service = ProjectAccentSwapService()
 
-        service.notifyExternalApply("#AABBCC")
+        service.notifyExternalApply(AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#AABBCC"))))
         service.onWindowActivatedForTest(makeEvent(window))
 
         verify(exactly = 1) { AccentResolver.resolve(project, AccentContext.External) }
@@ -291,7 +299,7 @@ class ProjectAccentSwapServiceTest {
 
         // Rotation tick path: external apply pushed a DIFFERENT color into UIManager
         // (because the tick resolved for a different focused project) and synced the cache.
-        service.notifyExternalApply("#DFBFFF")
+        service.notifyExternalApply(AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#DFBFFF"))))
 
         // Alt-tab back to the original project. Resolver still returns the override color;
         // cache-hex is lavender; the handler must notice the drift and re-apply cyan.
@@ -455,7 +463,7 @@ class ProjectAccentSwapServiceTest {
         every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returns "#FFCC66"
         val service = ProjectAccentSwapService()
 
-        service.notifyExternalApply("#FFCC66") // priming write
+        service.notifyExternalApply(AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#FFCC66"))))
         service.onWindowActivatedForTest(makeEvent(window))
 
         // resolve was called (project changed from null to projectA) but apply was skipped
@@ -465,21 +473,36 @@ class ProjectAccentSwapServiceTest {
     }
 
     @Test
-    fun `notifyExternalApply refuses to prime the cache after a torn apply`() {
-        // Pattern D, torn half: a mid-step throw leaves lastApplyOk=false, meaning
-        // the hex was never fully painted. Priming the cache anyway would make the
-        // next same-hex WINDOW_ACTIVATED skip the re-apply that self-heals the
-        // tear — so the write must be gated on the clean flag.
+    fun `current torn outcome cannot inherit a stale clean flag`() {
+        state.lastApplyOk = true
+        val (window, project) = wireMatchingFrame()
+        every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returns "#FFCC66"
+        val service = ProjectAccentSwapService()
+        val outcome =
+            AccentApplyOutcome.Torn(
+                requireNotNull(AccentHex.of("#FFCC66")),
+                listOf(
+                    AccentApplyStepFailure(AccentApplyStep.ApplyElements, IllegalStateException("element")),
+                ),
+            )
+
+        service.notifyExternalApply(outcome)
+        service.onWindowActivatedForTest(makeEvent(window))
+
+        verify(exactly = 1) { AccentApplicator.applyFromHexString("#FFCC66") }
+    }
+
+    @Test
+    fun `completed outcome primes cache despite a stale torn flag`() {
         state.lastApplyOk = false
         val (window, project) = wireMatchingFrame()
         every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returns "#FFCC66"
         val service = ProjectAccentSwapService()
 
-        service.notifyExternalApply("#FFCC66") // gated: must NOT prime the cache
+        service.notifyExternalApply(AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#FFCC66"))))
         service.onWindowActivatedForTest(makeEvent(window))
 
-        // The swap re-applies (self-heal) because the torn hex never entered the cache.
-        verify(exactly = 1) { AccentApplicator.applyFromHexString("#FFCC66") }
+        verify(exactly = 0) { AccentApplicator.applyFromHexString(any()) }
     }
 
     @Test
@@ -489,7 +512,15 @@ class ProjectAccentSwapServiceTest {
         // If the plan tore (lastApplyOk=false), priming the cache would freeze
         // the tear behind the same-hex branch; the swap path must keep retrying
         // on every activation instead — pre-plan behavior.
-        state.lastApplyOk = false
+        state.lastApplyOk = true
+        every { AccentApplicator.applyFromHexString(any()) } answers {
+            AccentApplyOutcome.Torn(
+                requireNotNull(AccentHex.of(firstArg<String>())),
+                listOf(
+                    AccentApplyStepFailure(AccentApplyStep.ApplyElements, IllegalStateException("paint")),
+                ),
+            )
+        }
         val (window, project) = wireMatchingFrame()
         every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returns "#FFCC66"
         val service = ProjectAccentSwapService()
@@ -509,7 +540,7 @@ class ProjectAccentSwapServiceTest {
         every { AccentResolver.resolve(project, AyuVariant.MIRAGE) } returns "#FFCC66"
         val service = ProjectAccentSwapService()
 
-        service.notifyExternalApply("#FFCC66")
+        service.notifyExternalApply(AccentApplyOutcome.Applied(requireNotNull(AccentHex.of("#FFCC66"))))
         service.onWindowActivatedForTest(makeEvent(window))
 
         verify(exactly = 0) { AccentApplicator.applyFromHexString(any()) }


### PR DESCRIPTION
## Summary

Accent callers could treat a valid color as a completed application, even when painting failed or execution was still queued. Return the outcome of the actual application and use it for cache updates and failure reporting while preserving saved preferences and override precedence.

## Changes

- Return `Applied`, `Torn`, or `Rejected`; keep synchronous EDT execution distinct from queued requests.
- Retain nested element, recovery, and publication failures without swallowing cancellation; update rotation, settings, startup, and entitlement callers atomically.
- Invalidate the swap cache after incomplete visual work, propagate cancellation through UI consumers, and restore only the affected pin on cancellation. Cover stale flags, callback ordering, cancellation, preference preservation, and SAM value-class dispatch.
- Remove an obsolete test source-read allowance and refresh two existing screenshot source bindings.

## Validation

- `./gradlew test integrationTest koverXmlReport koverVerify detekt ktlintCheck buildPlugin --offline --console=plain`: 3902 unit + 52 integration tests passed; line coverage 93.56% (17152/18332), with the unchanged 80% floor.
- After removing unsupported unordered-map iteration assertions during review, reran both affected test classes in full: 35/35 passed; Detekt and ktlint passed again. No production bytes changed after the full suite.
- IDEA warning/error inspections passed across all 54 Kotlin files in the PR, including fresh scans of all 19 repair files. Source-read guard, feature-manifest verifier, diff checks, and both commit hooks passed. Strict Pyright, Ruff, and theme-pair checks passed for the unchanged script/theme scope.
- Real IDE at `dfd131f0`: clean build after cache purge, installed/distribution JAR SHA-256 `37b81c718d85805b0ef480c3a87e9e172faee56011357eb2e953badf65ea1aee`; installed bytecode contains the cancellation helper and visual-tear cache invalidation. IDEA reopened the same branch; cached Mirage application completed with zero Ayu WARN/ERROR.
- Runtime acceptance is blocked: the startup scheme event from Ayu, forwarded through CodeGlance, reaches GitToolBox before its project store is initialized, producing SEVERE and subsequent initialization errors. The baseline already publishes the same event, but this PR changes when apply preparation happens relative to dispatch. Three paired process cold starts on baseline `746a28e7` and current `dfd131f0`, using the same IDE/profile/project/plugins, each produced 0/3 GitToolBox initialization failures. The original failure remains unexplained; these clean runs do not establish regression attribution or a fix.
- All 30 CI checks, including compatibility verification, passed at the repaired head `dfd131f0`. `verifyPlugin` was not run locally.

## Notes

Persisted schemas, user-selected ordering, granular preferences, theme files, and coverage thresholds are unchanged. The existing Sonar S6514 delegation suggestion is explicitly deferred. Python IDE diagnostics cannot resolve standard-library modules that the configured Python 3.14 interpreter imports successfully; strict Pyright and runtime checks pass. Existing Gradle 10 deprecation remains a separate follow-up.

## Review dispositions

- Sourcery cancellation finding: fixed at the shared cancellation policy and all affected UI apply boundaries, with regression coverage for original exception identity and pin rollback.
- Sourcery suggestion to skip the component-tree refresh after a visual tear: rejected under the existing focus-swap subscriber contract. Accepted partial applications still require the component refresh; `visual tear forces full apply when returning to the previous accent` verifies all three refreshes while requiring a full reapply of the original color. The actual stale-cache defect is fixed by invalidating the cache after a visual tear.

## Runtime validation blocker

The observed first GitToolBox failure at 02:46:01.367 preceded project-store initialization at 02:46:01.378 by 11 ms. Source inspection establishes the event chain, not baseline behavior. Do not treat the clean Ayu logger or green CI as a clean startup smoke. No speculative workaround, suppression, or third-party plugin disablement was applied.

The controlled A/B sequence preserved all 2118 other plugin JARs and all user settings/schemes; only a runtime license-check timestamp changed. The unmodified current PR artifact is restored and running. Next diagnostic step is identical narrow timing/readiness probes on both variants, pending consent for temporary real-IDE instrumentation. No production source changes were made during the comparison.
