### PR TITLE
test: reuse MockK instrumentation across expensive test classes

### DIFF
--- a/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
+++ b/src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt
@@ -34,11 +34,16 @@ import dev.ayuislands.theme.AyuEditorSchemeScope
 import dev.ayuislands.theme.EditorSchemeChange
 import io.mockk.clearAllMocks
 import io.mockk.every
+import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
+import io.mockk.unmockkObject
+import io.mockk.unmockkStatic
 import io.mockk.verify
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
 import java.awt.Color
 import java.awt.Window
 import java.awt.event.WindowEvent
@@ -66,7 +71,11 @@ import kotlin.test.assertTrue
  * Uses `mockkObject(AccentApplicator)` with `callOriginal()` to test the real
  * apply/revert logic while intercepting `applyElements` and `syncCodeGlanceProViewport`
  * which require the IntelliJ extension point system (unavailable in unit tests).
+ *
+ * Owns mock cleanup: [tearDown] clears each test, and [uninstallSharedMocks]
+ * removes shared instrumentation after the class instead of after every method.
  */
+@MockKExtension.KeepMocks
 class AccentApplicatorTest {
     private val mockScheme = mockk<EditorColorsScheme>(relaxed = true)
     private val mockColorsManager = mockk<EditorColorsManager>(relaxed = true)
@@ -80,21 +89,16 @@ class AccentApplicatorTest {
         AyuEditorSchemeScope.resetClaims()
         saveOriginalEpName()
 
-        mockkStatic(SwingUtilities::class)
         every { SwingUtilities.isEventDispatchThread() } returns true
 
-        mockkStatic(UIManager::class)
-
-        mockkStatic(EditorColorsManager::class)
         every { EditorColorsManager.getInstance() } returns mockColorsManager
         every { mockColorsManager.globalScheme } returns mockScheme
         every { mockScheme.name } returns "Ayu Islands Mirage"
         every { mockScheme.getAttributes(any<TextAttributesKey>()) } returns TextAttributes()
 
-        // ApplicationManager must be mocked BEFORE AyuIslandsSettings.Companion,
+        // ApplicationManager must be stubbed BEFORE AyuIslandsSettings.Companion,
         // because getInstance() calls ApplicationManager.getApplication().getService()
         // during MockK recording.
-        mockkStatic(ApplicationManager::class)
         every { ApplicationManager.getApplication() } returns mockApplication
         every { mockApplication.messageBus } returns mockMessageBus
         every { mockApplication.getService(ProjectAccentSwapService::class.java) } returns ProjectAccentSwapService()
@@ -103,34 +107,26 @@ class AccentApplicatorTest {
         // cast succeeds in this legacy headless test.
         every { mockMessageBus.syncPublisher(AccentChangedTopic.TOPIC) } returns mockk(relaxed = true)
 
-        mockkObject(EditorSchemeChange)
         every { EditorSchemeChange.publish() } returns Unit
 
-        mockkObject(AyuIslandsSettings.Companion)
         every { AyuIslandsSettings.getInstance() } returns mockSettings
         every { mockSettings.state } returns state
         state.isCgpOwnershipMigrated = true
         state.isIrOwnershipMigrated = true
-        mockkObject(LicenseChecker)
         every { LicenseChecker.isLicensedOrGrace() } returns true
 
-        mockkObject(AyuVariant.Companion)
         every { AyuVariant.detect() } returns AyuVariant.MIRAGE
 
-        mockkObject(ConflictRegistry)
         every { ConflictRegistry.getConflictFor(any()) } returns null
 
-        mockkStatic(Window::class)
         every { Window.getWindows() } returns emptyArray()
 
-        mockkObject(AyuPlugin)
         every { AyuPlugin.findLoadedPlugin(any()) } returns null
 
         // Per-project notify plumbing: revertAll iterates ProjectManager.openProjects
         // and calls ComponentTreeRefresher.notifyOnly per usable project. Unit tests
         // don't boot the platform, so both must be stubbed or the notifyOnly loop
         // blows up with "Can't get extension point" / a null ProjectManager.
-        mockkStatic(ProjectManager::class)
         val mockProjectManager = mockk<ProjectManager>(relaxed = true)
         every {
             ProjectManager
@@ -138,7 +134,6 @@ class AccentApplicatorTest {
         } returns mockProjectManager
         every { mockProjectManager.openProjects } returns emptyArray()
 
-        mockkObject(dev.ayuislands.ui.ComponentTreeRefresher)
         every {
             dev.ayuislands.ui.ComponentTreeRefresher
                 .notifyOnly(any())
@@ -153,7 +148,9 @@ class AccentApplicatorTest {
         AyuEditorSchemeScope.resetClaims()
         ExternalChromeOwnership.resetForTests()
         restoreOriginalEpName()
-        unmockkAll()
+        // Scenario-specific mocks must not remain active in the next test.
+        unmockkObject(IndentRainbowSync, ProjectAccentSwapService.Companion, AccentResolver, ChromeBaseColors)
+        unmockkStatic(WindowManager::class, com.intellij.notification.Notifications.Bus::class)
         clearAllMocks()
     }
 
@@ -2715,5 +2712,36 @@ class AccentApplicatorTest {
         private const val EXTERNAL_CHROME_TEST_KEY = "Ayu.Test.externalChrome"
         private const val CODE_GLANCE_METHOD_RESOLUTION =
             "resolve" + "C" + "g" + "p" + "Methods"
+
+        // Keep bytecode instrumentation for the class; each test still gets fresh
+        // fixture instances, stubs, and call history through `setUp`/`tearDown`.
+        @BeforeAll
+        @JvmStatic
+        fun installSharedMocks() {
+            mockkStatic(
+                SwingUtilities::class,
+                UIManager::class,
+                EditorColorsManager::class,
+                ApplicationManager::class,
+                Window::class,
+                ProjectManager::class,
+            )
+            mockkObject(
+                EditorSchemeChange,
+                AyuIslandsSettings.Companion,
+                LicenseChecker,
+                AyuVariant.Companion,
+                ConflictRegistry,
+                AyuPlugin,
+                dev.ayuislands.ui.ComponentTreeRefresher,
+            )
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun uninstallSharedMocks() {
+            unmockkAll()
+            clearAllMocks()
+        }
     }
 }

--- a/src/test/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanelTest.kt
+++ b/src/test/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanelTest.kt
@@ -30,7 +30,9 @@ import dev.ayuislands.syntax.SyntaxPreset
 import dev.ayuislands.syntax.SyntaxPresetConfig
 import dev.ayuislands.syntax.SyntaxReadabilityOptions
 import dev.ayuislands.syntax.SyntaxTransactionResult
+import io.mockk.clearAllMocks
 import io.mockk.every
+import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.mockk.mockkClass
 import io.mockk.mockkObject
@@ -38,6 +40,8 @@ import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
 import io.mockk.verifyOrder
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
 import java.awt.Color
 import java.awt.Container
 import java.awt.Font
@@ -84,7 +88,11 @@ import kotlin.test.assertTrue
  * Visual contracts are asserted against the materialized Swing tree rather
  * than production source text, so refactors remain free to change the build
  * mechanism while preserving observable behavior.
+ *
+ * Owns mock cleanup: [tearDown] clears each test, and [uninstallSharedMocks]
+ * removes shared instrumentation after the class instead of after every method.
  */
+@MockKExtension.KeepMocks
 class AyuIslandsSyntaxPanelTest {
     private companion object {
         val readabilityCheckboxTexts =
@@ -94,6 +102,20 @@ class AyuIslandsSyntaxPanelTest {
                 "Quiet operators",
                 "Emphasize declarations",
             )
+
+        @BeforeAll
+        @JvmStatic
+        fun installSharedMocks() {
+            mockkStatic(ApplicationManager::class, ActionManager::class)
+            mockkObject(SyntaxIntensityState.Companion, SyntaxIntensityService.Companion, LicenseChecker)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun uninstallSharedMocks() {
+            unmockkAll()
+            clearAllMocks()
+        }
     }
 
     private lateinit var stateBase: SyntaxIntensityBaseState
@@ -109,12 +131,10 @@ class AyuIslandsSyntaxPanelTest {
         schemeName = "Ayu Islands Mirage"
         stateService = mockk(relaxed = true)
         every { stateService.state } returns stateBase
-        mockkObject(SyntaxIntensityState.Companion)
         every { SyntaxIntensityState.getInstance() } returns stateService
 
         intensityService = mockk(relaxed = true)
         runtimeSession = mockk(relaxed = true)
-        mockkObject(SyntaxIntensityService.Companion)
         every { SyntaxIntensityService.getInstance() } returns intensityService
         every { intensityService.tunableCategories(any()) } returns null
         every { intensityService.openRuntimeSession() } returns runtimeSession
@@ -124,17 +144,14 @@ class AyuIslandsSyntaxPanelTest {
         every { runtimeSession.restore() } returns applied
         every { runtimeSession.close() } returns null
 
-        mockkObject(LicenseChecker)
         // Default: licensed. Individual tests override to false where needed.
         every { LicenseChecker.isLicensedOrGrace() } returns true
         every { LicenseChecker.requestLicense(any()) } returns Unit
 
-        mockkStatic(ApplicationManager::class)
         val appMock = mockk<Application>(relaxed = true)
         val actionManagerMock = mockk<ActionManagerEx>(relaxed = true)
         val editorColorsManager = mockk<EditorColorsManager>()
         val editorScheme = mockk<EditorColorsScheme>()
-        mockkStatic(ActionManager::class)
         every { ActionManager.getInstance() } returns actionManagerMock
         every { ApplicationManager.getApplication() } returns appMock
         every { appMock.invokeLater(any()) } answers { firstArg<Runnable>().run() }
@@ -157,7 +174,7 @@ class AyuIslandsSyntaxPanelTest {
 
     @AfterTest
     fun tearDown() {
-        unmockkAll()
+        clearAllMocks()
     }
 
     // ---------- Test 1 - initial state defaults to AMBIENT (D-23) ----------

--- a/src/test/kotlin/dev/ayuislands/syntax/SyntaxIntensityServiceTest.kt
+++ b/src/test/kotlin/dev/ayuislands/syntax/SyntaxIntensityServiceTest.kt
@@ -18,14 +18,18 @@ import dev.ayuislands.theme.EditorSchemeChange
 import dev.ayuislands.theme.EditorSchemeOverrides
 import dev.ayuislands.theme.EditorSchemeOwner
 import dev.ayuislands.theme.OverrideWriteResult
+import io.mockk.clearAllMocks
 import io.mockk.clearMocks
 import io.mockk.every
+import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.verify
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
 import java.awt.Color
 import java.awt.Font
 import kotlin.coroutines.cancellation.CancellationException
@@ -49,7 +53,11 @@ import kotlin.test.assertTrue
  * (R-7), and pins the R-1 fallback + service-layer
  * `CUSTOM` premium gate behaviour through `mockkObject` calls into
  * `RgbBlend` / `LicenseChecker` / `SyntaxIntensityApplicator`.
+ *
+ * Owns mock cleanup: [tearDown] clears each test, and [uninstallSharedMocks]
+ * removes shared instrumentation after the class instead of after every method.
  */
+@MockKExtension.KeepMocks
 class SyntaxIntensityServiceTest {
     companion object {
         /**
@@ -67,6 +75,33 @@ class SyntaxIntensityServiceTest {
                 "PACKAGE_PRIVATE_REFERENCE",
                 "PRIVATE_REFERENCE",
             )
+
+        @BeforeAll
+        @JvmStatic
+        fun installSharedMocks() {
+            mockkStatic(
+                PropertiesComponent::class,
+                TextAttributesKey::class,
+                EditorColorsManager::class,
+                ApplicationManager::class,
+            )
+            mockkObject(
+                EditorSchemeChange,
+                EditorSchemeOverrides,
+                SyntaxOverlayLoader.Companion,
+                SyntaxIntensityState.Companion,
+                LicenseChecker,
+                RgbBlend,
+                SyntaxIntensityApplicator,
+            )
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun uninstallSharedMocks() {
+            unmockkAll()
+            clearAllMocks()
+        }
     }
 
     private lateinit var mockMirage: EditorColorsScheme
@@ -89,10 +124,8 @@ class SyntaxIntensityServiceTest {
         // Default: no scheme has been retired yet, so the one-shot pass fires. Tests
         // that assert the "already retired" branch override this.
         props = mockk(relaxed = true)
-        mockkStatic(PropertiesComponent::class)
         every { PropertiesComponent.getInstance() } returns props
         every { props.getList(RETIREMENT_FLAG_KEY) } returns null
-        mockkStatic(TextAttributesKey::class)
         every { TextAttributesKey.find(any<String>()) } answers {
             val name = firstArg<String>()
             keyCache.getOrPut(name) { mockk(relaxed = true) { every { externalName } returns name } }
@@ -111,7 +144,6 @@ class SyntaxIntensityServiceTest {
         ayuSettings = mockk(relaxed = true)
         every { ayuSettings.state } returns ayuState
 
-        mockkStatic(EditorColorsManager::class)
         every { EditorColorsManager.getInstance() } returns mockManager
         every { mockManager.getScheme("Ayu Islands Mirage") } returns mockMirage
         every { mockManager.getScheme("Ayu Islands Dark") } returns mockDark
@@ -121,15 +153,12 @@ class SyntaxIntensityServiceTest {
         // this individually.
         every { mockManager.globalScheme } returns mockMirage
 
-        mockkStatic(ApplicationManager::class)
         every { ApplicationManager.getApplication() } returns mockApp
         every { mockApp.runReadAction(any<Runnable>()) } answers {
             firstArg<Runnable>().run()
         }
 
-        mockkObject(EditorSchemeChange)
         every { EditorSchemeChange.publish() } returns Unit
-        mockkObject(EditorSchemeOverrides)
         overrideCheckpoints = mockk()
         every { EditorSchemeOverrides.checkpoints } returns overrideCheckpoints
         every { EditorSchemeOverrides.restore(any(), EditorSchemeOwner.Syntax) } returns Unit
@@ -159,28 +188,23 @@ class SyntaxIntensityServiceTest {
             every { loader.loadBaselineForVariant(variant) } returns payload
             every { loader.fallbacksFor(variant) } returns emptyMap()
         }
-        mockkObject(SyntaxOverlayLoader.Companion)
         every { SyntaxOverlayLoader.getInstance() } returns loader
 
         stateInstance = mockk(relaxed = true)
         every { stateInstance.toPresetConfig() } returns
             SyntaxPresetConfig(selectedPreset = "AMBIENT", customOverrides = emptyMap())
-        mockkObject(SyntaxIntensityState.Companion)
         every { SyntaxIntensityState.getInstance() } returns stateInstance
 
         // Default: licensed so the CUSTOM gate doesn't normalise on every test.
         // Individual tests override to false where the gate is the subject.
-        mockkObject(LicenseChecker)
         every { LicenseChecker.isLicensedOrGrace() } returns true
 
         // R-1 fallback observer - overridden per test that needs to assert
         // engagement; default keeps the stub silent.
-        mockkObject(RgbBlend)
         every { RgbBlend.fallbackEditorBgFor(any()) } returns Color(0x1F, 0x24, 0x30)
 
         // Applicator returns the same payload it received - the service is the
         // unit under test, not the HSL math.
-        mockkObject(SyntaxIntensityApplicator)
         every {
             SyntaxIntensityApplicator.compute(any())
         } returns payload
@@ -213,7 +237,7 @@ class SyntaxIntensityServiceTest {
 
     @AfterTest
     fun tearDown() {
-        unmockkAll()
+        clearAllMocks()
     }
 
     // ---------- Test 1: H5 dual-write - 3 named schemes + active (or dedup) ----------


### PR DESCRIPTION
── Summary ─────────────────────────────────

Repeated MockK bytecode instrumentation dominated three expensive test classes. Keep shared instrumentation installed for each class while retaining fresh per-method fixtures, stubs and call history.

── Changes ─────────────────────────────────

- Test: [AccentApplicatorTest.kt](src/test/kotlin/dev/ayuislands/accent/AccentApplicatorTest.kt) — install shared mocks once and remove scenario-specific mocks after each test.
- Test: [AyuIslandsSyntaxPanelTest.kt](src/test/kotlin/dev/ayuislands/settings/AyuIslandsSyntaxPanelTest.kt) — retain shared instrumentation while recreating the preview fixture per method.
- Test: [SyntaxIntensityServiceTest.kt](src/test/kotlin/dev/ayuislands/syntax/SyntaxIntensityServiceTest.kt) — reuse instrumentation with fresh service state per test.

Each class owns cleanup through the public MockK `KeepMocks` annotation, per-test clearing and final class teardown. All 265 existing test bodies and assertions remain unchanged.

── Validation ──────────────────────────────

- `./gradlew test integrationTest koverXmlReport koverVerify --no-daemon --console=plain` — passed: 3,987 unit tests and 152 integration tests; zero failures or skips; 93.93% line coverage.
- `./gradlew detekt ktlintCheck` — passed.
- IDEA inspections — zero findings across all three changed files.
- `python3 scripts/verify-docs.py` and `git diff --check` — passed.
- Focused randomized-method runs, seed `20260911` — all 265 tests passed.

Paired local profiles used the same Kover and JFR settings for each before/after comparison:

| Test class | Tests | Before | After |
|---|---:|---:|---:|
| AccentApplicatorTest | 135 | 65.473 s | 6.751 s |
| AyuIslandsSyntaxPanelTest | 72 | 25.146 s | 5.721 s |
| SyntaxIntensityServiceTest | 58 | 26.070 s | 1.241 s |

Accent retransforms fell from 3,624 to 140; the two syntax classes fell from 2,612 to 80. These are local focused measurements, not a projected CI speedup.

── Notes ───────────────────────────────────

Review focus: cleanup ownership across MockK and JUnit lifecycle callbacks, especially scenario-specific mocks and class teardown. Production code, build configuration and coverage gates are unchanged.

## Summary by Sourcery

Reduce expensive test runtime by sharing MockK instrumentation across test classes without changing production code or test assertions.

Enhancements:
- Reuse MockK instrumentation across three expensive test classes while preserving fresh per-test fixtures, stubs, and call history.

Tests:
- Update test lifecycle cleanup to retain shared mocks during each class and remove instrumentation during class teardown.