### PR TITLE
ci(dependabot): automate safe dependency updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,14 +3,13 @@ name: CI
 on:
   push:
     branches: [main]
-    paths-ignore: &skip-paths
+    paths-ignore:
       - '**/*.md'
       - 'LICENSE'
       - '.gitignore'
       - '.sourcery.yaml'
   pull_request:
     branches: [main]
-    paths-ignore: *skip-paths
   workflow_dispatch:
 
 permissions:
@@ -41,7 +40,7 @@ jobs:
             || { echo "::error::Trailing whitespace found"; exit 1; }
       - name: Validate YAML
         run: |
-          find . -name '*.yml' -o -name '*.yaml' | while read f; do
+          find . -name '*.yml' -o -name '*.yaml' | while read -r f; do
             python3 -c "import yaml; yaml.safe_load(open('$f'))" \
               || { echo "::error::Invalid YAML: $f"; exit 1; }
           done
@@ -52,13 +51,13 @@ jobs:
           # excluded — other whatsnew test fixtures are valid JSON and must
           # still be checked so a maintainer typo in e.g. v9.9.5 gets caught.
           find . -name '*.json' -not -path '*/build/*' \
-            -not -path '*/src/test/resources/whatsnew/v9.9.1/*' | while read f; do
+            -not -path '*/src/test/resources/whatsnew/v9.9.1/*' | while read -r f; do
             python3 -c "import json; json.load(open('$f'))" \
               || { echo "::error::Invalid JSON: $f"; exit 1; }
           done
       - name: Validate XML
         run: |
-          find . -name '*.xml' -not -path '*/build/*' | while read f; do
+          find . -name '*.xml' -not -path '*/build/*' | while read -r f; do
             python3 -c "
           import xml.etree.ElementTree as ET
           ET.parse('$f')
@@ -116,6 +115,8 @@ jobs:
         run: uv run --project scripts --with pre-commit python scripts/tests/test-guard-linter-configs.py
       - name: Test screenshot restamping
         run: uv run --project scripts python scripts/tests/test-screenshot-restamp.py
+      - name: Test Dependabot auto-merge policy
+        run: uv run --project scripts python scripts/tests/test-dependabot-automerge.py
       - name: Verify docs sync (features.yml ↔ README + plugin.xml + CHANGELOG)
         run: scripts/verify-docs.py
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,14 +3,13 @@ name: CodeQL
 on:
   push:
     branches: [main]
-    paths-ignore: &skip-paths
+    paths-ignore:
       - '**/*.md'
       - 'LICENSE'
       - '.gitignore'
       - '.sourcery.yaml'
   pull_request:
     branches: [main]
-    paths-ignore: *skip-paths
   schedule:
     - cron: '37 4 * * 1'
   workflow_dispatch:

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,55 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions: {}
+
+concurrency:
+  group: dependabot-automerge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  automerge:
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.repository == 'barad1tos/ayu-jetbrains' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      # Metadata verification needs no checkout or execution of PR code.
+      - id: metadata
+        uses: dependabot/fetch-metadata@ffa630c65fa7e0ecfa0625b5ceda64399aea1b36 # v3.0.0
+      - name: Select updates eligible for auto-merge
+        id: eligibility
+        env:
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+          DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+        shell: bash
+        run: |
+          eligible=false
+          case "$UPDATE_TYPE" in
+            version-update:semver-patch|version-update:semver-minor)
+              eligible=$(jq -nr --arg names "$DEPENDENCY_NAMES" '
+                $names | split(",") | map(gsub("^\\s+|\\s+$"; "")) |
+                length > 0 and all(.[]; length > 0 and
+                  (test("^(org|com)\\.jetbrains\\.(kotlin|intellij)([.:]|$)") | not))
+              ')
+              ;;
+          esac
+          echo "eligible=$eligible" >> "$GITHUB_OUTPUT"
+      - name: Enable auto-merge after required checks
+        id: enable
+        if: steps.eligibility.outputs.eligible == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: gh pr merge --auto --merge --match-head-commit "$PR_HEAD_SHA" "$PR_URL"

--- a/scripts/tests/test-dependabot-automerge.py
+++ b/scripts/tests/test-dependabot-automerge.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Run the workflow's eligibility script against Dependabot update scenarios."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from typing import TypedDict, cast
+
+import yaml
+
+WORKFLOW = Path(__file__).resolve().parents[2] / ".github/workflows/dependabot-automerge.yml"
+
+
+class Step(TypedDict, total=False):
+    id: str
+    run: str
+
+
+class Job(TypedDict):
+    steps: list[Step]
+
+
+class Workflow(TypedDict):
+    jobs: dict[str, Job]
+
+
+def eligibility_script() -> str:
+    workflow = cast(Workflow, yaml.safe_load(WORKFLOW.read_text()))
+    for step in workflow["jobs"]["automerge"]["steps"]:
+        if step.get("id") == "eligibility" and "run" in step:
+            return step["run"]
+    raise ValueError("Workflow must contain an eligibility script")
+
+
+class DependabotAutomergeTest(unittest.TestCase):
+    def assert_eligible(self, update_type: str, names: str, expected: bool) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "output"
+            result = subprocess.run(
+                ["bash", "--noprofile", "--norc", "-euo", "pipefail", "-c", eligibility_script()],
+                env={**os.environ, "UPDATE_TYPE": update_type, "DEPENDENCY_NAMES": names,
+                     "GITHUB_OUTPUT": str(output)},
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=10,
+            )
+            self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+            self.assertEqual(f"eligible={str(expected).lower()}\n", output.read_text())
+
+    def test_allows_patch_and_minor(self) -> None:
+        for update in ("patch", "minor"):
+            for names in ("actions/checkout", "org.junit.jupiter:junit-jupiter",
+                          "github/codeql-action/analyze,github/codeql-action/init"):
+                with self.subTest(update=update, names=names):
+                    self.assert_eligible(f"version-update:semver-{update}", names, True)
+
+    def test_rejects_major_and_unknown(self) -> None:
+        for update in ("version-update:semver-major", "", "version-update:unknown"):
+            with self.subTest(update=update):
+                self.assert_eligible(update, "actions/checkout", False)
+
+    def test_protects_toolchain_groups(self) -> None:
+        for dependency in ("org.jetbrains.kotlin.jvm", "org.jetbrains.kotlin:kotlin-stdlib",
+                           "org.jetbrains.intellij.platform", "com.jetbrains.intellij.idea:ideaIC"):
+            for names in (dependency, f"org.junit.jupiter:junit-jupiter,{dependency}"):
+                with self.subTest(names=names):
+                    self.assert_eligible("version-update:semver-patch", names, False)
+
+    def test_rejects_empty_names(self) -> None:
+        for names in ("", " ", "actions/checkout,", ",actions/checkout"):
+            with self.subTest(names=names):
+                self.assert_eligible("version-update:semver-patch", names, False)
+
+    def test_names_are_not_executed(self) -> None:
+        self.assert_eligible("version-update:semver-patch", "$(exit 97)", True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
── Summary ─────────────────────────────────

Dependabot updates had no workflow enabling auto-merge, and main had no required CI checks. Enable native auto-merge for verified patch/minor updates while leaving major, Kotlin and IntelliJ Platform updates to a maintainer.

── Changes ─────────────────────────────────

- CI: Add a pinned Dependabot metadata action and head-matched auto-merge command, with no checkout or execution of PR code.
- CI: Run CI and all three CodeQL jobs on every PR so required checks also report on documentation-only changes. Preserve push path filters and fix shell reads to preserve backslashes.
- Test: Exercise the actual eligibility script across 22 ordinary, grouped, protected, empty and command-injection scenarios.

── Validation ──────────────────────────────

- All eight Python test files: 115 tests passed.
- `pyright --project scripts scripts/tests/test-dependabot-automerge.py`: zero errors/warnings.
- actionlint 1.7.12 and repository-configured zizmor 1.22.0: all three changed workflows passed.
- Pre-commit hooks passed; Python IDE inspections are clean. YAML inspections are unsupported by the IDE, so workflow validation uses the dedicated analyzers.
- Kotlin suites were not rerun locally because no Kotlin, Gradle or plugin code changed. Exact-head PR CI completed successfully: 28 successful checks, including Test with coverage, all six syntax groups, all four verifier groups, Gate and CodeQL; two auto-merge runs correctly skipped this maintainer-authored PR.

── Notes ───────────────────────────────────

Repository auto-merge is enabled. Main now requires Gate and CodeQL (actions, java-kotlin, python), tied to GitHub Actions, with the latest base required. Existing rules, merge methods and token defaults were preserved. Automatic approvals remain disabled.

End-to-end auto-merge activation still needs a real eligible Dependabot PR after this workflow is merged. The policy tests do not claim to validate GitHub token permissions at runtime.

Internal review found no open gaps. Sourcery and Codex both completed review at 372b5ff333fca9de171f6b9036cb0f0e41b9aeae. Their duplicate token-permissions findings were rejected with [official documentation and repository runtime evidence](https://github.com/barad1tos/ayu-jetbrains/pull/350#discussion_r3966325317); both threads are resolved.
